### PR TITLE
Fix for broken build tests

### DIFF
--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -32,7 +32,7 @@ def mock_event_service():
     with tempfile.TemporaryDirectory() as temp_dir:
         temp_path = Path(temp_dir)
         # Mock httpx.get to prevent HTTP calls to staging server during LLM init
-        with patch("openhands.sdk.llm.llm.httpx.get") as mock_get:
+        with patch("openhands.sdk.llm.utils.model_info.httpx.get") as mock_get:
             mock_get.return_value = MagicMock(json=lambda: {"data": []})
             service = EventService(
                 stored=StoredConversation(


### PR DESCRIPTION
Fix for broken tests in the main branch (I thought I had fixed these as part of a PR last week, so either I goofed or there was some sort of merge error).
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6118baf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6118baf-python \
  ghcr.io/openhands/agent-server:6118baf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6118baf-golang-amd64
ghcr.io/openhands/agent-server:6118baf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6118baf-golang-arm64
ghcr.io/openhands/agent-server:6118baf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6118baf-java-amd64
ghcr.io/openhands/agent-server:6118baf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6118baf-java-arm64
ghcr.io/openhands/agent-server:6118baf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6118baf-python-amd64
ghcr.io/openhands/agent-server:6118baf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6118baf-python-arm64
ghcr.io/openhands/agent-server:6118baf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6118baf-golang
ghcr.io/openhands/agent-server:6118baf-java
ghcr.io/openhands/agent-server:6118baf-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6118baf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6118baf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->