### PR TITLE
Allow over-riding system-level configurations from apptainer.conf in apptainer workspace

### DIFF
--- a/openhands-workspace/openhands/workspace/apptainer/workspace.py
+++ b/openhands-workspace/openhands/workspace/apptainer/workspace.py
@@ -102,6 +102,27 @@ class ApptainerWorkspace(RemoteWorkspace):
             "Set to False if fakeroot is not supported in your environment."
         ),
     )
+    disable_mount_hostfs: bool = Field(
+        default=True,
+        description=(
+            "Whether to over-ride the `mount hostfs = yes` setting in apptainer.conf"
+            "Set to False if you want to disable --no-mount hostfs"
+        ),
+    )
+    disable_mount_bind_path: bool = Field(
+        default=True,
+        description=(
+            "Whether to ignore the custom bind path entries in apptainer.conf"
+            "Set to False if you want to disable --no-mount bind-paths"
+        ),
+    )
+    enable_containall: bool = Field(
+        default=True,
+        description=(
+            "Whether to use --containall for maximum container isolation."
+            "Set to False if you do not want to start the apptainer with --containall"
+        ),
+    )
 
     _instance_name: str | None = PrivateAttr(default=None)
     _logs_thread: threading.Thread | None = PrivateAttr(default=None)
@@ -242,6 +263,12 @@ class ApptainerWorkspace(RemoteWorkspace):
         # Add fakeroot for consistent file ownership (user appears as root)
         if self.use_fakeroot:
             container_opts.append("--fakeroot")
+        if self.disable_mount_hostfs:
+            container_opts += ["--no-mount", "hostfs"]  # Disable hostfs mount
+        if self.disable_mount_bind_path:
+            container_opts += ["--no-mount", "bind-paths"]  # Disable custom bind paths
+        if self.enable_containall:
+            container_opts.append("--containall")  # Maximum isolation
 
         # Run the agent server using apptainer run to respect the image's entrypoint
         # This works with both 'source' and 'binary' build targets


### PR DESCRIPTION
## Summary
This PR adds config flags to `ApptainerWorkspace` class for the following command-line arguments in `apptainer run`:
- Allow disabling mounting of host filesystem - if the system-level configuration in `/etc/apptainer/apptainer.conf` sets `mount hostfs = yes`, all the file-systems on host machines are mounted by default without the option to disable it.
- Allow disabling pre-configured bind paths - if the system-level configuration in `/etc/apptainer/apptainer.conf` sets `bind path = <path on host machine to a file or directory>`, then all these directories/files are mounted by default in the apptainer, without the option to disable it.
- Allow configuring `--containall` - beyond the currently hard-coded config options like `--clean-env`, `--no-home`, etc, this flag allows for isolating the PID and IPC namespaces of the apptainer from the host, which is exactly how Docker containers work.
## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?
