### PR TITLE
Fix GPT-5 external access limitation by adding explicit CAPABILITIES section

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
@@ -5,6 +5,15 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 * If the user asks a question, like "why is X happening", don't try to fix the problem. Just give an answer to the question.
 </ROLE>
 
+<CAPABILITIES>
+* You HAVE FULL ACCESS to external resources through the tools provided to you.
+* You CAN and SHOULD use command-line tools (like curl, wget) to access web pages, APIs, and other online resources.
+* You CAN browse GitHub, GitLab, Bitbucket and other services using their public APIs (via curl/terminal) or browser tools.
+* You CAN download files, fetch data from URLs, and interact with any publicly accessible web service.
+* NEVER claim you "don't have access" to external resources - instead, USE YOUR TOOLS to access them.
+* If you're unsure how to access something, try using curl, browser tools, or other available commands.
+</CAPABILITIES>
+
 <MEMORY>
 * Use `.openhands/skills/repo.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.

--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt_planning.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt_planning.j2
@@ -5,6 +5,15 @@ You are a Planning Agent that analyzes codebases and helps the user make a detai
 * If the user asks a question, like "why is X happening", just give an answer to the question.
 </ROLE>
 
+<CAPABILITIES>
+* You HAVE FULL ACCESS to external resources through the tools provided to you.
+* You CAN and SHOULD use command-line tools (like curl, wget) to access web pages, APIs, and other online resources.
+* You CAN browse GitHub, GitLab, Bitbucket and other services using their public APIs (via curl/terminal) or browser tools.
+* You CAN download files, fetch data from URLs, and interact with any publicly accessible web service.
+* NEVER claim you "don't have access" to external resources - instead, USE YOUR TOOLS to access them.
+* If you're unsure how to access something, try using curl, browser tools, or other available commands.
+</CAPABILITIES>
+
 <EFFICIENCY>
 * Each action you take is somewhat expensive. Wherever possible, combine multiple actions into a single action, e.g. using sed and grep to view multiple files at once.
 * When exploring the codebase, use efficient tools like glob and grep with appropriate filters to minimize unnecessary operations.


### PR DESCRIPTION
## Problem

GPT-5 (litellm_proxy_gpt_5.1_codex_max) failed the `t06_github_pr_browsing` integration test in PR #1404, with this error:

> "I don't have live access to browse GitHub or view that pull request directly from here."

The model did not attempt to use any available tools (curl, GitHub API, browser) to access the PR. See artifacts: https://github.com/OpenHands/software-agent-sdk/actions/runs/20274635058

## Root Cause

GPT-5 has a pre-trained belief that it cannot access external resources, which overrides the system prompt instructions. This is a known issue with some GPT models where training is so strong that it supersedes system prompt guidance.

For comparison, Claude Sonnet 4.5 successfully completed the same test by using `curl` to fetch PR details from the GitHub API.

## Solution

Added an explicit `<CAPABILITIES>` section to system prompts immediately after the `<ROLE>` section that:

- ✅ Explicitly states the agent HAS FULL ACCESS to external resources through tools
- ✅ Uses strong, direct language ("CAN and SHOULD", "NEVER claim") to override pre-trained limitations  
- ✅ Lists specific tools (curl, wget, browser) and use cases (GitHub, GitLab, etc.)
- ✅ Instructs to USE TOOLS rather than claim lack of access
- ✅ Placed prominently early in the system prompt for high visibility

Example from the new section:
```
* You HAVE FULL ACCESS to external resources through the tools provided to you.
* You CAN and SHOULD use command-line tools (like curl, wget) to access web pages, APIs, and other online resources.
* NEVER claim you "don't have access" to external resources - instead, USE YOUR TOOLS to access them.
```

## Files Modified

- `openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2`
- `openhands-sdk/openhands/sdk/agent/prompts/system_prompt_planning.j2`

Other system prompt variants (interactive, long_horizon, tech_philosophy) automatically inherit this change as they include `system_prompt.j2`.

## Testing

This fix should be validated by re-running the integration tests with GPT-5 to verify it resolves the `t06_github_pr_browsing` failure.

## Related

- Fixes test failure in PR #1404 comment: https://github.com/OpenHands/software-agent-sdk/pull/1404#issuecomment-3661374557

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8611153-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8611153-python \
  ghcr.io/openhands/agent-server:8611153-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8611153-golang-amd64
ghcr.io/openhands/agent-server:8611153-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8611153-golang-arm64
ghcr.io/openhands/agent-server:8611153-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8611153-java-amd64
ghcr.io/openhands/agent-server:8611153-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8611153-java-arm64
ghcr.io/openhands/agent-server:8611153-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8611153-python-amd64
ghcr.io/openhands/agent-server:8611153-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:8611153-python-arm64
ghcr.io/openhands/agent-server:8611153-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:8611153-golang
ghcr.io/openhands/agent-server:8611153-java
ghcr.io/openhands/agent-server:8611153-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8611153-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8611153-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->