### PR TITLE
fix: handle apt repository metadata changes in Dockerfile

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -58,7 +58,7 @@ ARG USERNAME UID GID PORT
 # Install base packages and create user
 RUN set -eux; \
     # Install base packages (works for both Debian-based images)
-    apt-get update; \
+    apt-get update --allow-releaseinfo-change; \
     apt-get install -y --no-install-recommends \
         ca-certificates curl wget sudo apt-utils git jq tmux build-essential \
         coreutils util-linux procps findutils grep sed \


### PR DESCRIPTION
## Problem

When building agent-server images on top of base images with outdated apt repository configurations, builds fail with:

```
E: Repository 'https://repos.azul.com/zulu/deb stable InRelease' changed its 'Origin' value from 'Azul Systems' to 'Azul Systems, Inc.'
E: Repository 'https://repos.azul.com/zulu/deb stable InRelease' changed its 'Label' value from '. stable' to 'Azul Systems, Inc., Ubuntu Repository'
```

This is currently **blocking Multi-SWE-Bench evaluation builds**, where base images like `mswebench/alibaba_m_fastjson2:base` have repository metadata that has changed since the image was created.

## Root Cause

Upstream repositories sometimes update their metadata (Origin, Label, Suite, Codename, etc.). When `apt-get update` encounters these changes, it exits with error code 100 by default as a security precaution.

The Azul Zulu Java repository recently changed its metadata, affecting Multi-SWE-Bench base images that have this repository configured.

## Solution

Add `--allow-releaseinfo-change` flag to `apt-get update` in the Dockerfile:

```diff
-    apt-get update; \
+    apt-get update --allow-releaseinfo-change; \
```

This is the **recommended approach** for handling repository metadata changes in automated builds. It allows apt to proceed when only metadata has changed, which is safe for our use case.

## Impact

- ✅ Fixes Multi-SWE-Bench evaluation image builds
- ✅ Defensive practice that prevents future issues with other base images
- ✅ No breaking changes - this only makes builds more resilient
- ✅ Follows Debian/Ubuntu best practices for CI/CD environments

## Testing

- [ ] Test Multi-SWE-Bench evaluation run with `eval_limit=1`
- [ ] Verify image builds successfully
- [ ] Confirm evaluation proceeds to run_infer step

## Related Issues

Part of Multi-SWE-Bench evaluation support implementation.

---

**Note**: This PR is marked as draft while we test the fix. Will mark as ready for review once confirmed working.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:41afcd2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-41afcd2-python \
  ghcr.io/openhands/agent-server:41afcd2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:41afcd2-golang-amd64
ghcr.io/openhands/agent-server:41afcd2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:41afcd2-golang-arm64
ghcr.io/openhands/agent-server:41afcd2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:41afcd2-java-amd64
ghcr.io/openhands/agent-server:41afcd2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:41afcd2-java-arm64
ghcr.io/openhands/agent-server:41afcd2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:41afcd2-python-amd64
ghcr.io/openhands/agent-server:41afcd2-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:41afcd2-python-arm64
ghcr.io/openhands/agent-server:41afcd2-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:41afcd2-golang
ghcr.io/openhands/agent-server:41afcd2-java
ghcr.io/openhands/agent-server:41afcd2-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `41afcd2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `41afcd2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->