### PR TITLE
Add qwen3-coder-30b-a3b-instruct model to resolve_model_config.py

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -124,6 +124,11 @@ MODELS = {
         "display_name": "Qwen3 Coder Next",
         "llm_config": {"model": "litellm_proxy/openrouter/qwen/qwen3-coder-next"},
     },
+    "qwen3-coder-30b-a3b-instruct": {
+        "id": "qwen3-coder-30b-a3b-instruct",
+        "display_name": "Qwen3 Coder 30B A3B Instruct",
+        "llm_config": {"model": "litellm_proxy/Qwen3-Coder-30B-A3B-Instruct"},
+    },
 }
 
 

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -136,6 +136,7 @@ EXPECTED_MODELS = [
     "qwen-3-coder",
     "glm-4.7",
     "qwen3-coder-next",
+    "qwen3-coder-30b-a3b-instruct",
 ]
 
 


### PR DESCRIPTION
## Summary

Adds the model `litellm_proxy/Qwen3-Coder-30B-A3B-Instruct` with id `qwen3-coder-30b-a3b-instruct` to the expected models in `resolve_model_config.py`.

Fixes #1901

## Changes

- Added new model entry `qwen3-coder-30b-a3b-instruct` to the `MODELS` dictionary in `.github/run-eval/resolve_model_config.py`
- Added the model to `EXPECTED_MODELS` list in `tests/github_workflows/test_resolve_model_config.py`

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e8a69839daca4349b0f352efece9d91a)