### PR TITLE
Fix find_dotenv assertion error in local conversation

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/utils.py
+++ b/openhands-sdk/openhands/sdk/observability/utils.py
@@ -7,7 +7,13 @@ from openhands.sdk.event import ActionEvent
 
 def get_env(key: str) -> str | None:
     """Get an environment variable from the environment or the dotenv file."""
-    return os.getenv(key) or dotenv_values().get(key)
+    env_value = os.getenv(key)
+    if env_value:
+        return env_value
+    try:
+        return dotenv_values().get(key)
+    except (AssertionError, OSError):
+        return None
 
 
 def extract_action_name(action_event: ActionEvent) -> str:

--- a/tests/sdk/observability/__init__.py
+++ b/tests/sdk/observability/__init__.py
@@ -1,0 +1,1 @@
+# Tests for observability module

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -1,0 +1,41 @@
+"""Tests for laminar observability functions."""
+
+import os
+from unittest.mock import patch
+
+from openhands.sdk.observability.laminar import should_enable_observability
+
+
+def test_should_enable_observability_with_dotenv_error():
+    """Test that should_enable_observability handles dotenv errors gracefully."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("openhands.sdk.observability.utils.dotenv_values") as mock_dotenv:
+            mock_dotenv.side_effect = AssertionError("Frame stack exhausted")
+            with patch(
+                "openhands.sdk.observability.laminar.Laminar.is_initialized"
+            ) as mock_init:
+                mock_init.return_value = False
+                result = should_enable_observability()
+                assert result is False
+
+
+def test_should_enable_observability_returns_true_when_env_set():
+    """Test that should_enable_observability returns True when env vars are set."""
+    with patch.dict(os.environ, {"LMNR_PROJECT_API_KEY": "test_key"}):
+        with patch(
+            "openhands.sdk.observability.laminar.Laminar.is_initialized"
+        ) as mock_init:
+            mock_init.return_value = False
+            result = should_enable_observability()
+            assert result is True
+
+
+def test_should_enable_observability_returns_false_when_no_env():
+    """Test that should_enable_observability returns False when no env vars set."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch(
+            "openhands.sdk.observability.laminar.Laminar.is_initialized"
+        ) as mock_init:
+            mock_init.return_value = False
+            result = should_enable_observability()
+            assert result is False

--- a/tests/sdk/observability/test_utils.py
+++ b/tests/sdk/observability/test_utils.py
@@ -1,0 +1,56 @@
+"""Tests for observability utils."""
+
+import os
+from unittest.mock import patch
+
+from openhands.sdk.observability.utils import get_env
+
+
+def test_get_env_from_environment():
+    """Test that get_env returns value from environment variables."""
+    with patch.dict(os.environ, {"TEST_VAR": "test_value"}):
+        assert get_env("TEST_VAR") == "test_value"
+
+
+def test_get_env_not_found():
+    """Test that get_env returns None when variable is not found."""
+    with patch.dict(os.environ, {}, clear=True):
+        result = get_env("NONEXISTENT_VAR")
+        assert result is None
+
+
+def test_get_env_handles_dotenv_assertion_error():
+    """Test that get_env handles AssertionError from find_dotenv gracefully."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("openhands.sdk.observability.utils.dotenv_values") as mock_dotenv:
+            mock_dotenv.side_effect = AssertionError("Frame stack exhausted")
+            result = get_env("TEST_VAR")
+            assert result is None
+
+
+def test_get_env_handles_dotenv_os_error():
+    """Test that get_env handles OSError from dotenv gracefully."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("openhands.sdk.observability.utils.dotenv_values") as mock_dotenv:
+            mock_dotenv.side_effect = OSError("File not found")
+            result = get_env("TEST_VAR")
+            assert result is None
+
+
+def test_get_env_prefers_environment_over_dotenv():
+    """Test that environment variables take precedence over dotenv."""
+    with patch.dict(os.environ, {"TEST_VAR": "env_value"}):
+        with patch("openhands.sdk.observability.utils.dotenv_values") as mock_dotenv:
+            mock_dotenv.return_value = {"TEST_VAR": "dotenv_value"}
+            result = get_env("TEST_VAR")
+            assert result == "env_value"
+            mock_dotenv.assert_not_called()
+
+
+def test_get_env_from_dotenv():
+    """Test that get_env can retrieve values from dotenv file."""
+    with patch.dict(os.environ, {}, clear=True):
+        with patch("openhands.sdk.observability.utils.dotenv_values") as mock_dotenv:
+            mock_dotenv.return_value = {"TEST_VAR": "dotenv_value"}
+            result = get_env("TEST_VAR")
+            assert result == "dotenv_value"


### PR DESCRIPTION
## Description

This PR fixes issue #1325 where `find_dotenv` breaks local conversation with an `AssertionError`.

## Problem

The `get_env()` function in `openhands/sdk/observability/utils.py` calls `dotenv_values()` without any arguments. When `dotenv_values()` is called without arguments, it internally calls `find_dotenv()` to locate the .env file. The `find_dotenv()` function tries to walk up the call stack to find the directory of the calling file, but in certain execution contexts (like when running in local conversation or when the call stack is unusual), the assertion `assert frame.f_back is not None` can fail because the frame stack is exhausted.

## Solution

The fix catches `AssertionError` and `OSError` from `dotenv_values()` and returns `None` gracefully. This allows the code to continue execution without breaking. The implementation:

1. First checks environment variables (priority)
2. Only attempts to load from dotenv if environment variable is not set
3. Gracefully handles errors when dotenv file cannot be found or loaded
4. Returns `None` if value cannot be retrieved from either source

## Changes

- **Modified**: `openhands-sdk/openhands/sdk/observability/utils.py`
  - Updated `get_env()` function to handle `AssertionError` and `OSError` from `dotenv_values()`
  - Added explicit check for environment variables before attempting dotenv lookup

- **Added**: Tests for the fix
  - `tests/sdk/observability/test_utils.py` - Tests for `get_env()` function including error handling
  - `tests/sdk/observability/test_laminar.py` - Tests for `should_enable_observability()` with dotenv errors

## Testing

All tests pass:
```bash
uv run pytest tests/sdk/observability/ -v
```

The fix has been validated to:
- Return environment variables when set
- Return values from dotenv when available and env var not set
- Return `None` gracefully when dotenv fails with `AssertionError`
- Return `None` gracefully when dotenv fails with `OSError`
- Not break any existing functionality

Fixes #1325

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b38523778ced4f88b4c5b966e57842e1)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3d8c0fc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3d8c0fc-python \
  ghcr.io/openhands/agent-server:3d8c0fc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3d8c0fc-golang-amd64
ghcr.io/openhands/agent-server:3d8c0fc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3d8c0fc-golang-arm64
ghcr.io/openhands/agent-server:3d8c0fc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3d8c0fc-java-amd64
ghcr.io/openhands/agent-server:3d8c0fc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3d8c0fc-java-arm64
ghcr.io/openhands/agent-server:3d8c0fc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3d8c0fc-python-amd64
ghcr.io/openhands/agent-server:3d8c0fc-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3d8c0fc-python-arm64
ghcr.io/openhands/agent-server:3d8c0fc-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3d8c0fc-golang
ghcr.io/openhands/agent-server:3d8c0fc-java
ghcr.io/openhands/agent-server:3d8c0fc-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3d8c0fc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3d8c0fc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->