### PR TITLE
Fix: Make Check OpenAPI Schema workflow work with fork PRs

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -121,7 +121,6 @@ jobs:
             - name: Checkout PR branch
               uses: actions/checkout@v5
               with:
-                  ref: ${{ github.head_ref }}
                   fetch-depth: 0
 
             - name: Install uv


### PR DESCRIPTION
## Problem

The "Check OpenAPI Schema" workflow in `.github/workflows/server.yml` was failing for PRs from forks with the error:

```
Error: A branch or tag with the name 'disable-llm-analyzer' could not be found
```

This happened because the workflow was using `github.head_ref` in the checkout step, which only contains the branch name and works for PRs from the same repository. For fork PRs, this branch name doesn't exist in the base repository, causing the checkout to fail.

## Solution

Removed the `ref: ${{ github.head_ref }}` parameter from the `actions/checkout@v5` step. 

When no `ref` is specified, `actions/checkout` automatically checks out the correct commit for the PR event, which works correctly for both:
- PRs from branches in the same repository
- PRs from forks

This is the standard approach used by most GitHub Actions workflows.

## Testing

This fix will allow the workflow to run successfully on PR #802, which is from a fork.

## Related Issue

Fixes the workflow issue reported in PR #802 comment.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/034a3399c6cf4c56b29e8e5a8e04396a)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:5db52ef-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5db52ef-python \
  ghcr.io/all-hands-ai/agent-server:5db52ef-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:5db52ef-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:5db52ef-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:5db52ef-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `5db52ef` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->