### PR TITLE
only include HTTP exc_info when DEBUG mode is on

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -27,7 +27,7 @@ from openhands.sdk.event.conversation_state import (
     ConversationStateUpdateEvent,
 )
 from openhands.sdk.llm import LLM, Message, TextContent
-from openhands.sdk.logger import get_logger
+from openhands.sdk.logger import DEBUG, get_logger
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
@@ -67,7 +67,7 @@ def _send_request(
         )
         raise e
     except httpx.RequestError as e:
-        logger.error(f"Request failed: {e}", exc_info=True)
+        logger.error(f"Request failed: {e}", exc_info=DEBUG)
         raise e
 
 


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:72586bf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-72586bf-python \
  ghcr.io/openhands/agent-server:72586bf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:72586bf-golang-amd64
ghcr.io/openhands/agent-server:72586bf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:72586bf-golang-arm64
ghcr.io/openhands/agent-server:72586bf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:72586bf-java-amd64
ghcr.io/openhands/agent-server:72586bf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:72586bf-java-arm64
ghcr.io/openhands/agent-server:72586bf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:72586bf-python-amd64
ghcr.io/openhands/agent-server:72586bf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:72586bf-python-arm64
ghcr.io/openhands/agent-server:72586bf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:72586bf-golang
ghcr.io/openhands/agent-server:72586bf-java
ghcr.io/openhands/agent-server:72586bf-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `72586bf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `72586bf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->