### PR TITLE
fix browser tool cleanup

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -121,6 +121,7 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
     _config: dict[str, Any]
     _initialized: bool
     _async_executor: AsyncExecutor
+    _cleanup_initiated: bool
 
     def __init__(
         self,
@@ -169,6 +170,7 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
 
         self._initialized = False
         self._async_executor = AsyncExecutor()
+        self._cleanup_initiated = False
 
     def __call__(
         self,
@@ -331,6 +333,9 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
 
     def close(self):
         """Close the browser executor and cleanup resources."""
+        if self._cleanup_initiated:
+            return
+        self._cleanup_initiated = True
         try:
             # Run cleanup in the async executor with a shorter timeout
             self._async_executor.run_async(self.cleanup, timeout=30.0)


### PR DESCRIPTION
Fixes #833. Additionally makes sure `BrowserToolExecutor.close` is executed at most once – in the current code it is called once for every browser tool.

#### High-level overview

Register `atexit` handler explicitly on local conversations, so that the cleanup is handled before some Python interpreter lifecycle events can interrupt it. This issue was affecting browser use tools in particular (see linked issue), but generally breaks any async cleanup tasks.

#### Alternatives considered
1. Creating a new thread inside async executor's `_ensure_loop` if loop is alive, but thread is not. Turns out, it is not possible to create new threads during interpreter shutdown, so this was not an option.
2. Leaving things as is and asking users to call `conversation.close()` explicitly. While feasible, this undermines the whole idea behind having automatic cleanups in `__del__` methods.
3. Having similar `atexit` handler upstream at the very entry to the code. This option is still viable, and I'm happy to look at it if needed and update the PR accordingly.

#### Some root causing analysis

1. `BrowserUseServer.close()` is an async method that handles the cleanup gracefully.
1. This method is exposed in [[1]( https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/server.py#L10)] via inheritance
1. This method is called in `async def cleanup` on `BrowserToolExecutor` in [[2](https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/impl.py#L326)]
1. The asynchronous nature of the cleanup method requires running it in `AsyncExecutor` in `BrowserToolExecutor.close` [[3](https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/impl.py#L336)].

This method times out. Now, the reason it times out is very tricky. Unless `LocalConversation.close()` [[4](https://github.com/OpenHands/agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py#L360)] is called manually and explicitly, it is called in `LocalConversation.__del__()` [[5](https://github.com/OpenHands/agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py#L397)].

I am not very familiar with Python's lifecycles and runtimes, but what I noticed was that by the time `__del__` is called, some logic on `AsyncExecutor` was not robust. In particular, the check for the presence of the `loop` assumed the presence and the liveness of thread together with `loop` existence [[6](https://github.com/OpenHands/agent-sdk/blob/main/openhands-sdk/openhands/sdk/utils/async_executor.py#L28-L29)]. However, by the time `__del__` is called, the `AsyncExecutor._thread` daemon thread was already dead, thus preventing the scheduled async cleanup tasks from executing completely.

[1] https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/server.py#L10
[2] https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/impl.py#L326
[3] https://github.com/OpenHands/agent-sdk/blob/main/openhands-tools/openhands/tools/browser_use/impl.py#L336
[4] https://github.com/OpenHands/agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py#L360
[5] https://github.com/OpenHands/agent-sdk/blob/main/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py#L397
[6] https://github.com/OpenHands/agent-sdk/blob/main/openhands-sdk/openhands/sdk/utils/async_executor.py#L28-L29