### PR TITLE
fix: add openrouter/minimax to FORCE_STRING_SERIALIZER_MODELS

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -141,6 +141,9 @@ FORCE_STRING_SERIALIZER_MODELS: list[str] = [
     "glm",  # e.g., GLM-4.5 / GLM-4.6
     # Kimi K2-Instruct requires string serialization only on Groq
     "groq/kimi-k2-instruct",  # explicit provider-prefixed IDs
+    # MiniMax-M2 via OpenRouter rejects array content with
+    # "Input should be a valid string" for ChatCompletionToolMessage.content
+    "openrouter/minimax",
 ]
 
 # Models that we should send full reasoning content


### PR DESCRIPTION
## Summary

Fixes #1314 - MiniMax-M2 (and other MiniMax models) via OpenRouter raising errors due to tool message content format.

## Problem

MiniMax-M2 via OpenRouter rejects array content for tool messages with:
```
"Input should be a valid string" for ChatCompletionToolMessage.content
```

The SDK was serializing tool messages with array content format:
```json
{"role": "tool", "content": [{"type": "text", "text": "..."}], ...}
```

But MiniMax via OpenRouter expects plain string content.

## Solution

Add `openrouter/minimax` to `FORCE_STRING_SERIALIZER_MODELS` to force string serialization for all message content when using MiniMax models via OpenRouter.

This follows the same pattern used for other providers like DeepSeek, GLM, and Groq/Kimi-K2-Instruct.

## Changes

- `openhands-sdk/openhands/sdk/llm/utils/model_features.py`: Added `openrouter/minimax` to `FORCE_STRING_SERIALIZER_MODELS`

## Testing

### Integration Tests with MiniMax-M2 via OpenRouter

**Before fix:**
```
Test t01_fix_simple_typo: ✗ - Test execution failed: litellm.BadRequestError:
"Input should be a valid string" for ChatCompletionToolMessage.content
```

**After fix:**
```
Test t01_fix_simple_typo: ✓ - Successfully fixed all typos
Overall Success rate: 100.00% (1/1)
```

## Impact

- Enables MiniMax models via OpenRouter to work correctly
- No breaking changes for other providers
- Minimal change (3 lines added)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a1213bf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a1213bf-python \
  ghcr.io/openhands/agent-server:a1213bf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a1213bf-golang-amd64
ghcr.io/openhands/agent-server:a1213bf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a1213bf-golang-arm64
ghcr.io/openhands/agent-server:a1213bf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a1213bf-java-amd64
ghcr.io/openhands/agent-server:a1213bf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a1213bf-java-arm64
ghcr.io/openhands/agent-server:a1213bf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a1213bf-python-amd64
ghcr.io/openhands/agent-server:a1213bf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a1213bf-python-arm64
ghcr.io/openhands/agent-server:a1213bf-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a1213bf-golang
ghcr.io/openhands/agent-server:a1213bf-java
ghcr.io/openhands/agent-server:a1213bf-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a1213bf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a1213bf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->