### PR TITLE
APP-156 Set skill default trigger to None

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -27,7 +27,13 @@ TriggerType = Annotated[
 
 
 class Skill(BaseModel):
-    """A skill provides specialized knowledge or functionality."""
+    """A skill provides specialized knowledge or functionality.
+
+    Skills use triggers to determine when they should be activated:
+    - None: Always active, for repository-specific guidelines
+    - KeywordTrigger: Activated when keywords appear in user messages
+    - TaskTrigger: Activated for specific tasks, may require user input
+    """
 
     name: str
     content: str


### PR DESCRIPTION
Set a default value of None for the Skill trigger - skills now default to always active. (And can be deserialized)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2349467-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2349467-python \
  ghcr.io/openhands/agent-server:2349467-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2349467-golang-amd64
ghcr.io/openhands/agent-server:2349467-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2349467-golang-arm64
ghcr.io/openhands/agent-server:2349467-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2349467-java-amd64
ghcr.io/openhands/agent-server:2349467-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2349467-java-arm64
ghcr.io/openhands/agent-server:2349467-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2349467-python-amd64
ghcr.io/openhands/agent-server:2349467-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2349467-python-arm64
ghcr.io/openhands/agent-server:2349467-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2349467-golang
ghcr.io/openhands/agent-server:2349467-java
ghcr.io/openhands/agent-server:2349467-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2349467-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2349467-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->