### PR TITLE
fix(ci): use evaluation proxy for integration tests

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -275,7 +275,7 @@ jobs:
               env:
                   LLM_CONFIG: ${{ toJson(matrix.job-config['llm-config']) }}
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  LLM_BASE_URL: https://llm-proxy.app.all-hands.dev
+                  LLM_BASE_URL: https://llm-proxy.eval.all-hands.dev
               run: |
                   set -eo pipefail
 


### PR DESCRIPTION
## Summary

Fix integration test failures for `deepseek-reasoner` and `gemini-3-pro-preview` models by using the correct LLM proxy endpoint.

## Problem

Integration tests have been failing with errors like:
```
litellm.BadRequestError: Litellm_proxyException - {'error': '/chat/completions: Invalid model name passed in model=deepseek/deepseek-reasoner. Call `/v1/models` to view available models for your key.'}
```

Related issue: https://github.com/OpenHands/software-agent-sdk/issues/939#issuecomment-3868476022

## Root Cause

The integration tests were configured to use the **production proxy** (`llm-proxy.app.all-hands.dev`) which does NOT have wildcard routing for `deepseek/*` and `gemini/*` models.

The **evaluation proxy** (`llm-proxy.eval.all-hands.dev`) has the required wildcard routing:
```yaml
- model_name: "deepseek/*"
  litellm_params:
    model: "deepseek/*"
    api_key: os.environ/DEEPSEEK_API_KEY

- model_name: "gemini/*"
  litellm_params:
    model: "gemini/*"
    api_key: os.environ/GOOGLE_AI_STUDIO_API_KEY
```

## Fix

Change `LLM_BASE_URL` from:
- `https://llm-proxy.app.all-hands.dev` (production)

To:
- `https://llm-proxy.eval.all-hands.dev` (evaluation)

This reverts the URL change from commit a3c2dbe1 (Oct 28, 2025).

## Testing

After this change, integration tests should be able to route requests for:
- `deepseek/deepseek-reasoner`
- `gemini/gemini-3-pro-preview`
- Other wildcard model patterns configured in the evaluation proxy

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c0ebf9f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c0ebf9f-python \
  ghcr.io/openhands/agent-server:c0ebf9f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c0ebf9f-golang-amd64
ghcr.io/openhands/agent-server:c0ebf9f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c0ebf9f-golang-arm64
ghcr.io/openhands/agent-server:c0ebf9f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c0ebf9f-java-amd64
ghcr.io/openhands/agent-server:c0ebf9f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c0ebf9f-java-arm64
ghcr.io/openhands/agent-server:c0ebf9f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c0ebf9f-python-amd64
ghcr.io/openhands/agent-server:c0ebf9f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c0ebf9f-python-arm64
ghcr.io/openhands/agent-server:c0ebf9f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c0ebf9f-golang
ghcr.io/openhands/agent-server:c0ebf9f-java
ghcr.io/openhands/agent-server:c0ebf9f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c0ebf9f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c0ebf9f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->