### PR TITLE
Set add_security_analyzer=False by default and simplify examples

### DIFF
--- a/examples/01_standalone_sdk/01_hello_world.py
+++ b/examples/01_standalone_sdk/01_hello_world.py
@@ -18,13 +18,7 @@ llm = LLM(
     base_url=base_url,
     usage_id="agent",
 )
-
-add_security_analyzer = bool(os.getenv("ADD_SECURITY_ANALYZER", "").strip())
-if add_security_analyzer:
-    print("Agent security analyzer added.")
-agent = get_default_agent(
-    llm=llm, cli_mode=True, add_security_analyzer=add_security_analyzer
-)
+agent = get_default_agent(llm=llm, cli_mode=True)
 
 # Start a conversation and send some messages
 cwd = os.getcwd()

--- a/examples/01_standalone_sdk/04_confirmation_mode_example.py
+++ b/examples/01_standalone_sdk/04_confirmation_mode_example.py
@@ -88,7 +88,10 @@ llm = LLM(
     api_key=SecretStr(api_key),
 )
 
-agent = get_default_agent(llm=llm)
+add_security_analyzer = bool(os.getenv("ADD_SECURITY_ANALYZER", "").strip())
+if add_security_analyzer:
+    print("Agent security analyzer added.")
+agent = get_default_agent(llm=llm, add_security_analyzer=add_security_analyzer)
 conversation = Conversation(agent=agent, workspace=os.getcwd())
 
 # 1) Confirmation mode ON

--- a/examples/01_standalone_sdk/23_responses_reasoning.py
+++ b/examples/01_standalone_sdk/23_responses_reasoning.py
@@ -24,10 +24,8 @@ from openhands.tools.preset.default import get_default_agent
 logger = get_logger(__name__)
 
 
-api_key = os.getenv("LLM_API_KEY")
-if api_key is None:
-    api_key = os.getenv("OPENAI_API_KEY")
-assert api_key is not None, "Set LLM_API_KEY or OPENAI_API_KEY in your environment."
+api_key = os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
+assert api_key, "Set LLM_API_KEY or OPENAI_API_KEY in your environment."
 
 model = os.getenv("LLM_MODEL", "openhands/gpt-5-codex")
 base_url = os.getenv("LLM_BASE_URL")


### PR DESCRIPTION
## Summary
This PR addresses the feedback from #802 by:
1. Keeping `add_security_analyzer=False` as the default in `get_default_agent()` (already set)
2. Reverting example changes from #802 except for `examples/01_standalone_sdk/04_confirmation_mode_example.py`
3. Adding `ADD_SECURITY_ANALYZER` env var handling only to `04_confirmation_mode_example.py` to demonstrate its use

## Changes
- **Reverted**: `examples/01_standalone_sdk/01_hello_world.py` - Removed security analyzer code
- **Reverted**: `examples/01_standalone_sdk/23_responses_reasoning.py` - Simplified api_key check
- **Added**: `examples/01_standalone_sdk/04_confirmation_mode_example.py` - Added `ADD_SECURITY_ANALYZER` env var usage

## Rationale
As discussed in #802:
- Most examples should remain simple and focused on their primary purpose
- Only one example (`04_confirmation_mode_example.py`) needs to demonstrate the security analyzer toggle
- The default `add_security_analyzer=False` helps users with smaller models that may struggle as LLM-risk analyzers

## Related
- Closes #802 feedback from @xingyaoww
- Related to #300 (making security analyzer optional)

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c1f6417973be4932b7397bbaa6a45ec8)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:be08f7c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-be08f7c-python \
  ghcr.io/openhands/agent-server:be08f7c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:be08f7c-golang
ghcr.io/openhands/agent-server:v1.0.0a3_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:be08f7c-java
ghcr.io/openhands/agent-server:v1.0.0a3_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:be08f7c-python
ghcr.io/openhands/agent-server:v1.0.0a3_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `be08f7c` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->