### PR TITLE
fix: ReadTimeout when calling 01_convo_with_local_agent_server.py

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -19,7 +19,13 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     def client(self) -> httpx.Client:
         client = self._client
         if client is None:
-            client = httpx.Client(base_url=self.host)
+            # Configure reasonable timeouts for HTTP requests
+            # - connect: 10 seconds to establish connection
+            # - read: 60 seconds to read response (for LLM operations)
+            # - write: 10 seconds to send request
+            # - pool: 10 seconds to get connection from pool
+            timeout = httpx.Timeout(connect=10.0, read=60.0, write=10.0, pool=10.0)
+            client = httpx.Client(base_url=self.host, timeout=timeout)
             self._client = client
         return client
 


### PR DESCRIPTION
Fixes #835 

This change allows us to run the example 

` uv run python examples/02_remote_agent_server/01_convo_with_local_agent_server.py`

successfully without the ReadTimeout exception.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:2c98dc8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2c98dc8-python \
  ghcr.io/openhands/agent-server:2c98dc8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2c98dc8-golang
ghcr.io/openhands/agent-server:v1.0.0a3_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:2c98dc8-java
ghcr.io/openhands/agent-server:v1.0.0a3_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:2c98dc8-python
ghcr.io/openhands/agent-server:v1.0.0a3_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `2c98dc8` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->