### PR TITLE
fix: use simple delay for shell init instead of PTY-based detection

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -10,7 +10,6 @@ import signal
 import subprocess
 import threading
 import time
-import uuid
 from collections import deque
 
 from openhands.sdk.logger import get_logger
@@ -151,26 +150,15 @@ class SubprocessTerminal(TerminalInterface):
         self.reader_thread.start()
         self._initialized: bool = True
 
-        # ===== Deterministic readiness (no blind sleeps) =====
-        # 1) Single atomic init line: clear PROMPT_COMMAND, set PS2/PS1, print sentinel
-        # Disable history expansion to avoid ! mangling
-        sentinel = f"__OH_READY_{uuid.uuid4().hex}__"
+        # Configure bash: disable history expansion, set up PS1/PS2 prompts
         init_cmd = (
-            "set +H; "
-            f"export PROMPT_COMMAND='export PS1=\"{self.PS1}\"'; "
-            f'export PS2=""; '
-            f'printf "{sentinel}"'
+            f'set +H; export PROMPT_COMMAND=\'export PS1="{self.PS1}"\'; export PS2=""'
         ).encode("utf-8", "ignore")
 
         self._write_pty(init_cmd + ENTER)
-        if not self._wait_for_output(sentinel, timeout=8.0):
-            raise RuntimeError("Shell did not become ready (sentinel not seen)")
+        time.sleep(1.0)  # Wait for command to take effect
 
         self.clear_screen()
-
-        # 3) Wait for prompt to actually be visible
-        if not self._wait_for_prompt(timeout=5.0):
-            raise RuntimeError("Prompt not visible after init")
 
         logger.debug("PTY terminal initialized with work dir: %s", self.work_dir)
 


### PR DESCRIPTION
This PR fixes a bug that was preventing the SDK from working in Bitbucket pipelines.

PTY reads don't work reliably in some CI environments (e.g., Bitbucket Docker). The select()/read() on the PTY master FD returns nothing even though bash is producing output. This was causing OpenHands SDK to fail unnecessarily.

To fix, I replace sentinel-based detection with a simple time.sleep(1.0), matching the current pattern in this repo used by TmuxTerminal here: https://github.com/OpenHands/software-agent-sdk/blob/8f90b92c6172175edfb0c0e04df12d630065fead/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py#L87-L89

I've confirmed this PR works in a bitbucket pipeline.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6f57edf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6f57edf-python \
  ghcr.io/openhands/agent-server:6f57edf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6f57edf-golang-amd64
ghcr.io/openhands/agent-server:6f57edf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6f57edf-golang-arm64
ghcr.io/openhands/agent-server:6f57edf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6f57edf-java-amd64
ghcr.io/openhands/agent-server:6f57edf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6f57edf-java-arm64
ghcr.io/openhands/agent-server:6f57edf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6f57edf-python-amd64
ghcr.io/openhands/agent-server:6f57edf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6f57edf-python-arm64
ghcr.io/openhands/agent-server:6f57edf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6f57edf-golang
ghcr.io/openhands/agent-server:6f57edf-java
ghcr.io/openhands/agent-server:6f57edf-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6f57edf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6f57edf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->