### PR TITLE
delete image when docker workspace closes

### DIFF
--- a/tests/workspace/test_docker_workspace.py
+++ b/tests/workspace/test_docker_workspace.py
@@ -4,6 +4,36 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+import pytest
+
+
+@pytest.fixture
+def mock_docker_workspace():
+    """Fixture to create a mocked DockerWorkspace with minimal setup."""
+    from openhands.workspace import DockerWorkspace
+
+    with patch("openhands.workspace.docker.workspace.execute_command") as mock_exec:
+        # Mock execute_command to return success
+        mock_exec.return_value = Mock(returncode=0, stdout="", stderr="")
+
+        def _create_workspace(cleanup_image=False):
+            # Create workspace without triggering initialization
+            with patch.object(DockerWorkspace, "_start_container"):
+                workspace = DockerWorkspace(
+                    server_image="test:latest", cleanup_image=cleanup_image
+                )
+
+            # Manually set up state that would normally be set during startup
+            workspace._container_id = "container_id_123"
+            workspace._image_name = "test:latest"
+            workspace._stop_logs = MagicMock()
+            workspace._logs_thread = None
+
+            return workspace, mock_exec
+
+        yield _create_workspace
 
 
 def test_docker_workspace_import():
@@ -76,3 +106,36 @@ def test_docker_dev_workspace_has_build_fields():
     assert "server_image" in DockerDevWorkspace.model_fields
     assert "base_image" in DockerDevWorkspace.model_fields
     assert "target" in DockerDevWorkspace.model_fields
+
+
+def test_cleanup_without_image_deletion(mock_docker_workspace):
+    """Test that cleanup with cleanup_image=False does not delete the image."""
+    workspace, mock_exec = mock_docker_workspace(cleanup_image=False)
+
+    # Call cleanup
+    workspace.cleanup()
+
+    # Verify docker rmi was NOT called
+    calls = mock_exec.call_args_list
+    rmi_calls = [c for c in calls if c[0] and "rmi" in str(c[0])]
+    assert len(rmi_calls) == 0
+
+
+def test_cleanup_with_image_deletion(mock_docker_workspace):
+    """Test that cleanup with cleanup_image=True deletes the Docker image."""
+    workspace, mock_exec = mock_docker_workspace(cleanup_image=True)
+
+    # Call cleanup
+    workspace.cleanup()
+
+    # Verify docker rmi was called with correct arguments
+    calls = mock_exec.call_args_list
+    rmi_calls = [c for c in calls if c[0] and "rmi" in str(c[0])]
+    assert len(rmi_calls) == 1
+
+    # Verify the command includes -f flag and correct image name
+    rmi_call_args = rmi_calls[0][0][0]
+    assert "docker" in rmi_call_args
+    assert "rmi" in rmi_call_args
+    assert "-f" in rmi_call_args
+    assert "test:latest" in rmi_call_args


### PR DESCRIPTION
## Summary of PR

Support for deleting docker images when Docker Workspace closes.
Added a `cleanup_image` option, which defaults to `False` for now.

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolves https://github.com/OpenHands/software-agent-sdk/issues/1297

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.