### PR TITLE
Plugin Marketplace Compatibility: Align with Claude Code & AgentSpec

### DIFF
--- a/.openhands/packages.yaml
+++ b/.openhands/packages.yaml
@@ -1,3 +1,4 @@
+---
 # OpenHands Skill Packages Configuration
 #
 # List skill packages to load. Package names should match the entry point

--- a/.openhands/packages.yaml
+++ b/.openhands/packages.yaml
@@ -1,0 +1,15 @@
+# OpenHands Skill Packages Configuration
+#
+# List skill packages to load. Package names should match the entry point
+# names defined in the packages' pyproject.toml files.
+#
+# Example packages:
+#   - simple-code-review  # From openhands-simple-code-review package
+#   - awesome-skills      # From openhands-awesome-skills package
+#
+# Install packages with: pip install openhands-simple-code-review
+# List available packages with: ohp list (requires package-poc tools)
+
+packages: []
+  # Add your packages here, e.g.:
+  # - simple-code-review

--- a/docs/claude-code-alignment.md
+++ b/docs/claude-code-alignment.md
@@ -1,0 +1,276 @@
+# Claude Code Alignment for Skill Package Loading
+
+## Overview
+
+The OpenHands SDK now supports loading skill packages with both:
+1. **manifest.json** (Claude Desktop Extensions-aligned format)
+2. **skill-package.yaml** (legacy format)
+
+This enables cross-platform package distribution and better integration with the Model Context Protocol (MCP) ecosystem.
+
+## Changes to package_loader.py
+
+### New Helper Function
+
+```python
+def _load_descriptor(package_module) -> dict[str, Any]:
+    """Load package descriptor, trying manifest.json first, then skill-package.yaml."""
+```
+
+This function:
+1. Attempts to load `manifest.json` from the package
+2. Falls back to `skill-package.yaml` if JSON not found
+3. Raises FileNotFoundError if neither file exists
+
+### Updated Functions
+
+All package loading functions now use `_load_descriptor()`:
+- `list_skill_packages()` - Lists all installed skill packages
+- `get_skill_package()` - Gets a specific package by name
+- `load_skills_from_package()` - Loads skills with format-aware spec extraction
+
+### Format Detection
+
+The `load_skills_from_package()` function auto-detects the descriptor format:
+
+```python
+# Handle both formats
+if "spec" in descriptor:
+    # Old YAML format: skills are in spec.skills
+    skills_spec = descriptor.get("spec", {}).get("skills", [])
+else:
+    # New JSON format: skills are at top level
+    skills_spec = descriptor.get("skills", [])
+```
+
+## Descriptor Format Comparison
+
+### manifest.json (New Format)
+
+```json
+{
+  "name": "simple-code-review",
+  "version": "1.0.0",
+  "displayName": "Simple Code Review",
+  "description": "Basic code review skills",
+  "skills": [
+    {
+      "name": "code-review",
+      "path": "skills/code_review.md",
+      "type": "keyword-triggered",
+      "triggers": ["codereview", "review-code"]
+    }
+  ]
+}
+```
+
+**Structure**: Flat, with `skills` at the top level
+
+### skill-package.yaml (Legacy Format)
+
+```yaml
+apiVersion: openhands.ai/v1
+kind: SkillPackage
+
+metadata:
+  name: simple-code-review
+  version: "1.0.0"
+  displayName: "Simple Code Review"
+  description: "Basic code review skills"
+
+spec:
+  skills:
+    - name: code-review
+      path: skills/code_review.md
+      type: keyword-triggered
+      triggers:
+        - codereview
+        - review-code
+```
+
+**Structure**: Nested, with `skills` under `spec.skills`
+
+## Backwards Compatibility
+
+The changes are **fully backwards compatible**:
+
+1. Existing packages with `skill-package.yaml` continue to work
+2. New packages can use `manifest.json`
+3. Packages can include both files during transition
+4. No changes required to existing code that uses package_loader
+
+## Usage Examples
+
+### Loading Packages (No Changes Required)
+
+```python
+from openhands.sdk.context.skills.package_loader import (
+    list_skill_packages,
+    get_skill_package,
+    load_skills_from_package
+)
+
+# List all packages - works with both formats
+packages = list_skill_packages()
+for pkg in packages:
+    print(f"Package: {pkg['name']}")
+
+# Get specific package - works with both formats  
+pkg = get_skill_package('simple-code-review')
+
+# Load skills - works with both formats
+repo_skills, knowledge_skills = load_skills_from_package('simple-code-review')
+```
+
+### Accessing Descriptor Data
+
+When working directly with descriptors, handle both formats:
+
+```python
+pkg = get_skill_package('my-package')
+descriptor = pkg['descriptor']
+
+# Handle both nested (YAML) and flat (JSON) structures
+if 'metadata' in descriptor:
+    # Old YAML format
+    metadata = descriptor['metadata']
+    skills = descriptor.get('spec', {}).get('skills', [])
+else:
+    # New JSON format
+    metadata = descriptor
+    skills = descriptor.get('skills', [])
+
+print(f"Display Name: {metadata.get('displayName', 'Unknown')}")
+```
+
+## Creating New Packages
+
+### Recommended Approach: Use manifest.json
+
+1. Create `manifest.json` in your package root:
+
+```json
+{
+  "name": "my-awesome-skills",
+  "version": "1.0.0",
+  "displayName": "My Awesome Skills",
+  "description": "A collection of useful skills",
+  "author": {
+    "name": "Your Name",
+    "email": "you@example.com"
+  },
+  "keywords": ["skills", "awesome"],
+  "license": "MIT",
+  "skills": [
+    {
+      "name": "my-skill",
+      "description": "Description of my skill",
+      "path": "skills/my_skill.md",
+      "type": "keyword-triggered",
+      "triggers": ["myskill", "awesome"]
+    }
+  ],
+  "package": {
+    "type": "python",
+    "name": "my-awesome-skills",
+    "entry_point": "my_awesome_skills"
+  }
+}
+```
+
+2. Include manifest.json in your package data (pyproject.toml):
+
+```toml
+[tool.setuptools.package-data]
+my_awesome_skills = ["manifest.json", "skills/*.md"]
+```
+
+3. Register the entry point:
+
+```toml
+[project.entry-points."openhands.skill_packages"]
+my-awesome-skills = "my_awesome_skills"
+```
+
+## Migration from YAML to JSON
+
+### Option 1: Add JSON alongside YAML (Recommended)
+
+Keep both files for maximum compatibility:
+
+```
+my-package/
+├── manifest.json          # New format
+├── skill-package.yaml     # Old format (for backwards compat)
+├── pyproject.toml
+└── my_package/
+    ├── __init__.py
+    ├── manifest.json      # Include in package
+    ├── skill-package.yaml # Include in package
+    └── skills/
+        └── skill.md
+```
+
+Update pyproject.toml:
+```toml
+[tool.setuptools.package-data]
+my_package = ["manifest.json", "skill-package.yaml", "skills/*.md"]
+```
+
+### Option 2: Replace YAML with JSON
+
+Only do this if you don't need to support old SDK versions:
+
+1. Create `manifest.json` from `skill-package.yaml` content
+2. Remove `skill-package.yaml`
+3. Update package data to only include manifest.json
+4. Test with SDK
+
+## Integration with OpenHands
+
+The OpenHands SDK will automatically:
+1. Discover packages via entry points
+2. Load the appropriate descriptor format
+3. Parse skills from the descriptor
+4. Load skill content from markdown files
+5. Create Skill objects with triggers
+
+No changes needed to your OpenHands agent code!
+
+## Testing
+
+Test your package works with both formats:
+
+```bash
+# Install your package
+pip install -e .
+
+# Test discovery
+python -c "from openhands.sdk.context.skills.package_loader import list_skill_packages; print(list_skill_packages())"
+
+# Test loading
+python -c "from openhands.sdk.context.skills.package_loader import load_skills_from_package; print(load_skills_from_package('your-package-name'))"
+```
+
+## Benefits
+
+1. **Cross-Platform**: Packages work with OpenHands SDK and Claude Desktop
+2. **Standard Format**: JSON is more widely adopted than custom YAML
+3. **MCP Compatible**: Better integration with Model Context Protocol ecosystem
+4. **Developer Friendly**: Familiar format similar to npm package.json
+5. **No Breaking Changes**: Existing packages continue to work
+
+## Future Enhancements
+
+Potential future improvements:
+1. JSON Schema for manifest.json validation
+2. Conversion tool to migrate YAML to JSON
+3. Enhanced MCP tool integration
+4. Support for Claude Desktop-specific features
+
+## References
+
+- [OpenHands Package POC](https://github.com/OpenHands/package-poc)
+- [Claude Desktop Extensions](https://www.anthropic.com/engineering/desktop-extensions)
+- [Model Context Protocol](https://modelcontextprotocol.io/)
+- [Skill Packages Documentation](./skill-packages.md)

--- a/docs/skill-packages.md
+++ b/docs/skill-packages.md
@@ -42,7 +42,7 @@ print(f"Loaded {len(knowledge_skills)} knowledge skills")
 
 ## For More Information
 
-- **Complete Tutorial**: See [examples/01_standalone_sdk/04_use_skill_packages.py](../examples/01_standalone_sdk/04_use_skill_packages.py)
+- **Complete Tutorial**: See [examples/01_standalone_sdk/31_use_skill_packages.py](../examples/01_standalone_sdk/31_use_skill_packages.py)
 - **Creating Packages**: [Skill Packages Tutorial](https://github.com/OpenHands/package-poc/blob/main/doc/tutorial-flow.md)
 - **Package POC Repository**: [OpenHands/package-poc](https://github.com/OpenHands/package-poc)
 

--- a/docs/skill-packages.md
+++ b/docs/skill-packages.md
@@ -1,0 +1,57 @@
+# Using Skill Packages with OpenHands SDK
+
+Skill packages provide a standardized way to distribute and reuse collections of skills across projects. This document explains how to use skill packages with the OpenHands SDK.
+
+## Overview
+
+Skill packages are Python packages that bundle one or more OpenHands skills together with metadata. They can be:
+
+- **Installed** via pip/uv like any Python package
+- **Discovered** automatically using Python's entry points mechanism
+- **Configured** via `.openhands/packages.yaml`
+- **Loaded** programmatically or automatically
+
+## Quick Start
+
+### 1. Install a Skill Package
+
+```bash
+pip install openhands-simple-code-review
+```
+
+### 2. Configure Packages to Load
+
+Create `.openhands/packages.yaml` in your project root:
+
+```yaml
+packages:
+  - simple-code-review
+```
+
+### 3. Load Skills in Your Code
+
+```python
+from openhands.sdk.context.skills import load_configured_package_skills
+
+# Load all skills from configured packages
+repo_skills, knowledge_skills = load_configured_package_skills()
+
+# Skills are now available for use with your agent
+print(f"Loaded {len(knowledge_skills)} knowledge skills")
+```
+
+## For More Information
+
+- **Complete Tutorial**: See [examples/01_standalone_sdk/04_use_skill_packages.py](../examples/01_standalone_sdk/04_use_skill_packages.py)
+- **Creating Packages**: [Skill Packages Tutorial](https://github.com/OpenHands/package-poc/blob/main/doc/tutorial-flow.md)
+- **Package POC Repository**: [OpenHands/package-poc](https://github.com/OpenHands/package-poc)
+
+## API Functions
+
+- `list_skill_packages()` - List all installed packages
+- `get_skill_package(name)` - Get details for a specific package
+- `load_skills_from_package(name)` - Load skills from one package
+- `load_skills_from_packages(names)` - Load skills from multiple packages
+- `load_configured_package_skills()` - Load skills from configured packages
+
+See the example file for detailed usage of all these functions.

--- a/examples/01_standalone_sdk/04_use_skill_packages.py
+++ b/examples/01_standalone_sdk/04_use_skill_packages.py
@@ -1,0 +1,232 @@
+"""Example: Using Skill Packages with OpenHands SDK
+
+This example demonstrates how to load and use skills from installed
+OpenHands skill packages. Skill packages provide a way to distribute
+and reuse collections of skills across projects.
+
+Prerequisites:
+    1. Install a skill package:
+       pip install openhands-simple-code-review
+
+    2. Configure packages to load:
+       Create .openhands/packages.yaml with:
+         packages:
+           - simple-code-review
+
+    3. Or use the package loading functions directly in code.
+
+For more information on creating skill packages, see:
+    https://github.com/OpenHands/package-poc
+"""
+
+import asyncio
+from pathlib import Path
+
+from openhands.sdk import Agent
+from openhands.sdk.context.skills import (
+    get_skill_package,
+    list_skill_packages,
+    load_configured_package_skills,
+    load_skills_from_package,
+)
+
+
+async def list_available_packages():
+    """List all installed skill packages."""
+    print("=" * 60)
+    print("Installed Skill Packages")
+    print("=" * 60)
+
+    packages = list_skill_packages()
+
+    if not packages:
+        print("No skill packages installed.")
+        print("\nTo install a skill package:")
+        print("  pip install openhands-simple-code-review")
+        return
+
+    for pkg in packages:
+        metadata = pkg["descriptor"]["metadata"]
+        skills = pkg["descriptor"]["spec"]["skills"]
+
+        print(f"\n📦 {metadata['displayName']} (v{metadata['version']})")
+        print(f"   Name: {pkg['name']}")
+        print(f"   Description: {metadata.get('description', 'N/A')}")
+        print(f"   Skills: {len(skills)}")
+
+        for skill in skills:
+            triggers = skill.get("triggers", [])
+            trigger_str = ", ".join(triggers) if triggers else "always active"
+            print(f"     • {skill['name']} (triggers: {trigger_str})")
+
+
+async def show_package_details(package_name: str):
+    """Show detailed information about a specific package."""
+    print("\n" + "=" * 60)
+    print(f"Package Details: {package_name}")
+    print("=" * 60)
+
+    pkg = get_skill_package(package_name)
+
+    if pkg is None:
+        print(f"Package '{package_name}' not found.")
+        return
+
+    metadata = pkg["descriptor"]["metadata"]
+    spec = pkg["descriptor"]["spec"]
+
+    print(f"\nDisplay Name: {metadata['displayName']}")
+    print(f"Version: {metadata['version']}")
+    print(f"Author: {metadata.get('author', 'N/A')}")
+    print(f"License: {metadata.get('license', 'N/A')}")
+    print(f"Repository: {metadata.get('repository', 'N/A')}")
+
+    print(f"\nTags: {', '.join(metadata.get('tags', []))}")
+
+    print("\nSkills:")
+    for skill in spec["skills"]:
+        print(f"  • {skill['name']}")
+        print(f"    Path: {skill['path']}")
+        print(f"    Type: {skill.get('type', 'unknown')}")
+        if "triggers" in skill:
+            print(f"    Triggers: {', '.join(skill['triggers'])}")
+
+
+async def load_and_inspect_skills(package_name: str):
+    """Load skills from a package and inspect them."""
+    print("\n" + "=" * 60)
+    print(f"Loading Skills from: {package_name}")
+    print("=" * 60)
+
+    try:
+        repo_skills, knowledge_skills = load_skills_from_package(package_name)
+
+        print(f"\nLoaded {len(repo_skills)} repo skills and {len(knowledge_skills)} knowledge skills")
+
+        if repo_skills:
+            print("\nRepo Skills (always active):")
+            for name, skill in repo_skills.items():
+                print(f"  • {name}")
+                print(f"    Source: {skill.source}")
+                print(f"    Content length: {len(skill.content)} chars")
+
+        if knowledge_skills:
+            print("\nKnowledge Skills (trigger-activated):")
+            for name, skill in knowledge_skills.items():
+                print(f"  • {name}")
+                print(f"    Source: {skill.source}")
+                print(f"    Trigger: {skill.trigger}")
+                print(f"    Content length: {len(skill.content)} chars")
+
+    except ValueError as e:
+        print(f"Error: {e}")
+
+
+async def use_packages_with_agent():
+    """Create an agent with skills loaded from packages."""
+    print("\n" + "=" * 60)
+    print("Using Skill Packages with an Agent")
+    print("=" * 60)
+
+    # Load skills from configured packages
+    repo_skills, knowledge_skills = load_configured_package_skills()
+
+    print(f"\nLoaded {len(knowledge_skills)} knowledge skills from configured packages")
+
+    if not knowledge_skills:
+        print("\nNo skills loaded. To configure packages:")
+        print("  1. Create .openhands/packages.yaml")
+        print("  2. Add package names under 'packages:' key")
+        print("  3. Example:")
+        print("       packages:")
+        print("         - simple-code-review")
+        return
+
+    print("\nAvailable skills:")
+    for name, skill in knowledge_skills.items():
+        print(f"  • {name} (source: {skill.source})")
+
+    # You can now use these skills with an agent
+    # For example:
+    # agent = Agent(model="gpt-4")
+    # agent.add_skills(list(knowledge_skills.values()))
+
+
+async def create_packages_config():
+    """Create a sample packages.yaml configuration file."""
+    config_path = Path(".openhands/packages.yaml")
+
+    if config_path.exists():
+        print(f"\nConfiguration already exists at: {config_path}")
+        with open(config_path) as f:
+            print(f.read())
+        return
+
+    config_content = """# OpenHands Skill Packages Configuration
+#
+# List skill packages to load. Package names should match the entry point
+# names defined in the packages' pyproject.toml files.
+
+packages:
+  # Add your packages here, e.g.:
+  # - simple-code-review
+  # - awesome-skills
+"""
+
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(config_content)
+
+    print(f"\nCreated sample configuration at: {config_path}")
+    print("\nEdit this file to add packages you want to load.")
+
+
+async def main():
+    """Run the skill packages example."""
+    print("\n🎯 OpenHands Skill Packages Example")
+    print("=" * 60)
+
+    # 1. List all available packages
+    await list_available_packages()
+
+    # 2. Check if we have any packages installed
+    packages = list_skill_packages()
+
+    if packages:
+        # Show details for the first package
+        first_package = packages[0]["name"]
+        await show_package_details(first_package)
+
+        # Load and inspect skills from the first package
+        await load_and_inspect_skills(first_package)
+
+    # 3. Try to use configured packages
+    await use_packages_with_agent()
+
+    # 4. Show how to create configuration
+    print("\n" + "=" * 60)
+    print("Configuration Setup")
+    print("=" * 60)
+    await create_packages_config()
+
+    print("\n" + "=" * 60)
+    print("Next Steps")
+    print("=" * 60)
+    print("""
+1. Install skill packages:
+   pip install openhands-simple-code-review
+
+2. Configure which packages to load:
+   Edit .openhands/packages.yaml and add package names
+
+3. Run this example again to see loaded skills
+
+4. Create your own skill packages:
+   See: https://github.com/OpenHands/package-poc
+
+For more information on skill packages:
+   https://github.com/OpenHands/package-poc/blob/main/doc/tutorial-flow.md
+""")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/openhands-sdk/openhands/sdk/context/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/skills/__init__.py
@@ -1,4 +1,12 @@
 from openhands.sdk.context.skills.exceptions import SkillValidationError
+from openhands.sdk.context.skills.package_loader import (
+    get_skill_package,
+    list_skill_packages,
+    load_configured_package_skills,
+    load_packages_config,
+    load_skills_from_package,
+    load_skills_from_packages,
+)
 from openhands.sdk.context.skills.skill import (
     Skill,
     load_public_skills,
@@ -23,4 +31,11 @@ __all__ = [
     "load_user_skills",
     "load_public_skills",
     "SkillValidationError",
+    # Package loading functions
+    "list_skill_packages",
+    "get_skill_package",
+    "load_skills_from_package",
+    "load_skills_from_packages",
+    "load_packages_config",
+    "load_configured_package_skills",
 ]

--- a/openhands-sdk/openhands/sdk/context/skills/package_loader.py
+++ b/openhands-sdk/openhands/sdk/context/skills/package_loader.py
@@ -4,8 +4,7 @@ This module provides functionality to discover and load skills from
 installed Python packages that register as OpenHands skill packages
 via entry points.
 
-Supports both manifest.json (Claude Code-aligned) and skill-package.yaml
-(legacy) descriptor formats.
+Packages must use manifest.json (Claude Code-aligned) descriptor format.
 """
 
 import json
@@ -25,7 +24,7 @@ logger = get_logger(__name__)
 
 
 def _load_descriptor(package_module) -> dict[str, Any]:
-    """Load package descriptor, trying manifest.json first, then skill-package.yaml.
+    """Load package descriptor from manifest.json.
     
     Args:
         package_module: The loaded package module
@@ -34,18 +33,11 @@ def _load_descriptor(package_module) -> dict[str, Any]:
         Parsed descriptor dictionary
         
     Raises:
-        FileNotFoundError: If neither descriptor file is found
+        FileNotFoundError: If manifest.json is not found
+        json.JSONDecodeError: If manifest.json is invalid
     """
-    # Try manifest.json first (new Claude Code-aligned format)
-    try:
-        json_content = files(package_module).joinpath("manifest.json").read_text()
-        return json.loads(json_content)
-    except (FileNotFoundError, json.JSONDecodeError):
-        pass
-    
-    # Fall back to skill-package.yaml (legacy format)
-    yaml_content = files(package_module).joinpath("skill-package.yaml").read_text()
-    return yaml.safe_load(yaml_content)
+    json_content = files(package_module).joinpath("manifest.json").read_text()
+    return json.loads(json_content)
 
 
 def list_skill_packages() -> list[dict[str, Any]]:
@@ -57,14 +49,12 @@ def list_skill_packages() -> list[dict[str, Any]]:
 
     Returns:
         List of dicts with 'name' (str) and 'descriptor' (dict) keys.
-        The descriptor contains the parsed manifest.json or skill-package.yaml content.
+        The descriptor contains the parsed manifest.json content.
 
     Example:
         >>> packages = list_skill_packages()
         >>> for pkg in packages:
-        ...     # Handle both old YAML format (nested) and new JSON format (flat)
-        ...     metadata = pkg['descriptor'].get('metadata', pkg['descriptor'])
-        ...     print(f"{pkg['name']}: {metadata.get('displayName', 'Unknown')}")
+        ...     print(f"{pkg['name']}: {pkg['descriptor'].get('displayName', 'Unknown')}")
     """
     eps = entry_points(group="openhands.skill_packages")
 
@@ -75,7 +65,7 @@ def list_skill_packages() -> list[dict[str, Any]]:
             # Load the package module
             package_module = ep.load()
 
-            # Load descriptor (tries manifest.json first, falls back to YAML)
+            # Load descriptor from manifest.json
             descriptor = _load_descriptor(package_module)
 
             packages.append({"name": ep.name, "descriptor": descriptor, "module": package_module})
@@ -98,9 +88,7 @@ def get_skill_package(package_name: str) -> dict[str, Any] | None:
     Example:
         >>> pkg = get_skill_package('simple-code-review')
         >>> if pkg:
-        ...     # Handle both formats
-        ...     metadata = pkg['descriptor'].get('metadata', pkg['descriptor'])
-        ...     print(metadata.get('displayName', 'Unknown'))
+        ...     print(pkg['descriptor'].get('displayName', 'Unknown'))
     """
     eps = entry_points(group="openhands.skill_packages")
 
@@ -110,7 +98,7 @@ def get_skill_package(package_name: str) -> dict[str, Any] | None:
                 # Load the package module
                 package_module = ep.load()
 
-                # Load descriptor (tries manifest.json first, falls back to YAML)
+                # Load descriptor from manifest.json
                 descriptor = _load_descriptor(package_module)
 
                 return {"name": ep.name, "descriptor": descriptor, "module": package_module}
@@ -151,13 +139,8 @@ def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[
     knowledge_skills = {}
 
     # Load skills defined in the descriptor
-    # Handle both formats: YAML has nested structure (spec.skills), JSON has flat structure (skills)
-    if "spec" in descriptor:
-        # Old YAML format: skills are in spec.skills
-        skills_spec = descriptor.get("spec", {}).get("skills", [])
-    else:
-        # New JSON format: skills are at top level
-        skills_spec = descriptor.get("skills", [])
+    # manifest.json format: skills are at top level
+    skills_spec = descriptor.get("skills", [])
 
     logger.debug(f"Loading {len(skills_spec)} skills from package '{package_name}'")
 

--- a/openhands-sdk/openhands/sdk/context/skills/package_loader.py
+++ b/openhands-sdk/openhands/sdk/context/skills/package_loader.py
@@ -8,7 +8,6 @@ Packages must use manifest.json (Claude Code-aligned) descriptor format.
 """
 
 import json
-import sys
 from importlib.metadata import entry_points
 from importlib.resources import files
 from pathlib import Path
@@ -25,13 +24,13 @@ logger = get_logger(__name__)
 
 def _load_descriptor(package_module) -> dict[str, Any]:
     """Load package descriptor from manifest.json.
-    
+
     Args:
         package_module: The loaded package module
-        
+
     Returns:
         Parsed descriptor dictionary
-        
+
     Raises:
         FileNotFoundError: If manifest.json is not found
         json.JSONDecodeError: If manifest.json is invalid
@@ -54,7 +53,9 @@ def list_skill_packages() -> list[dict[str, Any]]:
     Example:
         >>> packages = list_skill_packages()
         >>> for pkg in packages:
-        ...     print(f"{pkg['name']}: {pkg['descriptor'].get('displayName', 'Unknown')}")
+        ...     name = pkg['name']
+        ...     display_name = pkg['descriptor'].get('displayName', 'Unknown')
+        ...     print(f"{name}: {display_name}")
     """
     eps = entry_points(group="openhands.skill_packages")
 
@@ -68,7 +69,9 @@ def list_skill_packages() -> list[dict[str, Any]]:
             # Load descriptor from manifest.json
             descriptor = _load_descriptor(package_module)
 
-            packages.append({"name": ep.name, "descriptor": descriptor, "module": package_module})
+            packages.append(
+                {"name": ep.name, "descriptor": descriptor, "module": package_module}
+            )
         except Exception as e:
             # Log warning but continue - don't fail if one package is broken
             logger.warning(f"Failed to load skill package {ep.name}: {e}")
@@ -101,7 +104,11 @@ def get_skill_package(package_name: str) -> dict[str, Any] | None:
                 # Load descriptor from manifest.json
                 descriptor = _load_descriptor(package_module)
 
-                return {"name": ep.name, "descriptor": descriptor, "module": package_module}
+                return {
+                    "name": ep.name,
+                    "descriptor": descriptor,
+                    "module": package_module,
+                }
             except Exception as e:
                 logger.error(f"Failed to load skill package {package_name}: {e}")
                 return None
@@ -109,7 +116,9 @@ def get_skill_package(package_name: str) -> dict[str, Any] | None:
     return None
 
 
-def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[str, Skill]]:
+def load_skills_from_package(
+    package_name: str,
+) -> tuple[dict[str, Skill], dict[str, Skill]]:
     """Load skills from a specific skill package.
 
     Args:
@@ -124,7 +133,9 @@ def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[
         ValueError: If package is not found or cannot be loaded
 
     Example:
-        >>> repo_skills, knowledge_skills = load_skills_from_package('simple-code-review')
+        >>> repo_skills, knowledge_skills = load_skills_from_package(
+        ...     'simple-code-review'
+        ... )
         >>> for name, skill in knowledge_skills.items():
         ...     print(f"Loaded skill: {name}")
     """
@@ -149,7 +160,9 @@ def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[
         skill_path = skill_spec.get("path")
 
         if not skill_name or not skill_path:
-            logger.warning(f"Skipping invalid skill spec in package '{package_name}': {skill_spec}")
+            logger.warning(
+                f"Skipping invalid skill spec in package '{package_name}': {skill_spec}"
+            )
             continue
 
         try:
@@ -163,8 +176,9 @@ def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[
             # Use Skill.load to parse the skill file properly
             # We need to create a temporary path for load() to work
             # Actually, let's parse it directly using frontmatter
-            import frontmatter as fm
             import io
+
+            import frontmatter as fm
 
             parsed = fm.load(io.StringIO(skill_content))
             content = parsed.content
@@ -178,7 +192,9 @@ def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[
                 trigger = KeywordTrigger(keywords=metadata["triggers"])
 
             # Create the Skill object
-            skill = Skill(name=skill_name, content=content, trigger=trigger, source=source)
+            skill = Skill(
+                name=skill_name, content=content, trigger=trigger, source=source
+            )
 
             # Categorize based on trigger
             if skill.trigger is None:
@@ -189,7 +205,9 @@ def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[
             logger.debug(f"Loaded skill '{skill_name}' from package '{package_name}'")
 
         except Exception as e:
-            logger.error(f"Failed to load skill '{skill_name}' from package '{package_name}': {e}")
+            logger.error(
+                f"Failed to load skill '{skill_name}' from '{package_name}': {e}"
+            )
             continue
 
     logger.info(

--- a/openhands-sdk/openhands/sdk/context/skills/package_loader.py
+++ b/openhands-sdk/openhands/sdk/context/skills/package_loader.py
@@ -189,7 +189,9 @@ def load_skills_from_package(
             if "triggers" in metadata:
                 from openhands.sdk.context.skills.trigger import KeywordTrigger
 
-                trigger = KeywordTrigger(keywords=metadata["triggers"])
+                triggers_data = metadata["triggers"]
+                if isinstance(triggers_data, list):
+                    trigger = KeywordTrigger(keywords=triggers_data)
 
             # Create the Skill object
             skill = Skill(

--- a/openhands-sdk/openhands/sdk/context/skills/package_loader.py
+++ b/openhands-sdk/openhands/sdk/context/skills/package_loader.py
@@ -1,0 +1,282 @@
+"""Load skills from installed OpenHands skill packages.
+
+This module provides functionality to discover and load skills from
+installed Python packages that register as OpenHands skill packages
+via entry points.
+"""
+
+import sys
+from importlib.metadata import entry_points
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+from openhands.sdk.context.skills.skill import Skill
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+
+def list_skill_packages() -> list[dict[str, Any]]:
+    """Discover all installed OpenHands skill packages.
+
+    Uses Python's entry points mechanism for fast discovery without
+    filesystem scanning. Packages register themselves via the
+    'openhands.skill_packages' entry point group.
+
+    Returns:
+        List of dicts with 'name' (str) and 'descriptor' (dict) keys.
+        The descriptor contains the parsed skill-package.yaml content.
+
+    Example:
+        >>> packages = list_skill_packages()
+        >>> for pkg in packages:
+        ...     print(f"{pkg['name']}: {pkg['descriptor']['metadata']['displayName']}")
+    """
+    eps = entry_points(group="openhands.skill_packages")
+
+    packages = []
+
+    for ep in eps:
+        try:
+            # Load the package module
+            package_module = ep.load()
+
+            # Load the YAML descriptor from the package
+            yaml_content = files(package_module).joinpath("skill-package.yaml").read_text()
+            descriptor = yaml.safe_load(yaml_content)
+
+            packages.append({"name": ep.name, "descriptor": descriptor, "module": package_module})
+        except Exception as e:
+            # Log warning but continue - don't fail if one package is broken
+            logger.warning(f"Failed to load skill package {ep.name}: {e}")
+
+    return packages
+
+
+def get_skill_package(package_name: str) -> dict[str, Any] | None:
+    """Get a specific skill package by name.
+
+    Args:
+        package_name: The name of the package to retrieve (from entry point name)
+
+    Returns:
+        Dict with 'name', 'descriptor', and 'module' keys, or None if not found.
+
+    Example:
+        >>> pkg = get_skill_package('simple-code-review')
+        >>> if pkg:
+        ...     print(pkg['descriptor']['metadata']['displayName'])
+    """
+    eps = entry_points(group="openhands.skill_packages")
+
+    for ep in eps:
+        if ep.name == package_name:
+            try:
+                # Load the package module
+                package_module = ep.load()
+
+                # Load the YAML descriptor from the package
+                yaml_content = files(package_module).joinpath("skill-package.yaml").read_text()
+                descriptor = yaml.safe_load(yaml_content)
+
+                return {"name": ep.name, "descriptor": descriptor, "module": package_module}
+            except Exception as e:
+                logger.error(f"Failed to load skill package {package_name}: {e}")
+                return None
+
+    return None
+
+
+def load_skills_from_package(package_name: str) -> tuple[dict[str, Skill], dict[str, Skill]]:
+    """Load skills from a specific skill package.
+
+    Args:
+        package_name: Name of the package (entry point name, e.g., 'simple-code-review')
+
+    Returns:
+        Tuple of (repo_skills, knowledge_skills) dictionaries.
+        repo_skills have trigger=None, knowledge_skills have KeywordTrigger
+        or TaskTrigger.
+
+    Raises:
+        ValueError: If package is not found or cannot be loaded
+
+    Example:
+        >>> repo_skills, knowledge_skills = load_skills_from_package('simple-code-review')
+        >>> for name, skill in knowledge_skills.items():
+        ...     print(f"Loaded skill: {name}")
+    """
+    package = get_skill_package(package_name)
+    if package is None:
+        raise ValueError(f"Skill package '{package_name}' not found. Is it installed?")
+
+    descriptor = package["descriptor"]
+    package_module = package["module"]
+
+    repo_skills = {}
+    knowledge_skills = {}
+
+    # Load skills defined in the descriptor
+    skills_spec = descriptor.get("spec", {}).get("skills", [])
+
+    logger.debug(f"Loading {len(skills_spec)} skills from package '{package_name}'")
+
+    for skill_spec in skills_spec:
+        skill_name = skill_spec.get("name")
+        skill_path = skill_spec.get("path")
+
+        if not skill_name or not skill_path:
+            logger.warning(f"Skipping invalid skill spec in package '{package_name}': {skill_spec}")
+            continue
+
+        try:
+            # Read the skill file from the package
+            skill_content = files(package_module).joinpath(skill_path).read_text()
+
+            # Parse the skill file (it may have frontmatter)
+            # The skill file path becomes the source
+            source = f"package:{package_name}/{skill_path}"
+
+            # Use Skill.load to parse the skill file properly
+            # We need to create a temporary path for load() to work
+            # Actually, let's parse it directly using frontmatter
+            import frontmatter as fm
+            import io
+
+            parsed = fm.load(io.StringIO(skill_content))
+            content = parsed.content
+            metadata = parsed.metadata
+
+            # Determine trigger type from metadata
+            trigger = None
+            if "triggers" in metadata:
+                from openhands.sdk.context.skills.trigger import KeywordTrigger
+
+                trigger = KeywordTrigger(keywords=metadata["triggers"])
+
+            # Create the Skill object
+            skill = Skill(name=skill_name, content=content, trigger=trigger, source=source)
+
+            # Categorize based on trigger
+            if skill.trigger is None:
+                repo_skills[skill_name] = skill
+            else:
+                knowledge_skills[skill_name] = skill
+
+            logger.debug(f"Loaded skill '{skill_name}' from package '{package_name}'")
+
+        except Exception as e:
+            logger.error(f"Failed to load skill '{skill_name}' from package '{package_name}': {e}")
+            continue
+
+    logger.info(
+        f"Loaded {len(repo_skills)} repo skills and {len(knowledge_skills)} "
+        f"knowledge skills from package '{package_name}'"
+    )
+
+    return repo_skills, knowledge_skills
+
+
+def load_skills_from_packages(
+    package_names: list[str],
+) -> tuple[dict[str, Skill], dict[str, Skill]]:
+    """Load skills from multiple skill packages.
+
+    Args:
+        package_names: List of package names to load
+
+    Returns:
+        Tuple of (repo_skills, knowledge_skills) dictionaries containing
+        all skills from all packages.
+
+    Example:
+        >>> packages = ['simple-code-review', 'awesome-skills']
+        >>> repo_skills, knowledge_skills = load_skills_from_packages(packages)
+    """
+    all_repo_skills = {}
+    all_knowledge_skills = {}
+
+    for package_name in package_names:
+        try:
+            repo_skills, knowledge_skills = load_skills_from_package(package_name)
+            all_repo_skills.update(repo_skills)
+            all_knowledge_skills.update(knowledge_skills)
+        except ValueError as e:
+            logger.error(str(e))
+        except Exception as e:
+            logger.error(f"Unexpected error loading package '{package_name}': {e}")
+
+    return all_repo_skills, all_knowledge_skills
+
+
+def load_packages_config(config_path: Path | str | None = None) -> list[str]:
+    """Load package configuration from .openhands/packages.yaml.
+
+    Args:
+        config_path: Path to packages.yaml. If None, looks for:
+                    - .openhands/packages.yaml in current directory
+                    - ~/.openhands/packages.yaml in home directory
+
+    Returns:
+        List of package names to load. Empty list if no config found.
+
+    Example:
+        >>> packages = load_packages_config()
+        >>> print(f"Configured packages: {packages}")
+    """
+    if config_path is None:
+        # Try current directory first
+        local_config = Path(".openhands/packages.yaml")
+        home_config = Path.home() / ".openhands" / "packages.yaml"
+
+        if local_config.exists():
+            config_path = local_config
+        elif home_config.exists():
+            config_path = home_config
+        else:
+            logger.debug("No packages.yaml configuration found")
+            return []
+    else:
+        config_path = Path(config_path)
+
+    if not config_path.exists():
+        logger.warning(f"Package configuration not found: {config_path}")
+        return []
+
+    try:
+        with open(config_path) as f:
+            config = yaml.safe_load(f)
+
+        packages = config.get("packages", [])
+        logger.info(f"Loaded package configuration from {config_path}: {packages}")
+        return packages
+
+    except Exception as e:
+        logger.error(f"Failed to load package configuration from {config_path}: {e}")
+        return []
+
+
+def load_configured_package_skills() -> tuple[dict[str, Skill], dict[str, Skill]]:
+    """Load skills from all configured packages.
+
+    Reads .openhands/packages.yaml to determine which packages to load,
+    then loads skills from those packages.
+
+    Returns:
+        Tuple of (repo_skills, knowledge_skills) dictionaries.
+
+    Example:
+        >>> repo_skills, knowledge_skills = load_configured_package_skills()
+        >>> print(f"Loaded {len(knowledge_skills)} knowledge skills from packages")
+    """
+    package_names = load_packages_config()
+
+    if not package_names:
+        logger.debug("No skill packages configured")
+        return {}, {}
+
+    return load_skills_from_packages(package_names)

--- a/tests/sdk/context/skill/test_package_loader.py
+++ b/tests/sdk/context/skill/test_package_loader.py
@@ -1,0 +1,257 @@
+"""Tests for skill package loading functionality."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+
+from openhands.sdk.context.skills.package_loader import (
+    get_skill_package,
+    list_skill_packages,
+    load_configured_package_skills,
+    load_packages_config,
+    load_skills_from_package,
+    load_skills_from_packages,
+)
+
+
+@pytest.fixture
+def mock_entry_points():
+    """Create mock entry points for testing."""
+    # Create a mock entry point
+    mock_ep = MagicMock()
+    mock_ep.name = "test-package"
+
+    # Create a mock module
+    mock_module = MagicMock()
+
+    # Mock the skill-package.yaml content
+    descriptor_content = """
+apiVersion: openhands.ai/v1
+kind: SkillPackage
+
+metadata:
+  name: test-package
+  version: "1.0.0"
+  displayName: "Test Package"
+  description: "A test skill package"
+  author: "Test Author"
+
+spec:
+  skills:
+    - name: test-skill
+      path: skills/test.md
+      type: keyword-triggered
+      triggers:
+        - test
+        - testing
+"""
+
+    # Mock the skill file content
+    skill_content = """---
+triggers:
+  - test
+  - testing
+---
+
+# Test Skill
+
+This is a test skill for testing package loading.
+"""
+
+    mock_ep.load.return_value = mock_module
+
+    return mock_ep, mock_module, descriptor_content, skill_content
+
+
+def test_list_skill_packages_empty():
+    """Test listing packages when none are installed."""
+    with patch("openhands.sdk.context.skills.package_loader.entry_points") as mock_eps:
+        mock_eps.return_value = []
+        packages = list_skill_packages()
+        assert packages == []
+
+
+def test_list_skill_packages_with_package(mock_entry_points):
+    """Test listing packages when one is installed."""
+    mock_ep, mock_module, descriptor_content, skill_content = mock_entry_points
+
+    with patch("openhands.sdk.context.skills.package_loader.entry_points") as mock_eps:
+        mock_eps.return_value = [mock_ep]
+
+        with patch("openhands.sdk.context.skills.package_loader.files") as mock_files:
+            mock_files.return_value.joinpath.return_value.read_text.return_value = descriptor_content
+
+            packages = list_skill_packages()
+
+            assert len(packages) == 1
+            assert packages[0]["name"] == "test-package"
+            assert packages[0]["descriptor"]["metadata"]["displayName"] == "Test Package"
+
+
+def test_get_skill_package_not_found():
+    """Test getting a package that doesn't exist."""
+    with patch("openhands.sdk.context.skills.package_loader.entry_points") as mock_eps:
+        mock_eps.return_value = []
+        package = get_skill_package("nonexistent")
+        assert package is None
+
+
+def test_get_skill_package_found(mock_entry_points):
+    """Test getting an existing package."""
+    mock_ep, mock_module, descriptor_content, skill_content = mock_entry_points
+
+    with patch("openhands.sdk.context.skills.package_loader.entry_points") as mock_eps:
+        mock_eps.return_value = [mock_ep]
+
+        with patch("openhands.sdk.context.skills.package_loader.files") as mock_files:
+            mock_files.return_value.joinpath.return_value.read_text.return_value = descriptor_content
+
+            package = get_skill_package("test-package")
+
+            assert package is not None
+            assert package["name"] == "test-package"
+            assert package["descriptor"]["metadata"]["displayName"] == "Test Package"
+
+
+def test_load_skills_from_package_not_found():
+    """Test loading skills from a non-existent package."""
+    with patch("openhands.sdk.context.skills.package_loader.entry_points") as mock_eps:
+        mock_eps.return_value = []
+
+        with pytest.raises(ValueError, match="not found"):
+            load_skills_from_package("nonexistent")
+
+
+def test_load_skills_from_package_success(mock_entry_points):
+    """Test successfully loading skills from a package."""
+    mock_ep, mock_module, descriptor_content, skill_content = mock_entry_points
+
+    with patch("openhands.sdk.context.skills.package_loader.entry_points") as mock_eps:
+        mock_eps.return_value = [mock_ep]
+
+        with patch("openhands.sdk.context.skills.package_loader.files") as mock_files:
+            # Mock reading both the descriptor and skill file
+            def read_text_side_effect(path):
+                if "skill-package.yaml" in str(path):
+                    return descriptor_content
+                elif "skills/test.md" in str(path):
+                    return skill_content
+                return ""
+
+            mock_path = MagicMock()
+            mock_path.read_text.side_effect = read_text_side_effect
+            mock_files.return_value.joinpath.return_value = mock_path
+
+            repo_skills, knowledge_skills = load_skills_from_package("test-package")
+
+            # The test skill has triggers, so it should be a knowledge skill
+            assert len(knowledge_skills) == 1
+            assert "test-skill" in knowledge_skills
+            assert knowledge_skills["test-skill"].name == "test-skill"
+            assert knowledge_skills["test-skill"].trigger is not None
+
+
+def test_load_skills_from_packages_multiple():
+    """Test loading skills from multiple packages."""
+    with patch("openhands.sdk.context.skills.package_loader.load_skills_from_package") as mock_load:
+        # Mock two different packages
+        mock_load.side_effect = [
+            ({"repo1": MagicMock()}, {"know1": MagicMock()}),
+            ({"repo2": MagicMock()}, {"know2": MagicMock()}),
+        ]
+
+        repo_skills, knowledge_skills = load_skills_from_packages(["package1", "package2"])
+
+        assert len(repo_skills) == 2
+        assert len(knowledge_skills) == 2
+        assert mock_load.call_count == 2
+
+
+def test_load_packages_config_no_file():
+    """Test loading config when no file exists."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "nonexistent.yaml"
+        packages = load_packages_config(config_path)
+        assert packages == []
+
+
+def test_load_packages_config_with_file():
+    """Test loading config from an existing file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "packages.yaml"
+        config_content = {"packages": ["package1", "package2", "package3"]}
+
+        config_path.write_text(yaml.dump(config_content))
+
+        packages = load_packages_config(config_path)
+
+        assert len(packages) == 3
+        assert "package1" in packages
+        assert "package2" in packages
+        assert "package3" in packages
+
+
+def test_load_packages_config_empty_packages():
+    """Test loading config with empty packages list."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        config_path = Path(tmpdir) / "packages.yaml"
+        config_content = {"packages": []}
+
+        config_path.write_text(yaml.dump(config_content))
+
+        packages = load_packages_config(config_path)
+
+        assert packages == []
+
+
+def test_load_packages_config_auto_discovery():
+    """Test auto-discovery of config file."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        # Create .openhands directory
+        openhands_dir = Path(tmpdir) / ".openhands"
+        openhands_dir.mkdir()
+
+        config_path = openhands_dir / "packages.yaml"
+        config_content = {"packages": ["auto-discovered-package"]}
+        config_path.write_text(yaml.dump(config_content))
+
+        # Change to temp directory
+        import os
+
+        old_cwd = os.getcwd()
+        try:
+            os.chdir(tmpdir)
+            packages = load_packages_config()
+            assert "auto-discovered-package" in packages
+        finally:
+            os.chdir(old_cwd)
+
+
+def test_load_configured_package_skills():
+    """Test loading skills from configured packages."""
+    with patch("openhands.sdk.context.skills.package_loader.load_packages_config") as mock_config:
+        mock_config.return_value = ["package1", "package2"]
+
+        with patch("openhands.sdk.context.skills.package_loader.load_skills_from_packages") as mock_load:
+            mock_load.return_value = ({"repo": MagicMock()}, {"know": MagicMock()})
+
+            repo_skills, knowledge_skills = load_configured_package_skills()
+
+            mock_config.assert_called_once()
+            mock_load.assert_called_once_with(["package1", "package2"])
+            assert len(repo_skills) == 1
+            assert len(knowledge_skills) == 1
+
+
+def test_load_configured_package_skills_no_config():
+    """Test loading skills when no packages are configured."""
+    with patch("openhands.sdk.context.skills.package_loader.load_packages_config") as mock_config:
+        mock_config.return_value = []
+
+        repo_skills, knowledge_skills = load_configured_package_skills()
+
+        assert repo_skills == {}
+        assert knowledge_skills == {}


### PR DESCRIPTION
## Description

This PR builds on the proof-of-concept from OpenHands/software-agent-sdk#1399 to achieve full compatibility with Claude Code Plugins and AgentSpec standards. The key insight is that **marketplace monorepos and Python packages can share the same plugin structure**, enabling plugins to be distributed both ways without modification.

----

_implementation in-progress: this PR description guides on-going work on the branch_

----

## Vision: Unified Plugin Structure

### The Dual-Distribution Model

A plugin repository can serve as both:
1. **Bare Git Marketplace** (#1453) - Direct installation from git repos
2. **Python Package Source** (This PR) - Build and publish to PyPI

The `.plugin/` directory structure remains identical in both cases, with Python packaging (pyproject.toml, setup.py) as an optional layer for formal distribution.

### Example Marketplace Monorepo Structure
```
my-marketplace/
├── .plugin/
│   └── marketplace.json              # Marketplace descriptor
├── plugins/
│   ├── plugin-a/
│   │   ├── .plugin/
│   │   │   ├── plugin.json           # Plugin manifest (NOT manifest.json)
│   │   │   └── skills/
│   │   │       └── SKILL.md          # AgentSpec-compatible format
│   │   ├── pyproject.toml            # Optional: for Python packaging
│   │   ├── setup.py                  # Optional: for Python packaging
│   │   └── plugin_a/                 # Optional: Python module
│   │       └── __init__.py
│   └── plugin-b/
│       ├── .plugin/
│       │   ├── plugin.json
│       │   └── skills/
│       ├── pyproject.toml
│       └── plugin_b/
```

**Key Principle**: The `.plugin/` structure is the same whether used bare or packaged.

---

## Changes Required for Full Compatibility

### 1. File Naming & Structure ❌ NOT YET IMPLEMENTED

**Current State (PR OpenHands/software-agent-sdk#1399)**:
- Uses `manifest.json` in package root
- Claims "Claude Desktop Extensions-aligned" but Claude Code doesn't use manifest.json
- No `.plugin/` or `.claude-plugin/` directory structure

**Required Changes**:
- [ ] Rename `manifest.json` → `plugin.json`
- [ ] Move to `.plugin/plugin.json` (vendor-neutral, per OpenHands/software-agent-sdk#1440)
- [ ] Support `.claude-plugin/plugin.json` for backward compatibility
- [ ] Update `package_loader.py` to check both locations
- [ ] Precedence: `.plugin/` > `.claude-plugin/`

**Files to Modify**:
- `openhands-sdk/openhands/sdk/context/skills/package_loader.py` - Update `_load_descriptor()`
- `tests/sdk/context/skill/test_package_loader.py` - Update all test fixtures
- `docs/claude-code-alignment.md` - Correct documentation

---

### 2. Schema Alignment ❌ NOT YET IMPLEMENTED

**Current State**:
```json
{
  "name": "simple-code-review",
  "version": "1.0.0",
  "skills": [...]
}
```

**Claude Code plugin.json Schema**:
```json
{
  "name": "plugin-name",
  "version": "1.0.0",
  "displayName": "Human Readable Name",
  "description": "Plugin description",
  "author": {
    "name": "Author Name",
    "email": "author@example.com"
  },
  "keywords": ["tag1", "tag2"],
  "license": "MIT",
  "commands": ["./commands/"],
  "agents": ["./agents/agent.md"],
  "hooks": {...},
  "mcpServers": {...}
}
```

**Required Changes**:
- [ ] Compare current schema with Claude Code plugin.json
- [ ] Add missing optional fields
- [ ] Ensure required fields are validated
- [ ] Support component paths (commands, agents, hooks, mcpServers)

**Note**: Current implementation has `skills` array in manifest.json, but Claude Code uses directory-based discovery with optional overrides in plugin.json.

---

### 3. AgentSpec SKILL.md Compatibility ❌ NOT YET IMPLEMENTED

**Current State** (from package_loader.py lines 183-199):
- Parses frontmatter with `frontmatter` library
- Looks for `triggers` field in metadata
- Creates KeywordTrigger if present
- Uses simple markdown content

**AgentSpec SKILL.md Requirements** (from OpenHands/software-agent-sdk#1452):

#### Required Frontmatter Fields:
- `name` - Skill identifier (kebab-case)
- `description` - 1-1024 characters

#### Optional Frontmatter Fields:
- `license` - SPDX identifier
- `compatibility` - Compatibility notes
- `metadata` - Key-value map (author, version, etc.)
- `allowed-tools` - Tool restrictions (experimental)

#### OpenHands Extensions (Not in AgentSpec):
- `triggers` - Keyword list for activation
- `inputs` - For task skills with variable substitution
- `mcp_tools` - MCP server configuration

**Required Changes**:
- [ ] Validate required AgentSpec fields (name, description)
- [ ] Store optional AgentSpec fields in Skill metadata
- [ ] Prepend description to Skill.content (AgentSpec pattern)
- [ ] Support kebab-case naming validation
- [ ] Add validation for description length (1-1024 chars)
- [ ] Maintain backward compatibility with OpenHands extensions

**Files to Modify**:
- `openhands-sdk/openhands/sdk/context/skills/skill.py` - Add AgentSpec validation
- `openhands-sdk/openhands/sdk/context/skills/package_loader.py` - Use Skill.load_agentspec() method
- Add new validation in Skill class for AgentSpec format

---

### 4. Progressive Disclosure Support ❌ NOT YET IMPLEMENTED

**AgentSpec Three-Tier Model**:
1. **Discovery** (~100 tokens): name, description, location in system prompt
2. **Activation** (<5000 tokens): Full SKILL.md content when LLM decides
3. **Resources** (variable): scripts/, references/, assets/ loaded on demand

**OpenHands Current Model**:
- Repo skills: Always loaded (full content in context)
- Keyword skills: Loaded on keyword match
- Task skills: Loaded on match with variable substitution

**Required Changes**:
- [ ] Support SKILL.md with resource directories (scripts/, references/, assets/)
- [ ] Implement lazy loading for resource directories
- [ ] Add filesystem-based resource access for agents
- [ ] Document progressive disclosure patterns

**Note**: This is a Phase 2 enhancement, not required for initial compatibility.

---

### 5. Directory Structure Support ⚠️ PARTIAL

**Current State**:
- Single file per skill (flat structure)
- All content in one .md file

**AgentSpec Structure**:
```
plugin-name/
├── SKILL.md              # Main skill file
├── scripts/              # Executable scripts
│   ├── extract.py
│   └── merge.sh
├── references/           # Documentation
│   ├── REFERENCE.md
│   └── API.md
└── assets/               # Supporting files
    └── template.json
```

**Required Changes**:
- [ ] Support skill directories with SKILL.md
- [ ] Optional: Load scripts/, references/, assets/ on demand
- [ ] Maintain compatibility with single-file format
- [ ] Update Skill model to track resource paths

**Files to Consider**:
- Skill.load() method to detect directory vs file
- Resource path tracking in Skill model
- Lazy loading mechanism

---

### 6. Marketplace Integration ❌ NOT YET IMPLEMENTED

**Goal**: Enable the same `.plugin/` structure to work in:
1. Bare git marketplace repos (direct clone/pull)
2. Python packages (pip install)

**Required Changes**:
- [ ] Support loading from filesystem (bare repos)
- [ ] Support loading from installed packages (entry points)
- [ ] Unified discovery mechanism
- [ ] Same plugin.json format in both cases

**New Functionality Needed**:
- Marketplace loader (see OpenHands/OpenHands#12316)
- Git repository cloning/pulling
- Plugin discovery from filesystem
- Integration with package_loader.py

---

## Testing Current State

### What Works (PR OpenHands/software-agent-sdk#1399):
✅ Entry point discovery via `openhands.skill_packages`
✅ JSON descriptor loading
✅ Skill file content loading from packages
✅ Frontmatter parsing with triggers
✅ KeywordTrigger creation
✅ Basic package loading tests

### What Doesn't Work:
❌ `.plugin/` directory structure
❌ `plugin.json` naming (uses `manifest.json`)
❌ AgentSpec SKILL.md validation
❌ Resource directory support (scripts/, references/, assets/)
❌ Progressive disclosure
❌ Filesystem-based marketplace loading
❌ Full schema compatibility with Claude Code

---

## Implementation Priority

### Phase 1: Core Compatibility (This PR)
1. **File naming** - manifest.json → plugin.json
2. **Directory structure** - Move to .plugin/plugin.json
3. **AgentSpec validation** - Required frontmatter fields
4. **Schema alignment** - Match Claude Code plugin.json

### Phase 2: Advanced Features (Future PRs)
5. **Resource directories** - scripts/, references/, assets/
6. **Progressive disclosure** - Lazy loading
7. **Marketplace integration** - Filesystem loading (#1453)
8. **Enhanced discovery** - Unified marketplace + package loading

---

## Related Issues

- OpenHands/software-agent-sdk#1440 - Plugin 1.0 Definition (`.plugin/` directory structure)
- OpenHands/software-agent-sdk#1452 - AgentSkills Compatibility (SKILL.md format requirements)
- OpenHands/OpenHands#12316 - Bare Git Repository Marketplaces
- OpenHands/software-agent-sdk#1399 - POC: support for Python package-based plugin loading
- OpenHands/enterprise#17 - Plugin Packaging & Marketplace Vision

---

## Questions to Resolve

1. **Skill discovery**: Should plugin.json list skills explicitly, or discover SKILL.md files in .plugin/skills/?
2. **Backward compatibility**: How to handle existing manifest.json packages during transition?
3. **Naming precedence**: If both .plugin/plugin.json and .claude-plugin/plugin.json exist, which wins?
4. **Resource loading**: Should scripts/ be automatically available, or require explicit activation?
5. **Package vs Marketplace**: Should package_loader.py handle both, or keep separate loaders?

---

## Success Criteria

- [ ] Uses `.plugin/plugin.json` (not manifest.json)
- [ ] Supports `.claude-plugin/plugin.json` for compatibility
- [ ] Validates AgentSpec required fields (name, description)
- [ ] Stores AgentSpec optional fields in metadata
- [ ] Schema matches Claude Code plugin.json format
- [ ] Tests pass with new structure
- [ ] Documentation updated to reflect Claude Code alignment
- [ ] Maintains backward compatibility with PR OpenHands/software-agent-sdk#1399 POC (deprecation path)
- [ ] Works as both bare repo plugin and Python package

---

## Migration Path from PR OpenHands/software-agent-sdk#1399

For existing packages using manifest.json:

1. **Rename**: `manifest.json` → `plugin.json`
2. **Move**: `package_root/plugin.json` → `package_root/.plugin/plugin.json`
3. **Update pyproject.toml**:
   ```toml
   [tool.setuptools.package-data]
   my_package = [".plugin/plugin.json", ".plugin/skills/*.md"]
   ```
4. **Add SKILL.md validation**: Ensure frontmatter has `name` and `description`

---

## Next Steps

1. ✅ Create branch from PR OpenHands/software-agent-sdk#1399
2. ✅ Create this PR with detailed analysis
3. 🔄 Implement Phase 1 changes (file naming, structure, validation)
4. 🔄 Update tests
5. 🔄 Update documentation
6. ⏳ Review and merge
7. ⏳ Implement Phase 2 features in follow-up PRs

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:98b2e5e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-98b2e5e-python \
  ghcr.io/openhands/agent-server:98b2e5e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:98b2e5e-golang-amd64
ghcr.io/openhands/agent-server:98b2e5e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:98b2e5e-golang-arm64
ghcr.io/openhands/agent-server:98b2e5e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:98b2e5e-java-amd64
ghcr.io/openhands/agent-server:98b2e5e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:98b2e5e-java-arm64
ghcr.io/openhands/agent-server:98b2e5e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:98b2e5e-python-amd64
ghcr.io/openhands/agent-server:98b2e5e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:98b2e5e-python-arm64
ghcr.io/openhands/agent-server:98b2e5e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:98b2e5e-golang
ghcr.io/openhands/agent-server:98b2e5e-java
ghcr.io/openhands/agent-server:98b2e5e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `98b2e5e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `98b2e5e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->