### PR TITLE
Fix poetry lock command in version-bump-prs workflow

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -227,14 +227,14 @@ jobs:
                   poetry add --lock "openhands-sdk==$VERSION" "openhands-tools==$VERSION" "openhands-agent-server==$VERSION"
                   cd ..
 
-                  # 3. Generate poetry.lock in root (regenerate from scratch)
+                  # 3. Generate poetry.lock in root (resolve dependencies based on updated pyproject.toml)
                   echo "🔒 Running poetry lock in root..."
-                  poetry lock --no-update
+                  poetry lock
 
-                  # 4. Generate poetry.lock in enterprise directory (regenerate from scratch)
+                  # 4. Generate poetry.lock in enterprise directory (resolve dependencies based on updated pyproject.toml)
                   echo "🔒 Running poetry lock in enterprise/..."
                   cd enterprise
-                  poetry lock --no-update
+                  poetry lock
                   cd ..
 
                   # 5. Update the hash in sandbox_spec_service.py


### PR DESCRIPTION
## Summary

Fixes the `version-bump-prs` workflow that failed due to an invalid Poetry command option.

**Fixes:** https://github.com/OpenHands/software-agent-sdk/actions/runs/21912320511

## Problem

The workflow used `poetry lock --no-update` but the `--no-update` flag doesn't exist in Poetry, causing the workflow to fail with:

```
The option "--no-update" does not exist
```

## Solution

Removed the invalid `--no-update` flag. Using `poetry lock` alone will resolve dependencies based on the updated `pyproject.toml` constraints, which is the intended behavior.

## Testing

After merging, re-trigger the workflow:
```bash
gh workflow run version-bump-prs.yml --repo OpenHands/software-agent-sdk -f version=1.11.3
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1f2967e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1f2967e-python \
  ghcr.io/openhands/agent-server:1f2967e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1f2967e-golang-amd64
ghcr.io/openhands/agent-server:1f2967e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1f2967e-golang-arm64
ghcr.io/openhands/agent-server:1f2967e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1f2967e-java-amd64
ghcr.io/openhands/agent-server:1f2967e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1f2967e-java-arm64
ghcr.io/openhands/agent-server:1f2967e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1f2967e-python-amd64
ghcr.io/openhands/agent-server:1f2967e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:1f2967e-python-arm64
ghcr.io/openhands/agent-server:1f2967e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:1f2967e-golang
ghcr.io/openhands/agent-server:1f2967e-java
ghcr.io/openhands/agent-server:1f2967e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1f2967e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1f2967e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->