### PR TITLE
Investigate Claude model names: remove unsupported dotted variants (fixes #1260)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -803,7 +803,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 m in self.model
                 for m in [
                     "claude-3-7-sonnet",
-                    "claude-3.7-sonnet",
                     "claude-sonnet-4",
                     "kimi-k2-thinking",
                 ]

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -54,18 +54,14 @@ EXTENDED_THINKING_PATTERNS: list[str] = [
 
 PROMPT_CACHE_PATTERNS: list[str] = [
     "claude-3-7-sonnet",
-    "claude-3.7-sonnet",
     "claude-sonnet-3-7-latest",
     "claude-3-5-sonnet",
-    "claude-3.5-sonnet",
     "claude-3-5-haiku",
-    "claude-3.5-haiku",
     "claude-3-haiku-20240307",
     "claude-3-opus-20240229",
     "claude-sonnet-4",
     "claude-opus-4",
-    # Anthropic Haiku 4.5 variants (dot and dash)
-    "claude-haiku-4.5",
+    # Anthropic Haiku 4.5 variants (dash only; official IDs use hyphens)
     "claude-haiku-4-5",
 ]
 

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -51,15 +51,12 @@ def test_reasoning_effort_support(model, expected_reasoning):
         # AWS Bedrock model ids (provider-prefixed)
         ("bedrock/anthropic.claude-3-5-sonnet-20241022-v2:0", True),
         ("bedrock/anthropic.claude-3-haiku-20240307-v1:0", True),
-        # Anthropic Haiku 4.5 variants (dot and dash)
-        ("claude-haiku-4.5", True),
+        # Anthropic Haiku 4.5 variants (dash only; official IDs use hyphens)
         ("claude-haiku-4-5", True),
-        ("us.anthropic.claude-haiku-4.5-20251001", True),
         ("us.anthropic.claude-haiku-4-5-20251001", True),
         ("bedrock/anthropic.claude-3-opus-20240229-v1:0", True),
-        # Anthropic 4.5 variants (dash and dot)
+        # Anthropic 4.5 variants (dash only; official IDs use hyphens)
         ("claude-sonnet-4-5", True),
-        ("claude-sonnet-4.5", True),
         # User-facing model names (no provider prefix)
         ("anthropic.claude-3-5-sonnet-20241022", True),
         ("anthropic.claude-3-haiku-20240307", True),


### PR DESCRIPTION
Summary
- Investigated Anthropic Claude model ID formats across providers
- Removed unsupported dotted version patterns (e.g., `claude-sonnet-4.5`) from feature detection
- Kept the official hyphenated IDs used by Anthropic, Amazon Bedrock, Google Vertex AI, and Microsoft Foundry
- Adjusted tests accordingly

Fixes: #1260

Context
The codebase allowed both hyphenated (e.g., `claude-sonnet-4-5-20250929`) and dotted (e.g., `claude-sonnet-4.5-20250929`) variants for Claude models. Based on a review of official provider docs and catalogs, the dotted pattern does not appear in real provider model IDs.

What changed
- openhands-sdk/openhands/sdk/llm/utils/model_features.py
  - Drop dotted patterns from PROMPT_CACHE_PATTERNS (keep hyphen-only)
- openhands-sdk/openhands/sdk/llm/llm.py
  - Remove dotted `claude-3.7` pattern variant from max_output_tokens guard
- tests/sdk/llm/test_model_features.py
  - Update tests to only assert hyphenated Anthropic IDs

Evidence / References
- Anthropic (Claude API and docs): `claude-sonnet-4-5-20250929`, `claude-opus-4-1-20250805`
  - https://docs.claude.com/claude/docs/models-overview
  - https://platform.claude.com/docs/en/about-claude/models/overview
- Amazon Bedrock: `anthropic.claude-sonnet-4-5-20250929-v1:0`, `anthropic.claude-3-7-sonnet-20250219-v1:0`
  - https://docs.aws.amazon.com/bedrock/latest/userguide/models-supported.html
- Google Vertex AI: `claude-sonnet-4-5@20250929`, `claude-sonnet-4@20250514`, `claude-3-7-sonnet@20250219`
  - https://docs.cloud.google.com/vertex-ai/generative-ai/docs/partner-models/claude/sonnet-4
- Microsoft Foundry: default deployment names `claude-sonnet-4-5`, `claude-opus-4-1`, `claude-haiku-4-5`
  - https://docs.claude.com/en/docs/build-with-claude/claude-in-microsoft-foundry

Testing
- Ran pre-commit (ruff, pyright, pycodestyle) on edited files
- Ran targeted tests in tests/sdk/llm/test_model_features.py: 96 passed

Breaking changes
- None expected. We only removed acceptance for dotted variants which are not used by official providers.

Checklist
- [x] Code follows repo conventions (no mypy; pyright clean)
- [x] Minimal, focused changes
- [x] Tests adjusted and passing for the affected module
- [x] No docs updates required in this repo

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f8aa3838c7b4497692dcfbf9a45fea32)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cbbd792-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cbbd792-python \
  ghcr.io/openhands/agent-server:cbbd792-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cbbd792-golang-amd64
ghcr.io/openhands/agent-server:cbbd792-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cbbd792-golang-arm64
ghcr.io/openhands/agent-server:cbbd792-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cbbd792-java-amd64
ghcr.io/openhands/agent-server:cbbd792-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cbbd792-java-arm64
ghcr.io/openhands/agent-server:cbbd792-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cbbd792-python-amd64
ghcr.io/openhands/agent-server:cbbd792-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:cbbd792-python-arm64
ghcr.io/openhands/agent-server:cbbd792-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:cbbd792-golang
ghcr.io/openhands/agent-server:cbbd792-java
ghcr.io/openhands/agent-server:cbbd792-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cbbd792-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cbbd792-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->