### PR TITLE
Standardize to PEP585 Generics and PEP604 Unions

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -1,7 +1,7 @@
 import io
 import re
 from pathlib import Path
-from typing import Annotated, ClassVar, Literal, Union
+from typing import Annotated, ClassVar, Literal
 from xml.sax.saxutils import escape as xml_escape
 
 import frontmatter
@@ -476,7 +476,7 @@ class Skill(BaseModel):
             )
 
     @classmethod
-    def _handle_third_party(cls, path: Path, file_content: str) -> Union["Skill", None]:
+    def _handle_third_party(cls, path: Path, file_content: str) -> "Skill | None":
         """Handle third-party skill files (e.g., .cursorrules, AGENTS.md).
 
         Creates a Skill with None trigger (always active) if the file type

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,11 +38,13 @@ indent-style = "space"
 
 [tool.ruff.lint]
 select = [
-    "E",    # pycodestyle errors
-    "F",    # pyflakes (includes F841: unused-variable)
-    "I",    # isort
-    "UP",   # pyupgrade
-    "ARG",  # flake8-unused-arguments
+    "E",      # pycodestyle errors
+    "F",      # pyflakes (includes F841: unused-variable)
+    "I",      # isort
+    "UP",     # pyupgrade
+    "UP006",  # PEP585: Use `list` instead of `List` for type annotations
+    "UP007",  # PEP604: Use `X | Y` for type unions
+    "ARG",    # flake8-unused-arguments
 ]
 # Enforce rules that catch mutable defaults and related pitfalls
 # - B006: mutable-argument-default


### PR DESCRIPTION
## Summary

This PR standardizes the codebase to use modern Python typing syntax as specified in PEP585 and PEP604:

- **PEP585**: Use built-in generics like `list`, `dict`, `tuple` instead of `typing.List`, `typing.Dict`, `typing.Tuple`
- **PEP604**: Use `X | Y` union syntax instead of `Union[X, Y]` and `X | None` instead of `Optional[X]`

### Changes

1. **pyproject.toml**: Explicitly enabled UP006 and UP007 linting rules in ruff configuration with descriptive comments
   - `UP006`: PEP585 - Use `list` instead of `List` for type annotations
   - `UP007`: PEP604 - Use `X | Y` for type unions

2. **skill.py**: Updated to use PEP604 union syntax
   - Changed `Union["Skill", None]` to `"Skill | None"`
   - Removed unused `Union` import

### Notes

- The remaining `Union` usages in the codebase are valid and cannot be replaced:
  - `models.py`: Uses `Union[*tuple(...)]` for dynamic union creation with unpacking syntax
  - `env_parser.py`: Uses `Union` as a runtime type check (`origin is Union`)

Fixes #1873

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f52862921ff7413d857d9a1ae89cc82b)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c5aa85c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c5aa85c-python \
  ghcr.io/openhands/agent-server:c5aa85c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c5aa85c-golang-amd64
ghcr.io/openhands/agent-server:c5aa85c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c5aa85c-golang-arm64
ghcr.io/openhands/agent-server:c5aa85c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c5aa85c-java-amd64
ghcr.io/openhands/agent-server:c5aa85c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c5aa85c-java-arm64
ghcr.io/openhands/agent-server:c5aa85c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c5aa85c-python-amd64
ghcr.io/openhands/agent-server:c5aa85c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:c5aa85c-python-arm64
ghcr.io/openhands/agent-server:c5aa85c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:c5aa85c-golang
ghcr.io/openhands/agent-server:c5aa85c-java
ghcr.io/openhands/agent-server:c5aa85c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c5aa85c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c5aa85c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->