### PR TITLE
Fix deprecated @model_validator usage in LLMSummarizingCondenser

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -16,15 +16,14 @@ class LLMSummarizingCondenser(RollingCondenser):
     keep_first: int = Field(default=4, ge=0)
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_keep_first_vs_max_size(cls, model):
-        events_from_tail = model.max_size // 2 - model.keep_first - 1
+    def validate_keep_first_vs_max_size(self):
+        events_from_tail = self.max_size // 2 - self.keep_first - 1
         if events_from_tail <= 0:
             raise ValueError(
                 "keep_first must be less than max_size // 2 to leave room for "
                 "condensation"
             )
-        return model
+        return self
 
     def handles_condensation_requests(self) -> bool:
         return True


### PR DESCRIPTION
## Description

This PR fixes the Pydantic V2.12 deprecation warning in `LLMSummarizingCondenser` by updating the `@model_validator` usage to follow the recommended pattern for instance methods.

## Changes

- Changed `validate_keep_first_vs_max_size` from a classmethod to an instance method
- Updated method signature from `cls, model` to `self`
- The method now accesses attributes directly via `self` instead of through a `model` parameter

## Context

The previous implementation used `@model_validator(mode="after")` with `@classmethod`, which is deprecated in Pydantic V2.12. According to the [Pydantic documentation](https://docs.pydantic.dev/2.12/concepts/validators/#model-after-validator), mode='after' validators should be instance methods, not classmethods.

## Testing

- All existing tests pass, including `test_invalid_config` which specifically tests the validator logic
- The deprecation warning is no longer emitted when importing the module
- Pre-commit hooks (ruff, pycodestyle, basedpyright) all pass

Fixes #815

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fb242ab767e042e5a35a3dc23d0c8471)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:a1a9c8d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a1a9c8d-python \
  ghcr.io/all-hands-ai/agent-server:a1a9c8d-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:a1a9c8d-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:a1a9c8d-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:a1a9c8d-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a2_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `a1a9c8d` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->