### PR TITLE
feat: handle proxied model names with canonical model_real_name

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -171,11 +171,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         ge=1,
         description="The maximum number of output tokens. This is sent to the LLM.",
     )
-    model_real_name: str | None = Field(
+    model_canonical_name: str | None = Field(
         default=None,
         description=(
-            "Optional canonical model id for capability lookups when the configured "
-            "model name is proxied or aliased."
+            "Optional canonical model name for feature registry lookups. "
+            "The OpenHands SDK maintains a model feature registry that "
+            "maps model names to capabilities (e.g., vision support, "
+            "prompt caching, responses API support). When using proxied or "
+            "aliased model identifiers, set this field to the canonical "
+            "model name (e.g., 'openai/gpt-4o') to ensure correct "
+            "capability detection. If not provided, the 'model' field "
+            "will be used for capability lookups."
         ),
     )
     extra_headers: dict[str, str] | None = Field(
@@ -818,7 +824,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     # =========================================================================
     def _model_name_for_capabilities(self) -> str:
         """Return canonical name for capability lookups (e.g., vision support)."""
-        return self.model_real_name or self.model
+        return self.model_canonical_name or self.model
 
     def _init_model_info_and_caps(self) -> None:
         self._model_info = get_litellm_model_info(

--- a/tests/sdk/llm/test_model_canonical_name_resolution.py
+++ b/tests/sdk/llm/test_model_canonical_name_resolution.py
@@ -15,8 +15,8 @@ class DummyFeatures:
         self.send_reasoning_content = False
 
 
-def test_model_real_name_used_for_capabilities(monkeypatch):
-    """Proxy/aliased model uses model_real_name for capability + feature lookups."""
+def test_model_canonical_name_used_for_capabilities(monkeypatch):
+    """Proxy/aliased model uses model_canonical_name for capability lookups."""
 
     model_info_calls: list[str] = []
     vision_calls: list[str] = []
@@ -44,7 +44,7 @@ def test_model_real_name_used_for_capabilities(monkeypatch):
 
     real_llm = LLM(model="openai/gpt-5-mini")
     proxy_llm = LLM(
-        model="proxy/test-renamed-model", model_real_name="openai/gpt-5-mini"
+        model="proxy/test-renamed-model", model_canonical_name="openai/gpt-5-mini"
     )
 
     # Model info and vision support come from the canonical model name
@@ -53,7 +53,7 @@ def test_model_real_name_used_for_capabilities(monkeypatch):
     assert real_llm.vision_is_active() is True
     assert proxy_llm.vision_is_active() is True
 
-    # Feature lookups (prompt cache / responses API) also respect model_real_name
+    # Feature lookups (prompt cache / responses API) also respect model_canonical_name
     assert real_llm.is_caching_prompt_active() is True
     assert proxy_llm.is_caching_prompt_active() is True
     assert real_llm.uses_responses_api() is True
@@ -65,11 +65,11 @@ def test_model_real_name_used_for_capabilities(monkeypatch):
     assert "openai/gpt-5-mini" in feature_calls
 
 
-def test_model_real_name_with_real_model_info():
+def test_model_canonical_name_with_real_model_info():
     """Integration-style check using litellm's built-in model info."""
 
     base = LLM(model="gpt-4o-mini")
-    proxied = LLM(model="proxy/test-renamed-model", model_real_name="gpt-4o-mini")
+    proxied = LLM(model="proxy/test-renamed-model", model_canonical_name="gpt-4o-mini")
 
     # Model info and derived flags should align with the canonical model
     assert proxied.model_info == base.model_info


### PR DESCRIPTION
canonical model_real_name

- add optional model_real_name to LLM for capability/model-info lookups when using proxied/aliased model ids
- use the canonical model name for litellm model info and vision support checks
- apply the canonical name to OpenHands feature lookups (prompt caching, responses API, serializer flags)
