### PR TITLE
Fix: Add missing windows cache path for Playwright detection

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -39,7 +39,7 @@ def _check_chromium_available() -> str | None:
     playwright_cache_candidates = [
         Path.home() / ".cache" / "ms-playwright",
         Path.home() / "Library" / "Caches" / "ms-playwright",
-        Path(os.environ.get("LOCALAPPDATA", "")) / "ms-playwright", # Windows
+        Path(os.environ.get("LOCALAPPDATA", "")) / "ms-playwright",  # Windows
     ]
     for playwright_cache in playwright_cache_candidates:
         if playwright_cache.exists():


### PR DESCRIPTION
https://github.com/OpenHands/software-agent-sdk/blob/b217e4047349b03f283bba7beaf6f1b5bd928ed2/openhands-tools/openhands/tools/browser_use/impl.py#L48-L57

Existing code checks for exe file in non Windows path.

Minimal implementation of #1014

Next refactor if needed: https://github.com/OpenHands/software-agent-sdk/pull/1014#discussion_r2577994037