### PR TITLE
fix: changed suffix in agent server naming from timestamp from random uuid

### DIFF
--- a/openhands/sdk/sandbox/docker.py
+++ b/openhands/sdk/sandbox/docker.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 import threading
 import time
+import uuid
 from collections.abc import Iterable
 from pathlib import Path
 from urllib.request import urlopen
@@ -237,7 +238,7 @@ class DockerSandboxedAgentServer:
             self._platform,
             "--rm",
             "--name",
-            f"agent-server-{int(time.time()*1000000)}",
+            f"agent-server-{uuid.uuid4()}",
             *flags,
             self._image,
             "--host",


### PR DESCRIPTION
Necessary for creating multiple agent servers quickly. For example, when running benchmarks.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:ee538d2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ee538d2-python \
  ghcr.io/all-hands-ai/agent-server:ee538d2-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:ee538d2-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:ee538d2-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:ee538d2-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `ee538d2` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->