### PR TITLE
fix: disable vision for GLM-5 model

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -158,6 +158,8 @@ MODELS = {
         "display_name": "GLM-5",
         "llm_config": {
             "model": "litellm_proxy/openrouter/z-ai/glm-5",
+            # OpenRouter glm-5 is text-only despite LiteLLM reporting vision support
+            "disable_vision": True,
         },
     },
     "qwen3-coder-next": {

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -253,3 +253,4 @@ def test_glm_5_config():
     assert model["id"] == "glm-5"
     assert model["display_name"] == "GLM-5"
     assert model["llm_config"]["model"] == "litellm_proxy/openrouter/z-ai/glm-5"
+    assert model["llm_config"]["disable_vision"] is True


### PR DESCRIPTION
## Problem

GLM-5 is currently failing on the swebenchmultimodal benchmark with continuous 503/502 errors because the model doesn't support vision, but the system is trying to send images to it.

**Evidence from production:**
- Job `eval-22117155121-glm-5-k2l7s` running swebenchmultimodal has been stuck for 42+ minutes with 0 output lines
- Runtime servers return `503 Service Unavailable` and `502 Bad Gateway` errors
- Regular text benchmarks (swebench, GAIA) work fine with GLM-5 (215 and 83 output lines respectively)
- Runtime pods fail to spawn or crash immediately when processing multimodal content

## Root Cause

Similar to GLM-4.7 (which already has `disable_vision: true` set), GLM-5 is a text-only model but LiteLLM may report it as supporting vision. When the system tries to send images to GLM-5, it causes runtime failures.

## Solution

This PR adds `disable_vision: true` to the GLM-5 configuration in `.github/run-eval/resolve_model_config.py`, following the same pattern used for GLM-4.7.

## Changes
- Added `disable_vision: True` flag to GLM-5 model configuration
- Added comment explaining why this is needed
- Updated test to verify the flag is set correctly

## Testing
- ✅ All model config validation tests pass
- ✅ Specific GLM-5 config test passes with new assertion

Fixes #2110
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:42703f9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-42703f9-python \
  ghcr.io/openhands/agent-server:42703f9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:42703f9-golang-amd64
ghcr.io/openhands/agent-server:42703f9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:42703f9-golang-arm64
ghcr.io/openhands/agent-server:42703f9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:42703f9-java-amd64
ghcr.io/openhands/agent-server:42703f9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:42703f9-java-arm64
ghcr.io/openhands/agent-server:42703f9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:42703f9-python-amd64
ghcr.io/openhands/agent-server:42703f9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:42703f9-python-arm64
ghcr.io/openhands/agent-server:42703f9-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:42703f9-golang
ghcr.io/openhands/agent-server:42703f9-java
ghcr.io/openhands/agent-server:42703f9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `42703f9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `42703f9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->