### PR TITLE
Add support for custom resource directories in skill loading

### DIFF
--- a/tests/sdk/context/skill/test_resource_directories.py
+++ b/tests/sdk/context/skill/test_resource_directories.py
@@ -20,6 +20,12 @@ def test_skill_resources_model(tmp_path: Path) -> None:
     resources = SkillResources(skill_root="/path", scripts=["run.sh"])
     assert resources.has_resources()
 
+    # With additional resources
+    resources = SkillResources(
+        skill_root="/path", additional={"examples": ["example.md"]}
+    )
+    assert resources.has_resources()
+
     # Directory path getters
     skill_dir = tmp_path / "my-skill"
     skill_dir.mkdir()
@@ -54,6 +60,47 @@ def test_discover_skill_resources(tmp_path: Path) -> None:
     assert resources.skill_root == str(skill_dir.resolve())
 
 
+def test_discover_skill_resources_with_additional_directories(tmp_path: Path) -> None:
+    """discover_skill_resources() should find files in additional directories."""
+    skill_dir = tmp_path / "my-skill"
+    skill_dir.mkdir()
+
+    # Create standard directory
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.sh").write_text("#!/bin/bash")
+
+    # Create additional custom directories
+    examples_dir = skill_dir / "examples"
+    examples_dir.mkdir()
+    (examples_dir / "example.md").write_text("# Example")
+    (examples_dir / "demo.json").write_text("{}")
+
+    templates_dir = skill_dir / "templates"
+    templates_dir.mkdir()
+    (templates_dir / "template.yaml").write_text("key: value")
+
+    # Without additional directories - only standard dirs found
+    resources = discover_skill_resources(skill_dir)
+    assert "run.sh" in resources.scripts
+    assert resources.additional == {}
+
+    # With additional directories
+    resources = discover_skill_resources(
+        skill_dir, additional_directories=["examples", "templates"]
+    )
+    assert "run.sh" in resources.scripts
+    assert "examples" in resources.additional
+    assert "example.md" in resources.additional["examples"]
+    assert "demo.json" in resources.additional["examples"]
+    assert "templates" in resources.additional
+    assert "template.yaml" in resources.additional["templates"]
+
+    # get_additional_dir helper
+    assert resources.get_additional_dir("examples") == examples_dir
+    assert resources.get_additional_dir("nonexistent") is None
+
+
 def test_resource_directories_constant() -> None:
     """RESOURCE_DIRECTORIES should contain standard directory names."""
     assert set(RESOURCE_DIRECTORIES) == {"scripts", "references", "assets"}
@@ -81,3 +128,39 @@ def test_skill_load_with_resources(tmp_path: Path) -> None:
     flat_skill.write_text("# Flat Skill")
     skill = Skill.load(flat_skill, skill_dir)
     assert skill.resources is None
+
+
+def test_skill_load_with_additional_directories(tmp_path: Path) -> None:
+    """Skill.load() should discover additional directories when specified."""
+    skill_dir = tmp_path / "skills"
+    skill_dir.mkdir()
+    my_skill_dir = skill_dir / "my-skill"
+    my_skill_dir.mkdir()
+
+    (my_skill_dir / "SKILL.md").write_text("# My Skill")
+
+    # Create standard and additional directories
+    scripts_dir = my_skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.sh").write_text("#!/bin/bash")
+
+    examples_dir = my_skill_dir / "examples"
+    examples_dir.mkdir()
+    (examples_dir / "example.md").write_text("# Example")
+
+    # Without additional directories
+    skill = Skill.load(my_skill_dir / "SKILL.md", skill_dir)
+    assert skill.resources is not None
+    assert "run.sh" in skill.resources.scripts
+    assert skill.resources.additional == {}
+
+    # With additional directories
+    skill = Skill.load(
+        my_skill_dir / "SKILL.md",
+        skill_dir,
+        additional_resource_directories=["examples"],
+    )
+    assert skill.resources is not None
+    assert "run.sh" in skill.resources.scripts
+    assert "examples" in skill.resources.additional
+    assert "example.md" in skill.resources.additional["examples"]


### PR DESCRIPTION
## Summary

Allow skills to specify additional resource directories beyond the standard `scripts/`, `references/`, and `assets/` directories. This enables compatibility with plugins that use custom directories like `examples/`.

## Motivation

The claude-code plugins use an `examples/` directory in their skills that is not part of the standard AgentSkills specification. Rather than hardcoding `examples/` into the standard directories, this PR adds a flexible mechanism to specify additional directories at load time.

## Changes

- Add `additional` field to `SkillResources` for custom directories (dict mapping directory name to list of files)
- Add `additional_directories` parameter to `discover_skill_resources()`
- Add `additional_resource_directories` parameter to `Skill.load()`
- Add `additional_resource_directories` parameter to `load_skills_from_dir()`
- Add `get_additional_dir()` helper method to `SkillResources`
- Add tests for new functionality

## Usage

```python
from openhands.sdk.context.skills import Skill, load_skills_from_dir

# Load a single skill with additional directories
skill = Skill.load(
    "path/to/SKILL.md",
    additional_resource_directories=["examples", "templates"]
)

# Access additional resources
if skill.resources:
    examples = skill.resources.additional.get("examples", [])
    examples_dir = skill.resources.get_additional_dir("examples")

# Load all skills from a directory with additional directories
repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
    "path/to/skills",
    additional_resource_directories=["examples"]
)
```

## Testing

- Added tests for `SkillResources` with additional directories
- Added tests for `discover_skill_resources()` with additional directories
- Added tests for `Skill.load()` with additional directories
- All existing tests pass

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/718eca80cd05425babec5f04df336781)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8702207-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8702207-python \
  ghcr.io/openhands/agent-server:8702207-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8702207-golang-amd64
ghcr.io/openhands/agent-server:8702207-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8702207-golang-arm64
ghcr.io/openhands/agent-server:8702207-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8702207-java-amd64
ghcr.io/openhands/agent-server:8702207-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8702207-java-arm64
ghcr.io/openhands/agent-server:8702207-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8702207-python-amd64
ghcr.io/openhands/agent-server:8702207-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:8702207-python-arm64
ghcr.io/openhands/agent-server:8702207-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:8702207-golang
ghcr.io/openhands/agent-server:8702207-java
ghcr.io/openhands/agent-server:8702207-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8702207-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8702207-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->