### PR TITLE
remove custom_llm_provider from LLM config

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -158,7 +158,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     top_p: float | None = Field(default=1.0, ge=0, le=1)
     top_k: float | None = Field(default=None, ge=0)
 
-    custom_llm_provider: str | None = Field(default=None)
     max_input_tokens: int | None = Field(
         default=None,
         ge=1,

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -23,7 +23,6 @@ def test_llm_config_defaults():
     assert config.temperature == 0.0
     assert config.top_p == 1.0
     assert config.top_k is None
-    assert config.custom_llm_provider is None
     assert config.max_input_tokens == 8192  # Auto-populated from model info
     assert config.max_output_tokens == 4096  # Auto-populated from model info
     assert config.input_cost_per_token is None
@@ -59,7 +58,6 @@ def test_llm_config_custom_values():
         temperature=0.5,
         top_p=0.9,
         top_k=50,
-        custom_llm_provider="custom",
         max_input_tokens=4000,
         max_output_tokens=1000,
         input_cost_per_token=0.001,
@@ -98,7 +96,6 @@ def test_llm_config_custom_values():
     assert config.temperature == 0.5
     assert config.top_p == 0.9
     assert config.top_k == 50
-    assert config.custom_llm_provider == "custom"
     assert config.max_input_tokens == 4000
     assert config.max_output_tokens == 1000
     assert config.input_cost_per_token == 0.001
@@ -331,7 +328,6 @@ def test_llm_config_optional_fields():
         aws_region_name=None,
         timeout=None,
         top_k=None,
-        custom_llm_provider=None,
         max_input_tokens=None,
         max_output_tokens=None,
         input_cost_per_token=None,
@@ -354,7 +350,6 @@ def test_llm_config_optional_fields():
     assert config.aws_region_name is None
     assert config.timeout is None
     assert config.top_k is None
-    assert config.custom_llm_provider is None
     assert (
         config.max_input_tokens == 8192
     )  # Auto-populated from model info even when set to None


### PR DESCRIPTION
HUMAN: We had this attribute in `LLM` class for very long time in V0, but it is:
- 100% unnecessary
- 99.99% probably, unused. (the exception is not in real world, it's in a PR we didn't merge)

This PR proposes to just clean it up. If we ever see a real case when it's necessary, I'd be happy to bring it back. Until then, I realized that it's confusing; developers using the SDK for client applications may assume it's meant for "provider" since it has "provider" in the name, but it's not: the SDK always includes the provider in the `model name`, e.g. `provider/model`.

---

This PR removes the `custom_llm_provider` field from the `LLM` configuration model and updates tests accordingly.

Notes:
- This is intentionally a breaking change (no backwards compatibility) as requested.
- Rationale: LiteLLM’s provider routing can be achieved via OpenAI-compat model naming using the `openai/` prefix + full provider/model name.

Changes:
- Remove `custom_llm_provider` from `openhands.sdk.llm.LLM` model.
- Update `tests/sdk/config/test_llm_config.py` to stop referencing/passing `custom_llm_provider`.

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8ae9e0198eb74916b1ca0fbe53b8ad30)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3955bea-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3955bea-python \
  ghcr.io/openhands/agent-server:3955bea-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3955bea-golang-amd64
ghcr.io/openhands/agent-server:3955bea-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3955bea-golang-arm64
ghcr.io/openhands/agent-server:3955bea-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3955bea-java-amd64
ghcr.io/openhands/agent-server:3955bea-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3955bea-java-arm64
ghcr.io/openhands/agent-server:3955bea-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3955bea-python-amd64
ghcr.io/openhands/agent-server:3955bea-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3955bea-python-arm64
ghcr.io/openhands/agent-server:3955bea-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3955bea-golang
ghcr.io/openhands/agent-server:3955bea-java
ghcr.io/openhands/agent-server:3955bea-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3955bea-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3955bea-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->