### PR TITLE
Add TaskTrackerStatusType type alias for task tracker status

### DIFF
--- a/openhands-tools/openhands/tools/task_tracker/__init__.py
+++ b/openhands-tools/openhands/tools/task_tracker/__init__.py
@@ -2,6 +2,7 @@ from .definition import (
     TaskTrackerAction,
     TaskTrackerExecutor,
     TaskTrackerObservation,
+    TaskTrackerStatusType,
     TaskTrackerTool,
 )
 
@@ -10,5 +11,6 @@ __all__ = [
     "TaskTrackerAction",
     "TaskTrackerExecutor",
     "TaskTrackerObservation",
+    "TaskTrackerStatusType",
     "TaskTrackerTool",
 ]

--- a/openhands-tools/openhands/tools/task_tracker/definition.py
+++ b/openhands-tools/openhands/tools/task_tracker/definition.py
@@ -25,11 +25,14 @@ from openhands.sdk.tool import (
 
 logger = get_logger(__name__)
 
+# Type alias for task tracker status
+TaskTrackerStatusType = Literal["todo", "in_progress", "done"]
+
 
 class TaskItem(BaseModel):
     title: str = Field(..., description="A brief title for the task.")
     notes: str = Field("", description="Additional details or notes about the task.")
-    status: Literal["todo", "in_progress", "done"] = Field(
+    status: TaskTrackerStatusType = Field(
         "todo",
         description="The current status of the task. "
         "One of 'todo', 'in_progress', or 'done'.",


### PR DESCRIPTION
## Summary
This PR adds a reusable type alias `TaskTrackerStatusType` for the task tracker status field, making it easier for external consumers (like the CLI) to properly type their status mappings.

## Changes
- Added `TaskTrackerStatusType = Literal["todo", "in_progress", "done"]` type alias in `definition.py`
- Updated `TaskItem.status` field to use the new type alias
- Exported `TaskTrackerStatusType` from the `task_tracker` module's `__init__.py`

## Motivation
The CLI needs to map task tracker statuses to ACP (Agent Client Protocol) plan entry statuses. By exporting this type from the SDK, we can ensure type safety and consistency across the codebase.

Related to OpenHands/OpenHands-CLI#69

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8921c6a0bb2e4ef8a14a5e803d16460f)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dd013a1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dd013a1-python \
  ghcr.io/openhands/agent-server:dd013a1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dd013a1-golang-amd64
ghcr.io/openhands/agent-server:dd013a1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dd013a1-golang-arm64
ghcr.io/openhands/agent-server:dd013a1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dd013a1-java-amd64
ghcr.io/openhands/agent-server:dd013a1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dd013a1-java-arm64
ghcr.io/openhands/agent-server:dd013a1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dd013a1-python-amd64
ghcr.io/openhands/agent-server:dd013a1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:dd013a1-python-arm64
ghcr.io/openhands/agent-server:dd013a1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:dd013a1-golang
ghcr.io/openhands/agent-server:dd013a1-java
ghcr.io/openhands/agent-server:dd013a1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dd013a1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dd013a1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->