### PR TITLE
make get_closest_git_repo robust to macOS symlink paths

### DIFF
--- a/tests/sdk/git/test_git_diff.py
+++ b/tests/sdk/git/test_git_diff.py
@@ -171,7 +171,10 @@ def test_get_closest_git_repo():
 
         # Test finding git repo from nested directory
         git_repo = get_closest_git_repo(nested_dir)
-        assert git_repo == Path(temp_dir)
+        # Compare resolved paths to avoid symlink differences on macOS
+        # Example: /var is a symlink to /private/var
+        assert git_repo is not None
+        assert git_repo.resolve() == Path(temp_dir).resolve()
 
         # Test with non-git directory
         with tempfile.TemporaryDirectory() as non_git_dir:


### PR DESCRIPTION
Context

In macOS, /var is a symlink to /private/var. Our test for get_closest_git_repo compared Path objects directly, which can differ depending on symlink resolution, causing flakiness.

What changed

- Updated tests/sdk/git/test_git_diff.py to compare resolved paths in the get_closest_git_repo test:
  - Assert the repo path is not None
  - Compare git_repo.resolve() == Path(temp_dir).resolve()

Why tests, not code

- The implementation already accepts Path and correctly discovers the repo using Path semantics. The inconsistency was in test expectations, not the function’s behavior. Fixing the test keeps implementation simple and avoids unnecessary path coercion logic like wrapping with Path(path).

Validation

- Ran tests locally: tests/sdk/git/test_git_diff.py (11 tests) all pass.
- Passed pre-commit (ruff format/check, pycodestyle, pyright, import checks).

No functional changes to the SDK code.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d601431ee3724cd4907cfbbff5de9b2d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1340749-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1340749-python \
  ghcr.io/openhands/agent-server:1340749-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1340749-golang-amd64
ghcr.io/openhands/agent-server:1340749-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1340749-golang-arm64
ghcr.io/openhands/agent-server:1340749-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1340749-java-amd64
ghcr.io/openhands/agent-server:1340749-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1340749-java-arm64
ghcr.io/openhands/agent-server:1340749-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1340749-python-amd64
ghcr.io/openhands/agent-server:1340749-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:1340749-python-arm64
ghcr.io/openhands/agent-server:1340749-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:1340749-golang
ghcr.io/openhands/agent-server:1340749-java
ghcr.io/openhands/agent-server:1340749-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1340749-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1340749-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->