### PR TITLE
docs: add package-scoped AGENTS.md guides

### DIFF
--- a/openhands-tools/openhands/tools/AGENTS.md
+++ b/openhands-tools/openhands/tools/AGENTS.md
@@ -1,0 +1,30 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- This directory (`openhands-tools/openhands/tools/`) contains runtime tool implementations under the `openhands.tools.*` namespace.
+- Most tools live in dedicated subpackages (for example `terminal/`, `file_editor/`, `browser_use/`) and typically split:
+  - `definition.py`: public schema/metadata/registration
+  - `impl.py` / `core.py`: runtime implementation
+- Treat `openhands-tools/openhands/tools/__init__.py` as the published surface for `openhands-tools`; `__all__` is considered public API.
+
+## Build, Test, and Development Commands
+
+- `make build`: set up the dev environment (`uv sync --dev`) and install pre-commit hooks.
+- `uv run pre-commit run --files <path>`: run checks only for the files you touched.
+- `uv run pytest tests/tools -k <pattern>`: run the tools test suite; prefer running a focused subset first (e.g. `uv run pytest tests/tools/terminal`).
+
+## Coding Style & Naming Conventions
+
+- Python target is 3.12; keep code Ruff-compliant (line length 88) and Pyright-friendly.
+- Tool names, parameter schemas, and output schemas are user-facing and often referenced in tests like `tests/tools/test_tool_name_consistency.py`; avoid breaking changes. If a schema must change, provide a backward-compatible loading path.
+- When adding runtime-loaded assets (Jinja `.j2` templates or JS under `browser_use/js/`), ensure they are included as package data (and update the agent-server PyInstaller spec when needed).
+
+## Testing Guidelines
+
+- Add/adjust unit tests under `tests/tools/`, mirroring the tool package. Keep tests focused on the behavior you changed.
+- Prefer real code paths over mocks; when mocking is unavoidable (e.g. external processes), centralize setup in `tests/conftest.py` or `tests/tools/<tool>/conftest.py`.
+
+## Commit & Pull Request Guidelines
+
+- Keep changes scoped to the tool(s) touched, and run the smallest relevant tests before running broader suites.

--- a/openhands-workspace/openhands/workspace/AGENTS.md
+++ b/openhands-workspace/openhands/workspace/AGENTS.md
@@ -1,0 +1,28 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+
+- This directory (`openhands-workspace/openhands/workspace/`) contains workspace implementations under the `openhands.workspace.*` namespace (Docker, Apptainer, cloud, and API-remote).
+- Each backend lives in its own subpackage (e.g. `docker/`, `cloud/`) and typically exposes a `*Workspace` class from `workspace.py`.
+- The published import surface is `openhands-workspace/openhands/workspace/__init__.py` (`__all__` is treated as public API). Keep imports lightweight so `import openhands.workspace` does not pull in build-time dependencies.
+- These classes should remain compatible with the SDK workspace interfaces and types (for example `openhands.sdk.workspace.RemoteWorkspace`, `TargetType`, `PlatformType`).
+
+## Build, Test, and Development Commands
+
+- `make build`: set up the dev environment (`uv sync --dev`) and install pre-commit hooks.
+- `uv run pre-commit run --files <path>`: run checks for only the files you changed.
+- `uv run pytest tests/workspace -k <pattern>`: run workspace tests; start with the narrowest file/directory that covers your change.
+
+## Coding Style & Naming Conventions
+
+- Python target is 3.12; keep code Ruff-compliant (line length 88) and Pyright-friendly.
+- Prefer small, explicit wrappers around external interactions (Docker/Apptainer/HTTP). Validate inputs early and keep side-effecting operations out of module import time.
+
+## Testing Guidelines
+
+- Tests live under `tests/workspace/` and generally validate import behavior, model fields, and command invocation. Prefer patching command executors instead of requiring real Docker in unit tests.
+- Add focused coverage for backend-specific behavior and for any changes that affect the public import surface.
+
+## Commit & Pull Request Guidelines
+
+- Avoid breaking changes to exported workspace classes/symbols; deprecate before removal when changing the public surface.


### PR DESCRIPTION
Adds package-level AGENTS.md guidelines for:\n- openhands-tools/openhands/tools\n- openhands-workspace/openhands/workspace\n\nThese follow the Codex-inspired concise Repository Guidelines format.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3b5a80d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3b5a80d-python \
  ghcr.io/openhands/agent-server:3b5a80d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3b5a80d-golang-amd64
ghcr.io/openhands/agent-server:3b5a80d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3b5a80d-golang-arm64
ghcr.io/openhands/agent-server:3b5a80d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3b5a80d-java-amd64
ghcr.io/openhands/agent-server:3b5a80d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3b5a80d-java-arm64
ghcr.io/openhands/agent-server:3b5a80d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3b5a80d-python-amd64
ghcr.io/openhands/agent-server:3b5a80d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3b5a80d-python-arm64
ghcr.io/openhands/agent-server:3b5a80d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3b5a80d-golang
ghcr.io/openhands/agent-server:3b5a80d-java
ghcr.io/openhands/agent-server:3b5a80d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3b5a80d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3b5a80d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->