### PR TITLE
Add env-configurable token view to visualizer (per-context vs accumulated)

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/__init__.py
+++ b/openhands-sdk/openhands/sdk/conversation/__init__.py
@@ -11,6 +11,12 @@ from openhands.sdk.conversation.state import (
     ConversationState,
 )
 from openhands.sdk.conversation.stuck_detector import StuckDetector
+from openhands.sdk.conversation.token_display import (
+    TokenDisplay,
+    TokenDisplayMode,
+    compute_token_display,
+    get_default_mode_from_env,
+)
 from openhands.sdk.conversation.types import (
     ConversationCallbackType,
     ConversationTokenCallbackType,
@@ -37,4 +43,9 @@ __all__ = [
     "RemoteConversation",
     "EventsListBase",
     "get_agent_final_response",
+    # Token display utilities (public SDK API)
+    "TokenDisplay",
+    "TokenDisplayMode",
+    "compute_token_display",
+    "get_default_mode_from_env",
 ]

--- a/openhands-sdk/openhands/sdk/conversation/token_display.py
+++ b/openhands-sdk/openhands/sdk/conversation/token_display.py
@@ -1,0 +1,124 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from enum import Enum
+
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.llm.utils.metrics import Metrics, TokenUsage
+
+
+class TokenDisplayMode(str, Enum):
+    PER_CONTEXT = "per_context"  # show metrics for the latest request only
+    ACCUMULATED = "accumulated"  # show accumulated tokens across all requests
+
+    @classmethod
+    def from_str(cls, value: str | None) -> TokenDisplayMode:
+        if not value:
+            return cls.PER_CONTEXT
+        v = value.strip().lower().replace("-", "_")
+        if v in {"per_context", "per_request", "latest", "current"}:
+            return cls.PER_CONTEXT
+        if v in {"accumulated", "total", "sum"}:
+            return cls.ACCUMULATED
+        # default to per-context to match current visual default and tests
+        return cls.PER_CONTEXT
+
+
+@dataclass(frozen=True)
+class TokenDisplay:
+    # Raw counts (not abbreviated)
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    reasoning_tokens: int
+    context_window: int
+    # Rate [0.0, 1.0] or None if undefined
+    cache_hit_rate: float | None
+    # Total accumulated cost in USD
+    total_cost: float
+    # Optional delta of input tokens compared to previous request
+    since_last_input_tokens: int | None = None
+
+
+def _get_combined_metrics(stats: ConversationStats | None) -> Metrics | None:
+    if not stats:
+        return None
+    try:
+        return stats.get_combined_metrics()
+    except Exception:
+        return None
+
+
+def compute_token_display(
+    stats: ConversationStats | None,
+    mode: TokenDisplayMode = TokenDisplayMode.PER_CONTEXT,
+    include_since_last: bool = False,
+) -> TokenDisplay | None:
+    """Compute token display values from conversation stats.
+
+    Args:
+        stats: ConversationStats to read metrics from
+        mode: Whether to show per-context (latest request) or accumulated values
+        include_since_last: If True, include the delta of input tokens compared to
+            the previous request (when available)
+
+    Returns:
+        TokenDisplay with raw numeric values, or None if metrics are unavailable
+    """
+    combined = _get_combined_metrics(stats)
+    if not combined:
+        return None
+
+    # No token usage recorded yet
+    if not combined.token_usages:
+        return None
+
+    total_cost = combined.accumulated_cost or 0.0
+
+    if mode == TokenDisplayMode.ACCUMULATED:
+        usage: TokenUsage | None = combined.accumulated_token_usage
+        if usage is None:
+            return None
+        input_tokens = usage.prompt_tokens or 0
+        output_tokens = usage.completion_tokens or 0
+        cache_read = usage.cache_read_tokens or 0
+        reasoning_tokens = usage.reasoning_tokens or 0
+        context_window = usage.context_window or 0
+        cache_hit_rate = (cache_read / input_tokens) if input_tokens > 0 else None
+        since_last: int | None = None
+    else:  # PER_CONTEXT
+        usage = combined.token_usages[-1]
+        input_tokens = usage.prompt_tokens or 0
+        output_tokens = usage.completion_tokens or 0
+        cache_read = usage.cache_read_tokens or 0
+        reasoning_tokens = usage.reasoning_tokens or 0
+        context_window = usage.context_window or 0
+        cache_hit_rate = (cache_read / input_tokens) if input_tokens > 0 else None
+        since_last = None
+        if include_since_last and len(combined.token_usages) >= 2:
+            prev = combined.token_usages[-2]
+            since_last = max(0, (usage.prompt_tokens or 0) - (prev.prompt_tokens or 0))
+
+    return TokenDisplay(
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        cache_read_tokens=cache_read,
+        reasoning_tokens=reasoning_tokens,
+        context_window=context_window,
+        cache_hit_rate=cache_hit_rate,
+        total_cost=total_cost,
+        since_last_input_tokens=since_last,
+    )
+
+
+def get_default_mode_from_env() -> TokenDisplayMode:
+    """Resolve default token display mode from env var.
+
+    Env var: OH_TOKENS_VIEW_MODE
+      - "per_context" (default)
+      - "accumulated"
+      - also accepts aliases: per_request/latest/current and total/sum
+    """
+    value = os.environ.get("OH_TOKENS_VIEW_MODE")
+    return TokenDisplayMode.from_str(value)

--- a/tests/sdk/conversation/test_token_display.py
+++ b/tests/sdk/conversation/test_token_display.py
@@ -1,0 +1,111 @@
+from unittest.mock import MagicMock
+
+import pytest
+
+from openhands.sdk.conversation import (
+    TokenDisplayMode,
+    compute_token_display,
+)
+from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.conversation.visualizer import DefaultConversationVisualizer
+from openhands.sdk.llm.utils.metrics import Metrics
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    # Ensure env vars do not leak between tests
+    monkeypatch.delenv("OH_TOKENS_VIEW_MODE", raising=False)
+    monkeypatch.delenv("OH_TOKENS_VIEW_DELTA", raising=False)
+
+
+def _make_stats_with_two_requests():
+    stats = ConversationStats()
+    m = Metrics(model_name="test-model")
+    # First call
+    m.add_cost(0.1)
+    m.add_token_usage(
+        prompt_tokens=100,
+        completion_tokens=25,
+        cache_read_tokens=10,
+        cache_write_tokens=0,
+        reasoning_tokens=5,
+        context_window=8000,
+        response_id="first",
+    )
+    # Second call
+    m.add_cost(0.05)
+    m.add_token_usage(
+        prompt_tokens=220,
+        completion_tokens=80,
+        cache_read_tokens=44,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=8000,
+        response_id="second",
+    )
+    stats.usage_to_metrics["usage-1"] = m
+    return stats
+
+
+def test_compute_token_display_per_context_with_delta():
+    stats = _make_stats_with_two_requests()
+
+    td = compute_token_display(
+        stats=stats, mode=TokenDisplayMode.PER_CONTEXT, include_since_last=True
+    )
+    assert td is not None
+
+    # Latest request values
+    assert td.input_tokens == 220
+    assert td.output_tokens == 80
+    assert td.reasoning_tokens == 0
+    assert td.cache_read_tokens == 44
+    assert td.context_window == 8000
+    assert td.total_cost == pytest.approx(0.15)
+    assert td.cache_hit_rate == pytest.approx(44 / 220)
+
+    # Delta vs previous
+    assert td.since_last_input_tokens == 120  # 220 - 100
+
+
+def test_compute_token_display_accumulated():
+    stats = _make_stats_with_two_requests()
+
+    td = compute_token_display(stats=stats, mode=TokenDisplayMode.ACCUMULATED)
+    assert td is not None
+
+    # Accumulated values: sums of prompt/completion/cache_read; max context_window
+    assert td.input_tokens == 100 + 220
+    assert td.output_tokens == 25 + 80
+    assert td.cache_read_tokens == 10 + 44
+    assert td.reasoning_tokens == 5 + 0
+    assert td.context_window == 8000
+    assert td.total_cost == pytest.approx(0.15)
+    assert td.cache_hit_rate == pytest.approx((10 + 44) / (100 + 220))
+
+    # No since-last in accumulated mode
+    assert td.since_last_input_tokens is None
+
+
+def test_visualizer_env_vars_toggle_delta(monkeypatch):
+    stats = _make_stats_with_two_requests()
+
+    # Force per-context and delta
+    monkeypatch.setenv("OH_TOKENS_VIEW_MODE", "per_context")
+    monkeypatch.setenv("OH_TOKENS_VIEW_DELTA", "true")
+
+    viz = DefaultConversationVisualizer()
+
+    # Attach stats via the base visualizer's initialize contract using a simple mock
+    state = MagicMock()
+    state.stats = stats
+    viz.initialize(state)
+    subtitle = viz._format_metrics_subtitle()
+    assert subtitle is not None
+    assert "(+" in subtitle  # shows since-last delta
+
+    # Force accumulated mode: should hide delta even if env says true
+    monkeypatch.setenv("OH_TOKENS_VIEW_MODE", "accumulated")
+    subtitle2 = viz._format_metrics_subtitle()
+    assert subtitle2 is not None
+    assert "(+" not in subtitle2


### PR DESCRIPTION
Summary
- Introduce a small token display utility API (TokenDisplay, TokenDisplayMode, compute_token_display, get_default_mode_from_env)
- Refactor DefaultConversationVisualizer to use this utility
- Default behavior shows per-context (latest request) token counts while keeping cumulative cost labeled as (total)
- Add env toggles:
  - OH_TOKENS_VIEW_MODE: per_context (default) or accumulated (aliases supported: per_request/latest/current and total/sum)
  - OH_TOKENS_VIEW_DELTA: optional since-last delta for input tokens in per_context mode
- Add focused tests covering token_display and visualizer subtitle formatting/toggles

Rationale
This follows reviewer feedback to keep both views available and make the SDK configurable, while simplifying the visualizer by extracting token computation into a reusable utility.

Testing
- make build
- uv run pytest tests/sdk/conversation/test_token_display.py -q
- uv run pytest tests/sdk/conversation/test_visualizer.py -q
- uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/token_display.py openhands-sdk/openhands/sdk/conversation/visualizer/default.py tests/sdk/conversation/test_token_display.py

Notes
- Backward compatible: default display remains concise and adds configurability via env
- Minimal surface change; no breaking API changes

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c9f9ab3d579e40338f63134a8a560ec3)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5aba694-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5aba694-python \
  ghcr.io/openhands/agent-server:5aba694-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5aba694-golang-amd64
ghcr.io/openhands/agent-server:5aba694-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5aba694-golang-arm64
ghcr.io/openhands/agent-server:5aba694-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5aba694-java-amd64
ghcr.io/openhands/agent-server:5aba694-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5aba694-java-arm64
ghcr.io/openhands/agent-server:5aba694-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5aba694-python-amd64
ghcr.io/openhands/agent-server:5aba694-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:5aba694-python-arm64
ghcr.io/openhands/agent-server:5aba694-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:5aba694-golang
ghcr.io/openhands/agent-server:5aba694-java
ghcr.io/openhands/agent-server:5aba694-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5aba694-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5aba694-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->