### PR TITLE
Add qwen3-coder-next to expected models

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -119,6 +119,11 @@ MODELS = {
         "display_name": "GLM-4.7",
         "llm_config": {"model": "litellm_proxy/openrouter/z-ai/glm-4.7"},
     },
+    "qwen3-coder-next": {
+        "id": "qwen3-coder-next",
+        "display_name": "Qwen3 Coder Next",
+        "llm_config": {"model": "litellm_proxy/together_ai/Qwen/Qwen3-Coder-Next-FP8"},
+    },
 }
 
 

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -135,6 +135,7 @@ EXPECTED_MODELS = [
     "deepseek-v3.2-reasoner",
     "qwen-3-coder",
     "glm-4.7",
+    "qwen3-coder-next",
 ]
 
 


### PR DESCRIPTION
## Summary

Add model `litellm_proxy/together_ai/Qwen/Qwen3-Coder-Next-FP8` with id `qwen3-coder-next` to the expected models in `resolve_model_config.py`.

Fixes #1891

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9fe86af900334fc5b5569eee95629886)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c0698be-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c0698be-python \
  ghcr.io/openhands/agent-server:c0698be-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c0698be-golang-amd64
ghcr.io/openhands/agent-server:c0698be-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c0698be-golang-arm64
ghcr.io/openhands/agent-server:c0698be-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c0698be-java-amd64
ghcr.io/openhands/agent-server:c0698be-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c0698be-java-arm64
ghcr.io/openhands/agent-server:c0698be-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c0698be-python-amd64
ghcr.io/openhands/agent-server:c0698be-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:c0698be-python-arm64
ghcr.io/openhands/agent-server:c0698be-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:c0698be-golang
ghcr.io/openhands/agent-server:c0698be-java
ghcr.io/openhands/agent-server:c0698be-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c0698be-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c0698be-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->