### PR TITLE
Hide pyinstaller vendored libraries from subprocesses

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -16,6 +16,7 @@ from openhands.agent_server.models import (
 )
 from openhands.agent_server.pub_sub import PubSub, Subscriber
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 
 
 logger = get_logger(__name__)
@@ -194,6 +195,7 @@ class BashEventService:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 shell=True,
+                env=sanitized_env(),
             )
 
             # Track output order and buffers

--- a/openhands-agent-server/openhands/agent_server/desktop_service.py
+++ b/openhands-agent-server/openhands/agent_server/desktop_service.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 from openhands.agent_server.config import get_default_config
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 
 
 logger = get_logger(__name__)
@@ -28,7 +29,7 @@ class DesktopService:
             return True
 
         # --- Env defaults (match bash behavior) ---
-        env = os.environ.copy()
+        env = sanitized_env()
         display = env.get("DISPLAY", ":1")
         user = env.get("USER") or env.get("USERNAME") or "openhands"
         home = Path(env.get("HOME") or f"/home/{user}")
@@ -68,6 +69,7 @@ class DesktopService:
                     capture_output=True,
                     text=True,
                     timeout=3,
+                    env=env,
                 ).returncode
                 == 0
             )
@@ -105,6 +107,7 @@ class DesktopService:
                     capture_output=True,
                     text=True,
                     timeout=3,
+                    env=env,
                 ).returncode
                 == 0
             )
@@ -180,7 +183,11 @@ class DesktopService:
         # Check if VNC server is running
         try:
             result = subprocess.run(
-                ["pgrep", "-f", "Xvnc"], capture_output=True, text=True, timeout=3
+                ["pgrep", "-f", "Xvnc"],
+                capture_output=True,
+                text=True,
+                timeout=3,
+                env=sanitized_env(),
             )
             return result.returncode == 0
         except Exception:

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -14,7 +14,6 @@ Precedence (later overrides earlier):
 sandbox < public < user < org < project
 """
 
-import os
 import shutil
 import subprocess
 import tempfile
@@ -37,6 +36,7 @@ from openhands.sdk.context.skills.utils import (
     update_skills_repository,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 
 
 logger = get_logger(__name__)
@@ -120,6 +120,8 @@ def load_org_skills_from_url(
         # Clone the organization repository (shallow clone for efficiency)
         logger.info(f"Cloning organization skills repository for {org_name}")
         try:
+            env = sanitized_env()
+            env["GIT_TERMINAL_PROMPT"] = "0"
             subprocess.run(
                 [
                     "git",
@@ -132,7 +134,7 @@ def load_org_skills_from_url(
                 check=True,
                 capture_output=True,
                 timeout=120,
-                env={**os.environ, "GIT_TERMINAL_PROMPT": "0"},
+                env=env,
             )
         except subprocess.CalledProcessError:
             # Repository doesn't exist or access denied - this is expected.

--- a/openhands-agent-server/openhands/agent_server/vscode_service.py
+++ b/openhands-agent-server/openhands/agent_server/vscode_service.py
@@ -5,6 +5,7 @@ import os
 from pathlib import Path
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 
 
 logger = get_logger(__name__)
@@ -160,6 +161,7 @@ class VSCodeService:
             cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.STDOUT,
+            env=sanitized_env(),
         )
 
         # Wait for server to start (look for startup message)

--- a/openhands-sdk/openhands/sdk/hooks/executor.py
+++ b/openhands-sdk/openhands/sdk/hooks/executor.py
@@ -8,6 +8,7 @@ from pydantic import BaseModel
 
 from openhands.sdk.hooks.config import HookDefinition
 from openhands.sdk.hooks.types import HookDecision, HookEvent
+from openhands.sdk.utils import sanitized_env
 
 
 class HookResult(BaseModel):
@@ -50,7 +51,7 @@ class HookExecutor:
     ) -> HookResult:
         """Execute a single hook."""
         # Prepare environment
-        hook_env = os.environ.copy()
+        hook_env = sanitized_env()
         hook_env["OPENHANDS_PROJECT_DIR"] = self.working_dir
         hook_env["OPENHANDS_SESSION_ID"] = event.session_id or ""
         hook_env["OPENHANDS_EVENT_TYPE"] = event.event_type

--- a/openhands-sdk/openhands/sdk/utils/__init__.py
+++ b/openhands-sdk/openhands/sdk/utils/__init__.py
@@ -1,5 +1,6 @@
 """Utility functions for the OpenHands SDK."""
 
+from .command import sanitized_env
 from .deprecation import (
     deprecated,
     warn_deprecated,
@@ -19,4 +20,5 @@ __all__ = [
     "deprecated",
     "warn_deprecated",
     "sanitize_openhands_mentions",
+    "sanitized_env",
 ]

--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
 
 from openhands.sdk.logger import DEBUG, get_logger
 from openhands.sdk.tool import ToolExecutor
+from openhands.sdk.utils import sanitized_env
 from openhands.sdk.utils.async_executor import AsyncExecutor
 from openhands.tools.browser_use.definition import BrowserAction, BrowserObservation
 from openhands.tools.browser_use.server import CustomBrowserUseServer
@@ -43,6 +44,7 @@ def _install_chromium() -> bool:
             capture_output=True,
             text=True,
             timeout=300,  # 5 minutes timeout for installation
+            env=sanitized_env(),
         )
 
         if result.returncode == 0:

--- a/openhands-tools/openhands/tools/file_editor/utils/shell.py
+++ b/openhands-tools/openhands/tools/file_editor/utils/shell.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import time
 
+from openhands.sdk.utils import sanitized_env
 from openhands.sdk.utils.truncate import maybe_truncate
 from openhands.tools.file_editor.utils.constants import (
     CONTENT_TRUNCATED_NOTICE,
@@ -32,7 +33,12 @@ def run_shell_cmd(
     process: subprocess.Popen[str] | None = None
     try:
         process = subprocess.Popen(
-            cmd, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+            cmd,
+            shell=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=sanitized_env(),
         )
 
         stdout, stderr = process.communicate(timeout=timeout)
@@ -65,6 +71,7 @@ def check_tool_installed(tool_name: str) -> bool:
             check=True,
             cwd=os.getcwd(),
             capture_output=True,
+            env=sanitized_env(),
         )
         return True
     except (subprocess.CalledProcessError, FileNotFoundError):

--- a/openhands-tools/openhands/tools/glob/impl.py
+++ b/openhands-tools/openhands/tools/glob/impl.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from openhands.sdk.tool import ToolExecutor
+from openhands.sdk.utils import sanitized_env
 
 
 if TYPE_CHECKING:
@@ -149,7 +150,12 @@ class GlobExecutor(ToolExecutor[GlobAction, GlobObservation]):
 
         # Execute ripgrep
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30, check=False
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=sanitized_env(),
         )
 
         # Parse output into file paths

--- a/openhands-tools/openhands/tools/grep/impl.py
+++ b/openhands-tools/openhands/tools/grep/impl.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 
 from openhands.sdk.tool import ToolExecutor
+from openhands.sdk.utils import sanitized_env
 
 
 if TYPE_CHECKING:
@@ -154,7 +155,12 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
 
         # Execute ripgrep
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30, check=False
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=sanitized_env(),
         )
 
         # Parse output into file paths
@@ -209,7 +215,12 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
 
         # Execute grep
         result = subprocess.run(
-            cmd, capture_output=True, text=True, timeout=30, check=False
+            cmd,
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+            env=sanitized_env(),
         )
 
         # Parse output into file paths

--- a/openhands-tools/openhands/tools/terminal/terminal/factory.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/factory.py
@@ -5,6 +5,7 @@ import subprocess
 from typing import Literal
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.terminal.terminal_session import TerminalSession
 
 
@@ -19,6 +20,7 @@ def _is_tmux_available() -> bool:
             capture_output=True,
             text=True,
             timeout=5.0,
+            env=sanitized_env(),
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):
@@ -40,6 +42,7 @@ def _is_powershell_available() -> bool:
             capture_output=True,
             text=True,
             timeout=5.0,
+            env=sanitized_env(),
         )
         return result.returncode == 0
     except (subprocess.TimeoutExpired, FileNotFoundError):

--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -13,6 +13,7 @@ import time
 from collections import deque
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.constants import (
     CMD_OUTPUT_PS1_BEGIN,
     CMD_OUTPUT_PS1_END,
@@ -106,7 +107,7 @@ class SubprocessTerminal(TerminalInterface):
         logger.info(f"Using shell: {resolved_shell_path}")
 
         # Inherit environment variables from the parent process
-        env = os.environ.copy()
+        env = sanitized_env()
         env["PS1"] = self.PS1
         env["PS2"] = ""
         env["TERM"] = "xterm-256color"

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -1,12 +1,12 @@
 """Tmux-based terminal backend implementation."""
 
-import os
 import time
 import uuid
 
 import libtmux
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.constants import HISTORY_LIMIT
 from openhands.tools.terminal.metadata import CmdOutputMetadata
 from openhands.tools.terminal.terminal import TerminalInterface
@@ -41,7 +41,8 @@ class TmuxTerminal(TerminalInterface):
         if self._initialized:
             return
 
-        self.server = libtmux.Server()
+        env = sanitized_env()
+        self.server = libtmux.Server(environment=env)
         _shell_command = "/bin/bash"
         if self.username in ["root", "openhands"]:
             # This starts a non-login (new) shell for the given user
@@ -58,7 +59,7 @@ class TmuxTerminal(TerminalInterface):
             x=1000,
             y=1000,
         )
-        for k, v in os.environ.items():
+        for k, v in env.items():
             self.session.set_environment(k, v)
 
         # Set history limit to a large number to avoid losing history

--- a/tests/sdk/utils/test_command.py
+++ b/tests/sdk/utils/test_command.py
@@ -1,0 +1,49 @@
+from collections import OrderedDict
+
+import pytest
+
+from openhands.sdk.utils.command import sanitized_env
+
+
+def test_sanitized_env_returns_copy():
+    """Returns a dict copy, not the original."""
+    env = {"FOO": "bar"}
+    result = sanitized_env(env)
+    assert result == {"FOO": "bar"}
+    assert result is not env
+
+
+def test_sanitized_env_defaults_to_os_environ(monkeypatch):
+    """When env is None, returns a dict based on os.environ."""
+    monkeypatch.setenv("TEST_SANITIZED_ENV_VAR", "test_value")
+    result = sanitized_env(None)
+    assert result["TEST_SANITIZED_ENV_VAR"] == "test_value"
+
+
+def test_sanitized_env_accepts_mapping_types():
+    """Accepts any Mapping type, not just dict."""
+    env: OrderedDict[str, str] = OrderedDict([("KEY", "value")])
+    assert isinstance(sanitized_env(env), dict)
+
+
+@pytest.mark.parametrize(
+    ("env", "expected_ld_path"),
+    [
+        # ORIG present and non-empty: restore original value
+        (
+            {"LD_LIBRARY_PATH": "/pyinstaller", "LD_LIBRARY_PATH_ORIG": "/original"},
+            "/original",
+        ),
+        # ORIG absent: leave unchanged
+        ({"LD_LIBRARY_PATH": "/some/path"}, "/some/path"),
+    ],
+)
+def test_sanitized_env_ld_library_path(env: dict[str, str], expected_ld_path: str):
+    """LD_LIBRARY_PATH is restored from ORIG or left unchanged."""
+    assert sanitized_env(env)["LD_LIBRARY_PATH"] == expected_ld_path
+
+
+def test_sanitized_env_removes_ld_library_path_when_orig_empty():
+    """When LD_LIBRARY_PATH_ORIG is empty, removes LD_LIBRARY_PATH."""
+    env = {"LD_LIBRARY_PATH": "/pyinstaller", "LD_LIBRARY_PATH_ORIG": ""}
+    assert "LD_LIBRARY_PATH" not in sanitized_env(env)


### PR DESCRIPTION
openhands-agent-server is built from a different container image than its eventually installed into. This is resulting in a downgraded libstdc++ being used at runtime from LD_LIBRARY_PATH with C++ apps compiled using newer system libstdc++.

## Summary

Request OpenHands to create, compile, and run a simple C++ and you will see an error similar to this because pyinstaller's LD_LIBRARY_PATH uses incompatible libstdc++ at runtime.

```
./helloworld: /tmp/_MEIOB99C3/libstdc++.so.6: version `GLIBCXX_3.4.32' not found (required by ./helloworld)
./helloworld: /tmp/_MEIOB99C3/libstdc++.so.6: version `CXXABI_1.3.15' not found (required by ./helloworld)
./helloworld: /tmp/_MEIOB99C3/libstdc++.so.6: version `GLIBCXX_3.4.29' not found (required by ./helloworld)
```

This uses pyinstallers suggested solution.  The alternative is to use the more brittle work around of forcing the Dockerfile to use a compatible container when building.  Or the usage of pyinstaller could be reconsidered.

Fixes: #1687

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [X] If there is an example, have you run the example to make sure that it works?
- [X] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?
