### PR TITLE
Disable Copilot chat command center icon by default (parity with OpenHands PR #11589)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/vscode_extensions/openhands-settings/extension.js
+++ b/openhands-agent-server/openhands/agent_server/vscode_extensions/openhands-settings/extension.js
@@ -14,6 +14,7 @@ function activate(context) {
   config.update('telemetry.telemetryLevel', 'off', target);
   config.update('extensions.autoCheckUpdates', false, target);
   config.update('extensions.autoUpdate', false, target);
+  config.update('chat.commandCenter.enabled', false, target);
 }
 
 function deactivate() {}


### PR DESCRIPTION
This ports the VS Code settings change from OpenHands/OpenHands PR #11589 to maintain parity across repositories.

Change:
- In `openhands-agent-server/openhands/agent_server/vscode_extensions/openhands-settings/extension.js`, add:
  - `config.update('chat.commandCenter.enabled', false, vscode.ConfigurationTarget.Global);`

Outcome:
- Disables the Copilot chat command center icon in VS Code by default when the OpenHands Settings extension activates.

Notes:
- This extension is a minimal CommonJS file; no build step required.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5e1235d3ea8246799c0b70b4f8f9884b)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:56ec2d7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-56ec2d7-python \
  ghcr.io/openhands/agent-server:56ec2d7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:56ec2d7-golang-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary-amd64
ghcr.io/openhands/agent-server:56ec2d7-golang-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary-arm64
ghcr.io/openhands/agent-server:56ec2d7-java-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary-amd64
ghcr.io/openhands/agent-server:56ec2d7-java-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary-arm64
ghcr.io/openhands/agent-server:56ec2d7-python-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-amd64
ghcr.io/openhands/agent-server:56ec2d7-python-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-arm64
ghcr.io/openhands/agent-server:56ec2d7-golang
ghcr.io/openhands/agent-server:56ec2d7-java
ghcr.io/openhands/agent-server:56ec2d7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `56ec2d7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `56ec2d7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->