### PR TITLE
feat: Add 'all' keyword support for model_ids in integration-runner workflow

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -22,6 +22,7 @@ on:
             model_ids:
                 description: >-
                     Comma-separated model IDs to test (from resolve_model_config.py).
+                    Use 'all' to run all available models.
                     Example: claude-sonnet-4-5-20250929,glm-4.7. Defaults to a standard set.
                 required: false
                 default: ''
@@ -65,9 +66,13 @@ jobs:
                   DEFAULT_MODEL_IDS: ${{ env.DEFAULT_MODEL_IDS }}
               run: |
                   # Use input model_ids if provided, otherwise use defaults
+                  # Special value 'all' expands to all available models
                   if [ -z "$MODEL_IDS_INPUT" ]; then
                     MODEL_IDS="$DEFAULT_MODEL_IDS"
                     echo "No model_ids specified, using defaults: $MODEL_IDS"
+                  elif [ "$MODEL_IDS_INPUT" = "all" ]; then
+                    MODEL_IDS="all"
+                    echo "Using all available models"
                   else
                     MODEL_IDS="$MODEL_IDS_INPUT"
                     echo "Using specified model_ids: $MODEL_IDS"
@@ -81,8 +86,15 @@ jobs:
                   sys.path.insert(0, '.github/run-eval')
                   from resolve_model_config import MODELS
 
-                  model_ids = "$MODEL_IDS".split(",")
-                  model_ids = [m.strip() for m in model_ids if m.strip()]
+                  model_ids_input = "$MODEL_IDS"
+
+                  # Handle 'all' keyword to expand to all available models
+                  if model_ids_input == "all":
+                      model_ids = list(MODELS.keys())
+                      print(f"Expanding 'all' to {len(model_ids)} models", file=sys.stderr)
+                  else:
+                      model_ids = model_ids_input.split(",")
+                      model_ids = [m.strip() for m in model_ids if m.strip()]
 
                   matrix = []
                   for model_id in model_ids:


### PR DESCRIPTION
## Summary

This PR adds support for the `all` keyword in the `model_ids` input of the integration-runner workflow. When `all` is specified, the workflow expands it to include all models defined in `resolve_model_config.py`, enabling comprehensive testing across all supported models.

Fixes #1986

### Changes
- Updated the workflow description to document the `all` keyword option
- Added shell logic to detect when `model_ids='all'` is specified
- Modified the Python matrix generation code to expand `all` to all available model IDs from the `MODELS` dictionary

### Usage
To run integration tests with all models and report results to issue #1986:
1. Go to Actions → Run Integration Tests
2. Click "Run workflow"
3. Set `model_ids` to `all`
4. Set `issue_number` to `1986`
5. Click "Run workflow"

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - This is a workflow configuration change. The existing tests in `tests/github_workflows/test_resolve_model_config.py` validate the model configurations. The workflow logic change is straightforward and will be validated when the workflow runs.
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - This is a workflow configuration change
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - N/A - This is a workflow configuration change that will be tested when triggered
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - The workflow input description has been updated inline
- [ ] Is the github CI passing?
  - Will be verified after PR is created

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9c7a5c144f7b45f9831d6135e7991842)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d4c3803-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d4c3803-python \
  ghcr.io/openhands/agent-server:d4c3803-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d4c3803-golang-amd64
ghcr.io/openhands/agent-server:d4c3803-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d4c3803-golang-arm64
ghcr.io/openhands/agent-server:d4c3803-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d4c3803-java-amd64
ghcr.io/openhands/agent-server:d4c3803-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d4c3803-java-arm64
ghcr.io/openhands/agent-server:d4c3803-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d4c3803-python-amd64
ghcr.io/openhands/agent-server:d4c3803-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:d4c3803-python-arm64
ghcr.io/openhands/agent-server:d4c3803-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:d4c3803-golang
ghcr.io/openhands/agent-server:d4c3803-java
ghcr.io/openhands/agent-server:d4c3803-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d4c3803-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d4c3803-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->