### PR TITLE
Add ARG USERNAME to base-image stage for podman

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -91,6 +91,7 @@ EXPOSE ${PORT}
 # It includes additional Docker, VNC, Desktop, and VSCode Web.
 ####################################################################################
 FROM base-image-minimal AS base-image
+ARG USERNAME
 
 USER root
 # --- VSCode Web ---


### PR DESCRIPTION
The `USERNAME` argument is declared globally but must be re-declared in the `base-image` stage to be available. This was causing "unknown USERNAME" errors during `podman build`.  Docker appears to be more lenient.

This was tested with `uv run python -m openhands.agent_server.docker.build --target binary --build-ctx-only` followed by:

```
sudo podman build \
  --file Dockerfile \
  --target binary \
  --build-arg BASE_IMAGE=nikolaik/python-nodejs:python3.12-nodejs22 \
  --tag ghcr.io/openhands/agent-server:test
```