### PR TITLE
Revert "fix(critic): Accept MessageEvent as valid finish signal in AgentFinishedCritic"

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/impl/agent_finished.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/agent_finished.py
@@ -2,14 +2,14 @@
 AgentFinishedCritic implementation.
 
 This critic evaluates whether an agent properly finished a task by checking:
-1. The agent finished properly (via FinishAction or final MessageEvent)
+1. The agent's last action was a FinishAction (proper completion)
 2. The generated git patch is non-empty (actual changes were made)
 """
 
 from collections.abc import Sequence
 
 from openhands.sdk.critic.base import CriticBase, CriticResult
-from openhands.sdk.event import ActionEvent, LLMConvertibleEvent, MessageEvent
+from openhands.sdk.event import ActionEvent, LLMConvertibleEvent
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool.builtins.finish import FinishAction
 
@@ -22,10 +22,7 @@ class AgentFinishedCritic(CriticBase):
     Critic that evaluates whether an agent properly finished a task.
 
     This critic checks two main criteria:
-    1. The agent finished properly - either via:
-       - A FinishAction (explicit completion), or
-       - A final MessageEvent from the agent (implicit completion when LLM
-         produces content and awaits user input)
+    1. The agent's last action was a FinishAction (proper completion)
     2. The generated git patch is non-empty (actual changes were made)
     """
 
@@ -54,10 +51,10 @@ class AgentFinishedCritic(CriticBase):
                 + "; ".join(reasons),
             )
 
-        # Check if agent properly finished
-        if not self._has_proper_finish(events):
-            reasons.append("No proper finish signal found")
-            logger.debug("AgentFinishedCritic: No proper finish signal")
+        # Check if agent properly finished with FinishAction
+        if not self._has_finish_action(events):
+            reasons.append("No FinishAction found")
+            logger.debug("AgentFinishedCritic: No FinishAction")
             return CriticResult(
                 score=0.0,
                 message="Agent did not finish properly. " + "; ".join(reasons),
@@ -66,43 +63,21 @@ class AgentFinishedCritic(CriticBase):
         logger.debug("AgentFinishedCritic: Successfully completed")
         return CriticResult(
             score=1.0,
-            message="Agent completed properly with non-empty patch",
+            message="Agent completed with FinishAction and non-empty patch",
         )
 
-    def _has_proper_finish(self, events: Sequence[LLMConvertibleEvent]) -> bool:
-        """Check if the agent finished properly.
-
-        The agent can finish in two ways:
-        1. By calling FinishAction explicitly
-        2. By sending a final MessageEvent (when LLM produces content and
-           the conversation awaits user input - this sets execution_status
-           to FINISHED in the SDK)
-
-        We check for either signal by looking at the last meaningful event
-        (skipping ConversationStateUpdateEvent which is just metadata).
-        """
+    def _has_finish_action(self, events: Sequence[LLMConvertibleEvent]) -> bool:
+        """Check if the last action was a FinishAction."""
         if not events:
             return False
 
-        # Look for the last meaningful event in the history
+        # Look for the last ActionEvent in the history
         for event in reversed(events):
-            # Check for FinishAction
             if isinstance(event, ActionEvent):
+                # Check if this is a FinishAction
                 if event.action and isinstance(event.action, FinishAction):
-                    logger.debug("AgentFinishedCritic: Found FinishAction")
                     return True
-                # If we find any other action type as the last event,
-                # the agent didn't finish properly
-                action_name = type(event.action).__name__
-                logger.debug(
-                    f"AgentFinishedCritic: Last action was {action_name}, "
-                    "not FinishAction"
-                )
+                # If we find any other action type, the agent didn't finish
                 return False
-
-            # Check for final MessageEvent from agent (implicit finish)
-            if isinstance(event, MessageEvent) and event.source == "agent":
-                logger.debug("AgentFinishedCritic: Found final MessageEvent from agent")
-                return True
 
         return False

--- a/tests/sdk/critic/test_critic.py
+++ b/tests/sdk/critic/test_critic.py
@@ -11,8 +11,8 @@ from openhands.sdk.critic import (
     EmptyPatchCritic,
     PassCritic,
 )
-from openhands.sdk.event import ActionEvent, MessageEvent
-from openhands.sdk.llm import Message, MessageToolCall, TextContent
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.llm import MessageToolCall, TextContent
 from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.sdk.tool.schema import Action
 
@@ -160,8 +160,8 @@ def test_agent_finished_critic_with_empty_patch():
     assert "empty" in result.message.lower()
 
 
-def test_agent_finished_critic_without_finish_signal():
-    """Test AgentFinishedCritic fails when no proper finish signal present."""
+def test_agent_finished_critic_without_finish_action():
+    """Test AgentFinishedCritic fails when no FinishAction present."""
     critic = AgentFinishedCritic()
 
     patch = "diff --git a/file.py"
@@ -171,7 +171,7 @@ def test_agent_finished_critic_without_finish_signal():
     assert result.score == 0.0
     assert result.success is False
 
-    # Events with only non-finish ActionEvent (no FinishAction, no MessageEvent)
+    # Events without FinishAction
     other_action = DummyAction()
     events = [
         ActionEvent(
@@ -196,7 +196,7 @@ def test_agent_finished_critic_without_finish_signal():
     assert "finish" in result.message.lower()
 
 
-def test_agent_finished_critic_success_with_finish_action():
+def test_agent_finished_critic_success():
     """Test AgentFinishedCritic succeeds with FinishAction and non-empty patch."""
     critic = AgentFinishedCritic()
 
@@ -236,53 +236,6 @@ def test_agent_finished_critic_success_with_finish_action():
                 origin="completion",
             ),
             llm_response_id="resp_finish_success",
-        ),
-    ]
-
-    result = critic.evaluate(events, patch)
-    assert result.score == 1.0
-    assert result.success is True
-
-
-def test_agent_finished_critic_success_with_message_event():
-    """Test AgentFinishedCritic succeeds with final MessageEvent and non-empty patch.
-
-    This tests the implicit finish case where the agent sends a text message
-    instead of calling FinishAction explicitly. This is valid because the SDK
-    marks the conversation as FINISHED when the LLM produces content.
-    """
-    critic = AgentFinishedCritic()
-
-    patch = """
-    diff --git a/file.py b/file.py
-    --- a/file.py
-    +++ b/file.py
-    @@ -1 +1,2 @@
-     original line
-    +new line
-    """
-
-    events = [
-        ActionEvent(
-            thought=[TextContent(text="Making changes")],
-            action=None,
-            tool_name="edit",
-            tool_call_id="edit_id",
-            tool_call=MessageToolCall(
-                id="edit_id",
-                name="edit",
-                arguments=json.dumps({}),
-                origin="completion",
-            ),
-            llm_response_id="resp_edit",
-        ),
-        # Agent finishes with a message instead of FinishAction
-        MessageEvent(
-            source="agent",
-            llm_message=Message(
-                role="assistant",
-                content=[TextContent(text="I've completed the task.")],
-            ),
         ),
     ]
 


### PR DESCRIPTION
Reverts OpenHands/software-agent-sdk#1695
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3b28ba0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3b28ba0-python \
  ghcr.io/openhands/agent-server:3b28ba0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3b28ba0-golang-amd64
ghcr.io/openhands/agent-server:3b28ba0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3b28ba0-golang-arm64
ghcr.io/openhands/agent-server:3b28ba0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3b28ba0-java-amd64
ghcr.io/openhands/agent-server:3b28ba0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3b28ba0-java-arm64
ghcr.io/openhands/agent-server:3b28ba0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3b28ba0-python-amd64
ghcr.io/openhands/agent-server:3b28ba0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3b28ba0-python-arm64
ghcr.io/openhands/agent-server:3b28ba0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3b28ba0-golang
ghcr.io/openhands/agent-server:3b28ba0-java
ghcr.io/openhands/agent-server:3b28ba0-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3b28ba0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3b28ba0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->