### PR TITLE
Add GitHub repository URLs to PyPI package metadata

### DIFF
--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 [project.urls]
 Source = "https://github.com/OpenHands/software-agent-sdk"
 Homepage = "https://github.com/OpenHands/software-agent-sdk"
-Documentation = "https://github.com/OpenHands/software-agent-sdk#readme"
+Documentation = "https://docs.openhands.dev/sdk"
 "Bug Tracker" = "https://github.com/OpenHands/software-agent-sdk/issues"
 
 [build-system]

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 [project.urls]
 Source = "https://github.com/OpenHands/software-agent-sdk"
 Homepage = "https://github.com/OpenHands/software-agent-sdk"
-Documentation = "https://github.com/OpenHands/software-agent-sdk#readme"
+Documentation = "https://docs.openhands.dev/sdk"
 "Bug Tracker" = "https://github.com/OpenHands/software-agent-sdk/issues"
 
 [project.optional-dependencies]

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
 [project.urls]
 Source = "https://github.com/OpenHands/software-agent-sdk"
 Homepage = "https://github.com/OpenHands/software-agent-sdk"
-Documentation = "https://github.com/OpenHands/software-agent-sdk#readme"
+Documentation = "https://docs.openhands.dev/sdk"
 "Bug Tracker" = "https://github.com/OpenHands/software-agent-sdk/issues"
 
 [build-system]

--- a/openhands-workspace/pyproject.toml
+++ b/openhands-workspace/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
 [project.urls]
 Source = "https://github.com/OpenHands/software-agent-sdk"
 Homepage = "https://github.com/OpenHands/software-agent-sdk"
-Documentation = "https://github.com/OpenHands/software-agent-sdk#readme"
+Documentation = "https://docs.openhands.dev/sdk"
 "Bug Tracker" = "https://github.com/OpenHands/software-agent-sdk/issues"
 
 [build-system]


### PR DESCRIPTION
## Summary

This PR adds GitHub repository metadata to all four PyPI packages (`openhands-sdk`, `openhands-tools`, `openhands-workspace`, `openhands-agent-server`) to enable GitHub's dependency graph to properly index dependents.

### Changes
- Added `[project.urls]` section to each package's `pyproject.toml`
- Includes Source, Homepage, Documentation, and Bug Tracker URLs pointing to this repository
- No version bump or functional changes

### Why This Matters
GitHub currently shows "We haven't found any dependents for this repository yet" because the PyPI packages lack explicit metadata linking them to this GitHub repository. Once these changes are published to PyPI (in the next release), GitHub will be able to:
- Automatically index projects that depend on these packages
- Display the dependency graph correctly
- Show dependents at `https://github.com/OpenHands/software-agent-sdk/network/dependents`

### Next Steps After Merge
The changes will take effect after:
1. Publishing new package versions to PyPI with this metadata
2. Waiting 24-48 hours for GitHub's indexer to process the updated metadata

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this? - N/A (metadata only)
- [x] If there is an example, have you run the example to make sure that it works? - N/A
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? - N/A
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? - N/A (metadata only)
- [ ] Is the github CI passing? - Pending

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6320022-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6320022-python \
  ghcr.io/openhands/agent-server:6320022-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6320022-golang-amd64
ghcr.io/openhands/agent-server:6320022-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6320022-golang-arm64
ghcr.io/openhands/agent-server:6320022-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6320022-java-amd64
ghcr.io/openhands/agent-server:6320022-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6320022-java-arm64
ghcr.io/openhands/agent-server:6320022-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6320022-python-amd64
ghcr.io/openhands/agent-server:6320022-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6320022-python-arm64
ghcr.io/openhands/agent-server:6320022-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6320022-golang
ghcr.io/openhands/agent-server:6320022-java
ghcr.io/openhands/agent-server:6320022-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6320022-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6320022-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->