### PR TITLE
examples: add Laminar observability example

### DIFF
--- a/examples/01_standalone_sdk/27_observability_laminar.py
+++ b/examples/01_standalone_sdk/27_observability_laminar.py
@@ -18,10 +18,14 @@ from openhands.tools.terminal import TerminalTool
 # For non-Laminar OTLP backends, set OTEL_* variables instead.
 
 # Configure LLM and Agent
-llm_api_key = os.getenv("LLM_API_KEY")
+api_key = os.getenv("LLM_API_KEY")
+model = os.getenv("LLM_MODEL", "openhands/claude-sonnet-4-5-20250929")
+base_url = os.getenv("LLM_BASE_URL")
 llm = LLM(
-    model="anthropic/claude-sonnet-4-5-20250929",
-    api_key=SecretStr(llm_api_key) if llm_api_key else None,
+    model=model,
+    api_key=SecretStr(api_key) if api_key else None,
+    base_url=base_url,
+    usage_id="agent",
 )
 
 agent = Agent(


### PR DESCRIPTION
Add examples/01_standalone_sdk/27_observability_laminar.py to demonstrate Laminar + OTEL tracing.

- Minimal runnable script
- Works with LMNR_PROJECT_API_KEY
- Generates spans via TerminalTool

Co-authored-by: openhands <openhands@all-hands.dev>





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:35b1270-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-35b1270-python \
  ghcr.io/openhands/agent-server:35b1270-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:35b1270-golang-amd64
ghcr.io/openhands/agent-server:35b1270-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:35b1270-golang-arm64
ghcr.io/openhands/agent-server:35b1270-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:35b1270-java-amd64
ghcr.io/openhands/agent-server:35b1270-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:35b1270-java-arm64
ghcr.io/openhands/agent-server:35b1270-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:35b1270-python-amd64
ghcr.io/openhands/agent-server:35b1270-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:35b1270-python-arm64
ghcr.io/openhands/agent-server:35b1270-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:35b1270-golang
ghcr.io/openhands/agent-server:35b1270-java
ghcr.io/openhands/agent-server:35b1270-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `35b1270-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `35b1270-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->