### PR TITLE
Add claude-opus-4-6 model to resolve_model_config.py

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -56,6 +56,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "claude-opus-4-6": {
+        "id": "claude-opus-4-6",
+        "display_name": "Claude Opus 4.6",
+        "llm_config": {
+            "model": "litellm_proxy/anthropic/claude-opus-4-6",
+            "temperature": 0.0,
+        },
+    },
     "gemini-3-pro": {
         "id": "gemini-3-pro",
         "display_name": "Gemini 3 Pro",

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -124,6 +124,7 @@ def test_find_models_by_id_preserves_full_config():
 # Note: claude-4.5-sonnet is implemented as claude-sonnet-4-5-20250929 (pinned version)
 EXPECTED_MODELS = [
     "claude-4.5-opus",
+    "claude-opus-4-6",
     "claude-sonnet-4-5-20250929",
     "gemini-3-pro",
     "gemini-3-flash",
@@ -194,3 +195,13 @@ def test_gpt_oss_20b_config():
     assert model["id"] == "gpt-oss-20b"
     assert model["display_name"] == "GPT OSS 20B"
     assert model["llm_config"]["model"] == "litellm_proxy/gpt-oss-20b"
+
+
+def test_claude_opus_4_6_config():
+    """Test that claude-opus-4-6 has correct configuration."""
+    model = MODELS["claude-opus-4-6"]
+
+    assert model["id"] == "claude-opus-4-6"
+    assert model["display_name"] == "Claude Opus 4.6"
+    assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-6"
+    assert model["llm_config"]["temperature"] == 0.0


### PR DESCRIPTION
## Summary

Add the `claude-opus-4-6` model with id `claude-opus-4-6` to the expected models in `resolve_model_config.py` as requested in issue #1931.

Changes:
- Add `claude-opus-4-6` model configuration with `litellm_proxy/anthropic/claude-opus-4-6` model path
- Add the model to `EXPECTED_MODELS` list in the test file
- Add a specific test `test_claude_opus_4_6_config` to verify the model configuration

Fixes #1931

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@neubig Please review this PR.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c047bef6a3ef41f68ff28783f2ee6abe)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a44250e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a44250e-python \
  ghcr.io/openhands/agent-server:a44250e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a44250e-golang-amd64
ghcr.io/openhands/agent-server:a44250e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a44250e-golang-arm64
ghcr.io/openhands/agent-server:a44250e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a44250e-java-amd64
ghcr.io/openhands/agent-server:a44250e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a44250e-java-arm64
ghcr.io/openhands/agent-server:a44250e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a44250e-python-amd64
ghcr.io/openhands/agent-server:a44250e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a44250e-python-arm64
ghcr.io/openhands/agent-server:a44250e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a44250e-golang
ghcr.io/openhands/agent-server:a44250e-java
ghcr.io/openhands/agent-server:a44250e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a44250e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a44250e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->