### PR TITLE
Add reviewer trigger for PR review workflow

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -5,7 +5,7 @@ on:
     # Use pull_request_target to allow fork PRs to access secrets when triggered by maintainers
     # Security: This workflow only runs when:
     #   1. A maintainer adds the 'review-this' label, OR
-    #   2. A maintainer requests OpenHands/OpenHands-agent as a reviewer
+    #   2. A maintainer requests openhands-agent as a reviewer
     # Only users with write access can add labels or request reviews, ensuring security.
     # The PR code is explicitly checked out for review, but secrets are only accessible
     # because the workflow runs in the base repository context
@@ -21,13 +21,11 @@ jobs:
     pr-review:
         # Security: Only run when one of the following conditions is met:
         #   1. 'review-this' label is added by a maintainer, OR
-        #   2. OpenHands or OpenHands-agent is requested as a reviewer by a maintainer
+        #   2. openhands-agent is requested as a reviewer by a maintainer
         # Maintainers should review PR code before triggering this workflow
         if: |
             github.event.label.name == 'review-this' ||
-            (github.event.requested_reviewer != null && 
-             (github.event.requested_reviewer.login == 'OpenHands' || 
-              github.event.requested_reviewer.login == 'OpenHands-agent'))
+            github.event.requested_reviewer.login == 'openhands-agent'
         runs-on: blacksmith-4vcpu-ubuntu-2404
         env:
             LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929

--- a/examples/03_github_workflows/02_pr_review/README.md
+++ b/examples/03_github_workflows/02_pr_review/README.md
@@ -1,6 +1,6 @@
 # PR Review Workflow
 
-This example demonstrates how to set up a GitHub Actions workflow for automated pull request reviews using the OpenHands agent SDK. When a PR is labeled with `review-this` or when OpenHands is added as a reviewer, OpenHands will analyze the changes and provide detailed, constructive feedback.
+This example demonstrates how to set up a GitHub Actions workflow for automated pull request reviews using the OpenHands agent SDK. When a PR is labeled with `review-this` or when openhands-agent is added as a reviewer, OpenHands will analyze the changes and provide detailed, constructive feedback.
 
 ## Files
 
@@ -13,7 +13,7 @@ This example demonstrates how to set up a GitHub Actions workflow for automated 
 
 - **Automatic Trigger**: Reviews are triggered when:
   - The `review-this` label is added to a PR, OR
-  - OpenHands or OpenHands-agent is requested as a reviewer
+  - openhands-agent is requested as a reviewer
 - **Comprehensive Analysis**: Analyzes code changes in context of the entire repository
 - **Detailed Feedback**: Provides structured review comments covering:
   - Overall assessment of changes
@@ -82,7 +82,7 @@ There are two ways to trigger an automated review of a pull request:
 
 1. Open the pull request you want reviewed
 2. Click on "Reviewers" in the right sidebar
-3. Search for and select "OpenHands" or "OpenHands-agent" as a reviewer
+3. Search for and select "openhands-agent" as a reviewer
 4. The workflow will automatically start and analyze the changes
 5. Review comments will be posted to the PR when complete
 

--- a/examples/03_github_workflows/02_pr_review/workflow.yml
+++ b/examples/03_github_workflows/02_pr_review/workflow.yml
@@ -5,7 +5,7 @@
 #  3. Commit this file to your repository
 #  4. Trigger the review by either:
 #     - Adding the "review-this" label to any PR, OR
-#     - Requesting OpenHands or OpenHands-agent as a reviewer
+#     - Requesting openhands-agent as a reviewer
 name: PR Review by OpenHands
 
 on:
@@ -20,12 +20,10 @@ permissions:
 
 jobs:
     pr-review:
-        # Run when review-this label is added OR OpenHands/OpenHands-agent is requested as reviewer
+        # Run when review-this label is added OR openhands-agent is requested as reviewer
         if: |
             github.event.label.name == 'review-this' ||
-            (github.event.requested_reviewer != null && 
-             (github.event.requested_reviewer.login == 'OpenHands' || 
-              github.event.requested_reviewer.login == 'OpenHands-agent'))
+            github.event.requested_reviewer.login == 'openhands-agent'
         runs-on: ubuntu-latest
         env:
             # Configuration (modify these values as needed)


### PR DESCRIPTION
## Description

This PR adds support for triggering the PR review workflow by requesting **OpenHands** or **OpenHands-agent** as a reviewer, in addition to the existing label-based trigger.

## Changes

### Workflow Configuration
- Updated `.github/workflows/pr-review-by-openhands.yml` to trigger on `review_requested` events
- Modified job condition to check for reviewer username (`OpenHands` or `OpenHands-agent`) in addition to the `review-this` label
- Enhanced security documentation explaining both methods are safe

### Documentation
- Updated `examples/03_github_workflows/02_pr_review/README.md` with instructions for both trigger methods
- Updated `examples/03_github_workflows/02_pr_review/workflow.yml` to match the production workflow

## How It Works

Users can now trigger the PR review workflow in two ways:

1. **Label-based (existing)**: Add the `review-this` label to a PR
2. **Reviewer-based (new)**: Request OpenHands or OpenHands-agent as a reviewer

Both methods are equally secure:
- Adding labels requires write access to the repository
- Requesting reviewers also requires write access to the repository
- This ensures only authorized users (maintainers/collaborators) can trigger the AI review

## Security Considerations

✅ **Safe for open-source repositories**: Both trigger methods use `pull_request_target`, which runs in the context of the base repository, not the fork. This prevents malicious code in PRs from accessing secrets.

✅ **Access control**: GitHub only allows users with write access to add labels or request reviewers, so average contributors cannot trigger the workflow.

## Testing

- ✅ YAML syntax validated
- ✅ Pre-commit hooks passed
- ✅ Documentation updated

## Related Issue

Closes #1036

## Checklist

- [x] Changes maintain backward compatibility (existing label trigger still works)
- [x] Documentation updated
- [x] Security considerations addressed
- [x] Pre-commit hooks passed

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/641a861a187e497ebe74045c6d3b8d6e)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b64c0cc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b64c0cc-python \
  ghcr.io/openhands/agent-server:b64c0cc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b64c0cc-golang-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary-amd64
ghcr.io/openhands/agent-server:b64c0cc-golang-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_golang_tag_1.21-bookworm_binary-arm64
ghcr.io/openhands/agent-server:b64c0cc-java-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary-amd64
ghcr.io/openhands/agent-server:b64c0cc-java-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_eclipse-temurin_tag_17-jdk_binary-arm64
ghcr.io/openhands/agent-server:b64c0cc-python-amd64
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-amd64
ghcr.io/openhands/agent-server:b64c0cc-python-arm64
ghcr.io/openhands/agent-server:v1.0.0a5_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-arm64
ghcr.io/openhands/agent-server:b64c0cc-golang
ghcr.io/openhands/agent-server:b64c0cc-java
ghcr.io/openhands/agent-server:b64c0cc-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b64c0cc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b64c0cc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->