### PR TITLE
Fix broken idle detection and websocket disconnect handling

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -23,7 +23,10 @@ from openhands.agent_server.desktop_service import get_desktop_service
 from openhands.agent_server.event_router import event_router
 from openhands.agent_server.file_router import file_router
 from openhands.agent_server.git_router import git_router
-from openhands.agent_server.middleware import LocalhostCORSMiddleware
+from openhands.agent_server.middleware import (
+    ActivityTrackingMiddleware,
+    LocalhostCORSMiddleware,
+)
 from openhands.agent_server.server_details_router import (
     get_server_info,
     server_details_router,
@@ -322,6 +325,10 @@ def create_app(config: Config | None = None) -> FastAPI:
     _add_api_routes(app, config)
     _setup_static_files(app, config)
     app.add_middleware(LocalhostCORSMiddleware, allow_origins=config.allow_cors_origins)
+    # Add activity tracking middleware to update last activity time on every
+    # HTTP request. This ensures runtime-api can accurately detect idle vs
+    # active runtimes.
+    app.add_middleware(ActivityTrackingMiddleware)
     _add_exception_handlers(app)
 
     return app

--- a/tests/agent_server/test_event_router_websocket.py
+++ b/tests/agent_server/test_event_router_websocket.py
@@ -231,7 +231,11 @@ class TestWebSocketDisconnectHandling:
     async def test_websocket_unsubscribe_in_finally_when_no_disconnect(
         self, mock_websocket, mock_event_service, sample_conversation_id
     ):
-        """Test that unsubscription happens in finally block when no disconnect."""
+        """Test that unsubscription happens in finally block when RuntimeError occurs.
+
+        RuntimeError is now handled gracefully (no exception raised) to avoid
+        server shutdown, but cleanup should still happen.
+        """
         # Simulate a different kind of exception that doesn't trigger disconnect handler
         mock_websocket.receive_json.side_effect = RuntimeError("Unexpected error")
 
@@ -249,11 +253,11 @@ class TestWebSocketDisconnectHandling:
 
             from openhands.agent_server.sockets import events_socket
 
-            # This should raise the RuntimeError but still clean up
-            with pytest.raises(RuntimeError):
-                await events_socket(
-                    sample_conversation_id, mock_websocket, session_api_key=None
-                )
+            # RuntimeError is now handled gracefully (no exception raised)
+            # to avoid server shutdown when websocket connection errors occur
+            await events_socket(
+                sample_conversation_id, mock_websocket, session_api_key=None
+            )
 
         # Should still unsubscribe in the finally block
         mock_event_service.unsubscribe_from_events.assert_called_once()

--- a/tests/agent_server/test_middleware.py
+++ b/tests/agent_server/test_middleware.py
@@ -1,0 +1,121 @@
+"""Tests for the agent server middleware functionality."""
+
+import time
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.middleware import ActivityTrackingMiddleware
+from openhands.agent_server.server_details_router import (
+    _last_event_time,
+    update_last_execution_time,
+)
+
+
+def test_activity_tracking_middleware_updates_last_activity_time():
+    """Test that ActivityTrackingMiddleware updates last activity time on requests."""
+    # Create a simple FastAPI app with the middleware
+    app = FastAPI()
+    app.add_middleware(ActivityTrackingMiddleware)
+
+    @app.get("/test")
+    async def test_endpoint():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+
+    # Record the initial last event time
+    initial_time = _last_event_time
+
+    # Wait a small amount to ensure time difference
+    time.sleep(0.01)
+
+    # Make a request
+    response = client.get("/test")
+    assert response.status_code == 200
+
+    # Import the module-level variable again to get the updated value
+    from openhands.agent_server import server_details_router
+
+    # The last event time should have been updated
+    assert server_details_router._last_event_time > initial_time
+
+
+def test_activity_tracking_middleware_updates_on_every_request():
+    """Test that ActivityTrackingMiddleware updates on every HTTP request."""
+    # Create a simple FastAPI app with the middleware
+    app = FastAPI()
+    app.add_middleware(ActivityTrackingMiddleware)
+
+    @app.get("/test1")
+    async def test_endpoint1():
+        return {"status": "ok"}
+
+    @app.get("/test2")
+    async def test_endpoint2():
+        return {"status": "ok"}
+
+    client = TestClient(app)
+
+    # Make first request
+    response1 = client.get("/test1")
+    assert response1.status_code == 200
+
+    from openhands.agent_server import server_details_router
+
+    time_after_first = server_details_router._last_event_time
+
+    # Wait a small amount
+    time.sleep(0.01)
+
+    # Make second request
+    response2 = client.get("/test2")
+    assert response2.status_code == 200
+
+    # The last event time should have been updated again
+    assert server_details_router._last_event_time > time_after_first
+
+
+def test_activity_tracking_middleware_updates_on_error_responses():
+    """Test that ActivityTrackingMiddleware updates even when endpoint returns error."""
+    # Create a simple FastAPI app with the middleware
+    app = FastAPI()
+    app.add_middleware(ActivityTrackingMiddleware)
+
+    @app.get("/error")
+    async def error_endpoint():
+        from fastapi import HTTPException
+
+        raise HTTPException(status_code=500, detail="Test error")
+
+    client = TestClient(app, raise_server_exceptions=False)
+
+    from openhands.agent_server import server_details_router
+
+    initial_time = server_details_router._last_event_time
+
+    # Wait a small amount
+    time.sleep(0.01)
+
+    # Make a request that will return an error
+    response = client.get("/error")
+    assert response.status_code == 500
+
+    # The last event time should still have been updated
+    assert server_details_router._last_event_time > initial_time
+
+
+def test_update_last_execution_time_function():
+    """Test that update_last_execution_time function works correctly."""
+    from openhands.agent_server import server_details_router
+
+    initial_time = server_details_router._last_event_time
+
+    # Wait a small amount
+    time.sleep(0.01)
+
+    # Call the function
+    update_last_execution_time()
+
+    # The time should have been updated
+    assert server_details_router._last_event_time > initial_time


### PR DESCRIPTION
## Summary

This PR fixes two critical bugs causing runtime instability as reported in #1633:

### 1. Broken Idle Time Detection (PRIMARY FIX)

**Problem:** The runtime-api was killing runtimes that were actively serving requests because it incorrectly calculated them as "idle". The idle time was only updated when events were processed in the conversation service, not when actual HTTP requests were being served.

**Solution:** Added `ActivityTrackingMiddleware` that updates the last activity timestamp on every HTTP request. This ensures that the `/server_info` endpoint accurately reflects actual HTTP activity, allowing runtime-api to correctly detect idle vs active runtimes.

### 2. Websocket Disconnect Handling (SECONDARY FIX)

**Problem:** When websocket connections encountered `RuntimeError` or `ConnectionError`, these exceptions were re-raised, potentially causing server instability.

**Solution:** Modified websocket handlers to gracefully handle these errors by logging a warning and returning normally instead of re-raising. Cleanup (unsubscription) still happens in the finally block.

## Changes

- **`middleware.py`**: Added `ActivityTrackingMiddleware` class that calls `update_last_execution_time()` on every HTTP request
- **`api.py`**: Added the `ActivityTrackingMiddleware` to the FastAPI application
- **`sockets.py`**: Modified exception handling to gracefully handle `RuntimeError` and `ConnectionError` instead of re-raising them
- **`test_middleware.py`**: Added tests for the activity tracking middleware
- **`test_event_router_websocket.py`**: Updated test to reflect new graceful error handling behavior

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

Fixes #1633

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/75cfb454f55247c2a225900bd8db4059)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bb0eaac-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bb0eaac-python \
  ghcr.io/openhands/agent-server:bb0eaac-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bb0eaac-golang-amd64
ghcr.io/openhands/agent-server:bb0eaac-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bb0eaac-golang-arm64
ghcr.io/openhands/agent-server:bb0eaac-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bb0eaac-java-amd64
ghcr.io/openhands/agent-server:bb0eaac-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bb0eaac-java-arm64
ghcr.io/openhands/agent-server:bb0eaac-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bb0eaac-python-amd64
ghcr.io/openhands/agent-server:bb0eaac-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:bb0eaac-python-arm64
ghcr.io/openhands/agent-server:bb0eaac-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:bb0eaac-golang
ghcr.io/openhands/agent-server:bb0eaac-java
ghcr.io/openhands/agent-server:bb0eaac-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bb0eaac-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bb0eaac-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->