### PR TITLE
Fix SystemPromptEvent to accept both ToolDefinition and OpenAI format tools

### DIFF
--- a/openhands-sdk/openhands/sdk/event/llm_convertible/system.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/system.py
@@ -1,6 +1,7 @@
 import json
+from typing import Annotated, Any
 
-from pydantic import Field
+from pydantic import BeforeValidator, Field
 from rich.text import Text
 
 from openhands.sdk.event.base import N_CHAR_PREVIEW, LLMConvertibleEvent
@@ -9,13 +10,47 @@ from openhands.sdk.llm import Message, TextContent
 from openhands.sdk.tool import ToolDefinition
 
 
+def _validate_tool_item(item: Any) -> ToolDefinition | dict[str, Any]:
+    """Validate a single tool item, accepting both ToolDefinition and OpenAI format."""
+    if isinstance(item, ToolDefinition):
+        return item
+    if isinstance(item, dict):
+        # Check if it's OpenAI format (has "type": "function")
+        if item.get("type") == "function" and "function" in item:
+            # Keep as dict - we'll handle it in visualize
+            return item
+        elif "kind" in item:
+            # ToolDefinition format - validate it
+            return ToolDefinition.model_validate(item)
+        else:
+            # Unknown format - keep as is
+            return item
+    return item
+
+
+def _validate_tools_list(v: Any) -> list[ToolDefinition | dict[str, Any]]:
+    """Validate the tools list, accepting both ToolDefinition and OpenAI format."""
+    if not isinstance(v, list):
+        return v
+    return [_validate_tool_item(item) for item in v]
+
+
+# Type alias for tools field with custom validation
+# We use list[Any] as the base type to avoid Pydantic trying to validate
+# the union type before our BeforeValidator runs
+ToolsList = Annotated[list[Any], BeforeValidator(_validate_tools_list)]
+
+
 class SystemPromptEvent(LLMConvertibleEvent):
     """System prompt added by the agent."""
 
     source: SourceType = "agent"
     system_prompt: TextContent = Field(..., description="The system prompt text")
-    tools: list[ToolDefinition] = Field(
-        ..., description="List of tools as ToolDefinition objects"
+    tools: ToolsList = Field(
+        ...,
+        description=(
+            "List of tools as ToolDefinition objects or OpenAI function format dicts"
+        ),
     )
 
     @property
@@ -26,22 +61,43 @@ class SystemPromptEvent(LLMConvertibleEvent):
         content.append(self.system_prompt.text)
         content.append(f"\n\nTools Available: {len(self.tools)}")
         for tool in self.tools:
-            # Use ToolDefinition properties directly
-            description = tool.description.split("\n")[0][:100]
-            if len(description) < len(tool.description):
-                description += "..."
+            if isinstance(tool, ToolDefinition):
+                # Use ToolDefinition properties directly
+                description = tool.description.split("\n")[0][:100]
+                if len(description) < len(tool.description):
+                    description += "..."
 
-            content.append(f"\n  - {tool.name}: {description}\n")
+                content.append(f"\n  - {tool.name}: {description}\n")
 
-            # Get parameters from the action type schema
-            try:
-                params_dict = tool.action_type.to_mcp_schema()
-                params_str = json.dumps(params_dict)
-                if len(params_str) > 200:
-                    params_str = params_str[:197] + "..."
-                content.append(f"  Parameters: {params_str}")
-            except Exception:
-                content.append("  Parameters: <unavailable>")
+                # Get parameters from the action type schema
+                try:
+                    params_dict = tool.action_type.to_mcp_schema()
+                    params_str = json.dumps(params_dict)
+                    if len(params_str) > 200:
+                        params_str = params_str[:197] + "..."
+                    content.append(f"  Parameters: {params_str}")
+                except Exception:
+                    content.append("  Parameters: <unavailable>")
+            elif isinstance(tool, dict):
+                # Handle OpenAI function format
+                func = tool.get("function", {})
+                name = func.get("name", "unknown")
+                description = func.get("description", "")
+                description_preview = description.split("\n")[0][:100]
+                if len(description_preview) < len(description):
+                    description_preview += "..."
+
+                content.append(f"\n  - {name}: {description_preview}\n")
+
+                # Get parameters from the function schema
+                params = func.get("parameters", {})
+                if params:
+                    params_str = json.dumps(params)
+                    if len(params_str) > 200:
+                        params_str = params_str[:197] + "..."
+                    content.append(f"  Parameters: {params_str}")
+                else:
+                    content.append("  Parameters: <unavailable>")
         return content
 
     def to_llm_message(self) -> Message:


### PR DESCRIPTION
## Summary

This PR fixes the `KeyError: 'kind'` error that occurs when parsing `SystemPromptEvent` from the server (OpenHands Cloud).

## Problem

The server (OpenHands Cloud) returns tools in OpenAI function format:
```json
{"type": "function", "function": {"name": "...", "description": "...", "parameters": {...}}}
```

But the SDK was updated (in commit `7b782a03`) to expect `ToolDefinition` format:
```json
{"kind": "...", "name": "...", "description": "...", ...}
```

This caused a `KeyError: 'kind'` when parsing events from the server, which led to the conversation creation failing and triggering cleanup. The cleanup then failed with `405 Method Not Allowed`, causing the script to exit with code 1.

## Solution

- Added a `BeforeValidator` to the `tools` field that accepts both formats
- Updated the `visualize` property to handle both formats
- Added tests for OpenAI format tools

## Testing

- All existing tests pass
- Added 5 new tests for OpenAI format tools
- Verified fix with actual script `06_convo_with_cloud_workspace.py` - now completes successfully with exit code 0

## Related

Fixes https://github.com/OpenHands/software-agent-sdk/actions/runs/20441641036/job/58735767242

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b7b9877d5ab5479b991b05e6e1ff5c0e)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2aff87a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2aff87a-python \
  ghcr.io/openhands/agent-server:2aff87a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2aff87a-golang-amd64
ghcr.io/openhands/agent-server:2aff87a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2aff87a-golang-arm64
ghcr.io/openhands/agent-server:2aff87a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2aff87a-java-amd64
ghcr.io/openhands/agent-server:2aff87a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2aff87a-java-arm64
ghcr.io/openhands/agent-server:2aff87a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2aff87a-python-amd64
ghcr.io/openhands/agent-server:2aff87a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2aff87a-python-arm64
ghcr.io/openhands/agent-server:2aff87a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2aff87a-golang
ghcr.io/openhands/agent-server:2aff87a-java
ghcr.io/openhands/agent-server:2aff87a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2aff87a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2aff87a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->