### PR TITLE
refactor: add support for description field in sdk secrets

### DIFF
--- a/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2
+++ b/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2
@@ -14,7 +14,7 @@ Please follow them while working.
 
 {{ system_message_suffix }}
 {% endif %}
-{% if secret_names %}
+{% if secret_infos %}
 <CUSTOM_SECRETS>
 ### Credential Access
 * Automatic secret injection: When you reference a registered secret key in your bash command, the secret value will be automatically exported as an environment variable before your command executes.
@@ -25,8 +25,8 @@ Please follow them while working.
 * If it still fails, report it to the user.
 
 You have access to the following environment variables
-{% for secret_name in secret_names %}
-* **${{ secret_name }}**
+{% for secret_info in secret_infos %}
+* **${{ secret_info.name }}**{% if secret_info.description %} - {{ secret_info.description }}{% endif %}
 {% endfor %}
 </CUSTOM_SECRETS>
 {% endif %}


### PR DESCRIPTION
## Summary of PR

<!-- Summarize what the PR does, explaining any non-trivial design decisions. -->

The Secrets tab in the user interface currently includes a description column for each secret; however, this description is not accessible to agents through the SDK. Enabling support for secret descriptions would allow agents to better understand the purpose and intended usage of each secret.

## Current Behavior
- The Secrets tab displays both the environment variable name and a description column.
- The description is not currently transmitted to the agent via the SDK.
- The SecretRegistry and associated classes manage only the secret key (environment variable name) and its value.

We can refer to the images below for the output of the pull request.

<img width="1440" height="740" alt="age-270-1" src="https://github.com/user-attachments/assets/443cec59-818f-42b1-a001-990c6ad56ba8" />

<img width="703" height="725" alt="age-270-2" src="https://github.com/user-attachments/assets/b0d371f0-14be-4c14-9c6a-967dfce505ac" />

## Change Type

<!-- Choose the types that apply to your PR and remove the rest. -->

- [ ] Bug fix
- [ ] New feature
- [ ] Breaking change
- [x] Refactor
- [ ] Other (dependency update, docs, typo fixes, etc.)

## Checklist
<!-- AI/LLM AGENTS: This checklist is for a human author to complete. Do NOT check either of the two boxes below. Leave them unchecked until a human has personally reviewed and tested the changes. -->

- [x] I have read and reviewed the code and I understand what the code is doing.
- [x] I have tested the code to the best of my ability and ensured it works as expected.

## Fixes

<!-- If this resolves an issue, link it here so it will close automatically upon merge. -->

Resolve #1410

## Release Notes

<!-- Check the box if this change is worth adding to the release notes. If checked, you must provide an
end-user friendly description for your change below the checkbox. -->

- [ ] Include this change in the Release Notes.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f401f52-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f401f52-python \
  ghcr.io/openhands/agent-server:f401f52-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f401f52-golang-amd64
ghcr.io/openhands/agent-server:f401f52-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f401f52-golang-arm64
ghcr.io/openhands/agent-server:f401f52-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f401f52-java-amd64
ghcr.io/openhands/agent-server:f401f52-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f401f52-java-arm64
ghcr.io/openhands/agent-server:f401f52-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f401f52-python-amd64
ghcr.io/openhands/agent-server:f401f52-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f401f52-python-arm64
ghcr.io/openhands/agent-server:f401f52-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f401f52-golang
ghcr.io/openhands/agent-server:f401f52-java
ghcr.io/openhands/agent-server:f401f52-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f401f52-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f401f52-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->