### PR TITLE
release version 1.0.0a5

### DIFF
--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-agent-server"
-version = "1.0.0a4"
+version = "1.0.0a5"
 description = "OpenHands Agent Server - REST/WebSocket interface for OpenHands AI Agent"
 
 requires-python = ">=3.12"

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-sdk"
-version = "1.0.0a4"
+version = "1.0.0a5"
 description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-tools"
-version = "1.0.0a4"
+version = "1.0.0a5"
 description = "OpenHands Tools - Runtime tools for AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-workspace/pyproject.toml
+++ b/openhands-workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-workspace"
-version = "1.0.0a4"
+version = "1.0.0a5"
 description = "OpenHands Workspace - Docker and container-based workspace implementations"
 
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -1867,7 +1867,7 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.0.0a4"
+version = "1.0.0a5"
 source = { editable = "openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -1896,7 +1896,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.0.0a4"
+version = "1.0.0a5"
 source = { editable = "openhands-sdk" }
 dependencies = [
     { name = "fastmcp" },
@@ -1930,7 +1930,7 @@ provides-extras = ["boto3"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.0.0a4"
+version = "1.0.0a5"
 source = { editable = "openhands-tools" }
 dependencies = [
     { name = "bashlex" },
@@ -1957,7 +1957,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.0.0a4"
+version = "1.0.0a5"
 source = { editable = "openhands-workspace" }
 dependencies = [
     { name = "openhands-sdk" },


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:08b8565-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-08b8565-python \
  ghcr.io/openhands/agent-server:08b8565-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:08b8565-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:08b8565-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:08b8565-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `08b8565` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->