### PR TITLE
Add pre-commit step to version-bump-prs workflow

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -238,6 +238,11 @@ jobs:
                     exit 1
                   fi
 
+                  # 4. Run pre-commit to fix formatting (pyproject-fmt removes parentheses from version specs)
+                  echo "🔧 Running pre-commit to fix formatting..."
+                  pip install pre-commit
+                  pre-commit run --files pyproject.toml enterprise/pyproject.toml --config ./dev_config/python/.pre-commit-config.yaml || true
+
                   # Check if there are changes
                   if git diff --quiet; then
                     echo "⚠️ No changes detected in $REPO - versions may already be up to date"


### PR DESCRIPTION
## Summary

Adds a pre-commit step to the version-bump-prs workflow to fix formatting issues in `pyproject.toml` files before committing.

**Fixes:** https://github.com/OpenHands/OpenHands/actions/runs/21912780237/job/63271278857?pr=12837

## Problem

Poetry's `add` command writes version specs with parentheses:
```
"openhands-agent-server (==1.11.3)"
```

But the OpenHands repo uses `pyproject-fmt` which reformats them without parentheses:
```
"openhands-agent-server==1.11.3"
```

This causes the CI linter to fail on the generated PR.

## Solution

Run pre-commit with `pyproject-fmt` on the modified `pyproject.toml` files before committing, so the formatting is consistent with the OpenHands repo's style.

## Testing

After merging, re-trigger the workflow:
```bash
gh workflow run version-bump-prs.yml --repo OpenHands/software-agent-sdk -f version=1.11.3
```

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c96efe9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c96efe9-python \
  ghcr.io/openhands/agent-server:c96efe9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c96efe9-golang-amd64
ghcr.io/openhands/agent-server:c96efe9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c96efe9-golang-arm64
ghcr.io/openhands/agent-server:c96efe9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c96efe9-java-amd64
ghcr.io/openhands/agent-server:c96efe9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c96efe9-java-arm64
ghcr.io/openhands/agent-server:c96efe9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c96efe9-python-amd64
ghcr.io/openhands/agent-server:c96efe9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c96efe9-python-arm64
ghcr.io/openhands/agent-server:c96efe9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c96efe9-golang
ghcr.io/openhands/agent-server:c96efe9-java
ghcr.io/openhands/agent-server:c96efe9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c96efe9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c96efe9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->