### PR TITLE
Add ask_agent support to ACPAgent via fork_session

### DIFF
--- a/examples/01_standalone_sdk/40_acp_agent_example.py
+++ b/examples/01_standalone_sdk/40_acp_agent_example.py
@@ -1,7 +1,9 @@
 """Example: Using ACPAgent with Claude Code ACP server.
 
 This example shows how to use an ACP-compatible server (claude-code-acp)
-as the agent backend instead of direct LLM calls.
+as the agent backend instead of direct LLM calls.  It also demonstrates
+``ask_agent()`` — a stateless side-question that forks the ACP session
+and leaves the main conversation untouched.
 
 Prerequisites:
     - Node.js / npx available
@@ -17,17 +19,25 @@ from openhands.sdk.agent import ACPAgent
 from openhands.sdk.conversation import Conversation
 
 
-agent = ACPAgent(acp_command=["npx", "-y", "claude-code-acp"])
+agent = ACPAgent(acp_command=["npx", "-y", "@zed-industries/claude-agent-acp"])
 
 try:
     cwd = os.getcwd()
     conversation = Conversation(agent=agent, workspace=cwd)
 
+    # --- Main conversation turn ---
     conversation.send_message(
         "List the Python source files under openhands-sdk/openhands/sdk/agent/, "
         "then read the __init__.py and summarize what agent classes are exported."
     )
     conversation.run()
+
+    # --- ask_agent: stateless side-question via fork_session ---
+    print("\n--- ask_agent ---")
+    response = conversation.ask_agent(
+        "Based on what you just saw, which agent class is the newest addition?"
+    )
+    print(f"ask_agent response: {response}")
 finally:
     # Clean up the ACP server subprocess
     agent.close()

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import asyncio
 import os
+import threading
 from collections.abc import Generator
 from typing import TYPE_CHECKING, Any
 
@@ -21,6 +22,7 @@ from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
     AllowedOutcome,
+    PromptResponse,
     RequestPermissionResponse,
     TextContentBlock,
     ToolCallProgress,
@@ -61,6 +63,17 @@ logger = get_logger(__name__)
 _NOTIFICATION_DRAIN_DELAY: float = float(
     os.environ.get("ACP_NOTIFICATION_DRAIN_DELAY", "0.1")
 )
+
+
+async def _drain_notifications() -> None:
+    """Best-effort drain of pending ``session_update`` notifications.
+
+    ACP does not yet signal when all notifications for a turn have been
+    delivered (see TODO above).  We yield to the event loop so already-queued
+    handlers run, then sleep briefly to allow in-flight IO handlers to finish.
+    """
+    await asyncio.sleep(0)
+    await asyncio.sleep(_NOTIFICATION_DRAIN_DELAY)
 
 
 def _make_dummy_llm() -> LLM:
@@ -116,6 +129,11 @@ class _OpenHandsACPBridge:
         self._last_cost: float = 0.0  # last cumulative cost seen
         self._context_window: int = 0  # context window size from ACP
         self._llm_ref: Any = None  # reference to the sentinel LLM
+        # Fork session state for ask_agent() — guarded by _fork_lock to
+        # prevent concurrent ask_agent() calls from colliding.
+        self._fork_lock = threading.Lock()
+        self._fork_session_id: str | None = None
+        self._fork_accumulated_text: list[str] = []
 
     def reset(self) -> None:
         self.accumulated_text.clear()
@@ -128,10 +146,17 @@ class _OpenHandsACPBridge:
 
     async def session_update(
         self,
-        session_id: str,  # noqa: ARG002
+        session_id: str,
         update: Any,
         **kwargs: Any,  # noqa: ARG002
     ) -> None:
+        # Route fork session updates to the fork accumulator
+        if self._fork_session_id is not None and session_id == self._fork_session_id:
+            if isinstance(update, AgentMessageChunk):
+                if isinstance(update.content, TextContentBlock):
+                    self._fork_accumulated_text.append(update.content.text)
+            return
+
         if isinstance(update, AgentMessageChunk):
             if isinstance(update.content, TextContentBlock):
                 text = update.content.text
@@ -249,13 +274,7 @@ class _OpenHandsACPBridge:
 
 
 class ACPAgent(AgentBase):
-    """Agent that delegates to an ACP (Agent Client Protocol) server.
-
-    Instead of calling an LLM directly, this agent spawns an ACP-compatible
-    server (e.g. ``claude-code-acp``) as a subprocess and communicates with
-    it via the ACP protocol.  The server manages its own LLM, tools, and
-    execution lifecycle.
-    """
+    """Agent that delegates to an ACP-compatible subprocess server."""
 
     # Override required fields with ACP-appropriate defaults
     llm: LLM = Field(default_factory=_make_dummy_llm)
@@ -286,6 +305,29 @@ class ACPAgent(AgentBase):
     _client: Any = PrivateAttr(default=None)  # _OpenHandsACPBridge
     _filtered_reader: Any = PrivateAttr(default=None)  # StreamReader
     _closed: bool = PrivateAttr(default=False)
+    _working_dir: str = PrivateAttr(default="")
+
+    # -- Helpers -----------------------------------------------------------
+
+    def _record_usage(self, response: PromptResponse | None, session_id: str) -> None:
+        """Record token usage and notify stats callback from a PromptResponse."""
+        if response is not None and response.usage is not None:
+            usage = response.usage
+            self.llm.metrics.add_token_usage(
+                prompt_tokens=usage.input_tokens,
+                completion_tokens=usage.output_tokens,
+                cache_read_tokens=usage.cached_read_tokens or 0,
+                cache_write_tokens=usage.cached_write_tokens or 0,
+                reasoning_tokens=usage.thought_tokens or 0,
+                context_window=self._client._context_window,
+                response_id=session_id,
+            )
+
+        if self.llm.telemetry._stats_update_callback is not None:
+            try:
+                self.llm.telemetry._stats_update_callback()
+            except Exception:
+                logger.debug("Stats update callback failed", exc_info=True)
 
     # -- Override base properties to be no-ops for ACP ---------------------
 
@@ -356,6 +398,8 @@ class ACPAgent(AgentBase):
         env = default_environment()
         env.update(os.environ)
         env.update(self.acp_env)
+        # Strip CLAUDECODE so nested Claude Code instances don't refuse to start
+        env.pop("CLAUDECODE", None)
 
         command = self.acp_command[0]
         args = list(self.acp_command[1:]) + list(self.acp_args)
@@ -402,6 +446,7 @@ class ACPAgent(AgentBase):
 
         result = self._executor.run_async(_init)
         self._conn, self._process, self._filtered_reader, self._session_id = result
+        self._working_dir = working_dir
 
     def step(
         self,
@@ -435,44 +480,18 @@ class ACPAgent(AgentBase):
 
         try:
 
-            async def _prompt() -> Any:
+            async def _prompt() -> PromptResponse:
                 response = await self._conn.prompt(
                     [text_block(user_message)],
                     self._session_id,
                 )
-                # Drain pending session_update notification handlers.
-                # First yield lets already-queued handlers run, then a
-                # short sleep covers handlers still arriving over IO.
-                await asyncio.sleep(0)
-                await asyncio.sleep(_NOTIFICATION_DRAIN_DELAY)
+                await _drain_notifications()
                 return response
 
             # Send prompt to ACP server
             response = self._executor.run_async(_prompt)
 
-            # Record per-turn token usage from PromptResponse
-            if (
-                response is not None
-                and hasattr(response, "usage")
-                and response.usage is not None
-            ):
-                usage = response.usage
-                self.llm.metrics.add_token_usage(
-                    prompt_tokens=usage.input_tokens,
-                    completion_tokens=usage.output_tokens,
-                    cache_read_tokens=usage.cached_read_tokens or 0,
-                    cache_write_tokens=usage.cached_write_tokens or 0,
-                    reasoning_tokens=usage.thought_tokens or 0,
-                    context_window=self._client._context_window,
-                    response_id=self._session_id or "",
-                )
-
-            # Notify stats callback
-            if self.llm.telemetry._stats_update_callback is not None:
-                try:
-                    self.llm.telemetry._stats_update_callback()
-                except Exception:
-                    logger.debug("Stats update callback failed", exc_info=True)
+            self._record_usage(response, self._session_id or "")
 
             # Build response message
             response_text = "".join(self._client.accumulated_text)
@@ -508,6 +527,43 @@ class ACPAgent(AgentBase):
             )
             on_event(error_event)
             state.execution_status = ConversationExecutionStatus.ERROR
+
+    def ask_agent(self, question: str) -> str | None:
+        """Fork the ACP session, prompt the fork, and return the response."""
+        if self._conn is None:
+            msg = "ACPAgent has no ACP connection; call init_state() first"
+            raise RuntimeError(msg)
+        if self._session_id is None:
+            msg = "ACPAgent has no session ID; call init_state() first"
+            raise RuntimeError(msg)
+
+        client = self._client
+
+        async def _fork_and_prompt() -> str:
+            fork_response = await self._conn.fork_session(
+                cwd=self._working_dir,
+                session_id=self._session_id,
+            )
+            fork_session_id = fork_response.session_id
+
+            client._fork_session_id = fork_session_id
+            client._fork_accumulated_text.clear()
+            try:
+                response = await self._conn.prompt(
+                    [text_block(question)],
+                    fork_session_id,
+                )
+                await _drain_notifications()
+
+                result = "".join(client._fork_accumulated_text)
+                self._record_usage(response, fork_session_id)
+                return result
+            finally:
+                client._fork_session_id = None
+                client._fork_accumulated_text.clear()
+
+        with client._fork_lock:
+            return self._executor.run_async(_fork_and_prompt)
 
     def close(self) -> None:
         """Terminate the ACP subprocess and clean up resources."""

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -565,3 +565,14 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         if not self._initialized:
             raise RuntimeError("Agent not initialized; call _initialize() before use")
         return self._tools
+
+    def ask_agent(self, question: str) -> str | None:  # noqa: ARG002
+        """Optional override for stateless question answering.
+
+        Subclasses (e.g. ACPAgent) may override this to provide their own
+        implementation of ask_agent that bypasses the default LLM-based path.
+
+        Returns:
+            Response string, or ``None`` to use the default LLM-based approach.
+        """
+        return None

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -757,6 +757,11 @@ class LocalConversation(BaseConversation):
         # Ensure agent is initialized (needs tools_map)
         self._ensure_agent_ready()
 
+        # Try agent-specific override first (e.g. ACPAgent uses fork_session)
+        agent_response = self.agent.ask_agent(question)
+        if agent_response is not None:
+            return agent_response
+
         # Import here to avoid circular imports
         from openhands.sdk.agent.utils import make_llm_completion, prepare_llm_messages
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -790,3 +790,216 @@ class TestACPAgentTelemetry:
         assert client._last_cost == 1.23
         assert client._context_window == 128000
         assert client._llm_ref is not None
+
+
+# ---------------------------------------------------------------------------
+# ask_agent
+# ---------------------------------------------------------------------------
+
+
+class TestACPAgentAskAgent:
+    def test_ask_agent_raises_if_not_initialized(self):
+        """ask_agent() raises RuntimeError when _conn is None."""
+        agent = _make_agent()
+        # _conn and _session_id are None by default
+        with pytest.raises(RuntimeError, match="no ACP connection"):
+            agent.ask_agent("What is 2+2?")
+
+    def test_ask_agent_raises_if_session_id_missing(self):
+        """ask_agent() raises RuntimeError when _session_id is None."""
+        agent = _make_agent()
+        agent._conn = MagicMock()
+        agent._session_id = None
+        with pytest.raises(RuntimeError, match="no session ID"):
+            agent.ask_agent("What is 2+2?")
+
+    def test_ask_agent_forks_and_prompts(self):
+        """ask_agent() forks the session, prompts, and returns the response."""
+        agent = _make_agent()
+        mock_client = _OpenHandsACPBridge()
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "main-session"
+        agent._working_dir = "/workspace"
+
+        # Mock fork_session response
+        mock_fork_response = MagicMock()
+        mock_fork_response.session_id = "fork-session-123"
+
+        # Mock prompt response (no usage)
+        mock_prompt_response = MagicMock()
+        mock_prompt_response.usage = None
+
+        async def _fake_prompt(*args, **kwargs):
+            # Simulate text arriving via session_update during prompt
+            mock_client._fork_accumulated_text.extend(["Hello", " world"])
+            return mock_prompt_response
+
+        def _fake_run_async(coro_fn):
+            """Simulate the async execution synchronously."""
+            loop = asyncio.new_event_loop()
+            try:
+                agent._conn.fork_session = AsyncMock(return_value=mock_fork_response)
+                agent._conn.prompt = _fake_prompt
+                return loop.run_until_complete(coro_fn())
+            finally:
+                loop.close()
+
+        mock_executor = MagicMock()
+        mock_executor.run_async = _fake_run_async
+        agent._executor = mock_executor
+
+        result = agent.ask_agent("What is 2+2?")
+
+        assert result == "Hello world"
+
+    def test_ask_agent_records_token_usage(self):
+        """ask_agent() records token usage from the PromptResponse."""
+        agent = _make_agent()
+        mock_client = _OpenHandsACPBridge()
+        mock_client._context_window = 200000
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "main-session"
+        agent._working_dir = "/workspace"
+
+        mock_fork_response = MagicMock()
+        mock_fork_response.session_id = "fork-session-456"
+
+        mock_usage = MagicMock()
+        mock_usage.input_tokens = 100
+        mock_usage.output_tokens = 50
+        mock_usage.cached_read_tokens = 10
+        mock_usage.cached_write_tokens = 5
+        mock_usage.thought_tokens = 20
+
+        mock_prompt_response = MagicMock()
+        mock_prompt_response.usage = mock_usage
+
+        async def _fake_prompt(*args, **kwargs):
+            mock_client._fork_accumulated_text.append("response")
+            return mock_prompt_response
+
+        def _fake_run_async(coro_fn):
+            loop = asyncio.new_event_loop()
+            try:
+                agent._conn.fork_session = AsyncMock(return_value=mock_fork_response)
+                agent._conn.prompt = _fake_prompt
+                return loop.run_until_complete(coro_fn())
+            finally:
+                loop.close()
+
+        mock_executor = MagicMock()
+        mock_executor.run_async = _fake_run_async
+        agent._executor = mock_executor
+
+        agent.ask_agent("Summarize this")
+
+        metrics = agent.llm.metrics
+        assert len(metrics.token_usages) == 1
+        usage = metrics.token_usages[0]
+        assert usage.prompt_tokens == 100
+        assert usage.completion_tokens == 50
+        assert usage.cache_read_tokens == 10
+        assert usage.cache_write_tokens == 5
+        assert usage.reasoning_tokens == 20
+        assert usage.context_window == 200000
+
+    def test_ask_agent_cleans_up_fork_state(self):
+        """ask_agent() cleans up fork state even on success."""
+        agent = _make_agent()
+        mock_client = _OpenHandsACPBridge()
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "main-session"
+        agent._working_dir = "/workspace"
+
+        mock_fork_response = MagicMock()
+        mock_fork_response.session_id = "fork-session-789"
+
+        mock_prompt_response = MagicMock()
+        mock_prompt_response.usage = None
+
+        async def _fake_prompt(*args, **kwargs):
+            mock_client._fork_accumulated_text.append("ok")
+            return mock_prompt_response
+
+        def _fake_run_async(coro_fn):
+            loop = asyncio.new_event_loop()
+            try:
+                agent._conn.fork_session = AsyncMock(return_value=mock_fork_response)
+                agent._conn.prompt = _fake_prompt
+                return loop.run_until_complete(coro_fn())
+            finally:
+                loop.close()
+
+        mock_executor = MagicMock()
+        mock_executor.run_async = _fake_run_async
+        agent._executor = mock_executor
+
+        agent.ask_agent("test")
+
+        # Fork state should be cleaned up
+        assert mock_client._fork_session_id is None
+        assert mock_client._fork_accumulated_text == []
+
+
+# ---------------------------------------------------------------------------
+# Client fork text routing
+# ---------------------------------------------------------------------------
+
+
+class TestClientForkTextRouting:
+    @pytest.mark.asyncio
+    async def test_fork_text_routed_to_fork_accumulator(self):
+        """When _fork_session_id is set, matching text goes to fork accumulator."""
+        from acp.schema import AgentMessageChunk, TextContentBlock
+
+        client = _OpenHandsACPBridge()
+        client._fork_session_id = "fork-sess"
+        client._fork_accumulated_text = []
+
+        update = MagicMock(spec=AgentMessageChunk)
+        update.content = MagicMock(spec=TextContentBlock)
+        update.content.text = "fork response"
+
+        await client.session_update("fork-sess", update)
+
+        assert client._fork_accumulated_text == ["fork response"]
+        # Main accumulator should be empty
+        assert client.accumulated_text == []
+
+    @pytest.mark.asyncio
+    async def test_main_text_unaffected_by_active_fork(self):
+        """Main session text routes to accumulated_text even when fork is active."""
+        from acp.schema import AgentMessageChunk, TextContentBlock
+
+        client = _OpenHandsACPBridge()
+        client._fork_session_id = "fork-sess"
+        client._fork_accumulated_text = []
+
+        update = MagicMock(spec=AgentMessageChunk)
+        update.content = MagicMock(spec=TextContentBlock)
+        update.content.text = "main response"
+
+        await client.session_update("main-sess", update)
+
+        assert client.accumulated_text == ["main response"]
+        assert client._fork_accumulated_text == []
+
+    @pytest.mark.asyncio
+    async def test_no_fork_normal_routing(self):
+        """When _fork_session_id is None, all text goes to main accumulator."""
+        from acp.schema import AgentMessageChunk, TextContentBlock
+
+        client = _OpenHandsACPBridge()
+        assert client._fork_session_id is None
+
+        update = MagicMock(spec=AgentMessageChunk)
+        update.content = MagicMock(spec=TextContentBlock)
+        update.content.text = "normal text"
+
+        await client.session_update("any-session", update)
+
+        assert client.accumulated_text == ["normal text"]
+        assert client._fork_accumulated_text == []


### PR DESCRIPTION
The ask_agent API (stateless question answering) failed for ACPAgent because its sentinel LLM can't make real LLM calls. This uses the ACP protocol's fork_session to create a temporary copy of the session, prompt it, collect the response, and discard the fork — preserving read-only semantics.

- Add AgentBase.ask_agent() default method (returns None → use LLM path)
- Override in ACPAgent with fork_session logic + token usage tracking
- Add fork text routing in _OpenHandsACPClient.session_update()
- Dispatch agent override in LocalConversation.ask_agent()
- Add 7 tests for ask_agent and fork text routing

## Summary

[fill in a summary of this PR]

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?







<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0729c45-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0729c45-python \
  ghcr.io/openhands/agent-server:0729c45-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0729c45-golang-amd64
ghcr.io/openhands/agent-server:0729c45-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0729c45-golang-arm64
ghcr.io/openhands/agent-server:0729c45-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0729c45-java-amd64
ghcr.io/openhands/agent-server:0729c45-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0729c45-java-arm64
ghcr.io/openhands/agent-server:0729c45-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0729c45-python-amd64
ghcr.io/openhands/agent-server:0729c45-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:0729c45-python-arm64
ghcr.io/openhands/agent-server:0729c45-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:0729c45-golang
ghcr.io/openhands/agent-server:0729c45-java
ghcr.io/openhands/agent-server:0729c45-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0729c45-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0729c45-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->