### PR TITLE
Add optional parallelization parameters to run-eval workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -56,12 +56,12 @@ on:
                 description: Comma-separated instance IDs to evaluate (optional, overrides eval_limit for supported benchmarks)
                 required: false
                 default: ''
-            num_workers:
+            num_infer_workers:
                 description: Number of inference workers (optional, overrides benchmark default)
                 required: false
                 default: ''
                 type: string
-            eval_workers:
+            num_eval_workers:
                 description: Number of evaluation workers (optional, overrides benchmark default)
                 required: false
                 default: ''
@@ -210,8 +210,8 @@ jobs:
                   TRIGGER_REASON: ${{ github.event.inputs.reason }}
                   PR_NUMBER: ${{ steps.params.outputs.pr_number }}
                   INSTANCE_IDS: ${{ github.event.inputs.instance_ids || '' }}
-                  NUM_WORKERS: ${{ github.event.inputs.num_workers || '' }}
-                  EVAL_WORKERS: ${{ github.event.inputs.eval_workers || '' }}
+                  NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers || '' }}
+                  NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers || '' }}
               run: |
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH)"
                   PAYLOAD=$(jq -n \
@@ -224,9 +224,9 @@ jobs:
                     --arg benchmarks "$BENCHMARKS_BRANCH" \
                     --arg benchmark "$BENCHMARK" \
                     --arg instance_ids "$INSTANCE_IDS" \
-                    --arg num_workers "$NUM_WORKERS" \
-                    --arg eval_workers "$EVAL_WORKERS" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_workers: $num_workers, eval_workers: $eval_workers}}')
+                    --arg num_infer_workers "$NUM_INFER_WORKERS" \
+                    --arg num_eval_workers "$NUM_EVAL_WORKERS" \
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

This PR adds optional `num_infer_workers` and `num_eval_workers` parameters to the `run-eval.yml` workflow dispatch inputs, allowing users to override the default benchmark parallelization settings when triggering evaluations.

## Changes

- Added `num_infer_workers` input: Number of inference workers (optional, overrides benchmark default)
- Added `num_eval_workers` input: Number of evaluation workers (optional, overrides benchmark default)
- Updated the workflow dispatch payload to pass these parameters to the evaluation workflow

## Usage

When manually triggering the workflow, users can now optionally specify:
- `num_infer_workers`: Override the default number of inference workers for the selected benchmark
- `num_eval_workers`: Override the default number of evaluation workers for the selected benchmark

If not specified, the benchmark defaults from the evaluation repository's `values.yaml` will be used (e.g., swebench defaults: NUM_WORKERS=30, EVAL_WORKERS=12).

## Related PR

This PR works in conjunction with a corresponding PR in the evaluation repository:
https://github.com/OpenHands/evaluation/pull/91