### PR TITLE
Expose max_retries input and dispatch to eval

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -170,8 +170,10 @@ jobs:
                     EVAL_LIMIT="${{ github.event.inputs.eval_limit }}"
                     SDK_REF="${{ github.event.inputs.sdk_ref }}"
                     # Convert ref to SHA for manual dispatch
-                    # Try with origin/ prefix first for remote branches, then without prefix, then use as-is
-                    SDK_SHA=$(git rev-parse "origin/$SDK_REF" 2>/dev/null || git rev-parse "$SDK_REF" 2>/dev/null || echo "$SDK_REF")
+                    # Resolve SHA robustly for both branch refs and raw SHAs (avoid double-prefix issues)
+                    SDK_SHA=$(git rev-parse --verify "$SDK_REF^{commit}" 2>/dev/null || \
+                              git rev-parse --verify "origin/$SDK_REF^{commit}" 2>/dev/null || \
+                              echo "$SDK_REF")
                     PR_NUMBER=""
                     REASON="${{ github.event.inputs.reason }}"
                     if [ -z "$REASON" ]; then


### PR DESCRIPTION
## Summary
- harden run-eval workflow outputs (sanitize values) and resolve sdk_ref correctly for raw SHAs
- ensure manual dispatch with a commit SHA succeeds so prebuilt images can be reused (`image_exists`)

## Validation
- Manual dispatch with raw SHA sdk_ref: https://github.com/OpenHands/software-agent-sdk/actions/runs/20827468571 (success)
- Downstream eval run: https://github.com/OpenHands/evaluation/actions/runs/20827472873 (success)
- Benchmarks build verified image reuse (image_exists): https://github.com/OpenHands/benchmarks/actions/runs/20827512895

## Checklist
- [x] CI passing
- [ ] Tests added/updated (not needed for workflow YAML change)
- [x] Manual validation performed (runs linked above)
