### PR TITLE
feat: add previous review context to PR review agent

### DIFF
--- a/examples/03_github_workflows/02_pr_review/README.md
+++ b/examples/03_github_workflows/02_pr_review/README.md
@@ -25,6 +25,7 @@ This example demonstrates how to set up a GitHub Actions workflow for automated 
   - **Review threads**: Fetches all review threads including their resolution status
   - **Smart commenting**: Avoids repeating issues that have already been raised and addressed
   - **Unresolved focus**: Prioritizes unresolved threads that may still need attention
+  - **Pagination limits**: Fetches up to 100 threads per page (with pagination) and up to 50 comments per thread. For PRs with extensive review history exceeding these limits, older threads/comments may be omitted.
 - **Skills-Based Review**: Uses public skills from <https://github.com/OpenHands/skills>:
   - **`/codereview`**: Standard pragmatic code review focusing on simplicity, type safety, and backward compatibility
   - **`/codereview-roasted`**: Linus Torvalds style brutally honest review with emphasis on "good taste" and data structures

--- a/examples/03_github_workflows/02_pr_review/prompt.py
+++ b/examples/03_github_workflows/02_pr_review/prompt.py
@@ -81,7 +81,8 @@ def format_prompt(
         pr_number: PR number
         commit_id: HEAD commit SHA
         diff: Git diff content
-        review_context: Formatted previous review context (optional)
+        review_context: Formatted previous review context. If empty or whitespace-only,
+            the review context section is omitted from the prompt.
 
     Returns:
         Formatted prompt string


### PR DESCRIPTION
## Summary

This PR enhances the PR review workflow by adding the ability to fetch and consider previous review history when reviewing a pull request.

## Changes

### New Features

The PR review agent now fetches and considers:

1. **Previous Review Decisions**: All past reviews with their state (APPROVED, CHANGES_REQUESTED, COMMENTED, DISMISSED, PENDING)
2. **Review Threads**: All review threads including:
   - Resolution status (resolved/unresolved)
   - Whether threads are outdated (code changed)
   - All comments in each thread with author information
3. **Formatted Context**: A well-structured review history section in the agent's prompt

### Implementation Details

- **GitHub REST API**: Used to fetch reviews (`/pulls/{pr_number}/reviews`)
- **GitHub GraphQL API**: Used to fetch review threads with resolution status (REST API doesn't expose this)
- **New helper functions**:
  - `get_pr_reviews()`: Fetches all reviews for a PR
  - `get_pr_review_comments()`: Fetches all inline review comments
  - `get_review_threads_graphql()`: Fetches threads with resolution status via GraphQL
  - `format_review_context()`: Formats all review data into a readable context string
  - `get_pr_review_context()`: Main entry point that combines all the above

### Agent Behavior

When reviewing, the agent is instructed to:
1. Not repeat comments that have already been made and are still relevant
2. Reference unresolved issues that are still present in the code
3. Not bring up resolved issues unless the fix introduced new problems
4. Focus on NEW issues in the current diff that haven't been discussed yet

### Files Changed

- `examples/03_github_workflows/02_pr_review/agent_script.py`: Added review context fetching functions and integrated them into the main workflow
- `examples/03_github_workflows/02_pr_review/prompt.py`: Added review context section template and `format_prompt()` function
- `examples/03_github_workflows/02_pr_review/README.md`: Updated documentation to include the new feature

## Testing

- All pre-commit hooks pass (ruff format, ruff lint, pycodestyle, pyright)
- The implementation gracefully handles errors when fetching review data (logs warnings and continues with empty context)

## Example Review Context Output

```markdown
### Previous Reviews

- ✅ **reviewer1** (APPROVED)
  > LGTM!

- 💬 **reviewer2** (COMMENTED)
  > A few suggestions below

### Unresolved Review Threads

*These threads have not been resolved and may need attention:*

**src/module.py:42** - ⚠️ UNRESOLVED
  - **reviewer2**:
  > This function should handle None input
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0ca994a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0ca994a-python \
  ghcr.io/openhands/agent-server:0ca994a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0ca994a-golang-amd64
ghcr.io/openhands/agent-server:0ca994a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0ca994a-golang-arm64
ghcr.io/openhands/agent-server:0ca994a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0ca994a-java-amd64
ghcr.io/openhands/agent-server:0ca994a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0ca994a-java-arm64
ghcr.io/openhands/agent-server:0ca994a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0ca994a-python-amd64
ghcr.io/openhands/agent-server:0ca994a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:0ca994a-python-arm64
ghcr.io/openhands/agent-server:0ca994a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:0ca994a-golang
ghcr.io/openhands/agent-server:0ca994a-java
ghcr.io/openhands/agent-server:0ca994a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0ca994a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0ca994a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->