### PR TITLE
Forward output_jsonl_gcs to evaluation job

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -66,6 +66,11 @@ on:
                 required: false
                 default: ''
                 type: string
+            output_jsonl_gcs:
+                description: Optional GCS path to output.jsonl or results tar.gz to skip inference
+                required: false
+                default: ''
+                type: string
 
 
 env:
@@ -212,6 +217,7 @@ jobs:
                   INSTANCE_IDS: ${{ github.event.inputs.instance_ids || '' }}
                   NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers || '' }}
                   NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers || '' }}
+                  OUTPUT_JSONL_GCS: ${{ github.event.inputs.output_jsonl_gcs || '' }}
               run: |
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH)"
                   PAYLOAD=$(jq -n \
@@ -226,7 +232,8 @@ jobs:
                     --arg instance_ids "$INSTANCE_IDS" \
                     --arg num_infer_workers "$NUM_INFER_WORKERS" \
                     --arg num_eval_workers "$NUM_EVAL_WORKERS" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers}}')
+                    --arg output_jsonl_gcs "$OUTPUT_JSONL_GCS" \
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, output_jsonl_gcs: $output_jsonl_gcs}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary
- add output_jsonl_gcs input to run-eval workflow
- forward to evaluation dispatch payload

## Testing
- gh workflow run run-eval.yml --ref issue-236-output-jsonl -f benchmark=gaia -f eval_limit=1 -f sdk_ref=issue-236-output-jsonl -f benchmarks_branch=issue-236-output-jsonl -f eval_branch=issue-236-output-jsonl -f output_jsonl_gcs=gs://openhands-evaluation-results/eval-20622411875-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_25-12-31-16-36.tar.gz -f reason="rerun latest gaia 1-image"
- gh workflow run run-eval.yml --ref issue-236-output-jsonl -f benchmark=commit0 -f eval_limit=1 -f sdk_ref=issue-236-output-jsonl -f benchmarks_branch=issue-236-output-jsonl -f eval_branch=issue-236-output-jsonl -f output_jsonl_gcs=gs://openhands-evaluation-results/eval-20622412428-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_25-12-31-18-13.tar.gz -f reason="rerun latest commit0 1-image"
- gh workflow run run-eval.yml --ref issue-236-output-jsonl -f benchmark=swebench -f eval_limit=1 -f sdk_ref=issue-236-output-jsonl -f benchmarks_branch=issue-236-output-jsonl -f eval_branch=issue-236-output-jsonl -f output_jsonl_gcs=gs://openhands-evaluation-results/eval-20600678832-claude-son_litellm_proxy-claude-sonnet-4-5-20250929_25-12-30-16-22.tar.gz -f reason="eval-only swebench reuse eval-20600678832 (fix)"
- gh workflow run run-eval.yml --ref issue-236-output-jsonl -f benchmark=swebench -f eval_limit=1 -f sdk_ref=issue-236-output-jsonl -f benchmarks_branch=issue-236-output-jsonl -f eval_branch=issue-236-output-jsonl -f reason="infer+eval swebench smoke (pydantic 2.12)"
