### PR TITLE
Include usage_id in LLM log events to preserve per-usage_id folders

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -235,18 +235,24 @@ class EventService:
     def _setup_llm_log_streaming(self, agent: Agent) -> None:
         """Configure LLM log callbacks to stream logs via events."""
 
-        def log_callback(filename: str, log_data: str) -> None:
-            """Callback to emit LLM completion logs as events."""
-            # Extract model name from filename (format: model__timestamp_uuid.json)
-            model_name = filename.split("-")[0].replace("__", "/")
-            event = LLMCompletionLogEvent(
-                filename=filename,
-                log_data=log_data,
-                model_name=model_name,
-            )
-            # Publish to all subscribers - schedule in the main event loop
-            if self._main_loop and self._main_loop.is_running():
-                asyncio.run_coroutine_threadsafe(self._pub_sub(event), self._main_loop)
+        def make_log_callback(usage_id: str):
+            def log_callback(filename: str, log_data: str) -> None:
+                """Callback to emit LLM completion logs as events."""
+                # Extract model name from filename (format: model__timestamp_uuid.json)
+                model_name = filename.split("-")[0].replace("__", "/")
+                event = LLMCompletionLogEvent(
+                    filename=filename,
+                    log_data=log_data,
+                    model_name=model_name,
+                    usage_id=usage_id,
+                )
+                # Publish to all subscribers - schedule in the main event loop
+                if self._main_loop and self._main_loop.is_running():
+                    asyncio.run_coroutine_threadsafe(
+                        self._pub_sub(event), self._main_loop
+                    )
+
+            return log_callback
 
         # Set callback for all LLMs in the agent that have logging enabled
         for llm in agent.get_all_llms():
@@ -254,7 +260,7 @@ class EventService:
                 # Access telemetry safely
                 telemetry = getattr(llm, "telemetry", None)
                 if telemetry is not None:
-                    telemetry.set_log_callback(log_callback)
+                    telemetry.set_log_callback(make_log_callback(llm.usage_id))
 
     def _setup_stats_streaming(self, agent: Agent) -> None:
         """Configure stats update callbacks to stream stats changes via events."""

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -568,11 +568,12 @@ class RemoteConversation(BaseConversation):
             # to match it against configured LLMs
             log_dir = None
 
-            # First, try to match by usage_id if we can determine it
-            # Since we don't have usage_id in the event, we'll use the first
-            # matching log folder, or fall back to a default
-            if self._log_completion_folders:
-                # Use the first configured log folder (typically there's only one)
+            # Prefer usage_id provided by the event to select the correct folder
+            if isinstance(event, LLMCompletionLogEvent) and event.usage_id:
+                log_dir = self._log_completion_folders.get(event.usage_id)
+
+            # Fallback to the first configured log folder if usage_id unavailable
+            if not log_dir and self._log_completion_folders:
                 log_dir = next(iter(self._log_completion_folders.values()))
 
             if not log_dir:

--- a/openhands-sdk/openhands/sdk/event/llm_completion_log.py
+++ b/openhands-sdk/openhands/sdk/event/llm_completion_log.py
@@ -27,6 +27,13 @@ class LLMCompletionLogEvent(Event):
         default="unknown",
         description="The model name for context",
     )
+    usage_id: str = Field(
+        default="default",
+        description="The LLM usage_id that produced this log",
+    )
 
     def __str__(self) -> str:
-        return f"LLMCompletionLog(model={self.model_name}, file={self.filename})"
+        return (
+            f"LLMCompletionLog(usage_id={self.usage_id}, model={self.model_name}, "
+            f"file={self.filename})"
+        )


### PR DESCRIPTION
I'm OpenHands-GPT-5, proposing a focused fix to ensure LLM completion logs are routed to the correct client folders.

## Summary

- The original PR streams LLM completion logs but the event does not include `usage_id`. On the client, `RemoteConversation` keeps a `usage_id -> folder` map, so missing `usage_id` forces a fallback to the first folder, breaking the intended per-usage_id directory layout.

## What this PR changes

- Adds `usage_id` to `LLMCompletionLogEvent`
- In the agent server, captures `llm.usage_id` when setting the telemetry callback and includes it in the emitted event
- On the client, uses `event.usage_id` to pick the correct `log_completions_folder`, with a safe fallback for robustness

## Rationale

- We have direct access to `llm.usage_id` in `EventService` where callbacks are registered, so including it in the event is simple and reliable
- Avoids guessing from `model_name` (which is ambiguous when multiple LLMs share the same model string)
- Preserves the user’s original intent to store logs per `usage_id`

## Backward compatibility

- `LLMCompletionLogEvent` was introduced in the base PR; adding a field is backward-compatible within this change set and only affects the new streaming path

## Implementation notes

- Server-side: closure capture of `usage_id` in `_setup_llm_log_streaming` via `make_log_callback(usage_id)` keeps `Telemetry` generic and unchanged
- Client-side: `_create_llm_completion_log_callback` now selects the folder by `usage_id` first, then falls back to the first configured directory if needed

## Tests and quality

- Pre-commit hooks (ruff fmt/lint, pycodestyle, pyright) pass on changed files
- The change is minimal and focused; no unrelated edits

---

@enyst Could you please take a look? This should address the concern about identifying the correct log directory per `usage_id` while keeping the streaming approach intact.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3ef737de758c4ae1b7691ad29a1026f1)