### PR TITLE
docs: set tags=["Server Details"] for `/` path

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -165,7 +165,7 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
     )
 
     # Add root redirect to static files
-    @app.get("/")
+    @app.get("/", tags=["Server Details"])
     async def root_redirect():
         """Redirect root endpoint to static files directory."""
         # Check if index.html exists in the static directory


### PR DESCRIPTION
This will allow us to display the openapi schema in doc site correctly

<img width="2068" height="1538" alt="image" src="https://github.com/user-attachments/assets/043575bb-c6e0-4122-b3f5-52cfdba1d2d0" />

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/All-Hands-AI/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/all-hands-ai/agent-server:78938ee-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-78938ee-python \
  ghcr.io/all-hands-ai/agent-server:78938ee-python
```

**All tags pushed for this build**
```
ghcr.io/all-hands-ai/agent-server:78938ee-golang
ghcr.io/all-hands-ai/agent-server:v1.0.0a3_golang_tag_1.21-bookworm_binary
ghcr.io/all-hands-ai/agent-server:78938ee-java
ghcr.io/all-hands-ai/agent-server:v1.0.0a3_eclipse-temurin_tag_17-jdk_binary
ghcr.io/all-hands-ai/agent-server:78938ee-python
ghcr.io/all-hands-ai/agent-server:v1.0.0a3_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `78938ee` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->