### PR TITLE
Optimize docker-like behaviour in apptainer with better code quality

### DIFF
--- a/openhands-workspace/openhands/workspace/apptainer/workspace.py
+++ b/openhands-workspace/openhands/workspace/apptainer/workspace.py
@@ -106,20 +106,21 @@ class ApptainerWorkspace(RemoteWorkspace):
     enable_docker_compat: bool = Field(
         default=True,
         description=(
-            "Whether to use --compat for maximum Docker compatibility."
-            "Check below URL for documentation"
+            "Whether to use --compat for maximum Docker compatibility. "
+            "Check this URL for documentation: "
             "https://apptainer.org/docs/user/main/docker_and_oci.html#docker-like-compat-flag"
-            "Set to False if you want custom Apptainer behavior."
+            " Set to False if you want custom Apptainer behavior."
         ),
     )
 
     disable_mount_locations: list[str] = Field(
         default=["hostfs", "bind-paths"],
         description=(
-            "List of locations to disable mounting for."
-            "Helpful for disabling system-level mounts/binds from apptainer.conf"
-            "Check https://apptainer.org/docs/user/main/bind_paths_and_mounts.html#disabling-system-binds"
-            "Specify locations to disable for custom Apptainer behavior."
+            "List of locations to disable mounting for. "
+            "Helpful for disabling system-level mounts/binds from apptainer.conf. "
+            "Check this URL for documentation: "
+            "https://apptainer.org/docs/user/main/bind_paths_and_mounts.html. "
+            "Specify locations to disable mounts for custom Apptainer behavior."
         ),
     )
 


### PR DESCRIPTION
## Summary

This PR introduces a simple fix that ensure Docker-like behaviour in Apptainer workspaces and allows disabling system-level mounts and bind-paths defined in apptainer.conf file. Previously many of the flags (like --containall, --no-home, --clean-env, etc.) were hard-coded to ensure Docker-like behaviour which can be ensure with a single flag --compat that is now configurable via class-level configs. Also instead of hard-coded logic of disabling system-level mounts and bind-paths, the code now allows passing a list of locations which the apptainer must not mount for Docker-like behaviour.

- NOTE: All the default flags are basically ensuring maximum isolation and Docker-like behaviour.

Empirical validation: after making these changes, the apptainer workspace was used for SWE-Bench Verified evaluation with `Qwen/Qwen3-4B-Instruct-2507` and it achieves a very similar resolve rate of 15.20% as compared to the 16.80% resolve rate achieved with Docker workspace

Check [this](https://apptainer.org/docs/user/main/docker_and_oci.html#docker-like-compat-flag) link for documentation on --compat flag and [this](https://apptainer.org/docs/user/main/bind_paths_and_mounts.html#disabling-system-binds) link for documentation on system-level binds.
## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?
