### PR TITLE
Fix: Add defensive filtering for duplicate observations and diagnostic logging

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -185,8 +185,9 @@ class Agent(AgentBase):
         pending_actions = ConversationState.get_unmatched_actions(state.events)
         if pending_actions:
             logger.info(
-                "Confirmation mode: Executing %d pending action(s)",
+                "Confirmation mode: Executing %d pending action(s): %s",
                 len(pending_actions),
+                [(a.id, a.tool_call_id, a.tool_name) for a in pending_actions],
             )
             self._execute_actions(conversation, pending_actions, on_event)
             return
@@ -625,6 +626,11 @@ class Agent(AgentBase):
             action_id=action_event.id,
             tool_name=tool.name,
             tool_call_id=action_event.tool_call.id,
+        )
+        logger.debug(
+            f"Creating ObservationEvent: id={obs_event.id}, "
+            f"action_id={action_event.id}, tool_call_id={action_event.tool_call.id}, "
+            f"tool={tool.name}"
         )
         on_event(obs_event)
 

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -405,12 +405,9 @@ class ConversationState(OpenHandsModel):
                 # Only executable actions (validated) are considered pending
                 # Check both action_id AND tool_call_id to ensure we don't
                 # re-execute actions that already have observations
-                is_observed = (
-                    event.id in observed_action_ids
-                    or (
-                        event.tool_call_id is not None
-                        and event.tool_call_id in observed_tool_call_ids
-                    )
+                is_observed = event.id in observed_action_ids or (
+                    event.tool_call_id is not None
+                    and event.tool_call_id in observed_tool_call_ids
                 )
                 if event.action is not None and not is_observed:
                     # Insert at beginning to maintain chronological order in result

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -402,6 +402,12 @@ class ConversationState(OpenHandsModel):
                     # Insert at beginning to maintain chronological order in result
                     unmatched_actions.insert(0, event)
 
+        if unmatched_actions:
+            logger.debug(
+                f"get_unmatched_actions found {len(unmatched_actions)} unmatched: "
+                f"{[(a.id, a.tool_call_id, a.tool_name) for a in unmatched_actions]}"
+            )
+
         return unmatched_actions
 
     # ===== FIFOLock delegation methods =====

--- a/tests/sdk/context/test_view.py
+++ b/tests/sdk/context/test_view.py
@@ -1121,7 +1121,7 @@ def test_filter_unmatched_tool_calls_independent_tool_calls_with_duplicates() ->
 
 
 def test_filter_unmatched_tool_calls_duplicate_none_tool_call_id() -> None:
-    """Test that observations with None tool_call_id are not affected by duplicate filtering.
+    """Test observations with None tool_call_id aren't affected by dup filtering.
 
     Observations with None tool_call_id should still be filtered based on
     the existing matching logic, not the duplicate detection.

--- a/tests/sdk/context/test_view.py
+++ b/tests/sdk/context/test_view.py
@@ -969,3 +969,186 @@ def test_should_keep_event_other_event_types() -> None:
         message_event, action_tool_call_ids, observation_tool_call_ids
     )
     assert result is True
+
+
+def test_filter_unmatched_tool_calls_duplicate_observations() -> None:
+    """Test that duplicate observations with the same tool_call_id are filtered.
+
+    This reproduces the issue from GitHub issue #1782 where duplicate
+    ObservationEvents with the same tool_call_id cause LLM API errors
+    (Claude requires exactly one tool_result per tool_use).
+
+    The defensive fix should keep only the first observation for each
+    tool_call_id and filter out subsequent duplicates.
+    """
+    # Create ActionEvent
+    action_event = create_autospec(ActionEvent, instance=True)
+    action_event.tool_call_id = "call_1"
+    action_event.id = "action_1"
+    action_event.llm_response_id = "response_1"
+
+    # Create first observation (should be kept)
+    observation_event_1 = create_autospec(ObservationEvent, instance=True)
+    observation_event_1.tool_call_id = "call_1"
+    observation_event_1.id = "obs_1"
+
+    # Create duplicate observation with same tool_call_id (should be filtered)
+    observation_event_duplicate = create_autospec(ObservationEvent, instance=True)
+    observation_event_duplicate.tool_call_id = "call_1"
+    observation_event_duplicate.id = "obs_duplicate"
+
+    # Create message events
+    msg1 = message_event("First message")
+    msg2 = message_event("Second message")
+
+    events = [
+        msg1,
+        action_event,
+        observation_event_1,
+        msg2,
+        observation_event_duplicate,  # Duplicate - should be filtered
+    ]
+
+    result = View.filter_unmatched_tool_calls(events)  # type: ignore
+
+    # Should keep the action, first observation, and both message events
+    # Duplicate observation should be filtered out
+    assert len(result) == 4
+    assert action_event in result
+    assert observation_event_1 in result
+    assert msg1 in result
+    assert msg2 in result
+    assert observation_event_duplicate not in result
+
+
+def test_filter_unmatched_tool_calls_multiple_duplicate_observations() -> None:
+    """Test filtering multiple duplicate observations for the same tool_call_id.
+
+    Ensures that only the first observation is kept even when multiple
+    duplicates exist.
+    """
+    # Create ActionEvent
+    action_event = create_autospec(ActionEvent, instance=True)
+    action_event.tool_call_id = "call_1"
+    action_event.id = "action_1"
+    action_event.llm_response_id = "response_1"
+
+    # Create first observation (should be kept)
+    observation_event_1 = create_autospec(ObservationEvent, instance=True)
+    observation_event_1.tool_call_id = "call_1"
+    observation_event_1.id = "obs_1"
+
+    # Create multiple duplicates (all should be filtered)
+    observation_event_dup1 = create_autospec(ObservationEvent, instance=True)
+    observation_event_dup1.tool_call_id = "call_1"
+    observation_event_dup1.id = "obs_dup1"
+
+    observation_event_dup2 = create_autospec(ObservationEvent, instance=True)
+    observation_event_dup2.tool_call_id = "call_1"
+    observation_event_dup2.id = "obs_dup2"
+
+    observation_event_dup3 = create_autospec(ObservationEvent, instance=True)
+    observation_event_dup3.tool_call_id = "call_1"
+    observation_event_dup3.id = "obs_dup3"
+
+    events = [
+        action_event,
+        observation_event_1,
+        observation_event_dup1,
+        observation_event_dup2,
+        observation_event_dup3,
+    ]
+
+    result = View.filter_unmatched_tool_calls(events)  # type: ignore
+
+    # Should keep only action and first observation
+    assert len(result) == 2
+    assert action_event in result
+    assert observation_event_1 in result
+    assert observation_event_dup1 not in result
+    assert observation_event_dup2 not in result
+    assert observation_event_dup3 not in result
+
+
+def test_filter_unmatched_tool_calls_independent_tool_calls_with_duplicates() -> None:
+    """Test that duplicate filtering is per-tool_call_id.
+
+    Multiple different tool_call_ids should each be allowed one observation,
+    even when some have duplicates.
+    """
+    # First action-observation pair
+    action_event_1 = create_autospec(ActionEvent, instance=True)
+    action_event_1.tool_call_id = "call_1"
+    action_event_1.id = "action_1"
+    action_event_1.llm_response_id = "response_1"
+
+    observation_event_1 = create_autospec(ObservationEvent, instance=True)
+    observation_event_1.tool_call_id = "call_1"
+    observation_event_1.id = "obs_1"
+
+    # Duplicate for first call
+    observation_event_1_dup = create_autospec(ObservationEvent, instance=True)
+    observation_event_1_dup.tool_call_id = "call_1"
+    observation_event_1_dup.id = "obs_1_dup"
+
+    # Second action-observation pair (no duplicates)
+    action_event_2 = create_autospec(ActionEvent, instance=True)
+    action_event_2.tool_call_id = "call_2"
+    action_event_2.id = "action_2"
+    action_event_2.llm_response_id = "response_2"
+
+    observation_event_2 = create_autospec(ObservationEvent, instance=True)
+    observation_event_2.tool_call_id = "call_2"
+    observation_event_2.id = "obs_2"
+
+    events = [
+        action_event_1,
+        observation_event_1,
+        action_event_2,
+        observation_event_1_dup,  # Duplicate for call_1
+        observation_event_2,
+    ]
+
+    result = View.filter_unmatched_tool_calls(events)  # type: ignore
+
+    # Should keep both action-observation pairs, filter the duplicate
+    assert len(result) == 4
+    assert action_event_1 in result
+    assert observation_event_1 in result
+    assert action_event_2 in result
+    assert observation_event_2 in result
+    assert observation_event_1_dup not in result
+
+
+def test_filter_unmatched_tool_calls_duplicate_none_tool_call_id() -> None:
+    """Test that observations with None tool_call_id are not affected by duplicate filtering.
+
+    Observations with None tool_call_id should still be filtered based on
+    the existing matching logic, not the duplicate detection.
+    """
+    # Action without tool_call_id
+    action_event = create_autospec(ActionEvent, instance=True)
+    action_event.tool_call_id = None
+    action_event.id = "action_none"
+    action_event.llm_response_id = "response_1"
+
+    # Two observations with None tool_call_id (these get filtered by matching logic)
+    observation_event_1 = create_autospec(ObservationEvent, instance=True)
+    observation_event_1.tool_call_id = None
+    observation_event_1.id = "obs_none_1"
+
+    observation_event_2 = create_autospec(ObservationEvent, instance=True)
+    observation_event_2.tool_call_id = None
+    observation_event_2.id = "obs_none_2"
+
+    events = [
+        action_event,
+        observation_event_1,
+        observation_event_2,
+    ]
+
+    result = View.filter_unmatched_tool_calls(events)  # type: ignore
+
+    # All events with None tool_call_id should be filtered by matching logic
+    # (not duplicate detection)
+    assert len(result) == 0


### PR DESCRIPTION
## Summary

This PR addresses issue #1782 where duplicate `ObservationEvent`s with the same `tool_call_id` cause LLM API errors and put conversations in an **unrecoverable state**.

Fixes #1782

## Problem

When a conversation is resumed after being paused/finished, a duplicate `ObservationEvent` can be created with the same `tool_call_id` as an existing observation. This causes the Anthropic API to reject requests with:

```
litellm.BadRequestError: ... "messages.59: \`tool_use\` ids were found without \`tool_result\` blocks immediately after: toolu_01CGASf7KnafqkuQMuLstHi4..."
```

Since the duplicate observation is persisted in the event stream, **every subsequent LLM call fails** - the conversation becomes permanently stuck.

## Solution

### 1. Source Prevention: `get_unmatched_actions()` fix

The root cause is that `get_unmatched_actions()` only checked `action_id` to match actions with observations. Now it **also checks `tool_call_id`**:

```python
observed_action_ids: set[str] = set()
observed_tool_call_ids: set[str] = set()  # NEW

for event in reversed(events):
    if isinstance(event, (ObservationEvent, UserRejectObservation)):
        observed_action_ids.add(event.action_id)
        if event.tool_call_id is not None:  # NEW
            observed_tool_call_ids.add(event.tool_call_id)
    elif isinstance(event, ActionEvent):
        is_observed = (
            event.id in observed_action_ids
            or (event.tool_call_id is not None  # NEW
                and event.tool_call_id in observed_tool_call_ids)
        )
```

This **prevents** duplicates from being created by ensuring actions with existing observations (matched by `tool_call_id`) are not re-executed.

### 2. Recovery: `filter_unmatched_tool_calls()` fix

Added duplicate observation filtering that tracks seen `tool_call_id`s and skips subsequent observations with the same ID:

```python
if event.tool_call_id in seen_observation_tool_call_ids:
    logger.warning(f"DUPLICATE_OBSERVATION_FILTERED: tool_call_id={event.tool_call_id}...")
    continue
seen_observation_tool_call_ids.add(event.tool_call_id)
```

This **recovers** existing corrupted conversations by filtering duplicates at View construction time.

### Combined Protection

| Layer | What it does | Protects against |
|-------|--------------|------------------|
| `get_unmatched_actions()` | Checks `tool_call_id` when identifying unmatched actions | New duplicates being created |
| `filter_unmatched_tool_calls()` | Filters duplicate observations in View | Existing corrupted conversations |

### 3. Diagnostic Logging

Added logging at key points to help trace issues:

| Location | Level | Purpose |
|----------|-------|---------|
| `get_unmatched_actions()` | DEBUG | Shows what actions are identified as unmatched |
| `agent.step()` pending actions | INFO | Logs tool_call_ids when pending actions are re-executed |
| `_execute_action_event()` | DEBUG | Logs when observations are created |
| `filter_unmatched_tool_calls()` | WARNING | Alerts when duplicates are filtered |

## Changes

- `openhands-sdk/openhands/sdk/conversation/state.py` - Fix `get_unmatched_actions()` to also check `tool_call_id` + debug logging
- `openhands-sdk/openhands/sdk/context/view.py` - Duplicate observation filtering + enhanced warning
- `openhands-sdk/openhands/sdk/agent/agent.py` - Enhanced pending actions log, observation creation log
- `tests/sdk/context/test_view.py` - 4 comprehensive tests for duplicate filtering

## Testing

All tests pass, including:
- `test_filter_unmatched_tool_calls_duplicate_observations`
- `test_filter_unmatched_tool_calls_multiple_duplicate_observations`
- `test_filter_unmatched_tool_calls_independent_tool_calls_with_duplicates`
- `test_filter_unmatched_tool_calls_duplicate_none_tool_call_id`
- `test_getting_unmatched_events` (confirmation mode test)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5e15eba-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5e15eba-python \
  ghcr.io/openhands/agent-server:5e15eba-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5e15eba-golang-amd64
ghcr.io/openhands/agent-server:5e15eba-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5e15eba-golang-arm64
ghcr.io/openhands/agent-server:5e15eba-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5e15eba-java-amd64
ghcr.io/openhands/agent-server:5e15eba-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5e15eba-java-arm64
ghcr.io/openhands/agent-server:5e15eba-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5e15eba-python-amd64
ghcr.io/openhands/agent-server:5e15eba-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:5e15eba-python-arm64
ghcr.io/openhands/agent-server:5e15eba-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:5e15eba-golang
ghcr.io/openhands/agent-server:5e15eba-java
ghcr.io/openhands/agent-server:5e15eba-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5e15eba-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5e15eba-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->