### PR TITLE
fix race during cleanup

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -79,6 +79,11 @@ class LocalConversation(BaseConversation):
                                   which agent/conversation is speaking.
             stuck_detection: Whether to enable stuck detection
         """
+        super().__init__()  # Initialize with span tracking
+        # Mark cleanup as initiated as early as possible to avoid races or partially
+        # initialized instances during interpreter shutdown.
+        self._cleanup_initiated = False
+
         self.agent = agent
         if isinstance(workspace, str):
             workspace = LocalWorkspace(working_dir=workspace)
@@ -139,8 +144,6 @@ class LocalConversation(BaseConversation):
             secret_values: dict[str, SecretValue] = {k: v for k, v in secrets.items()}
             self.update_secrets(secret_values)
 
-        super().__init__()  # Initialize base class with span tracking
-        self._cleanup_initiated = False
         atexit.register(self.close)
         self._start_observability_span(str(desired_id))
 
@@ -384,7 +387,11 @@ class LocalConversation(BaseConversation):
             return
         self._cleanup_initiated = True
         logger.debug("Closing conversation and cleaning up tool executors")
-        self._end_observability_span()
+        try:
+            self._end_observability_span()
+        except AttributeError:
+            # Object may be partially constructed; span fields may be missing.
+            pass
         for tool in self.agent.tools_map.values():
             try:
                 executable_tool = tool.as_executable()


### PR DESCRIPTION
The agent was running a bunch of tests and said:
> Follow-up fix discovered and applied                                                                
> - During targeted test runs, I observed occasional AttributeError on cleanup when a conversation is  partially constructed (e.g., during interpreter shutdown or early __init__ failure). I hardened LocalConversation.close:                                                                            
>   - Use getattr(self, "_cleanup_initiated", False) to guard the early return                        
>   - Wrap self._end_observability_span() with try/except AttributeError                              
> - Re-ran targeted suite; warning disappeared and all tests passed

Instead of its getattr, this PR proposes just some switch in the order of execution at init
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fdba74f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fdba74f-python \
  ghcr.io/openhands/agent-server:fdba74f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fdba74f-golang-amd64
ghcr.io/openhands/agent-server:v1.0.0_golang_tag_1.21-bookworm_binary-amd64
ghcr.io/openhands/agent-server:fdba74f-golang-arm64
ghcr.io/openhands/agent-server:v1.0.0_golang_tag_1.21-bookworm_binary-arm64
ghcr.io/openhands/agent-server:fdba74f-java-amd64
ghcr.io/openhands/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_binary-amd64
ghcr.io/openhands/agent-server:fdba74f-java-arm64
ghcr.io/openhands/agent-server:v1.0.0_eclipse-temurin_tag_17-jdk_binary-arm64
ghcr.io/openhands/agent-server:fdba74f-python-amd64
ghcr.io/openhands/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-amd64
ghcr.io/openhands/agent-server:fdba74f-python-arm64
ghcr.io/openhands/agent-server:v1.0.0_nikolaik_s_python-nodejs_tag_python3.12-nodejs22_binary-arm64
ghcr.io/openhands/agent-server:fdba74f-golang
ghcr.io/openhands/agent-server:fdba74f-java
ghcr.io/openhands/agent-server:fdba74f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fdba74f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fdba74f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->