### PR TITLE
Add test to verify working_dir standardization (closes #211)

### DIFF
--- a/tests/tools/test_working_dir_standardization.py
+++ b/tests/tools/test_working_dir_standardization.py
@@ -1,0 +1,99 @@
+"""Test that tools use standardized working directory.
+
+This test verifies that issue #211 has been resolved:
+"Standardize input argument for openhands tools"
+
+Both TerminalTool (BashTool) and FileEditorTool (StrReplaceEditorTool) should use
+the same source for working directory: conv_state.workspace.working_dir
+"""
+
+import tempfile
+from uuid import uuid4
+
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.llm import LLM
+from openhands.sdk.workspace import LocalWorkspace
+from openhands.tools.file_editor import FileEditorAction, FileEditorTool
+from openhands.tools.terminal import TerminalAction, TerminalTool
+
+
+def _create_test_conv_state(temp_dir: str) -> ConversationState:
+    """Helper to create a test conversation state."""
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
+    agent = Agent(llm=llm, tools=[])
+    return ConversationState.create(
+        id=uuid4(),
+        agent=agent,
+        workspace=LocalWorkspace(working_dir=temp_dir),
+    )
+
+
+def test_terminal_and_file_editor_use_same_working_dir():
+    """Test that TerminalTool and FileEditorTool use the same working directory.
+
+    This is a regression test for issue #211 to ensure that both tools
+    get their working directory from conv_state.workspace.working_dir.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+
+        # Create both tools from the same conv_state
+        terminal_tools = TerminalTool.create(conv_state)
+        file_editor_tools = FileEditorTool.create(conv_state)
+
+        terminal_tool = terminal_tools[0]
+        file_editor_tool = file_editor_tools[0]
+
+        # Verify terminal tool uses the correct working directory
+        pwd_action = TerminalAction(command="pwd")
+        pwd_result = terminal_tool(pwd_action)
+        assert temp_dir in pwd_result.text, (
+            f"TerminalTool should use working_dir from conv_state.workspace. "
+            f"Expected {temp_dir} in output, got: {pwd_result.text}"
+        )
+
+        # Verify file editor tool uses the correct working directory
+        # by checking that the description includes the working directory
+        assert temp_dir in file_editor_tool.description, (
+            f"FileEditorTool should include working_dir in description. "
+            f"Expected {temp_dir} in description."
+        )
+
+        # Verify file editor can create files in the working directory
+        test_file = f"{temp_dir}/test_standardization.txt"
+        create_action = FileEditorAction(
+            command="create",
+            path=test_file,
+            file_text="Test content",
+        )
+        create_result = file_editor_tool(create_action)
+        assert not create_result.is_error, (
+            f"FileEditorTool should be able to create files in working_dir. "
+            f"Error: {create_result.text}"
+        )
+
+
+def test_tools_do_not_require_params_for_working_dir():
+    """Test that tools don't require params={'working_dir': ...} anymore.
+
+    This verifies that the old pattern of passing working_dir via params
+    has been removed and tools now get it from conv_state.workspace.working_dir.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+
+        # Both tools should be creatable without any params for working_dir
+        # The create() method only takes conv_state (and optional tool-specific params)
+        terminal_tools = TerminalTool.create(conv_state)
+        file_editor_tools = FileEditorTool.create(conv_state)
+
+        # Verify tools were created successfully
+        assert len(terminal_tools) == 1
+        assert len(file_editor_tools) == 1
+
+        # Verify tools have executors
+        assert terminal_tools[0].executor is not None
+        assert file_editor_tools[0].executor is not None


### PR DESCRIPTION
## Summary

This PR confirms that issue #211 ("Standardize input argument for openhands tools") has been resolved and adds a regression test to ensure the standardization is maintained.

### Background

Issue #211 requested that `BashTool` (now `TerminalTool`) and `StrReplaceEditorTool` (now `FileEditorTool`) use the same `working_dir` parameter instead of different forms (`working_dir` vs `workspace_root`).

### Resolution

The issue was resolved in commit b3710eb4 ("Remove deprecated params={'working_dir'} and params={'workspace_root'} patterns from tools (#604)"). Both tools now:

1. Get their working directory from `conv_state.workspace.working_dir`
2. No longer require users to pass `params={'working_dir': ...}` or `params={'workspace_root': ...}`

### Changes in this PR

Added `tests/tools/test_working_dir_standardization.py` with two tests:
- `test_terminal_and_file_editor_use_same_working_dir`: Verifies both tools use the same working directory source
- `test_tools_do_not_require_params_for_working_dir`: Verifies tools can be created without params for working_dir

Closes #211

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4567f0b7a5c64175bef8d80ddc986e13)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4451a02-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4451a02-python \
  ghcr.io/openhands/agent-server:4451a02-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4451a02-golang-amd64
ghcr.io/openhands/agent-server:4451a02-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4451a02-golang-arm64
ghcr.io/openhands/agent-server:4451a02-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4451a02-java-amd64
ghcr.io/openhands/agent-server:4451a02-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4451a02-java-arm64
ghcr.io/openhands/agent-server:4451a02-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4451a02-python-amd64
ghcr.io/openhands/agent-server:4451a02-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:4451a02-python-arm64
ghcr.io/openhands/agent-server:4451a02-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:4451a02-golang
ghcr.io/openhands/agent-server:4451a02-java
ghcr.io/openhands/agent-server:4451a02-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4451a02-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4451a02-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->