### PR TITLE
fix(ci): block PR review auto-run for author_association NONE

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -8,7 +8,8 @@ on:
     #   2. A draft PR is marked as ready for review, OR
     #   3. A maintainer adds the 'review-this' label, OR
     #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
-    # Only users with write access can add labels or request reviews, ensuring security.
+    # Adding labels and requesting new reviewers requires write access. GitHub may also allow PR authors
+    # to re-request review from a previous reviewer.
     # The PR code is explicitly checked out for review, but secrets are only accessible
     # because the workflow runs in the base repository context
     pull_request_target:
@@ -22,14 +23,14 @@ permissions:
 jobs:
     pr-review:
         # Run when one of the following conditions is met:
-        #   1. A new non-draft PR is opened by a trusted contributor, OR
-        #   2. A draft PR is converted to ready for review by a trusted contributor, OR
+        #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+        #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
         #   3. 'review-this' label is added, OR
         #   4. openhands-agent or all-hands-bot is requested as a reviewer
         # Note: FIRST_TIME_CONTRIBUTOR PRs require manual trigger via label/reviewer request
         if: |
-            (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
-            (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR') ||
+            (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
+            (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
             github.event.label.name == 'review-this' ||
             github.event.requested_reviewer.login == 'openhands-agent' ||
             github.event.requested_reviewer.login == 'all-hands-bot'

--- a/examples/03_github_workflows/02_pr_review/README.md
+++ b/examples/03_github_workflows/02_pr_review/README.md
@@ -115,7 +115,7 @@ There are two ways to trigger an automated review of a pull request:
 4. The workflow will automatically start and analyze the changes
 5. Review comments will be posted to the PR when complete
 
-**Note**: Both methods require write access to the repository, ensuring only authorized users can trigger the AI review.
+**Note**: Adding labels or requesting a *new* reviewer requires write access. GitHub may still allow PR authors to use "Re-request review" for a reviewer who has already reviewed.
 
 ## Customizing the Code Review
 


### PR DESCRIPTION
### What
- Prevent the PR review workflow from auto-running on `opened` / `ready_for_review` when `author_association` is `NONE`.
- Clarify docs: adding labels or requesting a *new* reviewer requires write access, but GitHub may still allow re-requesting review from a previous reviewer.

### Why
We observed a new account with `author_association: NONE` triggering the auto-run path. This makes the gating match the intended behavior more closely.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:063cb9b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-063cb9b-python \
  ghcr.io/openhands/agent-server:063cb9b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:063cb9b-golang-amd64
ghcr.io/openhands/agent-server:063cb9b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:063cb9b-golang-arm64
ghcr.io/openhands/agent-server:063cb9b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:063cb9b-java-amd64
ghcr.io/openhands/agent-server:063cb9b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:063cb9b-java-arm64
ghcr.io/openhands/agent-server:063cb9b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:063cb9b-python-amd64
ghcr.io/openhands/agent-server:063cb9b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:063cb9b-python-arm64
ghcr.io/openhands/agent-server:063cb9b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:063cb9b-golang
ghcr.io/openhands/agent-server:063cb9b-java
ghcr.io/openhands/agent-server:063cb9b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `063cb9b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `063cb9b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->