### PR TITLE
Fix ValueError from tool execution causing conversation to fail

### DIFF
--- a/tests/sdk/agent/test_tool_execution_error_handling.py
+++ b/tests/sdk/agent/test_tool_execution_error_handling.py
@@ -1,0 +1,276 @@
+"""Test agent behavior when tool execution raises ValueError."""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Self
+from unittest.mock import patch
+
+from litellm import ChatCompletionMessageToolCall
+from litellm.types.utils import (
+    Choices,
+    Function,
+    Message as LiteLLMMessage,
+    ModelResponse,
+)
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import ActionEvent, AgentErrorEvent
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
+from openhands.sdk.tool.tool import ToolDefinition
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+
+class RaisingAction(Action):
+    """Action that will cause the executor to raise ValueError."""
+
+    value: str = ""
+
+
+class RaisingObservation(Observation):
+    """Observation for the raising tool."""
+
+    result: str = ""
+
+
+class RaisingExecutor(ToolExecutor[RaisingAction, RaisingObservation]):
+    """Executor that raises ValueError."""
+
+    def __call__(self, action: RaisingAction, conversation=None) -> RaisingObservation:
+        raise ValueError("Cannot use reset=True with is_input=True")
+
+
+class RaisingTool(ToolDefinition[RaisingAction, RaisingObservation]):
+    """Tool that raises ValueError during execution."""
+
+    name = "raising_tool"
+
+    @classmethod
+    def create(cls, conv_state: "ConversationState | None" = None) -> Sequence[Self]:
+        return [
+            cls(
+                description="A tool that raises ValueError",
+                action_type=RaisingAction,
+                observation_type=RaisingObservation,
+                executor=RaisingExecutor(),
+            )
+        ]
+
+
+# Register the tool so it can be resolved by name
+register_tool("RaisingTool", RaisingTool)
+
+
+def test_tool_execution_valueerror_returns_error_event():
+    """Test that ValueError from tool execution returns AgentErrorEvent."""
+
+    llm = LLM(
+        usage_id="test-llm",
+        model="test-model",
+        api_key=SecretStr("test-key"),
+        base_url="http://test",
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="RaisingTool")])
+
+    def mock_llm_response(messages, **kwargs):
+        return ModelResponse(
+            id="mock-response-1",
+            choices=[
+                Choices(
+                    index=0,
+                    message=LiteLLMMessage(
+                        role="assistant",
+                        content="I'll use the raising tool.",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="raising_tool",
+                                    arguments='{"value": "test"}',
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            created=0,
+            model="test-model",
+            object="chat.completion",
+        )
+
+    collected_events = []
+
+    def event_callback(event):
+        collected_events.append(event)
+
+    conversation = Conversation(agent=agent, callbacks=[event_callback])
+
+    with patch(
+        "openhands.sdk.llm.llm.litellm_completion", side_effect=mock_llm_response
+    ):
+        conversation.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="Please use the raising tool.")],
+            )
+        )
+
+        # Run one step to trigger the tool call
+        agent.step(conversation, on_event=event_callback)
+
+    # Verify that an AgentErrorEvent was generated
+    error_events = [e for e in collected_events if isinstance(e, AgentErrorEvent)]
+    assert len(error_events) == 1, (
+        f"Expected 1 AgentErrorEvent, got {len(error_events)}"
+    )
+
+    error_event = error_events[0]
+    assert "raising_tool" in error_event.error
+    assert "Cannot use reset=True with is_input=True" in error_event.error
+    assert error_event.tool_name == "raising_tool"
+    assert error_event.tool_call_id == "call_1"
+
+    # Verify that the conversation is NOT finished
+    with conversation.state:
+        assert (
+            conversation.state.execution_status != ConversationExecutionStatus.FINISHED
+        ), "Agent should not be finished after tool execution error"
+
+
+def test_conversation_continues_after_tool_execution_error():
+    """Test that conversation can continue after a tool execution error."""
+
+    llm = LLM(
+        usage_id="test-llm",
+        model="test-model",
+        api_key=SecretStr("test-key"),
+        base_url="http://test",
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="RaisingTool")])
+
+    call_count = 0
+
+    def mock_llm_response(messages, **kwargs):
+        nonlocal call_count
+        call_count += 1
+
+        if call_count == 1:
+            # First call: try the raising tool
+            return ModelResponse(
+                id="mock-response-1",
+                choices=[
+                    Choices(
+                        index=0,
+                        message=LiteLLMMessage(
+                            role="assistant",
+                            content="I'll try the raising tool first.",
+                            tool_calls=[
+                                ChatCompletionMessageToolCall(
+                                    id="call_1",
+                                    type="function",
+                                    function=Function(
+                                        name="raising_tool",
+                                        arguments='{"value": "test"}',
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason="tool_calls",
+                    )
+                ],
+                created=0,
+                model="test-model",
+                object="chat.completion",
+            )
+        else:
+            # Second call: respond with finish tool
+            return ModelResponse(
+                id="mock-response-2",
+                choices=[
+                    Choices(
+                        index=0,
+                        message=LiteLLMMessage(
+                            role="assistant",
+                            content=None,
+                            tool_calls=[
+                                ChatCompletionMessageToolCall(
+                                    id="finish-call-1",
+                                    type="function",
+                                    function=Function(
+                                        name="finish",
+                                        arguments=(
+                                            '{"message": "I see there '
+                                            'was an error. Task completed."}'
+                                        ),
+                                    ),
+                                )
+                            ],
+                        ),
+                        finish_reason="tool_calls",
+                    )
+                ],
+                created=0,
+                model="test-model",
+                object="chat.completion",
+            )
+
+    collected_events = []
+
+    def event_callback(event):
+        collected_events.append(event)
+
+    conversation = Conversation(agent=agent, callbacks=[event_callback])
+
+    with patch(
+        "openhands.sdk.llm.llm.litellm_completion", side_effect=mock_llm_response
+    ):
+        conversation.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="Please help me.")],
+            )
+        )
+
+        # Run first step - should generate error
+        agent.step(conversation, on_event=event_callback)
+
+        # Verify we got an error event
+        error_events = [e for e in collected_events if isinstance(e, AgentErrorEvent)]
+        assert len(error_events) == 1
+
+        # Verify conversation is not finished
+        with conversation.state:
+            assert (
+                conversation.state.execution_status
+                != ConversationExecutionStatus.FINISHED
+            )
+
+        # Run second step - should call finish tool
+        agent.step(conversation, on_event=event_callback)
+
+        # Verify we got an action event for the finish tool
+        action_events = [
+            e
+            for e in collected_events
+            if isinstance(e, ActionEvent)
+            and e.source == "agent"
+            and e.tool_name == "finish"
+        ]
+        assert len(action_events) == 1
+
+        # Now the conversation should be finished
+        with conversation.state:
+            assert (
+                conversation.state.execution_status
+                == ConversationExecutionStatus.FINISHED
+            )
+
+    # Verify we made two LLM calls
+    assert call_count == 2


### PR DESCRIPTION
## Summary

This PR fixes issue #1549 where a `ValueError` from tool execution (e.g., terminal tool with `reset=True` and `is_input=True`) was causing the entire conversation to fail with `ConversationRunError` instead of being returned to the agent as feedback.

### Problem
When the terminal tool executor raises a `ValueError` for invalid parameter combinations like `reset=True` with `is_input=True`, the error was bubbling up through the call stack and causing the conversation to fail completely.

### Solution
The fix catches `ValueError` during tool execution in `_execute_action_event` and converts it to an `AgentErrorEvent`, allowing the agent to:
1. Receive feedback about the error
2. Continue the conversation
3. Potentially fix the argument and retry

### Changes
- Modified `openhands-sdk/openhands/sdk/agent/agent.py`: Added try/except block in `_execute_action_event` to catch `ValueError` from tool execution and convert it to `AgentErrorEvent`
- Added `tests/sdk/agent/test_tool_execution_error_handling.py`: New test file with two tests:
  - `test_tool_execution_valueerror_returns_error_event`: Verifies that `ValueError` from tool execution returns `AgentErrorEvent`
  - `test_conversation_continues_after_tool_execution_error`: Verifies that the conversation can continue after a tool execution error

Fixes #1549

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9e8b736598b349aa8b79090a71e6debb)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f5d7346-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f5d7346-python \
  ghcr.io/openhands/agent-server:f5d7346-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f5d7346-golang-amd64
ghcr.io/openhands/agent-server:f5d7346-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f5d7346-golang-arm64
ghcr.io/openhands/agent-server:f5d7346-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f5d7346-java-amd64
ghcr.io/openhands/agent-server:f5d7346-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f5d7346-java-arm64
ghcr.io/openhands/agent-server:f5d7346-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f5d7346-python-amd64
ghcr.io/openhands/agent-server:f5d7346-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f5d7346-python-arm64
ghcr.io/openhands/agent-server:f5d7346-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f5d7346-golang
ghcr.io/openhands/agent-server:f5d7346-java
ghcr.io/openhands/agent-server:f5d7346-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f5d7346-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f5d7346-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->