### PR TITLE
Use AGENTS.md instead of repo.md in SDK examples/system prompt

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -110,7 +110,7 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             {
                 "skills": [
                     {
-                        "name": "repo.md",
+                        "name": "AGENTS.md",
                         "content": "When you see this message, you should reply like "
                         "you are a grumpy cat forced to use the internet.",
                         "type": "repo",

--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
@@ -6,7 +6,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 </ROLE>
 
 <MEMORY>
-* Use `.openhands/skills/repo.md` under the repository root as your persistent memory for repository-specific knowledge and context.
+* Use `AGENTS.md` under the repository root as your persistent memory for repository-specific knowledge and context.
 * Add important insights, patterns, and learnings to this file to improve future task performance.
 * This repository skill is automatically loaded for every conversation and helps maintain context across sessions.
 * For more information about skills, see: https://docs.openhands.dev/overview/skills

--- a/openhands-sdk/openhands/sdk/context/README.md
+++ b/openhands-sdk/openhands/sdk/context/README.md
@@ -25,7 +25,7 @@ agent_context = AgentContext(
         Skill(
             name="repo-guidelines",
             content="Repository-wide coding standards and best practices.",
-            source="repo.md",
+            source="AGENTS.md",
             trigger=None,  # Always-active skill
         ),
         Skill(


### PR DESCRIPTION
This aligns the SDK’s built-in examples/system prompt text with the docs change that prefers `AGENTS.md` for permanent repository context.

Changes:
- `Agent` config example: `repo.md` → `AGENTS.md`
- System prompt MEMORY guidance: `.openhands/skills/repo.md` → `AGENTS.md`
- Context README example: `source="repo.md"` → `source="AGENTS.md"`

Related docs PR: https://github.com/OpenHands/docs/pull/247

Co-authored-by: openhands <openhands@all-hands.dev>

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f3a665b26f2c4273b0c9cc502b3a9b66)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c325eb3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c325eb3-python \
  ghcr.io/openhands/agent-server:c325eb3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c325eb3-golang-amd64
ghcr.io/openhands/agent-server:c325eb3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c325eb3-golang-arm64
ghcr.io/openhands/agent-server:c325eb3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c325eb3-java-amd64
ghcr.io/openhands/agent-server:c325eb3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c325eb3-java-arm64
ghcr.io/openhands/agent-server:c325eb3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c325eb3-python-amd64
ghcr.io/openhands/agent-server:c325eb3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c325eb3-python-arm64
ghcr.io/openhands/agent-server:c325eb3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c325eb3-golang
ghcr.io/openhands/agent-server:c325eb3-java
ghcr.io/openhands/agent-server:c325eb3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c325eb3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c325eb3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->