### PR TITLE
Add GPT-5.2 high reasoning to model configurations

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -73,6 +73,14 @@ MODELS = {
         "display_name": "GPT-5.2",
         "llm_config": {"model": "litellm_proxy/openai/gpt-5.2-2025-12-11"},
     },
+    "gpt-5.2-high-reasoning": {
+        "id": "gpt-5.2-high-reasoning",
+        "display_name": "GPT-5.2 High Reasoning",
+        "llm_config": {
+            "model": "litellm_proxy/openai/gpt-5.2-2025-12-11",
+            "reasoning_effort": "high",
+        },
+    },
     "minimax-m2": {
         "id": "minimax-m2",
         "display_name": "MiniMax M2",

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -128,6 +128,7 @@ EXPECTED_MODELS = [
     "gemini-3-pro",
     "gemini-3-flash",
     "gpt-5.2",
+    "gpt-5.2-high-reasoning",
     "kimi-k2-thinking",
     "minimax-m2",
     "deepseek-v3.2-reasoner",
@@ -169,3 +170,13 @@ def test_find_all_expected_models():
     assert len(result) == len(EXPECTED_MODELS)
     for i, model_id in enumerate(EXPECTED_MODELS):
         assert result[i]["id"] == model_id
+
+
+def test_gpt_5_2_high_reasoning_config():
+    """Test that gpt-5.2-high-reasoning has correct configuration."""
+    model = MODELS["gpt-5.2-high-reasoning"]
+
+    assert model["id"] == "gpt-5.2-high-reasoning"
+    assert model["display_name"] == "GPT-5.2 High Reasoning"
+    assert model["llm_config"]["model"] == "litellm_proxy/openai/gpt-5.2-2025-12-11"
+    assert model["llm_config"]["reasoning_effort"] == "high"


### PR DESCRIPTION
## Summary

This PR adds `gpt-5.2-high-reasoning` to the model configurations dictionary in `.github/run-eval/resolve_model_config.py`. This is GPT-5.2 configured with `reasoning_effort="high"` for enhanced reasoning capabilities.

The configuration uses:
- Model: `litellm_proxy/openai/gpt-5.2-2025-12-11`
- Reasoning effort: `high`

According to [LiteLLM documentation](https://docs.litellm.ai/docs/providers/openai), GPT-5.2 supports reasoning effort values: `none`, `low`, `medium`, `high`, `xhigh`. The `high` setting provides deeper reasoning before producing responses.

## Testing

I verified the configuration works:

1. **Direct litellm query** with `reasoning_effort="high"` via OpenHands proxy:
   ```python
   response = litellm.completion(
       model="litellm_proxy/gpt-5.2",
       messages=[{"role": "user", "content": "What is 2+2?"}],
       api_key=api_key,
       base_url="https://llm-proxy.app.all-hands.dev/",
       reasoning_effort="high",
   )
   # Response: Four ✅
   ```

2. **SDK example** with `openhands/gpt-5.2` and `reasoning_effort="high"`:
   ```python
   llm = LLM(
       model="openhands/gpt-5.2",
       api_key=api_key,
       reasoning_effort="high",
   )
   response = llm.completion(messages=[Message(role="user", content="What is 2+2?")])
   # Response: Four ✅
   ```

3. **Full SDK agent example** ran successfully with cost tracking.

Fixes #1698

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?