### PR TITLE
Enabling GPU support on Docker

### DIFF
--- a/openhands-workspace/openhands/workspace/docker/workspace.py
+++ b/openhands-workspace/openhands/workspace/docker/workspace.py
@@ -116,6 +116,10 @@ class DockerWorkspace(RemoteWorkspace):
         default=False,
         description="Whether to expose additional ports (VSCode, VNC).",
     )
+    enable_gpu: bool = Field(
+        default=False,
+        description="Whether to enable GPU support with --gpus all.",
+    )
 
     _container_id: str | None = PrivateAttr(default=None)
     _logs_thread: threading.Thread | None = PrivateAttr(default=None)
@@ -207,6 +211,10 @@ class DockerWorkspace(RemoteWorkspace):
                 f"{self.host_port + 2}:8002",  # Desktop VNC
             ]
         flags += ports
+
+        # Add GPU support if enabled
+        if self.enable_gpu:
+            flags += ["--gpus", "all"]
 
         # Run container
         run_cmd = [


### PR DESCRIPTION
**Testing**: Tested this change out by running a unit test that prints the output for 'nvidia-smi' command when the flag is enabled. 

![WhatsApp Image 2025-11-15 at 18 24 28](https://github.com/user-attachments/assets/2464dd0a-c1ea-459b-8e0a-90dc29628034)

**Test Script**
`from openhands.workspace import DockerWorkspace
with DockerWorkspace(base_image="python:3.12", enable_gpu=True) as workspace:
    print(workspace.execute_command("nvidia-smi"))`