### PR TITLE
Revert "Expose runtime_resource_factor in run-eval"

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -67,11 +67,6 @@ on:
                 required: false
                 default: ''
                 type: string
-            runtime_resource_factor:
-                description: 'Resource multiplier for remote runtimes (optional: 1,2,4,8)'
-                required: false
-                default: ''
-                type: string
             push_to_index:
                 description: 'Push results to openhands-index-results (default: false)'
                 required: false
@@ -224,7 +219,6 @@ jobs:
                   NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers || '' }}
                   NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers || '' }}
                   PUSH_TO_INDEX: ${{ github.event.inputs.push_to_index || 'false' }}
-                  RUNTIME_RESOURCE_FACTOR: ${{ github.event.inputs.runtime_resource_factor || '' }}
               run: |
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH)"
                   PAYLOAD=$(jq -n \
@@ -240,8 +234,7 @@ jobs:
                     --arg num_infer_workers "$NUM_INFER_WORKERS" \
                     --arg num_eval_workers "$NUM_EVAL_WORKERS" \
                     --arg push_to_index "$PUSH_TO_INDEX" \
-                    --arg runtime_resource_factor "$RUNTIME_RESOURCE_FACTOR" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, runtime_resource_factor: $runtime_resource_factor}}')
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
Reverts OpenHands/software-agent-sdk#1605
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c22d3c9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c22d3c9-python \
  ghcr.io/openhands/agent-server:c22d3c9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c22d3c9-golang-amd64
ghcr.io/openhands/agent-server:c22d3c9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c22d3c9-golang-arm64
ghcr.io/openhands/agent-server:c22d3c9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c22d3c9-java-amd64
ghcr.io/openhands/agent-server:c22d3c9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c22d3c9-java-arm64
ghcr.io/openhands/agent-server:c22d3c9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c22d3c9-python-amd64
ghcr.io/openhands/agent-server:c22d3c9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c22d3c9-python-arm64
ghcr.io/openhands/agent-server:c22d3c9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c22d3c9-golang
ghcr.io/openhands/agent-server:c22d3c9-java
ghcr.io/openhands/agent-server:c22d3c9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c22d3c9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c22d3c9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->