### PR TITLE
Raise ValueError when condensing 0 events

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -120,7 +120,17 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         Returns:
             Condensation: The generated condensation object.
+
+        Raises:
+            ValueError: If forgotten_events is empty (0 events to condense).
         """
+        if len(forgotten_events) == 0:
+            raise ValueError(
+                "Cannot condense 0 events. This typically occurs when a tool loop "
+                "spans almost the entire view, leaving no valid range for forgetting "
+                "events. Consider adjusting keep_first or max_size parameters."
+            )
+
         # Convert events to strings for the template
         event_strings = [str(forgotten_event) for forgotten_event in forgotten_events]
 


### PR DESCRIPTION
## Summary

This PR adds a check in `_generate_condensation` to raise a `ValueError` when `forgotten_events` is empty (0 events to condense).

## Problem

When a tool loop spans almost the entire view, the `manipulation_indices` computed by `View` leave no valid range for forgetting events. This results in 0 events being condensed, which then causes the LLM to generate a confusing summary like:

```
"I don't see any events provided to summarize. Please share the list of events that need to be summarized..."
```

## Solution

Instead of silently calling the LLM with an empty event list, we now fail hard and throw an unhandled exception with a clear error message:

```python
ValueError: Cannot condense 0 events. This typically occurs when a tool loop 
spans almost the entire view, leaving no valid range for forgetting events. 
Consider adjusting keep_first or max_size parameters.
```

This makes the issue immediately visible and provides guidance on how to address it.

## Changes

1. **`openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py`**:
   - Added a check at the start of `_generate_condensation` to raise `ValueError` when `forgotten_events` is empty

2. **`tests/sdk/context/condenser/test_llm_summarizing_condenser.py`**:
   - Added `test_generate_condensation_raises_on_zero_events` test to verify the exception is raised

Fixes #1518

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2b591c748bf84facb9d971522af2bde0)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:06121f2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-06121f2-python \
  ghcr.io/openhands/agent-server:06121f2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:06121f2-golang-amd64
ghcr.io/openhands/agent-server:06121f2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:06121f2-golang-arm64
ghcr.io/openhands/agent-server:06121f2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:06121f2-java-amd64
ghcr.io/openhands/agent-server:06121f2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:06121f2-java-arm64
ghcr.io/openhands/agent-server:06121f2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:06121f2-python-amd64
ghcr.io/openhands/agent-server:06121f2-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:06121f2-python-arm64
ghcr.io/openhands/agent-server:06121f2-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:06121f2-golang
ghcr.io/openhands/agent-server:06121f2-java
ghcr.io/openhands/agent-server:06121f2-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `06121f2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `06121f2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->