### PR TITLE
Add tests for InternalServerError handling and mapping

### DIFF
--- a/tests/sdk/llm/test_exception_mapping.py
+++ b/tests/sdk/llm/test_exception_mapping.py
@@ -1,8 +1,14 @@
-from litellm.exceptions import BadRequestError
+from litellm.exceptions import (
+    APIConnectionError,
+    BadRequestError,
+    InternalServerError,
+    ServiceUnavailableError,
+)
 
 from openhands.sdk.llm.exceptions import (
     LLMAuthenticationError,
     LLMBadRequestError,
+    LLMServiceUnavailableError,
     map_provider_exception,
 )
 
@@ -39,3 +45,42 @@ def test_passthrough_unknown_exception():
     e = MyCustom("random")
     mapped = map_provider_exception(e)
     assert mapped is e
+
+
+def test_map_internal_server_error_to_service_unavailable():
+    """Test that InternalServerError is mapped to LLMServiceUnavailableError.
+
+    This covers the case where an LLM provider returns a 500 error,
+    such as 'Error code: 500 - {"error": "Error processing the request"}'.
+    """
+    e = InternalServerError(
+        message="InternalServerError: OpenAIException - Error code: 500 - "
+        "{'error': 'Error processing the request'}",
+        model=MODEL,
+        llm_provider=PROVIDER,
+    )
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMServiceUnavailableError)
+    assert "Error code: 500" in str(mapped)
+
+
+def test_map_service_unavailable_error():
+    """Test that ServiceUnavailableError is mapped to LLMServiceUnavailableError."""
+    e = ServiceUnavailableError(
+        message="Service temporarily unavailable",
+        model=MODEL,
+        llm_provider=PROVIDER,
+    )
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMServiceUnavailableError)
+
+
+def test_map_api_connection_error():
+    """Test that APIConnectionError is mapped to LLMServiceUnavailableError."""
+    e = APIConnectionError(
+        message="Connection refused",
+        model=MODEL,
+        llm_provider=PROVIDER,
+    )
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMServiceUnavailableError)


### PR DESCRIPTION
## Summary

This PR adds comprehensive tests for the `InternalServerError` exception handling that was reported in issue #1697.

The issue reported a `ConversationRunError` with `litellm.InternalServerError: InternalServerError: OpenAIException - Error code: 500 - {'error': 'Error processing the request'}`. After analyzing the conversation data from the issue, I found that:

1. The existing code **already handles `InternalServerError` correctly** by:
   - Including it in `LLM_RETRY_EXCEPTIONS` for automatic retry
   - Mapping it to `LLMServiceUnavailableError` in `map_provider_exception()`

2. However, there were **no tests** to verify this behavior, which made it difficult to confirm the code was working as expected.

This PR adds the following tests:

### In `test_exception_mapping.py`:
- `test_map_internal_server_error_to_service_unavailable` - Verifies `InternalServerError` is correctly mapped to `LLMServiceUnavailableError`
- `test_map_service_unavailable_error` - Verifies `ServiceUnavailableError` mapping
- `test_map_api_connection_error` - Verifies `APIConnectionError` mapping

### In `test_api_connection_error_retry.py`:
- `test_completion_retries_internal_server_error` - Verifies retry behavior for 500 errors
- `test_completion_max_retries_internal_server_error` - Verifies max retries and proper exception mapping when all retries are exhausted

These tests ensure the behavior is documented and protected against regression.

Fixes #1697

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43b6b4d5cf2c4aa4a11aa75ef76a869a)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3a0e919-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3a0e919-python \
  ghcr.io/openhands/agent-server:3a0e919-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3a0e919-golang-amd64
ghcr.io/openhands/agent-server:3a0e919-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3a0e919-golang-arm64
ghcr.io/openhands/agent-server:3a0e919-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3a0e919-java-amd64
ghcr.io/openhands/agent-server:3a0e919-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3a0e919-java-arm64
ghcr.io/openhands/agent-server:3a0e919-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3a0e919-python-amd64
ghcr.io/openhands/agent-server:3a0e919-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:3a0e919-python-arm64
ghcr.io/openhands/agent-server:3a0e919-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:3a0e919-golang
ghcr.io/openhands/agent-server:3a0e919-java
ghcr.io/openhands/agent-server:3a0e919-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3a0e919-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3a0e919-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->