### PR TITLE
Add dynamic run name title to Run Eval workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -1,5 +1,6 @@
 ---
 name: Run Eval
+run-name: Run Eval (${{ inputs.benchmark || 'swebench' }}) ${{ inputs.reason || github.event.label.name || 'release' }}
 
 on:
     pull_request_target:


### PR DESCRIPTION
The workflow run title will now show:
- Run Eval (benchmark) reason for manual triggers
- Run Eval (swebench) run-eval-X for PR labels
- Run Eval (swebench) release for releases

## Summary

Benchmark and reason field are now added to the title.
See [Run Eval (commit0) testing new title](https://github.com/OpenHands/software-agent-sdk/actions/runs/20751730762)

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:942ab92-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-942ab92-python \
  ghcr.io/openhands/agent-server:942ab92-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:942ab92-golang-amd64
ghcr.io/openhands/agent-server:942ab92-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:942ab92-golang-arm64
ghcr.io/openhands/agent-server:942ab92-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:942ab92-java-amd64
ghcr.io/openhands/agent-server:942ab92-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:942ab92-java-arm64
ghcr.io/openhands/agent-server:942ab92-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:942ab92-python-amd64
ghcr.io/openhands/agent-server:942ab92-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:942ab92-python-arm64
ghcr.io/openhands/agent-server:942ab92-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:942ab92-golang
ghcr.io/openhands/agent-server:942ab92-java
ghcr.io/openhands/agent-server:942ab92-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `942ab92-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `942ab92-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->