### PR TITLE
use older version of builder so the binary is compatible

### DIFF
--- a/openhands/agent_server/docker/Dockerfile
+++ b/openhands/agent_server/docker/Dockerfile
@@ -10,7 +10,7 @@ ARG PORT=8000
 # Builder (source mode)
 # We copy source + build a venv here for local dev and debugging.
 ####################################################################################
-FROM python:3.12-bookworm AS builder
+FROM python:3.12-bullseye AS builder
 ARG USERNAME UID GID
 ENV UV_PROJECT_ENVIRONMENT=/agent-server/.venv
 


### PR DESCRIPTION
Fix
```
                             b.eval.x86_64.astropy_1776_astropy-12907_tag_latest_binary-minimal               
                             --host 0.0.0.0 --port 8000                                                       
bcd101403833b947ab0dd048ab98d00ca2afb4705cc853434dcf59dc5b351a6b
[10/13/25 20:14:19] INFO     Started container:                                               workspace.py:232
                             bcd101403833b947ab0dd048ab98d00ca2afb4705cc853434dcf59dc5b351a6b                 
[10/13/25 20:14:19] INFO     $ docker inspect -f '{{.State.Running}}'                            command.py:27
                             bcd101403833b947ab0dd048ab98d00ca2afb4705cc853434dcf59dc5b351a6b                 
true
[10/13/25 20:14:20] INFO     $ docker inspect -f '{{.State.Running}}'                            command.py:27
                             bcd101403833b947ab0dd048ab98d00ca2afb4705cc853434dcf59dc5b351a6b                 
true
[10/13/25 20:14:21] INFO     $ docker inspect -f '{{.State.Running}}'                            command.py:27
                             bcd101403833b947ab0dd048ab98d00ca2afb4705cc853434dcf59dc5b351a6b                 
true
[DOCKER] Traceback (most recent call last):
[DOCKER]   File "__main__.py", line 5, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/agent_server/logging_config.py", line 6, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/__init__.py", line 3, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/agent/__init__.py", line 1, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/agent/agent.py", line 6, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/agent/base.py", line 10, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/security/analyzer.py", line 3, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/event/__init__.py", line 1, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/event/base.py", line 10, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/llm/__init__.py", line 1, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "openhands/sdk/llm/llm.py", line 33, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "litellm/__init__.py", line 977, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "litellm/cost_calculator.py", line 20, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "litellm/litellm_core_utils/llm_cost_calc/utils.py", line 17, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "litellm/utils.py", line 53, in <module>
[DOCKER]   File "pyimod02_importers.py", line 457, in exec_module
[DOCKER]   File "tokenizers/__init__.py", line 78, in <module>
[DOCKER] ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.36' not found (required by /tmp/_MEIIQLDsG/libstdc++.so.6)
[DOCKER] [PYI-7:ERROR] Failed to execute script '__main__' due to unhandled exception!
```
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:c5b20e6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c5b20e6-python \
  ghcr.io/all-hands-ai/agent-server:c5b20e6-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:c5b20e6-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:c5b20e6-java
ghcr.io/all-hands-ai/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:c5b20e6-python
ghcr.io/all-hands-ai/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `c5b20e6` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->