### PR TITLE
Fix prepare-release workflow to use ALLHANDS_BOT_GITHUB_PAT

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v5
               with:
-                  token: ${{ secrets.GITHUB_TOKEN }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -65,7 +65,7 @@ jobs:
 
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
               run: |
                   cat > pr_body.txt << 'EOF'
                   ## Release v${{ inputs.version }}


### PR DESCRIPTION
## Summary

The `prepare-release` workflow was failing at the "Push release branch" step with a 403 permission denied error:

```
remote: Permission to OpenHands/software-agent-sdk.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/OpenHands/software-agent-sdk/': The requested URL returned error: 403
```

See failed run: https://github.com/OpenHands/software-agent-sdk/actions/runs/20440743551

## Root Cause

The workflow was using `secrets.GITHUB_TOKEN` which has limited permissions and cannot push branches to the repository.

## Fix

Changed the workflow to use `secrets.ALLHANDS_BOT_GITHUB_PAT` for:
1. The checkout step (so the token is used for git push operations)
2. The `GH_TOKEN` environment variable (for creating the PR via `gh` CLI)

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b3a965431683489d9d4e2b7e0e267f53)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3dd7150-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3dd7150-python \
  ghcr.io/openhands/agent-server:3dd7150-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3dd7150-golang-amd64
ghcr.io/openhands/agent-server:3dd7150-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3dd7150-golang-arm64
ghcr.io/openhands/agent-server:3dd7150-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3dd7150-java-amd64
ghcr.io/openhands/agent-server:3dd7150-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3dd7150-java-arm64
ghcr.io/openhands/agent-server:3dd7150-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3dd7150-python-amd64
ghcr.io/openhands/agent-server:3dd7150-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3dd7150-python-arm64
ghcr.io/openhands/agent-server:3dd7150-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3dd7150-golang
ghcr.io/openhands/agent-server:3dd7150-java
ghcr.io/openhands/agent-server:3dd7150-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3dd7150-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3dd7150-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->