### PR TITLE
Deprecate safety_settings field in LLM configuration

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -22,6 +22,7 @@ from pydantic import (
 from pydantic.json_schema import SkipJsonSchema
 
 from openhands.sdk.llm.utils.model_info import get_litellm_model_info
+from openhands.sdk.utils.deprecation import warn_deprecated
 from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
 
 
@@ -283,10 +284,15 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     seed: int | None = Field(
         default=None, description="The seed to use for random number generation."
     )
+    # REMOVE_AT: 1.15.0 - Remove this field and its handling in chat_options.py
     safety_settings: list[dict[str, str]] | None = Field(
         default=None,
         description=(
-            "Safety settings for models that support them (like Mistral AI and Gemini)"
+            "Deprecated: Safety settings for models that support them "
+            "(like Mistral AI and Gemini). This field is deprecated in 1.10.0 "
+            "and will be removed in 1.15.0. Safety settings are designed for "
+            "consumer-facing content moderation, which is not relevant for "
+            "coding agents."
         ),
     )
     usage_id: str = Field(
@@ -341,6 +347,26 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     @classmethod
     def _validate_secrets(cls, v: str | SecretStr | None, info) -> SecretStr | None:
         return validate_secret(v, info)
+
+    # REMOVE_AT: 1.15.0 - Remove this validator
+    @field_validator("safety_settings", mode="before")
+    @classmethod
+    def _warn_safety_settings_deprecated(
+        cls, v: list[dict[str, str]] | None
+    ) -> list[dict[str, str]] | None:
+        """Emit deprecation warning when safety_settings is explicitly set."""
+        if v is not None:
+            warn_deprecated(
+                "LLM.safety_settings",
+                deprecated_in="1.10.0",
+                removed_in="1.15.0",
+                details=(
+                    "Safety settings are designed for consumer-facing content "
+                    "moderation, which is not relevant for coding agents."
+                ),
+                stacklevel=4,
+            )
+        return v
 
     @model_validator(mode="before")
     @classmethod

--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -71,7 +71,8 @@ def select_chat_options(
         out.pop("temperature", None)
         out.pop("top_p", None)
 
-    # Mistral / Gemini safety
+    # REMOVE_AT: 1.15.0 - Remove this block along with LLM.safety_settings field
+    # Mistral / Gemini safety (deprecated)
     if llm.safety_settings:
         ml = llm.model.lower()
         if "mistral" in ml or "gemini" in ml:

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -2,6 +2,7 @@ import os
 from unittest.mock import patch
 
 import pytest
+from deprecation import DeprecatedWarning
 from pydantic import SecretStr, ValidationError
 
 from openhands.sdk.llm import LLM
@@ -43,43 +44,51 @@ def test_llm_config_defaults():
 
 def test_llm_config_custom_values():
     """Test LLM with custom values."""
-    config = LLM(
-        usage_id="test-llm",
-        model="gpt-4",
-        api_key=SecretStr("test-key"),
-        base_url="https://api.example.com",
-        api_version="v1",
-        num_retries=3,
-        retry_multiplier=2,
-        retry_min_wait=1,
-        retry_max_wait=10,
-        timeout=30,
-        max_message_chars=10000,
-        temperature=0.5,
-        top_p=0.9,
-        top_k=50,
-        max_input_tokens=4000,
-        max_output_tokens=1000,
-        input_cost_per_token=0.001,
-        output_cost_per_token=0.002,
-        ollama_base_url="http://localhost:11434",
-        drop_params=False,
-        modify_params=False,
-        disable_vision=True,
-        disable_stop_word=True,
-        caching_prompt=False,
-        log_completions=True,
-        custom_tokenizer=None,  # Changed from "custom_tokenizer" to avoid HF API call
-        native_tool_calling=True,
-        reasoning_effort="high",
-        seed=42,
-        safety_settings=[
-            {
-                "category": "HARM_CATEGORY_HARASSMENT",
-                "threshold": "BLOCK_MEDIUM_AND_ABOVE",
-            }
-        ],
-    )
+    # safety_settings is deprecated starting in 1.10.0
+    # Mock the version to simulate being on 1.10.0+ to trigger the warning
+    with (
+        patch(
+            "openhands.sdk.utils.deprecation._current_version", return_value="1.10.0"
+        ),
+        pytest.warns(DeprecatedWarning, match="LLM.safety_settings"),
+    ):
+        config = LLM(
+            usage_id="test-llm",
+            model="gpt-4",
+            api_key=SecretStr("test-key"),
+            base_url="https://api.example.com",
+            api_version="v1",
+            num_retries=3,
+            retry_multiplier=2,
+            retry_min_wait=1,
+            retry_max_wait=10,
+            timeout=30,
+            max_message_chars=10000,
+            temperature=0.5,
+            top_p=0.9,
+            top_k=50,
+            max_input_tokens=4000,
+            max_output_tokens=1000,
+            input_cost_per_token=0.001,
+            output_cost_per_token=0.002,
+            ollama_base_url="http://localhost:11434",
+            drop_params=False,
+            modify_params=False,
+            disable_vision=True,
+            disable_stop_word=True,
+            caching_prompt=False,
+            log_completions=True,
+            custom_tokenizer=None,  # Avoid HF API call
+            native_tool_calling=True,
+            reasoning_effort="high",
+            seed=42,
+            safety_settings=[
+                {
+                    "category": "HARM_CATEGORY_HARASSMENT",
+                    "threshold": "BLOCK_MEDIUM_AND_ABOVE",
+                }
+            ],
+        )
 
     assert config.model == "gpt-4"
     assert config.api_key is not None


### PR DESCRIPTION
## Summary

Deprecate the `safety_settings` field from the LLM class configuration using the SDK's deprecation mechanism instead of removing it outright.

**Deprecation Timeline:**
- **Deprecated in:** 1.10.0
- **Will be removed in:** 1.15.0 (5 minor versions)

## Rationale

1. **Not applicable to coding agents**: Safety settings are designed for consumer-facing content moderation (blocking harmful content like violence, hate speech, etc. in chat applications). Coding agents don't generate this type of content.

2. **Unnecessary configuration complexity**: Exposes a configuration option that users of this SDK don't need.

3. **Cleaner API surface**: Removing unused options makes the SDK easier to understand and maintain.

## Changes

- Updated `safety_settings` field description in `LLM` class to indicate deprecation
- Added deprecation warning using `warn_deprecated` in the model validator (fires when field is set to non-None value on SDK >= 1.10.0)
- Field and functionality remain intact during the deprecation period for backward compatibility
- Updated test to verify deprecation warning is emitted correctly

Fixes #1802
