### PR TITLE
Enable Datadog persistence by default in eval job

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -76,9 +76,9 @@ on:
                 default: ''
                 type: string
             enable_conversation_event_logging:
-                description: 'Enable Datadog persistence for conversation events (default: false)'
+                description: 'Enable Datadog persistence for conversation events (default: true)'
                 required: false
-                default: false
+                default: true
                 type: boolean
             max_retries:
                 description: Max retries per instance (passed to benchmarks)


### PR DESCRIPTION
## Summary

This PR enables Datadog persistence by default in the eval job workflow by setting `enable_conversation_event_logging` to `true`.

## Changes

- Updated `.github/workflows/run-eval.yml`:
  - Changed `enable_conversation_event_logging` default value from `false` to `true`
  - Updated the description to reflect the new default

## Motivation

Having Datadog persistence enabled by default ensures that conversation events from eval runs are automatically logged to Datadog, improving observability and debugging capabilities without requiring manual intervention.

Fixes #2139

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2f65f25-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2f65f25-python \
  ghcr.io/openhands/agent-server:2f65f25-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2f65f25-golang-amd64
ghcr.io/openhands/agent-server:2f65f25-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2f65f25-golang-arm64
ghcr.io/openhands/agent-server:2f65f25-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2f65f25-java-amd64
ghcr.io/openhands/agent-server:2f65f25-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2f65f25-java-arm64
ghcr.io/openhands/agent-server:2f65f25-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2f65f25-python-amd64
ghcr.io/openhands/agent-server:2f65f25-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2f65f25-python-arm64
ghcr.io/openhands/agent-server:2f65f25-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2f65f25-golang
ghcr.io/openhands/agent-server:2f65f25-java
ghcr.io/openhands/agent-server:2f65f25-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2f65f25-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2f65f25-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->