### PR TITLE
Fix pypi-release workflow to update both dependency sections

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -160,8 +160,18 @@ jobs:
                   fi
                   echo "📦 SDK commit hash: $SDK_COMMIT_HASH"
 
-                  # 1. Update versions in pyproject.toml using poetry
-                  echo "📝 Updating pyproject.toml..."
+                  # 1. Update versions in pyproject.toml
+                  # The OpenHands pyproject.toml has dependencies in TWO places:
+                  # - [project].dependencies (PEP 621 format for UV compatibility)
+                  # - [tool.poetry.dependencies] (Poetry format)
+                  # We need to update both to avoid version conflicts during poetry lock
+
+                  echo "📝 Updating [project].dependencies section (PEP 621 format)..."
+                  sed -i 's/"openhands-sdk==[^"]*"/"openhands-sdk=='"$VERSION"'"/' pyproject.toml
+                  sed -i 's/"openhands-tools==[^"]*"/"openhands-tools=='"$VERSION"'"/' pyproject.toml
+                  sed -i 's/"openhands-agent-server==[^"]*"/"openhands-agent-server=='"$VERSION"'"/' pyproject.toml
+
+                  echo "📝 Updating [tool.poetry.dependencies] section..."
                   poetry add "openhands-sdk==$VERSION" "openhands-tools==$VERSION" "openhands-agent-server==$VERSION"
 
                   # 2. Generate poetry.lock in root


### PR DESCRIPTION
## Problem

The `create-version-bump-prs` job in the pypi-release workflow was failing with this error:

```
Cannot enrich dependency with incompatible constraints: openhands-agent-server (==1.9.0) and openhands-agent-server (==1.8.2)
```

See failed run: https://github.com/OpenHands/software-agent-sdk/actions/runs/21219466794/job/61050384856

## Root Cause

The OpenHands `pyproject.toml` has dependencies declared in **two places**:

1. **`[project].dependencies`** (PEP 621 format for UV compatibility):
   ```toml
   dependencies = [
     ...
     "openhands-agent-server==1.8.2",
     "openhands-sdk==1.8.2",
     "openhands-tools==1.8.2",
     ...
   ]
   ```

2. **`[tool.poetry.dependencies]`** (Poetry format):
   ```toml
   openhands-sdk = "1.8.2"
   openhands-agent-server = "1.8.2"
   openhands-tools = "1.8.2"
   ```

The workflow was only updating the `[tool.poetry.dependencies]` section via `poetry add`, leaving the `[project].dependencies` section with the old version. When `poetry lock` ran, it detected the conflict between the two sections.

## Solution

Added `sed` commands to update the `[project].dependencies` section **before** running `poetry add`:

```bash
sed -i 's/"openhands-sdk==[^"]*"/"openhands-sdk=='"$VERSION"'"/' pyproject.toml
sed -i 's/"openhands-tools==[^"]*"/"openhands-tools=='"$VERSION"'"/' pyproject.toml
sed -i 's/"openhands-agent-server==[^"]*"/"openhands-agent-server=='"$VERSION"'"/' pyproject.toml
```

This ensures both sections have the same version, avoiding the conflict during `poetry lock`.

## Testing

This can be tested by re-running the workflow after merging this PR, or by manually simulating the workflow steps on a clone of the OpenHands repo.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3cf2ab8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3cf2ab8-python \
  ghcr.io/openhands/agent-server:3cf2ab8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3cf2ab8-golang-amd64
ghcr.io/openhands/agent-server:3cf2ab8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3cf2ab8-golang-arm64
ghcr.io/openhands/agent-server:3cf2ab8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3cf2ab8-java-amd64
ghcr.io/openhands/agent-server:3cf2ab8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3cf2ab8-java-arm64
ghcr.io/openhands/agent-server:3cf2ab8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3cf2ab8-python-amd64
ghcr.io/openhands/agent-server:3cf2ab8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3cf2ab8-python-arm64
ghcr.io/openhands/agent-server:3cf2ab8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3cf2ab8-golang
ghcr.io/openhands/agent-server:3cf2ab8-java
ghcr.io/openhands/agent-server:3cf2ab8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3cf2ab8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3cf2ab8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->