### PR TITLE
Fix for issue where cipher was not set on deserialize

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -329,7 +329,12 @@ class ConversationService:
                 if not meta_file.exists():
                     continue
                 json_str = meta_file.read_text()
-                stored = StoredConversation.model_validate_json(json_str)
+                stored = StoredConversation.model_validate_json(
+                    json_str,
+                    context={
+                        "cipher": self.cipher,
+                    },
+                )
                 await self._start_event_service(stored)
             except Exception:
                 logger.exception(


### PR DESCRIPTION
This results in errors like the following when trying to restart a remote runtime:
```
litellm.AuthenticationError: AuthenticationError: Litellm_proxyException - Authentication Error, LiteLLM Virtual Key expected. Received=gAAAAAB...=, expected to start with 'sk-'."
```
<img width="1416" height="464" alt="image" src="https://github.com/user-attachments/assets/ea632343-337f-40bb-8e3d-6b9fe518f8fa" />

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:54e678b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-54e678b-python \
  ghcr.io/openhands/agent-server:54e678b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:54e678b-golang-amd64
ghcr.io/openhands/agent-server:54e678b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:54e678b-golang-arm64
ghcr.io/openhands/agent-server:54e678b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:54e678b-java-amd64
ghcr.io/openhands/agent-server:54e678b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:54e678b-java-arm64
ghcr.io/openhands/agent-server:54e678b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:54e678b-python-amd64
ghcr.io/openhands/agent-server:54e678b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:54e678b-python-arm64
ghcr.io/openhands/agent-server:54e678b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:54e678b-golang
ghcr.io/openhands/agent-server:54e678b-java
ghcr.io/openhands/agent-server:54e678b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `54e678b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `54e678b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->