### PR TITLE
Add litellm/anthropic/claude-opus-4-6 to the verified models list

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -23,6 +23,7 @@ VERIFIED_ANTHROPIC_MODELS = [
     "claude-sonnet-4-5-20250929",
     "claude-haiku-4-5-20251001",
     "claude-opus-4-5-20251101",
+    "claude-opus-4-6",
     "claude-sonnet-4-20250514",
     "claude-opus-4-20250514",
     "claude-opus-4-1-20250805",

--- a/tests/sdk/llm/test_model_list.py
+++ b/tests/sdk/llm/test_model_list.py
@@ -5,6 +5,10 @@ from openhands.sdk.llm.utils.unverified_models import (
     _list_bedrock_foundation_models,
     get_unverified_models,
 )
+from openhands.sdk.llm.utils.verified_models import (
+    VERIFIED_ANTHROPIC_MODELS,
+    VERIFIED_MODELS,
+)
 
 
 def test_organize_models_and_providers():
@@ -72,3 +76,9 @@ def test_list_bedrock_models_with_boto3(monkeypatch):
     result = _list_bedrock_foundation_models("us-east-1", "key", "secret")
 
     assert result == ["bedrock/anthropic.claude-3"]
+
+
+def test_claude_opus_4_6_in_verified_models():
+    """Verify that claude-opus-4-6 is in the verified Anthropic models list."""
+    assert "claude-opus-4-6" in VERIFIED_ANTHROPIC_MODELS
+    assert "claude-opus-4-6" in VERIFIED_MODELS["anthropic"]


### PR DESCRIPTION
## Summary

This PR adds `claude-opus-4-6` to the verified Anthropic models list, as requested in issue #1937.

Changes:
- Added `claude-opus-4-6` to `VERIFIED_ANTHROPIC_MODELS` in `verified_models.py`
- Added a test to verify `claude-opus-4-6` is present in the verified models list

Fixes #1937

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3d4ea3b790bd49ffb84519a2b05481e3)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:52def71-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-52def71-python \
  ghcr.io/openhands/agent-server:52def71-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:52def71-golang-amd64
ghcr.io/openhands/agent-server:52def71-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:52def71-golang-arm64
ghcr.io/openhands/agent-server:52def71-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:52def71-java-amd64
ghcr.io/openhands/agent-server:52def71-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:52def71-java-arm64
ghcr.io/openhands/agent-server:52def71-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:52def71-python-amd64
ghcr.io/openhands/agent-server:52def71-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:52def71-python-arm64
ghcr.io/openhands/agent-server:52def71-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:52def71-golang
ghcr.io/openhands/agent-server:52def71-java
ghcr.io/openhands/agent-server:52def71-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `52def71-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `52def71-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->