### PR TITLE
feat: Load project skills (AGENTS.md, etc.) in PR review action

### DIFF
--- a/examples/03_github_workflows/02_pr_review/agent_script.py
+++ b/examples/03_github_workflows/02_pr_review/agent_script.py
@@ -753,7 +753,6 @@ def main():
 
         # Load project-specific skills from the repository being reviewed
         # This includes AGENTS.md, .cursorrules, and skills from .agents/skills/
-        # or .openhands/skills/ directories
         project_skills = load_project_skills(cwd)
         logger.info(
             f"Loaded {len(project_skills)} project skills: "


### PR DESCRIPTION
## Summary

The PR review agent now loads project-specific skills from the repository being reviewed. This ensures the code review agent follows repository-specific guidelines and conventions documented in AGENTS.md.

## Changes

### Updated `examples/03_github_workflows/02_pr_review/agent_script.py`

- Added import for `load_project_skills` from `openhands.sdk.context.skills`
- Load project skills from the current working directory before creating the AgentContext
- Pass project skills to AgentContext alongside public skills

## What This Enables

The PR review agent will now load:
- **AGENTS.md** - Repository-specific guidance and conventions
- **.cursorrules** - Cursor-specific rules
- **Skills from `.agents/skills/`** - Project-specific skills (new standard location)
- **Skills from `.openhands/skills/`** - Project-specific skills (legacy location)

This is important because repositories like `software-agent-sdk` have specific guidelines in AGENTS.md (e.g., about `.pr/` directory artifacts being safe to ignore) that the code review agent should follow.

## Testing

- Pre-commit hooks pass
- The change is minimal and follows existing patterns in the codebase

## Related

This PR was created in response to a review comment on PR #2012 asking to verify if the code review action loads AGENTS.md.

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a03cbc9bc7874a008e2ce14deefac588)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e7aa8e7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e7aa8e7-python \
  ghcr.io/openhands/agent-server:e7aa8e7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e7aa8e7-golang-amd64
ghcr.io/openhands/agent-server:e7aa8e7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e7aa8e7-golang-arm64
ghcr.io/openhands/agent-server:e7aa8e7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e7aa8e7-java-amd64
ghcr.io/openhands/agent-server:e7aa8e7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e7aa8e7-java-arm64
ghcr.io/openhands/agent-server:e7aa8e7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e7aa8e7-python-amd64
ghcr.io/openhands/agent-server:e7aa8e7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:e7aa8e7-python-arm64
ghcr.io/openhands/agent-server:e7aa8e7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:e7aa8e7-golang
ghcr.io/openhands/agent-server:e7aa8e7-java
ghcr.io/openhands/agent-server:e7aa8e7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e7aa8e7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e7aa8e7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->