### PR TITLE
feat: add AgentSkills standard fields to Skill model

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -114,6 +114,28 @@ class Skill(BaseModel):
         ),
     )
 
+    @field_validator("allowed_tools", mode="before")
+    @classmethod
+    def _parse_allowed_tools(cls, v: str | list | None) -> list[str] | None:
+        """Parse allowed_tools from space-delimited string or list."""
+        if v is None:
+            return None
+        if isinstance(v, str):
+            return v.split()
+        if isinstance(v, list):
+            return [str(t) for t in v]
+        raise SkillValidationError("allowed-tools must be a string or list")
+
+    @field_validator("metadata", mode="before")
+    @classmethod
+    def _convert_metadata_values(cls, v: dict | None) -> dict[str, str] | None:
+        """Convert metadata values to strings."""
+        if v is None:
+            return None
+        if isinstance(v, dict):
+            return {str(k): str(val) for k, val in v.items()}
+        raise SkillValidationError("metadata must be a dictionary")
+
     PATH_TO_THIRD_PARTY_SKILL_NAME: ClassVar[dict[str, str]] = {
         ".cursorrules": "cursorrules",
         "agents.md": "agents",
@@ -158,73 +180,6 @@ class Skill(BaseModel):
             )
 
         return None
-
-    @classmethod
-    def _parse_agentskills_fields(cls, metadata_dict: dict) -> dict:
-        """Parse AgentSkills standard fields from frontmatter metadata.
-
-        Args:
-            metadata_dict: The frontmatter metadata dictionary.
-
-        Returns:
-            Dictionary with AgentSkills fields (description, license,
-            compatibility, metadata, allowed_tools).
-        """
-        agentskills_fields: dict = {}
-
-        # Parse description (string, max 1024 chars per spec)
-        if "description" in metadata_dict:
-            desc = metadata_dict["description"]
-            if isinstance(desc, str):
-                agentskills_fields["description"] = desc
-            else:
-                raise SkillValidationError("description must be a string")
-
-        # Parse license (string)
-        if "license" in metadata_dict:
-            lic = metadata_dict["license"]
-            if isinstance(lic, str):
-                agentskills_fields["license"] = lic
-            else:
-                raise SkillValidationError("license must be a string")
-
-        # Parse compatibility (string)
-        if "compatibility" in metadata_dict:
-            compat = metadata_dict["compatibility"]
-            if isinstance(compat, str):
-                agentskills_fields["compatibility"] = compat
-            else:
-                raise SkillValidationError("compatibility must be a string")
-
-        # Parse metadata (dict[str, str])
-        if "metadata" in metadata_dict:
-            meta = metadata_dict["metadata"]
-            if isinstance(meta, dict):
-                # Convert all values to strings for consistency
-                agentskills_fields["metadata"] = {
-                    str(k): str(v) for k, v in meta.items()
-                }
-            else:
-                raise SkillValidationError("metadata must be a dictionary")
-
-        # Parse allowed-tools (space-delimited string or list)
-        # AgentSkills spec uses "allowed-tools" with hyphen
-        allowed_tools_key = (
-            "allowed-tools"
-            if "allowed-tools" in metadata_dict
-            else ("allowed_tools" if "allowed_tools" in metadata_dict else None)
-        )
-        if allowed_tools_key:
-            tools = metadata_dict[allowed_tools_key]
-            if isinstance(tools, str):
-                # Parse space-delimited string
-                agentskills_fields["allowed_tools"] = tools.split()
-            elif isinstance(tools, list):
-                agentskills_fields["allowed_tools"] = [str(t) for t in tools]
-            else:
-                raise SkillValidationError("allowed-tools must be a string or list")
-
-        return agentskills_fields
 
     @classmethod
     def load(
@@ -272,8 +227,22 @@ class Skill(BaseModel):
         # Use name from frontmatter if provided, otherwise use derived name
         agent_name = str(metadata_dict.get("name", skill_name))
 
-        # Parse AgentSkills standard fields
-        agentskills_fields = cls._parse_agentskills_fields(metadata_dict)
+        # Extract AgentSkills standard fields (Pydantic validators handle
+        # transformation). Handle "allowed-tools" to "allowed_tools" key mapping.
+        allowed_tools_value = metadata_dict.get(
+            "allowed-tools", metadata_dict.get("allowed_tools")
+        )
+        agentskills_fields = {
+            "description": metadata_dict.get("description"),
+            "license": metadata_dict.get("license"),
+            "compatibility": metadata_dict.get("compatibility"),
+            "metadata": metadata_dict.get("metadata"),
+            "allowed_tools": allowed_tools_value,
+        }
+        # Remove None values to avoid passing unnecessary kwargs
+        agentskills_fields = {
+            k: v for k, v in agentskills_fields.items() if v is not None
+        }
 
         # Get trigger keywords from metadata
         keywords = metadata_dict.get("triggers", [])

--- a/tests/sdk/context/skill/test_agentskills_fields.py
+++ b/tests/sdk/context/skill/test_agentskills_fields.py
@@ -3,6 +3,7 @@
 from pathlib import Path
 
 import pytest
+from pydantic import ValidationError
 
 from openhands.sdk.context.skills import Skill, SkillValidationError
 
@@ -56,18 +57,18 @@ def test_skill_allowed_tools_formats() -> None:
 
 
 def test_skill_invalid_field_types() -> None:
-    """Skill should reject invalid field types."""
-    # Invalid description
-    with pytest.raises(SkillValidationError, match="description must be a string"):
+    """Skill should reject invalid field types via Pydantic validation."""
+    # Invalid description - Pydantic validates string type
+    with pytest.raises(ValidationError, match="description"):
         Skill.load(
             Path("s.md"), file_content="---\nname: s\ndescription:\n  - list\n---\n#"
         )
 
-    # Invalid metadata
+    # Invalid metadata - custom validator raises SkillValidationError
     with pytest.raises(SkillValidationError, match="metadata must be a dictionary"):
         Skill.load(Path("s.md"), file_content="---\nname: s\nmetadata: string\n---\n#")
 
-    # Invalid allowed-tools
+    # Invalid allowed-tools - custom validator raises SkillValidationError
     with pytest.raises(SkillValidationError, match="allowed-tools must be"):
         Skill.load(
             Path("s.md"), file_content="---\nname: s\nallowed-tools: 123\n---\n#"


### PR DESCRIPTION
## Summary

This PR adds support for the [AgentSkills standard](https://agentskills.io/specification) fields to the `Skill` model, enabling cross-platform compatibility for skill definitions.

## Changes

### New Fields Added to `Skill` Model

| Field | Type | Description |
|-------|------|-------------|
| `description` | `str \| None` | Brief description of what the skill does (max 1024 chars per spec) |
| `license` | `str \| None` | License under which the skill is distributed (e.g., 'Apache-2.0', 'MIT') |
| `compatibility` | `str \| None` | Environment requirements or compatibility notes |
| `metadata` | `dict[str, str] \| None` | Arbitrary key-value metadata for extensibility |
| `allowed_tools` | `list[str] \| None` | List of pre-approved tools for the skill |

### Frontmatter Parsing

The `Skill.load()` method now parses these fields from YAML frontmatter:

```yaml
---
name: pdf-processing
description: Extract text and tables from PDF files, fill forms, merge documents.
license: Apache-2.0
compatibility: Requires poppler-utils and ghostscript
metadata:
  author: example-org
  version: "1.0"
allowed-tools: Bash(pdftotext:*) Read Write
---

# PDF Processing Skill

Instructions for processing PDF files.
```

### Optional Dependency

Added `skills-ref` as an optional dependency for future validation and prompt generation utilities:

```bash
pip install openhands-sdk[agentskills]
```

## Backward Compatibility

All new fields are optional with `None` defaults, ensuring existing skills continue to work without modification.

## Testing

Added 14 new tests covering:
- Loading skills with all AgentSkills fields
- Loading skills with individual fields
- Parsing `allowed-tools` as both space-delimited string and YAML list
- Validation errors for invalid field types
- Serialization/deserialization roundtrip
- Backward compatibility with existing skills

## Related Issues

Closes #1474

Part of #1473 (Support AgentSkills standard)

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d0070c5410214a658fb43e81b4398851)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:faf2947-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-faf2947-python \
  ghcr.io/openhands/agent-server:faf2947-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:faf2947-golang-amd64
ghcr.io/openhands/agent-server:faf2947-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:faf2947-golang-arm64
ghcr.io/openhands/agent-server:faf2947-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:faf2947-java-amd64
ghcr.io/openhands/agent-server:faf2947-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:faf2947-java-arm64
ghcr.io/openhands/agent-server:faf2947-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:faf2947-python-amd64
ghcr.io/openhands/agent-server:faf2947-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:faf2947-python-arm64
ghcr.io/openhands/agent-server:faf2947-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:faf2947-golang
ghcr.io/openhands/agent-server:faf2947-java
ghcr.io/openhands/agent-server:faf2947-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `faf2947-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `faf2947-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->