### PR TITLE
Make thinking signatures optional

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/message.py
+++ b/openhands-sdk/openhands/sdk/llm/message.py
@@ -120,8 +120,8 @@ class ThinkingBlock(BaseModel):
 
     type: Literal["thinking"] = "thinking"
     thinking: str = Field(..., description="The thinking content")
-    signature: str = Field(
-        ..., description="Cryptographic signature for the thinking block"
+    signature: str | None = Field(
+        default=None, description="Cryptographic signature for the thinking block"
     )
 
 


### PR DESCRIPTION
When gemini-2.5-pro returns thinking summaries, it doesn't seem to include thought signatures which results in an exception. Thought signatures will be sent back for function calls but will appear in a different part than thinking.

    openhands.sdk.conversation.exceptions.ConversationRunError: Conversation run failed for id=2d3348aa-e2ca-4e23-80eb-55171fbb763a: 1 validation error for ThinkingBlock signature
      Field required [type=missing, input_value={'type': 'thinking', 'thi... question they have.\n'}, input_type=dict]

This is a possible fix/work around for #1392 