### PR TITLE
Add instance id input to run-eval dispatch

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -51,6 +51,10 @@ on:
                 required: false
                 default: main
                 type: string
+            instance_ids:
+                description: Comma-separated instance IDs to evaluate (optional, overrides eval_limit for supported benchmarks)
+                required: false
+                default: ''
 
 
 env:
@@ -194,6 +198,7 @@ jobs:
                   BENCHMARK: ${{ github.event.inputs.benchmark || 'swebench' }}
                   TRIGGER_REASON: ${{ github.event.inputs.reason }}
                   PR_NUMBER: ${{ steps.params.outputs.pr_number }}
+                  INSTANCE_IDS: ${{ github.event.inputs.instance_ids || '' }}
               run: |
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH)"
                   PAYLOAD=$(jq -n \
@@ -205,7 +210,8 @@ jobs:
                     --arg pr "$PR_NUMBER" \
                     --arg benchmarks "$BENCHMARKS_BRANCH" \
                     --arg benchmark "$BENCHMARK" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark}}')
+                    --arg instance_ids "$INSTANCE_IDS" \
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e4b408d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e4b408d-python \
  ghcr.io/openhands/agent-server:e4b408d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e4b408d-golang-amd64
ghcr.io/openhands/agent-server:e4b408d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e4b408d-golang-arm64
ghcr.io/openhands/agent-server:e4b408d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e4b408d-java-amd64
ghcr.io/openhands/agent-server:e4b408d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e4b408d-java-arm64
ghcr.io/openhands/agent-server:e4b408d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e4b408d-python-amd64
ghcr.io/openhands/agent-server:e4b408d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:e4b408d-python-arm64
ghcr.io/openhands/agent-server:e4b408d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:e4b408d-golang
ghcr.io/openhands/agent-server:e4b408d-java
ghcr.io/openhands/agent-server:e4b408d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e4b408d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e4b408d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->