### PR TITLE
feat: add load_repo_skills parameter to Conversation

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/skills/__init__.py
@@ -2,6 +2,7 @@ from openhands.sdk.context.skills.exceptions import SkillValidationError
 from openhands.sdk.context.skills.skill import (
     Skill,
     load_public_skills,
+    load_repo_skills,
     load_skills_from_dir,
     load_user_skills,
 )
@@ -22,5 +23,6 @@ __all__ = [
     "load_skills_from_dir",
     "load_user_skills",
     "load_public_skills",
+    "load_repo_skills",
     "SkillValidationError",
 ]

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -60,6 +60,7 @@ class Conversation:
             type[ConversationVisualizerBase] | ConversationVisualizerBase | None
         ) = DefaultConversationVisualizer,
         secrets: dict[str, SecretValue] | dict[str, str] | None = None,
+        load_repo_skills: bool = False,
     ) -> "LocalConversation": ...
 
     @overload
@@ -94,6 +95,7 @@ class Conversation:
             type[ConversationVisualizerBase] | ConversationVisualizerBase | None
         ) = DefaultConversationVisualizer,
         secrets: dict[str, SecretValue] | dict[str, str] | None = None,
+        load_repo_skills: bool = False,
     ) -> BaseConversation:
         from openhands.sdk.conversation.impl.local_conversation import LocalConversation
         from openhands.sdk.conversation.impl.remote_conversation import (
@@ -130,4 +132,5 @@ class Conversation:
             workspace=workspace,
             persistence_dir=persistence_dir,
             secrets=secrets,
+            load_repo_skills=load_repo_skills,
         )

--- a/tests/sdk/context/skill/test_load_repo_skills.py
+++ b/tests/sdk/context/skill/test_load_repo_skills.py
@@ -1,0 +1,66 @@
+"""Tests for load_repo_skills functionality."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from openhands.sdk.context.skills import (
+    KeywordTrigger,
+    load_repo_skills,
+)
+
+
+@pytest.fixture
+def temp_workspace_with_skills():
+    """Create a temporary workspace with .openhands/skills directory."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        workspace = Path(temp_dir)
+
+        # Create .openhands/skills directory
+        skills_dir = workspace / ".openhands" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        yield workspace, skills_dir
+
+
+def test_load_repo_skills_no_directories(tmp_path):
+    """Test load_repo_skills returns empty list when no .openhands directories exist."""
+    skills = load_repo_skills(tmp_path)
+    assert skills == []
+
+
+def test_load_repo_skills_with_skills_directory(temp_workspace_with_skills):
+    """Test load_repo_skills loads skills from .openhands/skills directory."""
+    workspace, skills_dir = temp_workspace_with_skills
+
+    # Create a repo skill (no triggers) and a knowledge skill (with triggers)
+    (skills_dir / "repo_guidelines.md").write_text(
+        "---\nname: repo_guidelines\n---\nAlways follow these guidelines."
+    )
+    (skills_dir / "python_help.md").write_text(
+        "---\nname: python_help\ntriggers:\n  - python\n---\nPython help."
+    )
+
+    skills = load_repo_skills(workspace)
+    assert len(skills) == 2
+
+    repo_skill = next(s for s in skills if s.name == "repo_guidelines")
+    knowledge_skill = next(s for s in skills if s.name == "python_help")
+
+    assert repo_skill.trigger is None  # Repo skill
+    assert isinstance(knowledge_skill.trigger, KeywordTrigger)  # Knowledge skill
+
+
+def test_load_repo_skills_with_microagents_directory(tmp_path):
+    """Test load_repo_skills loads from legacy .openhands/microagents directory."""
+    microagents_dir = tmp_path / ".openhands" / "microagents"
+    microagents_dir.mkdir(parents=True)
+
+    (microagents_dir / "legacy_skill.md").write_text(
+        "---\nname: legacy_skill\n---\nLegacy microagent skill."
+    )
+
+    skills = load_repo_skills(tmp_path)
+    assert len(skills) == 1
+    assert skills[0].name == "legacy_skill"


### PR DESCRIPTION
Add a new `load_repo_skills` parameter to the Conversation class that automatically loads skills from the workspace's `.openhands/skills/` and `.openhands/microagents/` directories.

This simplifies CI/workflow automation use cases where users previously had to manually wire up skill loading from the workspace. With this change, users can now simply pass `load_repo_skills=True` to have repository-specific skills automatically loaded and merged into the agent's context.

Without this PR, to load skills and microagent files when the workspace repo contains skills and microagent files (and it's not clear what explicit directory path those files exist), ends users need to add the following code:
```python
  def _load_repo_skills(repo_root: Path) -> list:
      skills: list = []
      for rel in [".openhands/skills", ".openhands/microagents"]:
          skill_dir = repo_root / rel
          if skill_dir.is_dir():
              repo_skills, knowledge_skills = load_skills_from_dir(skill_dir)
              skills.extend(repo_skills.values())
              skills.extend(knowledge_skills.values())
      return skills

  # ... later ...
  skills = _load_repo_skills(repo_root)
  agent_context = AgentContext(skills=skills) if skills else None
  agent = Agent(llm=llm, tools=tools, agent_context=agent_context)
  convo = Conversation(agent=agent, workspace=repo_root)
```

after this change, users can simply set a parameter:
```python
  agent = Agent(llm=llm, tools=tools)
  convo = Conversation(agent=agent, workspace=repo_root, load_repo_skills=True)
```

Changes:
- Add `load_repo_skills()` function in skill.py to load skills from a workspace directory
- Add `load_repo_skills` parameter to Conversation and LocalConversation
- Skills are loaded and merged before agent initialization
- Existing agent context skills take precedence over repo skills
- Add 6 essential tests for the new functionality
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:87ff282-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-87ff282-python \
  ghcr.io/openhands/agent-server:87ff282-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:87ff282-golang-amd64
ghcr.io/openhands/agent-server:87ff282-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:87ff282-golang-arm64
ghcr.io/openhands/agent-server:87ff282-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:87ff282-java-amd64
ghcr.io/openhands/agent-server:87ff282-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:87ff282-java-arm64
ghcr.io/openhands/agent-server:87ff282-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:87ff282-python-amd64
ghcr.io/openhands/agent-server:87ff282-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:87ff282-python-arm64
ghcr.io/openhands/agent-server:87ff282-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:87ff282-golang
ghcr.io/openhands/agent-server:87ff282-java
ghcr.io/openhands/agent-server:87ff282-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `87ff282-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `87ff282-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->