### PR TITLE
Update OpenHands version bump workflow to include all required steps

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -137,7 +137,8 @@ jobs:
                     sed -i "s|AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:[^']*'|AGENT_SERVER_IMAGE = 'ghcr.io/openhands/agent-server:${SDK_COMMIT_HASH}-python'|" "$SANDBOX_SPEC_FILE"
                     echo "✅ Updated AGENT_SERVER_IMAGE to: ghcr.io/openhands/agent-server:${SDK_COMMIT_HASH}-python"
                   else
-                    echo "⚠️ sandbox_spec_service.py not found at expected path"
+                    echo "❌ sandbox_spec_service.py not found at expected path"
+                    exit 1
                   fi
 
                   # Check if there are changes
@@ -147,7 +148,7 @@ jobs:
                   fi
 
                   # Commit and push
-                  git add pyproject.toml poetry.lock enterprise/poetry.lock "$SANDBOX_SPEC_FILE"
+                  git add .
                   git commit -m "Bump openhands-sdk, openhands-tools, openhands-agent-server to $VERSION" \
                     -m "Automated version bump after PyPI release." \
                     -m "" \


### PR DESCRIPTION
## Summary

Updates the `pypi-release.yml` workflow to perform all required steps when creating a version bump PR for the OpenHands repository after a release:

As per the comment: https://github.com/OpenHands/OpenHands/pull/12218#issuecomment-3700107044

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a0ed2f8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a0ed2f8-python \
  ghcr.io/openhands/agent-server:a0ed2f8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a0ed2f8-golang-amd64
ghcr.io/openhands/agent-server:a0ed2f8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a0ed2f8-golang-arm64
ghcr.io/openhands/agent-server:a0ed2f8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a0ed2f8-java-amd64
ghcr.io/openhands/agent-server:a0ed2f8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a0ed2f8-java-arm64
ghcr.io/openhands/agent-server:a0ed2f8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a0ed2f8-python-amd64
ghcr.io/openhands/agent-server:a0ed2f8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a0ed2f8-python-arm64
ghcr.io/openhands/agent-server:a0ed2f8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a0ed2f8-golang
ghcr.io/openhands/agent-server:a0ed2f8-java
ghcr.io/openhands/agent-server:a0ed2f8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a0ed2f8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a0ed2f8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->