### PR TITLE
refactor(git): drop redundant empty-tree ref fallback

### DIFF
--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -164,10 +164,6 @@ def get_valid_ref(repo_dir: str | Path) -> str | None:
     except GitCommandError:
         logger.debug("Could not get remote information")
 
-    # Add empty tree as fallback for new repositories
-    refs_to_try.append(GIT_EMPTY_TREE_HASH)
-    logger.debug(f"Added empty tree reference: {GIT_EMPTY_TREE_HASH}")
-
     # Find the first valid reference
     for ref in refs_to_try:
         try:


### PR DESCRIPTION
This is a follow-up to PR #1606.

### What
`get_valid_ref()` already returns `GIT_EMPTY_TREE_HASH` early for repositories with no commits. The function also appended the empty-tree hash into `refs_to_try`, which was redundant and mixed a sentinel value into the normal ref-resolution flow.

### Change
- Remove the `refs_to_try.append(GIT_EMPTY_TREE_HASH)` fallback and its debug log.

### Why
- Keeps the “empty repo” behavior explicit and isolated.
- Avoids treating the empty-tree hash as a normal candidate ref in non-empty repos.

Pre-commit checks were run on the touched file.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/808e1792a8c840dbacc46d9d624bba1a)