### PR TITLE
feat: add LSP server runtime support (#1745)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -22,6 +22,7 @@ from openhands.sdk.critic.base import CriticBase
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.model_prompt_spec import get_model_prompt_spec
 from openhands.sdk.logger import get_logger
+from openhands.sdk.lsp import create_lsp_tools
 from openhands.sdk.mcp import create_mcp_tools
 from openhands.sdk.tool import (
     BUILT_IN_TOOL_CLASSES,
@@ -84,6 +85,21 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         description="Optional MCP configuration dictionary to create MCP tools.",
         examples=[
             {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}}
+        ],
+    )
+    lsp_config: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Optional LSP configuration dictionary to create LSP tools.",
+        examples=[
+            {
+                "lspServers": {
+                    "typescript": {
+                        "command": "typescript-language-server",
+                        "args": ["--stdio"],
+                        "extensionToLanguage": {".ts": "typescript"},
+                    }
+                }
+            }
         ],
     )
     filter_tools_regex: str | None = Field(
@@ -271,6 +287,16 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             # Submit MCP tools creation if configured
             if self.mcp_config:
                 future = executor.submit(create_mcp_tools, self.mcp_config, 30)
+                futures.append(future)
+
+            # Submit LSP tools creation if configured
+            if self.lsp_config:
+                future = executor.submit(
+                    create_lsp_tools,
+                    self.lsp_config,
+                    state.workspace.working_dir,
+                    30,
+                )
                 futures.append(future)
 
             # Collect results as they complete

--- a/openhands-sdk/openhands/sdk/lsp/__init__.py
+++ b/openhands-sdk/openhands/sdk/lsp/__init__.py
@@ -1,0 +1,64 @@
+"""LSP (Language Server Protocol) integration for OpenHands SDK.
+
+This module provides runtime support for LSP servers configured in plugins/marketplace,
+enabling agents to leverage code intelligence capabilities like go-to-definition,
+find-references, and hover documentation.
+
+Example usage:
+    >>> from openhands.sdk.lsp import create_lsp_tools
+    >>>
+    >>> tools = create_lsp_tools({
+    ...     "lspServers": {
+    ...         "typescript": {
+    ...             "command": "typescript-language-server",
+    ...             "args": ["--stdio"],
+    ...             "extensionToLanguage": {
+    ...                 ".ts": "typescript",
+    ...                 ".tsx": "typescriptreact",
+    ...             }
+    ...         }
+    ...     }
+    ... }, workspace_root="/path/to/project")
+"""
+
+from openhands.sdk.lsp.client import LSPClient
+from openhands.sdk.lsp.definition import (
+    LSPOperation,
+    LSPToolAction,
+    LSPToolObservation,
+)
+from openhands.sdk.lsp.exceptions import (
+    LSPConnectionError,
+    LSPError,
+    LSPServerError,
+    LSPServerNotFoundError,
+    LSPTimeoutError,
+)
+from openhands.sdk.lsp.manager import LSPServerConfig, LSPServerManager
+from openhands.sdk.lsp.tool import LSPToolDefinition, LSPToolExecutor
+from openhands.sdk.lsp.utils import create_lsp_tools, validate_lsp_config
+
+
+__all__ = [
+    # Client
+    "LSPClient",
+    # Manager
+    "LSPServerConfig",
+    "LSPServerManager",
+    # Tool
+    "LSPToolDefinition",
+    "LSPToolExecutor",
+    # Schemas
+    "LSPOperation",
+    "LSPToolAction",
+    "LSPToolObservation",
+    # Exceptions
+    "LSPError",
+    "LSPTimeoutError",
+    "LSPServerError",
+    "LSPServerNotFoundError",
+    "LSPConnectionError",
+    # Utils
+    "create_lsp_tools",
+    "validate_lsp_config",
+]

--- a/openhands-sdk/openhands/sdk/lsp/client.py
+++ b/openhands-sdk/openhands/sdk/lsp/client.py
@@ -1,0 +1,485 @@
+"""LSP Client for communicating with Language Server Protocol servers."""
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.lsp.exceptions import (
+    LSPConnectionError,
+    LSPServerError,
+    LSPTimeoutError,
+)
+from openhands.sdk.utils.async_executor import AsyncExecutor
+
+
+logger = get_logger(__name__)
+
+
+class LSPClient:
+    """Manages a single LSP server process and JSON-RPC communication.
+
+    Uses AsyncExecutor for sync/async bridging, following the MCP client pattern.
+    Communicates with LSP servers via stdio using JSON-RPC 2.0 protocol.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str],
+        workspace_root: str,
+        env: dict[str, str] | None = None,
+        initialization_options: dict[str, Any] | None = None,
+    ):
+        """Initialize LSP client.
+
+        Args:
+            command: Command to run the LSP server (e.g., "typescript-language-server")
+            args: Arguments for the command (e.g., ["--stdio"])
+            workspace_root: Root directory of the workspace
+            env: Additional environment variables for the server process
+            initialization_options: Options passed to server during initialization
+        """
+        self._command = command
+        self._args = args
+        self._workspace_root = workspace_root
+        self._env = env or {}
+        self._initialization_options = initialization_options or {}
+        self._executor = AsyncExecutor()
+        self._process: asyncio.subprocess.Process | None = None
+        self._request_id = 0
+        self._pending_requests: dict[int, asyncio.Future[Any]] = {}
+        self._reader_task: asyncio.Task[None] | None = None
+        self._initialized = False
+        self._capabilities: dict[str, Any] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def is_running(self) -> bool:
+        """Check if the LSP server process is running."""
+        return self._process is not None and self._process.returncode is None
+
+    async def start(self) -> None:
+        """Start the LSP server process and perform initialize handshake."""
+        if self.is_running:
+            logger.debug(f"LSP server already running: {self._command}")
+            return
+
+        # Prepare environment
+        env = os.environ.copy()
+        env.update(self._env)
+
+        try:
+            self._process = await asyncio.create_subprocess_exec(
+                self._command,
+                *self._args,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            logger.info(f"Started LSP server: {self._command} {' '.join(self._args)}")
+        except FileNotFoundError as e:
+            raise LSPConnectionError(
+                f"LSP server command not found: {self._command}. "
+                "Make sure the language server is installed.",
+                server_name=self._command,
+            ) from e
+        except Exception as e:
+            raise LSPConnectionError(
+                f"Failed to start LSP server: {e}",
+                server_name=self._command,
+            ) from e
+
+        # Start reader task to handle incoming messages
+        self._reader_task = asyncio.create_task(self._read_messages())
+
+        # Perform LSP initialize handshake
+        await self._initialize()
+
+    async def _initialize(self) -> None:
+        """Perform LSP initialize/initialized handshake."""
+        workspace_uri = Path(self._workspace_root).as_uri()
+
+        init_params = {
+            "processId": os.getpid(),
+            "rootUri": workspace_uri,
+            "rootPath": self._workspace_root,
+            "capabilities": {
+                "textDocument": {
+                    "synchronization": {
+                        "dynamicRegistration": False,
+                        "willSave": False,
+                        "willSaveWaitUntil": False,
+                        "didSave": True,
+                    },
+                    "completion": {
+                        "dynamicRegistration": False,
+                        "completionItem": {
+                            "snippetSupport": False,
+                            "documentationFormat": ["plaintext", "markdown"],
+                        },
+                    },
+                    "hover": {
+                        "dynamicRegistration": False,
+                        "contentFormat": ["plaintext", "markdown"],
+                    },
+                    "definition": {"dynamicRegistration": False},
+                    "references": {"dynamicRegistration": False},
+                    "documentSymbol": {"dynamicRegistration": False},
+                },
+                "workspace": {
+                    "workspaceFolders": True,
+                },
+            },
+            "workspaceFolders": [
+                {
+                    "uri": workspace_uri,
+                    "name": Path(self._workspace_root).name,
+                }
+            ],
+        }
+
+        if self._initialization_options:
+            init_params["initializationOptions"] = self._initialization_options
+
+        result = await self._send_request("initialize", init_params)
+        self._capabilities = result.get("capabilities", {})
+
+        # Send initialized notification
+        await self._send_notification("initialized", {})
+        self._initialized = True
+        logger.debug(f"LSP server initialized: {self._command}")
+
+    async def stop(self) -> None:
+        """Send shutdown/exit and terminate the server process."""
+        if not self.is_running:
+            return
+
+        try:
+            # Send shutdown request
+            await self._send_request("shutdown", None, timeout=5.0)
+            # Send exit notification
+            await self._send_notification("exit", None)
+        except Exception as e:
+            logger.debug(f"Error during LSP shutdown: {e}")
+
+        # Terminate process
+        if self._process:
+            try:
+                self._process.terminate()
+                await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except TimeoutError:
+                self._process.kill()
+                await self._process.wait()
+            except Exception as e:
+                logger.debug(f"Error terminating LSP process: {e}")
+
+        # Cancel reader task
+        if self._reader_task:
+            self._reader_task.cancel()
+            try:
+                await self._reader_task
+            except asyncio.CancelledError:
+                pass
+
+        self._process = None
+        self._reader_task = None
+        self._initialized = False
+        logger.info(f"LSP server stopped: {self._command}")
+
+    async def _read_messages(self) -> None:
+        """Read and dispatch messages from the LSP server."""
+        assert self._process is not None
+        assert self._process.stdout is not None
+
+        while self.is_running:
+            try:
+                # Read Content-Length header
+                header = await self._process.stdout.readline()
+                if not header:
+                    break
+
+                header_str = header.decode("utf-8").strip()
+                if not header_str.startswith("Content-Length:"):
+                    continue
+
+                content_length = int(header_str.split(":")[1].strip())
+
+                # Read empty line after headers
+                await self._process.stdout.readline()
+
+                # Read content
+                content = await self._process.stdout.readexactly(content_length)
+                message = json.loads(content.decode("utf-8"))
+
+                # Dispatch message
+                await self._handle_message(message)
+
+            except asyncio.CancelledError:
+                break
+            except asyncio.IncompleteReadError:
+                break
+            except Exception as e:
+                logger.debug(f"Error reading LSP message: {e}")
+                break
+
+    async def _handle_message(self, message: dict[str, Any]) -> None:
+        """Handle incoming LSP message."""
+        if "id" in message and "method" not in message:
+            # Response to a request
+            request_id = message["id"]
+            if request_id in self._pending_requests:
+                future = self._pending_requests.pop(request_id)
+                if "error" in message:
+                    error = message["error"]
+                    future.set_exception(
+                        LSPServerError(
+                            message=error.get("message", "Unknown error"),
+                            code=error.get("code", -1),
+                            data=error.get("data"),
+                        )
+                    )
+                else:
+                    future.set_result(message.get("result"))
+        elif "method" in message:
+            # Server notification or request
+            method = message["method"]
+            logger.debug(f"Received LSP notification: {method}")
+            # Handle server-initiated requests if needed
+            if "id" in message:
+                # Server request - send empty response for now
+                await self._send_response(message["id"], None)
+
+    async def _send_request(
+        self,
+        method: str,
+        params: dict[str, Any] | None,
+        timeout: float = 30.0,
+    ) -> Any:
+        """Send a JSON-RPC request and wait for response."""
+        if not self.is_running:
+            raise LSPConnectionError(
+                "LSP server is not running", server_name=self._command
+            )
+
+        async with self._lock:
+            self._request_id += 1
+            request_id = self._request_id
+
+        message = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "method": method,
+        }
+        if params is not None:
+            message["params"] = params
+
+        future: asyncio.Future[Any] = asyncio.get_event_loop().create_future()
+        self._pending_requests[request_id] = future
+
+        await self._write_message(message)
+
+        try:
+            return await asyncio.wait_for(future, timeout=timeout)
+        except TimeoutError:
+            self._pending_requests.pop(request_id, None)
+            raise LSPTimeoutError(
+                f"LSP request '{method}' timed out after {timeout}s",
+                timeout=timeout,
+                server_name=self._command,
+                operation=method,
+            ) from None
+
+    async def _send_notification(
+        self, method: str, params: dict[str, Any] | None
+    ) -> None:
+        """Send a JSON-RPC notification (no response expected)."""
+        if not self.is_running:
+            return
+
+        message: dict[str, Any] = {
+            "jsonrpc": "2.0",
+            "method": method,
+        }
+        if params is not None:
+            message["params"] = params
+
+        await self._write_message(message)
+
+    async def _send_response(self, request_id: int, result: Any) -> None:
+        """Send a JSON-RPC response."""
+        message = {
+            "jsonrpc": "2.0",
+            "id": request_id,
+            "result": result,
+        }
+        await self._write_message(message)
+
+    async def _write_message(self, message: dict[str, Any]) -> None:
+        """Write a JSON-RPC message to the server."""
+        assert self._process is not None
+        assert self._process.stdin is not None
+
+        content = json.dumps(message)
+        content_bytes = content.encode("utf-8")
+
+        header = f"Content-Length: {len(content_bytes)}\r\n\r\n"
+        header_bytes = header.encode("utf-8")
+
+        self._process.stdin.write(header_bytes + content_bytes)
+        await self._process.stdin.drain()
+
+    # LSP Protocol Methods
+
+    async def text_document_definition(
+        self, uri: str, line: int, character: int
+    ) -> list[dict[str, Any]]:
+        """Send textDocument/definition request.
+
+        Args:
+            uri: Document URI (file:// format)
+            line: Line number (0-indexed)
+            character: Character position (0-indexed)
+
+        Returns:
+            List of location objects with uri, range
+        """
+        params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": character},
+        }
+        result = await self._send_request("textDocument/definition", params)
+        return self._normalize_locations(result)
+
+    async def text_document_references(
+        self, uri: str, line: int, character: int, include_declaration: bool = True
+    ) -> list[dict[str, Any]]:
+        """Send textDocument/references request.
+
+        Args:
+            uri: Document URI (file:// format)
+            line: Line number (0-indexed)
+            character: Character position (0-indexed)
+            include_declaration: Include the declaration location
+
+        Returns:
+            List of location objects with uri, range
+        """
+        params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": character},
+            "context": {"includeDeclaration": include_declaration},
+        }
+        result = await self._send_request("textDocument/references", params)
+        return self._normalize_locations(result)
+
+    async def text_document_hover(
+        self, uri: str, line: int, character: int
+    ) -> dict[str, Any] | None:
+        """Send textDocument/hover request.
+
+        Args:
+            uri: Document URI (file:// format)
+            line: Line number (0-indexed)
+            character: Character position (0-indexed)
+
+        Returns:
+            Hover object with contents and optional range, or None
+        """
+        params = {
+            "textDocument": {"uri": uri},
+            "position": {"line": line, "character": character},
+        }
+        return await self._send_request("textDocument/hover", params)
+
+    async def text_document_did_open(
+        self, uri: str, language_id: str, version: int, text: str
+    ) -> None:
+        """Send textDocument/didOpen notification.
+
+        Args:
+            uri: Document URI (file:// format)
+            language_id: Language identifier (e.g., "typescript", "python")
+            version: Document version
+            text: Full text content of the document
+        """
+        params = {
+            "textDocument": {
+                "uri": uri,
+                "languageId": language_id,
+                "version": version,
+                "text": text,
+            }
+        }
+        await self._send_notification("textDocument/didOpen", params)
+
+    async def text_document_did_close(self, uri: str) -> None:
+        """Send textDocument/didClose notification.
+
+        Args:
+            uri: Document URI (file:// format)
+        """
+        params = {"textDocument": {"uri": uri}}
+        await self._send_notification("textDocument/didClose", params)
+
+    async def text_document_did_change(
+        self, uri: str, version: int, text: str
+    ) -> None:
+        """Send textDocument/didChange notification (full sync).
+
+        Args:
+            uri: Document URI (file:// format)
+            version: Document version (incremented)
+            text: Full text content of the document
+        """
+        params = {
+            "textDocument": {"uri": uri, "version": version},
+            "contentChanges": [{"text": text}],
+        }
+        await self._send_notification("textDocument/didChange", params)
+
+    def _normalize_locations(
+        self, result: Any
+    ) -> list[dict[str, Any]]:
+        """Normalize location result to list format."""
+        if result is None:
+            return []
+        if isinstance(result, dict):
+            return [result]
+        if isinstance(result, list):
+            return result
+        return []
+
+    # Sync wrappers
+
+    def call_sync(
+        self, coro: Any, timeout: float = 30.0
+    ) -> Any:
+        """Execute async method from sync context using AsyncExecutor."""
+        return self._executor.run_async(coro, timeout=timeout)
+
+    def start_sync(self) -> None:
+        """Synchronously start the LSP server."""
+        self.call_sync(self.start())
+
+    def stop_sync(self) -> None:
+        """Synchronously stop the LSP server."""
+        try:
+            self.call_sync(self.stop(), timeout=10.0)
+        except Exception as e:
+            logger.debug(f"Error during sync stop: {e}")
+
+    def sync_close(self) -> None:
+        """Synchronously close the client and cleanup resources."""
+        self.stop_sync()
+        self._executor.close()
+
+    def __del__(self) -> None:
+        """Cleanup on deletion."""
+        try:
+            self.sync_close()
+        except Exception:
+            pass

--- a/openhands-sdk/openhands/sdk/lsp/definition.py
+++ b/openhands-sdk/openhands/sdk/lsp/definition.py
@@ -1,0 +1,257 @@
+"""LSP Tool action and observation schemas."""
+
+from collections.abc import Sequence
+from enum import Enum
+from typing import Any, ClassVar
+from urllib.parse import unquote, urlparse
+
+from pydantic import Field
+
+from openhands.sdk.llm import TextContent
+from openhands.sdk.tool.schema import Action, Observation
+
+
+class LSPOperation(str, Enum):
+    """Supported LSP operations."""
+
+    DEFINITION = "definition"
+    REFERENCES = "references"
+    HOVER = "hover"
+
+
+class LSPToolAction(Action):
+    """Action schema for LSP tool operations.
+
+    Provides code intelligence capabilities via Language Server Protocol.
+    """
+
+    operation: LSPOperation = Field(
+        description="The LSP operation to perform: "
+        "'definition' to go to symbol definition, "
+        "'references' to find all references, "
+        "'hover' to get documentation/type info"
+    )
+    file_path: str = Field(
+        description="Absolute path to the file to query"
+    )
+    line: int = Field(
+        description="Line number (1-indexed, first line is 1)"
+    )
+    character: int = Field(
+        description="Character position in the line (0-indexed)"
+    )
+    include_declaration: bool = Field(
+        default=True,
+        description="For 'references' operation: whether to include the declaration "
+        "location in the results"
+    )
+
+
+class LSPToolObservation(Observation):
+    """Observation from LSP tool operations.
+
+    Contains formatted results from LSP queries.
+    """
+
+    ERROR_MESSAGE_HEADER: ClassVar[str] = "[LSP Error]\n"
+
+    operation: LSPOperation = Field(description="The operation that was performed")
+    file_path: str = Field(description="File that was queried")
+    locations: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description="List of locations (for definition/references)"
+    )
+    hover_content: str | None = Field(
+        default=None,
+        description="Hover documentation content"
+    )
+
+    @classmethod
+    def from_locations(
+        cls,
+        operation: LSPOperation,
+        file_path: str,
+        locations: list[dict[str, Any]],
+    ) -> "LSPToolObservation":
+        """Create observation from location results (definition/references).
+
+        Args:
+            operation: The LSP operation performed
+            file_path: The file that was queried
+            locations: List of location objects with uri and range
+
+        Returns:
+            Formatted observation
+        """
+        if not locations:
+            text = (
+                f"No {operation.value} found for the symbol at the specified position."
+            )
+            return cls(
+                content=[TextContent(text=text)],
+                operation=operation,
+                file_path=file_path,
+                locations=[],
+            )
+
+        # Format locations for display
+        formatted_locations = []
+        for loc in locations:
+            uri = loc.get("uri", "")
+            range_info = loc.get("range", {})
+            start = range_info.get("start", {})
+            end = range_info.get("end", {})
+
+            # Convert URI to path
+            loc_path = _uri_to_path(uri)
+            start_line = start.get("line", 0) + 1  # Convert to 1-indexed
+            start_char = start.get("character", 0)
+            end_line = end.get("line", 0) + 1
+            end_char = end.get("character", 0)
+
+            formatted_locations.append({
+                "path": loc_path,
+                "start_line": start_line,
+                "start_character": start_char,
+                "end_line": end_line,
+                "end_character": end_char,
+            })
+
+        # Build text output
+        lines = [f"Found {len(formatted_locations)} {operation.value}(s):"]
+        for i, loc in enumerate(formatted_locations, 1):
+            lines.append(
+                f"  {i}. {loc['path']}:{loc['start_line']}:{loc['start_character']}"
+            )
+
+        text = "\n".join(lines)
+        return cls(
+            content=[TextContent(text=text)],
+            operation=operation,
+            file_path=file_path,
+            locations=formatted_locations,
+        )
+
+    @classmethod
+    def from_hover(
+        cls,
+        file_path: str,
+        hover_result: dict[str, Any] | None,
+    ) -> "LSPToolObservation":
+        """Create observation from hover result.
+
+        Args:
+            file_path: The file that was queried
+            hover_result: Hover response with contents field
+
+        Returns:
+            Formatted observation with hover documentation
+        """
+        if hover_result is None:
+            text = "No hover information available at the specified position."
+            return cls(
+                content=[TextContent(text=text)],
+                operation=LSPOperation.HOVER,
+                file_path=file_path,
+                hover_content=None,
+            )
+
+        # Extract hover contents
+        contents = hover_result.get("contents", "")
+        hover_text = _extract_hover_content(contents)
+
+        if not hover_text:
+            text = "No hover information available at the specified position."
+            return cls(
+                content=[TextContent(text=text)],
+                operation=LSPOperation.HOVER,
+                file_path=file_path,
+                hover_content=None,
+            )
+
+        return cls(
+            content=[TextContent(text=hover_text)],
+            operation=LSPOperation.HOVER,
+            file_path=file_path,
+            hover_content=hover_text,
+        )
+
+    @classmethod
+    def from_error(
+        cls,
+        operation: LSPOperation,
+        file_path: str,
+        error_message: str,
+    ) -> "LSPToolObservation":
+        """Create error observation.
+
+        Args:
+            operation: The LSP operation that failed
+            file_path: The file that was queried
+            error_message: Error description
+
+        Returns:
+            Error observation
+        """
+        return cls(
+            content=[TextContent(text=error_message)],
+            is_error=True,
+            operation=operation,
+            file_path=file_path,
+        )
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        """Format observation for LLM consumption."""
+        llm_content: list[TextContent] = []
+
+        if self.is_error:
+            llm_content.append(TextContent(text=self.ERROR_MESSAGE_HEADER))
+
+        llm_content.extend(
+            item for item in self.content if isinstance(item, TextContent)
+        )
+
+        return llm_content
+
+
+def _uri_to_path(uri: str) -> str:
+    """Convert a file:// URI to a file path."""
+    if uri.startswith("file://"):
+        parsed = urlparse(uri)
+        return unquote(parsed.path)
+    return uri
+
+
+def _extract_hover_content(contents: Any) -> str:
+    """Extract text from LSP hover contents.
+
+    The contents can be:
+    - A string
+    - A MarkupContent object {"kind": "markdown"|"plaintext", "value": "..."}
+    - A MarkedString {"language": "...", "value": "..."}
+    - A list of the above
+    """
+    if isinstance(contents, str):
+        return contents
+
+    if isinstance(contents, dict):
+        # MarkupContent or MarkedString
+        if "value" in contents:
+            value = contents["value"]
+            language = contents.get("language", "")
+            if language:
+                return f"```{language}\n{value}\n```"
+            return value
+        return ""
+
+    if isinstance(contents, list):
+        # List of content items
+        parts = []
+        for item in contents:
+            part = _extract_hover_content(item)
+            if part:
+                parts.append(part)
+        return "\n\n".join(parts)
+
+    return ""

--- a/openhands-sdk/openhands/sdk/lsp/exceptions.py
+++ b/openhands-sdk/openhands/sdk/lsp/exceptions.py
@@ -1,0 +1,58 @@
+"""Exceptions for LSP-related errors."""
+
+from typing import Any
+
+
+class LSPError(Exception):
+    """Base exception for LSP-related errors."""
+
+    pass
+
+
+class LSPTimeoutError(LSPError):
+    """Exception raised when LSP operations timeout."""
+
+    def __init__(
+        self,
+        message: str,
+        timeout: float,
+        server_name: str | None = None,
+        operation: str | None = None,
+    ):
+        self.timeout = timeout
+        self.server_name = server_name
+        self.operation = operation
+        super().__init__(message)
+
+
+class LSPServerError(LSPError):
+    """Exception raised when LSP server returns an error response."""
+
+    def __init__(
+        self,
+        message: str,
+        code: int,
+        data: Any | None = None,
+    ):
+        self.code = code
+        self.data = data
+        super().__init__(message)
+
+
+class LSPServerNotFoundError(LSPError):
+    """Exception raised when no LSP server is configured for a file type."""
+
+    def __init__(self, file_path: str, extension: str):
+        self.file_path = file_path
+        self.extension = extension
+        super().__init__(
+            f"No LSP server configured for file extension '{extension}': {file_path}"
+        )
+
+
+class LSPConnectionError(LSPError):
+    """Exception raised when LSP server connection fails."""
+
+    def __init__(self, message: str, server_name: str | None = None):
+        self.server_name = server_name
+        super().__init__(message)

--- a/openhands-sdk/openhands/sdk/lsp/manager.py
+++ b/openhands-sdk/openhands/sdk/lsp/manager.py
@@ -1,0 +1,327 @@
+"""LSP Server Manager for managing multiple LSP servers."""
+
+import threading
+from pathlib import Path
+from typing import Any
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.lsp.client import LSPClient
+
+
+logger = get_logger(__name__)
+
+
+class LSPServerConfig:
+    """Configuration for a single LSP server."""
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        extension_to_language: dict[str, str] | None = None,
+        initialization_options: dict[str, Any] | None = None,
+    ):
+        self.command = command
+        self.args = args or []
+        self.env = env or {}
+        self.extension_to_language = extension_to_language or {}
+        self.initialization_options = initialization_options or {}
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "LSPServerConfig":
+        """Create config from dictionary (supports camelCase keys)."""
+        return cls(
+            command=data["command"],
+            args=data.get("args", []),
+            env=data.get("env", {}),
+            extension_to_language=data.get("extensionToLanguage")
+            or data.get("extension_to_language", {}),
+            initialization_options=data.get("initializationOptions")
+            or data.get("initialization_options", {}),
+        )
+
+
+class LSPServerManager:
+    """Manages multiple LSP servers based on file extension routing.
+
+    This class handles:
+    - Starting LSP servers on-demand based on file extension
+    - Routing files to the appropriate server
+    - Tracking open documents per server
+    - Cleaning up servers on shutdown
+    """
+
+    def __init__(self, config: dict[str, Any], workspace_root: str):
+        """Initialize the server manager.
+
+        Args:
+            config: LSP configuration dictionary with format:
+                {"servers": {"name": {"command": "...", "args": [...], ...}}}
+                or {"lspServers": {"name": {...}}}
+            workspace_root: Root directory of the workspace
+        """
+        self._workspace_root = workspace_root
+        self._clients: dict[str, LSPClient] = {}
+        self._server_configs: dict[str, LSPServerConfig] = {}
+        self._extension_to_server: dict[str, str] = {}
+        # uri -> (server_name, version)
+        self._open_documents: dict[str, tuple[str, int]] = {}
+        self._lock = threading.Lock()
+
+        self._parse_config(config)
+
+    def _parse_config(self, config: dict[str, Any]) -> None:
+        """Parse LSP configuration and build routing table."""
+        # Support both "servers" and "lspServers" keys
+        servers = config.get("servers") or config.get("lspServers") or {}
+
+        for name, server_data in servers.items():
+            server_config = LSPServerConfig.from_dict(server_data)
+            self._server_configs[name] = server_config
+
+            # Build extension to server mapping
+            for ext, lang_id in server_config.extension_to_language.items():
+                # Normalize extension to include dot
+                ext_normalized = ext if ext.startswith(".") else f".{ext}"
+                self._extension_to_server[ext_normalized] = name
+                logger.debug(f"Registered LSP: {ext_normalized} -> {name}")
+
+    def get_server_for_file(self, file_path: str) -> str | None:
+        """Determine which server should handle a file.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            Server name or None if no server handles this file type
+        """
+        ext = Path(file_path).suffix.lower()
+        return self._extension_to_server.get(ext)
+
+    def get_language_id(self, file_path: str) -> str | None:
+        """Get the language ID for a file.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            Language ID or None if no server handles this file type
+        """
+        ext = Path(file_path).suffix.lower()
+        server_name = self._extension_to_server.get(ext)
+        if server_name is None:
+            return None
+
+        config = self._server_configs.get(server_name)
+        if config is None:
+            return None
+
+        return config.extension_to_language.get(ext)
+
+    def get_client_for_file(self, file_path: str) -> LSPClient | None:
+        """Get or start the appropriate LSP client for a file.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            LSPClient or None if no server handles this file type
+        """
+        server_name = self.get_server_for_file(file_path)
+        if server_name is None:
+            return None
+
+        return self._ensure_client(server_name)
+
+    def _ensure_client(self, server_name: str) -> LSPClient:
+        """Ensure a client is running for the given server.
+
+        Args:
+            server_name: Name of the LSP server
+
+        Returns:
+            Running LSPClient instance
+        """
+        with self._lock:
+            if server_name in self._clients:
+                client = self._clients[server_name]
+                if client.is_running:
+                    return client
+                # Client exists but not running, remove it
+                del self._clients[server_name]
+
+            # Start new client
+            config = self._server_configs[server_name]
+            client = LSPClient(
+                command=config.command,
+                args=config.args,
+                workspace_root=self._workspace_root,
+                env=config.env,
+                initialization_options=config.initialization_options,
+            )
+            client.start_sync()
+            self._clients[server_name] = client
+            logger.info(f"Started LSP server: {server_name}")
+            return client
+
+    def ensure_document_open(
+        self, file_path: str
+    ) -> tuple[LSPClient | None, str | None]:
+        """Ensure a document is open in the appropriate LSP server.
+
+        Args:
+            file_path: Path to the file
+
+        Returns:
+            Tuple of (client, language_id) or (None, None) if no server
+        """
+        server_name = self.get_server_for_file(file_path)
+        if server_name is None:
+            return None, None
+
+        language_id = self.get_language_id(file_path)
+        if language_id is None:
+            return None, None
+
+        client = self._ensure_client(server_name)
+        uri = Path(file_path).as_uri()
+
+        with self._lock:
+            if uri in self._open_documents:
+                # Document already open
+                return client, language_id
+
+            # Read file content and open it
+            try:
+                content = Path(file_path).read_text()
+            except Exception as e:
+                logger.warning(f"Failed to read file for LSP: {file_path}: {e}")
+                return client, language_id
+
+            # Open document in server
+            version = 1
+            client.call_sync(
+                client.text_document_did_open(uri, language_id, version, content)
+            )
+            self._open_documents[uri] = (server_name, version)
+            logger.debug(f"Opened document in LSP: {file_path}")
+
+        return client, language_id
+
+    def close_document(self, file_path: str) -> None:
+        """Close a document in the LSP server.
+
+        Args:
+            file_path: Path to the file
+        """
+        uri = Path(file_path).as_uri()
+
+        with self._lock:
+            if uri not in self._open_documents:
+                return
+
+            server_name, _ = self._open_documents.pop(uri)
+            client = self._clients.get(server_name)
+            if client and client.is_running:
+                try:
+                    client.call_sync(client.text_document_did_close(uri))
+                    logger.debug(f"Closed document in LSP: {file_path}")
+                except Exception as e:
+                    logger.debug(f"Error closing document: {e}")
+
+    def refresh_document(self, file_path: str) -> None:
+        """Refresh a document's content in the LSP server.
+
+        Call this after file modifications to update the server's view.
+
+        Args:
+            file_path: Path to the file
+        """
+        uri = Path(file_path).as_uri()
+
+        with self._lock:
+            if uri not in self._open_documents:
+                return
+
+            server_name, version = self._open_documents[uri]
+            client = self._clients.get(server_name)
+            if not client or not client.is_running:
+                return
+
+            try:
+                content = Path(file_path).read_text()
+                new_version = version + 1
+                client.call_sync(
+                    client.text_document_did_change(uri, new_version, content)
+                )
+                self._open_documents[uri] = (server_name, new_version)
+                logger.debug(f"Refreshed document in LSP: {file_path}")
+            except Exception as e:
+                logger.debug(f"Error refreshing document: {e}")
+
+    def close_server(self, server_name: str) -> None:
+        """Stop a specific LSP server.
+
+        Args:
+            server_name: Name of the server to stop
+        """
+        with self._lock:
+            client = self._clients.pop(server_name, None)
+            if client:
+                # Close all documents for this server
+                docs_to_remove = [
+                    uri
+                    for uri, (name, _) in self._open_documents.items()
+                    if name == server_name
+                ]
+                for uri in docs_to_remove:
+                    self._open_documents.pop(uri, None)
+
+                try:
+                    client.sync_close()
+                except Exception as e:
+                    logger.debug(f"Error closing LSP server {server_name}: {e}")
+
+    def close_all(self) -> None:
+        """Shutdown all running LSP servers."""
+        with self._lock:
+            server_names = list(self._clients.keys())
+
+        for server_name in server_names:
+            self.close_server(server_name)
+
+        logger.info("All LSP servers stopped")
+
+    @property
+    def running_servers(self) -> list[str]:
+        """Get list of currently running server names."""
+        with self._lock:
+            return [
+                name for name, client in self._clients.items() if client.is_running
+            ]
+
+    @property
+    def open_document_count(self) -> int:
+        """Get count of open documents across all servers."""
+        with self._lock:
+            return len(self._open_documents)
+
+
+def create_server_manager(
+    config: dict[str, Any], workspace_root: str
+) -> LSPServerManager | None:
+    """Create an LSP server manager from configuration.
+
+    Args:
+        config: LSP configuration dictionary
+        workspace_root: Root directory of the workspace
+
+    Returns:
+        LSPServerManager or None if no servers configured
+    """
+    servers = config.get("servers") or config.get("lspServers") or {}
+    if not servers:
+        return None
+
+    return LSPServerManager(config, workspace_root)

--- a/openhands-sdk/openhands/sdk/lsp/tool.py
+++ b/openhands-sdk/openhands/sdk/lsp/tool.py
@@ -1,0 +1,253 @@
+"""LSP Tool definition and executor."""
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.lsp.definition import (
+    LSPOperation,
+    LSPToolAction,
+    LSPToolObservation,
+)
+from openhands.sdk.lsp.exceptions import (
+    LSPConnectionError,
+    LSPServerError,
+    LSPServerNotFoundError,
+    LSPTimeoutError,
+)
+from openhands.sdk.lsp.manager import LSPServerManager
+from openhands.sdk.tool import ToolAnnotations, ToolDefinition, ToolExecutor
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation import LocalConversation
+
+
+logger = get_logger(__name__)
+
+
+LSP_TOOL_DESCRIPTION = """Code intelligence tool using Language Server Protocol (LSP).
+
+Provides capabilities to navigate and understand code:
+- 'definition': Go to the definition of a symbol (function, class, variable)
+- 'references': Find all references to a symbol across the codebase
+- 'hover': Get documentation, type information, and other details about a symbol
+
+Use this tool when you need to:
+- Find where a function or class is defined
+- Find all places where a symbol is used
+- Get type information or documentation for a symbol
+
+The tool supports multiple programming languages based on configured LSP servers.
+"""
+
+
+class LSPToolExecutor(ToolExecutor[LSPToolAction, LSPToolObservation]):
+    """Executor for LSP tool operations."""
+
+    def __init__(self, manager: LSPServerManager):
+        """Initialize LSP tool executor.
+
+        Args:
+            manager: LSP server manager for handling server lifecycle
+        """
+        self._manager = manager
+
+    def __call__(
+        self,
+        action: LSPToolAction,
+        conversation: "LocalConversation | None" = None,  # noqa: ARG002
+    ) -> LSPToolObservation:
+        """Execute an LSP operation.
+
+        Args:
+            action: The LSP action to execute
+            conversation: Optional conversation context (unused)
+
+        Returns:
+            Observation with the LSP query results
+        """
+        file_path = action.file_path
+
+        # Validate file exists
+        if not Path(file_path).exists():
+            return LSPToolObservation.from_error(
+                operation=action.operation,
+                file_path=file_path,
+                error_message=f"File not found: {file_path}",
+            )
+
+        try:
+            # Ensure document is open and get client
+            client, language_id = self._manager.ensure_document_open(file_path)
+
+            if client is None:
+                # No LSP server for this file type
+                ext = Path(file_path).suffix
+                return LSPToolObservation.from_error(
+                    operation=action.operation,
+                    file_path=file_path,
+                    error_message=f"No LSP server configured for file type '{ext}'. "
+                    "Make sure an LSP server is configured with the appropriate "
+                    "extensionToLanguage mapping.",
+                )
+
+            # Convert to URI and 0-indexed line
+            uri = Path(file_path).as_uri()
+            line = action.line - 1  # Convert from 1-indexed to 0-indexed
+            character = action.character
+
+            # Execute the appropriate operation
+            match action.operation:
+                case LSPOperation.DEFINITION:
+                    return self._execute_definition(
+                        client, action.operation, file_path, uri, line, character
+                    )
+                case LSPOperation.REFERENCES:
+                    return self._execute_references(
+                        client,
+                        action.operation,
+                        file_path,
+                        uri,
+                        line,
+                        character,
+                        action.include_declaration,
+                    )
+                case LSPOperation.HOVER:
+                    return self._execute_hover(
+                        client, action.operation, file_path, uri, line, character
+                    )
+                case _:
+                    return LSPToolObservation.from_error(
+                        operation=action.operation,
+                        file_path=file_path,
+                        error_message=f"Unsupported LSP operation: {action.operation}",
+                    )
+
+        except LSPServerNotFoundError as e:
+            return LSPToolObservation.from_error(
+                operation=action.operation,
+                file_path=file_path,
+                error_message=str(e),
+            )
+        except LSPTimeoutError as e:
+            return LSPToolObservation.from_error(
+                operation=action.operation,
+                file_path=file_path,
+                error_message=f"LSP request timed out after {e.timeout}s. "
+                "The language server may be busy or unresponsive.",
+            )
+        except LSPServerError as e:
+            return LSPToolObservation.from_error(
+                operation=action.operation,
+                file_path=file_path,
+                error_message=f"LSP server error (code {e.code}): {e}",
+            )
+        except LSPConnectionError as e:
+            return LSPToolObservation.from_error(
+                operation=action.operation,
+                file_path=file_path,
+                error_message=f"LSP connection error: {e}",
+            )
+        except Exception as e:
+            logger.exception(f"Unexpected error in LSP tool: {e}")
+            return LSPToolObservation.from_error(
+                operation=action.operation,
+                file_path=file_path,
+                error_message=f"Unexpected error: {e}",
+            )
+
+    def _execute_definition(
+        self,
+        client: Any,
+        operation: LSPOperation,
+        file_path: str,
+        uri: str,
+        line: int,
+        character: int,
+    ) -> LSPToolObservation:
+        """Execute textDocument/definition request."""
+        locations = client.call_sync(
+            client.text_document_definition(uri, line, character)
+        )
+        return LSPToolObservation.from_locations(operation, file_path, locations)
+
+    def _execute_references(
+        self,
+        client: Any,
+        operation: LSPOperation,
+        file_path: str,
+        uri: str,
+        line: int,
+        character: int,
+        include_declaration: bool,
+    ) -> LSPToolObservation:
+        """Execute textDocument/references request."""
+        locations = client.call_sync(
+            client.text_document_references(uri, line, character, include_declaration)
+        )
+        return LSPToolObservation.from_locations(operation, file_path, locations)
+
+    def _execute_hover(
+        self,
+        client: Any,
+        operation: LSPOperation,  # noqa: ARG002
+        file_path: str,
+        uri: str,
+        line: int,
+        character: int,
+    ) -> LSPToolObservation:
+        """Execute textDocument/hover request."""
+        hover_result = client.call_sync(
+            client.text_document_hover(uri, line, character)
+        )
+        return LSPToolObservation.from_hover(file_path, hover_result)
+
+    def close(self) -> None:
+        """Cleanup all LSP servers."""
+        self._manager.close_all()
+
+
+class LSPToolDefinition(ToolDefinition[LSPToolAction, LSPToolObservation]):
+    """LSP Tool definition that provides code intelligence capabilities.
+
+    This tool exposes LSP operations (definition, references, hover) to agents,
+    enabling them to navigate and understand code more effectively.
+    """
+
+    name: str = "lsp"
+
+    @classmethod
+    def create(
+        cls,
+        lsp_config: dict[str, Any],
+        workspace_root: str,
+    ) -> Sequence["LSPToolDefinition"]:
+        """Create LSP tool from configuration.
+
+        Args:
+            lsp_config: LSP configuration with server definitions
+            workspace_root: Root directory of the workspace
+
+        Returns:
+            List containing single LSPToolDefinition instance
+        """
+        manager = LSPServerManager(lsp_config, workspace_root)
+        executor = LSPToolExecutor(manager)
+
+        tool = cls(
+            description=LSP_TOOL_DESCRIPTION,
+            action_type=LSPToolAction,
+            observation_type=LSPToolObservation,
+            executor=executor,
+            annotations=ToolAnnotations(
+                title="Language Server Protocol",
+                readOnlyHint=True,
+                destructiveHint=False,
+                idempotentHint=True,
+                openWorldHint=False,
+            ),
+        )
+
+        return [tool]

--- a/openhands-sdk/openhands/sdk/lsp/utils.py
+++ b/openhands-sdk/openhands/sdk/lsp/utils.py
@@ -1,0 +1,107 @@
+"""Utility functions for LSP integration."""
+
+from typing import Any
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.lsp.tool import LSPToolDefinition
+
+
+logger = get_logger(__name__)
+
+
+def create_lsp_tools(
+    config: dict[str, Any],
+    workspace_root: str,
+    timeout: float = 30.0,  # noqa: ARG001
+) -> list[LSPToolDefinition]:
+    """Create LSP tools from configuration.
+
+    Similar to create_mcp_tools() in openhands/sdk/mcp/utils.py.
+
+    Args:
+        config: LSP configuration dictionary with format:
+            {"lspServers": {"name": {"command": "...", "args": [...], ...}}}
+            or {"servers": {"name": {...}}}
+        workspace_root: Root directory of the workspace
+        timeout: Default timeout for LSP operations (reserved for future use)
+
+    Returns:
+        List of LSPToolDefinition instances (empty if no servers configured)
+
+    Example:
+        >>> tools = create_lsp_tools({
+        ...     "lspServers": {
+        ...         "typescript": {
+        ...             "command": "typescript-language-server",
+        ...             "args": ["--stdio"],
+        ...             "extensionToLanguage": {
+        ...                 ".ts": "typescript",
+        ...                 ".tsx": "typescriptreact",
+        ...             }
+        ...         }
+        ...     }
+        ... }, workspace_root="/path/to/project")
+    """
+    # Support both "servers" and "lspServers" keys
+    servers = config.get("lspServers") or config.get("servers") or {}
+
+    if not servers:
+        logger.debug("No LSP servers configured, skipping LSP tool creation")
+        return []
+
+    # Normalize config to always use "servers" key internally
+    normalized_config = {"servers": servers}
+
+    try:
+        tools = LSPToolDefinition.create(
+            lsp_config=normalized_config,
+            workspace_root=workspace_root,
+        )
+        logger.info(
+            f"Created LSP tool with {len(servers)} server(s): {list(servers.keys())}"
+        )
+        return list(tools)
+    except Exception as e:
+        logger.error(f"Failed to create LSP tools: {e}", exc_info=True)
+        return []
+
+
+def validate_lsp_config(config: dict[str, Any]) -> list[str]:
+    """Validate LSP configuration and return list of errors.
+
+    Args:
+        config: LSP configuration dictionary
+
+    Returns:
+        List of validation error messages (empty if valid)
+    """
+    errors: list[str] = []
+    servers = config.get("lspServers") or config.get("servers") or {}
+
+    if not isinstance(servers, dict):
+        errors.append("LSP servers configuration must be a dictionary")
+        return errors
+
+    for name, server_config in servers.items():
+        if not isinstance(server_config, dict):
+            errors.append(f"Server '{name}' configuration must be a dictionary")
+            continue
+
+        if "command" not in server_config:
+            errors.append(f"Server '{name}' is missing required 'command' field")
+
+        ext_to_lang = server_config.get("extensionToLanguage") or server_config.get(
+            "extension_to_language"
+        )
+        if not ext_to_lang:
+            errors.append(
+                f"Server '{name}' is missing 'extensionToLanguage' mapping. "
+                "Without this, no files will be routed to the server."
+            )
+        elif not isinstance(ext_to_lang, dict):
+            errors.append(
+                f"Server '{name}' extensionToLanguage must be a dictionary "
+                "mapping file extensions to language IDs"
+            )
+
+    return errors

--- a/tests/sdk/lsp/__init__.py
+++ b/tests/sdk/lsp/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for LSP module."""

--- a/tests/sdk/lsp/test_lsp_tool.py
+++ b/tests/sdk/lsp/test_lsp_tool.py
@@ -1,0 +1,466 @@
+"""Tests for LSP tool functionality."""
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands.sdk.lsp.definition import (
+    LSPOperation,
+    LSPToolAction,
+    LSPToolObservation,
+    _extract_hover_content,
+    _uri_to_path,
+)
+from openhands.sdk.lsp.exceptions import (
+    LSPConnectionError,
+    LSPError,
+    LSPServerError,
+    LSPServerNotFoundError,
+    LSPTimeoutError,
+)
+from openhands.sdk.lsp.manager import LSPServerConfig, LSPServerManager
+from openhands.sdk.lsp.tool import LSPToolDefinition, LSPToolExecutor
+from openhands.sdk.lsp.utils import create_lsp_tools, validate_lsp_config
+
+
+class TestLSPToolAction:
+    """Tests for LSPToolAction schema."""
+
+    def test_create_definition_action(self):
+        """Test creating a definition action."""
+        action = LSPToolAction(
+            operation=LSPOperation.DEFINITION,
+            file_path="/path/to/file.ts",
+            line=10,
+            character=5,
+        )
+        assert action.operation == LSPOperation.DEFINITION
+        assert action.file_path == "/path/to/file.ts"
+        assert action.line == 10
+        assert action.character == 5
+        assert action.include_declaration is True  # default
+
+    def test_create_references_action(self):
+        """Test creating a references action with include_declaration."""
+        action = LSPToolAction(
+            operation=LSPOperation.REFERENCES,
+            file_path="/path/to/file.py",
+            line=20,
+            character=10,
+            include_declaration=False,
+        )
+        assert action.operation == LSPOperation.REFERENCES
+        assert action.include_declaration is False
+
+    def test_create_hover_action(self):
+        """Test creating a hover action."""
+        action = LSPToolAction(
+            operation=LSPOperation.HOVER,
+            file_path="/path/to/file.go",
+            line=1,
+            character=0,
+        )
+        assert action.operation == LSPOperation.HOVER
+
+
+class TestLSPToolObservation:
+    """Tests for LSPToolObservation schema."""
+
+    def test_from_locations_with_results(self):
+        """Test creating observation from location results."""
+        locations = [
+            {
+                "uri": "file:///path/to/definition.ts",
+                "range": {
+                    "start": {"line": 10, "character": 0},
+                    "end": {"line": 10, "character": 20},
+                },
+            },
+            {
+                "uri": "file:///path/to/other.ts",
+                "range": {
+                    "start": {"line": 5, "character": 4},
+                    "end": {"line": 5, "character": 15},
+                },
+            },
+        ]
+        obs = LSPToolObservation.from_locations(
+            LSPOperation.DEFINITION, "/query/file.ts", locations
+        )
+        assert not obs.is_error
+        assert "Found 2 definition(s)" in obs.text
+        assert "/path/to/definition.ts:11:0" in obs.text  # 1-indexed
+        assert "/path/to/other.ts:6:4" in obs.text
+
+    def test_from_locations_empty(self):
+        """Test creating observation from empty locations."""
+        obs = LSPToolObservation.from_locations(
+            LSPOperation.REFERENCES, "/query/file.ts", []
+        )
+        assert not obs.is_error
+        assert "No references found" in obs.text
+
+    def test_from_hover_with_result(self):
+        """Test creating observation from hover result."""
+        hover = {
+            "contents": {"kind": "markdown", "value": "**function** `greet(name: string)`"}
+        }
+        obs = LSPToolObservation.from_hover("/query/file.ts", hover)
+        assert not obs.is_error
+        assert "**function**" in obs.text
+
+    def test_from_hover_none(self):
+        """Test creating observation from None hover result."""
+        obs = LSPToolObservation.from_hover("/query/file.ts", None)
+        assert not obs.is_error
+        assert "No hover information available" in obs.text
+
+    def test_from_error(self):
+        """Test creating error observation."""
+        obs = LSPToolObservation.from_error(
+            LSPOperation.DEFINITION, "/query/file.ts", "Connection failed"
+        )
+        assert obs.is_error
+        assert "Connection failed" in obs.text
+
+
+class TestHoverContentExtraction:
+    """Tests for hover content extraction helper."""
+
+    def test_extract_string_content(self):
+        """Test extracting plain string content."""
+        assert _extract_hover_content("Hello world") == "Hello world"
+
+    def test_extract_markup_content(self):
+        """Test extracting MarkupContent."""
+        content = {"kind": "markdown", "value": "# Header\nText"}
+        assert _extract_hover_content(content) == "# Header\nText"
+
+    def test_extract_marked_string_with_language(self):
+        """Test extracting MarkedString with language."""
+        content = {"language": "typescript", "value": "const x: number = 5"}
+        result = _extract_hover_content(content)
+        assert "```typescript" in result
+        assert "const x: number = 5" in result
+
+    def test_extract_list_content(self):
+        """Test extracting list of content items."""
+        content = [
+            {"kind": "markdown", "value": "First"},
+            "Second",
+            {"language": "ts", "value": "code"},
+        ]
+        result = _extract_hover_content(content)
+        assert "First" in result
+        assert "Second" in result
+        assert "code" in result
+
+
+class TestUriToPath:
+    """Tests for URI to path conversion."""
+
+    def test_file_uri_unix(self):
+        """Test converting file:// URI on Unix."""
+        uri = "file:///home/user/project/file.ts"
+        assert _uri_to_path(uri) == "/home/user/project/file.ts"
+
+    def test_file_uri_with_spaces(self):
+        """Test converting URI with encoded spaces."""
+        uri = "file:///path/with%20spaces/file.ts"
+        assert _uri_to_path(uri) == "/path/with spaces/file.ts"
+
+    def test_non_file_uri(self):
+        """Test passing non-file URI returns as-is."""
+        uri = "https://example.com/file.ts"
+        assert _uri_to_path(uri) == uri
+
+
+class TestLSPExceptions:
+    """Tests for LSP exception classes."""
+
+    def test_lsp_error_base(self):
+        """Test base LSP error."""
+        error = LSPError("Something went wrong")
+        assert str(error) == "Something went wrong"
+
+    def test_lsp_timeout_error(self):
+        """Test timeout error with details."""
+        error = LSPTimeoutError(
+            "Request timed out",
+            timeout=30.0,
+            server_name="typescript",
+            operation="textDocument/definition",
+        )
+        assert error.timeout == 30.0
+        assert error.server_name == "typescript"
+        assert error.operation == "textDocument/definition"
+
+    def test_lsp_server_error(self):
+        """Test server error with code and data."""
+        error = LSPServerError(
+            "Method not found",
+            code=-32601,
+            data={"method": "unknown"},
+        )
+        assert error.code == -32601
+        assert error.data == {"method": "unknown"}
+
+    def test_lsp_server_not_found_error(self):
+        """Test server not found error."""
+        error = LSPServerNotFoundError("/path/to/file.xyz", ".xyz")
+        assert error.file_path == "/path/to/file.xyz"
+        assert error.extension == ".xyz"
+        assert ".xyz" in str(error)
+
+    def test_lsp_connection_error(self):
+        """Test connection error."""
+        error = LSPConnectionError("Failed to connect", server_name="pyright")
+        assert error.server_name == "pyright"
+
+
+class TestLSPServerConfig:
+    """Tests for LSP server configuration."""
+
+    def test_from_dict_basic(self):
+        """Test creating config from basic dict."""
+        data = {
+            "command": "typescript-language-server",
+            "args": ["--stdio"],
+        }
+        config = LSPServerConfig.from_dict(data)
+        assert config.command == "typescript-language-server"
+        assert config.args == ["--stdio"]
+        assert config.extension_to_language == {}
+
+    def test_from_dict_with_extensions(self):
+        """Test creating config with extension mappings."""
+        data = {
+            "command": "pyright",
+            "args": ["--stdio"],
+            "extensionToLanguage": {
+                ".py": "python",
+                ".pyi": "python",
+            },
+        }
+        config = LSPServerConfig.from_dict(data)
+        assert config.extension_to_language == {".py": "python", ".pyi": "python"}
+
+    def test_from_dict_snake_case(self):
+        """Test creating config with snake_case keys."""
+        data = {
+            "command": "gopls",
+            "extension_to_language": {".go": "go"},
+        }
+        config = LSPServerConfig.from_dict(data)
+        assert config.extension_to_language == {".go": "go"}
+
+
+class TestLSPServerManager:
+    """Tests for LSP server manager."""
+
+    def test_init_with_config(self):
+        """Test initializing manager with config."""
+        config = {
+            "lspServers": {
+                "typescript": {
+                    "command": "typescript-language-server",
+                    "args": ["--stdio"],
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        manager = LSPServerManager(config, "/workspace")
+        assert "typescript" in manager._server_configs
+
+    def test_get_server_for_file(self):
+        """Test file to server routing."""
+        config = {
+            "servers": {
+                "typescript": {
+                    "command": "tsserver",
+                    "extensionToLanguage": {".ts": "typescript", ".tsx": "typescriptreact"},
+                },
+                "python": {
+                    "command": "pyright",
+                    "extensionToLanguage": {".py": "python"},
+                },
+            }
+        }
+        manager = LSPServerManager(config, "/workspace")
+
+        assert manager.get_server_for_file("/path/file.ts") == "typescript"
+        assert manager.get_server_for_file("/path/file.tsx") == "typescript"
+        assert manager.get_server_for_file("/path/file.py") == "python"
+        assert manager.get_server_for_file("/path/file.xyz") is None
+
+    def test_get_language_id(self):
+        """Test getting language ID for file."""
+        config = {
+            "servers": {
+                "typescript": {
+                    "command": "tsserver",
+                    "extensionToLanguage": {".ts": "typescript", ".tsx": "typescriptreact"},
+                }
+            }
+        }
+        manager = LSPServerManager(config, "/workspace")
+
+        assert manager.get_language_id("/path/file.ts") == "typescript"
+        assert manager.get_language_id("/path/file.tsx") == "typescriptreact"
+        assert manager.get_language_id("/path/file.xyz") is None
+
+
+class TestValidateLspConfig:
+    """Tests for LSP config validation."""
+
+    def test_valid_config(self):
+        """Test validating correct config."""
+        config = {
+            "lspServers": {
+                "typescript": {
+                    "command": "typescript-language-server",
+                    "args": ["--stdio"],
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        errors = validate_lsp_config(config)
+        assert errors == []
+
+    def test_missing_command(self):
+        """Test validation catches missing command."""
+        config = {
+            "lspServers": {
+                "typescript": {
+                    "args": ["--stdio"],
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        errors = validate_lsp_config(config)
+        assert any("command" in e for e in errors)
+
+    def test_missing_extension_mapping(self):
+        """Test validation warns about missing extension mapping."""
+        config = {
+            "lspServers": {
+                "typescript": {
+                    "command": "tsserver",
+                }
+            }
+        }
+        errors = validate_lsp_config(config)
+        assert any("extensionToLanguage" in e for e in errors)
+
+    def test_invalid_servers_type(self):
+        """Test validation catches invalid servers type."""
+        config = {"lspServers": "invalid"}
+        errors = validate_lsp_config(config)
+        assert any("dictionary" in e for e in errors)
+
+
+class TestCreateLspTools:
+    """Tests for create_lsp_tools utility."""
+
+    def test_empty_config_returns_empty_list(self):
+        """Test that empty config returns empty list."""
+        tools = create_lsp_tools({}, "/workspace")
+        assert tools == []
+
+    def test_no_servers_returns_empty_list(self):
+        """Test that config with no servers returns empty list."""
+        tools = create_lsp_tools({"lspServers": {}}, "/workspace")
+        assert tools == []
+
+    def test_creates_tool_with_valid_config(self):
+        """Test creating tool with valid config."""
+        config = {
+            "lspServers": {
+                "typescript": {
+                    "command": "typescript-language-server",
+                    "args": ["--stdio"],
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        tools = create_lsp_tools(config, "/workspace")
+        assert len(tools) == 1
+        assert tools[0].name == "lsp"
+
+
+class TestLSPToolDefinition:
+    """Tests for LSPToolDefinition class."""
+
+    def test_create_tool(self):
+        """Test creating LSP tool definition."""
+        config = {
+            "servers": {
+                "typescript": {
+                    "command": "tsserver",
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        tools = LSPToolDefinition.create(config, "/workspace")
+        assert len(tools) == 1
+        tool = tools[0]
+        assert tool.name == "lsp"
+        assert tool.action_type == LSPToolAction
+        assert tool.observation_type == LSPToolObservation
+        assert tool.annotations is not None
+        assert tool.annotations.readOnlyHint is True
+
+
+class TestLSPToolExecutor:
+    """Tests for LSPToolExecutor."""
+
+    def test_file_not_found(self, tmp_path: Path):
+        """Test executor returns error for non-existent file."""
+        config = {
+            "servers": {
+                "typescript": {
+                    "command": "tsserver",
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        manager = LSPServerManager(config, str(tmp_path))
+        executor = LSPToolExecutor(manager)
+
+        action = LSPToolAction(
+            operation=LSPOperation.DEFINITION,
+            file_path="/nonexistent/file.ts",
+            line=1,
+            character=0,
+        )
+        result = executor(action)
+        assert result.is_error
+        assert "File not found" in result.text
+
+    def test_no_server_for_extension(self, tmp_path: Path):
+        """Test executor returns error when no server handles file type."""
+        # Create a file with unsupported extension
+        test_file = tmp_path / "file.xyz"
+        test_file.write_text("content")
+
+        config = {
+            "servers": {
+                "typescript": {
+                    "command": "tsserver",
+                    "extensionToLanguage": {".ts": "typescript"},
+                }
+            }
+        }
+        manager = LSPServerManager(config, str(tmp_path))
+        executor = LSPToolExecutor(manager)
+
+        action = LSPToolAction(
+            operation=LSPOperation.DEFINITION,
+            file_path=str(test_file),
+            line=1,
+            character=0,
+        )
+        result = executor(action)
+        assert result.is_error
+        assert "No LSP server configured" in result.text


### PR DESCRIPTION
Implements Language Server Protocol (LSP) runtime support for servers configured in plugins/marketplace, enabling agents to use code intelligence capabilities like go-to-definition, find-references, and hover documentation.

- Add openhands.sdk.lsp module with client, manager, and tool
- Support definition, references, and hover operations
- Integrate with Agent (lsp_config field) and Plugin (.lsp.json)
- Route files to appropriate servers via extensionToLanguage mapping
- Add 36 unit tests for LSP functionality

## Summary

[fill in a summary of this PR]

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

Issue: https://github.com/OpenHands/software-agent-sdk/issues/1745