### PR TITLE
build(deps): Bump libtmux to >=0.53.0 for v0.51.0 hard deprecations

### DIFF
--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
     "bashlex>=0.18",
     "binaryornot>=0.4.4",
     "cachetools",
-    "libtmux>=0.46.2",
+    "libtmux>=0.53.0",
     "pydantic>=2.11.7",
     "browser-use>=0.8.0",
     "func-timeout>=4.3.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1549,11 +1549,11 @@ wheels = [
 
 [[package]]
 name = "libtmux"
-version = "0.46.2"
+version = "0.53.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/9c/aa/7e1dcaa097156d6f3a7d8669be4389dced997feeb81744e3ff4681d65ee8/libtmux-0.46.2.tar.gz", hash = "sha256:9a398fec5d714129c8344555d466e1a903dfc0f741ba07aabe75a8ceb25c5dda", size = 346887, upload-time = "2025-05-26T19:40:04.096Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/28/e2b252817cb181aec2f42fe2d1d7fac5ec9c4d15bfb2b8ea4bd1179e4244/libtmux-0.53.0.tar.gz", hash = "sha256:1d19af4cea0c19543954d7e7317c7025c0739b029cccbe3b843212fae238f1bd", size = 405001, upload-time = "2025-12-14T11:59:11.337Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d6/2f/9d207039fcfa00d3b30e4d765f062fbcc42c873c7518a8cfebb3eafd00e0/libtmux-0.46.2-py3-none-any.whl", hash = "sha256:6c32dbf22bde8e5e33b2714a4295f6e838dc640f337cd4c085a044f6828c7793", size = 60873, upload-time = "2025-05-26T19:40:02.284Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/d0/2e8bc5caa639ebb9f8801ba0be7070a28d48d8ed60e2a428d40f71fb88b8/libtmux-0.53.0-py3-none-any.whl", hash = "sha256:024b7ae6a12aae55358e8feb914c8632b3ab9bd61c0987c53559643c6a58ee4f", size = 77582, upload-time = "2025-12-14T11:59:09.739Z" },
 ]
 
 [[package]]
@@ -2206,7 +2206,7 @@ requires-dist = [
     { name = "browser-use", specifier = ">=0.8.0" },
     { name = "cachetools" },
     { name = "func-timeout", specifier = ">=4.3.5" },
-    { name = "libtmux", specifier = ">=0.46.2" },
+    { name = "libtmux", specifier = ">=0.53.0" },
     { name = "openhands-sdk", editable = "openhands-sdk" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "tom-swe", specifier = ">=1.0.3" },


### PR DESCRIPTION
Coast is clear on this (none of the API changes hit here), but this ensures any new libtmux code doesn't write against old APIs.

## Summary

This PR raises the libtmux dependency floor to `>=0.53.0`, addressing [hard API deprecations introduced in v0.51.0](https://libtmux.git-pull.com/history.html#libtmux-0-51-0-2025-12-06). **No code changes required** - the OpenHands SDK already uses the modern libtmux API.

### Breaking Changes in libtmux (v0.46.2 → v0.53.0)

| Version | Change |
|---------|--------|
| **v0.53.0** | `Session.attach()` no longer calls `refresh()` after returning |
| **v0.52.0** | `Pane.capture_pane()` gains 5 new flag parameters |
| **v0.51.0** | Legacy APIs now raise `DeprecatedError` instead of `DeprecationWarning` |
| **v0.50.0** | Unified options/hooks API (`set_option()`, `show_option()`, etc.) |
| **v0.49.0** | Removed support for tmux < 3.2a |
| **v0.47.0** | Dropped Python 3.9 support (minimum is now Python 3.10) |

### v0.51.0 Hard Deprecations (now raise `DeprecatedError`)

| Deprecated | Replacement |
|------------|-------------|
| `kill_server()` | `Server.kill()` |
| `attach_session()`, `kill_session()` | `Session.attach()`, `Session.kill()` |
| `select_window()`, `kill_window()`, `split_window()` | `Window.select()`, `Window.kill()`, `Window.split()` |
| `resize_pane()`, `select_pane()` | `Pane.resize()`, `Pane.select()` |
| `attached_window`, `attached_pane` | `active_window`, `active_pane` |
| `list_*()`, `where()`, `find_where()`, `get_by_id()` | `.sessions`/`.windows`/`.panes` with `.filter()`/`.get()` |
| Dict-style access (`obj["key"]`) | Attribute access (`obj.key`) |

### Compatibility Verified

The codebase already uses modern APIs in `tmux_terminal.py`:
- `session.active_window`, `window.active_pane`
- `session.kill()`, `window.kill()`
- `session.set_option()`

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - No functionality changes; existing tmux terminal tests cover the usage
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - dependency version bump only
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A - dependency version bump only
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

## See also

- https://github.com/OpenHands/OpenHands/pull/11937