### PR TITLE
Fix pyright issues in agent status transition tests

### DIFF
--- a/tests/sdk/conversation/local/test_agent_status_transition.py
+++ b/tests/sdk/conversation/local/test_agent_status_transition.py
@@ -36,6 +36,7 @@ from openhands.sdk.llm import LLM, ImageContent, Message, TextContent
 from openhands.sdk.tool import (
     Action,
     Observation,
+    Tool,
     ToolDefinition,
     ToolExecutor,
     register_tool,
@@ -151,7 +152,7 @@ def test_agent_status_is_running_during_execution_from_idle(mock_completion):
     llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
     agent = Agent(
         llm=llm,
-        tools=[{"name": "test_tool"}],
+        tools=[Tool(name="test_tool")],
     )
     conversation = Conversation(agent=agent)
 
@@ -216,7 +217,7 @@ def test_agent_status_is_running_during_execution_from_idle(mock_completion):
     # Run in a separate thread so we can check status during execution
     status_checked = threading.Event()
     run_complete = threading.Event()
-    status_during_run = [None]
+    status_during_run: list[AgentExecutionStatus | None] = [None]
 
     def run_agent():
         conversation.run()
@@ -304,7 +305,7 @@ def test_agent_status_transitions_from_waiting_for_confirmation(mock_completion)
 
     register_tool("test_tool", _make_tool)
 
-    agent = Agent(llm=llm, tools=[{"name": "test_tool"}])
+    agent = Agent(llm=llm, tools=[Tool(name="test_tool")])
     conversation = Conversation(agent=agent)
     conversation.set_confirmation_policy(AlwaysConfirm())
 

--- a/uv.lock
+++ b/uv.lock
@@ -5223,15 +5223,15 @@ wheels = [
 
 [[package]]
 name = "pyright"
-version = "1.1.406"
+version = "1.1.407"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "nodeenv" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f7/16/6b4fbdd1fef59a0292cbb99f790b44983e390321eccbc5921b4d161da5d1/pyright-1.1.406.tar.gz", hash = "sha256:c4872bc58c9643dac09e8a2e74d472c62036910b3bd37a32813989ef7576ea2c", size = 4113151, upload-time = "2025-10-02T01:04:45.488Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/1b/0aa08ee42948b61745ac5b5b5ccaec4669e8884b53d31c8ec20b2fcd6b6f/pyright-1.1.407.tar.gz", hash = "sha256:099674dba5c10489832d4a4b2d302636152a9a42d317986c38474c76fe562262", size = 4122872, upload-time = "2025-10-24T23:17:15.145Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/a2/e309afbb459f50507103793aaef85ca4348b66814c86bc73908bdeb66d12/pyright-1.1.406-py3-none-any.whl", hash = "sha256:1d81fb43c2407bf566e97e57abb01c811973fdb21b2df8df59f870f688bdca71", size = 5980982, upload-time = "2025-10-02T01:04:43.137Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/93/b69052907d032b00c40cb656d21438ec00b3a471733de137a3f65a49a0a0/pyright-1.1.407-py3-none-any.whl", hash = "sha256:6dd419f54fcc13f03b52285796d65e639786373f433e243f8b94cf93a7444d21", size = 5997008, upload-time = "2025-10-24T23:17:13.159Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
Hi, I'm OpenHands-GPT-5, and here's what changed:
- Replace dict-based tool specs in status transition tests with typed Tool instances so Pyright's stricter checks pass.
- Tighten typing for runtime agent status tracking in tests.
- Upgrade Pyright to v1.1.407 in uv.lock to eliminate the outdated-version warning.

## Testing
- uv run pre-commit run --all-files
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:62a4b0b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-62a4b0b-python \
  ghcr.io/openhands/agent-server:62a4b0b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:62a4b0b-golang
ghcr.io/openhands/agent-server:v1.0.0a3_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:62a4b0b-java
ghcr.io/openhands/agent-server:v1.0.0a3_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:62a4b0b-python
ghcr.io/openhands/agent-server:v1.0.0a3_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `62a4b0b` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->