### PR TITLE
Fix/remove docstring for OpenHands tool package

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/__init__.py
+++ b/openhands-sdk/openhands/sdk/tool/__init__.py
@@ -1,5 +1,3 @@
-"""OpenHands tool package."""
-
 from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, FinishTool, ThinkTool
 from openhands.sdk.tool.registry import (
     list_registered_tools,


### PR DESCRIPTION


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Base Image | Docs / Tags |
|---|---|---|
| golang | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |
| java | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |


**Pull (multi-arch manifest)**
```bash
docker pull ghcr.io/openhands/agent-server:0524bb6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0524bb6-python \
  ghcr.io/openhands/agent-server:0524bb6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0524bb6-golang
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary
ghcr.io/openhands/agent-server:0524bb6-java
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary
ghcr.io/openhands/agent-server:0524bb6-python
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary
```

_The `0524bb6` tag is a multi-arch manifest (amd64/arm64); your client pulls the right arch automatically._
<!-- AGENT_SERVER_IMAGES_END -->