### PR TITLE
Fix flaky tools-tests by using larger runner for browser e2e tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -79,7 +79,8 @@ jobs:
                   if-no-files-found: warn
 
     tools-tests:
-        runs-on: blacksmith-2vcpu-ubuntu-2404
+        # Use larger runner for browser e2e tests which are resource-intensive
+        runs-on: blacksmith-4vcpu-ubuntu-2404
         steps:
             - name: Checkout
               uses: actions/checkout@v5


### PR DESCRIPTION
## Problem

The `tools-tests` job was intermittently failing with the self-hosted runner losing communication due to CPU/Memory starvation. Analysis of multiple failing runs showed the GitHub Actions annotation:

> "The self-hosted runner: blacksmith-... lost communication with the server. Anything that terminates the runner process, starves it for CPU/Memory, or blocks its network access can cause this error."

**Evidence from failing runs:**
- Run 20436102309 (job 58718083011): Runner died at ~14 min mark
- Run 20436089167 (job 58739552822): Same CPU/Memory starvation pattern

## Root Cause Analysis

The browser e2e tests in `test_browser_executor_e2e.py` are resource-intensive:
- 15+ tests that each create browser instances (function-scoped fixture)
- Each browser instance consumes significant CPU/memory
- The 2-vCPU runner was insufficient for these workloads under certain conditions

**Key observation:** The tests passed WITHOUT any code changes in some runs (e.g., run 20412170314), confirming this is a resource contention issue rather than a code bug.

## Solution

Increase the runner size to 4-vCPU for `tools-tests` only, providing adequate resources for the browser e2e tests while keeping other test jobs on smaller runners.

## Changes

- Change `tools-tests` runner from `blacksmith-2vcpu-ubuntu-2404` to `blacksmith-4vcpu-ubuntu-2404`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:127a8e3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-127a8e3-python \
  ghcr.io/openhands/agent-server:127a8e3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:127a8e3-golang-amd64
ghcr.io/openhands/agent-server:127a8e3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:127a8e3-golang-arm64
ghcr.io/openhands/agent-server:127a8e3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:127a8e3-java-amd64
ghcr.io/openhands/agent-server:127a8e3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:127a8e3-java-arm64
ghcr.io/openhands/agent-server:127a8e3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:127a8e3-python-amd64
ghcr.io/openhands/agent-server:127a8e3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:127a8e3-python-arm64
ghcr.io/openhands/agent-server:127a8e3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:127a8e3-golang
ghcr.io/openhands/agent-server:127a8e3-java
ghcr.io/openhands/agent-server:127a8e3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `127a8e3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `127a8e3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->