### PR TITLE
fix(security): prevent auth token leakage in trajectory exports

### DIFF
--- a/openhands-sdk/openhands/sdk/secret/secrets.py
+++ b/openhands-sdk/openhands/sdk/secret/secrets.py
@@ -92,8 +92,10 @@ class LookupSecret(SecretSource):
         return result
 
 
+# Patterns used for substring matching against header names (case-insensitive).
+# Headers containing any of these patterns will be redacted during serialization.
+# Examples: X-Access-Token, Cookie, Authorization, X-API-Key, X-API-Secret
 _SECRET_HEADERS = [
-    "AUTH",
     "AUTHORIZATION",
     "COOKIE",
     "CREDENTIAL",


### PR DESCRIPTION
## Summary

This PR extends the secret header detection patterns added in #1822 by including additional authentication-related patterns: `CREDENTIAL` and `PASSWORD`.

## Context

PR #1822 already added `TOKEN`, `COOKIE`, and `SESSION` to fix the most critical leaks. This PR adds two more patterns (`CREDENTIAL` and `PASSWORD`) to provide comprehensive coverage of authentication headers.

**Note**: Initially included `AUTH` pattern, but removed it after review feedback due to false positive concerns (would match `Author`, `Co-Author`, etc.).

## Changes

**openhands-sdk/openhands/sdk/secret/secrets.py**
- Added documentation comment explaining substring matching behavior
- Added `CREDENTIAL` pattern (catches any credential headers)
- Added `PASSWORD` pattern (catches password-related headers)
- Maintains alphabetical ordering of patterns

**tests/sdk/conversation/test_secret_source.py**
- Added `test_lookup_secret_redacts_token_and_cookie_headers()` - validates X-Access-Token, Cookie, and X-Auth-Token headers are properly redacted
- Added `test_lookup_secret_author_header_not_redacted()` - prevents false positives with Author-related headers
- Ensures non-secret headers like Content-Type are preserved

## Final Pattern List (8 patterns)

```python
# Patterns used for substring matching against header names (case-insensitive).
# Headers containing any of these patterns will be redacted during serialization.
_SECRET_HEADERS = [
    "AUTHORIZATION",  # Existing
    "COOKIE",         # From #1822
    "CREDENTIAL",     # ✅ NEW - Catches credential headers  
    "KEY",            # Existing
    "PASSWORD",       # ✅ NEW - Catches password headers
    "SECRET",         # Existing
    "SESSION",        # From #1822
    "TOKEN",          # From #1822
]
```

## Testing

✅ All 8 tests in test file pass (including 2 new tests)
✅ New test validates X-Auth-Token redaction  
✅ New test prevents false positives with Author headers
✅ Pre-commit hooks pass (ruff, pyright, pycodestyle)

## Impact

### Headers Newly Protected by This PR
- `Credential` → `**********` ✅
- `X-Credential` → `**********` ✅
- `Password` → `**********` ✅  
- `X-Password` → `**********` ✅

### Complete Protection (with #1822)
All authentication-related headers are now comprehensively redacted:
- `Authorization` / `X-Authorization` ✅ (existing)
- `Cookie` / `Set-Cookie` ✅ (from #1822)
- `X-Access-Token` / `Bearer-Token` ✅ (from #1822)
- `API-Key` / `X-API-Key` ✅ (existing)
- `X-API-Secret` / `Client-Secret` ✅ (existing)
- `Session-ID` / `Session-Token` ✅ (from #1822)
- `Credential` / `X-Credential` ✅ (this PR)
- `Password` / `X-Password` ✅ (this PR)

### False Positives Prevented
- `Author` → preserved (not redacted) ✅
- `Co-Author` → preserved (not redacted) ✅
- `GitHub-Author` → preserved (not redacted) ✅

Non-secret headers like `Content-Type`, `Accept`, `User-Agent` continue to be preserved for debugging.

## Related

- Builds on #1822 which fixed the initial TOKEN/COOKIE/SESSION leak
- Part of ongoing security hardening for trajectory exports

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:05f1698-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-05f1698-python \
  ghcr.io/openhands/agent-server:05f1698-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:05f1698-golang-amd64
ghcr.io/openhands/agent-server:05f1698-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:05f1698-golang-arm64
ghcr.io/openhands/agent-server:05f1698-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:05f1698-java-amd64
ghcr.io/openhands/agent-server:05f1698-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:05f1698-java-arm64
ghcr.io/openhands/agent-server:05f1698-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:05f1698-python-amd64
ghcr.io/openhands/agent-server:05f1698-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:05f1698-python-arm64
ghcr.io/openhands/agent-server:05f1698-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:05f1698-golang
ghcr.io/openhands/agent-server:05f1698-java
ghcr.io/openhands/agent-server:05f1698-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `05f1698-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `05f1698-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->