### PR TITLE
Fix PR review workflow subdirectory paths

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -60,8 +60,8 @@ jobs:
             - name: Install OpenHands dependencies
               run: |
                   # Install OpenHands SDK and tools from git repository
-                  uv pip install --system "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands/sdk"
-                  uv pip install --system "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands/tools"
+                  uv pip install --system "openhands-sdk @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands-sdk"
+                  uv pip install --system "openhands-tools @ git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands-tools"
 
             - name: Check required configuration
               env:


### PR DESCRIPTION
## Summary

This PR fixes the automatic PR review workflow that was failing due to incorrect subdirectory paths in the package installation step.

## Problem

The workflow in `.github/workflows/pr-review-by-openhands.yml` was trying to install packages from non-existent subdirectories:
- `openhands/sdk` (should be `openhands-sdk`)
- `openhands/tools` (should be `openhands-tools`)

This caused the workflow to fail with the error:
```
The source distribution git+https://github.com/All-Hands-AI/agent-sdk.git@main#subdirectory=openhands/sdk has no subdirectory `openhands/sdk`
```

## Solution

Updated the installation paths in the workflow to use the correct subdirectory names:
- `openhands/sdk` → `openhands-sdk`
- `openhands/tools` → `openhands-tools`

## Testing

- ✅ YAML syntax validation passed
- ✅ Pre-commit hooks passed
- ✅ The subdirectories exist and contain valid `pyproject.toml` files

## Closes

Fixes #823

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9c7689a4bf994afc9ad7adbe23901f45)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:8728560-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8728560-python \
  ghcr.io/all-hands-ai/agent-server:8728560-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:8728560-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a3_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:8728560-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a3_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:8728560-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a3_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `8728560` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->