### PR TITLE
bump browser-use version, infer screenshot mime type dynamically

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -44,8 +44,17 @@ class BrowserObservation(Observation):
         ]
 
         if self.screenshot_data:
+            mime_type = "image/png"
+            if self.screenshot_data.startswith("/9j/"):
+                mime_type = "image/jpeg"
+            elif self.screenshot_data.startswith("iVBORw0KGgo"):
+                mime_type = "image/png"
+            elif self.screenshot_data.startswith("R0lGODlh"):
+                mime_type = "image/gif"
+            elif self.screenshot_data.startswith("UklGR"):
+                mime_type = "image/webp"
             # Convert base64 to data URL format for ImageContent
-            data_url = f"data:image/png;base64,{self.screenshot_data}"
+            data_url = f"data:{mime_type};base64,{self.screenshot_data}"
             content.append(ImageContent(image_urls=[data_url]))
 
         return content

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "cachetools",
     "libtmux>=0.46.2",
     "pydantic>=2.11.7",
-    "browser-use>=0.7.7",
+    "browser-use>=0.8.0",
     "func-timeout>=4.3.5",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -1947,7 +1947,7 @@ dependencies = [
 requires-dist = [
     { name = "bashlex", specifier = ">=0.18" },
     { name = "binaryornot", specifier = ">=0.4.4" },
-    { name = "browser-use", specifier = ">=0.7.7" },
+    { name = "browser-use", specifier = ">=0.8.0" },
     { name = "cachetools" },
     { name = "func-timeout", specifier = ">=4.3.5" },
     { name = "libtmux", specifier = ">=0.46.2" },


### PR DESCRIPTION
Fixes #834 

Also bump browser-use to >= 0.8.0 because this import is only available since 0.8.0. https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/server.py#L1