### PR TITLE
nit(sdk): change usage_to_llm to return a MappingProxyType

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm_registry.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_registry.py
@@ -66,7 +66,7 @@ class LLMRegistry:
 
     @property
     def usage_to_llm(self) -> MappingProxyType[str, LLM]:
-        """Access the internal usage-ID-to-LLM mapping."""
+        """Access the internal usage-ID-to-LLM mapping (read-only view)."""
 
         return MappingProxyType(self._usage_to_llm)
 


### PR DESCRIPTION
## Summary

Currently, the property `usage_to_llm` returns the internal state `_usage_to_llm` rather than a copy or a frozen state. This is not ideal, and can cause bugs. The property was used only in a few tests, and since we do not want to change the API, I just changed to return a MappingProxyType (read-only-view).

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b719926-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b719926-python \
  ghcr.io/openhands/agent-server:b719926-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b719926-golang-amd64
ghcr.io/openhands/agent-server:b719926-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b719926-golang-arm64
ghcr.io/openhands/agent-server:b719926-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b719926-java-amd64
ghcr.io/openhands/agent-server:b719926-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b719926-java-arm64
ghcr.io/openhands/agent-server:b719926-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b719926-python-amd64
ghcr.io/openhands/agent-server:b719926-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b719926-python-arm64
ghcr.io/openhands/agent-server:b719926-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b719926-golang
ghcr.io/openhands/agent-server:b719926-java
ghcr.io/openhands/agent-server:b719926-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b719926-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b719926-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->