### PR TITLE
Block claude-sonnet-4-6 from integration tests and add eval_ids parameter

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -103,6 +103,9 @@ jobs:
 
                   model_ids = "$MODEL_IDS".split(",")
                   model_ids = [m.strip() for m in model_ids if m.strip()]
+                  
+                  # Known problematic models that cause hangs (see issue #2147)
+                  BLOCKED_MODELS = ["claude-sonnet-4-6"]
 
                   matrix = []
                   for model_id in model_ids:
@@ -110,6 +113,12 @@ jobs:
                           available = ", ".join(sorted(MODELS.keys()))
                           print(f"Error: Model ID '{model_id}' not found. Available: {available}", file=sys.stderr)
                           sys.exit(1)
+                      
+                      # Block known problematic models
+                      if model_id in BLOCKED_MODELS:
+                          print(f"Error: Model '{model_id}' is blocked from integration tests due to known issues (hangs indefinitely). See issue #2147.", file=sys.stderr)
+                          sys.exit(1)
+                      
                       model = MODELS[model_id]
                       # Create run-suffix from model id (replace special chars with underscore)
                       run_suffix = model_id.replace("-", "_").replace(".", "_") + "_run"


### PR DESCRIPTION
## Summary

This PR addresses issue #2124 by identifying and blocking the root cause of integration test hangs.

## Root Cause

Integration tests hang indefinitely when using the `claude-sonnet-4-6` model. After diagnosis with minimal test runs, we confirmed that:
- Tests with `claude-sonnet-4-6` hang indefinitely (see [Run #22222497509](https://github.com/OpenHands/software-agent-sdk/actions/runs/22222497509))
- Tests with `claude-sonnet-4-5-20250929` complete successfully in ~1 minute with 100% success rate (see [Run #22227002167](https://github.com/OpenHands/software-agent-sdk/actions/runs/22227002167))

## Changes

### 1. Add `eval_ids` parameter to workflow
- Allows running specific test IDs for debugging (e.g., `t01_fix_simple_typo`)
- Useful for quick diagnosis and testing

### 2. Block problematic models
- Added validation in `setup-matrix` job to block `claude-sonnet-4-6`
- Fails fast with clear error message: "Error: Model 'claude-sonnet-4-6' is blocked from integration tests due to known issues (hangs indefinitely). See issue #2147."
- Prevents workflows from hanging for hours

## Testing

✅ **Blocking validation**: [Run #22227146815](https://github.com/OpenHands/software-agent-sdk/actions/runs/22227146815) - Successfully blocks claude-sonnet-4-6 with clear error message

✅ **Allowed models still work**: [Run #22227178269](https://github.com/OpenHands/software-agent-sdk/actions/runs/22227178269) - Claude Sonnet 4.5 completes successfully with 100% success rate

## Impact

- Prevents integration test workflows from hanging indefinitely
- Protects CI resources from 6-8+ hour hangs
- Provides clear feedback when problematic models are attempted
- Blocks PR #2113 from merging until the claude-sonnet-4-6 model issues are resolved

## Related Issues

- Fixes #2147
- References #2124
- Blocks PR #2113

## Checklist

- [x] Tested that problematic model is properly blocked
- [x] Tested that allowed models still work
- [x] Added clear error messages with issue reference
- [x] Minimal changes to solve the immediate problem
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fcd799d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fcd799d-python \
  ghcr.io/openhands/agent-server:fcd799d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fcd799d-golang-amd64
ghcr.io/openhands/agent-server:fcd799d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fcd799d-golang-arm64
ghcr.io/openhands/agent-server:fcd799d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fcd799d-java-amd64
ghcr.io/openhands/agent-server:fcd799d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fcd799d-java-arm64
ghcr.io/openhands/agent-server:fcd799d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fcd799d-python-amd64
ghcr.io/openhands/agent-server:fcd799d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:fcd799d-python-arm64
ghcr.io/openhands/agent-server:fcd799d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:fcd799d-golang
ghcr.io/openhands/agent-server:fcd799d-java
ghcr.io/openhands/agent-server:fcd799d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fcd799d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fcd799d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->