### PR TITLE
tests(b01): make pinned commit checkout robust

### DIFF
--- a/tests/integration/tests/b01_no_premature_implementation.py
+++ b/tests/integration/tests/b01_no_premature_implementation.py
@@ -70,10 +70,7 @@ class NoPrematureImplementationTest(BaseIntegrationTest):
                 [
                     "git",
                     "clone",
-                    "--depth",
-                    "1",
-                    "--branch",
-                    "main",
+                    "--filter=blob:none",
                     "https://github.com/OpenHands/software-agent-sdk.git",
                     repo_dir,
                 ],
@@ -82,13 +79,28 @@ class NoPrematureImplementationTest(BaseIntegrationTest):
                 timeout=60,
             )
 
-            # Checkout the pinned commit
+            # Fetch and checkout the pinned commit
+            subprocess.run(
+                [
+                    "git",
+                    "fetch",
+                    "origin",
+                    "693c32618dca43e6506a785da4e37575e387a638",
+                    "--depth",
+                    "1",
+                ],
+                cwd=repo_dir,
+                check=True,
+                capture_output=True,
+                timeout=60,
+            )
+
             subprocess.run(
                 ["git", "checkout", "693c32618dca43e6506a785da4e37575e387a638"],
                 cwd=repo_dir,
                 check=True,
                 capture_output=True,
-                timeout=10,
+                timeout=30,
             )
 
             # Update the working directory context


### PR DESCRIPTION
This PR fixes the intermittent failure in the b01 behavior test setup when attempting to check out a historical commit after a shallow clone.

Problem
- The test previously did `git clone --depth 1 --branch main ...` and then tried to `git checkout 693c32618dca43e6506a785da4e37575e387a638`.
- With shallow history, that historical SHA isn’t available locally, causing checkout to fail and the test to proceed with a warning.

Fix
- Switch to a history-friendly but bandwidth-efficient approach:
  1) `git clone --filter=blob:none https://github.com/OpenHands/software-agent-sdk.git <repo_dir>`
  2) `git fetch origin 693c32618dca43e6506a785da4e37575e387a638 --depth 1`
  3) `git checkout 693c32618dca43e6506a785da4e37575e387a638`

This ensures the pinned commit is always present while keeping network usage minimal.

File changed
- `tests/integration/tests/b01_no_premature_implementation.py`

Verification
- Ran pre-commit on the modified file (ruff/pyright/pycodestyle) — all passed.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8e759fa7ea1142beae4aa0e62640dbcc)