### PR TITLE
Fix browser tool initialization timeout error

### DIFF
--- a/openhands/tools/browser_use/definition.py
+++ b/openhands/tools/browser_use/definition.py
@@ -593,6 +593,17 @@ class BrowserToolSet(ToolBase):
 
     The toolset automatically checks for Chromium availability
     when created and automatically installs it if missing.
+
+    Timeout Configuration:
+        If you experience browser initialization timeout errors
+        (e.g., "Event handler timed out after 30.0s"), you can increase
+        the timeout using the `browser_start_timeout_seconds` parameter:
+
+        Example:
+            BrowserToolSet.create(browser_start_timeout_seconds=60)
+
+        This is particularly useful for slower environments or when
+        running in resource-constrained systems.
     """
 
     @classmethod

--- a/openhands/tools/browser_use/impl.py
+++ b/openhands/tools/browser_use/impl.py
@@ -120,6 +120,7 @@ class BrowserToolExecutor(ToolExecutor):
         allowed_domains: list[str] | None = None,
         session_timeout_minutes: int = 30,
         init_timeout_seconds: int = 30,
+        browser_start_timeout_seconds: int | None = None,
         **config,
     ):
         """Initialize BrowserToolExecutor with timeout protection.
@@ -129,6 +130,10 @@ class BrowserToolExecutor(ToolExecutor):
             allowed_domains: List of allowed domains for browser operations
             session_timeout_minutes: Browser session timeout in minutes
             init_timeout_seconds: Timeout for browser initialization in seconds
+            browser_start_timeout_seconds: Timeout for browser start event in seconds.
+                If not specified, uses browser-use library default (30s). Set higher
+                for slower environments or if experiencing timeout errors during
+                browser startup.
             **config: Additional configuration options
 
         Raises:
@@ -138,6 +143,18 @@ class BrowserToolExecutor(ToolExecutor):
         def init_logic():
             nonlocal headless
             executable_path = _ensure_chromium_available()
+
+            # Configure browser-use timeouts via environment variables
+            # This sets the timeout for the BrowserStartEvent in the browser-use library
+            if browser_start_timeout_seconds is not None:
+                os.environ["TIMEOUT_BrowserStartEvent"] = str(
+                    float(browser_start_timeout_seconds)
+                )
+                logger.info(
+                    f"Browser start timeout configured to "
+                    f"{browser_start_timeout_seconds}s"
+                )
+
             self._server = CustomBrowserUseServer(
                 session_timeout_minutes=session_timeout_minutes,
             )

--- a/tests/tools/browser_use/test_browser_start_timeout.py
+++ b/tests/tools/browser_use/test_browser_start_timeout.py
@@ -1,0 +1,96 @@
+"""Test browser start timeout configuration."""
+
+import os
+from unittest.mock import MagicMock, patch
+
+from openhands.tools.browser_use.impl import BrowserToolExecutor
+
+
+def test_browser_start_timeout_default():
+    """Test that browser start timeout is not set by default."""
+    with (
+        patch(
+            "openhands.tools.browser_use.impl._ensure_chromium_available"
+        ) as mock_chromium,
+        patch("openhands.tools.browser_use.impl.CustomBrowserUseServer") as mock_server,
+    ):
+        mock_chromium.return_value = "/fake/chromium"
+        mock_server_instance = MagicMock()
+        mock_server.return_value = mock_server_instance
+
+        # Clear any existing env var
+        if "TIMEOUT_BrowserStartEvent" in os.environ:
+            del os.environ["TIMEOUT_BrowserStartEvent"]
+
+        BrowserToolExecutor()
+
+        # Should not set the env var if browser_start_timeout_seconds not provided
+        assert "TIMEOUT_BrowserStartEvent" not in os.environ
+
+
+def test_browser_start_timeout_custom():
+    """Test that custom browser start timeout is properly set."""
+    with (
+        patch(
+            "openhands.tools.browser_use.impl._ensure_chromium_available"
+        ) as mock_chromium,
+        patch("openhands.tools.browser_use.impl.CustomBrowserUseServer") as mock_server,
+    ):
+        mock_chromium.return_value = "/fake/chromium"
+        mock_server_instance = MagicMock()
+        mock_server.return_value = mock_server_instance
+
+        # Clear any existing env var
+        if "TIMEOUT_BrowserStartEvent" in os.environ:
+            del os.environ["TIMEOUT_BrowserStartEvent"]
+
+        BrowserToolExecutor(browser_start_timeout_seconds=60)
+
+        # Should set the env var to the custom value
+        assert os.environ["TIMEOUT_BrowserStartEvent"] == "60.0"
+
+
+def test_browser_start_timeout_integration():
+    """Integration test to verify timeout setting is used during initialization."""
+    with (
+        patch(
+            "openhands.tools.browser_use.impl._ensure_chromium_available"
+        ) as mock_chromium,
+        patch("openhands.tools.browser_use.impl.CustomBrowserUseServer") as mock_server,
+    ):
+        mock_chromium.return_value = "/fake/chromium"
+        mock_server_instance = MagicMock()
+        mock_server.return_value = mock_server_instance
+
+        # Clear any existing env var
+        if "TIMEOUT_BrowserStartEvent" in os.environ:
+            del os.environ["TIMEOUT_BrowserStartEvent"]
+
+        # Test with 90 second timeout
+        BrowserToolExecutor(browser_start_timeout_seconds=90)
+
+        # Verify the timeout was set before server creation
+        assert os.environ["TIMEOUT_BrowserStartEvent"] == "90.0"
+        mock_server.assert_called_once_with(session_timeout_minutes=30)
+
+
+def test_browser_start_timeout_zero():
+    """Test that timeout can be set to 0 (no timeout)."""
+    with (
+        patch(
+            "openhands.tools.browser_use.impl._ensure_chromium_available"
+        ) as mock_chromium,
+        patch("openhands.tools.browser_use.impl.CustomBrowserUseServer") as mock_server,
+    ):
+        mock_chromium.return_value = "/fake/chromium"
+        mock_server_instance = MagicMock()
+        mock_server.return_value = mock_server_instance
+
+        # Clear any existing env var
+        if "TIMEOUT_BrowserStartEvent" in os.environ:
+            del os.environ["TIMEOUT_BrowserStartEvent"]
+
+        # Zero means no timeout in browser-use
+        BrowserToolExecutor(browser_start_timeout_seconds=0)
+
+        assert os.environ["TIMEOUT_BrowserStartEvent"] == "0.0"


### PR DESCRIPTION
## Description

Fixes #703

This PR addresses browser initialization timeout errors that users were experiencing when running the browser tool examples. The error occurred when the browser-use library's `BrowserStartEvent` handler timed out after the default 30 seconds in slower environments or resource-constrained systems.

## Problem

The browser-use library (which our browser tool wraps) uses a default 30-second timeout for browser initialization. This timeout is configurable via the `TIMEOUT_BrowserStartEvent` environment variable, but we weren't exposing this configuration option to users. When browser initialization took longer than 30 seconds (e.g., in slow environments, high system load, or network issues), users would see:

```
Error: Browser operation failed: Event handler
browser_use.browser.watchdog_base.BrowserSession.on_BrowserStartEvent#3904(?▶ BrowserStartEvent#03a2 🏃)
timed out after 30.0s and interrupted any processing of 1 child events
```

## Solution

Added a new `browser_start_timeout_seconds` parameter to `BrowserToolExecutor` that allows users to configure the browser initialization timeout. When set, this parameter configures the `TIMEOUT_BrowserStartEvent` environment variable that the browser-use library respects.

### Changes Made

1. **Added `browser_start_timeout_seconds` parameter to `BrowserToolExecutor.__init__`**
   - Optional parameter that defaults to `None` (uses browser-use library default of 30s)
   - When set, configures the `TIMEOUT_BrowserStartEvent` environment variable before browser initialization
   - Fully documented in docstring

2. **Updated `BrowserToolSet` documentation**
   - Added clear documentation about timeout configuration
   - Provided example usage for users experiencing timeout errors
   - Explained when this configuration is useful

3. **Added comprehensive tests**
   - Test default behavior (timeout not set)
   - Test custom timeout configuration
   - Test integration with server creation
   - Test edge case (timeout set to 0)

## Usage

Users experiencing timeout errors can now configure a longer timeout:

```python
from openhands.tools.browser_use import BrowserToolSet

# Increase timeout to 60 seconds for slower environments
tools = BrowserToolSet.create(browser_start_timeout_seconds=60)
```

Or when using `BrowserToolExecutor` directly:

```python
from openhands.tools.browser_use.impl import BrowserToolExecutor

executor = BrowserToolExecutor(
    headless=True,
    browser_start_timeout_seconds=60
)
```

## Testing

- All existing 108 browser tool tests pass
- Added 4 new tests specifically for timeout configuration
- Verified fix works by testing browser initialization with custom timeout

## Backward Compatibility

This change is fully backward compatible:
- The new parameter is optional and defaults to `None`
- When not specified, the browser-use library uses its default 30s timeout
- Existing code continues to work without modification
- No breaking changes to any APIs

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0d7058ba2ca941789f7bbb1c594b8918)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:63785c2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-63785c2-python \
  ghcr.io/all-hands-ai/agent-server:63785c2-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:63785c2-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:63785c2-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:63785c2-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `63785c2` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->