### PR TITLE
DRAFT: fix: disable posix_spawn on Python 3.13+ to fix libtmux race condition

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -2,8 +2,19 @@
 
 import fcntl
 import os
+import subprocess
+import sys
 import time
 import uuid
+
+
+# Workaround for Python 3.13+ race condition with libtmux.
+# Python 3.13 uses posix_spawn() more aggressively for subprocess calls,
+# which can cause a race condition in libtmux where list-sessions query
+# runs before tmux has fully registered a newly created session.
+# See: https://docs.python.org/3/whatsnew/3.13.html#subprocess
+if sys.version_info >= (3, 13) and hasattr(subprocess, "_USE_POSIX_SPAWN"):
+    subprocess._USE_POSIX_SPAWN = False
 
 import libtmux
 from libtmux.exc import TmuxObjectDoesNotExist


### PR DESCRIPTION
## Summary

This PR fixes the Docker/Apptainer sandboxed server example tests failing in CI (issue #1886) **without downgrading Python 3.13**.

### Root Cause Analysis

Python 3.13 made a significant change to subprocess behavior ([gh-113117](https://github.com/python/cpython/issues/113117)):
> "The subprocess module now uses the `posix_spawn()` function in more situations, including when `close_fds` is `True` (the default) on many modern platforms."

This causes a race condition in libtmux where:
1. `server.new_session()` creates a tmux session via `tmux new-session`
2. Immediately after, it queries via `list-sessions` to get full session info
3. With Python 3.13's faster `posix_spawn()`, the query can execute before tmux has fully registered the session

### The Fix

This PR disables `posix_spawn` specifically for Python 3.13+ before importing libtmux:

```python
if sys.version_info >= (3, 13) and hasattr(subprocess, "_USE_POSIX_SPAWN"):
    subprocess._USE_POSIX_SPAWN = False
```

This is the [official control knob](https://docs.python.org/3/whatsnew/3.13.html#subprocess) provided by Python 3.13:
> "A private control knob `subprocess._USE_POSIX_SPAWN` can be set to `False` if you need to force subprocess to never use `posix_spawn()`."

### Alternative to PR #1910

This approach allows us to keep Python 3.13 in the Docker image instead of downgrading to Python 3.12.

### Testing

The `test-examples` label triggers CI to:
1. Build a new Docker image with this fix
2. Run the example tests against that new image

**Note**: Local testing cannot verify this fix because it requires a Docker image built with the fix. The pre-built `latest-python` image doesn't contain the fix.

Fixes #1886