### PR TITLE
Fix formatting: remove extra blank line in model_features.py

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -133,7 +133,6 @@ RESPONSES_API_PATTERNS: list[str] = [
 ]
 
 
-
 def get_features(model: str) -> ModelFeatures:
     """Get model features."""
     return ModelFeatures(


### PR DESCRIPTION
## Summary
This PR fixes a formatting issue found by running `pre-commit run --all-files`. An extra blank line was removed from `openhands-sdk/openhands/sdk/llm/utils/model_features.py` to comply with the project's formatting standards.

## Changes
- Removed one extra blank line in `openhands-sdk/openhands/sdk/llm/utils/model_features.py`

## Testing
✅ All pre-commit hooks pass:
- Format YAML files: Passed
- Ruff format: Passed
- Ruff lint: Passed
- PEP8 style check (pycodestyle): Passed
- Type check with pyright: Passed

Co-authored-by: openhands <openhands@all-hands.dev>

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/77b4e5a3c7c24eb0887d6baa52bcd9a2)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:772a264-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-772a264-python \
  ghcr.io/openhands/agent-server:772a264-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:772a264-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:772a264-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:772a264-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `772a264` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->