### PR TITLE
bug[conversationState] Wrong value for security_analyzer in ConversationState

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -210,7 +210,7 @@ class ConversationState(OpenHandsModel):
             stuck_detection=stuck_detection,
         )
         # Record existing analyzer configuration in state
-        state.security_analyzer = state.security_analyzer
+        state.security_analyzer = agent.security_analyzer
         state._fs = file_store
         state._events = EventLog(file_store, dir_path=EVENTS_DIR)
         state.stats = ConversationStats()


### PR DESCRIPTION
Wrong value for security_analyzer in ConversationState – it should be taken from the agent