### PR TITLE
chore(workflow): restrict auto-assigned reviewers to maintainers (write+)

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -96,7 +96,7 @@ jobs:
                 requesting review:
                    - Preferred: GET /repos/{owner}/{repo}/collaborators (no permission filter). Filter client-side using either:
                      role_name in ["write", "maintain", "admin"] OR permissions.push || permissions.admin. Note: paginate if > 30 collaborators.
-                   - Alternative: GET /repos/{owner}/{repo}/collaborators/{username}/permission and accept if permission ∈ {push, maintain, admin}.
+                   - Alternative: GET /repos/{owner}/{repo}/collaborators/{username}/permission and accept if permission in {push, maintain, admin}.
                 3) If multiple maintainers qualify, avoid assigning too many reviews to any single one.
                 4) Request review from exactly one maintainer and add this message:
 


### PR DESCRIPTION
This updates the Assign Reviews workflow to ensure that only maintainers (write/maintain/admin) are auto-requested as reviewers.

Changes
- Clarify reviewer selection: collaborators with write+ permissions
- Ask for GitHub API checks to verify permissions before requesting review

Rationale
Without restricting to maintainers, the LLM might assign contributors whose approvals do not count toward the required single approval for merging, leading to stalled PRs.

Notes
- No runtime logic changes; prompt-only adjustment inside .github/workflows/assign-reviews.yml
- Pre-commit YAML formatting ran and passed

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/67ba8cfa3dee47dca5fdb2e9f7539fa2)







<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:13c4b55-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-13c4b55-python \
  ghcr.io/openhands/agent-server:13c4b55-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:13c4b55-golang-amd64
ghcr.io/openhands/agent-server:13c4b55-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:13c4b55-golang-arm64
ghcr.io/openhands/agent-server:13c4b55-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:13c4b55-java-amd64
ghcr.io/openhands/agent-server:13c4b55-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:13c4b55-java-arm64
ghcr.io/openhands/agent-server:13c4b55-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:13c4b55-python-amd64
ghcr.io/openhands/agent-server:13c4b55-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:13c4b55-python-arm64
ghcr.io/openhands/agent-server:13c4b55-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:13c4b55-golang
ghcr.io/openhands/agent-server:13c4b55-java
ghcr.io/openhands/agent-server:13c4b55-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `13c4b55-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `13c4b55-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->