### PR TITLE
Handle nested field schema formatting for tool description

### DIFF
--- a/tests/sdk/llm/test_llm_fncall_converter.py
+++ b/tests/sdk/llm/test_llm_fncall_converter.py
@@ -531,24 +531,24 @@ def test_convert_tools_to_description_array_items():
         "Allowed values: [`view`, `plan`]\n"
     )
     assert expected_command_line in description
+    # Top-level parameter line should reflect the summarized array type
     assert (
-        "  (2) task_list (array, optional): The full task list. Required parameter of `plan` command.\n"  # noqa: E501
+        "  (2) task_list (array[object], optional): The full task list. Required parameter of `plan` command.\n"  # noqa: E501
         in description
     )
-    assert "       task_list array item structure:\n" in description
+    # Nested structure should be shown via the generic recursive formatter
+    assert "Object properties:" in description
+    assert "- title (string, required): A brief title for the task." in description
     assert (
-        "       - title (string, required): A brief title for the task.\n"
+        "- notes (string, optional): Additional details or notes about the task."
         in description
     )
     assert (
-        "       - notes (string, optional): Additional details or notes about the task.\n"  # noqa: E501
+        "- status (string, optional): The current status of the task. One of 'todo', 'in_progress', or 'done'."  # noqa: E501
         in description
     )
-    expected_status_line = (
-        "       - status (string, optional): The current status of the task. "
-        "One of 'todo', 'in_progress', or 'done'. Allowed values: [`todo`, `in_progress`, `done`]\n"  # noqa: E501
-    )
-    assert expected_status_line in description
+    # Nested enum values are described inline in the field description; no separate
+    # "Allowed values" line is required.
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Fix https://github.com/OpenHands/software-agent-sdk/issues/1074





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f7e54e7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f7e54e7-python \
  ghcr.io/openhands/agent-server:f7e54e7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f7e54e7-golang-amd64
ghcr.io/openhands/agent-server:f7e54e7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f7e54e7-golang-arm64
ghcr.io/openhands/agent-server:f7e54e7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f7e54e7-java-amd64
ghcr.io/openhands/agent-server:f7e54e7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f7e54e7-java-arm64
ghcr.io/openhands/agent-server:f7e54e7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f7e54e7-python-amd64
ghcr.io/openhands/agent-server:f7e54e7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f7e54e7-python-arm64
ghcr.io/openhands/agent-server:f7e54e7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f7e54e7-golang
ghcr.io/openhands/agent-server:f7e54e7-java
ghcr.io/openhands/agent-server:f7e54e7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f7e54e7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f7e54e7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->