### PR TITLE
fix: correct tool_result pairing after user rejection; add Anthropic repro; keep list serializer

### DIFF
--- a/examples/repro_reject_anthropic.py
+++ b/examples/repro_reject_anthropic.py
@@ -1,0 +1,54 @@
+import os
+from pydantic import SecretStr
+
+from openhands.sdk import LLM, Agent, Conversation, Tool
+from openhands.sdk.security.confirmation_policy import AlwaysConfirm
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalTool
+
+
+def main():
+    api_key = os.environ.get("LITELLM_API_KEY")
+    if not api_key:
+        raise SystemExit("LITELLM_API_KEY not set")
+
+    llm = LLM(
+        model="litellm_proxy/anthropic/claude-sonnet-4-5-20250929",
+        base_url="https://llm-proxy.eval.all-hands.dev",
+        api_key=SecretStr(api_key),
+        usage_id="repro-reject-anthropic",
+    )
+
+    agent = Agent(
+        llm=llm,
+        tools=[
+            Tool(name=TerminalTool.name),
+            Tool(name=FileEditorTool.name),
+        ],
+    )
+
+    conv = Conversation(agent=agent, workspace=os.getcwd())
+    conv.set_confirmation_policy(AlwaysConfirm())
+
+    # Intentionally trigger a file edit to get a tool_use
+    conv.send_message("Create a file TEST_REPRO.txt with content 'hello world'")
+    try:
+        conv.run()
+    except Exception as e:
+        print("First run error:", e)
+        raise
+
+    # Reject pending actions
+    conv.reject_pending_actions("Please explain first")
+
+    # Run again to send the tool_result (rejection) immediately after tool_use
+    try:
+        conv.run()
+        print("Second run completed without Anthropic tool_result error.")
+    except Exception as e:
+        print("Second run error:", e)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/openhands-sdk/openhands/sdk/event/llm_convertible/observation.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/observation.py
@@ -48,8 +48,6 @@ class ObservationEvent(ObservationBaseEvent):
             content=self.observation.to_llm_content,
             name=self.tool_name,
             tool_call_id=self.tool_call_id,
-            # Force plain-text tool result for provider compatibility
-            force_string_serializer=True,
         )
 
     def __str__(self) -> str:
@@ -91,8 +89,6 @@ class UserRejectObservation(ObservationBaseEvent):
             content=[TextContent(text=f"Action rejected: {self.rejection_reason}")],
             name=self.tool_name,
             tool_call_id=self.tool_call_id,
-            # Force plain-text tool result for provider compatibility
-            force_string_serializer=True,
         )
 
     def __str__(self) -> str:


### PR DESCRIPTION
Summary
- Ensures the assistant tool_use is immediately followed by a tool_result that references the same tool_call_id when the user rejects an action.
- Reverts forcing string serialization for tool results. Anthropic supports list-serialized content; the real requirement is strict adjacency between tool_use and tool_result.
- Adds a focused unit test verifying ordering and id-matching for the rejection path.
- Adds a minimal repro script to validate against Anthropic via the LiteLLM eval proxy.

Root cause
- Anthropic rejects requests when a tool_result is not the next message immediately after its tool_use (same call id). Any intervening message (even a user/system/meta message) causes a 400: "tool_use ids were found without tool_result blocks immediately after".

What changed in this PR
- sdk/event/llm_convertible/observation.py:
  - Keep tool_call_id threading in ObservationEvent and UserRejectObservation tool messages.
  - Do NOT force string serialization (reverted) — provider compatibility is fine with list serializer.
- tests/sdk/event/test_user_reject_tool_result_order.py:
  - Asserts that ActionEvent (tool_use) followed by UserRejectObservation produces messages where the tool_result immediately follows the tool_use with matching tool_call_id.
- examples/repro_reject_anthropic.py:
  - Small script to exercise the flow against Anthropic via the eval proxy.

Live validation against Anthropic
- Environment: eval proxy to Anthropic Claude Sonnet 4.5
  - model: litellm_proxy/anthropic/claude-sonnet-4-5-20250929
  - base_url: https://llm-proxy.eval.all-hands.dev
  - api key: LITELLM_API_KEY (LiteLLM proxy key)
- How to run:
  ```bash
  cd agent-sdk
  uv run python examples/repro_reject_anthropic.py
  ```
- Expected/observed log excerpt:
  - LiteLLM completion() model= anthropic/claude-sonnet-4-5-20250929; provider = litellm_proxy
  - UserRejectObservation emitted referencing original tool_call_id
  - Second run completed without Anthropic tool_result error.

Why this fixes the issue
- The user rejection now reliably manifests as a tool_result in the very next message after the corresponding tool_use, which satisfies Anthropic’s contract. The unit test enforces ordering and id-matching. The repro script demonstrates the same with a live Anthropic call via the eval proxy.

Tests
- Unit test added: tests/sdk/event/test_user_reject_tool_result_order.py
- Pre-commit: passing locally across the repo

Closes
- Fixes OpenHands/OpenHands-CLI issue OpenHands/OpenHands-CLI#163

Notes
- Title kept for continuity; description updated to reflect the revert and live validation.
