### PR TITLE
Add is_optional parameter to load_public_skills

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/utils.py
+++ b/openhands-sdk/openhands/sdk/context/skills/utils.py
@@ -312,6 +312,7 @@ def update_skills_repository(
     repo_url: str,
     branch: str,
     cache_dir: Path,
+    is_optional: bool = False,
 ) -> Path | None:
     """Clone or update the local skills repository.
 
@@ -322,12 +323,16 @@ def update_skills_repository(
         repo_url: URL of the skills repository.
         branch: Branch name to checkout and track.
         cache_dir: Directory where the repository should be cached.
+        is_optional: If True, logs at debug level on failure instead of warning.
+            Use for optional repositories where failure is expected and acceptable.
 
     Returns:
         Path to the local repository if successful, None otherwise.
     """
     repo_path = cache_dir / "public-skills"
-    return try_cached_clone_or_update(repo_url, repo_path, ref=branch, update=True)
+    return try_cached_clone_or_update(
+        repo_url, repo_path, ref=branch, update=True, is_optional=is_optional
+    )
 
 
 def discover_skill_resources(skill_dir: Path) -> SkillResources:


### PR DESCRIPTION
## Summary

Add `is_optional` parameter that propagates through the entire call chain to control log level when git operations fail for optional repositories.

## Changes

### `openhands-sdk/openhands/sdk/git/cached_repo.py`
- Added `is_optional: bool = False` parameter to `try_cached_clone_or_update()`
- When `is_optional=True`, logs at DEBUG level instead of WARNING on:
  - Lock timeout
  - Git command errors
  - General exceptions

### `openhands-sdk/openhands/sdk/context/skills/utils.py`
- Added `is_optional: bool = False` parameter to `update_skills_repository()`
- Passes through to `try_cached_clone_or_update()`

### `openhands-sdk/openhands/sdk/context/skills/skill.py`
- Added `is_optional: bool = True` parameter to `load_public_skills()`
- Passes through to `update_skills_repository()`
- Also uses `is_optional` for local logging in the function

## Motivation

This reduces noise in logs when:
- The public skills repository is temporarily unavailable
- Running in environments without network access
- Git operations fail for optional features

Since public skills are optional by default, `load_public_skills()` defaults to `is_optional=True`. The lower-level functions default to `False` for backward compatibility.

## Related Issue

Related to: https://github.com/All-Hands-AI/infra/issues/793

This follows the same pattern used in the main OpenHands repository where `is_optional` is used to control log levels for optional repository access.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c9c5413-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c9c5413-python \
  ghcr.io/openhands/agent-server:c9c5413-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c9c5413-golang-amd64
ghcr.io/openhands/agent-server:c9c5413-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c9c5413-golang-arm64
ghcr.io/openhands/agent-server:c9c5413-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c9c5413-java-amd64
ghcr.io/openhands/agent-server:c9c5413-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c9c5413-java-arm64
ghcr.io/openhands/agent-server:c9c5413-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c9c5413-python-amd64
ghcr.io/openhands/agent-server:c9c5413-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c9c5413-python-arm64
ghcr.io/openhands/agent-server:c9c5413-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c9c5413-golang
ghcr.io/openhands/agent-server:c9c5413-java
ghcr.io/openhands/agent-server:c9c5413-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c9c5413-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c9c5413-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->