### PR TITLE
Add visualize() for ConversationErrorEvent

### DIFF
--- a/openhands-sdk/openhands/sdk/event/conversation_error.py
+++ b/openhands-sdk/openhands/sdk/event/conversation_error.py
@@ -1,4 +1,5 @@
 from pydantic import Field
+from rich.text import Text
 
 from openhands.sdk.event.base import Event
 
@@ -23,3 +24,14 @@ class ConversationErrorEvent(Event):
 
     code: str = Field(description="Code for the error - typically a type")
     detail: str = Field(description="Details about the error")
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation of this conversation error event."""
+        content = Text()
+        content.append("Conversation Error\n", style="bold")
+        content.append("Code: ", style="bold")
+        content.append(self.code)
+        content.append("\n\nDetail:\n", style="bold")
+        content.append(self.detail)
+        return content

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -479,6 +479,23 @@ def test_event_base_fallback_visualize():
     assert "Unknown event type: _UnknownEventForVisualizerTest" in text_content
 
 
+def test_conversation_error_event_visualize():
+    """Test that ConversationErrorEvent provides a specific visualization."""
+    from openhands.sdk.event.conversation_error import ConversationErrorEvent
+
+    event = ConversationErrorEvent(
+        source="environment",
+        code="TestError",
+        detail="Something went wrong",
+    )
+    text_content = event.visualize.plain
+
+    assert "Unknown event type:" not in text_content
+    assert "Conversation Error" in text_content
+    assert "TestError" in text_content
+    assert "Something went wrong" in text_content
+
+
 def test_visualizer_conversation_state_update_event_skipped():
     """Test that ConversationStateUpdateEvent is not visualized."""
     visualizer = DefaultConversationVisualizer()


### PR DESCRIPTION
When running OpenHands-CLI, ConversationErrorEvent was rendered via Event.visualize fallback as: "Unknown event type: ConversationErrorEvent".

This adds a dedicated Rich visualization for ConversationErrorEvent (code + detail) and a small unit test to prevent regressions.

Files:
- openhands-sdk/openhands/sdk/event/conversation_error.py
- tests/sdk/conversation/test_visualizer.py