### PR TITLE
test: trim websocket readiness unit tests

### DIFF
--- a/tests/sdk/conversation/remote/test_websocket_subscription_ready.py
+++ b/tests/sdk/conversation/remote/test_websocket_subscription_ready.py
@@ -73,6 +73,8 @@ class TestWebSocketReadySignaling:
         waiter.join(timeout=0.1)
         assert waiter.is_alive()
 
+        # Set _stop directly to bypass the thread-exists check in stop()
+        # since we're testing without starting the WebSocket thread
         client._stop.set()
         waiter.join(timeout=1.0)
 


### PR DESCRIPTION
Follow-up to PR #1791: remove low-value unit tests that only check attribute existence/privates in websocket readiness coverage.

- Drops hasattr/callable tests and callback-only tests
- Keeps a small set of behavioral tests for wait_until_ready() and RemoteEventsList.reconcile()
- Avoids asserting on private caches like _cached_event_ids

Net: 6 concise tests instead of ~300 lines of brittle ones.