### PR TITLE
Fix SDK_SHA reference in run-eval.yml Comment on PR step

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -227,7 +227,7 @@ jobs:
             - name: Comment on PR
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-                  SDK_SHA: ${{ steps.get-sha.outputs.sdk_sha }}
+                  SDK_SHA: ${{ steps.params.outputs.sdk_sha }}
                   EVAL_LIMIT: ${{ steps.params.outputs.eval_limit }}
                   MODELS: ${{ steps.params.outputs.models }}
                   TRIGGER_DESC: ${{ steps.params.outputs.trigger_desc }}


### PR DESCRIPTION
## Summary

Fixes the failing `run-eval.yml` workflow by correcting a typo in the step output reference.

## Root Cause

In the "Comment on PR" step, the `SDK_SHA` environment variable was referencing a non-existent step `get-sha`:

```yaml
SDK_SHA: ${{ steps.get-sha.outputs.sdk_sha }}  # BUG: 'get-sha' step doesn't exist
```

The correct step id is `params`, which outputs `sdk_sha`.

## Impact

This caused the workflow to fail with:
```
jq: error (at <stdin>:5): Cannot index object with number
```

Because `SDK_SHA` was empty, the GitHub API call to `/commits/{SDK_SHA}/pulls` returned an error object instead of an array, causing the jq parsing to fail.

## Fix

Changed the reference from `steps.get-sha.outputs.sdk_sha` to `steps.params.outputs.sdk_sha`.

## Related

- Failed workflow run: https://github.com/OpenHands/software-agent-sdk/actions/runs/20464297297/job/58804118238

@simonrosenberg can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/9481e44fee63464486a159d23865f8f5)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5049e64-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5049e64-python \
  ghcr.io/openhands/agent-server:5049e64-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5049e64-golang-amd64
ghcr.io/openhands/agent-server:5049e64-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5049e64-golang-arm64
ghcr.io/openhands/agent-server:5049e64-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5049e64-java-amd64
ghcr.io/openhands/agent-server:5049e64-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5049e64-java-arm64
ghcr.io/openhands/agent-server:5049e64-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5049e64-python-amd64
ghcr.io/openhands/agent-server:5049e64-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:5049e64-python-arm64
ghcr.io/openhands/agent-server:5049e64-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:5049e64-golang
ghcr.io/openhands/agent-server:5049e64-java
ghcr.io/openhands/agent-server:5049e64-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5049e64-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5049e64-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->