### PR TITLE
Fix docker driver cache export issue in CI with Blacksmith

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -185,6 +185,7 @@ jobs:
             GITHUB_SHA: ${{ github.sha }}
             GITHUB_REF: ${{ github.ref }}
             CI: 'true'
+            USE_BLACKSMITH_CACHE: 'true'
 
         steps:
             - name: Checkout


### PR DESCRIPTION
## Description

This PR fixes issue #982 where the docker build fails in CI with the error:
```
ERROR: Cache export is not supported for the docker driver.
Switch to a different driver, or turn on the containerd image store, and try again.
```

## Problem

The issue occurred because `build.py` attempted to use `--cache-to type=registry` when `push=True`, but this doesn't work with buildx builders using the default docker driver. Even though the workflow uses `useblacksmith/setup-docker-builder@v1`, the build script was still explicitly adding cache arguments that conflict with Blacksmith's automatic caching mechanism.

## Solution

According to [Blacksmith's documentation](https://docs.blacksmith.sh/blacksmith-caching/docker-builds):

> "Any external caching that was configured with cache-from and cache-to directives can now be removed. Once you make this switch, the first Docker run will be an uncached run. Every subsequent run will have the hydrated layer cache mounted into your runners"

When using `useblacksmith/setup-docker-builder@v1`, Blacksmith handles Docker layer caching automatically through sticky disks. Explicit `--cache-from` and `--cache-to` arguments are not needed and can actually cause conflicts.

## Changes

### Modified Files

1. **`.github/workflows/server.yml`**
   - Added `USE_BLACKSMITH_CACHE: 'true'` environment variable to the `build-and-push-image` job

2. **`openhands-agent-server/openhands/agent_server/docker/build.py`**
   - Added detection for `USE_BLACKSMITH_CACHE` environment variable
   - When enabled, skips adding `--cache-from` and `--cache-to` arguments in push mode
   - Lets Blacksmith handle caching automatically via its sticky disk mechanism
   - Falls back to registry cache strategy when not using Blacksmith

## How It Works

When `USE_BLACKSMITH_CACHE=true`:
- The `useblacksmith/setup-docker-builder@v1` action sets up a buildx builder with access to cached layers from previous runs
- Docker builds leverage the cached layers automatically without explicit cache arguments
- At the end of the job, the runner commits changes to the layer cache for future runs
- This approach avoids the "cache export not supported" error entirely

When `USE_BLACKSMITH_CACHE` is not set (e.g., in other CI environments):
- Falls back to the original registry cache strategy with explicit `--cache-from` and `--cache-to` arguments
- Maintains backward compatibility for non-Blacksmith environments

## Testing

- ✅ Pre-commit checks passed (ruff format, ruff lint, pycodestyle, pyright)
- ✅ Changes are minimal and focused on the caching strategy
- ✅ Backward compatible - only affects builds when `USE_BLACKSMITH_CACHE=true`

## Fixes

Closes #982

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/79f72e555b0345c3942d263785354428)