### PR TITLE
Add OpenAgentSafety option to eval CI

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -18,6 +18,7 @@ on:
                     - swebench
                     - swtbench
                     - commit0
+                    - openagentsafety
             sdk_ref:
                 description: SDK commit/ref to evaluate
                 required: true


### PR DESCRIPTION
## Summary\n- add OpenAgentSafety option to run-eval workflow\n- surface the new eval target in CI\n\n## Testing\n- not run (CI only)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:31dd08e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-31dd08e-python \
  ghcr.io/openhands/agent-server:31dd08e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:31dd08e-golang-amd64
ghcr.io/openhands/agent-server:31dd08e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:31dd08e-golang-arm64
ghcr.io/openhands/agent-server:31dd08e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:31dd08e-java-amd64
ghcr.io/openhands/agent-server:31dd08e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:31dd08e-java-arm64
ghcr.io/openhands/agent-server:31dd08e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:31dd08e-python-amd64
ghcr.io/openhands/agent-server:31dd08e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:31dd08e-python-arm64
ghcr.io/openhands/agent-server:31dd08e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:31dd08e-golang
ghcr.io/openhands/agent-server:31dd08e-java
ghcr.io/openhands/agent-server:31dd08e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `31dd08e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `31dd08e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->