### PR TITLE
feat(skills): load user skills from ~/.agents/skills

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -656,6 +656,7 @@ def load_skills_from_dir(
 
 # Default user skills directories (in order of priority)
 USER_SKILLS_DIRS = [
+    Path.home() / ".agents" / "skills",
     Path.home() / ".openhands" / "skills",
     Path.home() / ".openhands" / "microagents",  # Legacy support
 ]
@@ -664,9 +665,10 @@ USER_SKILLS_DIRS = [
 def load_user_skills() -> list[Skill]:
     """Load skills from user's home directory.
 
-    Searches for skills in ~/.openhands/skills/ and ~/.openhands/microagents/
-    (legacy). Skills from both directories are merged, with skills/ taking
-    precedence for duplicate names.
+    Searches for skills in ~/.agents/skills/, ~/.openhands/skills/, and
+    ~/.openhands/microagents/ (legacy). Skills from all directories are merged,
+    with earlier entries in USER_SKILLS_DIRS taking precedence for duplicate
+    names.
 
     Returns:
         List of Skill objects loaded from user directories.


### PR DESCRIPTION
## Summary

This PR proposes support for user home `~/.agents/skills` directory.

This builds on #1914 which added support for `.agents/skills` in the project directory.  A good selection of agents have recently added support for user skills by looking in `~/.agents/skills` as well (Codex CLI/Gemini CLI/OpenCode/etc).  Lets support it for OpenHands CLI as well.

If this PR is approved, I'll raise a PR against the docs repo as well.

This was tested using web UI using Docker and with the agent-server mounting my ~/.agents inside the container.

## Checklist

- [X] If the PR is changing/adding functionality, are there tests to reflect this?
- [X] If there is an example, have you run the example to make sure that it works?
- [X] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?
