### PR TITLE
Update lmnr from 0.7.20 to 0.7.24

### DIFF
--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "python-json-logger>=3.3.0",
     "tenacity>=9.1.2",
     "websockets>=12",
-    "lmnr>=0.7.20"
+    "lmnr>=0.7.24"
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -1533,7 +1533,7 @@ wheels = [
 
 [[package]]
 name = "lmnr"
-version = "0.7.20"
+version = "0.7.24"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "grpcio" },
@@ -1553,9 +1553,9 @@ dependencies = [
     { name = "tenacity" },
     { name = "tqdm" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d4/c0/996403cc2f6967881a42af4b27ff8931956d57ab3ed2d8bf11e5b37aed40/lmnr-0.7.20.tar.gz", hash = "sha256:1f484cd618db2d71af65f90a0b8b36d20d80dc91a5138b811575c8677bf7c4fd", size = 194075, upload-time = "2025-11-04T16:53:34.49Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f7/77/db0400c1d72c1a060f337cac77ce5265874c9a08d57bed9719a67ec7b786/lmnr-0.7.24.tar.gz", hash = "sha256:aa6973f46fc4ba95c9061c1feceb58afc02eb43c9376c21e32545371ff6123d7", size = 203111, upload-time = "2025-11-30T10:26:54.531Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b5/df/4665a3931b2fbc5f5b66e4906ffab106f3f65ab7e78732ecdaf3ba4a3076/lmnr-0.7.20-py3-none-any.whl", hash = "sha256:5f9fa7444e6f96c25e097f66484ff29e632bdd1de0e9346948bf5595f4a8af38", size = 247465, upload-time = "2025-11-04T16:53:32.713Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/e3/b622a2e6430699381476b842822fb32c9d242fd8e2028cfdb7a493b1d172/lmnr-0.7.24-py3-none-any.whl", hash = "sha256:ad780d4a62ece897048811f3368639c240a9329ab31027da8c96545137a3a08a", size = 264639, upload-time = "2025-11-30T10:26:52.968Z" },
 ]
 
 [[package]]
@@ -2123,7 +2123,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=2.11.3" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "litellm", specifier = ">=1.80.7" },
-    { name = "lmnr", specifier = ">=0.7.20" },
+    { name = "lmnr", specifier = ">=0.7.24" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },
     { name = "python-json-logger", specifier = ">=3.3.0" },


### PR DESCRIPTION
## Description

This PR updates the `lmnr` package from version `0.7.20` to `0.7.24` in the `openhands-sdk` package.

## Motivation

Version `0.7.24` introduces support for passing span context to isolated environments (local docker containers or cloud), which is necessary for all spans to sit in one trace. This feature is critical for proper distributed tracing across different execution environments.

## Changes

- Updated `lmnr>=0.7.20` to `lmnr>=0.7.24` in `openhands-sdk/pyproject.toml`
- Ran `uv lock` to update the lock file with the new dependency version

## Testing

- Pre-commit hooks passed successfully
- Lock file updated correctly with lmnr v0.7.24

## References

Related discussion about the need for this update to enable proper tracing across isolated environments.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0dd396823e9543a8be8d2b8ffe7374e8)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:06d4505-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-06d4505-python \
  ghcr.io/openhands/agent-server:06d4505-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:06d4505-golang-amd64
ghcr.io/openhands/agent-server:06d4505-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:06d4505-golang-arm64
ghcr.io/openhands/agent-server:06d4505-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:06d4505-java-amd64
ghcr.io/openhands/agent-server:06d4505-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:06d4505-java-arm64
ghcr.io/openhands/agent-server:06d4505-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:06d4505-python-amd64
ghcr.io/openhands/agent-server:06d4505-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:06d4505-python-arm64
ghcr.io/openhands/agent-server:06d4505-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:06d4505-golang
ghcr.io/openhands/agent-server:06d4505-java
ghcr.io/openhands/agent-server:06d4505-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `06d4505-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `06d4505-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->