### PR TITLE
Sanitize missing security_risk tool arg errors

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -451,10 +451,11 @@ class Agent(AgentBase):
 
             action: Action = tool.action_from_arguments(arguments)
         except (json.JSONDecodeError, ValidationError, ValueError) as e:
-            err = (
-                f"Error validating args {tool_call.arguments} for tool "
-                f"'{tool.name}': {e}"
-            )
+            err_tool_args = tool_call.arguments
+            if isinstance(e, ValueError) and "security_risk" in str(e):
+                err_tool_args = "<omitted>"
+
+            err = f"Error validating args {err_tool_args} for tool '{tool.name}': {e}"
             # Persist assistant function_call so next turn has matching call_id
             tc_event = ActionEvent(
                 source="agent",

--- a/tests/sdk/agent/test_extract_security_risk.py
+++ b/tests/sdk/agent/test_extract_security_risk.py
@@ -97,7 +97,12 @@ def test_extract_security_risk(
     tool_name = "test_tool"
 
     if should_raise:
-        with pytest.raises(ValueError):
+        if security_risk_value is None:
+            match = "security_risk"
+        else:
+            match = "SecurityRisk"
+
+        with pytest.raises(ValueError, match=match):
             agent._extract_security_risk(arguments, tool_name, False, security_analyzer)
     else:
         result = agent._extract_security_risk(


### PR DESCRIPTION
## Summary

When a model omits the required `security_risk` argument (with an `LLMSecurityAnalyzer` enabled), `Agent._get_action_event()` raises and wraps a `ValueError` that currently embeds the *full* tool-call JSON string in the error message. This can produce a huge persistent error banner in the UI.

This PR:
- Omits tool arguments from the error string specifically for missing-`security_risk` failures (uses `<omitted>`), while keeping the underlying error message intact.
- Adds/updates a unit test to assert the missing-field error message contains `security_risk`.

Fixes #1653.

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3d3a2898481247ebb70c52ff52105aac)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:63b20f7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-63b20f7-python \
  ghcr.io/openhands/agent-server:63b20f7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:63b20f7-golang-amd64
ghcr.io/openhands/agent-server:63b20f7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:63b20f7-golang-arm64
ghcr.io/openhands/agent-server:63b20f7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:63b20f7-java-amd64
ghcr.io/openhands/agent-server:63b20f7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:63b20f7-java-arm64
ghcr.io/openhands/agent-server:63b20f7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:63b20f7-python-amd64
ghcr.io/openhands/agent-server:63b20f7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:63b20f7-python-arm64
ghcr.io/openhands/agent-server:63b20f7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:63b20f7-golang
ghcr.io/openhands/agent-server:63b20f7-java
ghcr.io/openhands/agent-server:63b20f7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `63b20f7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `63b20f7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->