### PR TITLE
Fix unhandled ConversationRunError causing non-JSON logs

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -319,6 +319,12 @@ class EventService:
                 except Exception:
                     logger.exception("Error during conversation run from send_message")
 
+            # Fire-and-forget: This task is intentionally not tracked because
+            # send_message() is designed to return immediately after queuing the
+            # message. The conversation run happens in the background and any
+            # errors are logged. Unlike the run() method which is explicitly
+            # awaited, this pattern allows clients to send messages without
+            # blocking on the full conversation execution.
             loop.create_task(_run_with_error_handling())
 
     async def subscribe_to_events(self, subscriber: Subscriber[Event]) -> UUID:


### PR DESCRIPTION
## Problem

Non-JSON formatted logs were appearing in Datadog for `service:agent-server`. Investigation revealed that exceptions from `conversation.run()` were not being caught, causing Python's default exception handler to print tracebacks directly to stderr as plain text, bypassing the JSON logger.

Example of the problematic logs (each line appearing as a separate log entry with `Logger: unknown`):
```
Traceback (most recent call last):
File "openhands/sdk/conversation/impl/local_conversation.py", line 411, in run
...
openhands.sdk.conversation.exceptions.ConversationRunError: Conversation run failed for id=...
```

## Root Cause

Two places in `event_service.py` were calling `conversation.run()` without proper exception handling:

1. **Line 314 (send_message)**: `loop.run_in_executor(None, self._conversation.run)` - fire-and-forget call with NO exception handling
2. **Lines 499-500 (run method)**: Had a try/except but used `logger.error(f"...")` which doesn't include the traceback

## Changes

1. **event_service.py send_message()**: Wrapped the fire-and-forget `run_in_executor` call in an async task with exception handling. This preserves the original fire-and-forget behavior while adding proper error logging.

2. **event_service.py run()**: Changed `logger.error(f"Error during conversation run: {e}")` to `logger.exception("Error during conversation run")` to include the full traceback in structured JSON logs.

3. **Updated test**: Modified `test_send_message_with_run_true_agent_idle` to work with the new async wrapper pattern.

## Result

After this fix:
- All exceptions from `conversation.run()` will be caught and logged through the JSON logger
- Full tracebacks will be included in the structured log output
- The original fire-and-forget behavior is preserved (no behavioral changes)




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:aee005c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-aee005c-python \
  ghcr.io/openhands/agent-server:aee005c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:aee005c-golang-amd64
ghcr.io/openhands/agent-server:aee005c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:aee005c-golang-arm64
ghcr.io/openhands/agent-server:aee005c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:aee005c-java-amd64
ghcr.io/openhands/agent-server:aee005c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:aee005c-java-arm64
ghcr.io/openhands/agent-server:aee005c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:aee005c-python-amd64
ghcr.io/openhands/agent-server:aee005c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:aee005c-python-arm64
ghcr.io/openhands/agent-server:aee005c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:aee005c-golang
ghcr.io/openhands/agent-server:aee005c-java
ghcr.io/openhands/agent-server:aee005c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `aee005c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `aee005c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->