### PR TITLE
Make function calling the default behavior

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -77,32 +77,11 @@ class ModelFeatures:
 
 
 # Pattern tables capturing current behavior. Keep patterns lowercase.
-FUNCTION_CALLING_PATTERNS: list[str] = [
-    # Anthropic families
-    "claude-3-7-sonnet*",
-    "claude-3.7-sonnet*",
-    "claude-sonnet-3-7-latest",
-    "claude-3-5-sonnet*",
-    "claude-3.5-haiku*",
-    "claude-3-5-haiku*",
-    "claude-sonnet-4*",
-    "claude-haiku-4*",
-    "claude-opus-4*",
-    # OpenAI families
-    "gpt-4o*",
-    "gpt-4.1",
-    "gpt-5*",
-    # o-series (keep exact o1 support per existing list)
-    "o1-2024-12-17",
-    "o3*",
-    "o4-mini",
-    # Google Gemini
-    "gemini-2.5-pro",
-    # Others
-    "kimi-k2-0711-preview",
-    "kimi-k2-instruct",
-    "qwen3-coder*",
-    "qwen3-coder-480b-a35b-instruct",
+# Most modern models support function calling, so we list exceptions instead
+NON_FUNCTION_CALLING_PATTERNS: list[str] = [
+    # Older open-source base models without instruction tuning typically
+    # don't support function calling. Add specific patterns here as needed.
+    # Examples: older LLaMA 2.x models, base Mistral models, etc.
 ]
 
 REASONING_EFFORT_PATTERNS: list[str] = [
@@ -162,7 +141,9 @@ RESPONSES_API_PATTERNS: list[str] = [
 
 def get_features(model: str) -> ModelFeatures:
     return ModelFeatures(
-        supports_function_calling=model_matches(model, FUNCTION_CALLING_PATTERNS),
+        supports_function_calling=not model_matches(
+            model, NON_FUNCTION_CALLING_PATTERNS
+        ),
         supports_reasoning_effort=model_matches(model, REASONING_EFFORT_PATTERNS),
         supports_extended_thinking=model_matches(model, EXTENDED_THINKING_PATTERNS),
         supports_prompt_cache=model_matches(model, PROMPT_CACHE_PATTERNS),

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -57,11 +57,12 @@ def test_model_matches(name, pattern, expected):
         ("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", True),
         ("bedrock/anthropic.claude-3-7-sonnet-20250219-v1:0", True),
         ("bedrock/anthropic.claude-sonnet-4-20250514-v1:0", True),
+        # Most modern models support function calling
+        ("llama-3.1-70b", True),
         (
-            "llama-3.1-70b",
-            False,
-        ),  # Most open source models don't support native function calling
-        ("unknown-model", False),  # Default to False for unknown models
+            "unknown-model",
+            True,
+        ),  # Default to True - most models support function calling
     ],
 )
 def test_function_calling_support(model, expected_function_calling):
@@ -217,8 +218,10 @@ def test_get_features_unknown_model():
     """Test get_features with completely unknown model."""
     features = get_features("completely-unknown-model-12345")
 
-    # Unknown models should have conservative defaults
-    assert features.supports_function_calling is False
+    # Unknown models should have permissive defaults
+    assert (
+        features.supports_function_calling is True
+    )  # Most models support function calling
     assert features.supports_reasoning_effort is False
     assert features.supports_prompt_cache is False
     assert features.supports_stop_words is True  # Most models support stop words
@@ -229,9 +232,9 @@ def test_get_features_empty_model():
     features_empty = get_features("")
     features_none = get_features(None)  # type: ignore[arg-type]
 
-    # Both should return conservative defaults
-    assert features_empty.supports_function_calling is False
-    assert features_none.supports_function_calling is False
+    # Both should return permissive defaults
+    assert features_empty.supports_function_calling is True
+    assert features_none.supports_function_calling is True
     assert features_empty.supports_reasoning_effort is False
     assert features_none.supports_reasoning_effort is False
 


### PR DESCRIPTION
## Description

This PR fixes #952 by inverting the function calling support logic in `model_features.py`.

## Changes

- **Replaced `FUNCTION_CALLING_PATTERNS` with `NON_FUNCTION_CALLING_PATTERNS`**: Instead of maintaining a whitelist of models that support function calling, we now maintain a blacklist of models that don't support it.

- **Updated `get_features()` logic**: Changed from `model_matches(model, FUNCTION_CALLING_PATTERNS)` to `not model_matches(model, NON_FUNCTION_CALLING_PATTERNS)`, making function calling support the default behavior.

- **Updated tests**: Modified test cases to reflect that unknown models now default to supporting function calling, which aligns with the reality that most modern LLMs support this feature.

## Rationale

Almost all modern models support function calling, including:
- All major API providers (OpenAI, Anthropic, Google, etc.)
- Most instruction-tuned open-source models
- Newer model families

By defaulting to `True`, we:
- Simplify maintenance (much shorter exception list)
- Reduce the need for frequent updates when new models are released
- Align with similar patterns in the codebase (e.g., `SUPPORTS_STOP_WORDS_FALSE_PATTERNS`)
- Make the behavior more permissive and practical for users

## Testing

- All existing tests pass (71 tests)
- Pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright)
- Updated test cases to verify new default behavior

Fixes #952

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7203aa6fb66a4b1da69240d408e531f6)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:73c6751-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-73c6751-python \
  ghcr.io/openhands/agent-server:73c6751-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:73c6751-golang
ghcr.io/openhands/agent-server:v1.0.0a4_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:73c6751-java
ghcr.io/openhands/agent-server:v1.0.0a4_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:73c6751-python
ghcr.io/openhands/agent-server:v1.0.0a4_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `73c6751` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->