### PR TITLE
fix: create parent directories in observation truncation

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/truncate.py
+++ b/openhands-sdk/openhands/sdk/utils/truncate.py
@@ -29,7 +29,7 @@ def _save_full_content(content: str, save_dir: str, tool_prefix: str) -> str | N
     """Save full content to the specified directory and return the file path."""
 
     save_dir_path = Path(save_dir)
-    save_dir_path.mkdir(exist_ok=True)
+    save_dir_path.mkdir(parents=True, exist_ok=True)
 
     # Generate hash-based filename for deduplication
     content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()[:8]


### PR DESCRIPTION
## Problem

When the SDK saves full observation content in remote workspace scenarios (e.g., Kubernetes pods), it fails with `FileNotFoundError` because parent directories don't exist.

**Error:**
```
FileNotFoundError: [Errno 2] No such file or directory: 
'workspace/conversations/f340bac550504adc92b4d88d4c450240/observations'
```

This affects **16.7% of GAIA evaluation instances** (8 out of 48 in recent runs).

## Root Cause

Location: `openhands-sdk/openhands/sdk/utils/truncate.py:32`

```python
save_dir_path.mkdir(exist_ok=True)  # ❌ Only creates last directory
```

`mkdir(exist_ok=True)` only creates the final directory and assumes all parent directories already exist. In remote workspaces, the directory structure isn't pre-initialized.

## Solution

```python
save_dir_path.mkdir(parents=True, exist_ok=True)  # ✅ Creates all parent dirs
```

Adding `parents=True` ensures all missing parent directories are created automatically (equivalent to `mkdir -p` in bash).

## Impact

- **Fixes:** 8+ instances with FileNotFoundError
- **Affected:** Observation truncation in browser tool and other large outputs
- **Risk:** Very low - only adds safe directory creation
- **Testing:** Existing behavior preserved, just handles missing parents gracefully

## Testing

Verified that:
- ✅ Creates nested directory structure when missing
- ✅ Works when directories already exist (`exist_ok=True`)
- ✅ No change to file writing logic

Relates to #1293

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/71d329d71f1c4abb94caa1b923735398)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc4da07-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc4da07-python \
  ghcr.io/openhands/agent-server:dc4da07-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc4da07-golang-amd64
ghcr.io/openhands/agent-server:dc4da07-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc4da07-golang-arm64
ghcr.io/openhands/agent-server:dc4da07-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc4da07-java-amd64
ghcr.io/openhands/agent-server:dc4da07-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc4da07-java-arm64
ghcr.io/openhands/agent-server:dc4da07-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc4da07-python-amd64
ghcr.io/openhands/agent-server:dc4da07-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:dc4da07-python-arm64
ghcr.io/openhands/agent-server:dc4da07-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:dc4da07-golang
ghcr.io/openhands/agent-server:dc4da07-java
ghcr.io/openhands/agent-server:dc4da07-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc4da07-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc4da07-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->