### PR TITLE
Fix tool serialization test flakiness

### DIFF
--- a/tests/sdk/tool/test_tool_definition.py
+++ b/tests/sdk/tool/test_tool_definition.py
@@ -84,8 +84,12 @@ class ComplexObservation(Observation):
         return [TextContent(text=f"Data: {self.data}, Count: {self.count}")]
 
 
-class StrictObservation(Observation):
-    """Observation with required fields for validation testing."""
+class RequiredFieldsObservation(Observation):
+    """Observation with required fields for validation testing.
+
+    Note: Defined at module level to ensure a stable qualified name for
+    JSON serialization/deserialization.
+    """
 
     message: str = Field(description="Required message field")
     value: int = Field(description="Required value field")
@@ -435,19 +439,19 @@ class TestTool:
         """Test that executor return values are validated."""
 
         class ValidExecutor(ToolExecutor):
-            def __call__(self, action, conversation=None) -> StrictObservation:
-                return StrictObservation(message="success", value=42)
+            def __call__(self, action, conversation=None) -> RequiredFieldsObservation:
+                return RequiredFieldsObservation(message="success", value=42)
 
         tool = MockTestTool(
-            description="Tool with strict observation",
+            description="Tool with required fields observation",
             action_type=ToolMockAction,
-            observation_type=StrictObservation,
+            observation_type=RequiredFieldsObservation,
             executor=ValidExecutor(),
         )
 
         action = ToolMockAction(command="test")
         result = tool(action)
-        assert isinstance(result, StrictObservation)
+        assert isinstance(result, RequiredFieldsObservation)
         assert result.message == "success"
         assert result.value == 42
 


### PR DESCRIPTION
## Summary

Refactor the tool definition tests to avoid local observation classes so JSON deserialization no longer fails intermittently.

Fix https://github.com/OpenHands/software-agent-sdk/issues/1958

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

Fixes #1958.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3e6383c488ef448bb87ddb40c87cc0ea)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:790e590-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-790e590-python \
  ghcr.io/openhands/agent-server:790e590-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:790e590-golang-amd64
ghcr.io/openhands/agent-server:790e590-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:790e590-golang-arm64
ghcr.io/openhands/agent-server:790e590-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:790e590-java-amd64
ghcr.io/openhands/agent-server:790e590-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:790e590-java-arm64
ghcr.io/openhands/agent-server:790e590-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:790e590-python-amd64
ghcr.io/openhands/agent-server:790e590-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:790e590-python-arm64
ghcr.io/openhands/agent-server:790e590-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:790e590-golang
ghcr.io/openhands/agent-server:790e590-java
ghcr.io/openhands/agent-server:790e590-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `790e590-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `790e590-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->