### PR TITLE
Remove redundant poetry lock calls in version-bump-prs workflow

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -215,29 +215,18 @@ jobs:
                   fi
                   echo "📦 SDK commit hash: $SDK_COMMIT_HASH"
 
-                  # 1. Update versions in pyproject.toml using poetry (root)
-                  # Use --lock to only update pyproject.toml without modifying lock file
-                  echo "📝 Updating root pyproject.toml..."
+                  # 1. Update versions in pyproject.toml and poetry.lock using poetry (root)
+                  # The --lock flag updates both pyproject.toml AND poetry.lock
+                  echo "📝 Updating root pyproject.toml and poetry.lock..."
                   poetry add --lock "openhands-sdk==$VERSION" "openhands-tools==$VERSION" "openhands-agent-server==$VERSION"
 
-                  # 2. Update versions in enterprise/pyproject.toml using poetry
-                  # Use --lock to only update pyproject.toml without modifying lock file
-                  echo "📝 Updating enterprise/pyproject.toml..."
+                  # 2. Update versions in enterprise/pyproject.toml and poetry.lock using poetry
+                  echo "📝 Updating enterprise/pyproject.toml and poetry.lock..."
                   cd enterprise
                   poetry add --lock "openhands-sdk==$VERSION" "openhands-tools==$VERSION" "openhands-agent-server==$VERSION"
                   cd ..
 
-                  # 3. Generate poetry.lock in root (resolve dependencies based on updated pyproject.toml)
-                  echo "🔒 Running poetry lock in root..."
-                  poetry lock
-
-                  # 4. Generate poetry.lock in enterprise directory (resolve dependencies based on updated pyproject.toml)
-                  echo "🔒 Running poetry lock in enterprise/..."
-                  cd enterprise
-                  poetry lock
-                  cd ..
-
-                  # 5. Update the hash in sandbox_spec_service.py
+                  # 3. Update the hash in sandbox_spec_service.py
                   echo "🔧 Updating AGENT_SERVER_IMAGE hash..."
                   SANDBOX_SPEC_FILE="openhands/app_server/sandbox/sandbox_spec_service.py"
                   if [ -f "$SANDBOX_SPEC_FILE" ]; then


### PR DESCRIPTION
## Summary

Fixes the `version-bump-prs` workflow that failed due to redundant `poetry lock` calls causing dependency conflicts.

**Fixes:** https://github.com/OpenHands/software-agent-sdk/actions/runs/21912524474

## Problem

The workflow was running `poetry add --lock` followed by `poetry lock`, but `poetry add --lock` already updates both `pyproject.toml` AND `poetry.lock`. Running `poetry lock` again caused a dependency conflict:

```
Cannot enrich dependency with incompatible constraints: openhands-agent-server (==1.11.3) and openhands-agent-server (==1.11.2)
```

## Solution

Removed the redundant `poetry lock` calls since `poetry add --lock` already handles lock file updates.

## Testing

After merging, re-trigger the workflow:
```bash
gh workflow run version-bump-prs.yml --repo OpenHands/software-agent-sdk -f version=1.11.3
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:91fa318-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-91fa318-python \
  ghcr.io/openhands/agent-server:91fa318-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:91fa318-golang-amd64
ghcr.io/openhands/agent-server:91fa318-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:91fa318-golang-arm64
ghcr.io/openhands/agent-server:91fa318-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:91fa318-java-amd64
ghcr.io/openhands/agent-server:91fa318-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:91fa318-java-arm64
ghcr.io/openhands/agent-server:91fa318-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:91fa318-python-amd64
ghcr.io/openhands/agent-server:91fa318-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:91fa318-python-arm64
ghcr.io/openhands/agent-server:91fa318-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:91fa318-golang
ghcr.io/openhands/agent-server:91fa318-java
ghcr.io/openhands/agent-server:91fa318-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `91fa318-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `91fa318-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->