### PR TITLE
Use default agent preset for integration tests

### DIFF
--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -25,6 +25,7 @@ from openhands.sdk.event.llm_convertible import (
     MessageEvent,
 )
 from openhands.sdk.tool import Tool
+from openhands.tools.preset.default import get_default_condenser, get_default_tools
 from tests.integration.early_stopper import EarlyStopperBase, EarlyStopResult
 
 
@@ -195,19 +196,39 @@ class BaseIntegrationTest(ABC):
             self.teardown()
 
     @property
-    @abstractmethod
+    def enable_browser(self) -> bool:
+        """Whether to enable browser tools. Override to enable browser.
+
+        Returns:
+            True to enable browser tools, False otherwise (default)
+        """
+        return False
+
+    @property
     def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        pass
+        """List of tools available to the agent.
+
+        By default, uses the default preset tools from openhands.tools.preset.default.
+        Override this property to provide custom tools.
+
+        Returns:
+            List of Tool instances
+        """
+        return get_default_tools(enable_browser=self.enable_browser)
 
     @property
     def condenser(self) -> CondenserBase | None:
-        """Optional condenser for the agent. Override to provide a custom condenser.
+        """Optional condenser for the agent.
+
+        By default, uses the default condenser from openhands.tools.preset.default.
+        Override to provide a custom condenser or return None to disable.
 
         Returns:
-            CondenserBase instance or None (default)
+            CondenserBase instance (default condenser) or None
         """
-        return None
+        return get_default_condenser(
+            llm=self.llm.model_copy(update={"usage_id": "condenser"})
+        )
 
     @property
     def max_iteration_per_run(self) -> int:

--- a/tests/integration/tests/b05_do_not_create_redundant_files.py
+++ b/tests/integration/tests/b05_do_not_create_redundant_files.py
@@ -7,9 +7,6 @@ import subprocess
 from textwrap import dedent
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, SkipTest, TestResult
 from tests.integration.behavior_utils import (
     get_conversation_summary,
@@ -28,15 +25,12 @@ logger = get_logger(__name__)
 
 class NoRedundantFilesTest(BaseIntegrationTest):
     """Ensure the agent does not create any redundant files (e.g., .md files)
-    that are not asked by users when performing the task."""
+    that are not asked by users when performing the task.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
-
-    @property
-    def tools(self) -> list[Tool]:
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [Tool(name="TerminalTool"), Tool(name="FileEditorTool")]
 
     def setup(self) -> None:  # noqa: D401
         """Set up a realistic codebase by cloning the lerobot repo."""

--- a/tests/integration/tests/t01_fix_simple_typo.py
+++ b/tests/integration/tests/t01_fix_simple_typo.py
@@ -3,9 +3,6 @@
 import os
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -26,23 +23,16 @@ logger = get_logger(__name__)
 
 
 class TypoFixTest(BaseIntegrationTest):
-    """Test that an agent can fix typos in a text file."""
+    """Test that an agent can fix typos in a text file.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.document_path: str = os.path.join(self.workspace, "document.txt")
-
-    @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
 
     def setup(self) -> None:
         """Create a text file with typos for the agent to fix."""

--- a/tests/integration/tests/t02_add_bash_hello.py
+++ b/tests/integration/tests/t02_add_bash_hello.py
@@ -3,9 +3,6 @@
 import os
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -16,23 +13,16 @@ logger = get_logger(__name__)
 
 
 class BashHelloTest(BaseIntegrationTest):
-    """Test that an agent can write a shell script that prints 'hello'."""
+    """Test that an agent can write a shell script that prints 'hello'.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.script_path: str = os.path.join(self.workspace, "shell", "hello.sh")
-
-    @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
 
     def setup(self) -> None:
         """Setup is not needed - agent will create directories as needed."""

--- a/tests/integration/tests/t03_jupyter_write_file.py
+++ b/tests/integration/tests/t03_jupyter_write_file.py
@@ -3,9 +3,6 @@
 import os
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -19,23 +16,16 @@ logger = get_logger(__name__)
 
 
 class JupyterWriteFileTest(BaseIntegrationTest):
-    """Test that an agent can use Jupyter IPython to write a text file."""
+    """Test that an agent can use Jupyter IPython to write a text file.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.file_path: str = os.path.join(self.workspace, "test.txt")
-
-    @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
 
     def setup(self) -> None:
         """Setup is not needed - agent will create directories as needed."""

--- a/tests/integration/tests/t04_git_staging.py
+++ b/tests/integration/tests/t04_git_staging.py
@@ -4,9 +4,6 @@ import os
 import subprocess
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -19,19 +16,12 @@ logger = get_logger(__name__)
 
 
 class GitStagingTest(BaseIntegrationTest):
-    """Test that an agent can write a git commit message and commit changes."""
+    """Test that an agent can write a git commit message and commit changes.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
-
-    @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
 
     def setup(self) -> None:
         """Set up git repository with staged changes."""

--- a/tests/integration/tests/t05_simple_browsing.py
+++ b/tests/integration/tests/t05_simple_browsing.py
@@ -7,9 +7,6 @@ import time
 
 from openhands.sdk import get_logger
 from openhands.sdk.conversation import get_agent_final_response
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -92,7 +89,10 @@ logger = get_logger(__name__)
 
 
 class SimpleBrowsingTest(BaseIntegrationTest):
-    """Test that an agent can browse a local web page and extract information."""
+    """Test that an agent can browse a local web page and extract information.
+
+    Uses the default agent preset with browser enabled.
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
@@ -101,14 +101,9 @@ class SimpleBrowsingTest(BaseIntegrationTest):
         self.server_process: subprocess.Popen[bytes] | None = None
 
     @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
+    def enable_browser(self) -> bool:
+        """Enable browser tools for this browsing test."""
+        return True
 
     def setup(self) -> None:
         """Set up a local web server with the HTML file."""

--- a/tests/integration/tests/t06_github_pr_browsing.py
+++ b/tests/integration/tests/t06_github_pr_browsing.py
@@ -2,9 +2,6 @@
 
 from openhands.sdk import get_logger
 from openhands.sdk.conversation import get_agent_final_response
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -18,19 +15,17 @@ logger = get_logger(__name__)
 
 
 class GitHubPRBrowsingTest(BaseIntegrationTest):
-    """Test that an agent can browse a GitHub PR and extract information."""
+    """Test that an agent can browse a GitHub PR and extract information.
+
+    Uses the default agent preset with browser enabled.
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
     @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
+    def enable_browser(self) -> bool:
+        """Enable browser tools for this browsing test."""
+        return True
 
     def setup(self) -> None:
         """No special setup needed for GitHub PR browsing."""

--- a/tests/integration/tests/t07_interactive_commands.py
+++ b/tests/integration/tests/t07_interactive_commands.py
@@ -4,9 +4,6 @@ import hashlib
 import os
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, TestResult
 
 
@@ -32,23 +29,16 @@ logger = get_logger(__name__)
 
 
 class InteractiveCommandsTest(BaseIntegrationTest):
-    """Test that an agent can execute interactive Python scripts with input."""
+    """Test that an agent can execute interactive Python scripts with input.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.script_path: str = os.path.join(self.workspace, "python_script.py")
-
-    @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
 
     def setup(self) -> None:
         """Set up the interactive Python script."""

--- a/tests/integration/tests/t08_image_file_viewing.py
+++ b/tests/integration/tests/t08_image_file_viewing.py
@@ -5,9 +5,6 @@ import urllib.request
 
 from openhands.sdk import get_logger
 from openhands.sdk.conversation.response_utils import get_agent_final_response
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
 from tests.integration.base import BaseIntegrationTest, SkipTest, TestResult
 
 
@@ -23,7 +20,10 @@ logger = get_logger(__name__)
 
 
 class ImageFileViewingTest(BaseIntegrationTest):
-    """Test that an agent can view and analyze image files."""
+    """Test that an agent can view and analyze image files.
+
+    Uses the default agent preset (TerminalTool, FileEditorTool, TaskTrackerTool).
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
@@ -37,16 +37,6 @@ class ImageFileViewingTest(BaseIntegrationTest):
                 "This test requires a vision-capable LLM model. "
                 "Please use a model that supports image input."
             )
-
-    @property
-    def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        register_tool("FileEditorTool", FileEditorTool)
-        return [
-            Tool(name="TerminalTool"),
-            Tool(name="FileEditorTool"),
-        ]
 
     def setup(self) -> None:
         """Download the OpenHands logo for the agent to analyze."""

--- a/tests/integration/tests/t09_token_condenser.py
+++ b/tests/integration/tests/t09_token_condenser.py
@@ -9,8 +9,8 @@ This integration test verifies that:
 from openhands.sdk import get_logger
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.event.condenser import Condensation
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.terminal import TerminalTool
+from openhands.sdk.tool import Tool
+from openhands.tools.preset.default import get_default_tools
 from tests.integration.base import BaseIntegrationTest, SkipTest, TestResult
 
 
@@ -34,7 +34,11 @@ logger = get_logger(__name__)
 
 
 class TokenCondenserTest(BaseIntegrationTest):
-    """Test that agent with token-based condenser triggers condensation."""
+    """Test that agent with token-based condenser triggers condensation.
+
+    Uses the default tools but with a custom condenser configuration
+    to test token-based condensation behavior.
+    """
 
     INSTRUCTION: str = INSTRUCTION
 
@@ -59,11 +63,8 @@ class TokenCondenserTest(BaseIntegrationTest):
 
     @property
     def tools(self) -> list[Tool]:
-        """List of tools available to the agent."""
-        register_tool("TerminalTool", TerminalTool)
-        return [
-            Tool(name="TerminalTool"),
-        ]
+        """Use default tools without browser for this test."""
+        return get_default_tools(enable_browser=False)
 
     @property
     def condenser(self) -> LLMSummarizingCondenser:

--- a/tests/integration/utils/behavior_helpers.py
+++ b/tests/integration/utils/behavior_helpers.py
@@ -8,9 +8,8 @@ from textwrap import dedent
 from typing import Any
 
 from openhands.sdk import get_logger
-from openhands.sdk.tool import Tool, register_tool
-from openhands.tools.file_editor import FileEditorTool
-from openhands.tools.terminal import TerminalTool
+from openhands.sdk.tool import Tool
+from openhands.tools.preset.default import get_default_tools
 from tests.integration.base import BaseIntegrationTest, SkipTest
 from tests.integration.early_stopper import EarlyStopperBase
 
@@ -84,10 +83,11 @@ def clone_pinned_software_agent_repo(workspace: str) -> Path:
 
 
 def default_behavior_tools() -> list[Tool]:
-    """Register and return the default tools for behavior tests."""
-    register_tool("TerminalTool", TerminalTool)
-    register_tool("FileEditorTool", FileEditorTool)
-    return [Tool(name="TerminalTool"), Tool(name="FileEditorTool")]
+    """Register and return the default tools for behavior tests.
+
+    Uses the default preset tools without browser support.
+    """
+    return get_default_tools(enable_browser=False)
 
 
 ENVIRONMENT_TIPS_BODY = """\


### PR DESCRIPTION
## Summary

Update integration tests to use the default agent preset from `openhands.tools.preset.default` so tests validate the same agent configuration shipped to production (GUI/CLI).

### Changes:
- **BaseIntegrationTest** now uses `get_default_tools()` and `get_default_condenser()` by default, with an `enable_browser` property for tests that need browser support
- **Functional tests (t01-t08)** now inherit default tools from base class, removing redundant tool registration
- **t05 and t06** (browsing tests) enable browser via `enable_browser` property
- **t09** keeps custom condenser for token-based condensation testing (special case)
- **behavior_helpers.py** uses `get_default_tools()` for behavior tests
- **b05** uses default tools from base class

This ensures integration tests validate the exact agent configuration that will be used in production.

Fixes #372

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - The changes update existing integration tests to use the default preset - no new tests needed as the existing tests now validate the production configuration
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - this PR modifies test infrastructure
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - Verified imports work correctly and pre-commit hooks pass
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - this is an internal test infrastructure change
- [ ] Is the github CI passing?
  - Awaiting CI results

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d7068022feab415c937874b16b9ca9e2)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d2506a1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d2506a1-python \
  ghcr.io/openhands/agent-server:d2506a1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d2506a1-golang-amd64
ghcr.io/openhands/agent-server:d2506a1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d2506a1-golang-arm64
ghcr.io/openhands/agent-server:d2506a1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d2506a1-java-amd64
ghcr.io/openhands/agent-server:d2506a1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d2506a1-java-arm64
ghcr.io/openhands/agent-server:d2506a1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d2506a1-python-amd64
ghcr.io/openhands/agent-server:d2506a1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:d2506a1-python-arm64
ghcr.io/openhands/agent-server:d2506a1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:d2506a1-golang
ghcr.io/openhands/agent-server:d2506a1-java
ghcr.io/openhands/agent-server:d2506a1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d2506a1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d2506a1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->