### PR TITLE
Set default sdk_ref to v1.11.1 in run-eval workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -24,6 +24,7 @@ on:
             sdk_ref:
                 description: SDK commit/ref to evaluate (must be a semantic version like v1.0.0 unless 'Allow unreleased branches' is checked)
                 required: true
+                default: v1.11.1
             allow_unreleased_branches:
                 description: Allow unreleased branches (bypasses semantic version requirement)
                 required: false


### PR DESCRIPTION
## Summary

Sets the default value for the `sdk_ref` field in the run-eval workflow to `v1.11.1` as requested in the issue.

Fixes #1934

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - N/A - This is a configuration change only (workflow default value)
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - No example involved
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A - This is a workflow configuration change
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - No documentation needed
- [x] Is the github CI passing?
  - Will be verified after PR creation

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0a0b500674b4436e952f69346cdedd05)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f5a97f8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f5a97f8-python \
  ghcr.io/openhands/agent-server:f5a97f8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f5a97f8-golang-amd64
ghcr.io/openhands/agent-server:f5a97f8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f5a97f8-golang-arm64
ghcr.io/openhands/agent-server:f5a97f8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f5a97f8-java-amd64
ghcr.io/openhands/agent-server:f5a97f8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f5a97f8-java-arm64
ghcr.io/openhands/agent-server:f5a97f8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f5a97f8-python-amd64
ghcr.io/openhands/agent-server:f5a97f8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:f5a97f8-python-arm64
ghcr.io/openhands/agent-server:f5a97f8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:f5a97f8-golang
ghcr.io/openhands/agent-server:f5a97f8-java
ghcr.io/openhands/agent-server:f5a97f8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f5a97f8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f5a97f8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->