### PR TITLE
fix(condenser):  When condensation is triggered by the unhandled_condensation_request condition,  it will result in empty condensation.

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -39,7 +39,7 @@ class LLMSummarizingCondenser(RollingCondenser):
         head = view[: self.keep_first]
         target_size = self.max_size // 2
         if view.unhandled_condensation_request:
-            # Condensation triggered by a condensation request 
+            # Condensation triggered by a condensation request
             # should be calculated based on the view size.
             target_size = len(view) // 2
         # Number of events to keep from the tail -- target size, minus however many


### PR DESCRIPTION
**Background:** When condensation is triggered by the unhandled_condensation_request condition, if the number of events in the current view is less than half of the max_size, it will result in empty condensation.

forExample: 

    keep_first = 4
    len(view) = 10
    max_size = 30

    target_size = 15
    events_from_tail = 10 
  
    forgotten_events = view[self.keep_first : -events_from_tail]
                     = view[4:-10]
    result: forgotten_events is empty

**Optimization:** When condensation is triggered by the unhandled_condensation_request condition, adjust the current target_size to len(view) // 2.