### PR TITLE
Use shell:bash in run-examples workflow

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -41,6 +41,7 @@ jobs:
               run: uv sync --frozen --group dev
 
             - name: Run examples
+              shell: bash
               env:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
                   LLM_MODEL: openhands/claude-haiku-4-5-20251001
@@ -60,7 +61,6 @@ jobs:
                   # - 16_llm_security_analyzer.py: requires user input
                   # - 04_convo_with_api_sandboxed_server.py: requires sandbox API keys
                   # - 04_vscode_with_docker_sandboxed_server.py: requires VSCode setup
-                  set -e
                   EXAMPLES=(
                       "examples/01_standalone_sdk/02_custom_tools.py"
                       "examples/01_standalone_sdk/03_activate_skill.py"
@@ -286,6 +286,7 @@ jobs:
             - name: Read examples report for issue comment
               if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
               id: read_report
+              shell: bash
               run: |
                   if [ -f examples_report.md ]; then
                       REPORT_CONTENT=$(cat examples_report.md)


### PR DESCRIPTION
## Summary

This PR implements Ray's suggestion to use `shell: bash` in the GitHub Actions workflow for running examples. This ensures that failures won't get masked by automatically applying `set -euo pipefail`.

## Changes

1. **Added `shell: bash` to the "Run examples" step**: This is the main long-running script that tests all examples with a real LLM
2. **Removed redundant `set -e`**: Since `shell: bash` automatically applies `set -euo pipefail` (which includes `-e` plus additional safety flags), the explicit `set -e` is no longer needed
3. **Added `shell: bash` to the "Read examples report" step**: For consistency and safety in bash script execution

## Benefits

- **Better error handling**: The `-e` flag ensures the script exits on any command failure
- **Stricter variable checking**: The `-u` flag treats unset variables as errors
- **Pipefail safety**: The `-o pipefail` option ensures that failures in piped commands are not masked

## Context

From the conversation thread, Ray noted:

> BTW when using a long script in a GitHub action, you usually want to use `shell: bash` which adds
> ```set -euo pipefail```
> So failures won't get masked.

This change follows that best practice recommendation.

## Testing

- ✅ Pre-commit hooks passed (yamlfmt)
- The workflow syntax remains valid (no changes to the actual script logic)

Co-authored-by: openhands <openhands@all-hands.dev>

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0ad4df971f4e4ffcaf665d62bd1ac57d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:92d13d3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-92d13d3-python \
  ghcr.io/openhands/agent-server:92d13d3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:92d13d3-golang-amd64
ghcr.io/openhands/agent-server:v1.0.0_golang_tag_1.21-bookworm_binary-amd64
ghcr.io/openhands/agent-server:92d13d3-golang-arm64
ghcr.io/openhands/agent-server:v1.0.0_golang_tag_1.21-bookworm_binary-arm64
ghcr.io/openhands/agent-server:92d13d3-java-amd64
ghcr.io/openhands/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_binary-amd64
ghcr.io/openhands/agent-server:92d13d3-java-arm64
ghcr.io/openhands/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_binary-arm64
ghcr.io/openhands/agent-server:92d13d3-python-amd64
ghcr.io/openhands/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-amd64
ghcr.io/openhands/agent-server:92d13d3-python-arm64
ghcr.io/openhands/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-arm64
ghcr.io/openhands/agent-server:92d13d3-golang
ghcr.io/openhands/agent-server:92d13d3-java
ghcr.io/openhands/agent-server:92d13d3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `92d13d3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `92d13d3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->