### PR TITLE
Fix condensation for 0 events by adjusting default parameters

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -36,9 +36,9 @@ class LLMSummarizingCondenser(RollingCondenser):
     """
 
     llm: LLM
-    max_size: int = Field(default=120, gt=0)
+    max_size: int = Field(default=240, gt=0)
     max_tokens: int | None = None
-    keep_first: int = Field(default=4, ge=0)
+    keep_first: int = Field(default=2, ge=0)
 
     @model_validator(mode="after")
     def validate_keep_first_vs_max_size(self):

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -83,6 +83,22 @@ def mock_llm() -> LLM:
     return mock_llm
 
 
+def test_default_values(mock_llm: LLM) -> None:
+    """Test that LLMSummarizingCondenser has correct default values.
+
+    These defaults are tuned to ensure workable manipulation indices for condensation.
+    See https://github.com/OpenHands/software-agent-sdk/issues/1518 for context.
+    """
+    condenser = LLMSummarizingCondenser(llm=mock_llm)
+
+    # Default max_size should be 240 (raised from 120 to allow more room for tool loops)
+    assert condenser.max_size == 240
+
+    # Default keep_first should be 2 (reduced from 4 to leave more room for
+    # condensation)
+    assert condenser.keep_first == 2
+
+
 def test_should_condense(mock_llm: LLM) -> None:
     """Test that LLMSummarizingCondenser correctly determines when to condense."""
     max_size = 100


### PR DESCRIPTION
## Summary

This is a short-term fix for issue #1518 where condensation fails when a tool loop spans almost the entire view, leaving no valid range for forgetting events.

Fixes #1518

## Changes

- Reduce default `keep_first` from 4 to 2
- Raise default `max_size` from 120 to 240

These adjustments make it more likely to get workable manipulation indices for condensation to act on.

## Root Cause

When a tool loop (a sequence of ActionEvent/ObservationEvent pairs starting with thinking blocks) spans almost the entire view, the `manipulation_indices` computed by `View` leave no valid range for forgetting events. With the previous defaults (`keep_first=4`, `max_size=120`), the manipulation indices could be something like `[0, 1, 2, 122]`, leaving no valid range for condensation.

## Testing

- Added a test to verify the new default values
- All existing tests pass (1562 tests)

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/61c70fcbe68f452a8039f7e32b7835eb)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b69a3b6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b69a3b6-python \
  ghcr.io/openhands/agent-server:b69a3b6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b69a3b6-golang-amd64
ghcr.io/openhands/agent-server:b69a3b6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b69a3b6-golang-arm64
ghcr.io/openhands/agent-server:b69a3b6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b69a3b6-java-amd64
ghcr.io/openhands/agent-server:b69a3b6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b69a3b6-java-arm64
ghcr.io/openhands/agent-server:b69a3b6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b69a3b6-python-amd64
ghcr.io/openhands/agent-server:b69a3b6-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b69a3b6-python-arm64
ghcr.io/openhands/agent-server:b69a3b6-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b69a3b6-golang
ghcr.io/openhands/agent-server:b69a3b6-java
ghcr.io/openhands/agent-server:b69a3b6-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b69a3b6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b69a3b6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->