### PR TITLE
Add server-side automatic conversion of string secrets to StaticSecret

### DIFF
--- a/tests/agent_server/test_models.py
+++ b/tests/agent_server/test_models.py
@@ -1,0 +1,115 @@
+"""Tests for agent_server models."""
+
+from typing import Any
+
+import pytest
+from pydantic import SecretStr, ValidationError
+
+from openhands.agent_server.models import UpdateSecretsRequest
+from openhands.sdk.conversation.secret_source import LookupSecret, StaticSecret
+
+
+def test_update_secrets_request_string_conversion():
+    """Test that plain string secrets are converted to StaticSecret objects."""
+
+    # Test with plain string secrets
+    request = UpdateSecretsRequest(
+        secrets={  # type: ignore[arg-type]
+            "API_KEY": "plain-secret-value",
+            "TOKEN": "another-secret",
+        }
+    )
+
+    # Verify conversion happened
+    assert isinstance(request.secrets["API_KEY"], StaticSecret)
+    assert isinstance(request.secrets["TOKEN"], StaticSecret)
+
+    # Verify values are correct
+    assert request.secrets["API_KEY"].get_value() == "plain-secret-value"
+    assert request.secrets["TOKEN"].get_value() == "another-secret"
+
+
+def test_update_secrets_request_proper_secret_source():
+    """Test that properly formatted SecretSource objects are preserved."""
+
+    # Test with properly formatted SecretSource objects
+    request = UpdateSecretsRequest(
+        secrets={
+            "STATIC_SECRET": StaticSecret(value=SecretStr("static-value")),
+            "LOOKUP_SECRET": LookupSecret(url="https://example.com/secret"),
+        }
+    )
+
+    # Verify objects are preserved as-is
+    assert isinstance(request.secrets["STATIC_SECRET"], StaticSecret)
+    assert isinstance(request.secrets["LOOKUP_SECRET"], LookupSecret)
+
+    # Verify values
+    assert request.secrets["STATIC_SECRET"].get_value() == "static-value"
+    assert request.secrets["LOOKUP_SECRET"].url == "https://example.com/secret"
+
+
+def test_update_secrets_request_mixed_formats():
+    """Test that mixed formats (strings and SecretSource objects) work together."""
+
+    secrets_dict: dict[str, Any] = {
+        "PLAIN_SECRET": "plain-value",
+        "STATIC_SECRET": StaticSecret(value=SecretStr("static-value")),
+        "LOOKUP_SECRET": LookupSecret(url="https://example.com/secret"),
+    }
+    request = UpdateSecretsRequest(secrets=secrets_dict)  # type: ignore[arg-type]
+
+    # Verify all types are correct
+    assert isinstance(request.secrets["PLAIN_SECRET"], StaticSecret)
+    assert isinstance(request.secrets["STATIC_SECRET"], StaticSecret)
+    assert isinstance(request.secrets["LOOKUP_SECRET"], LookupSecret)
+
+    # Verify values
+    assert request.secrets["PLAIN_SECRET"].get_value() == "plain-value"
+    assert request.secrets["STATIC_SECRET"].get_value() == "static-value"
+    assert request.secrets["LOOKUP_SECRET"].url == "https://example.com/secret"
+
+
+def test_update_secrets_request_dict_without_kind():
+    """Test handling of dict values without 'kind' field."""
+
+    request = UpdateSecretsRequest(
+        secrets={  # type: ignore[arg-type]
+            "SECRET_WITH_VALUE": {
+                "value": "secret-value",
+                "description": "A test secret",
+            },
+        }
+    )
+
+    # Secret with value should be converted to StaticSecret
+    assert isinstance(request.secrets["SECRET_WITH_VALUE"], StaticSecret)
+    assert request.secrets["SECRET_WITH_VALUE"].get_value() == "secret-value"
+    assert request.secrets["SECRET_WITH_VALUE"].description == "A test secret"
+
+
+def test_update_secrets_request_invalid_dict():
+    """Test handling of invalid dict values without 'kind' or 'value' field."""
+
+    # This should raise a validation error since the dict is invalid
+    with pytest.raises(ValidationError):
+        UpdateSecretsRequest(
+            secrets={  # type: ignore[arg-type]
+                "SECRET_WITHOUT_VALUE": {"description": "No value"},
+            }
+        )
+
+
+def test_update_secrets_request_empty_secrets():
+    """Test that empty secrets dict is handled correctly."""
+
+    request = UpdateSecretsRequest(secrets={})
+    assert request.secrets == {}
+
+
+def test_update_secrets_request_invalid_input():
+    """Test that invalid input types are handled appropriately."""
+
+    # Non-dict input should be preserved (will fail validation later)
+    with pytest.raises(ValidationError):
+        UpdateSecretsRequest(secrets="not-a-dict")  # type: ignore[arg-type]


### PR DESCRIPTION
## Summary

This PR adds server-side automatic conversion of plain string secrets to `StaticSecret` objects in the `UpdateSecretsRequest` model. This provides backward compatibility for clients that send plain string secrets instead of properly formatted `SecretSource` objects.

## Changes

### Core Implementation
- **Added field validator** to `UpdateSecretsRequest.secrets` that automatically converts plain strings to `StaticSecret` objects
- **Handles multiple input formats**:
  - Plain strings: `"secret-value"` → `StaticSecret(value=SecretStr("secret-value"))`
  - Dict with value field: `{"value": "secret-value"}` → `StaticSecret(value=SecretStr("secret-value"))`
  - Proper `SecretSource` objects: passed through unchanged

### Testing
- **7 comprehensive unit tests** for model validation covering:
  - Plain string conversion
  - Proper `SecretSource` objects (no conversion)
  - Mixed formats (strings + proper objects)
  - Dict without `kind` field conversion
  - Invalid dict handling
  - Empty secrets dict
  - Invalid input types
- **2 integration tests** for API endpoint functionality:
  - String conversion through HTTP API
  - Mixed format handling through HTTP API

## Problem Solved

Fixes the issue where clients sending plain string secrets receive a 422 validation error:
```
{'detail': [{'type': 'union_tag_invalid', 'loc': ['body', 'secrets', 'GITHUB_TOKEN'], 
'msg': "Input tag 'str' found using kind_of() does not match any of the expected tags: 
'LookupSecret', 'StaticSecret'", 'input': 'ghp_...', 'ctx': {'discriminator': 'kind_of()', 
'tag': 'str', 'expected_tags': "'LookupSecret', 'StaticSecret'"}}]}
```

## Backward Compatibility

✅ **Fully backward compatible** - existing clients using proper `SecretSource` objects continue to work unchanged

✅ **Enables legacy clients** - clients sending plain strings now work automatically

## Testing Results

All tests pass:
- 7/7 model validation tests ✅
- 2/2 API integration tests ✅
- Pre-commit hooks pass ✅
- Type checking passes ✅

## Related

This is the **server-side solution** that complements the client-side fix in PR #1231. Together, they provide a complete solution:
- **Client-side**: Ensures new SDK versions send properly formatted secrets
- **Server-side**: Accepts both formats for backward compatibility

## Review Notes

The field validator uses Pydantic's validation system to safely convert string inputs to the expected `StaticSecret` format before the discriminated union validation occurs. This approach is clean, type-safe, and maintains the existing API contract while adding flexibility.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/beb924d3d3534cf290e22d42101ac63d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d7ed6b0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d7ed6b0-python \
  ghcr.io/openhands/agent-server:d7ed6b0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d7ed6b0-golang-amd64
ghcr.io/openhands/agent-server:d7ed6b0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d7ed6b0-golang-arm64
ghcr.io/openhands/agent-server:d7ed6b0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d7ed6b0-java-amd64
ghcr.io/openhands/agent-server:d7ed6b0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d7ed6b0-java-arm64
ghcr.io/openhands/agent-server:d7ed6b0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d7ed6b0-python-amd64
ghcr.io/openhands/agent-server:d7ed6b0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:d7ed6b0-python-arm64
ghcr.io/openhands/agent-server:d7ed6b0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:d7ed6b0-golang
ghcr.io/openhands/agent-server:d7ed6b0-java
ghcr.io/openhands/agent-server:d7ed6b0-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d7ed6b0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d7ed6b0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->