### PR TITLE
refactor: deprecate vision_enabled field on Message, pass as parameter instead

### DIFF
--- a/tests/sdk/llm/test_message.py
+++ b/tests/sdk/llm/test_message.py
@@ -99,11 +99,11 @@ def test_message_tool_role_with_image_cache_prompt():
         ],
         tool_call_id="call_123",
         name="test_tool",
-        vision_enabled=True,
         cache_enabled=True,
     )
 
-    result = message.to_chat_dict()
+    # Pass vision_enabled as parameter (new API)
+    result = message.to_chat_dict(vision_enabled=True)
     assert result["role"] == "tool"
     assert result["tool_call_id"] == "call_123"
     assert result["cache_control"] == {"type": "ephemeral"}

--- a/tests/sdk/llm/test_thinking_blocks.py
+++ b/tests/sdk/llm/test_thinking_blocks.py
@@ -259,7 +259,7 @@ def test_message_list_serializer_with_thinking_blocks():
         thinking_blocks=[thinking_block],
     )
 
-    serialized = message._list_serializer()
+    serialized = message._list_serializer(vision_enabled=False)
 
     # Thinking blocks should be in a separate field, not in content
     assert "thinking_blocks" in serialized
@@ -340,7 +340,7 @@ def test_multiple_thinking_blocks():
     assert message.thinking_blocks[1].signature is not None
 
     # Test serialization - thinking blocks should be in separate field
-    serialized = message._list_serializer()
+    serialized = message._list_serializer(vision_enabled=False)
 
     # Verify thinking_blocks field
     assert "thinking_blocks" in serialized
@@ -403,7 +403,7 @@ def test_thinking_blocks_in_message_dict():
     )
 
     # Test via _list_serializer
-    message_dict = message._list_serializer()
+    message_dict = message._list_serializer(vision_enabled=False)
 
     # Verify thinking_blocks is a top-level field in message_dict
     assert "thinking_blocks" in message_dict
@@ -454,7 +454,7 @@ def test_no_thinking_blocks_field_when_empty():
         function_calling_enabled=True,
     )
 
-    message_dict = message._list_serializer()
+    message_dict = message._list_serializer(vision_enabled=False)
 
     # When there are no thinking blocks, the field should not be present
     assert "thinking_blocks" not in message_dict
@@ -476,7 +476,7 @@ def test_thinking_blocks_only_for_assistant_role():
         function_calling_enabled=True,
     )
 
-    user_dict = user_message._list_serializer()
+    user_dict = user_message._list_serializer(vision_enabled=False)
 
     # Thinking blocks should not be added for non-assistant roles
     assert "thinking_blocks" not in user_dict
@@ -489,7 +489,7 @@ def test_thinking_blocks_only_for_assistant_role():
         function_calling_enabled=True,
     )
 
-    assistant_dict = assistant_message._list_serializer()
+    assistant_dict = assistant_message._list_serializer(vision_enabled=False)
 
     # Thinking blocks should be added for assistant role
     assert "thinking_blocks" in assistant_dict
@@ -511,7 +511,7 @@ def test_redacted_thinking_block_in_message_dict():
         function_calling_enabled=True,
     )
 
-    message_dict = message._list_serializer()
+    message_dict = message._list_serializer(vision_enabled=False)
 
     # Verify redacted thinking block is in message_dict
     assert "thinking_blocks" in message_dict
@@ -537,7 +537,7 @@ def test_mixed_thinking_and_redacted_blocks():
         function_calling_enabled=True,
     )
 
-    message_dict = message._list_serializer()
+    message_dict = message._list_serializer(vision_enabled=False)
 
     # Verify both types are in message_dict
     assert "thinking_blocks" in message_dict


### PR DESCRIPTION
## Summary

This PR refactors the `vision_enabled` field on Message objects by deprecating it as a stored field and passing it as a parameter to serialization methods instead.

## Problem

The `vision_enabled` field was being stored on each Message object, but this created several issues:
1. **Semantic mismatch**: Whether vision is enabled is a property of the LLM configuration, not of individual messages
2. **Storage bloat**: The field was being serialized to storage unnecessarily
3. **Confusion**: The field's purpose was unclear and it was set at message creation time based on `_supports_vision()` state

## Solution

- `to_chat_dict()` now accepts an optional `vision_enabled: bool | None = None` parameter
- `_list_serializer()` now requires `vision_enabled: bool` as a keyword-only parameter
- `format_messages_for_llm()` now passes `vision_enabled=self._supports_vision()` to the serializer
- Added deprecation warning for the field (deprecated in 1.10.0, to be removed in 1.11.0)
- Maintained backward compatibility for messages that already have the field stored

## Changes

### `openhands-sdk/openhands/sdk/llm/message.py`
- Updated `to_chat_dict()` to accept optional `vision_enabled` parameter
- Updated `_list_serializer()` to require `vision_enabled` as keyword-only parameter
- Added deprecation warning when `vision_enabled` field is used directly

### `openhands-sdk/openhands/sdk/llm/llm.py`
- Updated `format_messages_for_llm()` to pass `vision_enabled=self._supports_vision()`

### Test files updated
- `test_message_serialization.py` - updated calls to `_list_serializer()`
- `test_thinking_blocks.py` - updated calls to `_list_serializer()`
- `test_message.py` - updated calls to `_list_serializer()`

## Testing

All 495 tests pass.

## Related

This is a follow-up to PR #1795 which fixed vision detection for proxy model names. During investigation of that issue, it was discovered that the `vision_enabled` field design could be improved.

## Migration Guide

**For users directly calling `_list_serializer()`:**
```python
# Before
messages = Message._list_serializer(msg_list)

# After
messages = Message._list_serializer(msg_list, vision_enabled=True)
```

**For users relying on stored `vision_enabled` field:**
The field is deprecated and will be removed in v1.11.0. The field value is still respected for backward compatibility, but new code should pass vision_enabled as a parameter to serialization methods.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b47690c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b47690c-python \
  ghcr.io/openhands/agent-server:b47690c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b47690c-golang-amd64
ghcr.io/openhands/agent-server:b47690c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b47690c-golang-arm64
ghcr.io/openhands/agent-server:b47690c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b47690c-java-amd64
ghcr.io/openhands/agent-server:b47690c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b47690c-java-arm64
ghcr.io/openhands/agent-server:b47690c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b47690c-python-amd64
ghcr.io/openhands/agent-server:b47690c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b47690c-python-arm64
ghcr.io/openhands/agent-server:b47690c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b47690c-golang
ghcr.io/openhands/agent-server:b47690c-java
ghcr.io/openhands/agent-server:b47690c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b47690c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b47690c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->