### PR TITLE
Add --no-pager instruction for git commands in system prompt

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
@@ -43,6 +43,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 * When committing changes, use `git status` to see all modified files, and stage all files necessary for the commit. Use `git commit -a` whenever possible.
 * Do NOT commit files that typically shouldn't go into version control (e.g., node_modules/, .env files, build directories, cache files, large binaries) unless explicitly instructed by the user.
 * If unsure about committing certain files, check for the presence of .gitignore files or ask the user for clarification.
+* When running git commands that may produce paged output (e.g., `git diff`, `git log`, `git show`), use `git --no-pager <command>` or set `GIT_PAGER=cat` to prevent the command from getting stuck waiting for interactive input.
 </VERSION_CONTROL>
 
 <PULL_REQUESTS>


### PR DESCRIPTION
## Summary

Agents can get stuck waiting for interactive input when running git commands that produce paged output (e.g., `git diff`, `git log`, `git show`). This PR adds an instruction to the `<VERSION_CONTROL>` section of the system prompt advising the agent to use `git --no-pager <command>` or set `GIT_PAGER=cat` to prevent this issue.

### Changes:
- Added a new bullet point in the `<VERSION_CONTROL>` section of `system_prompt.j2`

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - This is a prompt text change, no code logic changed
- [ ] If there is an example, have you run the example to make sure that it works?
  - N/A - This is a prompt template change, not a code example
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - Verified template rendering works correctly
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - This is an internal prompt improvement, no external documentation needed
- [ ] Is the github CI passing?
  - Awaiting CI run

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ff9e601-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ff9e601-python \
  ghcr.io/openhands/agent-server:ff9e601-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ff9e601-golang-amd64
ghcr.io/openhands/agent-server:ff9e601-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ff9e601-golang-arm64
ghcr.io/openhands/agent-server:ff9e601-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ff9e601-java-amd64
ghcr.io/openhands/agent-server:ff9e601-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ff9e601-java-arm64
ghcr.io/openhands/agent-server:ff9e601-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ff9e601-python-amd64
ghcr.io/openhands/agent-server:ff9e601-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:ff9e601-python-arm64
ghcr.io/openhands/agent-server:ff9e601-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:ff9e601-golang
ghcr.io/openhands/agent-server:ff9e601-java
ghcr.io/openhands/agent-server:ff9e601-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ff9e601-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ff9e601-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->