### PR TITLE
feat: add get_git_short_sha utility function

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -149,6 +149,29 @@ def _base_slug(image: str, max_len: int = 64) -> str:
     return kept + suffix
 
 
+def get_git_short_sha(repo_path: str | Path | None = None) -> str:
+    """
+    Get the short SHA (first 7 chars) of the current git commit.
+
+    Args:
+        repo_path: Path to the git repository. If None, uses current working directory.
+
+    Returns:
+        7-character short SHA, or "unknown" if git info cannot be determined.
+
+    Example:
+        >>> get_git_short_sha("/path/to/repo")
+        'c118297'
+    """
+    cwd = str(repo_path) if repo_path else None
+    try:
+        result = _run(["git", "rev-parse", "--verify", "HEAD"], cwd=cwd)
+        git_sha = result.stdout.strip()
+        return git_sha[:7] if git_sha else "unknown"
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
 def _git_info() -> tuple[str, str, str]:
     """
     Get git info (ref, sha, short_sha) for the current working directory.


### PR DESCRIPTION
## Summary

Add a public `get_git_short_sha()` utility function to compute the short SHA for any git repository. This allows downstream projects (like benchmarks) to explicitly compute the correct repository SHA instead of relying on the module-level `SHORT_SHA` constant which depends on import-time context.

## Motivation

The current `SHORT_SHA` constant is computed at module import time with `cwd=None`, making it context-dependent and potentially confusing. When the SDK is used as a submodule or in complex project structures, it's not always clear which repository's SHA will be computed.

## Changes

- Added `get_git_short_sha(repo_path)` function that explicitly computes SHA for a given directory
- Takes optional `repo_path` parameter (defaults to current directory)
- Returns 7-character short SHA or "unknown" if git info cannot be determined
- Reuses existing `_run()` infrastructure

## Usage Example

```python
from openhands.agent_server.docker.build import get_git_short_sha

# Get SHA from current directory
benchmarks_sha = get_git_short_sha()

# Get SHA from specific repository
sdk_sha = get_git_short_sha('/path/to/sdk')
```

## Benefits

1. **Explicit**: Callers explicitly compute SHA rather than relying on import-time side effects
2. **Flexible**: Works with any repository path, not just current directory
3. **Clear**: Makes it obvious which repository's SHA is being used
4. **Backward Compatible**: Existing `SHORT_SHA` constant remains unchanged

This is being used by OpenHands/benchmarks#51 to ensure images are tagged with the correct benchmarks repo commit.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/86944ef0e7ca4634b41a44b28a851a8a)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a70de7b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a70de7b-python \
  ghcr.io/openhands/agent-server:a70de7b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a70de7b-golang-amd64
ghcr.io/openhands/agent-server:a70de7b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a70de7b-golang-arm64
ghcr.io/openhands/agent-server:a70de7b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a70de7b-java-amd64
ghcr.io/openhands/agent-server:a70de7b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a70de7b-java-arm64
ghcr.io/openhands/agent-server:a70de7b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a70de7b-python-amd64
ghcr.io/openhands/agent-server:a70de7b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a70de7b-python-arm64
ghcr.io/openhands/agent-server:a70de7b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a70de7b-golang
ghcr.io/openhands/agent-server:a70de7b-java
ghcr.io/openhands/agent-server:a70de7b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a70de7b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a70de7b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->