### PR TITLE
Install GitHub CLI (gh) in agent-server Docker image

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -65,6 +65,14 @@ RUN set -eux; \
         # Docker dependencies
         apt-transport-https gnupg lsb-release; \
     \
+    # Install GitHub CLI from official apt repo
+    install -m 0755 -d /etc/apt/keyrings; \
+    curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg -o /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    chmod a+r /etc/apt/keyrings/githubcli-archive-keyring.gpg; \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null; \
+    apt-get update; \
+    apt-get install -y gh; \
+    \
     # Create user and group
     (getent group ${GID} || groupadd -g ${GID} ${USERNAME}); \
     (id -u ${USERNAME} >/dev/null 2>&1 || useradd -m -u ${UID} -g ${GID} -s /bin/bash ${USERNAME}); \


### PR DESCRIPTION
Summary
- Install GitHub CLI (gh) using the official GitHub apt repository.
- Added to base-image-minimal so it is available in both minimal and full images, and all build targets inheriting from it.

Rationale
- Several workflows and developer tasks rely on gh for GitHub interactions.
- Using the official apt repo is the simplest, most maintainable, and distro-native installation path for Debian/Ubuntu base images.

Implementation Details
- Add GitHub CLI apt key and repo under /etc/apt/keyrings and /etc/apt/sources.list.d, respectively.
- Install gh with apt-get install -y gh.
- Keep image minimal and consistent with other system packages; no curl | bash installers used.

Verification
- Locally verified the apt repo/keys and installation commands work in a Debian-based environment.
- The installation is done in the base-image-minimal stage so all derived targets (source, binary, etc.) have gh available.

Notes
- No changes to runtime behavior other than making gh available in the container.
- No impact on Python dependencies or agent-server build.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e5b435394dea484f8260037fea75efc0)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0154a81-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0154a81-python \
  ghcr.io/openhands/agent-server:0154a81-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0154a81-golang-amd64
ghcr.io/openhands/agent-server:0154a81-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0154a81-golang-arm64
ghcr.io/openhands/agent-server:0154a81-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0154a81-java-amd64
ghcr.io/openhands/agent-server:0154a81-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0154a81-java-arm64
ghcr.io/openhands/agent-server:0154a81-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0154a81-python-amd64
ghcr.io/openhands/agent-server:0154a81-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:0154a81-python-arm64
ghcr.io/openhands/agent-server:0154a81-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:0154a81-golang
ghcr.io/openhands/agent-server:0154a81-java
ghcr.io/openhands/agent-server:0154a81-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0154a81-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0154a81-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->