### PR TITLE
Align eval labels with benchmarks build tiers (1, 50, 200)

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -19,10 +19,8 @@ on:
                 type: choice
                 options:
                     - '1'
-                    - '2'
-                    - '10'
                     - '50'
-                    - '100'
+                    - '200'
             model_stubs:
                 description: Comma-separated model stubs to evaluate (must be allowlisted)
                 required: false
@@ -55,9 +53,8 @@ jobs:
             github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'pull_request_target' &&
              (github.event.label.name == 'run-eval-1' ||
-              github.event.label.name == 'run-eval-2' ||
               github.event.label.name == 'run-eval-50' ||
-              github.event.label.name == 'run-eval-100'))
+              github.event.label.name == 'run-eval-200'))
         runs-on: blacksmith-32vcpu-ubuntu-2204
         permissions:
             contents: read
@@ -117,9 +114,8 @@ jobs:
                     LABEL="${{ github.event.label.name }}"
                     case "$LABEL" in
                       run-eval-1) EVAL_LIMIT=1 ;;
-                      run-eval-2) EVAL_LIMIT=2 ;;
                       run-eval-50) EVAL_LIMIT=50 ;;
-                      run-eval-100) EVAL_LIMIT=100 ;;
+                      run-eval-200) EVAL_LIMIT=200 ;;
                       *) echo "Unsupported label $LABEL" >&2; exit 1 ;;
                     esac
                     SDK_REF="${{ github.event.pull_request.head.ref }}"


### PR DESCRIPTION
## Summary

This PR updates the `run-eval` workflow to use eval labels that align with the benchmarks repository's image build tiers.

## Changes

**Updated eval labels:**
- ✅ `run-eval-1`: Quick debugging (1 instance)
- ✅ `run-eval-50`: Standard testing (50 instances)  
- ✅ `run-eval-200`: Extended testing (200 instances)

**Removed labels:**
- ❌ `run-eval-2`: No matching benchmarks build tier
- ❌ `run-eval-10`: No matching benchmarks build tier
- ❌ `run-eval-100`: No matching benchmarks build tier

## Rationale

The benchmarks repo provides these build label tiers:
- `build-swebench-50`: Build 50 images (~5-10 minutes)
- `build-swebench-200`: Build 200 images (~20-40 minutes)
- `build-swebench`: Build all images (full evaluation)

By aligning our eval labels with these tiers, we ensure:
1. Pre-built images are available for requested eval instance counts
2. No wasted image builds for instance counts we don't use
3. Consistent tier structure across SDK and benchmarks repos

## Testing

- Workflow validation passed (YAML formatting, pre-commit hooks)
- Labels updated in three places:
  - `workflow_dispatch` input options
  - `pull_request_target` label condition
  - Parameter resolution case statement

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9d2fed1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9d2fed1-python \
  ghcr.io/openhands/agent-server:9d2fed1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9d2fed1-golang-amd64
ghcr.io/openhands/agent-server:9d2fed1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9d2fed1-golang-arm64
ghcr.io/openhands/agent-server:9d2fed1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9d2fed1-java-amd64
ghcr.io/openhands/agent-server:9d2fed1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9d2fed1-java-arm64
ghcr.io/openhands/agent-server:9d2fed1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9d2fed1-python-amd64
ghcr.io/openhands/agent-server:9d2fed1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:9d2fed1-python-arm64
ghcr.io/openhands/agent-server:9d2fed1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:9d2fed1-golang
ghcr.io/openhands/agent-server:9d2fed1-java
ghcr.io/openhands/agent-server:9d2fed1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9d2fed1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9d2fed1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->