### PR TITLE
Return 502 Bad Gateway for MCP service errors

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -13,7 +13,6 @@ from openhands.agent_server.config import (
     Config,
     get_default_config,
 )
-from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
 from openhands.agent_server.conversation_router import conversation_router
 from openhands.agent_server.conversation_service import (
     get_default_conversation_service,
@@ -36,6 +35,7 @@ from openhands.agent_server.tool_router import tool_router
 from openhands.agent_server.vscode_router import vscode_router
 from openhands.agent_server.vscode_service import get_vscode_service
 from openhands.sdk.logger import DEBUG, get_logger
+from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
 
 
 logger = get_logger(__name__)
@@ -222,9 +222,7 @@ def _add_exception_handlers(api: FastAPI) -> None:
     """Add exception handlers to the FastAPI application."""
 
     @api.exception_handler(MCPError)
-    async def _mcp_exception_handler(
-        request: Request, exc: MCPError
-    ) -> JSONResponse:
+    async def _mcp_exception_handler(request: Request, exc: MCPError) -> JSONResponse:
         """Handle MCP-related errors as 502 Bad Gateway.
 
         MCP errors indicate failures in external MCP services (user-configured

--- a/tests/agent_server/test_api_mcp_exception_handler.py
+++ b/tests/agent_server/test_api_mcp_exception_handler.py
@@ -6,10 +6,11 @@ servers like SSE endpoints, stdio processes, etc.). Using 502 signals
 that the agent-server itself is healthy but an upstream dependency failed.
 """
 
+from unittest.mock import AsyncMock
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from unittest.mock import AsyncMock
 
 from openhands.agent_server.api import _add_exception_handlers
 from openhands.agent_server.conversation_router import conversation_router
@@ -180,7 +181,7 @@ def test_non_mcp_error_returns_500(client, mock_conversation_service):
 
 
 def test_mcp_error_response_does_not_leak_secrets(client, mock_conversation_service):
-    """Test that MCP error response does not include full config with potential secrets."""
+    """Test that MCP error response does not leak config secrets."""
     timeout = 30.0
     mcp_config = {
         "mcpServers": {


### PR DESCRIPTION
## Summary

This PR adds a dedicated exception handler for MCP (Model Context Protocol) errors that returns HTTP 502 Bad Gateway instead of 500 Internal Server Error.

**Background:** When users configure external MCP services (like SSE endpoints or stdio processes) that fail to respond, the agent-server was returning a generic 500 error. This made it difficult to:
1. Distinguish between internal agent-server bugs and external MCP service failures
2. Provide meaningful error messages to users about their MCP configuration
3. Implement appropriate retry strategies in downstream services

**Changes:**
- Added `MCPError` exception handler in `api.py` that returns 502 Bad Gateway
- Response includes structured error details:
  - `detail`: "MCP service error"
  - `error_type`: Exception class name (e.g., "MCPTimeoutError")
  - `message`: Full error message with troubleshooting hints
  - `timeout`: (for MCPTimeoutError) The timeout value that was exceeded
  - `mcp_servers`: (for MCPTimeoutError with config) List of configured MCP server names
- Logs at WARNING level since this is an expected failure mode (user misconfiguration)
- Only exposes MCP server **names**, not full config (which may contain secrets like auth headers)

**Example response:**
```json
{
  "detail": "MCP service error",
  "error_type": "MCPTimeoutError",
  "message": "MCP tool listing timed out after 30 seconds.\nMCP servers configured: fetch, custom_sse\n\nPossible solutions:\n  1. Increase the timeout value...",
  "timeout": 30.0,
  "mcp_servers": ["fetch", "custom_sse"]
}
```

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@tofarr can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a2e9ada-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a2e9ada-python \
  ghcr.io/openhands/agent-server:a2e9ada-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a2e9ada-golang-amd64
ghcr.io/openhands/agent-server:a2e9ada-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a2e9ada-golang-arm64
ghcr.io/openhands/agent-server:a2e9ada-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a2e9ada-java-amd64
ghcr.io/openhands/agent-server:a2e9ada-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a2e9ada-java-arm64
ghcr.io/openhands/agent-server:a2e9ada-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a2e9ada-python-amd64
ghcr.io/openhands/agent-server:a2e9ada-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a2e9ada-python-arm64
ghcr.io/openhands/agent-server:a2e9ada-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a2e9ada-golang
ghcr.io/openhands/agent-server:a2e9ada-java
ghcr.io/openhands/agent-server:a2e9ada-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a2e9ada-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a2e9ada-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->