### PR TITLE
Fix websocket disconnect handling to avoid server shutdown

### DIFF
--- a/tests/agent_server/test_event_router_websocket.py
+++ b/tests/agent_server/test_event_router_websocket.py
@@ -231,7 +231,11 @@ class TestWebSocketDisconnectHandling:
     async def test_websocket_unsubscribe_in_finally_when_no_disconnect(
         self, mock_websocket, mock_event_service, sample_conversation_id
     ):
-        """Test that unsubscription happens in finally block when no disconnect."""
+        """Test that unsubscription happens in finally block when RuntimeError occurs.
+
+        RuntimeError is re-raised to surface bugs, but cleanup should still happen
+        in the finally block.
+        """
         # Simulate a different kind of exception that doesn't trigger disconnect handler
         mock_websocket.receive_json.side_effect = RuntimeError("Unexpected error")
 
@@ -249,7 +253,7 @@ class TestWebSocketDisconnectHandling:
 
             from openhands.agent_server.sockets import events_socket
 
-            # This should raise the RuntimeError but still clean up
+            # RuntimeError should be re-raised to surface bugs
             with pytest.raises(RuntimeError):
                 await events_socket(
                     sample_conversation_id, mock_websocket, session_api_key=None


### PR DESCRIPTION
## Summary

This PR fixes the **secondary issue** from #1633: websocket disconnect handling that could potentially cause server instability.

### Problem

When websocket connections encountered `ConnectionError`, these exceptions were being re-raised along with `RuntimeError`, which could potentially cause server instability.

### Solution

Modified websocket handlers to:
- Handle `ConnectionError` gracefully (connection-related errors are safe to suppress)
- Keep re-raising `RuntimeError` to surface actual bugs (as suggested in code review)
- Use explicit `except ConnectionError` clause instead of `isinstance` check (cleaner)

### Changes

- **`sockets.py`**: Modified `events_socket` and `bash_events_socket` to handle `ConnectionError` gracefully while still re-raising `RuntimeError`
- **`test_event_router_websocket.py`**: Updated test to verify `RuntimeError` is still re-raised

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

Fixes #1633 (partial - websocket disconnect fix)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f2091f2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f2091f2-python \
  ghcr.io/openhands/agent-server:f2091f2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f2091f2-golang-amd64
ghcr.io/openhands/agent-server:f2091f2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f2091f2-golang-arm64
ghcr.io/openhands/agent-server:f2091f2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f2091f2-java-amd64
ghcr.io/openhands/agent-server:f2091f2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f2091f2-java-arm64
ghcr.io/openhands/agent-server:f2091f2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f2091f2-python-amd64
ghcr.io/openhands/agent-server:f2091f2-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f2091f2-python-arm64
ghcr.io/openhands/agent-server:f2091f2-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f2091f2-golang
ghcr.io/openhands/agent-server:f2091f2-java
ghcr.io/openhands/agent-server:f2091f2-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f2091f2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f2091f2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->