### PR TITLE
Update sdk_ref default in run-eval.yml during release preparation

### DIFF
--- a/.github/scripts/update_sdk_ref_default.py
+++ b/.github/scripts/update_sdk_ref_default.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Update the sdk_ref default value in run-eval.yml.
+
+This script updates the default SDK reference version in the run-eval workflow
+to match a new release version.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+RUN_EVAL_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "run-eval.yml"
+
+# Pattern to match the sdk_ref default line
+# Matches: "default: vX.Y.Z" with optional prerelease suffix like -rc1, -beta.1
+SDK_REF_PATTERN = re.compile(
+    r"^(\s*default:\s*v)[\d]+\.[\d]+\.[\d]+(-[a-zA-Z0-9.]+)?(\s*)$"
+)
+
+
+def update_sdk_ref_default(new_version: str, dry_run: bool = False) -> bool:
+    """Update the sdk_ref default in run-eval.yml.
+
+    Args:
+        new_version: The new version (without 'v' prefix, e.g., "1.12.0")
+        dry_run: If True, print what would change without modifying the file
+
+    Returns:
+        True if successful, False otherwise
+    """
+    if not RUN_EVAL_WORKFLOW.exists():
+        print(f"❌ File not found: {RUN_EVAL_WORKFLOW}", file=sys.stderr)
+        return False
+
+    content = RUN_EVAL_WORKFLOW.read_text()
+    lines = content.splitlines(keepends=True)
+
+    # Find the sdk_ref input section and its default line
+    in_sdk_ref_section = False
+    updated = False
+    old_version = None
+
+    for i, line in enumerate(lines):
+        stripped = line.strip()
+
+        # Track when we enter the sdk_ref input section
+        if stripped == "sdk_ref:":
+            in_sdk_ref_section = True
+            continue
+
+        # Track when we exit the sdk_ref section (another input starts)
+        if (
+            in_sdk_ref_section
+            and stripped.endswith(":")
+            and not stripped.startswith("default")
+        ):
+            in_sdk_ref_section = False
+
+        # Update the default line within the sdk_ref section
+        if in_sdk_ref_section:
+            match = SDK_REF_PATTERN.match(line)
+            if match:
+                old_version = line.strip().replace("default: ", "")
+                new_line = f"{match.group(1)}{new_version}{match.group(3) or ''}"
+                if not line.endswith("\n") and lines[i].endswith("\n"):
+                    new_line += "\n"
+                elif line.endswith("\n"):
+                    new_line += "\n"
+                lines[i] = new_line
+                updated = True
+                break
+
+    if not updated:
+        print("❌ Could not find sdk_ref default line to update", file=sys.stderr)
+        return False
+
+    if dry_run:
+        print(f"Would update sdk_ref default: {old_version} → v{new_version}")
+        return True
+
+    # Write the updated content
+    RUN_EVAL_WORKFLOW.write_text("".join(lines))
+    print(f"✅ Updated sdk_ref default: {old_version} → v{new_version}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Update the sdk_ref default value in run-eval.yml"
+    )
+    parser.add_argument(
+        "version",
+        help="New version (without 'v' prefix, e.g., '1.12.0')",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print what would change without modifying the file",
+    )
+    args = parser.parse_args()
+
+    # Validate version format
+    version_pattern = re.compile(r"^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?$")
+    if not version_pattern.match(args.version):
+        print(
+            f"❌ Invalid version format: {args.version}. "
+            "Expected: X.Y.Z or X.Y.Z-suffix",
+            file=sys.stderr,
+        )
+        return 1
+
+    success = update_sdk_ref_default(args.version, dry_run=args.dry_run)
+    return 0 if success else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -50,15 +50,7 @@ jobs:
                   make set-package-version version=${{ inputs.version }}
 
             - name: Update sdk_ref default in run-eval workflow
-              run: |
-                  OLD_VERSION=$(grep -oP "default: v\K[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?" .github/workflows/run-eval.yml || echo "unknown")
-                  echo "🔧 Updating sdk_ref default from v${OLD_VERSION} to v${{ inputs.version }} in run-eval.yml"
-                  sed -i "s/^\([[:space:]]*default: v\)[0-9]\+\.[0-9]\+\.[0-9]\+\(-[a-zA-Z0-9.]\+\)\?\([[:space:]]*$\)/\1${{ inputs.version }}\3/" .github/workflows/run-eval.yml
-                  if ! grep -q "default: v${{ inputs.version }}" .github/workflows/run-eval.yml; then
-                    echo "❌ Failed to update sdk_ref default in run-eval.yml"
-                    exit 1
-                  fi
-                  echo "✅ Successfully updated sdk_ref to v${{ inputs.version }}"
+              run: python3 .github/scripts/update_sdk_ref_default.py "${{ inputs.version }}"
 
             - name: Commit version changes
               run: |


### PR DESCRIPTION
## Summary

This PR updates the `prepare-release.yml` workflow to automatically update the default `sdk_ref` value in `run-eval.yml` from the old version to `v{version}` when preparing a new release.

This makes it easier to always evaluate the current release by ensuring the default SDK reference in the run-eval workflow stays up to date.

Fixes #1936

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - N/A - This is a workflow configuration change that doesn't require tests
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - No example involved
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - The sed command was tested locally to verify it correctly updates the version
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - No documentation needed
- [ ] Is the github CI passing?

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d93af6b21b794d80bbfb744a5199ae9d)





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e4c1dfc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e4c1dfc-python \
  ghcr.io/openhands/agent-server:e4c1dfc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e4c1dfc-golang-amd64
ghcr.io/openhands/agent-server:e4c1dfc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e4c1dfc-golang-arm64
ghcr.io/openhands/agent-server:e4c1dfc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e4c1dfc-java-amd64
ghcr.io/openhands/agent-server:e4c1dfc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e4c1dfc-java-arm64
ghcr.io/openhands/agent-server:e4c1dfc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e4c1dfc-python-amd64
ghcr.io/openhands/agent-server:e4c1dfc-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:e4c1dfc-python-arm64
ghcr.io/openhands/agent-server:e4c1dfc-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:e4c1dfc-golang
ghcr.io/openhands/agent-server:e4c1dfc-java
ghcr.io/openhands/agent-server:e4c1dfc-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e4c1dfc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e4c1dfc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->