### PR TITLE
ALL-4516 Fix selfish coroutines in event service state lock operations

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -74,7 +74,8 @@ class EventService:
             raise ValueError("inactive_service")
         return self._conversation
 
-    async def get_event(self, event_id: str) -> Event | None:
+    def _get_event_sync(self, event_id: str) -> Event | None:
+        """Private sync function to get event with state lock."""
         if not self._conversation:
             raise ValueError("inactive_service")
         with self._conversation._state as state:
@@ -82,7 +83,13 @@ class EventService:
             event = state.events[index]
             return event
 
-    async def search_events(
+    async def get_event(self, event_id: str) -> Event | None:
+        if not self._conversation:
+            raise ValueError("inactive_service")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self._get_event_sync, event_id)
+
+    def _search_events_sync(
         self,
         page_id: str | None = None,
         limit: int = 100,
@@ -93,6 +100,7 @@ class EventService:
         timestamp__gte: datetime | None = None,
         timestamp__lt: datetime | None = None,
     ) -> EventPage:
+        """Private sync function to search events with state lock."""
         if not self._conversation:
             raise ValueError("inactive_service")
 
@@ -161,7 +169,34 @@ class EventService:
 
         return EventPage(items=items, next_page_id=next_page_id)
 
-    async def count_events(
+    async def search_events(
+        self,
+        page_id: str | None = None,
+        limit: int = 100,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+        sort_order: EventSortOrder = EventSortOrder.TIMESTAMP,
+        timestamp__gte: datetime | None = None,
+        timestamp__lt: datetime | None = None,
+    ) -> EventPage:
+        if not self._conversation:
+            raise ValueError("inactive_service")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            self._search_events_sync,
+            page_id,
+            limit,
+            kind,
+            source,
+            body,
+            sort_order,
+            timestamp__gte,
+            timestamp__lt,
+        )
+
+    def _count_events_sync(
         self,
         kind: str | None = None,
         source: str | None = None,
@@ -169,7 +204,7 @@ class EventService:
         timestamp__gte: datetime | None = None,
         timestamp__lt: datetime | None = None,
     ) -> int:
-        """Count events matching the given filters."""
+        """Private sync function to count events with state lock."""
         if not self._conversation:
             raise ValueError("inactive_service")
 
@@ -209,6 +244,28 @@ class EventService:
                 count += 1
 
         return count
+
+    async def count_events(
+        self,
+        kind: str | None = None,
+        source: str | None = None,
+        body: str | None = None,
+        timestamp__gte: datetime | None = None,
+        timestamp__lt: datetime | None = None,
+    ) -> int:
+        """Count events matching the given filters."""
+        if not self._conversation:
+            raise ValueError("inactive_service")
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            self._count_events_sync,
+            kind,
+            source,
+            body,
+            timestamp__gte,
+            timestamp__lt,
+        )
 
     def _event_matches_body(self, event: Event, body: str) -> bool:
         """Check if event's message content matches body filter (case-insensitive)."""


### PR DESCRIPTION
## Problem

Server stalls were occurring due to selfish coroutines in the event service. The `search_events`, `get_event`, and `count_events` methods were using `with self._conversation._state as state:` context managers directly in async methods, causing blocking operations that prevented the main event loop from processing other tasks.

## Solution

Refactored the problematic methods to use `run_in_executor` for state lock operations:

### Changes Made

1. **Created private sync helper functions:**
   - `_get_event_sync()` - handles state lock for single event retrieval
   - `_search_events_sync()` - handles state lock for event searching with filters  
   - `_count_events_sync()` - handles state lock for event counting

2. **Refactored async methods:**
   - Modified `get_event()`, `search_events()`, and `count_events()` to use `loop.run_in_executor(None, ...)` 
   - Moves blocking state lock operations to a thread pool executor
   - Prevents the main event loop from being blocked

### Technical Details

**Before (blocking):**
```python
async def search_events(...):
    with self._conversation._state as state:  # BLOCKING!
        # ... state operations
```

**After (non-blocking):**
```python
def _search_events_sync(...):  # Private sync function
    with self._conversation._state as state:
        # ... state operations

async def search_events(...):
    loop = asyncio.get_running_loop()
    return await loop.run_in_executor(None, self._search_events_sync, ...)  # NON-BLOCKING!
```

## Benefits

- ✅ **Eliminates server stalls** - State lock operations no longer block the main event loop
- ✅ **Maintains functionality** - All existing behavior is preserved
- ✅ **Follows existing patterns** - Uses the same executor pattern already used elsewhere in the codebase
- ✅ **Comprehensive testing** - All 76 related tests pass (event_service: 47, event_router: 18, websocket: 11)

## Testing

- All existing tests continue to pass
- Pre-commit hooks pass (formatting, linting, type checking)
- No breaking changes to the API

## Steps to Reproduce

* Use the static agent server test site
* Use 2 tabs - one pointed at the static site, one at the openapi docs.
* Create a new conversation - the conversation does not run until you select it and the websocket connects.
* Select the conversation to connect the websocket and run the /alive endpoint in a second tab.
* The /alive endpoint takes longer than usual to execute
* It looks like the conversation execution is locking the main runloop. You can see from my screenshot this is intermittent

<img width="1134" height="1322" alt="image" src="https://github.com/user-attachments/assets/f78590f7-71e2-4a60-920b-b751d5807451" />

<img width="1266" height="722" alt="image" src="https://github.com/user-attachments/assets/0836c9b4-c3b3-4d5a-8d9d-65612e977226" />

<img width="2966" height="1030" alt="image" src="https://github.com/user-attachments/assets/83b9dae2-de44-4f4b-8c1a-a964821d305f" />

**Before:**
<img width="1639" height="111" alt="image" src="https://github.com/user-attachments/assets/771ff756-39b6-435a-9832-d27bc5a83161" />

**After:**
<img width="1636" height="287" alt="image" src="https://github.com/user-attachments/assets/d1b8eedc-afb1-421b-8f9c-3c08ec1fe3e8" />

## Files Changed

- `openhands-agent-server/openhands/agent_server/event_service.py`

This fix resolves the selfish coroutines issue while maintaining full backward compatibility and functionality.

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a3f3000-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a3f3000-python \
  ghcr.io/openhands/agent-server:a3f3000-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a3f3000-golang-amd64
ghcr.io/openhands/agent-server:a3f3000-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a3f3000-golang-arm64
ghcr.io/openhands/agent-server:a3f3000-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a3f3000-java-amd64
ghcr.io/openhands/agent-server:a3f3000-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a3f3000-java-arm64
ghcr.io/openhands/agent-server:a3f3000-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a3f3000-python-amd64
ghcr.io/openhands/agent-server:a3f3000-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a3f3000-python-arm64
ghcr.io/openhands/agent-server:a3f3000-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a3f3000-golang
ghcr.io/openhands/agent-server:a3f3000-java
ghcr.io/openhands/agent-server:a3f3000-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a3f3000-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a3f3000-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->