### PR TITLE
make eval_limit param optional

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -23,7 +23,7 @@ on:
                 default: main
             eval_limit:
                 description: Number of instances to run
-                required: true
+                required: false
                 default: '1'
                 type: choice
                 options:


### PR DESCRIPTION
Make eval_limit optional because now instance_ids can override eval_limit. 
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0243a35-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0243a35-python \
  ghcr.io/openhands/agent-server:0243a35-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0243a35-golang-amd64
ghcr.io/openhands/agent-server:0243a35-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0243a35-golang-arm64
ghcr.io/openhands/agent-server:0243a35-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0243a35-java-amd64
ghcr.io/openhands/agent-server:0243a35-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0243a35-java-arm64
ghcr.io/openhands/agent-server:0243a35-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0243a35-python-amd64
ghcr.io/openhands/agent-server:0243a35-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:0243a35-python-arm64
ghcr.io/openhands/agent-server:0243a35-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:0243a35-golang
ghcr.io/openhands/agent-server:0243a35-java
ghcr.io/openhands/agent-server:0243a35-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0243a35-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0243a35-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->