### PR TITLE
fix: avoid temp+top_p on Claude 4+

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -62,7 +62,6 @@ MODELS = {
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-6",
             "temperature": 0.0,
-            "top_p": None,
         },
     },
     "gemini-3-pro": {


### PR DESCRIPTION
## Summary

- ensure Claude 4+ requests do not send both temperature and top_p
- add single-sampling guard for Claude 4+ in chat options and model features
- update claude-4.6-opus eval config to omit top_p and add coverage tests

Fixes #1913

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f812cb231fb549d398602636bd1c85b2)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8794046-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8794046-python \
  ghcr.io/openhands/agent-server:8794046-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8794046-golang-amd64
ghcr.io/openhands/agent-server:8794046-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8794046-golang-arm64
ghcr.io/openhands/agent-server:8794046-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8794046-java-amd64
ghcr.io/openhands/agent-server:8794046-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8794046-java-arm64
ghcr.io/openhands/agent-server:8794046-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8794046-python-amd64
ghcr.io/openhands/agent-server:8794046-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:8794046-python-arm64
ghcr.io/openhands/agent-server:8794046-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:8794046-golang
ghcr.io/openhands/agent-server:8794046-java
ghcr.io/openhands/agent-server:8794046-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8794046-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8794046-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->