### PR TITLE
refactor: enable configuring the llm proxy base url for the openhands provider

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -356,7 +356,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         if model_val.startswith("openhands/"):
             model_name = model_val.removeprefix("openhands/")
             d["model"] = f"litellm_proxy/{model_name}"
-            # Set base_url (default to prod when base_url is unset)
+            # Set base_url (default to the app proxy when base_url is unset)
             d["base_url"] = d.get("base_url", "https://llm-proxy.app.all-hands.dev/")
 
         # HF doesn't support the OpenAI default value for top_p (1)


### PR DESCRIPTION
As illustrated in the image below, we utilize the OpenHands provider.
 
<img width="832" height="478" alt="image" src="https://github.com/user-attachments/assets/59ee7357-5a82-4032-acf3-a52f06b7186b" />

When initiating a new V1 conversation and prompt, I encounter the following error.

<img width="924" height="706" alt="image" src="https://github.com/user-attachments/assets/f89828e2-d0e8-4caa-bfa9-7ffd75322ba3" />

The pull request ensures that the current environment is correctly passed when setting up the LLM in the software-agent-sdk. If the environment is set to staging, the SDK will utilize the LLM proxy staging server; otherwise, it will connect to the production server.

Additionally, the video below demonstrates the output of the pull request.

https://github.com/user-attachments/assets/b4241859-050e-4229-b712-acce926e4955





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:71e23c5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-71e23c5-python \
  ghcr.io/openhands/agent-server:71e23c5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:71e23c5-golang-amd64
ghcr.io/openhands/agent-server:71e23c5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:71e23c5-golang-arm64
ghcr.io/openhands/agent-server:71e23c5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:71e23c5-java-amd64
ghcr.io/openhands/agent-server:71e23c5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:71e23c5-java-arm64
ghcr.io/openhands/agent-server:71e23c5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:71e23c5-python-amd64
ghcr.io/openhands/agent-server:71e23c5-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:71e23c5-python-arm64
ghcr.io/openhands/agent-server:71e23c5-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:71e23c5-golang
ghcr.io/openhands/agent-server:71e23c5-java
ghcr.io/openhands/agent-server:71e23c5-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `71e23c5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `71e23c5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->