### PR TITLE
docs: align AGENTS.md guidance across repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -315,7 +315,7 @@ These are enforced by `check_sdk_api_breakage.py` (runs on release PRs). Depreca
 - AFTER you edit ONE file, you should run pre-commit hook on that file via `uv run pre-commit run --files [filepath]` to make sure you didn't break it.
 - Don't write TOO MUCH test, you should write just enough to cover edge cases.
 - Check how we perform tests in .github/workflows/tests.yml
-- You should put unit tests in the corresponding test folder. For example, to test `openhands.sdk.tool/tool.py`, you should put tests under `openhands.sdk.tests/tool/test_tool.py`.
+- Put unit tests under the corresponding domain folder in `tests/` (e.g., `tests/sdk`, `tests/tools`, `tests/workspace`). For example, changes to `openhands-sdk/openhands/sdk/tool/tool.py` should be covered in `tests/sdk/tool/test_tool.py`.
 - DON'T write TEST CLASSES unless absolutely necessary!
 - If you find yourself duplicating logics in preparing mocks, loading data etc, these logic should be fixtures in conftest.py!
 - Please test only the logic implemented in the current codebase. Do not test functionality (e.g., BaseModel.model_dumps()) that is not implemented in this repository.
@@ -370,7 +370,8 @@ Note: This is separate from `persistence_dir` which is used for conversation sta
 
 <REPO>
 <PROJECT_STRUCTURE>
-- `openhands-sdk/` core SDK; `openhands-tools/` built-in tools; `openhands-workspace/` workspace management; `openhands-agent-server/` server runtime; `examples/` runnable patterns; `tests/` split by domain (`tests/sdk`, `tests/tools`, `tests/agent_server`, etc.).
+- This is a `uv`-managed Python monorepo (single `uv.lock` at repo root) with multiple distributable packages: `openhands-sdk/` (SDK), `openhands-tools/` (built-in tools), `openhands-workspace/` (workspace impls), and `openhands-agent-server/` (server runtime).
+- `examples/` contains runnable patterns; `tests/` is split by domain (`tests/sdk`, `tests/tools`, `tests/workspace`, `tests/agent_server`, etc.).
 - Python namespace is `openhands.*` across packages; keep new modules within the matching package and mirror test paths under `tests/`.
 </PROJECT_STRUCTURE>
 

--- a/openhands-sdk/openhands/sdk/AGENTS.md
+++ b/openhands-sdk/openhands/sdk/AGENTS.md
@@ -1,6 +1,6 @@
-# Repository Guidelines
+# Package Guidelines
 
-## Project Structure & Module Organization
+## Package Structure & Module Organization
 
 - This directory (`openhands-sdk/openhands/sdk/`) contains the core Python SDK under the `openhands.sdk.*` namespace.
 - Keep new modules within the closest existing subpackage (e.g., `llm/`, `tool/`, `event/`, `agent/`) and follow local naming patterns.

--- a/openhands-tools/openhands/tools/AGENTS.md
+++ b/openhands-tools/openhands/tools/AGENTS.md
@@ -1,6 +1,6 @@
-# Repository Guidelines
+# Package Guidelines
 
-## Project Structure & Module Organization
+## Package Structure & Module Organization
 
 - This directory (`openhands-tools/openhands/tools/`) contains runtime tool implementations under the `openhands.tools.*` namespace.
 - Most tools live in dedicated subpackages (for example `terminal/`, `file_editor/`, `browser_use/`) and typically split:

--- a/openhands-workspace/openhands/workspace/AGENTS.md
+++ b/openhands-workspace/openhands/workspace/AGENTS.md
@@ -1,6 +1,6 @@
-# Repository Guidelines
+# Package Guidelines
 
-## Project Structure & Module Organization
+## Package Structure & Module Organization
 
 - This directory (`openhands-workspace/openhands/workspace/`) contains workspace implementations under the `openhands.workspace.*` namespace (Docker, Apptainer, cloud, and API-remote).
 - Each backend lives in its own subpackage (e.g. `docker/`, `cloud/`) and typically exposes a `*Workspace` class from `workspace.py`.


### PR DESCRIPTION
Aligns AGENTS.md guidance across the monorepo and package scopes:\n\n- Root AGENTS.md: clarify uv-managed monorepo structure + correct test path example\n- Package AGENTS.md (sdk/tools/workspace): rename to 'Package Guidelines' for clarity\n\nCo-authored-by: openhands <openhands@all-hands.dev>
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a7f4858-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a7f4858-python \
  ghcr.io/openhands/agent-server:a7f4858-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a7f4858-golang-amd64
ghcr.io/openhands/agent-server:a7f4858-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a7f4858-golang-arm64
ghcr.io/openhands/agent-server:a7f4858-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a7f4858-java-amd64
ghcr.io/openhands/agent-server:a7f4858-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a7f4858-java-arm64
ghcr.io/openhands/agent-server:a7f4858-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a7f4858-python-amd64
ghcr.io/openhands/agent-server:a7f4858-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:a7f4858-python-arm64
ghcr.io/openhands/agent-server:a7f4858-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:a7f4858-golang
ghcr.io/openhands/agent-server:a7f4858-java
ghcr.io/openhands/agent-server:a7f4858-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a7f4858-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a7f4858-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->