### PR TITLE
Re-add discriminator field to discriminated union JSON schema

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/models.py
+++ b/openhands-sdk/openhands/sdk/utils/models.py
@@ -222,7 +222,18 @@ class DiscriminatedUnionMixin(OpenHandsModel):
                 for sub in subclasses.values():
                     sub_schema = gen.generate_inner(sub.__pydantic_core_schema__)
                     schemas.append(sub_schema)
-                schema = {"oneOf": schemas}
+
+                # Build discriminator mapping from $ref schemas
+                mapping = {}
+                for option in schemas:
+                    if "$ref" in option:
+                        kind = option["$ref"].split("/")[-1]
+                        mapping[kind] = option["$ref"]
+
+                schema = {
+                    "oneOf": schemas,
+                    "discriminator": {"propertyName": "kind", "mapping": mapping},
+                }
             else:
                 schema = handler(core_schema)
                 schema["properties"]["kind"] = {

--- a/tests/sdk/utils/test_discriminated_union.py
+++ b/tests/sdk/utils/test_discriminated_union.py
@@ -100,43 +100,52 @@ class SomeImpl(SomeBase):
 def test_json_schema_expected() -> None:
     json_schema = Animal.model_json_schema()
 
-    assert json_schema == {
-        "$defs": {
-            "Cat": {
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "kind": {"const": "Cat", "title": "Kind", "type": "string"},
-                },
-                "required": ["name"],
-                "title": "Cat",
-                "type": "object",
-            },
-            "Dog": {
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "barking": {"title": "Barking", "type": "boolean"},
-                    "kind": {"const": "Dog", "title": "Kind", "type": "string"},
-                },
-                "required": ["name", "barking"],
-                "title": "Dog",
-                "type": "object",
-            },
-            "Wolf": {
-                "additionalProperties": False,
-                "properties": {
-                    "name": {"title": "Name", "type": "string"},
-                    "kind": {"const": "Wolf", "title": "Kind", "type": "string"},
-                },
-                "required": ["name"],
-                "title": "Wolf",
-                "type": "object",
-            },
+    # Verify the schema has the expected structure
+    assert "$defs" in json_schema
+    assert "oneOf" in json_schema
+    assert "discriminator" in json_schema
+
+    # Check discriminator structure
+    discriminator = json_schema["discriminator"]
+    assert discriminator["propertyName"] == "kind"
+    assert "mapping" in discriminator
+
+    # Check the oneOf variants
+    assert json_schema["oneOf"] == [
+        {"$ref": "#/$defs/Cat"},
+        {"$ref": "#/$defs/Dog"},
+        {"$ref": "#/$defs/Wolf"},
+    ]
+
+    # Check the $defs structure
+    assert json_schema["$defs"]["Cat"] == {
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "kind": {"const": "Cat", "title": "Kind", "type": "string"},
         },
-        "oneOf": [
-            {"$ref": "#/$defs/Cat"},
-            {"$ref": "#/$defs/Dog"},
-            {"$ref": "#/$defs/Wolf"},
-        ],
+        "required": ["name"],
+        "title": "Cat",
+        "type": "object",
+    }
+    assert json_schema["$defs"]["Dog"] == {
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "barking": {"title": "Barking", "type": "boolean"},
+            "kind": {"const": "Dog", "title": "Kind", "type": "string"},
+        },
+        "required": ["name", "barking"],
+        "title": "Dog",
+        "type": "object",
+    }
+    assert json_schema["$defs"]["Wolf"] == {
+        "additionalProperties": False,
+        "properties": {
+            "name": {"title": "Name", "type": "string"},
+            "kind": {"const": "Wolf", "title": "Kind", "type": "string"},
+        },
+        "required": ["name"],
+        "title": "Wolf",
+        "type": "object",
     }
 
 


### PR DESCRIPTION
## Summary

After PR #1555, the discriminator field was removed from the generated JSON schema for discriminated unions. This caused the OpenAPI documentation tests (`tests/agent_server/test_openapi_discriminator.py::test_action_schema_has_discriminator`) to fail because Swagger UI needs the discriminator field to properly display discriminated unions instead of showing them as "object | object | object...".

This PR re-adds the discriminator field with the proper mapping in the `__get_pydantic_json_schema__` method of `DiscriminatedUnionMixin`. The test expectation was also updated to include the discriminator field.

### Changes:
1. **`openhands-sdk/openhands/sdk/utils/models.py`**: Added code to build a discriminator mapping from the `$ref` schemas and include the discriminator field in the generated JSON schema
2. **`tests/sdk/utils/test_discriminated_union.py`**: Updated the `test_json_schema_expected` test to verify the discriminator field is present

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@tofarr can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:472e283-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-472e283-python \
  ghcr.io/openhands/agent-server:472e283-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:472e283-golang-amd64
ghcr.io/openhands/agent-server:472e283-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:472e283-golang-arm64
ghcr.io/openhands/agent-server:472e283-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:472e283-java-amd64
ghcr.io/openhands/agent-server:472e283-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:472e283-java-arm64
ghcr.io/openhands/agent-server:472e283-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:472e283-python-amd64
ghcr.io/openhands/agent-server:472e283-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:472e283-python-arm64
ghcr.io/openhands/agent-server:472e283-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:472e283-golang
ghcr.io/openhands/agent-server:472e283-java
ghcr.io/openhands/agent-server:472e283-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `472e283-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `472e283-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->