### PR TITLE
fix: unable to start a new v1 conversation when using the latest sdk code

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -34,8 +34,11 @@ logger = logging.getLogger(__name__)
 def _compose_conversation_info(
     stored: StoredConversation, state: ConversationState
 ) -> ConversationInfo:
+    # Use mode='json' so SecretStr in nested structures (e.g. LookupSecret.headers,
+    # agent.agent_context.secrets) serialize to strings. Without it, validation
+    # fails because ConversationInfo expects dict[str, str] but receives SecretStr.
     return ConversationInfo(
-        **state.model_dump(),
+        **state.model_dump(mode="json"),
         title=stored.title,
         metrics=stored.metrics,
         created_at=stored.created_at,
@@ -241,9 +244,14 @@ class ConversationService:
         # 1. Fetch and load plugins on first run()/send_message()
         # 2. Resolve refs to commit SHAs for deterministic resume
         # 3. Merge plugin skills/MCP/hooks into the agent
+        #
+        # Use mode='json' so SecretStr in nested structures (e.g. LookupSecret.headers)
+        # serialize to plain strings. Pass expose_secrets=True so StaticSecret values
+        # are preserved through the round-trip; the dict is only used in-process to
+        # construct StoredConversation, not sent over the network.
         stored = StoredConversation(
             id=conversation_id,
-            **request.model_dump(),
+            **request.model_dump(mode="json", context={"expose_secrets": True}),
         )
         event_service = await self._start_event_service(stored)
         initial_message = request.initial_message

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -526,7 +526,7 @@ class TestConversationServiceStartConversation:
                 mock_event_service.get_state.return_value = mock_state
                 mock_event_service.stored = StoredConversation(
                     id=mock_state.id,
-                    **request.model_dump(),
+                    **request.model_dump(mode="json", context={"expose_secrets": True}),
                     created_at=datetime.now(UTC),
                     updated_at=datetime.now(UTC),
                 )
@@ -588,7 +588,7 @@ class TestConversationServiceStartConversation:
                 mock_event_service.get_state.return_value = mock_state
                 mock_event_service.stored = StoredConversation(
                     id=mock_state.id,
-                    **request.model_dump(),
+                    **request.model_dump(mode="json", context={"expose_secrets": True}),
                     created_at=datetime.now(UTC),
                     updated_at=datetime.now(UTC),
                 )


### PR DESCRIPTION
## Summary

Currently, when using the latest code from the SDK, it is not possible to start a new v1 conversation.

This issue should be addressed so that v1 conversations can be created successfully when using the most recent SDK version.

**Acceptance Criteria:**
- It is possible to start a new v1 conversation when using the latest code from the SDK.

Fixes validation errors when creating conversations with secrets that use `LookupSecret` with authentication headers. The issue was caused by improper serialization of `SecretStr` objects in nested structures during conversation initialization.

## Demo Video

https://github.com/user-attachments/assets/344789a8-fba6-4c0b-9432-8f549ba32956

## Root Cause

After commit `3863f012` added `"TOKEN"` to the `_SECRET_HEADERS` list (for security hardening), the header `X-Access-Token` in `LookupSecret` instances became treated as a secret header. This caused a serialization/validation mismatch:

1. **In `StoredConversation` construction** (line 252):

   - `request.model_dump()` was called without `mode='json'`
   - `SecretStr` objects in `LookupSecret.headers` remained as Python objects
   - When `StoredConversation` validated, it expected `dict[str, str]` but received `dict[str, SecretStr]`
   - **Result**: Pydantic validation error

2. **In `_compose_conversation_info`** (line 37):
   - `state.model_dump()` was called without `mode='json'`
   - Nested `SecretStr` in `state.agent.agent_context.secrets` and `state.secret_registry` remained as objects
   - When `ConversationInfo` validated, same type mismatch occurred
   - **Result**: Pydantic validation error

## Changes Made

### 1. Fix `StoredConversation` construction

```python
stored = StoredConversation(
    id=conversation_id,
    **request.model_dump(mode="json", context={"expose_secrets": True}),
)
```

- **`mode="json"`**: Ensures all `SecretStr` objects serialize to strings (including nested ones in `LookupSecret.headers`)
- **`context={"expose_secrets": True}`**: Preserves actual secret values (not masked) because `StoredConversation` is internal—the agent needs real secrets to function

### 2. Fix `_compose_conversation_info`

```python
return ConversationInfo(
    **state.model_dump(mode="json"),
    title=stored.title,
    metrics=stored.metrics,
    created_at=stored.created_at,
    updated_at=stored.updated_at,
)
```

- **`mode="json"`**: Ensures all `SecretStr` objects serialize to strings
- **No `expose_secrets`**: Secrets are redacted (`"**********"`) because `ConversationInfo` is returned in API responses and webhooks—we must not expose secrets externally

### 3. Update test mocks

Updated `test_conversation_service.py` to use the same serialization in mocks so tests match production behavior.

## Testing

- All 41 tests in `tests/agent_server/test_conversation_service.py` pass
- Specifically verified `test_start_conversation_with_secrets` which tests secret preservation
- Pre-commit hooks pass (format, lint, type check)

## Impact

- **Before**: Conversations with `LookupSecret` (e.g., GitHub/GitLab tokens via webhooks) failed to start with validation errors
- **After**: Conversations start successfully, secrets work correctly internally, and are properly redacted in external responses


## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:66b52cb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-66b52cb-python \
  ghcr.io/openhands/agent-server:66b52cb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:66b52cb-golang-amd64
ghcr.io/openhands/agent-server:66b52cb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:66b52cb-golang-arm64
ghcr.io/openhands/agent-server:66b52cb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:66b52cb-java-amd64
ghcr.io/openhands/agent-server:66b52cb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:66b52cb-java-arm64
ghcr.io/openhands/agent-server:66b52cb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:66b52cb-python-amd64
ghcr.io/openhands/agent-server:66b52cb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:66b52cb-python-arm64
ghcr.io/openhands/agent-server:66b52cb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:66b52cb-golang
ghcr.io/openhands/agent-server:66b52cb-java
ghcr.io/openhands/agent-server:66b52cb-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `66b52cb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `66b52cb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->