### PR TITLE
Add support for `claude-4-5-haiku`

### DIFF
--- a/openhands/sdk/llm/llm.py
+++ b/openhands/sdk/llm/llm.py
@@ -283,8 +283,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         # default reasoning_effort unless Gemini 2.5
         # (we keep consistent with old behavior)
-        if d.get("reasoning_effort") is None and (
-            "gemini-2.5-pro" not in model_val and "claude-sonnet-4-5" not in model_val
+        excluded_models = ["gemini-2.5-pro", "claude-sonnet-4-5", "claude-haiku-4-5"]
+        if d.get("reasoning_effort") is None and not any(
+            model in model_val for model in excluded_models
         ):
             d["reasoning_effort"] = "high"
 

--- a/openhands/sdk/llm/utils/model_features.py
+++ b/openhands/sdk/llm/utils/model_features.py
@@ -125,6 +125,7 @@ EXTENDED_THINKING_PATTERNS: list[str] = [
     # We did not include sonnet 3.7 and 4 here as they don't brings
     # significant performance improvements for agents
     "claude-sonnet-4-5*",
+    "claude-haiku-4-5*",
 ]
 
 PROMPT_CACHE_PATTERNS: list[str] = [

--- a/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands/sdk/llm/utils/verified_models.py
@@ -15,6 +15,7 @@ VERIFIED_OPENAI_MODELS = [
 
 VERIFIED_ANTHROPIC_MODELS = [
     "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5-20251001",
     "claude-sonnet-4-20250514",
     "claude-opus-4-20250514",
     "claude-opus-4-1-20250805",
@@ -35,6 +36,7 @@ VERIFIED_MISTRAL_MODELS = [
 
 VERIFIED_OPENHANDS_MODELS = [
     "claude-sonnet-4-5-20250929",
+    "claude-haiku-4-5-20251001",
     "gpt-5-codex",
     "gpt-5-2025-08-07",
     "gpt-5-mini-2025-08-07",


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:ea22a0e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ea22a0e-python \
  ghcr.io/all-hands-ai/agent-server:ea22a0e-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:ea22a0e-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:ea22a0e-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:ea22a0e-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a1_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `ea22a0e` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->