### PR TITLE
feat: Add source variant builds to server.yml workflow

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -255,8 +255,8 @@ jobs:
         env:
             IMAGE: ${{ inputs.image != '' && inputs.image || 'ghcr.io/openhands/agent-server' }}
             BASE_IMAGE: ${{ inputs.base_image != '' && inputs.base_image || matrix.base_image }}
-            # For source builds, append '-source' to the variant tag
-            CUSTOM_TAGS: ${{ matrix.target == 'source' && format('{0}-source', matrix.variant) || matrix.variant }}
+            # Use variant as custom tag - build.py handles target suffix (e.g., -source) automatically
+            CUSTOM_TAGS: ${{ matrix.variant }}
             VARIANT: ${{ matrix.variant }}
             ARCH: ${{ matrix.arch }}
             TARGET: ${{ matrix.target }}
@@ -571,8 +571,13 @@ jobs:
                           SHORT_SHA="$VARIANT_SHA"
                       fi
                       
-                      # Use custom_tags as the key (includes -source suffix for source builds)
-                      KEY="$CUSTOM_TAGS"
+                      # Construct key from custom_tags and target
+                      # For source builds, append -source suffix to match tag format
+                      if [[ "$TARGET" == "source" ]]; then
+                          KEY="${CUSTOM_TAGS}-source"
+                      else
+                          KEY="$CUSTOM_TAGS"
+                      fi
                       
                       # Store variant information
                       VARIANT_BASE_IMAGE[$KEY]=$BASE_IMAGE

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -402,24 +402,25 @@ class BuildOptions(BaseModel):
     def all_tags(self) -> list[str]:
         tags: list[str] = []
         arch_suffix = f"-{self.arch}" if self.arch else ""
+        # Target suffix comes before arch suffix (e.g., python-source-amd64)
+        target_suffix = f"-{self.target}" if self.target != "binary" else ""
 
         # Use git commit SHA for commit-based tags
         for t in self.custom_tag_list:
-            tags.append(f"{self.image}:{self.short_sha}-{t}{arch_suffix}")
+            tags.append(
+                f"{self.image}:{self.short_sha}-{t}{target_suffix}{arch_suffix}"
+            )
 
         if self.git_ref in ("main", "refs/heads/main"):
             for t in self.custom_tag_list:
-                tags.append(f"{self.image}:main-{t}{arch_suffix}")
+                tags.append(f"{self.image}:main-{t}{target_suffix}{arch_suffix}")
 
         if self.include_base_tag:
-            tags.append(f"{self.image}:{self.base_tag}{arch_suffix}")
+            tags.append(f"{self.image}:{self.base_tag}{target_suffix}{arch_suffix}")
         if self.include_versioned_tag:
             for versioned_tag in self.versioned_tags:
-                tags.append(f"{self.image}:{versioned_tag}{arch_suffix}")
+                tags.append(f"{self.image}:{versioned_tag}{target_suffix}{arch_suffix}")
 
-        # Append target suffix for clarity (binary is default, no suffix needed)
-        if self.target != "binary":
-            tags = [f"{t}-{self.target}" for t in tags]
         return tags
 
 


### PR DESCRIPTION
## Summary

This PR adds source variant builds alongside the existing binary builds for all server images (python, java, golang). This addresses issue #1531 where custom tools do not work with binary agent server builds.

### Problem

When the agent server is bundled into a binary executable using PyInstaller (the `binary` target in the Dockerfile), custom tools cannot be dynamically imported at runtime because:
1. PyInstaller creates a frozen executable with all Python modules bundled inside
2. The frozen Python interpreter can only import modules that were bundled at build time
3. External Python files copied into the Docker image are not accessible to the binary's internal importer

### Solution

Add `source` variant builds that use the Python source with a full interpreter, which supports custom tools via dynamic module loading (`importlib.import_module()`).

### Changes

- **Build matrix expanded**: 12 jobs total (3 variants × 2 targets × 2 architectures)
  - Binary target: Production mode with PyInstaller binary (smaller, faster startup)
  - Source target: Development mode with Python source (supports custom tools)
- **Updated merge-manifests job**: Now handles both binary and source variants
- **Updated consolidate-build-info**: Tracks target information for PR descriptions
- **Updated PR description template**: Documents binary vs source targets

### Image Tags

After this change, users can choose between:
- `ghcr.io/openhands/agent-server:<sha>-python` - Binary build (production)
- `ghcr.io/openhands/agent-server:<sha>-python-source` - Source build (supports custom tools)

Closes #1531

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - This is a CI workflow change, not application code. The workflow itself will be tested when it runs.
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - This is a CI workflow change
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A - This is a CI workflow change
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - Documentation may be needed to explain when to use binary vs source images
- [ ] Is the github CI passing?
  - Will be verified after PR is created

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/40983c2fe26146c0871cd7a5af6bdfb1)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Target | Architectures | Base Image |
|---|---|---|---|
| golang-source | source | amd64, arm64 | `golang:1.21-bookworm` |
| java | binary | amd64, arm64 | `eclipse-temurin:17-jdk` |
| python-source | source | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` |
| python | binary | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` |
| java-source | source | amd64, arm64 | `eclipse-temurin:17-jdk` |
| golang | binary | amd64, arm64 | `golang:1.21-bookworm` |


> **Note:** `binary` targets are production-optimized PyInstaller builds. `source` targets support custom tools via dynamic module loading.

**Pull (multi-arch manifest)**
```bash
# Binary variant (production, smaller image)
docker pull ghcr.io/openhands/agent-server:2280f38-python

# Source variant (supports custom tools)
docker pull ghcr.io/openhands/agent-server:2280f38-python-source
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2280f38-python \
  ghcr.io/openhands/agent-server:2280f38-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2280f38-golang-amd64
ghcr.io/openhands/agent-server:2280f38-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2280f38-golang-arm64
ghcr.io/openhands/agent-server:2280f38-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2280f38-golang-source-amd64
ghcr.io/openhands/agent-server:2280f38-golang_tag_1.21-bookworm-source-amd64
ghcr.io/openhands/agent-server:2280f38-golang-source-arm64
ghcr.io/openhands/agent-server:2280f38-golang_tag_1.21-bookworm-source-arm64
ghcr.io/openhands/agent-server:2280f38-java-amd64
ghcr.io/openhands/agent-server:2280f38-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2280f38-java-arm64
ghcr.io/openhands/agent-server:2280f38-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2280f38-java-source-amd64
ghcr.io/openhands/agent-server:2280f38-eclipse-temurin_tag_17-jdk-source-amd64
ghcr.io/openhands/agent-server:2280f38-java-source-arm64
ghcr.io/openhands/agent-server:2280f38-eclipse-temurin_tag_17-jdk-source-arm64
ghcr.io/openhands/agent-server:2280f38-python-amd64
ghcr.io/openhands/agent-server:2280f38-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2280f38-python-arm64
ghcr.io/openhands/agent-server:2280f38-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2280f38-python-source-amd64
ghcr.io/openhands/agent-server:2280f38-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-source-amd64
ghcr.io/openhands/agent-server:2280f38-python-source-arm64
ghcr.io/openhands/agent-server:2280f38-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-source-arm64
ghcr.io/openhands/agent-server:2280f38-golang
ghcr.io/openhands/agent-server:2280f38-golang-source
ghcr.io/openhands/agent-server:2280f38-java
ghcr.io/openhands/agent-server:2280f38-java-source
ghcr.io/openhands/agent-server:2280f38-python
ghcr.io/openhands/agent-server:2280f38-python-source
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2280f38-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2280f38-python-amd64`) are also available if needed

**Binary vs Source Targets**
- **Binary**: Production-optimized PyInstaller builds. Smaller image size, faster startup. Does not support custom tools.
- **Source**: Python source with full interpreter. Larger image size, but supports custom tools via dynamic module loading.
<!-- AGENT_SERVER_IMAGES_END -->