### PR TITLE
Make `integration-test` label run integration tests only

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -130,6 +130,9 @@ jobs:
                   if [ "${{ github.event_name }}" = "pull_request_target" ] && [ "${{ github.event.label.name }}" = "behavior-test" ]; then
                     TEST_TYPE_ARGS="--test-type behavior"
                     echo "behavior-test label detected; running behavior tests only."
+                  elif [ "${{ github.event_name }}" = "pull_request_target" ] && [ "${{ github.event.label.name }}" = "integration-test" ]; then
+                    TEST_TYPE_ARGS="--test-type integration"
+                    echo "integration-test label detected; running integration tests only."
                   elif [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
                     test_type="${{ github.event.inputs.test_type }}"
                     case "$test_type" in


### PR DESCRIPTION

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6fceaea-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6fceaea-python \
  ghcr.io/openhands/agent-server:6fceaea-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6fceaea-golang-amd64
ghcr.io/openhands/agent-server:6fceaea-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6fceaea-golang-arm64
ghcr.io/openhands/agent-server:6fceaea-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6fceaea-java-amd64
ghcr.io/openhands/agent-server:6fceaea-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6fceaea-java-arm64
ghcr.io/openhands/agent-server:6fceaea-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6fceaea-python-amd64
ghcr.io/openhands/agent-server:6fceaea-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6fceaea-python-arm64
ghcr.io/openhands/agent-server:6fceaea-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6fceaea-golang
ghcr.io/openhands/agent-server:6fceaea-java
ghcr.io/openhands/agent-server:6fceaea-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6fceaea-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6fceaea-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->