### PR TITLE
APP-190 Fix PyInstaller GCC 14 compatibility for Chromium

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -86,6 +86,10 @@ a = Analysis(
     optimize=0,
 )
 
+# Remove problematic system libraries that should use host versions
+# This prevents bundling incompatible libgcc_s.so.1 that lacks GCC_14.0 symbols
+a.binaries = [x for x in a.binaries if not x[0].startswith('libgcc_s.so')]
+
 pyz = PYZ(a.pure)
 
 exe = EXE(

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -230,10 +230,14 @@ ARG USERNAME
 
 COPY --chown=${USERNAME}:${USERNAME} --from=binary-builder /agent-server/dist/openhands-agent-server /usr/local/bin/openhands-agent-server
 RUN chmod +x /usr/local/bin/openhands-agent-server
+# Fix library path to use system GCC libraries instead of bundled ones
+ENV LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 ENTRYPOINT ["/usr/local/bin/openhands-agent-server"]
 
 FROM base-image-minimal AS binary-minimal
 ARG USERNAME
 COPY --chown=${USERNAME}:${USERNAME} --from=binary-builder /agent-server/dist/openhands-agent-server /usr/local/bin/openhands-agent-server
 RUN chmod +x /usr/local/bin/openhands-agent-server
+# Fix library path to use system GCC libraries instead of bundled ones
+ENV LD_LIBRARY_PATH=/usr/lib/aarch64-linux-gnu:/usr/lib:/usr/lib/x86_64-linux-gnu:$LD_LIBRARY_PATH
 ENTRYPOINT ["/usr/local/bin/openhands-agent-server"]


### PR DESCRIPTION
## Problem

The web navigation tool was failing due to PyInstaller bundling an incompatible `libgcc_s.so.1` library that lacks `GCC_14.0` symbols. This caused Chromium to fail with:

```
/usr/lib/chromium/chromium: /tmp/_MEItGo3ZE/libgcc_s.so.1: version `GCC_14.0' not found (required by /usr/lib/chromium/chromium)
```

## Root Cause

PyInstaller was automatically including an older `libgcc_s.so.1` in the bundle that doesn't support GCC 14, and this bundled library was taking precedence over the system's compatible library via `LD_LIBRARY_PATH=/tmp/_MEItGo3ZE`.

## Solution

### Primary Fix: PyInstaller Spec Modification
- Modified `agent-server.spec` to exclude `libgcc_s.so.1` from the PyInstaller bundle
- This forces the binary to use the system's compatible GCC library instead

### Backup Fix: Dockerfile Environment Variable
- Added `LD_LIBRARY_PATH` environment variable in Dockerfile to prioritize system libraries
- Provides compatibility for both x86_64 and aarch64 architectures

## Testing

- ✅ PyInstaller build completes successfully
- ✅ Binary runs without GCC library errors
- ✅ Chromium can be launched with proper library path
- ✅ Web navigation tool can navigate to URLs

<img width="934" height="614" alt="image" src="https://github.com/user-attachments/assets/4942bab6-d166-429a-8690-1599f4a78a5f" />
<img width="859" height="488" alt="image" src="https://github.com/user-attachments/assets/1afe566e-0b04-45a0-809c-8c1652c3e761" />


## Files Changed

- `openhands-agent-server/openhands/agent_server/agent-server.spec`: Filter out problematic libgcc_s.so from bundle
- `openhands-agent-server/openhands/agent_server/docker/Dockerfile`: Add LD_LIBRARY_PATH for both binary targets

This fix resolves the core issue preventing Chromium from running in PyInstaller-built environments while maintaining compatibility across different architectures.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9ac51b9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9ac51b9-python \
  ghcr.io/openhands/agent-server:9ac51b9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9ac51b9-golang-amd64
ghcr.io/openhands/agent-server:9ac51b9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9ac51b9-golang-arm64
ghcr.io/openhands/agent-server:9ac51b9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9ac51b9-java-amd64
ghcr.io/openhands/agent-server:9ac51b9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9ac51b9-java-arm64
ghcr.io/openhands/agent-server:9ac51b9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9ac51b9-python-amd64
ghcr.io/openhands/agent-server:9ac51b9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:9ac51b9-python-arm64
ghcr.io/openhands/agent-server:9ac51b9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:9ac51b9-golang
ghcr.io/openhands/agent-server:9ac51b9-java
ghcr.io/openhands/agent-server:9ac51b9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9ac51b9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9ac51b9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->