### PR TITLE
fix: Wait for PyPI propagation and add Slack notification to release workflow

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -248,3 +248,12 @@ jobs:
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- [OpenHands](https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
                   echo "- [OpenHands-CLI](https://github.com/All-Hands-AI/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+
+            - name: Notify Slack
+              uses: slackapi/slack-github-action@v2.1.1
+              with:
+                  method: chat.postMessage
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: C08E1SYKEM9
+                      text: "🚀 *SDK v${{ env.VERSION }} published to PyPI!*\n\nVersion bump PRs created:\n• <https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-${{ env.VERSION }}|OpenHands>\n• <https://github.com/All-Hands-AI/openhands-cli/pulls?q=is%3Apr+bump-sdk-${{ env.VERSION }}|OpenHands-CLI>\n\n<https://github.com/OpenHands/software-agent-sdk/releases/tag/v${{ env.VERSION }}|View Release>"


### PR DESCRIPTION
## Problem

The `create-version-bump-prs` job in the pypi-release workflow fails because it tries to run `poetry add` / `uv add` immediately after the `publish` job completes, but the packages are not yet available on PyPI's index due to propagation delays.

**Failed workflow run:** https://github.com/OpenHands/software-agent-sdk/actions/runs/20602528880/job/59171188697#step:6:68

## Solution

### 1. Wait for PyPI Propagation

Add a new step "Wait for packages to be available on PyPI" that polls PyPI's JSON API to verify each package version is available before proceeding with the version bump PR creation.

The verification step:
- Checks all 4 packages (`openhands-sdk`, `openhands-tools`, `openhands-workspace`, `openhands-agent-server`)
- Uses PyPI's JSON API endpoint (`https://pypi.org/pypi/{package}/{version}/json`)
- Polls with a maximum of 60 attempts (20 minutes total) with 20-second intervals
- Fails with a clear error message if packages don't become available within the timeout

### 2. Slack Notification

Add a Slack notification step that sends a message to channel `C08E1SYKEM9` after successful publish and PR creation.

- Uses `slackapi/slack-github-action@v2.1.1` with `chat.postMessage` method
- Message includes version published, links to version bump PRs, and release page link
- **Requires**: `SLACK_BOT_TOKEN` secret with `chat:write` scope

## Changes

- Added "Wait for packages to be available on PyPI" step before "Install uv" in the `create-version-bump-prs` job
- Added "Notify Slack" step at the end of the `create-version-bump-prs` job
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:78212a3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-78212a3-python \
  ghcr.io/openhands/agent-server:78212a3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:78212a3-golang-amd64
ghcr.io/openhands/agent-server:78212a3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:78212a3-golang-arm64
ghcr.io/openhands/agent-server:78212a3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:78212a3-java-amd64
ghcr.io/openhands/agent-server:78212a3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:78212a3-java-arm64
ghcr.io/openhands/agent-server:78212a3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:78212a3-python-amd64
ghcr.io/openhands/agent-server:78212a3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:78212a3-python-arm64
ghcr.io/openhands/agent-server:78212a3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:78212a3-golang
ghcr.io/openhands/agent-server:78212a3-java
ghcr.io/openhands/agent-server:78212a3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `78212a3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `78212a3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->