### PR TITLE
Remove jade-spark-2862 alias, add its settings to minimax-m2.5

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -108,21 +108,16 @@ MODELS = {
     "minimax-m2.5": {
         "id": "minimax-m2.5",
         "display_name": "MiniMax M2.5",
-        "llm_config": {"model": "litellm_proxy/minimax/MiniMax-M2.5"},
+        "llm_config": {
+            "model": "litellm_proxy/minimax/MiniMax-M2.5",
+            "temperature": 1.0,
+            "top_p": 0.95,
+        },
     },
     "minimax-m2.1": {
         "id": "minimax-m2.1",
         "display_name": "MiniMax M2.1",
         "llm_config": {"model": "litellm_proxy/minimax/MiniMax-M2.1"},
-    },
-    "jade-spark-2862": {
-        "id": "jade-spark-2862",
-        "display_name": "Jade Spark 2862",
-        "llm_config": {
-            "model": "litellm_proxy/jade-spark-2862",
-            "temperature": 1.0,
-            "top_p": 0.95,
-        },
     },
     "deepseek-v3.2-reasoner": {
         "id": "deepseek-v3.2-reasoner",


### PR DESCRIPTION
## Summary

`jade-spark-2862` was an alias for `minimax/MiniMax-M2.5` in the litellm proxy configuration. This PR:

1. **Removes** the redundant `jade-spark-2862` model entry
2. **Transfers** its `temperature: 1.0` and `top_p: 0.95` settings to the `minimax-m2.5` model config

## Why

Having both entries caused confusion when pushing evaluation results to the index - results were being attributed to "jade-spark-2862" instead of the actual model "MiniMax-M2.5".

The `minimax-m2.5` model ID should be used going forward for evaluations.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:746f01c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-746f01c-python \
  ghcr.io/openhands/agent-server:746f01c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:746f01c-golang-amd64
ghcr.io/openhands/agent-server:746f01c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:746f01c-golang-arm64
ghcr.io/openhands/agent-server:746f01c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:746f01c-java-amd64
ghcr.io/openhands/agent-server:746f01c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:746f01c-java-arm64
ghcr.io/openhands/agent-server:746f01c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:746f01c-python-amd64
ghcr.io/openhands/agent-server:746f01c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:746f01c-python-arm64
ghcr.io/openhands/agent-server:746f01c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:746f01c-golang
ghcr.io/openhands/agent-server:746f01c-java
ghcr.io/openhands/agent-server:746f01c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `746f01c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `746f01c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->