### PR TITLE
feat(llm): add gpt-5.2-codex to verified models

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -1,5 +1,6 @@
 VERIFIED_OPENAI_MODELS = [
     "gpt-5.2",
+    "gpt-5.2-codex",
     "gpt-5.1",
     "gpt-5.1-codex-max",
     "gpt-5.1-codex",
@@ -46,6 +47,7 @@ VERIFIED_OPENHANDS_MODELS = [
     "claude-opus-4-5-20251101",
     "claude-sonnet-4-5-20250929",
     "gpt-5.2",
+    "gpt-5.2-codex",
     "gpt-5.1-codex-max",
     "gpt-5.1-codex",
     "gpt-5.1",

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -36,6 +36,9 @@ def test_model_matches(name, pattern, expected):
         # Gemini 3 family
         ("gemini-3-pro-preview", True),
         ("gemini-3-flash-preview", True),
+        # GPT-5 family
+        ("gpt-5.2", True),
+        ("gpt-5.2-codex", True),
         ("gpt-4o", False),
         ("claude-3-5-sonnet", False),
         ("gemini-1.5-pro", False),
@@ -222,6 +225,8 @@ def test_supports_stop_words_false_models(model):
         ("gpt-5.1", True),
         ("openai/gpt-5.1-codex-mini", True),
         ("gpt-5", True),
+        ("gpt-5.2", True),
+        ("gpt-5.2-codex", True),
         ("openai/gpt-5-mini", True),
         ("codex-mini-latest", True),
         ("openai/codex-mini-latest", True),
@@ -256,6 +261,7 @@ def test_force_string_serializer_full_model_names():
         ("gpt-5", True),
         # New GPT-5.2 family should support extended retention
         ("gpt-5.2", True),
+        ("gpt-5.2-codex", True),
         ("openai/gpt-5.2-chat-latest", True),
         ("openai/gpt-5.2-pro", True),
         ("openai/gpt-5-mini", False),


### PR DESCRIPTION
Add gpt-5.2-codex to both VERIFIED_OPENAI_MODELS and VERIFIED_OPENHANDS_MODELS to enable support in the OpenHands provider interface.

## Changes
- Added `gpt-5.2-codex` to `VERIFIED_OPENAI_MODELS`
- Added `gpt-5.2-codex` to `VERIFIED_OPENHANDS_MODELS`
- Added comprehensive tests for gpt-5.2-codex:
  - Prompt cache retention support
  - Reasoning effort support
  - Responses API support

This completes the gpt-5.2 family support alongside the existing gpt-5.2 model.

Related to OpenHands/OpenHands#12720