### PR TITLE
Fix: makes sure conversation stats is passed to conversation visualizer

### DIFF
--- a/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands/sdk/conversation/impl/local_conversation.py
@@ -84,7 +84,9 @@ class LocalConversation(BaseConversation):
         composed_list = (callbacks if callbacks else []) + [_default_callback]
         # Add default visualizer if requested
         if visualize:
-            self._visualizer = create_default_visualizer()
+            self._visualizer = create_default_visualizer(
+                conversation_stats=self._state.stats
+            )
             composed_list = [self._visualizer.on_event] + composed_list
             # visualize should happen first for visibility
         else:


### PR DESCRIPTION
Note that cost displayed includes the cost of the current event and all those that came before it.