### PR TITLE
Update integration test to use OpenHands proxy instead of litellm proxy

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -40,7 +40,7 @@ jobs:
                       llm-config:
                           model: openhands/gpt-5-mini-2025-08-07
                           temperature: 1.0
-                    - name: Devstral Small 2507
+                    - name: Devstral Medium 2507
                       run-suffix: devstral_run
                       llm-config:
                           model: openhands/devstral-medium-2507


### PR DESCRIPTION
## Description

This PR updates the integration test workflow to use the OpenHands proxy instead of the litellm proxy, aligning the configuration with the examples in the repository.

## Changes

- Changed model prefix from `litellm_proxy/` to `openhands/`
- Updated Claude Sonnet 4.5 model to use `openhands/claude-sonnet-4-5-20250929`
- Updated GPT-5 Mini model to use `openhands/gpt-5-mini`
- Replaced DeepSeek Chat with Qwen3 Coder 480B (`openhands/qwen3-coder-480b`)

This aligns the integration test configuration with the examples (e.g., `examples/01_standalone_sdk/01_hello_world.py`) which use the OpenHands proxy format.

## Testing

The integration tests will verify this change works correctly when the workflow runs. No new tests are needed as this is a configuration change.

## Related Issues

Fixes #943

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2cfa0a0cd9a54e66adf1bf4650cfd5d3)




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:f53e61c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f53e61c-python \
  ghcr.io/openhands/agent-server:f53e61c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f53e61c-golang
ghcr.io/openhands/agent-server:v1.0.0a4_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:f53e61c-java
ghcr.io/openhands/agent-server:v1.0.0a4_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:f53e61c-python
ghcr.io/openhands/agent-server:v1.0.0a4_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `f53e61c` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->