### PR TITLE
Add pr_url metadata to Laminar logging in PR review bot

### DIFF
--- a/examples/03_github_workflows/02_pr_review/agent_script.py
+++ b/examples/03_github_workflows/02_pr_review/agent_script.py
@@ -850,10 +850,12 @@ def main():
                 parent_span_context=laminar_span_context,
             ) as _:
                 # Set trace metadata within this active span context
+                pr_url = f"https://github.com/{pr_info['repo_name']}/pull/{pr_info['number']}"
                 Laminar.set_trace_metadata(
                     {
                         "pr_number": pr_info["number"],
                         "repo_name": pr_info["repo_name"],
+                        "pr_url": pr_url,
                         "workflow_phase": "review",
                         "review_style": review_style,
                     }


### PR DESCRIPTION
## Summary

Add the full PR URL as a metadata column to the Laminar logging in the PR review bot. This makes it easier to click through to the PR directly from the Laminar dashboard to see what happened there.

## Changes

- Added `pr_url` field to the trace metadata in `agent_script.py`
- The URL is constructed as `https://github.com/{repo_name}/pull/{pr_number}`

## Example

The trace metadata now includes:
```python
{
    "pr_number": 123,
    "repo_name": "owner/repo",
    "pr_url": "https://github.com/owner/repo/pull/123",  # NEW
    "workflow_phase": "review",
    "review_style": "standard",
}
```

This allows users viewing Laminar traces to quickly navigate to the associated PR with a single click.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:187b5cb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-187b5cb-python \
  ghcr.io/openhands/agent-server:187b5cb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:187b5cb-golang-amd64
ghcr.io/openhands/agent-server:187b5cb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:187b5cb-golang-arm64
ghcr.io/openhands/agent-server:187b5cb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:187b5cb-java-amd64
ghcr.io/openhands/agent-server:187b5cb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:187b5cb-java-arm64
ghcr.io/openhands/agent-server:187b5cb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:187b5cb-python-amd64
ghcr.io/openhands/agent-server:187b5cb-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:187b5cb-python-arm64
ghcr.io/openhands/agent-server:187b5cb-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:187b5cb-golang
ghcr.io/openhands/agent-server:187b5cb-java
ghcr.io/openhands/agent-server:187b5cb-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `187b5cb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `187b5cb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->