### PR TITLE
Fix event ordering in RemoteEventsList by inserting events sorted by timestamp

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -228,11 +228,12 @@ class RemoteEventsList(EventsListBase):
         with self._lock:
             # Check if event already exists to avoid duplicates
             if event.id not in self._cached_event_ids:
-                # Use bisect to insert in sorted order by timestamp
+                # Use bisect with key function for O(log N) insertion
                 # This ensures events are always ordered correctly even if
                 # WebSocket delivers them out of order
-                timestamps = [e.timestamp for e in self._cached_events]
-                insert_pos = bisect.bisect_right(timestamps, event.timestamp)
+                insert_pos = bisect.bisect_right(
+                    self._cached_events, event.timestamp, key=lambda e: e.timestamp
+                )
                 self._cached_events.insert(insert_pos, event)
                 self._cached_event_ids.add(event.id)
                 logger.debug(

--- a/tests/sdk/conversation/remote/test_remote_events_list.py
+++ b/tests/sdk/conversation/remote/test_remote_events_list.py
@@ -261,3 +261,47 @@ def test_remote_events_list_timestamp_order_with_existing_events(
     assert events_list[0].id == "initial-1"
     assert events_list[1].id == "middle"
     assert events_list[2].id == "initial-2"
+
+
+def test_remote_events_list_identical_timestamps_stable_order(
+    mock_client, conversation_id
+):
+    """Test that events with identical timestamps maintain insertion order."""
+    mock_response = create_mock_api_response([])
+    mock_client.request.return_value = mock_response
+
+    events_list = RemoteEventsList(mock_client, conversation_id)
+
+    # Create events with identical timestamps
+    same_timestamp = "2024-01-01T10:00:00"
+    event1 = MessageEvent(
+        id="event-1",
+        timestamp=same_timestamp,
+        source="user",
+        llm_message=Message(role="user", content=[TextContent(text="First")]),
+    )
+    event2 = MessageEvent(
+        id="event-2",
+        timestamp=same_timestamp,
+        source="agent",
+        llm_message=Message(role="assistant", content=[TextContent(text="Second")]),
+    )
+    event3 = MessageEvent(
+        id="event-3",
+        timestamp=same_timestamp,
+        source="agent",
+        llm_message=Message(role="assistant", content=[TextContent(text="Third")]),
+    )
+
+    # Add events in order
+    events_list.add_event(event1)
+    events_list.add_event(event2)
+    events_list.add_event(event3)
+
+    # Events with identical timestamps should maintain insertion order.
+    # bisect_right ensures new events are inserted after existing ones
+    # with the same timestamp.
+    assert len(events_list) == 3
+    assert events_list[0].id == "event-1"
+    assert events_list[1].id == "event-2"
+    assert events_list[2].id == "event-3"


### PR DESCRIPTION
## Problem

When using `RemoteConversation`, events delivered via WebSocket could arrive out of order due to network non-determinism. This caused issues where an `ActionEvent` could appear in the local event cache before its corresponding `MessageEvent`, even though the `MessageEvent` was created first on the server.

Users reported that when polling `conversation.state.events`, the `MessageEvent` was sometimes missing or appeared after the `ActionEvent`, despite `send_message()` being called before `run()`.

## Root Cause

The `RemoteEventsList.add_event()` method was simply appending events to the list in the order they arrived via WebSocket, without considering their timestamps. Since WebSocket delivery is asynchronous and non-deterministic, events could be added to the local cache in the wrong order.

## Solution

This fix modifies `add_event()` to use `bisect.bisect_right()` to insert events in sorted order by timestamp. This ensures the local cache always reflects the correct temporal ordering regardless of WebSocket delivery order.

### Key Changes

- Import `bisect` module in `remote_conversation.py`
- Modified `RemoteEventsList.add_event()` to insert events in sorted position by timestamp
- Added two new tests to verify timestamp-based ordering

## Why This Approach?

This solution was chosen over the previous approach (PR #1736) because:

1. **No breaking API changes** - The REST API and method signatures remain unchanged
2. **Client-side only fix** - No server modifications required
3. **Simple and efficient** - Uses Python's built-in `bisect` for O(log n) insertion position lookup
4. **Maintains backward compatibility** - Existing clients continue to work without changes

## Testing

Added two new tests:
- `test_remote_events_list_maintains_timestamp_order` - Verifies events added out of order are sorted correctly
- `test_remote_events_list_timestamp_order_with_existing_events` - Verifies new events are inserted in correct position among existing events

All 58 remote conversation tests pass.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/83ec21979aa1476d8d333183f654eac1)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2373a1c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2373a1c-python \
  ghcr.io/openhands/agent-server:2373a1c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2373a1c-golang-amd64
ghcr.io/openhands/agent-server:2373a1c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2373a1c-golang-arm64
ghcr.io/openhands/agent-server:2373a1c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2373a1c-java-amd64
ghcr.io/openhands/agent-server:2373a1c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2373a1c-java-arm64
ghcr.io/openhands/agent-server:2373a1c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2373a1c-python-amd64
ghcr.io/openhands/agent-server:2373a1c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2373a1c-python-arm64
ghcr.io/openhands/agent-server:2373a1c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2373a1c-golang
ghcr.io/openhands/agent-server:2373a1c-java
ghcr.io/openhands/agent-server:2373a1c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2373a1c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2373a1c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->