### PR TITLE
fix: Path(__file__) points to workspace.py not docker.py 

### DIFF
--- a/openhands/workspace/docker/workspace.py
+++ b/openhands/workspace/docker/workspace.py
@@ -153,9 +153,9 @@ def build_agent_server_image(
         env.update(extra_env)
 
     if not project_root:
-        # Path is: openhands/sdk/workspace/remote/docker.py
-        # parents[4] gives us the SDK root
-        project_root = str(Path(__file__).resolve().parents[4])
+        # Path is: openhands/workspace/docker/workspace.py
+        # parents[3] gives us the SDK root
+        project_root = str(Path(__file__).resolve().parents[3])
 
     proc = execute_command(["bash", str(script_path)], env=env, cwd=project_root)
 


### PR DESCRIPTION
which have different parents. So it should be parent [3] instead of parent [4].
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:1d373df-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1d373df-python \
  ghcr.io/all-hands-ai/agent-server:1d373df-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:1d373df-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:1d373df-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:1d373df-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `1d373df` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->