### PR TITLE
docs: rewrite CONTRIBUTING around SDK architecture

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ You may find that occasionally we are opinionated about several things:
 - **Avoid hidden assumptions**: don’t rely on particular env vars, workspace layouts, request
   contexts, or runtime quirks that only exist in one app.
   - Workspaces *do* encode environment specifics (local/Docker/remote), but keep those assumptions
-    explicit (params + validation) and contained to the `workspace` / `agent-server` layers.
+    explicit (params + validation) and contained to the `workspace` layer.
 - **No client-specific code paths**: avoid logic that only makes sense for one
   downstream app.
   - It’s fine to have multiple workspace implementations; it’s not fine for SDK core behavior to
@@ -54,7 +54,7 @@ You may find that occasionally we are opinionated about several things:
 - **Keep the agent loop stable**: treat stability as a feature; be cautious with control-flow
   changes and "small" behavior tweaks.
 - **Compatibility is part of the API**: if something could break downstream clients, call it
-  out explicitly and consider a migration path.
+  out explicitly and consider a migration path. We have a deprecation mechanism you may want to use.
 
 If you’re not sure whether a change crosses these lines, please ask early. We’re happy to help think
 through the shape of a clean interface.


### PR DESCRIPTION
Rewrites CONTRIBUTING.md to focus on the architectural lesson (SDK-first, avoid downstream coupling), while clarifying SDK (Python interface) vs agent-server (REST/WS interface).

If you'd like the tone to be closer to the previous style, I can iterate in follow-up commits.










<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7943581-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7943581-python \
  ghcr.io/openhands/agent-server:7943581-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7943581-golang-amd64
ghcr.io/openhands/agent-server:7943581-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7943581-golang-arm64
ghcr.io/openhands/agent-server:7943581-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7943581-java-amd64
ghcr.io/openhands/agent-server:7943581-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7943581-java-arm64
ghcr.io/openhands/agent-server:7943581-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7943581-python-amd64
ghcr.io/openhands/agent-server:7943581-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:7943581-python-arm64
ghcr.io/openhands/agent-server:7943581-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:7943581-golang
ghcr.io/openhands/agent-server:7943581-java
ghcr.io/openhands/agent-server:7943581-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7943581-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7943581-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->