### PR TITLE
fix: Remove python-version from setup-uv in create-version-bump-prs job

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -128,7 +128,6 @@ jobs:
               uses: astral-sh/setup-uv@v7
               with:
                   version: latest
-                  python-version: '3.13'
 
             - name: Install Poetry
               run: |


### PR DESCRIPTION
## Summary

Fixes the failing `pypi-release.yml` workflow by removing the `python-version: '3.13'` parameter from the `setup-uv` action in the `create-version-bump-prs` job.

### Root Cause
The `setup-uv` action was setting `UV_PYTHON=3.13` as an environment variable, which overrides the target project's Python requirements. When the workflow cloned `openhands-cli` (which requires Python 3.12 via `project.requires-python: ==3.12.*`) and ran `uv add`, it failed with:

```
error: The requested interpreter resolved to Python 3.13.12, which is incompatible with the project's Python requirement: `==3.12.*` (from `project.requires-python`)
```

### Fix
By not specifying `python-version` in the `setup-uv` action for the `create-version-bump-prs` job, `uv` will respect each target project's `requires-python` setting instead of using a globally enforced Python version.

Fixes #1922

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - N/A - This is a workflow configuration fix, no code tests needed
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - Workflow changes can only be tested by running the workflow
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - No documentation changes needed
- [ ] Is the github CI passing?
  - Will be verified after PR is created

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/89c0e4cff713471bbe22fa4deebddecb)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8a26504-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8a26504-python \
  ghcr.io/openhands/agent-server:8a26504-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8a26504-golang-amd64
ghcr.io/openhands/agent-server:8a26504-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8a26504-golang-arm64
ghcr.io/openhands/agent-server:8a26504-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8a26504-java-amd64
ghcr.io/openhands/agent-server:8a26504-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8a26504-java-arm64
ghcr.io/openhands/agent-server:8a26504-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8a26504-python-amd64
ghcr.io/openhands/agent-server:8a26504-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:8a26504-python-arm64
ghcr.io/openhands/agent-server:8a26504-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:8a26504-golang
ghcr.io/openhands/agent-server:8a26504-java
ghcr.io/openhands/agent-server:8a26504-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8a26504-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8a26504-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->