### PR TITLE
Add user tracking to evaluation workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -235,6 +235,7 @@ jobs:
                   NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers || '' }}
                   PUSH_TO_INDEX: ${{ github.event.inputs.push_to_index || 'false' }}
                   MAX_RETRIES: ${{ github.event.inputs.max_retries || '3' }}
+                  TRIGGERED_BY: ${{ github.actor }}
               run: |
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH)"
                   PAYLOAD=$(jq -n \
@@ -251,7 +252,8 @@ jobs:
                     --arg num_eval_workers "$NUM_EVAL_WORKERS" \
                     --arg push_to_index "$PUSH_TO_INDEX" \
                     --arg max_retries "$MAX_RETRIES" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, max_retries: $max_retries}}')
+                    --arg triggered_by "$TRIGGERED_BY" \
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, max_retries: $max_retries, triggered_by: $triggered_by}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
This PR adds tracking of which GitHub user triggered each evaluation run.

**Changes:**
- Captures `github.actor` in the run-eval workflow
- Passes the username through to the evaluation workflow as `triggered_by` parameter

This enables the evaluation workflow to display "Run by: @User Name" in Slack notifications.

**Related PR:** A corresponding PR in the evaluation repo adds the logic to fetch the user's real name from GitHub API and display it in Slack messages.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:77469dc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-77469dc-python \
  ghcr.io/openhands/agent-server:77469dc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:77469dc-golang-amd64
ghcr.io/openhands/agent-server:77469dc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:77469dc-golang-arm64
ghcr.io/openhands/agent-server:77469dc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:77469dc-java-amd64
ghcr.io/openhands/agent-server:77469dc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:77469dc-java-arm64
ghcr.io/openhands/agent-server:77469dc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:77469dc-python-amd64
ghcr.io/openhands/agent-server:77469dc-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:77469dc-python-arm64
ghcr.io/openhands/agent-server:77469dc-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:77469dc-golang
ghcr.io/openhands/agent-server:77469dc-java
ghcr.io/openhands/agent-server:77469dc-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `77469dc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `77469dc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->