### PR TITLE
[DO NOT MERGE] chore: update litellm base url for testing

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -354,7 +354,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         if model_val.startswith("openhands/"):
             model_name = model_val.removeprefix("openhands/")
             d["model"] = f"litellm_proxy/{model_name}"
-            d["base_url"] = "https://llm-proxy.app.all-hands.dev/"
+            d["base_url"] = "https://llm-proxy.staging.all-hands.dev/"
 
         # HF doesn't support the OpenAI default value for top_p (1)
         if model_val.startswith("huggingface"):


### PR DESCRIPTION
Update litellm base url for testing
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4b5b19a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4b5b19a-python \
  ghcr.io/openhands/agent-server:4b5b19a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4b5b19a-golang-amd64
ghcr.io/openhands/agent-server:4b5b19a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4b5b19a-golang-arm64
ghcr.io/openhands/agent-server:4b5b19a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4b5b19a-java-amd64
ghcr.io/openhands/agent-server:4b5b19a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4b5b19a-java-arm64
ghcr.io/openhands/agent-server:4b5b19a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4b5b19a-python-amd64
ghcr.io/openhands/agent-server:4b5b19a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:4b5b19a-python-arm64
ghcr.io/openhands/agent-server:4b5b19a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:4b5b19a-golang
ghcr.io/openhands/agent-server:4b5b19a-java
ghcr.io/openhands/agent-server:4b5b19a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4b5b19a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4b5b19a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->