### PR TITLE
fix: add UTF-8 encoding and ensure_ascii=False for JSON telemetry logs

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -297,8 +297,8 @@ class Telemetry(BaseModel):
                 and "tools" in data["kwargs"]
             ):
                 data["kwargs"].pop("tools")
-            with open(fname, "w") as f:
-                f.write(json.dumps(data, default=_safe_json))
+            with open(fname, "w", encoding="utf-8") as f:
+                f.write(json.dumps(data, default=_safe_json, ensure_ascii=False))
         except Exception as e:
             warnings.warn(f"Telemetry logging failed: {e}")
 


### PR DESCRIPTION
## Summary

Fix non-ASCII character support in telemetry JSON log files by adding explicit UTF-8 encoding and disabling ASCII escaping.

## Problem

When LLM prompts or responses contain non-ASCII characters (Chinese, Japanese, Korean, etc.), the telemetry log files become difficult to read because:

1. `open()` is called without specifying `encoding="utf-8"`, causing the file to use system default encoding
2. `json.dumps()` is called without `ensure_ascii=False`, causing characters to be escaped as `\uXXXX`

**Example of current behavior:**
```json
{"prompt": "\\u4f60\\u662f\\u4e00\\u4e2a\\u667a\\u80fd\\u52a9\\u624b"}
```

**Expected behavior:**
```json
{"prompt": "你是一个智能助手"}
```

## Solution

Modified `openhands/sdk/llm/utils/telemetry.py` line 300-301:

```python
# Before
with open(fname, "w") as f:
    f.write(json.dumps(data, default=_safe_json))

# After
with open(fname, "w", encoding="utf-8") as f:
    f.write(json.dumps(data, default=_safe_json, ensure_ascii=False))
```

## Testing

1. Create an LLM call with non-ASCII text in the prompt
2. Check the generated JSON log file in `llm_log_dir`
3. Verify that non-ASCII characters are displayed correctly (not escaped)