### PR TITLE
feat: Create conversation when provided ID doesn't exist

### DIFF
--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -52,6 +52,7 @@ class TestRemoteConversation:
                 # Return conversation info response with finished status
                 # (needed for run() polling to complete)
                 response = Mock()
+                response.status_code = 200
                 response.raise_for_status.return_value = None
                 conv_info = mock_conv_response.json.return_value.copy()
                 conv_info["execution_status"] = "finished"
@@ -60,6 +61,7 @@ class TestRemoteConversation:
             elif method == "POST" and "/events" in url:
                 # POST to events endpoint (send_message)
                 response = Mock()
+                response.status_code = 200
                 response.raise_for_status.return_value = None
                 response.json.return_value = {}
                 return response
@@ -73,11 +75,13 @@ class TestRemoteConversation:
             elif method == "POST" or method == "PUT":
                 # Default success response for other POST/PUT requests
                 response = Mock()
+                response.status_code = 200
                 response.raise_for_status.return_value = None
                 response.json.return_value = {}
                 return response
             else:
                 response = Mock()
+                response.status_code = 200
                 response.raise_for_status.return_value = None
                 return response
 
@@ -90,6 +94,7 @@ class TestRemoteConversation:
             conversation_id = str(uuid.uuid4())
 
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {
             "id": conversation_id,
@@ -103,6 +108,7 @@ class TestRemoteConversation:
             events = []
 
         mock_response = Mock()
+        mock_response.status_code = 200
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {
             "items": events,
@@ -220,6 +226,91 @@ class TestRemoteConversation:
         assert len(get_events_calls) >= 1, (
             "Should have made at least one GET call to /events/search "
             "to fetch initial events"
+        )
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
+    def test_remote_conversation_initialization_nonexistent_conversation_creates_new(
+        self, mock_ws_client
+    ):
+        """Test RemoteConversation creates conversation when ID doesn't exist."""
+        conversation_id = uuid.uuid4()
+        mock_client_instance = Mock()
+        self.workspace._client = mock_client_instance
+
+        mock_conv_response = self.create_mock_conversation_response(
+            str(conversation_id)
+        )
+        mock_events_response = self.create_mock_events_response()
+
+        def request_side_effect(method, url, **kwargs):
+            # GET for specific conversation returns 404
+            if method == "GET" and url == f"/api/conversations/{conversation_id}":
+                response = Mock()
+                response.status_code = 404
+                response.raise_for_status.side_effect = None
+                return response
+            elif method == "POST" and url == "/api/conversations":
+                return mock_conv_response
+            elif method == "GET" and "/events/search" in url:
+                return mock_events_response
+            elif method == "GET" and url.startswith("/api/conversations/"):
+                response = Mock()
+                response.status_code = 200
+                response.raise_for_status.return_value = None
+                conv_info = mock_conv_response.json.return_value.copy()
+                conv_info["execution_status"] = "finished"
+                response.json.return_value = conv_info
+                return response
+            else:
+                response = Mock()
+                response.status_code = 200
+                response.raise_for_status.return_value = None
+                response.json.return_value = {}
+                return response
+
+        mock_client_instance.request.side_effect = request_side_effect
+
+        mock_ws_instance = Mock()
+        mock_ws_client.return_value = mock_ws_instance
+
+        # Create RemoteConversation with a non-existent ID
+        conversation = RemoteConversation(
+            agent=self.agent,
+            workspace=self.workspace,
+            conversation_id=conversation_id,
+        )
+
+        # Verify conversation ID is set correctly
+        assert conversation.id == conversation_id
+
+        # Verify GET call was made to check if conversation exists
+        get_conversation_calls = [
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "GET"
+            and call[0][1] == f"/api/conversations/{conversation_id}"
+        ]
+        assert len(get_conversation_calls) == 1, (
+            "Should have made exactly one GET call to check if conversation exists"
+        )
+
+        # Verify POST call was made to create the conversation
+        post_create_calls = [
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "POST" and call[0][1] == "/api/conversations"
+        ]
+        assert len(post_create_calls) == 1, (
+            "Should have made exactly one POST call to create the conversation"
+        )
+
+        # Verify the POST payload contains the conversation_id
+        post_call = post_create_calls[0]
+        payload = post_call[1].get("json", {})
+        assert payload.get("conversation_id") == str(conversation_id), (
+            "POST payload should contain the specified conversation_id"
         )
 
     @patch(


### PR DESCRIPTION
## Summary

When a `conversation_id` is passed to `RemoteConversation` but doesn't exist on the server (404 response), this PR changes the behavior to create the conversation with that ID instead of raising an error.

**Before:**
- If `conversation_id is None`: Create a new conversation
- If `conversation_id` is provided: Validate it exists via GET request (raises error if not found)

**After:**
- If `conversation_id is None`: Create a new conversation (same as before)
- If `conversation_id` is provided:
  - First check if it exists via GET request (accepts 404 as a valid response)
  - If it returns 404, create the conversation with the specified ID
  - If it exists, attach to the existing conversation (same as before)

This allows clients to specify their own conversation IDs without first checking if they exist, making the API more flexible and resilient.

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a6c84b7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a6c84b7-python \
  ghcr.io/openhands/agent-server:a6c84b7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a6c84b7-golang-amd64
ghcr.io/openhands/agent-server:a6c84b7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a6c84b7-golang-arm64
ghcr.io/openhands/agent-server:a6c84b7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a6c84b7-java-amd64
ghcr.io/openhands/agent-server:a6c84b7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a6c84b7-java-arm64
ghcr.io/openhands/agent-server:a6c84b7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a6c84b7-python-amd64
ghcr.io/openhands/agent-server:a6c84b7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a6c84b7-python-arm64
ghcr.io/openhands/agent-server:a6c84b7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a6c84b7-golang
ghcr.io/openhands/agent-server:a6c84b7-java
ghcr.io/openhands/agent-server:a6c84b7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a6c84b7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a6c84b7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->