### PR TITLE
feat(fifolock): acquire and release Logic optimization

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/fifo_lock.py
+++ b/openhands-sdk/openhands/sdk/conversation/fifo_lock.py
@@ -75,6 +75,7 @@ class FIFOLock:
             while True:
                 # If I'm at the front of the queue and nobody owns it → acquire
                 if self._waiters[0] is me and self._owner is None:
+                    self._waiters.popleft()
                     self._owner = ident
                     self._count = 1
                     return True
@@ -105,7 +106,6 @@ class FIFOLock:
             self._count -= 1
             if self._count == 0:
                 self._owner = None
-                self._waiters.popleft()
                 if self._waiters:
                     self._waiters[0].notify()
 


### PR DESCRIPTION
1 Reduce redundant enqueue-dequeue operations when in non-blocking mode or when the current lock resource has not been acquired.
2 Add assert checks when releasing resources.
3 Clarify the definition of _waiters: it should only store objects that are in blocking wait.