### PR TITLE
Fix abbreviation formatting in visualizer

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/visualizer.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer.py
@@ -285,15 +285,14 @@ class ConversationVisualizer:
         def abbr(n: int | float) -> str:
             n = int(n or 0)
             if n >= 1_000_000_000:
-                s = f"{n / 1_000_000_000:.2f}B"
+                val, suffix = n / 1_000_000_000, "B"
             elif n >= 1_000_000:
-                s = f"{n / 1_000_000:.2f}M"
+                val, suffix = n / 1_000_000, "M"
             elif n >= 1_000:
-                s = f"{n / 1_000:.2f}K"
+                val, suffix = n / 1_000, "K"
             else:
                 return str(n)
-            suffix = s[-1]
-            return s[:-1].rstrip("0").rstrip(".") + suffix
+            return f"{val:.2f}".rstrip("0").rstrip(".") + suffix
 
         input_tokens = abbr(usage.prompt_tokens or 0)
         output_tokens = abbr(usage.completion_tokens or 0)


### PR DESCRIPTION
Replaces the previous method of removing trailing '.0' with a more robust approach using rstrip to remove trailing zeros and periods.


---

input 88k to 898k

<img width="645" height="649" alt="image" src="https://github.com/user-attachments/assets/4c3a89fa-463f-49f4-8cab-08f3342b6a3f" />

---

```py
s='89.08'
print(s.replace('.0',''))
print(s.rstrip("0").rstrip("."))
print('===')
s='89.00'
print(s.replace('.0',''))
print(s.rstrip("0").rstrip("."))
```
Output:
```
898
89.08
===
890
89
```