### PR TITLE
Add support for loading CLAUDE.md and GEMINI.md as repo skills

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -90,23 +90,26 @@ class Skill(BaseModel):
         # Create Skill with None trigger (always active) if we recognized the file type
         if skill_name is not None:
             # Truncate content if it exceeds the limit
-            # Third-party files are always active, so we want to keep them reasonably sized
+            # Third-party files are always active, so we want to keep them
+            # reasonably sized
             truncated_content = maybe_truncate(
                 file_content,
                 truncate_after=THIRD_PARTY_SKILL_MAX_CHARS,
                 truncate_notice=(
-                    f"\n\n<TRUNCATED><NOTE>The file {path} exceeded the maximum length "
-                    f"({THIRD_PARTY_SKILL_MAX_CHARS} characters) and has been truncated. "
-                    "Only the beginning and end are shown. You can read the full file if needed.</NOTE>\n\n"
+                    f"\n\n<TRUNCATED><NOTE>The file {path} exceeded the "
+                    f"maximum length ({THIRD_PARTY_SKILL_MAX_CHARS} "
+                    f"characters) and has been truncated. Only the "
+                    f"beginning and end are shown. You can read the full "
+                    f"file if needed.</NOTE>\n\n"
                 ),
             )
-            
+
             if len(file_content) > THIRD_PARTY_SKILL_MAX_CHARS:
                 logger.warning(
                     f"Third-party skill file {path} ({len(file_content)} chars) "
                     f"exceeded limit ({THIRD_PARTY_SKILL_MAX_CHARS} chars), truncating"
                 )
-            
+
             return Skill(
                 name=skill_name,
                 content=truncated_content,

--- a/tests/sdk/context/skill/test_skill_utils.py
+++ b/tests/sdk/context/skill/test_skill_utils.py
@@ -458,9 +458,7 @@ def test_load_skills_with_uppercase_claude_gemini(
     temp_skills_dir_with_uppercase_context_files,
 ):
     """Test loading skills when CLAUDE.MD and GEMINI.MD files exist (uppercase)."""
-    skills_dir = (
-        temp_skills_dir_with_uppercase_context_files / ".openhands" / "skills"
-    )
+    skills_dir = temp_skills_dir_with_uppercase_context_files / ".openhands" / "skills"
 
     repo_agents, knowledge_agents = load_skills_from_dir(skills_dir)
 
@@ -485,7 +483,8 @@ def test_load_skills_with_uppercase_claude_gemini(
 
 @pytest.fixture
 def temp_skills_dir_with_large_context_file():
-    """Create a temporary directory with a very large CLAUDE.md file to test truncation."""
+    """Create a temporary directory with a very large CLAUDE.md file to test
+    truncation."""
     with tempfile.TemporaryDirectory() as temp_dir:
         root = Path(temp_dir)
 
@@ -497,9 +496,11 @@ def temp_skills_dir_with_large_context_file():
         # Pattern: repeat "CLAUDE INSTRUCTION X\n" many times
         claude_content = "# Claude Instructions - Start\n\n"
         for i in range(800):  # This will create ~15,000+ characters
-            claude_content += f"Claude instruction line {i:04d}: Follow this guideline carefully.\n"
+            claude_content += (
+                f"Claude instruction line {i:04d}: Follow this guideline carefully.\n"
+            )
         claude_content += "\n# Claude Instructions - End\n"
-        
+
         (root / "claude.md").write_text(claude_content)
 
         # Create test repo agent
@@ -521,7 +522,7 @@ Repository-specific test instructions.
 def test_load_skills_with_truncated_large_file(temp_skills_dir_with_large_context_file):
     """Test that large third-party skill files are truncated properly."""
     from openhands.sdk.context.skills.skill import THIRD_PARTY_SKILL_MAX_CHARS
-    
+
     root, original_size = temp_skills_dir_with_large_context_file
     skills_dir = root / ".openhands" / "skills"
 
@@ -535,20 +536,20 @@ def test_load_skills_with_truncated_large_file(temp_skills_dir_with_large_contex
     claude_agent = repo_agents["claude"]
     assert claude_agent.trigger is None
     assert claude_agent.name == "claude"
-    
+
     # Content should be less than or equal to limit
     assert len(claude_agent.content) <= THIRD_PARTY_SKILL_MAX_CHARS
-    
+
     # Should contain the truncation notice
     assert "<TRUNCATED>" in claude_agent.content
     assert "exceeded the maximum length" in claude_agent.content
     assert "claude.md" in claude_agent.content  # Should mention the filename
     assert "You can read the full file if needed" in claude_agent.content
-    
+
     # Should contain parts from beginning and end
     assert "Claude Instructions - Start" in claude_agent.content
     assert "Claude Instructions - End" in claude_agent.content
-    
+
     # Original file should have been larger
     assert original_size > THIRD_PARTY_SKILL_MAX_CHARS
 


### PR DESCRIPTION
## Summary
This PR adds support for loading CLAUDE.md and GEMINI.md files from the repository root as always-active repo skills, similar to how AGENTS.md and .cursorrules are currently handled.

## Changes
- Added `claude.md` and `gemini.md` to `PATH_TO_THIRD_PARTY_SKILL_NAME` in the Skill class
- These files are automatically loaded from the repository root (when calling `load_skills_from_dir` on `.openhands/skills` or `.openhands/microagents`)
- Files are loaded as always-active skills (trigger=None) for LLM-specific instructions
- Added comprehensive test coverage:
  - `test_load_skills_with_claude_gemini` - tests lowercase variants (claude.md, gemini.md)
  - `test_load_skills_with_uppercase_claude_gemini` - tests uppercase variants (CLAUDE.MD, GEMINI.MD)

## Testing
- All 53 skill tests passing
- Verified both lowercase and uppercase filename variants work correctly
- Consistent with existing third-party file handling (.cursorrules, AGENTS.md)

## Related
This enables OpenHands-CLI issue #143 - allowing users to provide LLM-specific context through dedicated markdown files in their project root.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7f14286e330242d1a05a691229ef3d18)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b751c0e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b751c0e-python \
  ghcr.io/openhands/agent-server:b751c0e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b751c0e-golang-amd64
ghcr.io/openhands/agent-server:b751c0e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b751c0e-golang-arm64
ghcr.io/openhands/agent-server:b751c0e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b751c0e-java-amd64
ghcr.io/openhands/agent-server:b751c0e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b751c0e-java-arm64
ghcr.io/openhands/agent-server:b751c0e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b751c0e-python-amd64
ghcr.io/openhands/agent-server:b751c0e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b751c0e-python-arm64
ghcr.io/openhands/agent-server:b751c0e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b751c0e-golang
ghcr.io/openhands/agent-server:b751c0e-java
ghcr.io/openhands/agent-server:b751c0e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b751c0e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b751c0e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->