### PR TITLE
Revert "Fix FastAPI discriminated union patch to be called consistently"

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -29,10 +29,14 @@ from openhands.agent_server.server_details_router import (
 )
 from openhands.agent_server.sockets import sockets_router
 from openhands.agent_server.tool_router import tool_router
+from openhands.agent_server.utils import patch_fastapi_discriminated_union_support
 from openhands.agent_server.vscode_router import vscode_router
 from openhands.agent_server.vscode_service import get_vscode_service
 from openhands.sdk.logger import DEBUG, get_logger
 
+
+# Apply FastAPI patch for discriminated union support
+patch_fastapi_discriminated_union_support()
 
 logger = get_logger(__name__)
 

--- a/openhands-agent-server/openhands/agent_server/utils.py
+++ b/openhands-agent-server/openhands/agent_server/utils.py
@@ -156,16 +156,7 @@ def patch_fastapi_discriminated_union_support():
 
     Also extracts inline discriminated unions as separate schema components for
     better OpenAPI documentation and Swagger UI display.
-
-    Skips patching if SKIP_FASTAPI_DISCRIMINATED_UNION_FIX environment variable is set.
     """
-    # Skip patching if environment variable flag is defined
-    if os.environ.get("SKIP_FASTAPI_DISCRIMINATED_UNION_FIX"):
-        logger.debug(
-            "Skipping FastAPI discriminated union patch due to environment variable"
-        )
-        return
-
     try:
         import fastapi._compat.v2 as fastapi_v2
         from fastapi import FastAPI

--- a/openhands-sdk/openhands/sdk/utils/models.py
+++ b/openhands-sdk/openhands/sdk/utils/models.py
@@ -12,8 +12,6 @@ from pydantic import (
     TypeAdapter,
 )
 
-from openhands.agent_server.utils import patch_fastapi_discriminated_union_support
-
 
 logger = logging.getLogger(__name__)
 _rebuild_required = True
@@ -302,7 +300,3 @@ class DiscriminatedUnionMixin(OpenHandsModel, ABC):
 def _rebuild_if_required():
     if _rebuild_required:
         rebuild_all()
-
-
-# Always call the FastAPI patch after DiscriminatedUnionMixin definition
-patch_fastapi_discriminated_union_support()


### PR DESCRIPTION
Reverts OpenHands/software-agent-sdk#1256

We should not import openhands.agent_server inside openhands.sdk - this will cause dependency issue as ppl install sdk won't necessarily install agent_server
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:20d17b4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-20d17b4-python \
  ghcr.io/openhands/agent-server:20d17b4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:20d17b4-golang-amd64
ghcr.io/openhands/agent-server:20d17b4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:20d17b4-golang-arm64
ghcr.io/openhands/agent-server:20d17b4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:20d17b4-java-amd64
ghcr.io/openhands/agent-server:20d17b4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:20d17b4-java-arm64
ghcr.io/openhands/agent-server:20d17b4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:20d17b4-python-amd64
ghcr.io/openhands/agent-server:20d17b4-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:20d17b4-python-arm64
ghcr.io/openhands/agent-server:20d17b4-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:20d17b4-golang
ghcr.io/openhands/agent-server:20d17b4-java
ghcr.io/openhands/agent-server:20d17b4-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `20d17b4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `20d17b4-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->