### PR TITLE
feat(agent-server): load hooks.json for v1 hooks

### DIFF
--- a/openhands-sdk/openhands/sdk/hooks/__init__.py
+++ b/openhands-sdk/openhands/sdk/hooks/__init__.py
@@ -11,6 +11,8 @@ from openhands.sdk.hooks.config import (
     HookDefinition,
     HookMatcher,
     HookType,
+    load_project_hooks,
+    load_user_hooks,
 )
 from openhands.sdk.hooks.conversation_hooks import (
     HookEventProcessor,
@@ -35,4 +37,6 @@ __all__ = [
     "HookDecision",
     "HookEventProcessor",
     "create_hook_callback",
+    "load_project_hooks",
+    "load_user_hooks",
 ]

--- a/openhands-sdk/openhands/sdk/hooks/config.py
+++ b/openhands-sdk/openhands/sdk/hooks/config.py
@@ -327,3 +327,46 @@ class HookConfig(BaseModel):
             return None
 
         return merged
+
+
+def load_project_hooks(working_dir: str | Path) -> HookConfig | None:
+    """Load hooks from the project's .openhands/hooks.json file.
+
+    Args:
+        working_dir: Path to the project/working directory.
+
+    Returns:
+        HookConfig if hooks.json exists and is valid, None otherwise.
+    """
+    hooks_path = Path(working_dir) / ".openhands" / "hooks.json"
+    if not hooks_path.exists():
+        return None
+
+    try:
+        with open(hooks_path) as f:
+            data = json.load(f)
+        config = HookConfig.model_validate(data)
+        return config if not config.is_empty() else None
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        logger.warning(f"Failed to load project hooks from {hooks_path}: {e}")
+        return None
+
+
+def load_user_hooks() -> HookConfig | None:
+    """Load hooks from the user's ~/.openhands/hooks.json file.
+
+    Returns:
+        HookConfig if hooks.json exists and is valid, None otherwise.
+    """
+    hooks_path = Path.home() / ".openhands" / "hooks.json"
+    if not hooks_path.exists():
+        return None
+
+    try:
+        with open(hooks_path) as f:
+            data = json.load(f)
+        config = HookConfig.model_validate(data)
+        return config if not config.is_empty() else None
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        logger.warning(f"Failed to load user hooks from {hooks_path}: {e}")
+        return None


### PR DESCRIPTION
## Summary

  Enable V1 agent‑server to auto‑load .openhands/hooks.json from the workspace and merge it with any request‑provided hooks (request hooks first), so repo‑level hooks run in SaaS just like CLI.

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?






<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ee040f3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ee040f3-python \
  ghcr.io/openhands/agent-server:ee040f3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ee040f3-golang-amd64
ghcr.io/openhands/agent-server:ee040f3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ee040f3-golang-arm64
ghcr.io/openhands/agent-server:ee040f3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ee040f3-java-amd64
ghcr.io/openhands/agent-server:ee040f3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ee040f3-java-arm64
ghcr.io/openhands/agent-server:ee040f3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ee040f3-python-amd64
ghcr.io/openhands/agent-server:ee040f3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:ee040f3-python-arm64
ghcr.io/openhands/agent-server:ee040f3-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:ee040f3-golang
ghcr.io/openhands/agent-server:ee040f3-java
ghcr.io/openhands/agent-server:ee040f3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ee040f3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ee040f3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->