### PR TITLE
Test Health Endpoints Do not merge!

### DIFF
--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 server_details_router = APIRouter(prefix="", tags=["Server Details"])
 _start_time = time.time()
 _last_event_time = time.time()
+_service_suspended = False
 
 
 class ServerInfo(BaseModel):
@@ -26,18 +27,31 @@ def update_last_execution_time():
 
 @server_details_router.get("/alive")
 async def alive():
+    if _service_suspended:
+        raise ValueError("Service suspended!")
     return {"status": "ok"}
 
 
 @server_details_router.get("/health")
 async def health() -> str:
+    if _service_suspended:
+        raise ValueError("Service suspended!")
     return "OK"
 
 
 @server_details_router.get("/server_info")
 async def get_server_info() -> ServerInfo:
+    if _service_suspended:
+        raise ValueError("Service suspended!")
     now = time.time()
     return ServerInfo(
         uptime=int(now - _start_time),
         idle_time=int(now - _last_event_time),
     )
+
+
+@server_details_router.post("/service-suspended")
+async def set_service_suspended(service_suspended: bool) -> bool:
+    global _service_suspended
+    _service_suspended = service_suspended
+    return service_suspended

--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -1,3 +1,4 @@
+import asyncio
 import time
 from importlib.metadata import version
 
@@ -55,3 +56,9 @@ async def set_service_suspended(service_suspended: bool) -> bool:
     global _service_suspended
     _service_suspended = service_suspended
     return service_suspended
+
+
+@server_details_router.get("/long-stand")
+async def long_stand(time: int = 10) -> str:
+    await asyncio.sleep(time)
+    return f"Slept for {time} seconds"


### PR DESCRIPTION
Added method to disable health endpoints for testing in K8

## Summary

[fill in a summary of this PR]

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5c120f7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5c120f7-python \
  ghcr.io/openhands/agent-server:5c120f7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5c120f7-golang-amd64
ghcr.io/openhands/agent-server:5c120f7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5c120f7-golang-arm64
ghcr.io/openhands/agent-server:5c120f7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5c120f7-java-amd64
ghcr.io/openhands/agent-server:5c120f7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5c120f7-java-arm64
ghcr.io/openhands/agent-server:5c120f7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5c120f7-python-amd64
ghcr.io/openhands/agent-server:5c120f7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:5c120f7-python-arm64
ghcr.io/openhands/agent-server:5c120f7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:5c120f7-golang
ghcr.io/openhands/agent-server:5c120f7-java
ghcr.io/openhands/agent-server:5c120f7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5c120f7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5c120f7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->