### PR TITLE
Switch LLM profiles

### DIFF
--- a/examples/01_standalone_sdk/26_runtime_llm_switch.py
+++ b/examples/01_standalone_sdk/26_runtime_llm_switch.py
@@ -1,0 +1,125 @@
+"""Demonstrate switching LLM profiles at runtime and persisting the result."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from openhands.sdk import LLM, Agent, Conversation, LLMRegistry, Message, TextContent
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+# ---------------------------------------------------------------------------
+# Prerequisites
+# ---------------------------------------------------------------------------
+# 1. Configure the API key for the provider you want to use
+api_key = os.getenv("LLM_API_KEY")
+assert api_key is not None, "LLM_API_KEY environment variable is not set."
+
+# 2. Disable inline conversations so profile references are stored instead
+os.environ.setdefault("OPENHANDS_INLINE_CONVERSATIONS", "false")
+
+# 3. Profiles live under ~/.openhands/llm-profiles by default. We create two
+#    variants that share the same service_id so they can be swapped at runtime.
+registry = LLMRegistry()
+service_id = "support-agent"
+
+base_profile_id = "support-mini"
+alt_profile_id = "support-pro"
+
+base_llm = LLM(
+    service_id=service_id,
+    model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",
+    base_url="https://llm-proxy.eval.all-hands.dev",
+    api_key=SecretStr(api_key),
+    temperature=0.0,
+)
+alt_llm = base_llm.model_copy(
+    update={
+        "model": "litellm_proxy/anthropic/claude-3-5-sonnet-20240620",
+        "temperature": 0.4,
+    }
+)
+
+registry.save_profile(base_profile_id, base_llm)
+registry.save_profile(alt_profile_id, alt_llm)
+
+logger.info("Saved profiles %s and %s", base_profile_id, alt_profile_id)
+
+# ---------------------------------------------------------------------------
+# Start a conversation with the base profile and persist it to disk
+# ---------------------------------------------------------------------------
+conversation_id = uuid.uuid4()
+persistence_dir = Path("./.conversations_switch_demo").resolve()
+workspace_dir = Path.cwd()
+
+agent = Agent(llm=registry.load_profile(base_profile_id), tools=[])
+conversation = Conversation(
+    agent=agent,
+    workspace=str(workspace_dir),
+    persistence_dir=str(persistence_dir),
+    conversation_id=conversation_id,
+    visualize=False,
+)
+
+conversation.send_message(
+    Message(
+        role="user",
+        content=[TextContent(text="What model are you using? Keep it short.")],
+    )
+)
+conversation.run()
+
+print("First run finished with profile:", conversation.agent.llm.profile_id)
+
+# ---------------------------------------------------------------------------
+# Switch to the alternate profile while the conversation is idle
+# ---------------------------------------------------------------------------
+conversation.switch_llm(alt_profile_id)
+print("Switched runtime profile to:", conversation.agent.llm.profile_id)
+
+conversation.send_message(
+    Message(
+        role="user", content=[TextContent(text="Now say hello using the new profile.")]
+    )
+)
+conversation.run()
+
+print("Second run finished with profile:", conversation.agent.llm.profile_id)
+
+# Verify the persistence artefacts mention the new profile
+base_state_path = Path(conversation.state.persistence_dir or ".") / "base_state.json"
+print("base_state.json saved to:", base_state_path)
+state_payload = json.loads(base_state_path.read_text())
+print("Persisted profile entry:", state_payload["agent"]["llm"])
+
+# ---------------------------------------------------------------------------
+# Delete the in-memory conversation and reload from disk
+# ---------------------------------------------------------------------------
+print("\nReloading conversation from disk...")
+del conversation
+
+reloaded_agent = Agent(llm=registry.load_profile(alt_profile_id), tools=[])
+reloaded = Conversation(
+    agent=reloaded_agent,
+    workspace=str(workspace_dir),
+    persistence_dir=str(persistence_dir),
+    conversation_id=conversation_id,
+    visualize=False,
+)
+
+print("Reloaded conversation is using profile:", reloaded.state.agent.llm.profile_id)
+print("Active LLM model:", reloaded.state.agent.llm.model)
+
+reloaded.send_message(
+    Message(role="user", content=[TextContent(text="Confirm you survived a reload.")])
+)
+reloaded.run()
+
+print("Reloaded run finished with profile:", reloaded.state.agent.llm.profile_id)

--- a/examples/01_standalone_sdk/26_runtime_llm_switch.py
+++ b/examples/01_standalone_sdk/26_runtime_llm_switch.py
@@ -26,15 +26,15 @@ assert api_key is not None, "LLM_API_KEY environment variable is not set."
 os.environ.setdefault("OPENHANDS_INLINE_CONVERSATIONS", "false")
 
 # 3. Profiles live under ~/.openhands/llm-profiles by default. We create two
-#    variants that share the same service_id so they can be swapped at runtime.
+#    variants that share the same usage_id so they can be swapped at runtime.
 registry = LLMRegistry()
-service_id = "support-agent"
+usage_id = "support-agent"
 
 base_profile_id = "support-mini"
 alt_profile_id = "support-pro"
 
 base_llm = LLM(
-    service_id=service_id,
+    usage_id=usage_id,
     model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",
     base_url="https://llm-proxy.eval.all-hands.dev",
     api_key=SecretStr(api_key),
@@ -65,7 +65,7 @@ conversation = Conversation(
     workspace=str(workspace_dir),
     persistence_dir=str(persistence_dir),
     conversation_id=conversation_id,
-    visualize=False,
+    visualizer=None,
 )
 
 conversation.send_message(
@@ -111,7 +111,7 @@ reloaded = Conversation(
     workspace=str(workspace_dir),
     persistence_dir=str(persistence_dir),
     conversation_id=conversation_id,
-    visualize=False,
+    visualizer=None,
 )
 
 print("Reloaded conversation is using profile:", reloaded.state.agent.llm.profile_id)
@@ -140,7 +140,7 @@ inline_conversation = Conversation(
     workspace=str(workspace_dir),
     persistence_dir=str(inline_persistence_dir),
     conversation_id=uuid.uuid4(),
-    visualize=False,
+    visualizer=None,
 )
 
 try:

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -366,6 +366,13 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             )
         return reconciled
 
+    def _clone_with_llm(self, llm: LLM) -> "AgentBase":
+        """Return a copy of this agent with ``llm`` swapped in."""
+
+        clone = self.model_copy(update={"llm": llm})
+        clone._tools = dict(self._tools)
+        return clone
+
     def model_dump_succint(self, **kwargs):
         """Like model_dump, but excludes None fields by default."""
         if "exclude_none" not in kwargs:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -250,6 +250,18 @@ class LocalConversation(BaseConversation):
         """Get the stuck detector instance if enabled."""
         return self._stuck_detector
 
+    def switch_llm(self, profile_id: str) -> None:
+        """Switch the active agent LLM to ``profile_id`` at runtime."""
+
+        with self._state:
+            self._state.switch_agent_llm(profile_id, registry=self.llm_registry)
+            self.agent = self._state.agent
+        logger.info(
+            "Switched conversation %s to profile %s",
+            self._state.id,
+            profile_id,
+        )
+
     @observe(name="conversation.send_message")
     def send_message(self, message: str | Message, sender: str | None = None) -> None:
         """Send a message to the agent.

--- a/openhands-sdk/openhands/sdk/llm/llm_registry.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_registry.py
@@ -128,6 +128,27 @@ class LLMRegistry:
         safe_id = self._ensure_safe_profile_id(profile_id)
         return self.profile_dir / f"{safe_id}.json"
 
+    def switch_profile(self, usage_id: str, profile_id: str) -> LLM:
+        """Replace ``usage_id``'s active LLM with ``profile_id`` and return it."""
+
+        if usage_id not in self._usage_to_llm:
+            raise KeyError(f"Usage ID '{usage_id}' not found in registry")
+
+        current_llm = self._usage_to_llm[usage_id]
+        safe_id = self._ensure_safe_profile_id(profile_id)
+        if getattr(current_llm, "profile_id", None) == safe_id:
+            return current_llm
+
+        llm = self.load_profile(safe_id)
+        llm = llm.model_copy(update={"usage_id": usage_id})
+        self._usage_to_llm[usage_id] = llm
+        self.notify(RegistryEvent(llm=llm))
+        logger.info(
+            f"[LLM registry {self.registry_id}]: Switched usage {usage_id} "
+            f"to profile {safe_id}"
+        )
+        return llm
+
     def load_profile(self, profile_id: str) -> LLM:
         """Load profile_id from disk and return an LLM."""
 

--- a/tests/sdk/conversation/local/test_state_serialization.py
+++ b/tests/sdk/conversation/local/test_state_serialization.py
@@ -674,7 +674,7 @@ def test_local_conversation_switch_llm_persists_profile(tmp_path, monkeypatch):
         agent=agent,
         workspace=str(workspace_dir),
         persistence_dir=str(persistence_dir),
-        visualize=False,
+        visualizer=None,
     )
     assert isinstance(conversation, LocalConversation)
 
@@ -697,7 +697,7 @@ def test_local_conversation_switch_llm_persists_profile(tmp_path, monkeypatch):
         workspace=str(workspace_dir),
         persistence_dir=str(persistence_dir),
         conversation_id=conversation.id,
-        visualize=False,
+        visualizer=None,
     )
     assert isinstance(reloaded, LocalConversation)
     assert reloaded.state.agent.llm.profile_id == "alt"
@@ -719,7 +719,7 @@ def test_local_conversation_switch_llm_inline_mode_rejected(tmp_path, monkeypatc
         agent=agent,
         workspace=str(tmp_path / "workspace"),
         persistence_dir=str(tmp_path / "persist"),
-        visualize=False,
+        visualizer=None,
     )
     assert isinstance(conversation, LocalConversation)
 
@@ -743,7 +743,7 @@ def test_local_conversation_switch_llm_requires_idle(tmp_path, monkeypatch):
         agent=agent,
         workspace=str(tmp_path / "workspace"),
         persistence_dir=str(tmp_path / "persist"),
-        visualize=False,
+        visualizer=None,
     )
     assert isinstance(conversation, LocalConversation)
 

--- a/tests/sdk/llm/test_llm_registry_profiles.py
+++ b/tests/sdk/llm/test_llm_registry_profiles.py
@@ -344,6 +344,7 @@ def test_profile_serialization_mode_reference_only(tmp_path):
     assert "model" not in ref_data
     assert "usage_id" not in ref_data
 
+
 def test_switch_profile_replaces_active_llm(tmp_path):
     registry = LLMRegistry(profile_dir=tmp_path)
     base_llm = LLM(model="gpt-4o-mini", usage_id="primary")


### PR DESCRIPTION
## Summary
- add runtime LLM profile switching support for local conversations
- document the workflow and provide an example script
- enforce safe switching: only when conversation is idle (not RUNNING)

## Testing
- unit tests via pre-commit hooks


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3148251-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3148251-python \
  ghcr.io/openhands/agent-server:3148251-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3148251-golang-amd64
ghcr.io/openhands/agent-server:3148251-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3148251-golang-arm64
ghcr.io/openhands/agent-server:3148251-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3148251-java-amd64
ghcr.io/openhands/agent-server:3148251-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3148251-java-arm64
ghcr.io/openhands/agent-server:3148251-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3148251-python-amd64
ghcr.io/openhands/agent-server:3148251-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3148251-python-arm64
ghcr.io/openhands/agent-server:3148251-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3148251-golang
ghcr.io/openhands/agent-server:3148251-java
ghcr.io/openhands/agent-server:3148251-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3148251-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3148251-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->


Docs PR (documents new examples for check-examples): OpenHands/docs#219

