### PR TITLE
fix(ci): Fix PR review evaluation workflow artifact detection

### DIFF
--- a/.github/workflows/pr-review-evaluation.yml
+++ b/.github/workflows/pr-review-evaluation.yml
@@ -32,8 +32,8 @@ jobs:
         steps:
             # Note: actions/download-artifact@v5 only works within the same workflow run.
             # We use dawidd6/action-download-artifact to download from a different workflow.
-            - name: Check if review trace exists
-              id: check-trace
+            - name: Download review trace artifact
+              id: download-trace
               uses: dawidd6/action-download-artifact@v6
               continue-on-error: true
               with:
@@ -43,41 +43,47 @@ jobs:
                   search_artifacts: true
                   if_no_artifact_found: warn
 
-            - name: Skip if no review trace
-              if: steps.check-trace.outcome == 'failure'
+            # Check if the trace file actually exists (the artifact download may
+            # succeed but with no matching artifact, only issuing a warning)
+            - name: Check if trace file exists
+              id: check-trace
               run: |
-                  echo "No review trace found for PR #$PR_NUMBER"
-                  echo "This PR may not have been reviewed by the agent"
-                  echo "Skipping evaluation"
-                  exit 0
+                  if [ -f "trace-info/laminar_trace_info.json" ]; then
+                    echo "trace_exists=true" >> $GITHUB_OUTPUT
+                    echo "Found trace file for PR #$PR_NUMBER"
+                  else
+                    echo "trace_exists=false" >> $GITHUB_OUTPUT
+                    echo "No trace file found for PR #$PR_NUMBER"
+                    echo "This PR may not have been reviewed by the agent, skipping evaluation"
+                  fi
 
             - name: Checkout software-agent-sdk repository
-              if: steps.check-trace.outcome == 'success'
+              if: steps.check-trace.outputs.trace_exists == 'true'
               uses: actions/checkout@v5
               with:
                   repository: OpenHands/software-agent-sdk
                   path: software-agent-sdk
 
             - name: Set up Python
-              if: steps.check-trace.outcome == 'success'
+              if: steps.check-trace.outputs.trace_exists == 'true'
               uses: actions/setup-python@v6
               with:
                   python-version: '3.13'
 
             - name: Install uv
-              if: steps.check-trace.outcome == 'success'
+              if: steps.check-trace.outputs.trace_exists == 'true'
               uses: astral-sh/setup-uv@v7
               with:
                   enable-cache: true
 
             - name: Install dependencies
-              if: steps.check-trace.outcome == 'success'
+              if: steps.check-trace.outputs.trace_exists == 'true'
               run: |
                   # Install lmnr SDK for Laminar integration
                   uv pip install --system lmnr
 
             - name: Run evaluation
-              if: steps.check-trace.outcome == 'success'
+              if: steps.check-trace.outputs.trace_exists == 'true'
               env:
                   LMNR_PROJECT_API_KEY: ${{ secrets.LMNR_SKILLS_API_KEY }}
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -90,7 +96,7 @@ jobs:
 
             - name: Upload evaluation logs
               uses: actions/upload-artifact@v5
-              if: always() && steps.check-trace.outcome == 'success'
+              if: always() && steps.check-trace.outputs.trace_exists == 'true'
               with:
                   name: pr-review-evaluation-${{ github.event.pull_request.number }}
                   path: |

--- a/examples/03_github_workflows/02_pr_review/evaluate_review.py
+++ b/examples/03_github_workflows/02_pr_review/evaluate_review.py
@@ -362,6 +362,10 @@ def main():
             }
         )
 
+        # Capture trace ID while inside the span context
+        # (get_trace_id() returns None outside a span context)
+        eval_trace_id = Laminar.get_trace_id()
+
     # Flush to ensure span is sent
     Laminar.flush()
 
@@ -416,8 +420,7 @@ def main():
             logger.warning(f"Failed to score original trace: {e}")
             # Don't fail the workflow if scoring fails
 
-    # Get and print the evaluation trace ID
-    eval_trace_id = Laminar.get_trace_id()
+    # Print evaluation summary
     print("\n=== PR Review Evaluation ===")
     print(f"PR: {repo_name}#{pr_number}")
     print(f"Merged: {pr_merged}")


### PR DESCRIPTION
## Summary

Fixes issues with the PR review evaluation workflow that was causing failures when:
1. The artifact download step would succeed with a warning (due to `if_no_artifact_found: warn`) even when no artifact was found
2. Subsequent steps checking for `outcome=='failure'` would not trigger, leading to errors when trying to copy the non-existent trace file
3. The evaluation trace ID wasn't being captured correctly because `Laminar.get_trace_id()` was called outside the span context

## Root Cause Analysis

The evaluation workflow was failing because the `dawidd6/action-download-artifact` action with `if_no_artifact_found: warn` issues a warning but still succeeds (outcome='success'). This meant the condition `steps.check-trace.outcome == 'failure'` never triggered to skip evaluation, causing the `cp trace-info/laminar_trace_info.json .` command to fail.

Additionally, in `evaluate_review.py`, the call to `Laminar.get_trace_id()` was outside the span context, so it always returned `None`.

## Changes

### 1. GitHub Workflow (`.github/workflows/pr-review-evaluation.yml`)
- Added explicit file existence check after artifact download
- Use output variable (`trace_exists`) instead of step outcome
- All subsequent steps now check `steps.check-trace.outputs.trace_exists == 'true'`

### 2. Evaluation Script (`evaluate_review.py`)
- Move `Laminar.get_trace_id()` inside the span context where it correctly returns the trace ID
- Removed duplicate call that was outside the span context

## Testing

The workflow changes ensure that:
- PRs without a previous review trace will skip evaluation cleanly
- PRs with a valid trace file will proceed with evaluation
- The evaluation trace ID is correctly captured and logged

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bc8f860-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bc8f860-python \
  ghcr.io/openhands/agent-server:bc8f860-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bc8f860-golang-amd64
ghcr.io/openhands/agent-server:bc8f860-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bc8f860-golang-arm64
ghcr.io/openhands/agent-server:bc8f860-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bc8f860-java-amd64
ghcr.io/openhands/agent-server:bc8f860-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bc8f860-java-arm64
ghcr.io/openhands/agent-server:bc8f860-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bc8f860-python-amd64
ghcr.io/openhands/agent-server:bc8f860-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:bc8f860-python-arm64
ghcr.io/openhands/agent-server:bc8f860-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:bc8f860-golang
ghcr.io/openhands/agent-server:bc8f860-java
ghcr.io/openhands/agent-server:bc8f860-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bc8f860-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bc8f860-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->