### PR TITLE
Fix multiple inheritance issue in ConversationState (#583)

### DIFF
--- a/openhands/sdk/conversation/state.py
+++ b/openhands/sdk/conversation/state.py
@@ -109,11 +109,6 @@ class ConversationState(OpenHandsModel):
         default_factory=FIFOLock
     )  # FIFO lock for thread safety
 
-    def model_post_init(self, __context) -> None:
-        """Initialize private attributes after Pydantic model initialization."""
-        # The _lock is already initialized by default_factory
-        pass
-
     # ===== Public "events" facade (Sequence[Event]) =====
     @property
     def events(self) -> EventLog:


### PR DESCRIPTION
## Summary

This PR fixes the multiple inheritance issue reported in #583 where `ConversationState` was inheriting from both `OpenHandsModel` and `FIFOLock`, causing basedpyright to report:

> Multiple inheritance is not allowed because the following base classes contain `__init__` or `__new__` methods that may not get called: OpenHandsModel, FIFOLock (basedpyright reportUnsafeMultipleInheritance)

## Changes

### Core Fix
- **Replaced multiple inheritance with composition pattern** in `ConversationState`
- Changed from `class ConversationState(OpenHandsModel, FIFOLock)` to `class ConversationState(OpenHandsModel)`
- Added `_lock: FIFOLock` as a private attribute
- Implemented delegation methods to maintain the same public API:
  - `acquire()`, `release()`, `__enter__()`, `__exit__()`
  - `locked()`, `owned()`

### Testing
- Added comprehensive test suite in `tests/sdk/conversation/test_conversation_state_composition.py`
- Tests verify that composition works correctly and lock functionality is preserved
- All existing tests continue to pass (136 conversation tests, 787 SDK tests)

### Development Improvements
- Added `basedpyright>=1.21.0` to dev dependencies
- Added basedpyright to pre-commit hooks (warnings-only mode to avoid blocking on pre-existing issues)
- This will help catch similar multiple inheritance issues in the future

## Verification

The fix has been verified by:
1. ✅ All existing tests pass
2. ✅ New composition-based tests pass
3. ✅ basedpyright no longer reports the multiple inheritance error
4. ✅ Lock functionality works correctly through delegation
5. ✅ Backward compatibility is maintained

## Technical Details

The composition pattern is preferred over multiple inheritance because:
- It avoids the diamond problem and method resolution order issues
- It makes the relationship between classes clearer
- It prevents potential conflicts between `__init__` methods
- It's more maintainable and follows the "favor composition over inheritance" principle

Fixes #583

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/05c07f15516a4b229f9e73712f18ea0e)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:5bba7e9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5bba7e9-python \
  ghcr.io/all-hands-ai/agent-server:5bba7e9-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:5bba7e9-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:5bba7e9-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:5bba7e9-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `5bba7e9` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->