### PR TITLE
Fix PR review workflow

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -2,17 +2,11 @@
 name: PR Review by OpenHands
 
 on:
-    # Use pull_request_target to allow fork PRs to access secrets when triggered by maintainers
-    # Security: This workflow runs when:
-    #   1. A new PR is opened (non-draft), OR
-    #   2. A draft PR is marked as ready for review, OR
-    #   3. A maintainer adds the 'review-this' label, OR
-    #   4. A maintainer requests openhands-agent or all-hands-bot as a reviewer
-    # Adding labels and requesting new reviewers requires write access. GitHub may also allow PR authors
-    # to re-request review from a previous reviewer.
-    # The PR code is explicitly checked out for review, but secrets are only accessible
-    # because the workflow runs in the base repository context
-    pull_request_target:
+    # TEMPORARY MITIGATION (Clinejection hardening)
+    #
+    # We temporarily avoid `pull_request_target` here. We'll restore it after the PR review
+    # workflow is fully hardened for untrusted execution.
+    pull_request:
         types: [opened, ready_for_review, labeled, review_requested]
 
 permissions:
@@ -22,18 +16,27 @@ permissions:
 
 jobs:
     pr-review:
-        # Run when one of the following conditions is met:
-        #   1. A new non-draft PR is opened by a non-first-time contributor, OR
-        #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
-        #   3. 'review-this' label is added, OR
-        #   4. openhands-agent or all-hands-bot is requested as a reviewer
-        # Note: FIRST_TIME_CONTRIBUTOR PRs require manual trigger via label/reviewer request
+        # Note: fork PRs will not have access to repository secrets under `pull_request`.
+        # Skip forks to avoid noisy failures until we restore a hardened `pull_request_target` flow.
         if: |
-            (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
-            (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
-            github.event.label.name == 'review-this' ||
-            github.event.requested_reviewer.login == 'openhands-agent' ||
-            github.event.requested_reviewer.login == 'all-hands-bot'
+            github.event.pull_request.head.repo.full_name == github.repository &&
+            (
+                github.event.pull_request.author_association == 'OWNER' ||
+                github.event.pull_request.author_association == 'MEMBER' ||
+                github.event.pull_request.author_association == 'COLLABORATOR'
+            ) &&
+            (
+                (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
+                github.event.action == 'ready_for_review' ||
+                (github.event.action == 'labeled' && github.event.label.name == 'review-this') ||
+                (
+                    github.event.action == 'review_requested' &&
+                    (
+                        github.event.requested_reviewer.login == 'openhands-agent' ||
+                        github.event.requested_reviewer.login == 'all-hands-bot'
+                    )
+                )
+            )
         concurrency:
             group: pr-review-${{ github.event.pull_request.number }}
             cancel-in-progress: true


### PR DESCRIPTION
This temporarily removes the `pull_request_target` trigger from the PR reviewer workflow as a mitigation related to the Clinejection class of issues.

We will restore `pull_request_target` after the PR review workflow is fully hardened for untrusted execution.

What changed:
- Switch to `pull_request` trigger (opened/ready_for_review/labeled/review_requested).
- The job runs only for same-repo PRs where the author association is **OWNER/MEMBER/COLLABORATOR**.
- For `labeled`, we require `review-this`.
- For `review_requested`, we require the requested reviewer to be `openhands-agent` or `all-hands-bot`.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ea25e4c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ea25e4c-python \
  ghcr.io/openhands/agent-server:ea25e4c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ea25e4c-golang-amd64
ghcr.io/openhands/agent-server:ea25e4c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ea25e4c-golang-arm64
ghcr.io/openhands/agent-server:ea25e4c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ea25e4c-java-amd64
ghcr.io/openhands/agent-server:ea25e4c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ea25e4c-java-arm64
ghcr.io/openhands/agent-server:ea25e4c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ea25e4c-python-amd64
ghcr.io/openhands/agent-server:ea25e4c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:ea25e4c-python-arm64
ghcr.io/openhands/agent-server:ea25e4c-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:ea25e4c-golang
ghcr.io/openhands/agent-server:ea25e4c-java
ghcr.io/openhands/agent-server:ea25e4c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ea25e4c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ea25e4c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->