### PR TITLE
feat: Add recoverable field to AgentErrorEvent

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -387,6 +387,7 @@ class Agent(AgentBase):
                 error=err,
                 tool_name=tool_name,
                 tool_call_id=tool_call.id,
+                recoverable=True,
             )
             on_event(event)
             return
@@ -432,6 +433,7 @@ class Agent(AgentBase):
                 error=err,
                 tool_name=tool_name,
                 tool_call_id=tool_call.id,
+                recoverable=True,
             )
             on_event(event)
             return

--- a/openhands-sdk/openhands/sdk/event/llm_convertible/observation.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/observation.py
@@ -111,6 +111,10 @@ class AgentErrorEvent(ObservationBaseEvent):
 
     source: SourceType = "agent"
     error: str = Field(..., description="The error message from the scaffold")
+    recoverable: bool = Field(
+        default=False,
+        description="Whether the LLM can self-correct from this error",
+    )
 
     @property
     def visualize(self) -> Text:

--- a/tests/sdk/agent/test_nonexistent_tool_handling.py
+++ b/tests/sdk/agent/test_nonexistent_tool_handling.py
@@ -94,6 +94,7 @@ def test_nonexistent_tool_returns_error_and_continues_conversation():
     assert "not found" in error_event.error
     assert error_event.tool_name == "nonexistent_tool"
     assert error_event.tool_call_id == "call_1"
+    assert error_event.recoverable is True
 
     # Verify that the conversation is NOT finished (this is the key fix)
     with conversation.state:


### PR DESCRIPTION
## Summary

This PR adds a `recoverable` boolean field to `AgentErrorEvent` to distinguish between errors that need user attention and errors that the LLM can self-correct.

## Motivation

Currently, all `AgentErrorEvent`s are treated identically by the frontend, resulting in a big red error banner even for recoverable errors. This creates a poor UX when:

1. LLM makes a tool call without `security_risk` field
2. SDK's `agent.py` raises a `ValueError`
3. SDK creates `AgentErrorEvent` with the error message
4. Event is sent via WebSocket to frontend
5. Frontend's `conversation-websocket-context.tsx` receives it
6. `setErrorMessage(event.error)` stores it in error-message-store
7. `chat-interface.tsx` renders `ErrorMessageBanner` (big red banner!)
8. LLM receives error, self-corrects, continues working fine
9. **But user still sees a scary red banner**

The problem is that ALL `AgentErrorEvent`s are treated as critical errors. But validation errors (like missing `security_risk`) are:
- **Recoverable** - the LLM can retry with corrected parameters
- **Internal/technical** - not user-actionable
- **Not actually blocking** the conversation

## Changes

1. **`AgentErrorEvent`** now has a `recoverable: bool` field (default: `False`)
2. **Validation errors** (missing/invalid arguments, non-existent tools) are marked as `recoverable=True`
3. **Tests updated** to verify the recoverable field is set correctly

## Related PR

A companion PR for the OpenHands frontend will use this field to avoid showing the big red error banner for recoverable errors.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f31273d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f31273d-python \
  ghcr.io/openhands/agent-server:f31273d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f31273d-golang-amd64
ghcr.io/openhands/agent-server:f31273d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f31273d-golang-arm64
ghcr.io/openhands/agent-server:f31273d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f31273d-java-amd64
ghcr.io/openhands/agent-server:f31273d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f31273d-java-arm64
ghcr.io/openhands/agent-server:f31273d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f31273d-python-amd64
ghcr.io/openhands/agent-server:f31273d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f31273d-python-arm64
ghcr.io/openhands/agent-server:f31273d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f31273d-golang
ghcr.io/openhands/agent-server:f31273d-java
ghcr.io/openhands/agent-server:f31273d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f31273d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f31273d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->