### PR TITLE
Disable uv Actions cache in PR review agent workflow

### DIFF
--- a/.github/actions/pr-review/action.yml
+++ b/.github/actions/pr-review/action.yml
@@ -67,10 +67,14 @@ runs:
           with:
               python-version: '3.12'
 
+        # Security: this workflow executes untrusted PR content (diff/title/body) via an
+        # LLM-powered reviewer agent that can run Bash. GitHub Actions caches are shared
+        # across workflows within a repository and can enable cache-poisoning pivots into
+        # more-privileged workflows. Keep caching disabled here.
         - name: Install uv
           uses: astral-sh/setup-uv@v6
           with:
-              enable-cache: true
+              enable-cache: false
 
         - name: Install GitHub CLI
           shell: bash


### PR DESCRIPTION
This PR disables `astral-sh/setup-uv` GitHub Actions caching in the PR review agent composite action.

Rationale (concise): this workflow processes **untrusted PR content** (diff/title/body) with an LLM-powered reviewer that can run **Bash**. GitHub Actions caches are shared across workflows in a repo and can enable cache-poisoning pivots into more-privileged workflows (see the Clinejection class of issues). Disabling caching here reduces that pivot surface.

References:
- https://adnanthekhan.com/posts/clinejection/
- https://github.com/cline/cline/security/advisories/GHSA-9ppg-jx86-fqw7

Addresses part of
- #2120 
- #2026

Change:
- `.github/actions/pr-review/action.yml`: set `enable-cache: false` and add an explanatory comment.
