### PR TITLE
Remove push_to_index option from run-eval.yml workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -70,11 +70,6 @@ on:
                 required: false
                 default: ''
                 type: string
-            push_to_index:
-                description: 'Push results to openhands-index-results (default: false)'
-                required: false
-                default: 'false'
-                type: string
             enable_conversation_event_logging:
                 description: 'Enable Datadog persistence for conversation events (default: false)'
                 required: false
@@ -240,7 +235,6 @@ jobs:
                   INSTANCE_IDS: ${{ github.event.inputs.instance_ids || '' }}
                   NUM_INFER_WORKERS: ${{ github.event.inputs.num_infer_workers || '' }}
                   NUM_EVAL_WORKERS: ${{ github.event.inputs.num_eval_workers || '' }}
-                  PUSH_TO_INDEX: ${{ github.event.inputs.push_to_index || 'false' }}
                   ENABLE_CONVERSATION_EVENT_LOGGING: ${{ github.event.inputs.enable_conversation_event_logging || false }}
                   MAX_RETRIES: ${{ github.event.inputs.max_retries || '3' }}
                   TRIGGERED_BY: ${{ github.actor }}
@@ -258,11 +252,10 @@ jobs:
                     --arg instance_ids "$INSTANCE_IDS" \
                     --arg num_infer_workers "$NUM_INFER_WORKERS" \
                     --arg num_eval_workers "$NUM_EVAL_WORKERS" \
-                    --arg push_to_index "$PUSH_TO_INDEX" \
                     --argjson enable_conversation_event_logging "$ENABLE_CONVERSATION_EVENT_LOGGING" \
                     --arg max_retries "$MAX_RETRIES" \
                     --arg triggered_by "$TRIGGERED_BY" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, push_to_index: $push_to_index, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries, triggered_by: $triggered_by}}')
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries, triggered_by: $triggered_by}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

Remove the `push_to_index` option from the `run-eval.yml` workflow as it is being removed from downstream actions.

Fixes #1749

## Changes

- Removed the `push_to_index` input parameter definition from workflow_dispatch inputs
- Removed the `PUSH_TO_INDEX` environment variable from the dispatch evaluation workflow step
- Removed the `push_to_index` argument from the jq command that builds the payload
- Removed the `push_to_index` field from the JSON payload sent to the evaluation workflow

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - N/A - This is a configuration file change, no tests needed
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - No examples affected
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A - No instructions affected
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - No documentation needed
- [x] Is the github CI passing?
  - Pre-commit hooks passed locally

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b0ed87d393dc49ffb816128f60ad574c)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2741856-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2741856-python \
  ghcr.io/openhands/agent-server:2741856-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2741856-golang-amd64
ghcr.io/openhands/agent-server:2741856-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2741856-golang-arm64
ghcr.io/openhands/agent-server:2741856-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2741856-java-amd64
ghcr.io/openhands/agent-server:2741856-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2741856-java-arm64
ghcr.io/openhands/agent-server:2741856-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2741856-python-amd64
ghcr.io/openhands/agent-server:2741856-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2741856-python-arm64
ghcr.io/openhands/agent-server:2741856-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2741856-golang
ghcr.io/openhands/agent-server:2741856-java
ghcr.io/openhands/agent-server:2741856-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2741856-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2741856-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->