### PR TITLE
Make cronjob run integration test only

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -151,6 +151,9 @@ jobs:
                         echo "workflow_dispatch provided unknown test_type '$test_type'; defaulting to full suite."
                         ;;
                     esac
+                  elif [ "${{ github.event_name }}" = "schedule" ]; then
+                    TEST_TYPE_ARGS="--test-type integration"
+                    echo "Scheduled run; running integration tests only."
                   else
                     echo "Running full integration test suite."
                   fi


### PR DESCRIPTION
Currently the integration test cron job [runs both integration and behavior tests](https://github.com/OpenHands/software-agent-sdk/issues/939#issuecomment-3667529634). This PR adjusts it to run integration tests only.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2a6cf58-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2a6cf58-python \
  ghcr.io/openhands/agent-server:2a6cf58-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2a6cf58-golang-amd64
ghcr.io/openhands/agent-server:2a6cf58-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2a6cf58-golang-arm64
ghcr.io/openhands/agent-server:2a6cf58-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2a6cf58-java-amd64
ghcr.io/openhands/agent-server:2a6cf58-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2a6cf58-java-arm64
ghcr.io/openhands/agent-server:2a6cf58-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2a6cf58-python-amd64
ghcr.io/openhands/agent-server:2a6cf58-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2a6cf58-python-arm64
ghcr.io/openhands/agent-server:2a6cf58-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2a6cf58-golang
ghcr.io/openhands/agent-server:2a6cf58-java
ghcr.io/openhands/agent-server:2a6cf58-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2a6cf58-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2a6cf58-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->