### PR TITLE
Expose runtime_resource_factor in run-eval

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -66,6 +66,11 @@ on:
                 required: false
                 default: ''
                 type: string
+            runtime_resource_factor:
+                description: 'Resource multiplier for remote runtimes (optional: 1,2,4,8)'
+                required: false
+                default: ''
+                type: string
             push_to_index:
                 description: 'Push results to openhands-index-results (default: false)'
                 required: false
@@ -218,6 +223,7 @@ jobs:
                   NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers || '' }}
                   NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers || '' }}
                   PUSH_TO_INDEX: ${{ github.event.inputs.push_to_index || 'false' }}
+                  RUNTIME_RESOURCE_FACTOR: ${{ github.event.inputs.runtime_resource_factor || '' }}
               run: |
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH)"
                   PAYLOAD=$(jq -n \
@@ -233,7 +239,8 @@ jobs:
                     --arg num_infer_workers "$NUM_INFER_WORKERS" \
                     --arg num_eval_workers "$NUM_EVAL_WORKERS" \
                     --arg push_to_index "$PUSH_TO_INDEX" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index}}')
+                    --arg runtime_resource_factor "$RUNTIME_RESOURCE_FACTOR" \
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, runtime_resource_factor: $runtime_resource_factor}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary
- add runtime_resource_factor input to run-eval workflow and pass it through to the evaluation dispatch payload so benchmarks can request higher runtime resources

## Testing
- ran run-eval.yml (sdk branch add-push-to-index-flag) with runtime_resource_factor=2, eval_branch=openhands/push-results-to-index, benchmarks_branch=feature/swebench-report-model, eval_limit=1; evaluation workflow completed and downstream job created runtime with resource_factor=2 (job eval-eval-20741406980-claude-son)
