### PR TITLE
Change qwen3-coder-next model from together.ai to openrouter

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -122,7 +122,7 @@ MODELS = {
     "qwen3-coder-next": {
         "id": "qwen3-coder-next",
         "display_name": "Qwen3 Coder Next",
-        "llm_config": {"model": "litellm_proxy/together_ai/Qwen/Qwen3-Coder-Next-FP8"},
+        "llm_config": {"model": "litellm_proxy/openrouter/qwen/qwen3-coder-next"},
     },
 }
 


### PR DESCRIPTION
## Summary

This PR changes the `qwen3-coder-next` model configuration from `together.ai` to `openrouter` provider.

The together.ai model does not support tools, causing the following error:
```
litellm.UnsupportedParamsError: together_ai does not support parameters: ['tools'], for model=Qwen/Qwen3-Coder-Next-FP8
```

**Change:**
- From: `litellm_proxy/together_ai/Qwen/Qwen3-Coder-Next-FP8`
- To: `litellm_proxy/openrouter/qwen/qwen3-coder-next`

Fixes #1899

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - This is a configuration change only; existing tests verify the model is present and has required fields
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - configuration change only
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A - configuration change only
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - no documentation changes needed
- [x] Is the github CI passing?
  - Pre-commit hooks passed locally

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cb690421791840758c1e87959142c9a2)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:182e590-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-182e590-python \
  ghcr.io/openhands/agent-server:182e590-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:182e590-golang-amd64
ghcr.io/openhands/agent-server:182e590-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:182e590-golang-arm64
ghcr.io/openhands/agent-server:182e590-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:182e590-java-amd64
ghcr.io/openhands/agent-server:182e590-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:182e590-java-arm64
ghcr.io/openhands/agent-server:182e590-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:182e590-python-amd64
ghcr.io/openhands/agent-server:182e590-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:182e590-python-arm64
ghcr.io/openhands/agent-server:182e590-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:182e590-golang
ghcr.io/openhands/agent-server:182e590-java
ghcr.io/openhands/agent-server:182e590-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `182e590-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `182e590-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->