### PR TITLE
Release 1.5.1

### DIFF
--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-agent-server"
-version = "1.5.0"
+version = "1.5.1"
 description = "OpenHands Agent Server - REST/WebSocket interface for OpenHands AI Agent"
 
 requires-python = ">=3.12"

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-sdk"
-version = "1.5.0"
+version = "1.5.1"
 description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-tools"
-version = "1.5.0"
+version = "1.5.1"
 description = "OpenHands Tools - Runtime tools for AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-workspace/pyproject.toml
+++ b/openhands-workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-workspace"
-version = "1.5.0"
+version = "1.5.1"
 description = "OpenHands Workspace - Docker and container-based workspace implementations"
 
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2065,7 +2065,7 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2096,7 +2096,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "openhands-sdk" }
 dependencies = [
     { name = "deprecation" },
@@ -2134,7 +2134,7 @@ provides-extras = ["boto3"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "openhands-tools" }
 dependencies = [
     { name = "bashlex" },
@@ -2163,7 +2163,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.5.0"
+version = "1.5.1"
 source = { editable = "openhands-workspace" }
 dependencies = [
     { name = "openhands-sdk" },


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7762304-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7762304-python \
  ghcr.io/openhands/agent-server:7762304-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7762304-golang-amd64
ghcr.io/openhands/agent-server:7762304-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7762304-golang-arm64
ghcr.io/openhands/agent-server:7762304-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7762304-java-amd64
ghcr.io/openhands/agent-server:7762304-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7762304-java-arm64
ghcr.io/openhands/agent-server:7762304-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7762304-python-amd64
ghcr.io/openhands/agent-server:7762304-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:7762304-python-arm64
ghcr.io/openhands/agent-server:7762304-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:7762304-golang
ghcr.io/openhands/agent-server:7762304-java
ghcr.io/openhands/agent-server:7762304-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7762304-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7762304-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->