### PR TITLE
fix: explicitly initialize Laminar with API key in PR review workflow

### DIFF
--- a/examples/03_github_workflows/02_pr_review/agent_script.py
+++ b/examples/03_github_workflows/02_pr_review/agent_script.py
@@ -28,6 +28,7 @@ Environment Variables:
     PR_HEAD_BRANCH: Head branch name (required)
     REPO_NAME: Repository name in format owner/repo (required)
     REVIEW_STYLE: Review style ('standard' or 'roasted', default: 'standard')
+    LMNR_PROJECT_API_KEY: Laminar API key for observability (optional)
 
 For setup instructions, usage examples, and GitHub Actions integration,
 see README.md in this directory.
@@ -144,6 +145,14 @@ def get_head_commit_sha(repo_dir: Path | None = None) -> str:
 def main():
     """Run the PR review agent."""
     logger.info("Starting PR review process...")
+
+    # Initialize Laminar for observability (if API key is provided)
+    lmnr_api_key = os.getenv("LMNR_PROJECT_API_KEY")
+    if lmnr_api_key:
+        Laminar.initialize(project_api_key=lmnr_api_key)
+        logger.info("Laminar observability initialized")
+    else:
+        logger.info("Laminar API key not provided - observability disabled")
 
     # Validate required environment variables
     required_vars = [


### PR DESCRIPTION
## Summary

The PR review agent script was importing Laminar but never calling `Laminar.initialize()` with the project API key. This meant observability was not properly enabled even when the `LMNR_PROJECT_API_KEY` environment variable was set.

## Changes

- Added explicit `Laminar.initialize(project_api_key=...)` call at the start of `main()` to ensure Laminar tracing is properly configured before the agent runs
- Added `LMNR_PROJECT_API_KEY` to the docstring environment variables list for documentation completeness

## Context

The Laminar SDK requires explicit initialization to enable tracing. While the workflow was correctly passing the API key via the `lmnr-api-key` input (which set `LMNR_PROJECT_API_KEY` environment variable), the script never called `Laminar.initialize()` to actually use it.

Fixes the issue identified at: https://github.com/OpenHands/software-agent-sdk/blob/69d5249fa1af3ed869098fb578929a9f2fd989ba/.github/workflows/pr-review-by-openhands.yml#L52

## Testing

The change is straightforward - it adds the required initialization call that was missing. The existing workflow configuration remains unchanged.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4510580-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4510580-python \
  ghcr.io/openhands/agent-server:4510580-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4510580-golang-amd64
ghcr.io/openhands/agent-server:4510580-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4510580-golang-arm64
ghcr.io/openhands/agent-server:4510580-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4510580-java-amd64
ghcr.io/openhands/agent-server:4510580-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4510580-java-arm64
ghcr.io/openhands/agent-server:4510580-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4510580-python-amd64
ghcr.io/openhands/agent-server:4510580-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:4510580-python-arm64
ghcr.io/openhands/agent-server:4510580-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:4510580-golang
ghcr.io/openhands/agent-server:4510580-java
ghcr.io/openhands/agent-server:4510580-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4510580-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4510580-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->