### PR TITLE
Fix workflow_run trigger for version-bump-prs

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -3,10 +3,10 @@ name: Create Version Bump PRs
 
 on:
     # Triggered by pypi-release workflow after successful publish
+    # Note: No branches filter - releases run on tags (e.g., v1.11.4), not branches
     workflow_run:
         workflows: [Publish all OpenHands packages (uv)]
         types: [completed]
-        branches: [main, rel-*]
     # Allow manual trigger with version input
     workflow_dispatch:
         inputs:


### PR DESCRIPTION
## Summary

Fixes the automatic trigger for the version-bump-prs workflow after a PyPI release.

**Issue:** The workflow was not automatically triggered after https://github.com/OpenHands/software-agent-sdk/actions/runs/21913816132 completed.

## Problem

The `workflow_run` trigger had a `branches` filter:
```yaml
branches: [main, rel-*]
```

But when a release is published, GitHub Actions runs the workflow on the **tag reference** (e.g., `v1.11.4`), not on a branch. The `branches` filter was preventing the automatic trigger from matching.

## Solution

Remove the `branches` filter. The job-level `if` condition already checks that the triggering workflow was successful and was triggered by a release event, which is sufficient filtering.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:546f4c1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-546f4c1-python \
  ghcr.io/openhands/agent-server:546f4c1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:546f4c1-golang-amd64
ghcr.io/openhands/agent-server:546f4c1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:546f4c1-golang-arm64
ghcr.io/openhands/agent-server:546f4c1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:546f4c1-java-amd64
ghcr.io/openhands/agent-server:546f4c1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:546f4c1-java-arm64
ghcr.io/openhands/agent-server:546f4c1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:546f4c1-python-amd64
ghcr.io/openhands/agent-server:546f4c1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:546f4c1-python-arm64
ghcr.io/openhands/agent-server:546f4c1-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:546f4c1-golang
ghcr.io/openhands/agent-server:546f4c1-java
ghcr.io/openhands/agent-server:546f4c1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `546f4c1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `546f4c1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->