### PR TITLE
update  patterns in FORCE_STRING_SERIALIZER_PATTERNS

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -90,12 +90,9 @@ RESPONSES_API_PATTERNS: list[str] = [
 # These models don't support structured content format [{"type":"text","text":"..."}]
 # and need plain strings instead
 FORCE_STRING_SERIALIZER_PATTERNS: list[str] = [
-    "*deepseek*",
-    "glm*",
-    # kimi-k2-instruct on groq provider requires string serialization
-    # Pattern contains '/' so it matches against full model string
-    # (e.g., "groq/kimi-k2-instruct")
-    "*groq*/kimi-k2-instruct*",
+    "deepseek",
+    "glm",
+    "groq/kimi-k2-instruct",
 ]
 
 


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:cb7c8a1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cb7c8a1-python \
  ghcr.io/openhands/agent-server:cb7c8a1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cb7c8a1-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:cb7c8a1-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:cb7c8a1-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `cb7c8a1` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->