### PR TITLE
fix: Add AttributeError to escape_bash_special_chars exception handling

### DIFF
--- a/openhands-tools/openhands/tools/terminal/utils/command.py
+++ b/openhands-tools/openhands/tools/terminal/utils/command.py
@@ -141,7 +141,7 @@ def escape_bash_special_chars(command: str) -> str:
         remaining = command[last_pos:]
         parts.append(remaining)
         return "".join(parts)
-    except (ParsingError, NotImplementedError, TypeError):
+    except (ParsingError, NotImplementedError, TypeError, AttributeError):
         logger.debug(
             f"Failed to parse bash commands for special characters escape\n[input]: "
             f"{command}\n[warning]: {traceback.format_exc()}\nThe original command "


### PR DESCRIPTION
## Summary

Fixes #1870

When parsing comment-only bash commands (e.g., `# comment`), bashlex can return strings in `node.parts` instead of node objects. Accessing `.kind` on these strings causes an `AttributeError` crash that kills the entire conversation.

## Changes

- Added `AttributeError` to the except clause in `escape_bash_special_chars()` (line 144)

## Why this fix?

This is consistent with `split_bash_commands()` in the same file which already handles this case:

```python
# Lines 19-24
except (
    ParsingError,
    NotImplementedError,
    TypeError,
    AttributeError,  # Already handled here!
):
    # Added AttributeError to catch 'str' object has no attribute 'kind' error
    # (issue #8369)
```

The same pattern was missed for `escape_bash_special_chars()`.

## Test plan

- [x] Verify comment-only bash commands no longer crash
- [x] Verify normal bash commands still work correctly

🤖 Generated with [Claude Code](https://claude.ai/code)