### PR TITLE
refactor: update request timeout handling when fetching secrets

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/secret_source.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_source.py
@@ -45,7 +45,7 @@ class LookupSecret(SecretSource):
     headers: dict[str, str] = Field(default_factory=dict)
 
     def get_value(self):
-        response = httpx.get(self.url, headers=self.headers)
+        response = httpx.get(self.url, headers=self.headers, timeout=30.0)
         response.raise_for_status()
         return response.text
 


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c5f2654-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c5f2654-python \
  ghcr.io/openhands/agent-server:c5f2654-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c5f2654-golang-amd64
ghcr.io/openhands/agent-server:c5f2654-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c5f2654-golang-arm64
ghcr.io/openhands/agent-server:c5f2654-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c5f2654-java-amd64
ghcr.io/openhands/agent-server:c5f2654-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c5f2654-java-arm64
ghcr.io/openhands/agent-server:c5f2654-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c5f2654-python-amd64
ghcr.io/openhands/agent-server:c5f2654-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c5f2654-python-arm64
ghcr.io/openhands/agent-server:c5f2654-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c5f2654-golang
ghcr.io/openhands/agent-server:c5f2654-java
ghcr.io/openhands/agent-server:c5f2654-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c5f2654-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c5f2654-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->