### PR TITLE
fix: prevent agent server crash on tmux session creation failure

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/__init__.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/__init__.py
@@ -10,7 +10,10 @@ from openhands.tools.terminal.terminal.terminal_session import (
     TerminalCommandStatus,
     TerminalSession,
 )
-from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
+from openhands.tools.terminal.terminal.tmux_terminal import (
+    TerminalInitializationError,
+    TmuxTerminal,
+)
 
 
 __all__ = [
@@ -20,5 +23,6 @@ __all__ = [
     "SubprocessTerminal",
     "TerminalSession",
     "TerminalCommandStatus",
+    "TerminalInitializationError",
     "create_terminal_session",
 ]


### PR DESCRIPTION
## Summary

[fill in a summary of this PR]

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5a278ab-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5a278ab-python \
  ghcr.io/openhands/agent-server:5a278ab-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5a278ab-golang-amd64
ghcr.io/openhands/agent-server:5a278ab-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5a278ab-golang-arm64
ghcr.io/openhands/agent-server:5a278ab-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5a278ab-java-amd64
ghcr.io/openhands/agent-server:5a278ab-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5a278ab-java-arm64
ghcr.io/openhands/agent-server:5a278ab-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5a278ab-python-amd64
ghcr.io/openhands/agent-server:5a278ab-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:5a278ab-python-arm64
ghcr.io/openhands/agent-server:5a278ab-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:5a278ab-golang
ghcr.io/openhands/agent-server:5a278ab-java
ghcr.io/openhands/agent-server:5a278ab-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5a278ab-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5a278ab-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->