### PR TITLE
Fix multi-arch manifest merge to use correct tag names

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -374,8 +374,8 @@ jobs:
                       LATEST_TAG="latest-${VARIANT}"
                       echo "Creating latest multi-arch manifest: ${IMAGE}:${LATEST_TAG}"
                       docker buildx imagetools create -t ${IMAGE}:${LATEST_TAG} \
-                        ${IMAGE}:latest-${VARIANT}-amd64 \
-                        ${IMAGE}:latest-${VARIANT}-arm64
+                        ${IMAGE}:main-${VARIANT}-amd64 \
+                        ${IMAGE}:main-${VARIANT}-arm64
                       
                       echo "Inspecting latest multi-arch manifest:"
                       docker buildx imagetools inspect ${IMAGE}:${LATEST_TAG}


### PR DESCRIPTION
## Summary
Fixes #1023 - The merge-manifests job in the GitHub Actions workflow was failing because it was trying to create multi-arch manifests using non-existent image tags.

## Root Cause Analysis
The `merge-manifests` job was attempting to combine:
- `ghcr.io/openhands/agent-server:latest-{variant}-amd64`
- `ghcr.io/openhands/agent-server:latest-{variant}-arm64`

However, the `build.py` script actually creates these tags on the main branch:
- `ghcr.io/openhands/agent-server:main-{variant}-amd64`
- `ghcr.io/openhands/agent-server:main-{variant}-arm64`

This mismatch caused the error:
```
ERROR: ghcr.io/openhands/agent-server:latest-python-arm64: not found
```

## Changes Made
Updated `.github/workflows/server.yml` (lines 377-378) to use the correct source tag pattern `main-{variant}-{arch}` instead of `latest-{variant}-{arch}` when creating the `latest-{variant}` multi-arch manifest.

## Testing
- Pre-commit hooks passed locally
- The fix aligns with the actual tag naming convention used by `build.py` (see lines 305-308)

## Additional Context
The workflow successfully creates the SHA-based multi-arch manifest (e.g., `7cdc067-python`) but was failing only when attempting to create the `latest-{variant}` manifest on the main branch. This fix ensures both manifest types can be created successfully.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/946be90aa11045fdb57120acb471f7b5)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:80b0bfb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-80b0bfb-python \
  ghcr.io/openhands/agent-server:80b0bfb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:80b0bfb-golang-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary-amd64
ghcr.io/openhands/agent-server:80b0bfb-golang-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary-arm64
ghcr.io/openhands/agent-server:80b0bfb-java-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary-amd64
ghcr.io/openhands/agent-server:80b0bfb-java-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary-arm64
ghcr.io/openhands/agent-server:80b0bfb-python-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-amd64
ghcr.io/openhands/agent-server:80b0bfb-python-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-arm64
ghcr.io/openhands/agent-server:80b0bfb-golang
ghcr.io/openhands/agent-server:80b0bfb-java
ghcr.io/openhands/agent-server:80b0bfb-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `80b0bfb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `80b0bfb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->