### PR TITLE
Fix assign-reviews workflow subdirectory paths

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -94,8 +94,8 @@ jobs:
             - name: Install OpenHands dependencies
               run: |
                   # Install OpenHands SDK and tools from git repository
-                  uv pip install --system "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands/sdk"
-                  uv pip install --system "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands/tools"
+                  uv pip install --system "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands-sdk"
+                  uv pip install --system "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands-tools"
 
             - name: Check required configuration
               env:


### PR DESCRIPTION
## Description

Fixes #806

This PR fixes the broken `assign-reviews` workflow by updating the subdirectory paths in the workflow file to match the refactored directory structure.

## Changes

- Updated `openhands/sdk` → `openhands-sdk`
- Updated `openhands/tools` → `openhands-tools`

## Root Cause

The workflow was failing because it was using the old subdirectory paths (`openhands/sdk` and `openhands/tools`) which no longer exist after the repository was refactored. The correct paths are now `openhands-sdk` and `openhands-tools` (with hyphens instead of slashes).

## Testing

The fix aligns the `assign-reviews.yml` workflow with the example workflows in `examples/03_github_workflows/01_basic_action/workflow.yml` which use the correct subdirectory paths.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7c3d2fdacc4246588fedb3cd51de92ca)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:a34622d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a34622d-python \
  ghcr.io/all-hands-ai/agent-server:a34622d-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:a34622d-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:a34622d-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:a34622d-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `a34622d` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->