### PR TITLE
Add description field support for secrets in the SDK

### DIFF
--- a/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2
+++ b/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2
@@ -14,7 +14,7 @@ Please follow them while working.
 
 {{ system_message_suffix }}
 {% endif %}
-{% if secret_names %}
+{% if secrets_info %}
 <CUSTOM_SECRETS>
 ### Credential Access
 * Automatic secret injection: When you reference a registered secret key in your bash command, the secret value will be automatically exported as an environment variable before your command executes.
@@ -25,8 +25,9 @@ Please follow them while working.
 * If it still fails, report it to the user.
 
 You have access to the following environment variables
-{% for secret_name in secret_names %}
-* **${{ secret_name }}**
+{% for secret in secrets_info %}
+* **${{ secret.name }}**{% if secret.description %}: {{ secret.description }}{% endif %}
+
 {% endfor %}
 </CUSTOM_SECRETS>
 {% endif %}

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -116,6 +116,27 @@ class SecretRegistry(OpenHandsModel):
 
         return masked_text
 
+    def get_secret_descriptions(self) -> dict[str, str | None]:
+        """Get descriptions for all registered secrets.
+
+        Returns:
+            Dictionary mapping secret keys to their descriptions.
+            If a secret has no description, the value will be None.
+        """
+        return {key: source.description for key, source in self.secret_sources.items()}
+
+    def get_secrets_info(self) -> list[dict[str, str | None]]:
+        """Get information about all registered secrets.
+
+        Returns:
+            List of dictionaries containing secret name and description.
+            Each dict has 'name' and 'description' keys.
+        """
+        return [
+            {"name": key, "description": source.description}
+            for key, source in self.secret_sources.items()
+        ]
+
 
 def _wrap_secret(value: SecretValue) -> SecretSource:
     """Convert the value given to a secret source"""


### PR DESCRIPTION
## Summary

This PR adds support for an optional `description` field in the secrets system, allowing agents to better understand the purpose and usage of each secret.

Fixes #1410

## Changes

### SecretRegistry (`openhands-sdk/openhands/sdk/conversation/secret_registry.py`)
- Added `get_secret_descriptions()` method: Returns a dictionary mapping secret names to their descriptions (or `None` if no description)
- Added `get_secrets_info()` method: Returns a list of dictionaries with `name` and `description` keys for each secret

### AgentContext (`openhands-sdk/openhands/sdk/context/agent_context.py`)
- Added `get_secrets_with_descriptions()` method: Returns a list of dictionaries with secret names and descriptions
- Updated `get_system_message_suffix()` to pass `secrets_info` (with descriptions) to the template instead of just `secret_names`

### Template (`openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2`)
- Updated to use `secrets_info` instead of `secret_names`
- Now displays descriptions alongside secret names when available (e.g., `**$GITHUB_TOKEN**: Personal access token for GitHub API`)

### Tests
- Added tests for `get_secret_descriptions()` and `get_secrets_info()` in `test_secrets_manager.py`
- Added tests for `get_secrets_with_descriptions()` in `test_agent_context.py`
- Added test for system message suffix rendering with secret descriptions

## Example

When users provide secrets with descriptions:

```python
secrets = {
    "GITHUB_TOKEN": StaticSecret(
        value=SecretStr("ghp_xxx"),
        description="Personal access token for GitHub API",
    ),
    "API_KEY": "plain-api-key",  # No description
}
```

The agent will see in the system prompt:

```
You have access to the following environment variables
* **$GITHUB_TOKEN**: Personal access token for GitHub API
* **$API_KEY**
```

## Backward Compatibility

This change is fully backward compatible:
- The `description` field on `SecretSource` was already optional
- Plain string secrets continue to work as before (with `None` description)
- The template gracefully handles secrets without descriptions

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7e55d3cfc9c246c083af1a91ac23e47d)