### PR TITLE
terminal: populate TerminalObservation.exit_code (fixes #1468)

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
@@ -190,6 +190,7 @@ class TerminalSession(TerminalSessionBase):
             command=command,
             text=command_output,
             metadata=metadata,
+            exit_code=metadata.exit_code,
         )
 
     def _handle_nochange_timeout_command(
@@ -224,6 +225,7 @@ class TerminalSession(TerminalSessionBase):
             command=command,
             text=command_output,
             metadata=metadata,
+            exit_code=metadata.exit_code,
         )
 
     def _handle_hard_timeout_command(
@@ -257,6 +259,7 @@ class TerminalSession(TerminalSessionBase):
         )
         return TerminalObservation.from_text(
             command=command,
+            exit_code=metadata.exit_code,
             text=command_output,
             metadata=metadata,
         )
@@ -392,6 +395,7 @@ class TerminalSession(TerminalSessionBase):
                 command=command,
                 text=command_output,
                 metadata=metadata,
+                exit_code=metadata.exit_code,
                 is_error=True,
             )
             logger.debug(f"RETURNING OBSERVATION (previous-command): {obs}")

--- a/tests/tools/terminal/test_terminal_exit_code_top_level.py
+++ b/tests/tools/terminal/test_terminal_exit_code_top_level.py
@@ -1,0 +1,49 @@
+import os
+
+import pytest
+
+from openhands.tools.terminal.definition import TerminalAction
+from openhands.tools.terminal.terminal import create_terminal_session
+
+
+@pytest.mark.parametrize("terminal_type", ["tmux", "subprocess"])
+def test_exit_code_top_level_completed(terminal_type):
+    session = create_terminal_session(work_dir=os.getcwd(), terminal_type=terminal_type)
+    session.initialize()
+    try:
+        obs = session.execute(TerminalAction(command="echo top-level"))
+        assert obs.metadata.exit_code == 0
+        assert obs.exit_code == 0
+        assert obs.exit_code == obs.metadata.exit_code
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("terminal_type", ["tmux", "subprocess"])
+def test_exit_code_top_level_soft_timeout(terminal_type):
+    session = create_terminal_session(
+        work_dir=os.getcwd(), no_change_timeout_seconds=1, terminal_type=terminal_type
+    )
+    session.initialize()
+    try:
+        # Command produces no output and should trigger no-change timeout
+        obs = session.execute(TerminalAction(command="sleep 2"))
+        assert obs.metadata.exit_code == -1
+        assert obs.exit_code == -1
+        assert obs.exit_code == obs.metadata.exit_code
+    finally:
+        session.close()
+
+
+@pytest.mark.parametrize("terminal_type", ["tmux", "subprocess"])
+def test_exit_code_top_level_hard_timeout(terminal_type):
+    session = create_terminal_session(work_dir=os.getcwd(), terminal_type=terminal_type)
+    session.initialize()
+    try:
+        # Hard timeout should set exit_code to -1 as per schema docs
+        obs = session.execute(TerminalAction(command="sleep 10", timeout=1.0))
+        assert obs.metadata.exit_code == -1
+        assert obs.exit_code == -1
+        assert obs.exit_code == obs.metadata.exit_code
+    finally:
+        session.close()


### PR DESCRIPTION
HUMAN: This PR proposes to fill in `exit_code` as client code expects in the terminal observation, I think. I tested it and it works. `exit_code` is an attribute of the `TerminalObservation`, it just wasn't populated.

### Before:

<img width="432" height="141" alt="image" src="https://github.com/user-attachments/assets/5542325c-52c2-4e56-8454-872d0b3e0bd6" />


### After:
<img width="477" height="132" alt="image" src="https://github.com/user-attachments/assets/8b4b2025-c4b9-4e08-a8ae-2c7b51985b11" />




Summary
- Fix TerminalObservation.exit_code being null while metadata.exit_code is set when using the terminal tool.
- Ensure the top-level exit_code mirrors the parsed PS1 metadata so UIs and consumers can display an accurate exit status.

What changed
- openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
  - Set exit_code=metadata.exit_code when constructing observations in:
    - _handle_completed_command
    - _handle_nochange_timeout_command
    - _handle_hard_timeout_command
    - Previous-command-still-running error path (when a new command is sent while another is running)

- tests/tools/terminal/test_terminal_exit_code_top_level.py
  - Added tests to assert TerminalObservation.exit_code equals metadata.exit_code for:
    - Completed commands (0)
    - No-change (soft) timeout (-1)
    - Hard timeout (-1)

Rationale
Previously, TerminalSession created observations via TerminalObservation.from_text(...) without passing exit_code, leaving the top-level field as None. While metadata.exit_code contained the actual value, consumers relying on the top-level field showed "code unknown". This change propagates the code to TerminalObservation.exit_code to keep both consistent.

Backwards compatibility
- This is additive and aligns the top-level field with existing metadata. No breaking changes expected.

Testing
- Added focused unit tests that pass locally for both tmux and subprocess terminal types (environment permitting). Ran pre-commit hooks on changed files.

Issue
- Fixes #1468

Notes
- No documentation changes required; behavior now matches the tool schema docs where -1 indicates a soft-timeout / still-running state.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ad19ff04b22141aa954feda8177ec1de)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:99d3712-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-99d3712-python \
  ghcr.io/openhands/agent-server:99d3712-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:99d3712-golang-amd64
ghcr.io/openhands/agent-server:99d3712-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:99d3712-golang-arm64
ghcr.io/openhands/agent-server:99d3712-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:99d3712-java-amd64
ghcr.io/openhands/agent-server:99d3712-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:99d3712-java-arm64
ghcr.io/openhands/agent-server:99d3712-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:99d3712-python-amd64
ghcr.io/openhands/agent-server:99d3712-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:99d3712-python-arm64
ghcr.io/openhands/agent-server:99d3712-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:99d3712-golang
ghcr.io/openhands/agent-server:99d3712-java
ghcr.io/openhands/agent-server:99d3712-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `99d3712-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `99d3712-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->