### PR TITLE
feat: add DeepSeek v3.2 model support

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -1,6 +1,5 @@
 VERIFIED_OPENAI_MODELS = [
     "gpt-5.2",
-    "gpt-5.2-codex",
     "gpt-5.1",
     "gpt-5.1-codex-max",
     "gpt-5.1-codex",


### PR DESCRIPTION
## Summary

Adds support for DeepSeek v3.2 model as requested in #1298.

## Changes

- Added `VERIFIED_DEEPSEEK_MODELS` list with:
  - `deepseek-chat`
  - `deepseek-chat-v3.2`
  - `deepseek-reasoner`
- Added `deepseek-chat-v3.2` to `VERIFIED_OPENHANDS_MODELS`
- Fixed typo: `deekseek-chat` → `deepseek-chat`
- Added `deepseek` to `VERIFIED_MODELS` dict

## References

- Issue: #1298
- DeepSeek v3.2 Release: https://api-docs.deepseek.com/news/news251201

Closes #1298