### PR TITLE
Remove default path from ENV_ROOT assignment

### DIFF
--- a/scripts/conversation_viewer.py
+++ b/scripts/conversation_viewer.py
@@ -31,9 +31,7 @@ from typing import Any
 import streamlit as st
 
 
-ENV_ROOT = os.getenv(
-    "OPENHANDS_CONVERSATIONS_ROOT", "/home/xingyaow/.openhands/conversation"
-)
+ENV_ROOT = os.getenv("OPENHANDS_CONVERSATIONS_ROOT")
 DEFAULT_CONVERSATIONS_ROOT = (
     Path(ENV_ROOT).expanduser()
     if ENV_ROOT


### PR DESCRIPTION
The OPENHANDS_CONVERSATIONS_ROOT environment variable no longer falls back to a hardcoded default path. This change ensures that the path is only set if the environment variable is present.