### PR TITLE
Bug: fix Visualizer "Message To User" that should be "Message from User" 

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/visualizer.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer.py
@@ -208,9 +208,15 @@ class ConversationVisualizer:
             )
 
             if event.llm_message.role == "user":
-                title_text = f"[bold {role_color}]User Message to {agent_name}Agent[/bold {role_color}]"
+                title_text = (
+                    f"[bold {role_color}]User Message to "
+                    f"{agent_name}Agent[/bold {role_color}]"
+                )
             else:
-                title_text = f"[bold {role_color}]Message from {agent_name}Agent[/bold {role_color}]"
+                title_text = (
+                    f"[bold {role_color}]Message from "
+                    f"{agent_name}Agent[/bold {role_color}]"
+                )
             return Panel(
                 content,
                 title=title_text,


### PR DESCRIPTION


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:e9c83d3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e9c83d3-python \
  ghcr.io/openhands/agent-server:e9c83d3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e9c83d3-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:e9c83d3-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:e9c83d3-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `e9c83d3` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->