### PR TITLE
Fix secrets bug: Convert strings to StaticSecret objects in RemoteConversation

### DIFF
--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -495,6 +495,29 @@ class TestRemoteConversation:
             "Should have made a POST call to secrets endpoint"
         )
 
+        # Verify the payload format - secrets should be wrapped in StaticSecret objects
+        secrets_call = request_calls[0]
+        payload = secrets_call.kwargs.get("json", {})
+        assert "secrets" in payload
+
+        # Check that each secret is properly formatted as StaticSecret
+        sent_secrets = payload["secrets"]
+        assert "api_key" in sent_secrets
+        assert "token" in sent_secrets
+
+        # Verify StaticSecret format
+        api_key_secret = sent_secrets["api_key"]
+        assert isinstance(api_key_secret, dict)
+        assert api_key_secret["kind"] == "StaticSecret"
+        assert api_key_secret["value"] == "secret_value"
+        assert "description" in api_key_secret
+
+        token_secret = sent_secrets["token"]
+        assert isinstance(token_secret, dict)
+        assert token_secret["kind"] == "StaticSecret"
+        assert token_secret["value"] == "another_secret"
+        assert "description" in token_secret
+
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
@@ -529,6 +552,30 @@ class TestRemoteConversation:
         assert len(request_calls) >= 1, (
             "Should have made a POST call to secrets endpoint"
         )
+
+        # Verify the payload format - secrets should be wrapped in StaticSecret objects
+        secrets_call = request_calls[0]
+        payload = secrets_call.kwargs.get("json", {})
+        assert "secrets" in payload
+
+        # Check that each secret is properly formatted as StaticSecret
+        sent_secrets = payload["secrets"]
+        assert "api_key" in sent_secrets
+        assert "callable_secret" in sent_secrets
+
+        # Verify StaticSecret format for string secret
+        api_key_secret = sent_secrets["api_key"]
+        assert isinstance(api_key_secret, dict)
+        assert api_key_secret["kind"] == "StaticSecret"
+        assert api_key_secret["value"] == "string_secret"
+        assert "description" in api_key_secret
+
+        # Verify StaticSecret format for callable secret (should be resolved)
+        callable_secret = sent_secrets["callable_secret"]
+        assert isinstance(callable_secret, dict)
+        assert callable_secret["kind"] == "StaticSecret"
+        assert callable_secret["value"] == "callable_secret_value"
+        assert "description" in callable_secret
 
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"


### PR DESCRIPTION
## Problem

Fixes a bug where string secrets passed to `RemoteConversation.update_secrets()` were causing 422 Unprocessable Entity errors. The server expects secrets to be wrapped in `StaticSecret` objects with a discriminated union format, but the client was sending plain strings.

**Error**: 
```
HTTP request failed (422 Unprocessable Entity): 
{'detail': [{'type': 'union_tag_invalid', 'loc': ['body', 'secrets', 'GITHUB_TOKEN'], 
'msg': "Input tag 'str' found using kind_of() does not match any of the expected tags: 'LookupSecret', 'StaticSecret'", 
'input': 'ghp_...', 'ctx': {'discriminator': 'kind_of()', 'tag': 'str', 'expected_tags': "'LookupSecret', 'StaticSecret'"}}]}
```

## Solution

- **Fixed `RemoteConversation.update_secrets()`** to automatically convert string secrets to `StaticSecret` objects using the existing `_wrap_secret()` helper function
- **Enhanced payload serialization** using `model_dump(context={"expose_secrets": True})` to ensure proper format
- **Maintains backward compatibility** with both string and callable secret values

## Changes

### Core Fix
- **File**: `openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py`
- **Method**: `update_secrets()` (lines 635-656)
- **Change**: Convert strings to `StaticSecret` objects before sending to server

**Before**: `{"API_KEY": "secret-value"}`  
**After**: `{"API_KEY": {"kind": "StaticSecret", "value": "secret-value", "description": null}}`

### Enhanced Tests
- **File**: `tests/sdk/conversation/remote/test_remote_conversation.py`
- **Enhancement**: Added comprehensive assertions to verify payload format matches server expectations
- **Coverage**: Tests both string and callable secret values

## Testing

- ✅ All existing tests pass (17/17 remote conversation tests)
- ✅ Pre-commit hooks pass (formatting, linting, type checking)
- ✅ Manual verification confirms strings are automatically converted to `StaticSecret` objects
- ✅ Backward compatibility maintained for both string and callable secrets

## Impact

This fix resolves the 422 error when using `RemoteWorkspace` with string secrets, ensuring seamless integration with the server API while maintaining the existing user interface.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/beb924d3d3534cf290e22d42101ac63d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:558bdc6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-558bdc6-python \
  ghcr.io/openhands/agent-server:558bdc6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:558bdc6-golang-amd64
ghcr.io/openhands/agent-server:558bdc6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:558bdc6-golang-arm64
ghcr.io/openhands/agent-server:558bdc6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:558bdc6-java-amd64
ghcr.io/openhands/agent-server:558bdc6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:558bdc6-java-arm64
ghcr.io/openhands/agent-server:558bdc6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:558bdc6-python-amd64
ghcr.io/openhands/agent-server:558bdc6-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:558bdc6-python-arm64
ghcr.io/openhands/agent-server:558bdc6-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:558bdc6-golang
ghcr.io/openhands/agent-server:558bdc6-java
ghcr.io/openhands/agent-server:558bdc6-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `558bdc6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `558bdc6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->