### PR TITLE
fix: Pass agent_context at Agent initialization in PR review script

### DIFF
--- a/examples/03_github_workflows/02_pr_review/agent_script.py
+++ b/examples/03_github_workflows/02_pr_review/agent_script.py
@@ -34,10 +34,10 @@ import subprocess
 import sys
 from pathlib import Path
 
-from openhands.sdk import LLM, AgentContext, Conversation, get_logger
+from openhands.sdk import LLM, Agent, AgentContext, Conversation, get_logger
 from openhands.sdk.conversation import get_agent_final_response
 from openhands.sdk.utils.github import sanitize_openhands_mentions
-from openhands.tools.preset.default import get_default_agent
+from openhands.tools.preset.default import get_default_condenser, get_default_tools
 
 
 # Add the script directory to Python path so we can import prompt.py
@@ -169,12 +169,16 @@ def main():
         )
 
         # Create agent with default tools and agent context
-        agent = get_default_agent(
+        # Note: agent_context must be passed at initialization since Agent is frozen
+        agent = Agent(
             llm=llm,
-            cli_mode=True,
+            tools=get_default_tools(enable_browser=False),  # CLI mode - no browser
+            agent_context=agent_context,
+            system_prompt_kwargs={"cli_mode": True},
+            condenser=get_default_condenser(
+                llm=llm.model_copy(update={"usage_id": "condenser"})
+            ),
         )
-        # Set agent_context on the agent
-        agent.agent_context = agent_context
 
         # Create conversation
         conversation = Conversation(


### PR DESCRIPTION
## Summary

Fixes the "Instance is frozen" error in the PR review workflow by passing `agent_context` at Agent initialization instead of setting it as an attribute afterwards.

**Root cause:** `AgentBase` is a frozen Pydantic model (`frozen=True`), which means its attributes cannot be modified after creation. The original code tried to set `agent.agent_context = agent_context` after the agent was already instantiated, causing:

```
pydantic_core._pydantic_core.ValidationError: 1 validation error for Agent
agent_context
  Instance is frozen [type=frozen_instance, ...]
```

**Fix:** Create the Agent directly with `agent_context` passed to the constructor instead of using `get_default_agent()` and then modifying the agent.

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f17b108-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f17b108-python \
  ghcr.io/openhands/agent-server:f17b108-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f17b108-golang-amd64
ghcr.io/openhands/agent-server:f17b108-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f17b108-golang-arm64
ghcr.io/openhands/agent-server:f17b108-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f17b108-java-amd64
ghcr.io/openhands/agent-server:f17b108-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f17b108-java-arm64
ghcr.io/openhands/agent-server:f17b108-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f17b108-python-amd64
ghcr.io/openhands/agent-server:f17b108-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f17b108-python-arm64
ghcr.io/openhands/agent-server:f17b108-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f17b108-golang
ghcr.io/openhands/agent-server:f17b108-java
ghcr.io/openhands/agent-server:f17b108-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f17b108-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f17b108-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->