### PR TITLE
Fix: Condenser LLM should not pass extra_body (Fixes #1252)

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -69,9 +69,10 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
 
+        # Do not pass extra_body explicitly. The LLM handles forwarding
+        # litellm_extra_body only when it is non-empty.
         llm_response = self.llm.completion(
             messages=messages,
-            extra_body=self.llm.litellm_extra_body,
         )
         # Extract summary from the LLMResponse message
         summary = None


### PR DESCRIPTION
Summary
- Remove explicit extra_body forwarding from LLMSummarizingCondenser
- Add unit test to ensure condenser does not pass extra_body to llm.completion
- Confirm agent LLM path already handles litellm_extra_body via options layer only

Problem
For 1p Anthropic models, passing extra_body triggers a LiteLLM error:
"extra_body: Extra inputs are not permitted". The condenser was explicitly forwarding extra_body, causing failures even when the main agent path did not.

Changes
- openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
  - Stop passing extra_body explicitly to LLM.completion; rely on LLM option normalization to include extra_body only when appropriate.
- tests/sdk/context/condenser/test_llm_summarizing_condenser.py
  - Add test_get_condensation_does_not_pass_extra_body to assert that condenser does not pass extra_body argument.

Why this is safe
- The centralized options selection (select_chat_options / select_responses_options) already attaches extra_body from llm.litellm_extra_body when appropriate. Removing the hardcoded extra_body from the condenser prevents provider rejections and keeps behavior consistent with the Agent path.

Backward compatibility
- No breaking API changes. If users set LLM.litellm_extra_body and the model supports it, it will still be attached via the options layer. Condenser now mirrors the same behavior as the agent flow.

Testing
- Ran pre-commit hooks for the changed files (ruff, pyright, pycodestyle); all passed.
- New unit test added; condenser tests pass (7 tests in condenser package).
- Spot ran a subset of repository tests; unrelated intermittent warnings observed but no failures due to this change.

Fixes: #1252

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d29a2729897a4e2582135b4e181e2965)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9961a9f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9961a9f-python \
  ghcr.io/openhands/agent-server:9961a9f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9961a9f-golang-amd64
ghcr.io/openhands/agent-server:9961a9f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9961a9f-golang-arm64
ghcr.io/openhands/agent-server:9961a9f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9961a9f-java-amd64
ghcr.io/openhands/agent-server:9961a9f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9961a9f-java-arm64
ghcr.io/openhands/agent-server:9961a9f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9961a9f-python-amd64
ghcr.io/openhands/agent-server:9961a9f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:9961a9f-python-arm64
ghcr.io/openhands/agent-server:9961a9f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:9961a9f-golang
ghcr.io/openhands/agent-server:9961a9f-java
ghcr.io/openhands/agent-server:9961a9f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9961a9f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9961a9f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->