### PR TITLE
Rename ConversationState field to secret_registry with read-alias

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -353,8 +353,8 @@ class LocalConversation(BaseConversation):
                      when a command references the secret key.
         """
 
-        secrets_manager = self._state.secrets_manager
-        secrets_manager.update_secrets(secrets)
+        secret_registry = self._state.secret_registry
+        secret_registry.update_secrets(secrets)
         logger.info(f"Added {len(secrets)} secrets to conversation")
 
     def close(self) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -4,7 +4,7 @@ from collections.abc import Sequence
 from enum import Enum
 from typing import Any, Self
 
-from pydantic import Field, PrivateAttr
+from pydantic import AliasChoices, Field, PrivateAttr
 
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.conversation_stats import ConversationStats
@@ -91,10 +91,12 @@ class ConversationState(OpenHandsModel):
         description="Conversation statistics for tracking LLM metrics",
     )
 
-    # Secrets manager for handling sensitive data (changed from private attribute)
-    secrets_manager: SecretRegistry = Field(
+    # Secret registry for handling sensitive data
+    secret_registry: SecretRegistry = Field(
         default_factory=SecretRegistry,
-        description="Manager for handling secrets and sensitive data",
+        description="Registry for handling secrets and sensitive data",
+        validation_alias=AliasChoices("secret_registry", "secrets_manager"),
+        serialization_alias="secret_registry",
     )
 
     # ===== Private attrs (NOT Fields) =====

--- a/openhands-tools/openhands/tools/execute_bash/impl.py
+++ b/openhands-tools/openhands/tools/execute_bash/impl.py
@@ -64,8 +64,8 @@ class BashExecutor(ToolExecutor[ExecuteBashAction, ExecuteBashObservation]):
         env_vars = {}
         if conversation is not None:
             try:
-                secrets_manager = conversation.state.secrets_manager
-                env_vars = secrets_manager.get_secrets_as_env_vars(action.command)
+                secret_registry = conversation.state.secret_registry
+                env_vars = secret_registry.get_secrets_as_env_vars(action.command)
             except Exception:
                 env_vars = {}
 
@@ -160,8 +160,8 @@ class BashExecutor(ToolExecutor[ExecuteBashAction, ExecuteBashObservation]):
         # Apply automatic secrets masking
         if observation.output and conversation is not None:
             try:
-                secrets_manager = conversation.state.secrets_manager
-                masked_output = secrets_manager.mask_secrets_in_output(
+                secret_registry = conversation.state.secret_registry
+                masked_output = secret_registry.mask_secrets_in_output(
                     observation.output
                 )
                 if masked_output:

--- a/tests/sdk/conversation/test_conversation_secrets_constructor.py
+++ b/tests/sdk/conversation/test_conversation_secrets_constructor.py
@@ -43,18 +43,18 @@ def test_local_conversation_constructor_with_secrets():
         assert isinstance(conv, LocalConversation)
 
         # Verify secrets were initialized
-        secrets_manager = conv.state.secrets_manager
-        assert secrets_manager is not None
+        secret_registry = conv.state.secret_registry
+        assert secret_registry is not None
 
-        # Verify secrets are accessible through the secrets manager
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $API_KEY")
+        # Verify secrets are accessible through the secret registry
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $API_KEY")
         assert env_vars == {"API_KEY": "test-api-key-123"}
 
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $DATABASE_URL")
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $DATABASE_URL")
         assert env_vars == {"DATABASE_URL": "postgresql://localhost/test"}
 
         # Test multiple secrets in one command
-        env_vars = secrets_manager.get_secrets_as_env_vars(
+        env_vars = secret_registry.get_secrets_as_env_vars(
             "export API_KEY=$API_KEY && export AUTH_TOKEN=$AUTH_TOKEN"
         )
         assert env_vars == {
@@ -90,15 +90,15 @@ def test_local_conversation_constructor_with_callable_secrets():
         assert isinstance(conv, LocalConversation)
 
         # Verify callable secrets work
-        secrets_manager = conv.state.secrets_manager
+        secret_registry = conv.state.secret_registry
 
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $DYNAMIC_TOKEN")
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $DYNAMIC_TOKEN")
         assert env_vars == {"DYNAMIC_TOKEN": "dynamic-token-789"}
 
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $API_KEY")
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $API_KEY")
         assert env_vars == {"API_KEY": "callable-api-key"}
 
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $STATIC_KEY")
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $STATIC_KEY")
         assert env_vars == {"STATIC_KEY": "static-value"}
 
 
@@ -118,11 +118,11 @@ def test_local_conversation_constructor_without_secrets():
         assert isinstance(conv, LocalConversation)
 
         # Verify secrets manager exists but is empty
-        secrets_manager = conv.state.secrets_manager
-        assert secrets_manager is not None
+        secret_registry = conv.state.secret_registry
+        assert secret_registry is not None
 
         # Should return empty dict for any command
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $API_KEY")
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $API_KEY")
         assert env_vars == {}
 
 
@@ -142,11 +142,11 @@ def test_local_conversation_constructor_with_empty_secrets():
         assert isinstance(conv, LocalConversation)
 
         # Verify secrets manager exists but is empty
-        secrets_manager = conv.state.secrets_manager
-        assert secrets_manager is not None
+        secret_registry = conv.state.secret_registry
+        assert secret_registry is not None
 
         # Should return empty dict for any command
-        env_vars = secrets_manager.get_secrets_as_env_vars("echo $API_KEY")
+        env_vars = secret_registry.get_secrets_as_env_vars("echo $API_KEY")
         assert env_vars == {}
 
 

--- a/tests/tools/execute_bash/test_secrets_masking.py
+++ b/tests/tools/execute_bash/test_secrets_masking.py
@@ -32,7 +32,7 @@ def test_bash_executor_without_conversation():
 
 
 def test_bash_executor_with_conversation_secrets():
-    """Test that BashExecutor uses secrets from conversation.state.secrets_manager."""
+    """Test that BashExecutor uses secrets from conversation.state.secret_registry."""
     with tempfile.TemporaryDirectory() as temp_dir:
         # Create a conversation with secrets
         llm = LLM(


### PR DESCRIPTION
Summary

This PR completes the SecretManager → SecretRegistry transition by renaming the ConversationState attribute from secrets_manager to secret_registry and updating all usages across SDK, tools, and tests. To preserve backward compatibility for persisted conversations and remote payloads, we add a read-time alias so older state can still be loaded.

Key changes
- ConversationState
  - secrets_manager → secret_registry: SecretRegistry
  - Add Pydantic migration helpers:
    - validation_alias=AliasChoices("secret_registry", "secrets_manager")
    - serialization_alias="secret_registry"
  - Effect: Older payloads with "secrets_manager" load successfully; new serialization always uses "secret_registry".

- SDK & Tools updates
  - LocalConversation: use self._state.secret_registry.update_secrets(...)
  - BashExecutor (execute_bash): reference conversation.state.secret_registry for env export and output masking

- Tests & docstrings
  - Updated tests and docstrings to reference secret_registry

Compatibility & migration
- Backward loading preserved: Persisted state and remote payloads containing "secrets_manager" will still load because of validation_alias.
- Serialization change: State now serializes with the key "secret_registry" going forward.

Testing
- Pre-commit: ruff format/lint, pycodestyle, pyright — passed
- Targeted tests:
  - tests/tools/execute_bash/test_secrets_masking.py::test_bash_executor_with_conversation_secrets — passed
  - tests/sdk/conversation/test_conversation_secrets_constructor.py — passed
  - tests/cross/test_agent_secrets_integration.py — passed
- Broader grep confirms no residual runtime usages of secrets_manager remain (only appears in validation_alias by design).

Related docs
- Follow-up to the SecretRegistry rename. Existing docs PR: https://github.com/OpenHands/docs/pull/61

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8781ec96e38742b88144b386ee6113ec)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:4f18754-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4f18754-python \
  ghcr.io/openhands/agent-server:4f18754-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4f18754-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:4f18754-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:4f18754-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `4f18754` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->