### PR TITLE
Fix Claude Opus 4.6 rejecting requests with both temperature and top_p

### DIFF
--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -146,3 +146,83 @@ def test_extended_thinking_budget_clamped_below_max_tokens():
         "budget_tokens": 500,
     }
     assert out.get("max_tokens") == 1000
+
+
+def test_claude_opus_4_6_removes_top_p_when_both_temp_and_top_p_present():
+    """Test that Claude Opus 4.6 removes top_p when both temperature and top_p are set.
+
+    Claude Opus 4.6 (and similar Anthropic models) cannot have both temperature
+    and top_p specified in the same request. The SDK should prefer temperature
+    and remove top_p.
+    """
+    # Test with dash variant (claude-opus-4-6)
+    llm = DummyLLM(
+        model="anthropic/claude-opus-4-6",
+        temperature=0.7,
+        top_p=0.9,
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    # For reasoning models, both temp and top_p are removed by the reasoning logic
+    # But if temperature is added back (e.g., by retry logic), top_p should
+    # not be present. Since claude-opus-4-6 is a reasoning model, both should
+    # be removed initially
+    assert "temperature" not in out
+    assert "top_p" not in out
+
+    # Test with dot variant (claude-opus-4.6)
+    llm = DummyLLM(
+        model="anthropic/claude-opus-4.6",
+        temperature=0.7,
+        top_p=0.9,
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    # claude-opus-4.6 (with dot) is NOT in REASONING_EFFORT_MODELS, so temp/top_p
+    # are not removed by reasoning logic. But the exclusive sampling logic should
+    # remove top_p when both are present.
+    assert out.get("temperature") == 0.7
+    assert "top_p" not in out
+
+
+def test_claude_opus_4_6_with_user_provided_temperature():
+    """Test that user-provided temperature is preserved and top_p is removed."""
+    llm = DummyLLM(
+        model="claude-opus-4.6",
+        temperature=0.5,
+        top_p=0.8,
+    )
+    # User provides temperature in kwargs
+    out = select_chat_options(llm, user_kwargs={"temperature": 1.0}, has_tools=True)
+
+    # User-provided temperature should be preserved, top_p should be removed
+    assert out.get("temperature") == 1.0
+    assert "top_p" not in out
+
+
+def test_claude_opus_4_6_only_temperature_no_top_p():
+    """Test that when only temperature is set (no top_p), it's preserved."""
+    llm = DummyLLM(
+        model="claude-opus-4.6",
+        temperature=0.7,
+        top_p=None,
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    # Only temperature should be present
+    assert out.get("temperature") == 0.7
+    assert "top_p" not in out
+
+
+def test_claude_opus_4_6_only_top_p_no_temperature():
+    """Test that when only top_p is set (no temperature), it's preserved."""
+    llm = DummyLLM(
+        model="claude-opus-4.6",
+        temperature=None,
+        top_p=0.9,
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    # Only top_p should be present (no conflict since temperature is None)
+    assert "temperature" not in out
+    assert out.get("top_p") == 0.9


### PR DESCRIPTION
## Summary

This PR fixes issue #1945 where Claude Opus 4.6 model via Anthropic API rejects requests when both `temperature` and `top_p` parameters are specified.

The Anthropic API returns an error: `temperature and top_p cannot both be specified for this model. Please use only one.`

### Changes

1. **Added `ANTHROPIC_EXCLUSIVE_SAMPLING_MODELS` list** in `chat_options.py` to track Anthropic models that cannot have both `temperature` and `top_p` specified (includes both `claude-opus-4-6` and `claude-opus-4.6` variants)

2. **Added logic to remove `top_p`** when both `temperature` and `top_p` are present for affected models, preferring `temperature` as the sampling parameter

3. **Added comprehensive tests** to verify the fix works correctly for:
   - Models with both parameters set (top_p is removed)
   - User-provided temperature (preserved, top_p removed)
   - Only temperature set (preserved)
   - Only top_p set (preserved, no conflict)

Fixes #1945

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/db22566703c24017a4a31218d2e53625)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6a6eb8b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6a6eb8b-python \
  ghcr.io/openhands/agent-server:6a6eb8b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6a6eb8b-golang-amd64
ghcr.io/openhands/agent-server:6a6eb8b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6a6eb8b-golang-arm64
ghcr.io/openhands/agent-server:6a6eb8b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6a6eb8b-java-amd64
ghcr.io/openhands/agent-server:6a6eb8b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6a6eb8b-java-arm64
ghcr.io/openhands/agent-server:6a6eb8b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6a6eb8b-python-amd64
ghcr.io/openhands/agent-server:6a6eb8b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6a6eb8b-python-arm64
ghcr.io/openhands/agent-server:6a6eb8b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6a6eb8b-golang
ghcr.io/openhands/agent-server:6a6eb8b-java
ghcr.io/openhands/agent-server:6a6eb8b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6a6eb8b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6a6eb8b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->