### PR TITLE
fix: route qwen-3-coder through Fireworks provider

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -86,7 +86,9 @@ MODELS = {
     "qwen-3-coder": {
         "id": "qwen-3-coder",
         "display_name": "Qwen 3 Coder",
-        "llm_config": {"model": "litellm_proxy/qwen/qwen3-coder"},
+        "llm_config": {
+            "model": "litellm_proxy/fireworks_ai/qwen3-coder-480b-a35b-instruct"
+        },
     },
 }
 


### PR DESCRIPTION
## Summary

Fix benchmark evaluation failures for `qwen-3-coder` model by routing it through the Fireworks provider.

## Problem

When running benchmarks with `qwen-3-coder`, the evaluation fails with:
```
ERROR    Script failed: No valid entries   eval_infer.py:280
                             were converted
```

The model was configured to use `litellm_proxy/qwen/qwen3-coder` which was not properly served.

## Solution

Changed the model endpoint from `litellm_proxy/qwen/qwen3-coder` to `fireworks/qwen3-coder-480b-a35b-instruct` which is the correct Fireworks provider endpoint for this model.

## Changes

- Updated `qwen-3-coder` model config in `.github/run-eval/resolve_model_config.py`

## Testing

- All relevant tests pass:
  - `test_all_expected_models_present`
  - `test_expected_models_have_required_fields`
  - `test_expected_models_id_matches_key`
  - `test_find_all_expected_models`
- Pre-commit checks pass

Fixes https://github.com/OpenHands/software-agent-sdk/issues/1702

@neubig can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/None)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a8426f1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a8426f1-python \
  ghcr.io/openhands/agent-server:a8426f1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a8426f1-golang-amd64
ghcr.io/openhands/agent-server:a8426f1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a8426f1-golang-arm64
ghcr.io/openhands/agent-server:a8426f1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a8426f1-java-amd64
ghcr.io/openhands/agent-server:a8426f1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a8426f1-java-arm64
ghcr.io/openhands/agent-server:a8426f1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a8426f1-python-amd64
ghcr.io/openhands/agent-server:a8426f1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a8426f1-python-arm64
ghcr.io/openhands/agent-server:a8426f1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a8426f1-golang
ghcr.io/openhands/agent-server:a8426f1-java
ghcr.io/openhands/agent-server:a8426f1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a8426f1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a8426f1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->