### PR TITLE
Remove gpt-mini model from model lists

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -24,14 +24,6 @@ MODELS = {
             "temperature": 0.0,
         },
     },
-    "gpt-5-mini-2025-08-07": {
-        "id": "gpt-5-mini-2025-08-07",
-        "display_name": "GPT-5 Mini",
-        "llm_config": {
-            "model": "litellm_proxy/gpt-5-mini-2025-08-07",
-            "temperature": 1.0,
-        },
-    },
     "kimi-k2-thinking": {
         "id": "kimi-k2-thinking",
         "display_name": "Kimi K2 Thinking",

--- a/examples/01_standalone_sdk/23_responses_reasoning.py
+++ b/examples/01_standalone_sdk/23_responses_reasoning.py
@@ -26,7 +26,7 @@ logger = get_logger(__name__)
 api_key = os.getenv("LLM_API_KEY") or os.getenv("OPENAI_API_KEY")
 assert api_key, "Set LLM_API_KEY or OPENAI_API_KEY in your environment."
 
-model = "openhands/gpt-5-mini-2025-08-07"  # Use a model that supports Responses API
+model = "openhands/gpt-5.2"  # Use a model that supports Responses API
 base_url = os.getenv("LLM_BASE_URL")
 
 llm = LLM(

--- a/examples/02_remote_agent_server/01_convo_with_local_agent_server.py
+++ b/examples/02_remote_agent_server/01_convo_with_local_agent_server.py
@@ -132,7 +132,7 @@ llm = LLM(
 )
 title_gen_llm = LLM(
     usage_id="title-gen-llm",
-    model=os.getenv("LLM_MODEL", "openhands/gpt-5-mini-2025-08-07"),
+    model=os.getenv("LLM_MODEL", "openhands/gpt-5.2"),
     base_url=os.getenv("LLM_BASE_URL"),
     api_key=SecretStr(api_key),
 )

--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -6,7 +6,6 @@ VERIFIED_OPENAI_MODELS = [
     "gpt-5.1-codex-mini",
     "gpt-5-codex",
     "gpt-5-2025-08-07",
-    "gpt-5-mini-2025-08-07",
     "o4-mini",
     "gpt-4o",
     "gpt-4o-mini",

--- a/tests/sdk/agent/test_agent_step_responses_gating.py
+++ b/tests/sdk/agent/test_agent_step_responses_gating.py
@@ -112,7 +112,7 @@ class ModelGateLLM(LLM):
 @pytest.mark.parametrize(
     "model, expected",
     [
-        ("gpt-5-mini-2025-08-07", "responses"),  # Responses-capable per model_features
+        ("gpt-5.2", "responses"),  # Responses-capable per model_features
         ("gpt-4o-mini", "completion"),  # Completion path
     ],
 )

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -45,7 +45,7 @@ def test_opus_4_5_uses_reasoning_effort_and_strips_temp_top_p():
 
 def test_gpt5_uses_reasoning_effort_and_strips_temp_top_p():
     llm = DummyLLM(
-        model="gpt-5-mini-2025-08-07",
+        model="gpt-5.2",
         temperature=0.5,
         top_p=0.8,
         reasoning_effort="high",


### PR DESCRIPTION
## Summary

Removes gpt-5-mini-2025-08-07 from the model lists as requested in #1747.

This follows the same pattern as #1734 which removed other unsupported models.

Changes:
- Removed `gpt-5-mini-2025-08-07` from `.github/run-eval/resolve_model_config.py` MODELS dictionary
- Removed `gpt-5-mini-2025-08-07` from `openhands-sdk/openhands/sdk/llm/utils/verified_models.py` VERIFIED_OPENAI_MODELS list
- Updated example files to use `gpt-5.2` instead of `gpt-5-mini-2025-08-07`
- Updated test files to use `gpt-5.2` instead of `gpt-5-mini-2025-08-07`

Fixes #1747

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9380b444fccd4bf1be6386a4f68ab9a8)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cdc1ba3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cdc1ba3-python \
  ghcr.io/openhands/agent-server:cdc1ba3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cdc1ba3-golang-amd64
ghcr.io/openhands/agent-server:cdc1ba3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cdc1ba3-golang-arm64
ghcr.io/openhands/agent-server:cdc1ba3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cdc1ba3-java-amd64
ghcr.io/openhands/agent-server:cdc1ba3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cdc1ba3-java-arm64
ghcr.io/openhands/agent-server:cdc1ba3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cdc1ba3-python-amd64
ghcr.io/openhands/agent-server:cdc1ba3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:cdc1ba3-python-arm64
ghcr.io/openhands/agent-server:cdc1ba3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:cdc1ba3-golang
ghcr.io/openhands/agent-server:cdc1ba3-java
ghcr.io/openhands/agent-server:cdc1ba3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cdc1ba3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cdc1ba3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->