### PR TITLE
Fix: Include Jinja2 template files in package distribution

### DIFF
--- a/openhands/core/pyproject.toml
+++ b/openhands/core/pyproject.toml
@@ -20,3 +20,6 @@ build-backend = "setuptools.build_meta"
 where = ["../.."]
 include = ["openhands*"]
 
+[tool.setuptools.package-data]
+"*" = ["*.j2"]
+


### PR DESCRIPTION
## Problem

When installing and using the agent-sdk, the `CodeActAgent` fails with a `FileNotFoundError` when trying to load `system_prompt.j2`:

```
FileNotFoundError: [Errno 2] No such file or directory: '/path/to/site-packages/openhands/core/agent/codeact_agent/prompts/system_prompt.j2'
```

This occurs because setuptools only includes Python files (`.py`) by default, excluding the Jinja2 template files (`.j2`) that contain the agent's system prompts.

## Fix

Added `[tool.setuptools.package-data]` configuration to `openhands/core/pyproject.toml` to explicitly include all `.j2` template files in the package distribution.

This ensures that all prompt templates in `openhands/core/agent/codeact_agent/prompts/` are properly bundled when the package is installed via pip/uv.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/449b037f803e4f869decffb2e540170a)