### PR TITLE
Fix DockerWorkspace execute_command timeout issue

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/remote_workspace_mixin.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/remote_workspace_mixin.py
@@ -67,7 +67,7 @@ class RemoteWorkspaceMixin(BaseModel):
             # Start the command
             response: httpx.Response = yield {
                 "method": "POST",
-                "url": f"{self.host}/api/bash/execute_bash_command",
+                "url": f"{self.host}/api/bash/start_bash_command",
                 "json": payload,
                 "headers": self._headers,
                 "timeout": timeout + 5.0,  # Add buffer to HTTP timeout

--- a/tests/sdk/workspace/remote/test_remote_workspace_mixin.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace_mixin.py
@@ -78,7 +78,7 @@ def test_execute_command_generator_basic_flow():
     # First yield - start command
     start_kwargs = next(generator)
     assert start_kwargs["method"] == "POST"
-    assert start_kwargs["url"] == "http://localhost:8000/api/bash/execute_bash_command"
+    assert start_kwargs["url"] == "http://localhost:8000/api/bash/start_bash_command"
     assert start_kwargs["json"]["command"] == "echo hello"
     assert start_kwargs["json"]["cwd"] == "/tmp"
     assert start_kwargs["json"]["timeout"] == 30


### PR DESCRIPTION
## Summary
Fixes #870 - Resolves the timeout issue when using `execute_command` in RemoteWorkspace.

## Root Cause Analysis
The SDK was calling the wrong API endpoint for asynchronous command execution:

1. **Wrong endpoint used**: `/api/bash/execute_bash_command` 
   - This is a **synchronous** endpoint that waits for command completion
   - Returns `BashOutput` with `id=output_event_id` and a separate `command_id` field
   
2. **ID mismatch**: SDK used the wrong ID for polling
   - SDK extracted `bash_command["id"]` which was the output event ID
   - Used this output event ID to poll for bash events
   - Polling endpoint searches by command ID, not output event ID
   - Result: 0 events found → timeout after 30 seconds

3. **Correct endpoint**: `/api/bash/start_bash_command`
   - This is the **asynchronous** endpoint designed for polling
   - Returns `BashCommand` with `id=command_id`
   - SDK's existing polling logic works correctly with this command ID

## Changes Made
- Changed API endpoint from `execute_bash_command` to `start_bash_command` in `remote_workspace_mixin.py`
- Updated test to reflect the correct endpoint URL

## Testing
✅ All existing tests pass  
✅ Manual integration test with actual RemoteWorkspace confirms commands execute successfully without timeout

## Impact
- **Minimal code change**: Single line endpoint URL change
- **No breaking changes**: All existing functionality preserved
- **Fixes critical bug**: Commands that previously timed out now work correctly
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:cd99d7f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cd99d7f-python \
  ghcr.io/openhands/agent-server:cd99d7f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cd99d7f-golang
ghcr.io/openhands/agent-server:v1.0.0a3_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:cd99d7f-java
ghcr.io/openhands/agent-server:v1.0.0a3_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:cd99d7f-python
ghcr.io/openhands/agent-server:v1.0.0a3_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `cd99d7f` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->