### PR TITLE
Prefix MCP tool action models to avoid kind collisions

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -108,9 +108,8 @@ def _create_mcp_action_type(action_type: mcp.types.Tool) -> type[Schema]:
     if mcp_action_type:
         return mcp_action_type
 
-    mcp_action_type = Schema.from_mcp_schema(
-        f"{to_camel_case(action_type.name)}Action", action_type.inputSchema
-    )
+    model_name = f"MCP{to_camel_case(action_type.name)}Action"
+    mcp_action_type = Schema.from_mcp_schema(model_name, action_type.inputSchema)
     _mcp_dynamic_action_type[action_type.name] = mcp_action_type
     return mcp_action_type
 


### PR DESCRIPTION
This PR is to:
- prepend `MCP` to dynamically generated action-model names  
- ensures MCP tools don’t clash with built-in tool kinds when the remote agent server starts

With this change, the `02_convo_with_docker_sandboxed_server.py` example with the Playwright MCP server can run successfully:

<img width="1242" height="857" alt="image" src="https://github.com/user-attachments/assets/5358a3c7-92e3-4b7f-adff-9a33c706e561" />

Issue: #1154
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:68bdcc3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-68bdcc3-python \
  ghcr.io/openhands/agent-server:68bdcc3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:68bdcc3-golang-amd64
ghcr.io/openhands/agent-server:68bdcc3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:68bdcc3-golang-arm64
ghcr.io/openhands/agent-server:68bdcc3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:68bdcc3-java-amd64
ghcr.io/openhands/agent-server:68bdcc3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:68bdcc3-java-arm64
ghcr.io/openhands/agent-server:68bdcc3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:68bdcc3-python-amd64
ghcr.io/openhands/agent-server:68bdcc3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:68bdcc3-python-arm64
ghcr.io/openhands/agent-server:68bdcc3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:68bdcc3-golang
ghcr.io/openhands/agent-server:68bdcc3-java
ghcr.io/openhands/agent-server:68bdcc3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `68bdcc3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `68bdcc3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->