### PR TITLE
Add /reset_idle_time endpoint to prevent premature pausing of claimed runtimes

### DIFF
--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -24,6 +24,18 @@ def update_last_execution_time():
     _last_event_time = time.time()
 
 
+@server_details_router.post("/reset_idle_time")
+async def reset_idle_time():
+    """Reset the idle time counter.
+
+    This endpoint is called when a warm runtime is claimed to prevent
+    the runtime from being immediately paused due to inherited idle time
+    from the warm pool.
+    """
+    update_last_execution_time()
+    return {"status": "ok"}
+
+
 @server_details_router.get("/alive")
 async def alive():
     return {"status": "ok"}


### PR DESCRIPTION
## Problem

When a warm runtime is claimed, it inherits the idle time from when the agent-server started (potentially 25+ minutes). The cleanup job in `runtime-api` then sees this high idle time and immediately pauses the runtime, even though it was just claimed seconds ago.

This causes `404 Not Found` errors when the deploy service tries to call `/api/conversations` on the runtime, because the Service/Ingress have been deleted.

### Timeline of the bug

| Time | Event |
|------|-------|
| 02:07:26 | Warm runtime created, `idle_time` starts counting |
| 02:32:18.493Z | "Claimed warm runtime" - `api_key_name` set in database |
| 02:32:24.713Z | Cleanup job runs, sees `idle_time` = 1481s |
| 02:32:24.713Z | "Pausing idle runtime (idle for 1481.0 seconds)" |
| 02:32:26.228Z | **404 errors** - Service/Ingress deleted |

## Solution

Add a `/reset_idle_time` endpoint that resets the idle time counter. The `runtime-api` will call this endpoint **before** claiming a warm runtime, ensuring the runtime starts fresh with zero idle time.

## Changes

- Added `POST /reset_idle_time` endpoint to `server_details_router.py`
- The endpoint calls `update_last_execution_time()` which resets `_last_event_time` to `time.time()`

## Related PR

This change requires a corresponding change in `runtime-api` to call this endpoint:
- OpenHands/runtime-api PR (will be linked after creation)

## Testing

The endpoint is minimal and reuses the existing `update_last_execution_time()` function that is already tested through the conversation event flow.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6e74c2b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6e74c2b-python \
  ghcr.io/openhands/agent-server:6e74c2b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6e74c2b-golang-amd64
ghcr.io/openhands/agent-server:6e74c2b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6e74c2b-golang-arm64
ghcr.io/openhands/agent-server:6e74c2b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6e74c2b-java-amd64
ghcr.io/openhands/agent-server:6e74c2b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6e74c2b-java-arm64
ghcr.io/openhands/agent-server:6e74c2b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6e74c2b-python-amd64
ghcr.io/openhands/agent-server:6e74c2b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6e74c2b-python-arm64
ghcr.io/openhands/agent-server:6e74c2b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6e74c2b-golang
ghcr.io/openhands/agent-server:6e74c2b-java
ghcr.io/openhands/agent-server:6e74c2b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6e74c2b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6e74c2b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->