### PR TITLE
Add no-mocking instructions to system prompt

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
@@ -52,6 +52,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
    * For bug fixes: Create tests to verify issues before implementing fixes
    * For new features: Consider test-driven development when appropriate
    * Do NOT write tests for documentation changes, README updates, configuration files, or other non-functionality changes
+   * Do not use mocks in tests unless strictly necessary and justify their use when they are used. You must always test real code paths in tests, NOT mocks.
    * If the repository lacks testing infrastructure and implementing tests would require extensive setup, consult with the user before investing time in building testing infrastructure
    * If the environment is not set up to run tests, consult with the user first before investing time to install all dependencies
 4. IMPLEMENTATION:


### PR DESCRIPTION
Instruct the agent to avoid using mocks in tests unless strictly necessary, and to always test real code paths instead.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc79925-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc79925-python \
  ghcr.io/openhands/agent-server:dc79925-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc79925-golang-amd64
ghcr.io/openhands/agent-server:dc79925-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc79925-golang-arm64
ghcr.io/openhands/agent-server:dc79925-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc79925-java-amd64
ghcr.io/openhands/agent-server:dc79925-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc79925-java-arm64
ghcr.io/openhands/agent-server:dc79925-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc79925-python-amd64
ghcr.io/openhands/agent-server:dc79925-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:dc79925-python-arm64
ghcr.io/openhands/agent-server:dc79925-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:dc79925-golang
ghcr.io/openhands/agent-server:dc79925-java
ghcr.io/openhands/agent-server:dc79925-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc79925-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc79925-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->