### PR TITLE
Fix JSON encoding to preserve non-ASCII characters in model_dump_json

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/models.py
+++ b/openhands-sdk/openhands/sdk/utils/models.py
@@ -146,7 +146,7 @@ class OpenHandsModel(BaseModel):
         # duplicate fields are produced by model_dump_json which does not appear
         # in model_dump
         kwargs["mode"] = "json"
-        return json.dumps(self.model_dump(**kwargs))
+        return json.dumps(self.model_dump(**kwargs), ensure_ascii=False)
 
     def __init_subclass__(cls, **kwargs):
         """


### PR DESCRIPTION
## Summary
- Add `ensure_ascii=False` to `json.dumps()` in `OpenHandsModel.model_dump_json()` method
- This preserves non-ASCII characters (e.g., Chinese, Japanese) in their original form instead of escaping them to `\uXXXX` format

This is a similar fix to #1178, which addressed the same issue in a different location.

## Test plan
- [x] Verify that models containing non-ASCII characters serialize correctly without escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)