### PR TITLE
Auto-create log directory for telemetry

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -217,10 +217,8 @@ class Telemetry(BaseModel):
         if not self.log_dir:
             return
         try:
-            # Only log if directory exists and is writable.
-            # Do not create directories implicitly.
-            if not os.path.isdir(self.log_dir):
-                raise FileNotFoundError(f"log_dir does not exist: {self.log_dir}")
+            # Create log directory if it doesn't exist
+            os.makedirs(self.log_dir, exist_ok=True)
             if not os.access(self.log_dir, os.W_OK):
                 raise PermissionError(f"log_dir is not writable: {self.log_dir}")
 


### PR DESCRIPTION
### Problem
When `log_completions=True` is set, logging silently fails if the directory doesn't exist:
- Users see a `UserWarning` at the end of the output.
- All logs for the entire session are lost

```python
llm = LLM(model="gpt-4", log_completions=True)
# UserWarning: Telemetry logging failed: log_dir does not exist: logs/completions
```

### Solution
Auto-create the log directory.

### Why This Approach?
1. **Better UX**: Users expect `log_completions=True` to work out of the box
2. **Fail fast**: Permission errors still raise immediately with clear messages
3. **Standard practice**: SDKs routinely create directories (cache dirs, config dirs, etc.)
4. **No data loss**: Previous behavior silently dropped all logs
