### PR TITLE
Remove tool preambles from gpt-5-codex

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/prompts/model_specific/openai_gpt/gpt-5-codex.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/model_specific/openai_gpt/gpt-5-codex.j2
@@ -1,3 +1,2 @@
 * Stream your thinking and responses while staying concise; surface key assumptions and environment prerequisites explicitly.
-* ALWAYS send a brief preamble to the user explaining what you're about to do before each tool call, using 8 - 12 words, with a friendly and curious tone.
 * You have access to external resources and should actively use available tools to try accessing them first, rather than claiming you can’t access something without making an attempt.


### PR DESCRIPTION
This PR proposes to remove tool preambles from gpt-5-codex.

OpenAI docs are clear that `-codex` variants should NOT have tool preambles. Presumably they’ve tried to build them in, or otherwise conflict with the behavior of the regular GPT-5 models. (TBH I think actually that this is an old OpenAI specific thing on `/completions` API too, IIRC, tool calls didn’t have `content` for a long time, Anthropic did)

For example, in the [5.1-Codex-Max prompting guide](https://cookbook.openai.com/examples/gpt-5/gpt-5-1-codex-max_prompting_guide):
> You should also remove all prompting for the model to communicate an upfront plan, preambles, or other status updates during the rollout, as this can cause the model to stop abruptly before the rollout is complete.

Another example, in [5.1-codex prompting guide](https://cookbook.openai.com/examples/gpt-5-codex_prompting_guide):
> Remove any prompting for preambles, because the model does not support them. Asking for preambles will lead to the model stopping early before completing the task.

NOTE: for non-codex models, this is the opposite: they need prompting or `verbosity` to speak during the agent’s turn.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:40ed16d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-40ed16d-python \
  ghcr.io/openhands/agent-server:40ed16d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:40ed16d-golang-amd64
ghcr.io/openhands/agent-server:40ed16d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:40ed16d-golang-arm64
ghcr.io/openhands/agent-server:40ed16d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:40ed16d-java-amd64
ghcr.io/openhands/agent-server:40ed16d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:40ed16d-java-arm64
ghcr.io/openhands/agent-server:40ed16d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:40ed16d-python-amd64
ghcr.io/openhands/agent-server:40ed16d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:40ed16d-python-arm64
ghcr.io/openhands/agent-server:40ed16d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:40ed16d-golang
ghcr.io/openhands/agent-server:40ed16d-java
ghcr.io/openhands/agent-server:40ed16d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `40ed16d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `40ed16d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->