### PR TITLE
Update assign reviewers script based on experience

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -42,7 +42,7 @@ jobs:
                 1. The PR is waiting for review (there are no open review comments or change requests)
                 2. The PR is in a "clean" state (CI passing, no merge conflicts)
                 3. The PR has had no activity (comments, commits, reviews) for more than 3 days.
-                
+
                 In this case, send a message to the reviewers:
                 [Automatic Post]: This PR seems to be currently waiting for review.
                 {reviewer_names}, could you please take a look when you have a chance?
@@ -51,7 +51,7 @@ jobs:
 
                 Find all open PRs where the most recent change or comment was made on the pull
                 request more than 5 days ago. Then do the following in order:
-                
+
                 And send a message to the author:
 
                 [Automatic Post]: It has been a while since there was any activity on this PR.
@@ -73,9 +73,6 @@ jobs:
 
                 [Automatic Post]: I have assigned {reviewer} as a reviewer based on git blame information.
                 Thanks in advance for the help!
-
-                
-
 
             LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929
             LLM_BASE_URL: https://llm-proxy.eval.all-hands.dev


### PR DESCRIPTION
The previous assign reviewers script had a few small issues:

1. Posting multiple messages on a single PR
2. Assigning a single reviewer to many issues
3. The messages were not the most friendly
4. It didn't consider reminding reviewers who hadn't submitted reviews

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:8cbd08a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8cbd08a-python \
  ghcr.io/all-hands-ai/agent-server:8cbd08a-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:8cbd08a-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:8cbd08a-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:8cbd08a-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `8cbd08a` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->