### PR TITLE
feat: allow xhigh reasoning_effort

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -247,10 +247,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             "like HuggingFace and Groq."
         ),
     )
-    reasoning_effort: Literal["low", "medium", "high", "none"] | None = Field(
+    reasoning_effort: Literal["low", "medium", "high", "xhigh", "none"] | None = Field(
         default="high",
         description="The effort to put into reasoning. "
-        "This is a string that can be one of 'low', 'medium', 'high', or 'none'. "
+        "This is a string that can be one of 'low', 'medium', 'high', 'xhigh', "
+        "or 'none'. "
         "Can apply to all reasoning models.",
     )
     reasoning_summary: Literal["auto", "concise", "detailed"] | None = Field(

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -179,6 +179,8 @@ def test_llm_config_post_init_reasoning_effort_default():
     # Test that explicit reasoning_effort is preserved
     config = LLM(model="gpt-4", reasoning_effort="low", usage_id="test-llm")
     assert config.reasoning_effort == "low"
+    config = LLM(model="gpt-4", reasoning_effort="xhigh", usage_id="test-llm")
+    assert config.reasoning_effort == "xhigh"
 
 
 def test_llm_config_post_init_azure_api_version():


### PR DESCRIPTION
Adds `xhigh` as an allowed value for `LLM.reasoning_effort` and covers it with a config regression test.