### PR TITLE
Test logging (Do not merge!)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -189,11 +189,12 @@ def _add_exception_handlers(api: FastAPI) -> None:
     ) -> JSONResponse:
         """Handle unhandled exceptions."""
         # Always log that we're in the exception handler for debugging
-        print("TRACE!!!")
-        logger.exception(
-            "Exception handler called for {request.method} {request.url.path}",
-            exc_info=True,
-            stack_info=True,
+        logger.debug(
+            "Exception handler called for %s %s with %s: %s",
+            request.method,
+            request.url.path,
+            type(exc).__name__,
+            str(exc),
         )
 
         content = {


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b1d9685-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b1d9685-python \
  ghcr.io/openhands/agent-server:b1d9685-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b1d9685-golang-amd64
ghcr.io/openhands/agent-server:b1d9685-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b1d9685-golang-arm64
ghcr.io/openhands/agent-server:b1d9685-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b1d9685-java-amd64
ghcr.io/openhands/agent-server:b1d9685-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b1d9685-java-arm64
ghcr.io/openhands/agent-server:b1d9685-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b1d9685-python-amd64
ghcr.io/openhands/agent-server:b1d9685-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b1d9685-python-arm64
ghcr.io/openhands/agent-server:b1d9685-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b1d9685-golang
ghcr.io/openhands/agent-server:b1d9685-java
ghcr.io/openhands/agent-server:b1d9685-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b1d9685-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b1d9685-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->