### PR TITLE
Improve workflow step name for clarity

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -169,7 +169,7 @@ jobs:
                   git fetch origin "$REF" --force
                   git checkout FETCH_HEAD
 
-            - name: Get current commit SHA
+            - name: Resolve SDK commit SHA for evaluation
               id: get-sha
               run: |
                   SDK_SHA=$(git rev-parse HEAD)


### PR DESCRIPTION
## Description

Improves the clarity of a workflow step name in `run-eval.yml`.

**Changed**: `Get current commit SHA` → `Resolve SDK commit SHA for evaluation`

## Motivation

The previous name "Get current commit SHA" was misleading because it sounded like it was just getting metadata about the workflow run itself. In reality, this step determines **which SDK version will be evaluated** by:

1. For PRs: Capturing the PR head commit (after checkout)
2. For manual triggers: Capturing whatever ref was specified in `sdk_ref`
3. For releases: Capturing the release commit

This SHA is then passed to the evaluation workflow to test that specific SDK version.

## Changes

- Renamed workflow step to better reflect its purpose
- No functional changes

## Related

Closes #1265

This improvement was identified during code review of the cross-repository evaluation workflow orchestration refactor.

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/48ce82677b22434f9190541cbca9af88)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6db9b14-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6db9b14-python \
  ghcr.io/openhands/agent-server:6db9b14-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6db9b14-golang-amd64
ghcr.io/openhands/agent-server:6db9b14-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6db9b14-golang-arm64
ghcr.io/openhands/agent-server:6db9b14-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6db9b14-java-amd64
ghcr.io/openhands/agent-server:6db9b14-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6db9b14-java-arm64
ghcr.io/openhands/agent-server:6db9b14-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6db9b14-python-amd64
ghcr.io/openhands/agent-server:6db9b14-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6db9b14-python-arm64
ghcr.io/openhands/agent-server:6db9b14-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6db9b14-golang
ghcr.io/openhands/agent-server:6db9b14-java
ghcr.io/openhands/agent-server:6db9b14-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6db9b14-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6db9b14-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->