### PR TITLE
Add Kimi K2.5 and Qwen3 Max Thinking models to eval config

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -29,10 +29,7 @@ MODELS = {
         "display_name": "Kimi K2 Thinking",
         "llm_config": {"model": "litellm_proxy/moonshot/kimi-k2-thinking"},
     },
-    # Kimi K2.5 - Native multimodal model with visual agentic capabilities
-    # Official parameters from https://www.kimi.com/blog/kimi-k2-5.html:
-    # - temperature=1.0, top_p=0.95, context_length=256k
-    # - thinking enabled by default via thinking={"type": "enabled"}
+    # https://www.kimi.com/blog/kimi-k2-5.html
     "kimi-k2.5": {
         "id": "kimi-k2.5",
         "display_name": "Kimi K2.5",
@@ -42,9 +39,7 @@ MODELS = {
             "top_p": 0.95,
         },
     },
-    # Qwen3-Max-Thinking - Alibaba's reasoning model with thinking capabilities
-    # Official parameters from https://www.alibabacloud.com/help/en/model-studio/deep-thinking:
-    # - enable_thinking=True for reasoning mode (passed via litellm_extra_body)
+    # https://www.alibabacloud.com/help/en/model-studio/deep-thinking
     "qwen3-max-thinking": {
         "id": "qwen3-max-thinking",
         "display_name": "Qwen3 Max Thinking",

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -155,7 +155,7 @@ FORCE_STRING_SERIALIZER_MODELS: list[str] = [
 # in the message input
 SEND_REASONING_CONTENT_MODELS: list[str] = [
     "kimi-k2-thinking",
-    "kimi-k2.5",  # Kimi K2.5 also requires reasoning_content in messages
+    "kimi-k2.5",
     "openrouter/minimax-m2",  # MiniMax-M2 via OpenRouter (interleaved thinking)
     "deepseek/deepseek-reasoner",
 ]
@@ -182,7 +182,7 @@ def get_features(model: str) -> ModelFeatures:
 # Each entry: (pattern, default_temperature)
 DEFAULT_TEMPERATURE_MODELS: list[tuple[str, float]] = [
     ("kimi-k2-thinking", 1.0),
-    ("kimi-k2.5", 1.0),  # Kimi K2.5 requires temperature=1.0
+    ("kimi-k2.5", 1.0),
 ]
 
 


### PR DESCRIPTION
## Summary

Add two new models to the evaluation configuration based on feedback from marketing and CRO teams.

## Changes

### 1. Kimi K2.5 (`moonshot/kimi-k2.5`)
- Native multimodal model with visual agentic capabilities
- Parameters per [official blog](https://www.kimi.com/blog/kimi-k2-5.html):
  - `temperature=1.0` (required, only value allowed)
  - `top_p=0.95` (required, only value allowed)
- 256k context window, thinking enabled by default
- Added to `SEND_REASONING_CONTENT_MODELS` for proper `reasoning_content` handling
- Added to `DEFAULT_TEMPERATURE_MODELS` with `temperature=1.0`

### 2. Qwen3 Max Thinking (`dashscope/qwen3-max-2026-01-23`)
- Alibaba's reasoning model with thinking capabilities
- Parameters per [official docs](https://www.alibabacloud.com/help/en/model-studio/deep-thinking):
  - `enable_thinking=True` passed via `litellm_extra_body`

## Integration Test Results

Both models were tested against the integration test suite:

| Model | Pass Rate | Details |
|-------|-----------|---------|
| **Kimi K2.5** | ✅ **100%** (7/7) | All applicable tests passed |
| **Qwen3 Max Thinking** | ✅ **85.7%** (6/7) | 1 test failed due to Dashscope JSON format issue |

### Detailed Results

**Kimi K2.5:**
- ✅ t01_fix_simple_typo
- ✅ t02_add_bash_hello
- ✅ t03_jupyter_write_file
- ✅ t04_git_staging
- ✅ t05_simple_browsing
- ✅ t06_github_pr_browsing
- ✅ t07_interactive_commands
- ⊘ t08_image_file_viewing (skipped - requires vision model)

**Qwen3 Max Thinking:**
- ✅ t01_fix_simple_typo
- ❌ t02_add_bash_hello (Dashscope JSON format issue)
- ✅ t03_jupyter_write_file
- ✅ t04_git_staging
- ✅ t05_simple_browsing
- ✅ t06_github_pr_browsing
- ✅ t07_interactive_commands
- ⊘ t08_image_file_viewing (skipped - requires vision model)

## Files Changed

- `.github/run-eval/resolve_model_config.py` - Added new model configurations
- `openhands-sdk/openhands/sdk/llm/utils/model_features.py` - Added Kimi K2.5 to `SEND_REASONING_CONTENT_MODELS` and `DEFAULT_TEMPERATURE_MODELS`

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:12e096f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-12e096f-python \
  ghcr.io/openhands/agent-server:12e096f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:12e096f-golang-amd64
ghcr.io/openhands/agent-server:12e096f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:12e096f-golang-arm64
ghcr.io/openhands/agent-server:12e096f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:12e096f-java-amd64
ghcr.io/openhands/agent-server:12e096f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:12e096f-java-arm64
ghcr.io/openhands/agent-server:12e096f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:12e096f-python-amd64
ghcr.io/openhands/agent-server:12e096f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:12e096f-python-arm64
ghcr.io/openhands/agent-server:12e096f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:12e096f-golang
ghcr.io/openhands/agent-server:12e096f-java
ghcr.io/openhands/agent-server:12e096f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `12e096f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `12e096f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->