### PR TITLE
Bug: Add litellm patch for gpt5 responses API 

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -568,8 +568,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     typed_input: ResponseInputParam | str = (
                         cast(ResponseInputParam, input_items) if input_items else ""
                     )
+                    # LiteLLM BUG WORKAROUND
+                    # The proxy's does not route correctly to Responses API if
+                    # the model name is prefixed with "litellm_proxy/"
+                    # This bug is fixed by
+                    # https://github.com/BerriAI/litellm/issues/15342#event-20174587826
+                    # https://github.com/BerriAI/litellm/pull/15347
+                    responses_model = self.model
+                    if responses_model.startswith("litellm_proxy/openai/gpt-5"):
+                        responses_model = responses_model[len("litellm_proxy/") :]
                     ret = litellm_responses(
-                        model=self.model,
+                        model=responses_model,
                         input=typed_input,
                         instructions=instructions,
                         tools=resp_tools,


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:47ce3cb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-47ce3cb-python \
  ghcr.io/all-hands-ai/agent-server:47ce3cb-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:47ce3cb-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_golang
ghcr.io/all-hands-ai/agent-server:47ce3cb-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_java
ghcr.io/all-hands-ai/agent-server:47ce3cb-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_python
```

_The `47ce3cb` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->