### PR TITLE
Add per-test timeout to prevent hanging example scripts

### DIFF
--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -119,8 +119,15 @@ def test_example_scripts(
         returncode = process.returncode
     except subprocess.TimeoutExpired as e:
         timed_out = True
-        stdout = e.stdout or ""
-        stderr = e.stderr or ""
+        # e.stdout/e.stderr are bytes|str|None; ensure we have str
+        raw_stdout = e.stdout
+        raw_stderr = e.stderr
+        stdout = (
+            raw_stdout.decode() if isinstance(raw_stdout, bytes) else (raw_stdout or "")
+        )
+        stderr = (
+            raw_stderr.decode() if isinstance(raw_stderr, bytes) else (raw_stderr or "")
+        )
         returncode = -1
 
     duration = time.perf_counter() - start


### PR DESCRIPTION
## Problem

The "Run Examples Scripts" workflow [timed out after 60 minutes](https://github.com/OpenHands/software-agent-sdk/actions/runs/20855799789/job/59921972130?pr=1663) because the test for `02_gemini_file_tools.py` hung for ~48 minutes without completing.

**Timeline from logs:**
- `15:07:18` - Test `02_gemini_file_tools.py` started  
- `15:55:08` - Job cancelled after hitting 60-minute workflow timeout
- The Gemini test was stuck for ~48 minutes

**Root cause:** The test harness uses `subprocess.run()` without a timeout parameter, so if an example script hangs (LLM API issues, rate limiting, conversation loops), it blocks indefinitely until the workflow timeout kills everything.

## Solution

Add a 10-minute (600 second) per-test timeout to `subprocess.run()`. If an example script hangs, it will now:
- Fail quickly with a clear "Timed out after 600 seconds" error message
- Allow other tests to continue running
- Not block the entire workflow

## Changes

- Added `EXAMPLE_TIMEOUT_SECONDS = 600` constant
- Added `timeout=EXAMPLE_TIMEOUT_SECONDS` to `subprocess.run()`
- Handle `subprocess.TimeoutExpired` exception properly
- Record timeout failures in the test results JSON

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d275dd7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d275dd7-python \
  ghcr.io/openhands/agent-server:d275dd7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d275dd7-golang-amd64
ghcr.io/openhands/agent-server:d275dd7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d275dd7-golang-arm64
ghcr.io/openhands/agent-server:d275dd7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d275dd7-java-amd64
ghcr.io/openhands/agent-server:d275dd7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d275dd7-java-arm64
ghcr.io/openhands/agent-server:d275dd7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d275dd7-python-amd64
ghcr.io/openhands/agent-server:d275dd7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:d275dd7-python-arm64
ghcr.io/openhands/agent-server:d275dd7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:d275dd7-golang
ghcr.io/openhands/agent-server:d275dd7-java
ghcr.io/openhands/agent-server:d275dd7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d275dd7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d275dd7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->