### PR TITLE
Agent Server UUIDs without hyphens

### DIFF
--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -2,11 +2,11 @@ from abc import ABC
 from datetime import datetime
 from enum import Enum
 from typing import Literal
-from uuid import UUID, uuid4
+from uuid import uuid4
 
 from pydantic import BaseModel, Field
 
-from openhands.agent_server.utils import utc_now
+from openhands.agent_server.utils import OpenHandsUUID, utc_now
 from openhands.sdk import LLM, AgentBase, Event, ImageContent, Message, TextContent
 from openhands.sdk.conversation.secret_source import SecretSource
 from openhands.sdk.conversation.state import AgentExecutionStatus, ConversationState
@@ -64,7 +64,7 @@ class StartConversationRequest(BaseModel):
         ...,
         description="Working directory for agent operations and tool execution",
     )
-    conversation_id: UUID | None = Field(
+    conversation_id: OpenHandsUUID | None = Field(
         default=None,
         description=(
             "Optional conversation ID. If not provided, a random UUID will be "
@@ -99,7 +99,7 @@ class StartConversationRequest(BaseModel):
 class StoredConversation(StartConversationRequest):
     """Stored details about a conversation"""
 
-    id: UUID
+    id: OpenHandsUUID
     title: str | None = Field(
         default=None, description="User-defined title for the conversation"
     )
@@ -190,7 +190,7 @@ class GenerateTitleResponse(BaseModel):
 class BashEventBase(DiscriminatedUnionMixin, ABC):
     """Base class for all bash event types"""
 
-    id: UUID = Field(default_factory=uuid4)
+    id: OpenHandsUUID = Field(default_factory=uuid4)
     timestamp: datetime = Field(default_factory=utc_now)
 
 
@@ -213,7 +213,7 @@ class BashOutput(BashEventBase):
     depending on how large the output is.
     """
 
-    command_id: UUID
+    command_id: OpenHandsUUID
     order: int = Field(
         default=0, description="The order for this output, sequentially starting with 0"
     )

--- a/openhands-agent-server/openhands/agent_server/utils.py
+++ b/openhands-agent-server/openhands/agent_server/utils.py
@@ -1,4 +1,8 @@
 from datetime import UTC, datetime
+from typing import Annotated
+from uuid import UUID
+
+from pydantic import PlainSerializer
 
 
 def utc_now():
@@ -177,3 +181,11 @@ def patch_fastapi_discriminated_union_support():
     except (ImportError, AttributeError):
         # FastAPI not available or internal API changed
         pass
+
+
+def _uuid_to_hex(uuid_obj: UUID) -> str:
+    """Converts a UUID object to a hex string without hyphens."""
+    return uuid_obj.hex
+
+
+OpenHandsUUID = Annotated[UUID, PlainSerializer(_uuid_to_hex, when_used="json")]


### PR DESCRIPTION
We have standardized on all uuids being serialized without hyphens. This should apply universally
(e.g.: `40f8fc34-a4ba-48fb-92b2-c0494ef0c47c` -> `40f8fc34a4ba48fb92b2c0494ef0c47c`)

* You can double click the non hyphenated versions to select all for copying.
* Pydantic parses either hyphenated or non hyphenated versions without issue.
* Most people don't use the hyphens as a memory aid - when they see a uuid they will note the first / last 4 characters or just give up
* The hyphens make uuids needlessly longer
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:897d509-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-897d509-python \
  ghcr.io/openhands/agent-server:897d509-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:897d509-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:897d509-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:897d509-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `897d509` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->