### PR TITLE
Fix datadog debugging workflow example

### DIFF
--- a/examples/03_github_workflows/04_datadog_debugging/workflow.yml
+++ b/examples/03_github_workflows/04_datadog_debugging/workflow.yml
@@ -86,7 +86,7 @@ jobs:
                   DD_SITE: ${{ secrets.DD_SITE }}
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
                   LLM_BASE_URL: ${{ secrets.LLM_BASE_URL }}
-                  LLM_MODEL:  <YOUR_LLM_MODEL>
+                  LLM_MODEL: <YOUR_LLM_MODEL>
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   PYTHONPATH: ''
               run: |


### PR DESCRIPTION
## Summary

Fix the Datadog debugging workflow example to match the actual script capabilities and use correct configuration formats.

## Changes

1. **Remove unsupported `--max-errors` parameter**
   - The `datadog_debugging.py` script doesn't support this parameter
   - Removed `max_errors` input from workflow
   - Removed `--max-errors` from script invocation

2. **Fix LLM model format**
   - Changed default from `openhands/claude-sonnet-4-5-20250929` to `litellm_proxy/claude-sonnet-4-5-20250929`
   - This matches the correct format for LiteLLM proxy integration

## Testing

- ✅ Pre-commit checks pass
- ✅ Tested in graham-sandbox with successful workflow execution
- ✅ Verified script doesn't support `--max-errors` parameter
- ✅ Confirmed LLM model format works with `litellm_proxy/` prefix

## Impact

This ensures the example workflow in the SDK repository is accurate and can be used as-is by users without encountering errors from unsupported parameters or incorrect model formats.

## Related

- Original PR: #272 (merged)
- Infra repo PR: All-Hands-AI/infra#705




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:f21808f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f21808f-python \
  ghcr.io/openhands/agent-server:f21808f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f21808f-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:f21808f-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:f21808f-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `f21808f` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->