### PR TITLE
Fix PydanticSerializationUnexpectedValue warnings in log_completions

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -305,7 +305,10 @@ def _safe_json(obj: Any) -> Any:
     # Centralized serializer for telemetry logs.
     # Today, responses are Pydantic ModelResponse or ResponsesAPIResponse; rely on it.
     if isinstance(obj, ModelResponse) or isinstance(obj, ResponsesAPIResponse):
-        return obj.model_dump()
+        # Use mode='json' to ensure proper serialization of nested Pydantic models
+        # and avoid PydanticSerializationUnexpectedValue warnings.
+        # exclude_none=True reduces payload size by omitting None fields.
+        return obj.model_dump(mode="json", exclude_none=True)
 
     # Fallbacks for non-Pydantic objects used elsewhere in the log payload
     try:

--- a/tests/sdk/llm/test_llm_log_completions_integration.py
+++ b/tests/sdk/llm/test_llm_log_completions_integration.py
@@ -1,0 +1,189 @@
+"""Integration test for LLM log_completions feature.
+
+This test verifies that log_completions doesn't produce Pydantic
+serialization warnings when used with real LLM responses.
+"""
+
+import json
+import os
+import tempfile
+import warnings
+from unittest.mock import patch
+
+from pydantic import SecretStr
+
+from openhands.sdk.llm import LLM, Message, TextContent
+
+# Import common test utilities
+from tests.conftest import create_mock_litellm_response
+
+
+def test_llm_log_completions_integration_no_warnings():
+    """Test that LLM with log_completions enabled doesn't produce warnings.
+
+    This is an end-to-end test that creates an actual LLM instance with
+    log_completions enabled and verifies no serialization warnings are raised.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create LLM with log_completions enabled
+        llm = LLM(
+            model="gpt-4o",
+            api_key=SecretStr("test-key"),
+            usage_id="test-log-completions-llm",
+            log_completions=True,
+            log_completions_folder=temp_dir,
+            num_retries=0,
+        )
+
+        # Create a realistic mock response
+        mock_response = create_mock_litellm_response(
+            content="This is a test response with realistic structure.",
+            response_id="integration-test-id",
+            model="gpt-4o",
+            prompt_tokens=100,
+            completion_tokens=50,
+            finish_reason="stop",
+        )
+
+        # Mock the litellm completion call
+        with patch("openhands.sdk.llm.llm.litellm_completion") as mock_completion:
+            mock_completion.return_value = mock_response
+
+            # Capture any warnings
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+
+                # Make a completion call
+                messages = [
+                    Message(
+                        role="user",
+                        content=[TextContent(text="Test message")],
+                    )
+                ]
+                llm.completion(messages)
+
+                # Check for Pydantic serialization warnings
+                pydantic_warnings = [
+                    warning
+                    for warning in w
+                    if "PydanticSerializationUnexpectedValue" in str(warning.message)
+                    or "Circular reference detected" in str(warning.message)
+                ]
+
+                warning_messages = [str(pw.message) for pw in pydantic_warnings]
+                assert len(pydantic_warnings) == 0, (
+                    f"Got unexpected serialization warnings: {warning_messages}"
+                )
+
+        # Verify that a log file was created
+        log_files = os.listdir(temp_dir)
+        assert len(log_files) == 1, f"Expected 1 log file, got {len(log_files)}"
+
+        # Verify the log file is valid JSON and contains expected data
+        log_path = os.path.join(temp_dir, log_files[0])
+        with open(log_path) as f:
+            log_data = json.loads(f.read())
+
+        assert "response" in log_data
+        assert "cost" in log_data
+        assert "timestamp" in log_data
+        assert "latency_sec" in log_data
+
+
+def test_llm_log_completions_with_tool_calls():
+    """Test log_completions with tool calls in the response.
+
+    Tool calls add additional complexity to the response structure,
+    so we want to ensure they serialize correctly too.
+    """
+    from litellm.types.utils import (
+        ChatCompletionMessageToolCall,
+        Choices,
+        Function,
+        Message as LiteLLMMessage,
+        ModelResponse,
+        Usage,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        # Create LLM with log_completions enabled
+        llm = LLM(
+            model="gpt-4o",
+            api_key=SecretStr("test-key"),
+            usage_id="test-tool-calls-llm",
+            log_completions=True,
+            log_completions_folder=temp_dir,
+            num_retries=0,
+        )
+
+        # Create a response with tool calls
+        tool_call = ChatCompletionMessageToolCall(
+            id="call_1",
+            function=Function(name="test_function", arguments='{"param": "value"}'),
+            type="function",
+        )
+        message = LiteLLMMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[tool_call],
+        )
+        choice = Choices(
+            finish_reason="tool_calls",
+            index=0,
+            message=message,
+        )
+        usage = Usage(
+            prompt_tokens=100,
+            completion_tokens=50,
+            total_tokens=150,
+        )
+        mock_response = ModelResponse(
+            id="tool-call-test-id",
+            choices=[choice],
+            created=1234567890,
+            model="gpt-4o",
+            object="chat.completion",
+            usage=usage,
+        )
+
+        # Mock the litellm completion call
+        with patch("openhands.sdk.llm.llm.litellm_completion") as mock_completion:
+            mock_completion.return_value = mock_response
+
+            # Capture any warnings
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+
+                # Make a completion call
+                messages = [
+                    Message(
+                        role="user",
+                        content=[TextContent(text="Call a tool")],
+                    )
+                ]
+                llm.completion(messages)
+
+                # Check for Pydantic serialization warnings
+                pydantic_warnings = [
+                    warning
+                    for warning in w
+                    if "PydanticSerializationUnexpectedValue" in str(warning.message)
+                    or "Circular reference detected" in str(warning.message)
+                ]
+
+                warning_messages = [str(pw.message) for pw in pydantic_warnings]
+                assert len(pydantic_warnings) == 0, (
+                    f"Got unexpected serialization warnings: {warning_messages}"
+                )
+
+        # Verify that a log file was created
+        log_files = os.listdir(temp_dir)
+        assert len(log_files) == 1
+
+        # Verify the log contains tool call information
+        log_path = os.path.join(temp_dir, log_files[0])
+        with open(log_path) as f:
+            log_data = json.loads(f.read())
+
+        assert "response" in log_data
+        assert log_data["response"]["choices"][0]["message"]["tool_calls"] is not None


### PR DESCRIPTION
## Description

Fixes #903 

This PR fixes the `PydanticSerializationUnexpectedValue` warnings that occurred when `log_completions` is enabled with an existing `log_completions_folder` for the `LLM` class.

## Problem

When logging LLM completions, the telemetry module's `_safe_json()` function was calling `model_dump()` on Pydantic models without specifying the serialization mode. This caused warnings when serializing nested models like `Message` and `Choices`:

```
PydanticSerializationUnexpectedValue(Expected 10 fields but got 7: Expected `Message` - serialized value may not be as expected [field_name='message', input_value=Message(content=None, rol...XXXX'}), input_type=Message])
PydanticSerializationUnexpectedValue(Expected `StreamingChoices` - serialized value may not be as expected [field_name='choices', input_value=Choices(finish_reason='to...ider_specific_fields={}), input_type=Choices])
```

## Solution

Updated the `_safe_json()` function in `telemetry.py` to use `model_dump(mode="json", exclude_none=True)` when serializing Pydantic models. The `mode="json"` parameter ensures proper JSON-compatible serialization of nested models, and `exclude_none=True` prevents null fields from being included in the output.

## Changes

- **openhands-sdk/openhands/sdk/llm/utils/telemetry.py**: Updated `_safe_json()` to use `model_dump(mode="json", exclude_none=True)`
- **tests/sdk/llm/test_llm_telemetry.py**: Added unit test `test_log_completions_no_serialization_warnings()` to reproduce and verify the fix
- **tests/sdk/llm/test_llm_log_completions_integration.py**: Added integration tests to verify end-to-end behavior with LLM completion logging, including tests for tool calls

## Testing

All new tests pass without warnings:
- Unit tests verify that logging `ModelResponse` objects doesn't produce Pydantic serialization warnings
- Integration tests verify end-to-end behavior with the `LLM` class and `log_completions` enabled
- All existing tests continue to pass

```bash
pytest tests/sdk/llm/test_llm_telemetry.py::TestTelemetryEdgeCases::test_log_completions_no_serialization_warnings -xvs
pytest tests/sdk/llm/test_llm_log_completions_integration.py -xvs
pytest tests/sdk/llm/test_llm_telemetry.py -xvs
pytest tests/sdk/llm/test_llm.py -xvs
```

## Notes

- The pyright warnings in test files are pre-existing and not introduced by this PR (verified by running pre-commit on main branch)
- The fix is minimal and focused on the root cause of the serialization warnings

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a3794720ab7d426da82a9e55c85fd343)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:50102a1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-50102a1-python \
  ghcr.io/openhands/agent-server:50102a1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:50102a1-golang
ghcr.io/openhands/agent-server:v1.0.0a4_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:50102a1-java
ghcr.io/openhands/agent-server:v1.0.0a4_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:50102a1-python
ghcr.io/openhands/agent-server:v1.0.0a4_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `50102a1` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->