### PR TITLE
fix: browser tool

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -364,6 +364,7 @@ class EventService:
             stuck_detection=self.stored.stuck_detection,
             visualizer=None,
             secrets=self.stored.secrets,
+            main_event_loop=self._main_loop,
         )
 
         # Set confirmation mode if enabled

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1,3 +1,4 @@
+import asyncio
 import atexit
 import uuid
 from collections.abc import Mapping
@@ -69,6 +70,7 @@ class LocalConversation(BaseConversation):
             type[ConversationVisualizerBase] | ConversationVisualizerBase | None
         ) = DefaultConversationVisualizer,
         secrets: Mapping[str, SecretValue] | None = None,
+        main_event_loop: asyncio.AbstractEventLoop | None = None,
         **_: object,
     ):
         """Initialize the conversation.
@@ -96,6 +98,9 @@ class LocalConversation(BaseConversation):
         # Mark cleanup as initiated as early as possible to avoid races or partially
         # initialized instances during interpreter shutdown.
         self._cleanup_initiated = False
+
+        # Store reference to main event loop for async tool execution (e.g., browser)
+        self.main_event_loop = main_event_loop
 
         self.agent = agent
         if isinstance(workspace, (str, Path)):


### PR DESCRIPTION



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5f6c5a7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5f6c5a7-python \
  ghcr.io/openhands/agent-server:5f6c5a7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5f6c5a7-golang-amd64
ghcr.io/openhands/agent-server:5f6c5a7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5f6c5a7-golang-arm64
ghcr.io/openhands/agent-server:5f6c5a7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5f6c5a7-java-amd64
ghcr.io/openhands/agent-server:5f6c5a7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5f6c5a7-java-arm64
ghcr.io/openhands/agent-server:5f6c5a7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5f6c5a7-python-amd64
ghcr.io/openhands/agent-server:5f6c5a7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:5f6c5a7-python-arm64
ghcr.io/openhands/agent-server:5f6c5a7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:5f6c5a7-golang
ghcr.io/openhands/agent-server:5f6c5a7-java
ghcr.io/openhands/agent-server:5f6c5a7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5f6c5a7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5f6c5a7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->