### PR TITLE
Add automated version bump PRs for downstream repos

### DIFF
--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -55,9 +55,22 @@ Once the release is published, the **pypi-release.yml** workflow will automatica
 
 You can monitor the progress in the [Actions tab](https://github.com/OpenHands/software-agent-sdk/actions/workflows/pypi-release.yml).
 
-### Step 5: Post-Release Tasks
+### Step 5: Version Bump PRs (Automated)
+
+After successful PyPI publication, the workflow will automatically create PRs to update SDK versions in downstream repositories:
+
+- **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** - Updates `openhands-sdk`, `openhands-tools`, and `openhands-agent-server` versions
+- **[OpenHands-CLI](https://github.com/All-Hands-AI/openhands-cli)** - Updates `openhands-sdk` and `openhands-tools` versions
+
+These PRs will:
+- Be created automatically with branch name `bump-sdk-X.Y.Z`
+- Include links back to the SDK release
+- Need to be reviewed and merged by the respective repository maintainers
+
+### Step 6: Post-Release Tasks
 
 - [ ] Merge the release PR to main
+- [ ] Review and merge the auto-created version bump PRs in OpenHands and OpenHands-CLI
 - [ ] Run evaluation on OpenHands Index (manual step)
 - [ ] Announce the release
 

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -11,9 +11,25 @@ on:
 jobs:
     publish:
         runs-on: blacksmith-4vcpu-ubuntu-2404
+        outputs:
+            version: ${{ steps.extract_version.outputs.version }}
         steps:
             - name: Checkout
               uses: actions/checkout@v5
+
+            - name: Extract version from release tag
+              id: extract_version
+              run: |
+                  # Get version from release tag (e.g., v1.2.3 -> 1.2.3)
+                  if [[ "${{ github.event_name }}" == "release" ]]; then
+                    VERSION="${{ github.event.release.tag_name }}"
+                    VERSION="${VERSION#v}"  # Remove 'v' prefix if present
+                  else
+                    # For manual dispatch, extract from pyproject.toml
+                    VERSION=$(grep -m1 '^version = ' openhands-sdk/pyproject.toml | cut -d'"' -f2)
+                  fi
+                  echo "version=$VERSION" >> $GITHUB_OUTPUT
+                  echo "📦 Version: $VERSION"
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -45,3 +61,148 @@ jobs:
                     done
                   uv publish --token "$UV_PUBLISH_TOKEN"
                   echo "✅ All packages built and published successfully!"
+
+    create-version-bump-prs:
+        needs: publish
+        runs-on: blacksmith-4vcpu-ubuntu-2404
+        if: github.event_name == 'release'
+        env:
+            VERSION: ${{ needs.publish.outputs.version }}
+            GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+        steps:
+            - name: Validate version
+              run: |
+                  if [ -z "$VERSION" ]; then
+                    echo "❌ Version is empty"
+                    exit 1
+                  fi
+                  echo "📦 Creating version bump PRs for version: $VERSION"
+
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: latest
+
+            - name: Install Poetry
+              run: |
+                  pipx install poetry
+
+            - name: Create PR for OpenHands repo
+              run: |
+                  set -euo pipefail
+
+                  REPO="All-Hands-AI/OpenHands"
+                  BRANCH="bump-sdk-$VERSION"
+
+                  echo "🔄 Creating PR for $REPO..."
+
+                  # Clone the repo
+                  git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" openhands-repo
+                  cd openhands-repo
+
+                  # Configure git
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Create branch
+                  git checkout -b "$BRANCH"
+
+                  # Update versions using poetry
+                  poetry add "openhands-sdk==$VERSION" "openhands-tools==$VERSION" "openhands-agent-server==$VERSION" --lock
+
+                  # Check if there are changes
+                  if git diff --quiet; then
+                    echo "⚠️ No changes detected in $REPO - versions may already be up to date"
+                    exit 0
+                  fi
+
+                  # Commit and push
+                  git add pyproject.toml poetry.lock
+                  git commit -m "Bump openhands-sdk, openhands-tools, openhands-agent-server to $VERSION" \
+                    -m "Automated version bump after PyPI release." \
+                    -m "Co-authored-by: openhands <openhands@all-hands.dev>"
+                  git push -u origin "$BRANCH"
+
+                  # Create PR
+                  gh pr create \
+                    --repo "$REPO" \
+                    --title "Bump SDK packages to v$VERSION" \
+                    --body "## Automated Version Bump
+
+                  This PR updates the following packages to version **$VERSION**:
+                  - \`openhands-sdk\`
+                  - \`openhands-tools\`
+                  - \`openhands-agent-server\`
+
+                  **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
+
+                  ---
+                  _This PR was automatically created by the pypi-release workflow._" \
+                    --base main \
+                    --head "$BRANCH"
+
+                  echo "✅ PR created for $REPO"
+
+            - name: Create PR for OpenHands-CLI repo
+              run: |
+                  set -euo pipefail
+
+                  REPO="All-Hands-AI/openhands-cli"
+                  BRANCH="bump-sdk-$VERSION"
+
+                  echo "🔄 Creating PR for $REPO..."
+
+                  # Clone the repo
+                  git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" openhands-cli-repo
+                  cd openhands-cli-repo
+
+                  # Configure git
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Create branch
+                  git checkout -b "$BRANCH"
+
+                  # Update versions using uv
+                  uv add "openhands-sdk==$VERSION" "openhands-tools==$VERSION"
+
+                  # Check if there are changes
+                  if git diff --quiet; then
+                    echo "⚠️ No changes detected in $REPO - versions may already be up to date"
+                    exit 0
+                  fi
+
+                  # Commit and push
+                  git add pyproject.toml uv.lock
+                  git commit -m "Bump openhands-sdk, openhands-tools to $VERSION" \
+                    -m "Automated version bump after PyPI release." \
+                    -m "Co-authored-by: openhands <openhands@all-hands.dev>"
+                  git push -u origin "$BRANCH"
+
+                  # Create PR
+                  gh pr create \
+                    --repo "$REPO" \
+                    --title "Bump SDK packages to v$VERSION" \
+                    --body "## Automated Version Bump
+
+                  This PR updates the following packages to version **$VERSION**:
+                  - \`openhands-sdk\`
+                  - \`openhands-tools\`
+
+                  **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
+
+                  ---
+                  _This PR was automatically created by the pypi-release workflow._" \
+                    --base main \
+                    --head "$BRANCH"
+
+                  echo "✅ PR created for $REPO"
+
+            - name: Summary
+              run: |
+                  echo "## ✅ Version Bump PRs Created" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "PRs have been created to bump SDK packages to version **$VERSION**:" >> $GITHUB_STEP_SUMMARY
+                  echo "" >> $GITHUB_STEP_SUMMARY
+                  echo "- [OpenHands](https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  echo "- [OpenHands-CLI](https://github.com/All-Hands-AI/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

This PR adds automation to the `pypi-release.yml` workflow to automatically create pull requests in downstream repositories (OpenHands and OpenHands-CLI) after a successful PyPI release, bumping the SDK package versions.

## Changes

### `pypi-release.yml`

Added a new job `create-version-bump-prs` that runs after the `publish` job succeeds:

- **Triggers**: Only on release events (not manual workflow dispatch)
- **Authentication**: Uses `secrets.ALLHANDS_BOT_GITHUB_PAT` for cross-repo access

**For OpenHands (All-Hands-AI/OpenHands):**
- Uses `poetry add` to update `openhands-sdk`, `openhands-tools`, and `openhands-agent-server`
- Updates both `pyproject.toml` and `poetry.lock`

**For OpenHands-CLI (All-Hands-AI/openhands-cli):**
- Uses `uv add` to update `openhands-sdk` and `openhands-tools`
- Updates both `pyproject.toml` and `uv.lock`

Both PRs will:
- Be created with branch name `bump-sdk-X.Y.Z`
- Include a clear description linking back to the SDK release
- Require review and merge by the respective repository maintainers

### `README-RELEASE.md`

Updated the release documentation to include:
- New Step 5 explaining the automated version bump PRs
- Updated post-release tasks to include reviewing the auto-created PRs

## Testing

- YAML syntax validated
- Workflow logic follows GitHub Actions best practices

## Checklist

- [x] Uses `poetry` for OpenHands repo (Poetry-based project)
- [x] Uses `uv` for OpenHands-CLI repo (uv/hatchling-based project)
- [x] Uses `secrets.ALLHANDS_BOT_GITHUB_PAT` for cross-repo access
- [x] Documentation updated

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e39e4c6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e39e4c6-python \
  ghcr.io/openhands/agent-server:e39e4c6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e39e4c6-golang-amd64
ghcr.io/openhands/agent-server:e39e4c6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e39e4c6-golang-arm64
ghcr.io/openhands/agent-server:e39e4c6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e39e4c6-java-amd64
ghcr.io/openhands/agent-server:e39e4c6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e39e4c6-java-arm64
ghcr.io/openhands/agent-server:e39e4c6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e39e4c6-python-amd64
ghcr.io/openhands/agent-server:e39e4c6-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:e39e4c6-python-arm64
ghcr.io/openhands/agent-server:e39e4c6-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:e39e4c6-golang
ghcr.io/openhands/agent-server:e39e4c6-java
ghcr.io/openhands/agent-server:e39e4c6-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e39e4c6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e39e4c6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->