### PR TITLE
Add "assign reviewers" workflow

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -51,9 +51,8 @@ jobs:
                 And send a message to the author:
                 [Automatic Post]: It has been a while since there was any activity on this PR, are you still working on it?
 
-            # PROMPT_STRING: 'Check for outdated dependencies and create a PR'
-            LLM_MODEL: openhands/claude-sonnet-4-5-20250929
-            LLM_BASE_URL: ''
+            LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929
+            LLM_BASE_URL: https://llm-proxy.eval.all-hands.dev
         steps:
             - name: Checkout repository
               uses: actions/checkout@v4


### PR DESCRIPTION
This PR adds a workflow to assign reviewers to PRs that do not have assigned reviewers, and remind authors of old PRs.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:a8c6c1b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a8c6c1b-python \
  ghcr.io/all-hands-ai/agent-server:a8c6c1b-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:a8c6c1b-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:a8c6c1b-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:a8c6c1b-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `a8c6c1b` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->