### PR TITLE
fix(pyinstaller): include delegate tool templates in bundle

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -41,6 +41,9 @@ a = Analysis(
         *collect_data_files("openhands.sdk.context.condenser", includes=["prompts/*.j2"]),
         *collect_data_files("openhands.sdk.context.prompts", includes=["templates/*.j2"]),
 
+        # OpenHands Tools templates
+        *collect_data_files("openhands.tools.delegate", includes=["templates/*.j2"]),
+
         # Package metadata for importlib.metadata
         *copy_metadata("fastmcp"),
         *copy_metadata("litellm"),


### PR DESCRIPTION
## Summary

Fixes a `FileNotFoundError` that occurs when starting a remote conversation with the delegate tool enabled.

## Problem

The `delegate_tool_description.j2` template file was not being included in the PyInstaller bundle. When the bundled agent server tried to initialize the delegate tool, it failed with:

```
FileNotFoundError: Prompt file /tmp/_MEId5doXk/openhands/tools/delegate/templates/delegate_tool_description.j2 not found
```

The error occurred in `openhands/tools/delegate/definition.py` when calling `render_template()` during tool creation.

## Solution

Added `collect_data_files("openhands.tools.delegate", includes=["templates/*.j2"])` to the `datas` section of the PyInstaller spec file, alongside the existing SDK template collections.

## Testing

After rebuilding the PyInstaller bundle with this fix, the delegate tool templates will be properly included and conversations using the delegate tool should initialize successfully.

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1ceeae3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1ceeae3-python \
  ghcr.io/openhands/agent-server:1ceeae3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1ceeae3-golang-amd64
ghcr.io/openhands/agent-server:1ceeae3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1ceeae3-golang-arm64
ghcr.io/openhands/agent-server:1ceeae3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1ceeae3-java-amd64
ghcr.io/openhands/agent-server:1ceeae3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1ceeae3-java-arm64
ghcr.io/openhands/agent-server:1ceeae3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1ceeae3-python-amd64
ghcr.io/openhands/agent-server:1ceeae3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:1ceeae3-python-arm64
ghcr.io/openhands/agent-server:1ceeae3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:1ceeae3-golang
ghcr.io/openhands/agent-server:1ceeae3-java
ghcr.io/openhands/agent-server:1ceeae3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1ceeae3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1ceeae3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->