### PR TITLE
Fix datetime.utcnow() deprecation warning

### DIFF
--- a/tests/integration/utils/consolidate_results.py
+++ b/tests/integration/utils/consolidate_results.py
@@ -11,7 +11,7 @@ import json
 import os
 import re
 import sys
-from datetime import datetime
+from datetime import UTC, datetime
 
 from tests.integration.utils.format_costs import format_cost
 
@@ -54,7 +54,7 @@ def process_result_file(filepath):
 
 def generate_report(results, trigger_text, commit_sha):
     """Generate the consolidated markdown report."""
-    timestamp = datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+    timestamp = datetime.now(UTC).strftime("%Y-%m-%d %H:%M UTC")
 
     # Calculate total cost
     total_cost = sum(result.get("total_cost", 0.0) for result in results)


### PR DESCRIPTION
## Summary

This PR fixes the deprecation warning for `datetime.utcnow()` which is scheduled for removal in a future Python version.

## Changes Made

- **Updated import**: Added `UTC` to the datetime import in `tests/integration/utils/consolidate_results.py`
- **Replaced deprecated method**: Changed `datetime.utcnow()` to `datetime.now(UTC)` on line 57

## Details

The deprecation warning was:
```
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC).
```

The fix follows the recommended approach from the warning message and uses the modern timezone-aware datetime approach.

## Testing

- ✅ All pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright)
- ✅ Verified the function works correctly without deprecation warnings
- ✅ No functional changes - the behavior remains identical

## Files Changed

- `tests/integration/utils/consolidate_results.py`: Updated datetime usage to use modern timezone-aware approach

## Backward Compatibility

This change maintains full backward compatibility. The output format and functionality remain exactly the same, only the internal implementation uses the modern datetime API.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/86ba3320a9ac4b69a55875de58e06b05)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a3ac878-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a3ac878-python \
  ghcr.io/openhands/agent-server:a3ac878-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a3ac878-golang-amd64
ghcr.io/openhands/agent-server:a3ac878-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a3ac878-golang-arm64
ghcr.io/openhands/agent-server:a3ac878-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a3ac878-java-amd64
ghcr.io/openhands/agent-server:a3ac878-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a3ac878-java-arm64
ghcr.io/openhands/agent-server:a3ac878-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a3ac878-python-amd64
ghcr.io/openhands/agent-server:a3ac878-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a3ac878-python-arm64
ghcr.io/openhands/agent-server:a3ac878-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a3ac878-golang
ghcr.io/openhands/agent-server:a3ac878-java
ghcr.io/openhands/agent-server:a3ac878-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a3ac878-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a3ac878-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->