### PR TITLE
Update idle time on bash, git, and file operations

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_router.py
+++ b/openhands-agent-server/openhands/agent_server/bash_router.py
@@ -21,6 +21,7 @@ from openhands.agent_server.models import (
     BashOutput,
     ExecuteBashRequest,
 )
+from openhands.agent_server.server_details_router import update_last_execution_time
 
 
 bash_router = APIRouter(prefix="/bash", tags=["Bash"])
@@ -84,6 +85,7 @@ async def batch_get_bash_events(
 @bash_router.post("/start_bash_command")
 async def start_bash_command(request: ExecuteBashRequest) -> BashCommand:
     """Execute a bash command in the background"""
+    update_last_execution_time()
     command, _ = await bash_event_service.start_bash_command(request)
     return command
 
@@ -91,6 +93,7 @@ async def start_bash_command(request: ExecuteBashRequest) -> BashCommand:
 @bash_router.post("/execute_bash_command")
 async def execute_bash_command(request: ExecuteBashRequest) -> BashOutput:
     """Execute a bash command and wait for a result"""
+    update_last_execution_time()
     command, task = await bash_event_service.start_bash_command(request)
     await task
     page = await bash_event_service.search_bash_events(command_id__eq=command.id)

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -17,6 +17,7 @@ from openhands.agent_server.bash_service import get_default_bash_event_service
 from openhands.agent_server.config import get_default_config
 from openhands.agent_server.conversation_service import get_default_conversation_service
 from openhands.agent_server.models import ExecuteBashRequest, Success
+from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.sdk.logger import get_logger
 
 
@@ -33,6 +34,7 @@ async def upload_file(
     file: Annotated[UploadFile, File(...)],
 ) -> Success:
     """Upload a file to the workspace."""
+    update_last_execution_time()
     logger.info(f"Uploading file: {path}")
     try:
         target_path = Path(path)
@@ -66,6 +68,7 @@ async def download_file(
     path: Annotated[str, FastApiPath(description="Absolute file path.")],
 ) -> FileResponse:
     """Download a file from the workspace."""
+    update_last_execution_time()
     logger.info(f"Downloading file: {path}")
     try:
         target_path = Path(path)

--- a/openhands-agent-server/openhands/agent_server/git_router.py
+++ b/openhands-agent-server/openhands/agent_server/git_router.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 from fastapi import APIRouter
 
+from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.sdk.git.git_changes import get_git_changes
 from openhands.sdk.git.git_diff import get_git_diff
 from openhands.sdk.git.models import GitChange, GitDiff
@@ -19,16 +20,17 @@ logger = logging.getLogger(__name__)
 async def git_changes(
     path: Path,
 ) -> list[GitChange]:
+    update_last_execution_time()
     loop = asyncio.get_running_loop()
     changes = await loop.run_in_executor(None, get_git_changes, path)
     return changes
 
 
-# bash event routes
 @git_router.get("/diff/{path:path}")
 async def git_diff(
     path: Path,
 ) -> GitDiff:
+    update_last_execution_time()
     loop = asyncio.get_running_loop()
     changes = await loop.run_in_executor(None, get_git_diff, path)
     return changes


### PR DESCRIPTION
## Problem

When a warm runtime is claimed, it inherits the idle time from when the agent-server started (potentially 25+ minutes). The cleanup job then sees this high idle time and immediately pauses the runtime, even though it's actively being used.

### Timeline of the bug

| Time | Event |
|------|-------|
| 02:07:26 | Warm runtime created, `idle_time` starts counting |
| 02:32:18 | Runtime claimed, deploy service starts workspace setup |
| 02:32:18-25 | Deploy service makes `/api/bash/*` calls (all return 200) |
| 02:32:24 | Cleanup job checks `idle_time` = 1481s → **pauses runtime** |
| 02:32:26 | Deploy service gets **404** on `/api/conversations` |

### Root cause

Previously, `idle_time` was only reset when **conversation events** occurred (in `_EventSubscriber`). This meant:
- ❌ `/api/bash/*` calls didn't reset idle time
- ❌ `/api/git/*` calls didn't reset idle time  
- ❌ `/api/files/*` calls didn't reset idle time
- ✅ Only conversation events reset idle time

So a runtime could be actively processing bash commands but still appear "idle" to the cleanup job.

## Solution

Call `update_last_execution_time()` in the bash, git, and file routers on operations that execute work:

**Changed endpoints:**
- `POST /api/bash/start_bash_command`
- `POST /api/bash/execute_bash_command`
- `GET /api/git/changes/{path}`
- `GET /api/git/diff/{path}`
- `POST /api/file/upload/{path}`
- `GET /api/file/download/{path}`

### Why these specific endpoints?

These are the endpoints that perform actual work on the runtime. Read-only endpoints like `search_bash_events` or `get_bash_event` don't need to update idle time since they're just retrieving stored data.

## Benefits

- **Minimal change**: 6 lines of code across 3 files
- **No new endpoints**: Uses existing `update_last_execution_time()` function
- **No runtime-api changes needed**: The fix is entirely in agent-server
- **Semantically correct**: "last execution time" is updated when we actually execute something

## Testing

- ✅ Pre-commit passes (ruff format, ruff lint, pycodestyle, pyright)
- ✅ All routers import successfully
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7edaf47-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7edaf47-python \
  ghcr.io/openhands/agent-server:7edaf47-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7edaf47-golang-amd64
ghcr.io/openhands/agent-server:7edaf47-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7edaf47-golang-arm64
ghcr.io/openhands/agent-server:7edaf47-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7edaf47-java-amd64
ghcr.io/openhands/agent-server:7edaf47-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7edaf47-java-arm64
ghcr.io/openhands/agent-server:7edaf47-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7edaf47-python-amd64
ghcr.io/openhands/agent-server:7edaf47-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:7edaf47-python-arm64
ghcr.io/openhands/agent-server:7edaf47-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:7edaf47-golang
ghcr.io/openhands/agent-server:7edaf47-java
ghcr.io/openhands/agent-server:7edaf47-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7edaf47-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7edaf47-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->