### PR TITLE
Skip visualizing ConversationStateUpdateEvent in default visualizer

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
@@ -10,6 +10,7 @@ from openhands.sdk.conversation.visualizer.base import (
 from openhands.sdk.event import (
     ActionEvent,
     AgentErrorEvent,
+    ConversationStateUpdateEvent,
     MessageEvent,
     ObservationEvent,
     PauseEvent,
@@ -265,6 +266,9 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
                 padding=_PANEL_PADDING,
                 expand=True,
             )
+        elif isinstance(event, ConversationStateUpdateEvent):
+            # Skip visualizing conversation state updates - these are internal events
+            return None
         else:
             # Fallback panel for unknown event types
             title = f"[bold {_ERROR_COLOR}]"

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -12,6 +12,7 @@ from openhands.sdk.event import (
     ActionEvent,
     AgentErrorEvent,
     CondensationRequest,
+    ConversationStateUpdateEvent,
     MessageEvent,
     ObservationEvent,
     PauseEvent,
@@ -411,3 +412,13 @@ def test_event_base_fallback_visualize():
 
     text_content = result.plain
     assert "Unknown event type: UnknownEvent" in text_content
+
+
+def test_visualizer_conversation_state_update_event_skipped():
+    """Test that ConversationStateUpdateEvent is not visualized."""
+    visualizer = DefaultConversationVisualizer()
+    event = ConversationStateUpdateEvent(key="execution_status", value="finished")
+
+    panel = visualizer._create_event_panel(event)
+    # Should return None to skip visualization
+    assert panel is None


### PR DESCRIPTION
## Overview
This PR fixes the issue where `ConversationStateUpdateEvent` was being displayed as an "UNKNOWN Event" in red in the console output.

## Problem
`ConversationStateUpdateEvent` is an internal event used for syncing conversation state over websocket. It should not be displayed in the console output, but it was falling through to the "unknown event" handler in the default visualizer, resulting in red error messages like:

```
UNKNOWN Event: ConversationStateUpdateEvent
```

## Solution
Added explicit handling for `ConversationStateUpdateEvent` in the `DefaultConversationVisualizer._create_event_panel()` method to return `None`, which skips visualization entirely.

## Changes
- **Added**: Import of `ConversationStateUpdateEvent` in the default visualizer
- **Added**: Handler for `ConversationStateUpdateEvent` that returns `None` to skip visualization
- **Added**: Test case to verify the event is properly skipped

## Testing
- All existing visualizer tests pass
- New test case verifies that `ConversationStateUpdateEvent` is not visualized

## Before
![image](https://github.com/user-attachments/assets/a6e89c48-6826-4f2c-bcd1-47d9f9fecda9)

## After
No "UNKNOWN Event" messages for `ConversationStateUpdateEvent` - these internal state sync events are now silently skipped as intended.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/716cfe31423b4cf6a7b74f40cc279096)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ad16b8c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ad16b8c-python \
  ghcr.io/openhands/agent-server:ad16b8c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ad16b8c-golang-amd64
ghcr.io/openhands/agent-server:ad16b8c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ad16b8c-golang-arm64
ghcr.io/openhands/agent-server:ad16b8c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ad16b8c-java-amd64
ghcr.io/openhands/agent-server:ad16b8c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ad16b8c-java-arm64
ghcr.io/openhands/agent-server:ad16b8c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ad16b8c-python-amd64
ghcr.io/openhands/agent-server:ad16b8c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:ad16b8c-python-arm64
ghcr.io/openhands/agent-server:ad16b8c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:ad16b8c-golang
ghcr.io/openhands/agent-server:ad16b8c-java
ghcr.io/openhands/agent-server:ad16b8c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ad16b8c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ad16b8c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->