### PR TITLE
utils(release): Fix poetry lock conflict and move openhands-cli step earlier

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -139,7 +139,7 @@ jobs:
               run: |
                   set -euo pipefail
 
-                  REPO="All-Hands-AI/openhands-cli"
+                  REPO="OpenHands/openhands-cli"
                   BRANCH="bump-sdk-$VERSION"
 
                   echo "🔄 Creating PR for $REPO..."


### PR DESCRIPTION
## Summary

This PR fixes the failing GitHub Actions workflow (https://github.com/OpenHands/software-agent-sdk/actions/runs/21639490412/job/62374987438) and reorders the version bump steps.

## The Problem

The workflow was failing with:
```
Cannot enrich dependency with incompatible constraints: openhands-agent-server (==1.11.0) and openhands-agent-server (==1.10)
```

This happened because `poetry add` updates **both** `pyproject.toml` AND `poetry.lock`, and then the subsequent `poetry lock` tried to resolve constraints between the partially updated lock file and the new specs.

## The Fix

1. **Use `poetry add --lock`** - Only updates `pyproject.toml` without modifying the lock file, avoiding constraint conflicts

2. **Use `poetry lock --no-update`** - Regenerates lock files cleanly from the updated `pyproject.toml` specs without trying to update other dependencies

## Additional Change

3. **Move OpenHands-CLI PR creation step before OpenHands PR step** - As requested, since it's simpler (uses `uv add` directly) and less error-prone than the OpenHands step which involves poetry operations in both root and enterprise directories.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:95bfc91-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-95bfc91-python \
  ghcr.io/openhands/agent-server:95bfc91-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:95bfc91-golang-amd64
ghcr.io/openhands/agent-server:95bfc91-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:95bfc91-golang-arm64
ghcr.io/openhands/agent-server:95bfc91-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:95bfc91-java-amd64
ghcr.io/openhands/agent-server:95bfc91-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:95bfc91-java-arm64
ghcr.io/openhands/agent-server:95bfc91-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:95bfc91-python-amd64
ghcr.io/openhands/agent-server:95bfc91-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:95bfc91-python-arm64
ghcr.io/openhands/agent-server:95bfc91-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:95bfc91-golang
ghcr.io/openhands/agent-server:95bfc91-java
ghcr.io/openhands/agent-server:95bfc91-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `95bfc91-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `95bfc91-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->