### PR TITLE
Fix: Enable explicit vision control via disable_vision flag

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -911,7 +911,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def vision_is_active(self) -> bool:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
-            return not self.disable_vision and self._supports_vision()
+            # If explicitly disabled, return False
+            if self.disable_vision is True:
+                return False
+            # If explicitly enabled (False), force vision on regardless of model detection
+            if self.disable_vision is False:
+                return True
+            # Otherwise (None), auto-detect based on model capabilities
+            return self._supports_vision()
 
     def _supports_vision(self) -> bool:
         """Acquire from litellm if model is vision capable.


### PR DESCRIPTION
## Problem

SWE-bench Multimodal evaluations were failing because `vision_enabled=False` even though:
- Images were being included in messages
- Models (Claude Opus, Gemini Flash, GPT-4o) support vision
- LiteLLM's model detection was failing due to proxy prefixes (`litellm_proxy/anthropic/...`)

The root cause was that `vision_is_active()` required both:
1. `disable_vision` to not be True
2. `_supports_vision()` to return True

This meant that even if you set `disable_vision=False` explicitly, vision would still be disabled if LiteLLM couldn't detect the model's vision capability.

## Solution

Modified `vision_is_active()` to treat `disable_vision` as a tri-state flag:
- `True`: Force vision OFF (explicit disable)
- `False`: Force vision ON (explicit enable, bypass model detection)
- `None` (default): Auto-detect based on model capabilities

This allows multimodal benchmarks to explicitly enable vision by setting `disable_vision: false` in the LLM config, regardless of model detection results.

## Changes

1. **LLM.vision_is_active()**: Updated logic to respect explicit True/False values
2. **Tests**: Added comprehensive tests for explicit vision enable/disable behavior

## Testing

All existing and new tests pass:
```
pytest tests/sdk/llm/test_vision_support.py -v
===== 18 passed in 0.06s =====
```

## Related PR

Companion PR in evaluation repo will auto-set `disable_vision=false` for multimodal benchmarks.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f892306-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f892306-python \
  ghcr.io/openhands/agent-server:f892306-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f892306-golang-amd64
ghcr.io/openhands/agent-server:f892306-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f892306-golang-arm64
ghcr.io/openhands/agent-server:f892306-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f892306-java-amd64
ghcr.io/openhands/agent-server:f892306-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f892306-java-arm64
ghcr.io/openhands/agent-server:f892306-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f892306-python-amd64
ghcr.io/openhands/agent-server:f892306-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f892306-python-arm64
ghcr.io/openhands/agent-server:f892306-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f892306-golang
ghcr.io/openhands/agent-server:f892306-java
ghcr.io/openhands/agent-server:f892306-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f892306-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f892306-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->