### PR TITLE
Align eval labels with benchmarks build tiers (1, 50, 200)

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -271,7 +271,6 @@ jobs:
                   SDK_SHA: ${{ steps.get-sha.outputs.sdk_sha }}
                   EVAL_LIMIT: ${{ steps.params.outputs.eval_limit }}
                   MODELS: ${{ steps.params.outputs.models }}
-                  PR_NUMBER: ${{ steps.params.outputs.pr_number }}
                   EVAL_REPO: ${{ env.EVAL_REPO }}
                   EVAL_WORKFLOW: ${{ env.EVAL_WORKFLOW }}
               run: |
@@ -280,9 +279,7 @@ jobs:
                     --arg sdk "$SDK_SHA" \
                     --arg eval_limit "$EVAL_LIMIT" \
                     --arg models "$MODELS" \
-                    --arg pr_number "$PR_NUMBER" \
-                    --arg sdk_repo "${{ github.repository }}" \
-                    '{ref: "main", inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models: $models, sdk_pr_number: $pr_number, sdk_repo: $sdk_repo}}')
+                    '{ref: "main", inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models: $models}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

This PR updates the `run-eval` workflow to use eval labels that align with the benchmarks repository's image build tiers.

## Changes

**Updated eval labels:**
- ✅ `run-eval-1`: Quick debugging (1 instance)
- ✅ `run-eval-50`: Standard testing (50 instances)  
- ✅ `run-eval-200`: Extended testing (200 instances)

**Removed labels:**
- ❌ `run-eval-2`: No matching benchmarks build tier
- ❌ `run-eval-10`: No matching benchmarks build tier
- ❌ `run-eval-100`: No matching benchmarks build tier

## Rationale

The benchmarks repo provides these build label tiers:
- `build-swebench-50`: Build 50 images (~5-10 minutes)
- `build-swebench-200`: Build 200 images (~20-40 minutes)
- `build-swebench`: Build all images (full evaluation)

By aligning our eval labels with these tiers, we ensure:
1. Pre-built images are available for requested eval instance counts
2. No wasted image builds for instance counts we don't use
3. Consistent tier structure across SDK and benchmarks repos

## Testing

- Workflow validation passed (YAML formatting, pre-commit hooks)
- Labels updated in three places:
  - `workflow_dispatch` input options (lines 21-23)
  - `pull_request_target` label condition (lines 55-57)
  - Parameter resolution case statement (lines 116-118)

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c6fd3db-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c6fd3db-python \
  ghcr.io/openhands/agent-server:c6fd3db-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c6fd3db-golang-amd64
ghcr.io/openhands/agent-server:c6fd3db-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c6fd3db-golang-arm64
ghcr.io/openhands/agent-server:c6fd3db-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c6fd3db-java-amd64
ghcr.io/openhands/agent-server:c6fd3db-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c6fd3db-java-arm64
ghcr.io/openhands/agent-server:c6fd3db-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c6fd3db-python-amd64
ghcr.io/openhands/agent-server:c6fd3db-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c6fd3db-python-arm64
ghcr.io/openhands/agent-server:c6fd3db-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c6fd3db-golang
ghcr.io/openhands/agent-server:c6fd3db-java
ghcr.io/openhands/agent-server:c6fd3db-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c6fd3db-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c6fd3db-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->