### PR TITLE
Add claude-sonnet-4-6 to expected models

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -64,6 +64,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "claude-sonnet-4-6": {
+        "id": "claude-sonnet-4-6",
+        "display_name": "Claude Sonnet 4.6",
+        "llm_config": {
+            "model": "litellm_proxy/anthropic/claude-sonnet-4-6",
+            "temperature": 0.0,
+        },
+    },
     "gemini-3-pro": {
         "id": "gemini-3-pro",
         "display_name": "Gemini 3 Pro",


### PR DESCRIPTION
## Summary

Adds the `claude-sonnet-4-6` model to the expected models configuration in `resolve_model_config.py`.

- Model ID: `claude-sonnet-4-6`
- Model path: `litellm_proxy/anthropic/claude-sonnet-4-6`
- Display name: `Claude Sonnet 4.6`

Fixes #2101

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - N/A - This is a configuration change (adding a model to a dictionary)
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - No example changes
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - Tested the script manually: `MODEL_IDS="claude-sonnet-4-6" python .github/run-eval/resolve_model_config.py`
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - No documentation changes needed
- [x] Is the github CI passing?
  - Pre-commit checks pass locally

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:add78a8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-add78a8-python \
  ghcr.io/openhands/agent-server:add78a8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:add78a8-golang-amd64
ghcr.io/openhands/agent-server:add78a8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:add78a8-golang-arm64
ghcr.io/openhands/agent-server:add78a8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:add78a8-java-amd64
ghcr.io/openhands/agent-server:add78a8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:add78a8-java-arm64
ghcr.io/openhands/agent-server:add78a8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:add78a8-python-amd64
ghcr.io/openhands/agent-server:add78a8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:add78a8-python-arm64
ghcr.io/openhands/agent-server:add78a8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:add78a8-golang
ghcr.io/openhands/agent-server:add78a8-java
ghcr.io/openhands/agent-server:add78a8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `add78a8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `add78a8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->