### PR TITLE
fix: redact credentials from plugin/extension URL logs

### DIFF
--- a/openhands-sdk/openhands/sdk/extensions/fetch.py
+++ b/openhands-sdk/openhands/sdk/extensions/fetch.py
@@ -8,6 +8,7 @@ from openhands.sdk.git.cached_repo import GitHelper, try_cached_clone_or_update
 from openhands.sdk.git.utils import extract_repo_name, is_git_url, normalize_git_url
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.path import is_local_path_source
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 logger = get_logger(__name__)
@@ -266,13 +267,17 @@ def _fetch_remote_source_with_resolution(
     )
 
     if result is None:
-        raise ExtensionFetchError(f"Failed to fetch extension from {source}")
+        raise ExtensionFetchError(
+            f"Failed to fetch extension from {redact_url_credentials(source)}"
+        )
 
     # Get the actual commit SHA that was checked out
     try:
         resolved_ref = git_helper.get_head_commit(repo_cache_path)
     except Exception as e:
-        logger.warning(f"Could not get commit SHA for {source}: {e}")
+        logger.warning(
+            f"Could not get commit SHA for {redact_url_credentials(source)}: {e}"
+        )
         # Fall back to the requested ref if we can't get the SHA
         resolved_ref = ref or "HEAD"
 

--- a/openhands-sdk/openhands/sdk/extensions/installation/manager.py
+++ b/openhands-sdk/openhands/sdk/extensions/installation/manager.py
@@ -16,6 +16,7 @@ from openhands.sdk.extensions.installation.metadata import (
 )
 from openhands.sdk.extensions.installation.utils import validate_extension_name
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 logger = get_logger(__name__)
@@ -83,7 +84,7 @@ class InstallationManager[T: ExtensionProtocol]:
         if isinstance(source, Path):
             source = str(source)
 
-        logger.info(f"Fetching extension from {source}")
+        logger.info(f"Fetching extension from {redact_url_credentials(source)}")
         fetched_path, resolved_ref = fetch_with_resolution(
             source=source,
             cache_dir=DEFAULT_CACHE_DIR,
@@ -314,7 +315,8 @@ class InstallationManager[T: ExtensionProtocol]:
             logger.warning(f"Extension {name} not installed")
             return None
 
-        logger.info(f"Updating extension {name} from {current_info.source}")
+        redacted = redact_url_credentials(current_info.source)
+        logger.info(f"Updating extension {name} from {redacted}")
         return self.install(
             source=current_info.source,
             ref=None,

--- a/openhands-sdk/openhands/sdk/git/cached_repo.py
+++ b/openhands-sdk/openhands/sdk/git/cached_repo.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from filelock import FileLock, Timeout
 
 from openhands.sdk.git.exceptions import GitCommandError
-from openhands.sdk.git.utils import run_git_command
+from openhands.sdk.git.utils import redact_url_credentials, run_git_command
 from openhands.sdk.logger import get_logger
 
 
@@ -285,7 +285,7 @@ def _do_clone_or_update(
         else:
             logger.debug(f"Using cached repository at {repo_path}")
     else:
-        logger.info(f"Cloning repository from {url}")
+        logger.info(f"Cloning repository from {redact_url_credentials(url)}")
         _clone_repository(url, repo_path, ref, git)
 
     return repo_path

--- a/openhands-sdk/openhands/sdk/git/cached_repo.py
+++ b/openhands-sdk/openhands/sdk/git/cached_repo.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from filelock import FileLock, Timeout
 
 from openhands.sdk.git.exceptions import GitCommandError
-from openhands.sdk.git.utils import run_git_command
+from openhands.sdk.git.utils import redact_url_credentials, run_git_command
 from openhands.sdk.logger import get_logger
 
 
@@ -289,7 +289,7 @@ def _do_clone_or_update(
         else:
             logger.debug(f"Using cached repository at {repo_path}")
     else:
-        logger.info(f"Cloning repository from {url}")
+        logger.info(f"Cloning repository from {redact_url_credentials(url)}")
         _clone_repository(url, repo_path, ref, git)
 
     return repo_path

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 logger = logging.getLogger(__name__)
@@ -12,6 +13,21 @@ logger = logging.getLogger(__name__)
 # Git empty tree hash - this is a well-known constant in git
 # representing the hash of an empty tree object
 GIT_EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
+
+
+def _redact_args_for_logging(args: list[str]) -> str:
+    """Redact credentials from git command arguments for safe logging.
+
+    Joins command args with shlex.join and redacts any URLs containing credentials.
+
+    Args:
+        args: List of command arguments.
+
+    Returns:
+        A string representation of the command with credentials redacted.
+    """
+    redacted_args = [redact_url_credentials(arg) for arg in args]
+    return shlex.join(redacted_args)
 
 
 def run_git_command(
@@ -43,7 +59,8 @@ def run_git_command(
         )
 
         if result.returncode != 0:
-            cmd_str = shlex.join(args)
+            # Redact credentials from command for logging and error messages
+            cmd_str = _redact_args_for_logging(args)
             error_msg = f"Git command failed: {cmd_str}"
             logger.error(
                 f"{error_msg}. Exit code: {result.returncode}. Stderr: {result.stderr}"
@@ -55,11 +72,11 @@ def run_git_command(
                 stderr=result.stderr.strip(),
             )
 
-        logger.debug(f"Git command succeeded: {shlex.join(args)}")
+        logger.debug(f"Git command succeeded: {_redact_args_for_logging(args)}")
         return result.stdout.strip()
 
     except subprocess.TimeoutExpired as e:
-        cmd_str = shlex.join(args)
+        cmd_str = _redact_args_for_logging(args)
         error_msg = f"Git command timed out: {cmd_str}"
         logger.error(error_msg)
         raise GitCommandError(

--- a/openhands-sdk/openhands/sdk/plugin/loader.py
+++ b/openhands-sdk/openhands/sdk/plugin/loader.py
@@ -15,6 +15,7 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.plugin.plugin import Plugin
 from openhands.sdk.plugin.types import PluginSource
 from openhands.sdk.skills.utils import SecretLookup, expand_mcp_variables
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 if TYPE_CHECKING:
@@ -77,7 +78,7 @@ def load_plugins(
     all_hooks: list[HookConfig] = []
 
     for spec in plugin_specs:
-        logger.info(f"Loading plugin from {spec.source}")
+        logger.info(f"Loading plugin from {redact_url_credentials(spec.source)}")
 
         # Fetch (downloads if needed, returns cached path)
         path = Plugin.fetch(

--- a/openhands-sdk/openhands/sdk/plugin/source.py
+++ b/openhands-sdk/openhands/sdk/plugin/source.py
@@ -13,6 +13,7 @@ from typing import NamedTuple
 from openhands.sdk.git.cached_repo import try_cached_clone_or_update
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.path import is_absolute_path_source, is_local_path_source
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 logger = get_logger(__name__)
@@ -94,7 +95,7 @@ def resolve_source_path(
 
         if try_cached_clone_or_update(clone_url, repo_path, gh.branch, update):
             return repo_path / gh.path
-        logger.warning(f"Failed to clone/update: {source}")
+        logger.warning(f"Failed to clone/update: {redact_url_credentials(source)}")
         return None
 
     path = Path(source).expanduser()

--- a/openhands-sdk/openhands/sdk/plugin/types.py
+++ b/openhands-sdk/openhands/sdk/plugin/types.py
@@ -10,6 +10,8 @@ from typing import TYPE_CHECKING, Any
 import frontmatter
 from pydantic import BaseModel, Field, field_validator, model_validator
 
+from openhands.sdk.git.utils import redact_url_credentials
+
 
 # Directories to check for marketplace manifest
 MARKETPLACE_MANIFEST_DIRS = [".plugin", ".claude-plugin"]
@@ -79,10 +81,22 @@ class ResolvedPluginSource(BaseModel):
     The resolved_ref is the actual commit SHA that was fetched, even if the
     original ref was a branch name like 'main'. This prevents drift when
     branches are updated between pause and resume.
+
+    Security Note:
+        The source URL is redacted when created via from_plugin_source() to
+        prevent credential exposure in persisted state. Any credentials in
+        the original URL (e.g., https://oauth2:TOKEN@host) are replaced with
+        "****" (e.g., https://****@host). This is safe because:
+        1. The plugin is fetched and cached BEFORE this object is created
+        2. The resolved_ref (commit SHA) uniquely identifies the exact version
+        3. Resume operations can re-fetch using the SHA from the local cache
     """
 
     source: str = Field(
-        description="Plugin source: 'github:owner/repo', any git URL, or local path"
+        description=(
+            "Plugin source: 'github:owner/repo', any git URL, or local path. "
+            "Note: Credentials are redacted for security when persisted."
+        )
     )
     resolved_ref: str | None = Field(
         default=None,
@@ -105,9 +119,14 @@ class ResolvedPluginSource(BaseModel):
     def from_plugin_source(
         cls, plugin_source: PluginSource, resolved_ref: str | None
     ) -> ResolvedPluginSource:
-        """Create a ResolvedPluginSource from a PluginSource and resolved ref."""
+        """Create a ResolvedPluginSource from a PluginSource and resolved ref.
+
+        The source URL is automatically redacted to prevent credential exposure
+        in persisted state. This is safe because the plugin should already be
+        fetched and cached before creating the ResolvedPluginSource.
+        """
         return cls(
-            source=plugin_source.source,
+            source=redact_url_credentials(plugin_source.source),
             resolved_ref=resolved_ref,
             repo_path=plugin_source.repo_path,
             original_ref=plugin_source.ref,
@@ -118,6 +137,10 @@ class ResolvedPluginSource(BaseModel):
 
         When loading from persistence, use the resolved_ref to ensure we get
         the exact same version that was originally fetched.
+
+        Note: The source URL may have redacted credentials. This is safe because
+        the plugin should already be in the local cache, and the resolved_ref
+        (commit SHA) allows fetching without re-authenticating.
         """
         return PluginSource(
             source=self.source,

--- a/openhands-sdk/openhands/sdk/plugin/types.py
+++ b/openhands-sdk/openhands/sdk/plugin/types.py
@@ -9,6 +9,7 @@ import frontmatter
 from pydantic import BaseModel, Field, field_validator
 
 from openhands.sdk.utils.path import to_posix_path
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 class PluginSource(BaseModel):
@@ -116,10 +117,22 @@ class ResolvedPluginSource(BaseModel):
     The resolved_ref is the actual commit SHA that was fetched, even if the
     original ref was a branch name like 'main'. This prevents drift when
     branches are updated between pause and resume.
+
+    Security Note:
+        The source URL is redacted when created via from_plugin_source() to
+        prevent credential exposure in persisted state. Any credentials in
+        the original URL (e.g., https://oauth2:TOKEN@host) are replaced with
+        "****" (e.g., https://****@host). This is safe because:
+        1. The plugin is fetched and cached BEFORE this object is created
+        2. The resolved_ref (commit SHA) uniquely identifies the exact version
+        3. Resume operations can re-fetch using the SHA from the local cache
     """
 
     source: str = Field(
-        description="Plugin source: 'github:owner/repo', any git URL, or local path"
+        description=(
+            "Plugin source: 'github:owner/repo', any git URL, or local path. "
+            "Note: Credentials are redacted for security when persisted."
+        )
     )
     resolved_ref: str | None = Field(
         default=None,
@@ -142,9 +155,14 @@ class ResolvedPluginSource(BaseModel):
     def from_plugin_source(
         cls, plugin_source: PluginSource, resolved_ref: str | None
     ) -> ResolvedPluginSource:
-        """Create a ResolvedPluginSource from a PluginSource and resolved ref."""
+        """Create a ResolvedPluginSource from a PluginSource and resolved ref.
+
+        The source URL is automatically redacted to prevent credential exposure
+        in persisted state. This is safe because the plugin should already be
+        fetched and cached before creating the ResolvedPluginSource.
+        """
         return cls(
-            source=plugin_source.source,
+            source=redact_url_credentials(plugin_source.source),
             resolved_ref=resolved_ref,
             repo_path=plugin_source.repo_path,
             original_ref=plugin_source.ref,
@@ -155,6 +173,10 @@ class ResolvedPluginSource(BaseModel):
 
         When loading from persistence, use the resolved_ref to ensure we get
         the exact same version that was originally fetched.
+
+        Note: The source URL may have redacted credentials. This is safe because
+        the plugin should already be in the local cache, and the resolved_ref
+        (commit SHA) allows fetching without re-authenticating.
         """
         return PluginSource(
             source=self.source,

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -138,6 +138,34 @@ def http_error_log_content(response: httpx.Response) -> str | dict:
         return f"<non-JSON response body omitted ({body_len} chars)>"
 
 
+def redact_url_credentials(url: str) -> str:
+    """Redact credentials embedded in a URL (e.g. https://user:token@host).
+
+    Replaces the ``user:password`` or bare-token portion before the ``@`` with
+    ``****`` so the URL is safe for logs, error messages, and persisted state.
+    SSH URLs (``git@host``) and credential-free URLs are returned unchanged.
+
+    Args:
+        url: A URL that may contain embedded credentials.
+
+    Returns:
+        URL with the credential portion replaced by ``****``, or the original
+        URL if no embedded credentials are found.
+
+    Examples:
+        >>> redact_url_credentials("https://oauth2:SECRET@gitlab.com/repo.git")
+        'https://****@gitlab.com/repo.git'
+        >>> redact_url_credentials("https://github.com/owner/repo.git")
+        'https://github.com/owner/repo.git'
+        >>> redact_url_credentials("git@github.com:owner/repo.git")
+        'git@github.com:owner/repo.git'
+    """
+    match = re.match(r"^(https?://)([^@/]+)@(.+)$", url)
+    if match:
+        return f"{match.group(1)}****@{match.group(3)}"
+    return url
+
+
 def redact_url_params(url: str) -> str:
     """Redact sensitive query parameter values from a URL string.
 

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -1,0 +1,181 @@
+"""Tests for URL credential redaction utilities."""
+
+from openhands.sdk.git.utils import redact_url_credentials
+from openhands.sdk.plugin.types import PluginSource, ResolvedPluginSource
+
+
+class TestRedactUrlCredentials:
+    """Tests for redact_url_credentials function."""
+
+    def test_https_with_oauth2_token(self):
+        """Should redact oauth2 tokens in HTTPS URLs."""
+        url = "https://oauth2:SECRET_TOKEN@gitlab.com/org/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@gitlab.com/org/repo.git"
+        assert "SECRET_TOKEN" not in result
+
+    def test_https_with_username_password(self):
+        """Should redact username:password in HTTPS URLs."""
+        url = "https://user:password123@github.com/owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/owner/repo.git"
+        assert "user" not in result
+        assert "password123" not in result
+
+    def test_https_with_x_token_auth(self):
+        """Should redact x-token-auth credentials (Bitbucket style)."""
+        url = "https://x-token-auth:MY_TOKEN@bitbucket.org/team/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@bitbucket.org/team/repo.git"
+        assert "MY_TOKEN" not in result
+
+    def test_https_with_just_token(self):
+        """Should redact token-only auth (GitHub PAT style)."""
+        url = "https://ghp_xxxxxxxxxxxx@github.com/owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/owner/repo.git"
+        assert "ghp_xxxxxxxxxxxx" not in result
+
+    def test_https_without_credentials(self):
+        """Should not modify URLs without credentials."""
+        url = "https://github.com/owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == url
+
+    def test_http_with_credentials(self):
+        """Should redact credentials in HTTP URLs."""
+        url = "http://user:pass@internal-git.company.com/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "http://****@internal-git.company.com/repo.git"
+        assert "user" not in result
+        assert "pass" not in result
+
+    def test_ssh_url_unchanged(self):
+        """Should not modify SSH URLs (no embedded credentials)."""
+        url = "git@github.com:owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == url
+
+    def test_ssh_gitlab_url_unchanged(self):
+        """Should not modify GitLab SSH URLs."""
+        url = "git@gitlab.com:org/project.git"
+        result = redact_url_credentials(url)
+        assert result == url
+
+    def test_local_path_unchanged(self):
+        """Should not modify local paths."""
+        path = "/path/to/local/repo"
+        result = redact_url_credentials(path)
+        assert result == path
+
+    def test_github_shorthand_unchanged(self):
+        """Should not modify GitHub shorthand format (no credentials)."""
+        source = "github:owner/repo"
+        result = redact_url_credentials(source)
+        assert result == source
+
+    def test_preserves_port_in_url(self):
+        """Should preserve port numbers in URLs while redacting credentials."""
+        url = "https://user:pass@git.company.com:8443/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@git.company.com:8443/repo.git"
+        assert "8443" in result
+        assert "user" not in result
+
+    def test_preserves_path_with_subdirectories(self):
+        """Should preserve full path with subdirectories."""
+        url = "https://token@github.com/org/repo/tree/main/subdir"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/org/repo/tree/main/subdir"
+        assert "/org/repo/tree/main/subdir" in result
+
+    def test_empty_string(self):
+        """Should handle empty string."""
+        result = redact_url_credentials("")
+        assert result == ""
+
+    def test_special_characters_in_token(self):
+        """Should handle special characters in tokens."""
+        # URL-encoded special characters in credentials
+        url = "https://user%40domain:p%40ss%3Aword@github.com/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/repo.git"
+        assert "user%40domain" not in result
+
+
+class TestResolvedPluginSourceCredentialRedaction:
+    """Tests for credential redaction in ResolvedPluginSource."""
+
+    def test_from_plugin_source_redacts_credentials(self):
+        """Should redact credentials when creating from PluginSource."""
+        plugin_source = PluginSource(
+            source="https://oauth2:SECRET_TOKEN@gitlab.com/org/repo.git",
+            ref="main",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123def456"
+        )
+        assert resolved.source == "https://****@gitlab.com/org/repo.git"
+        assert "SECRET_TOKEN" not in resolved.source
+        assert resolved.resolved_ref == "abc123def456"
+        assert resolved.original_ref == "main"
+
+    def test_from_plugin_source_preserves_url_without_credentials(self):
+        """Should not modify URLs without credentials."""
+        plugin_source = PluginSource(
+            source="https://github.com/owner/repo.git",
+            ref="v1.0.0",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123def456"
+        )
+        assert resolved.source == "https://github.com/owner/repo.git"
+        assert resolved.resolved_ref == "abc123def456"
+
+    def test_from_plugin_source_preserves_local_path(self):
+        """Should not modify local paths."""
+        plugin_source = PluginSource(source="/path/to/local/plugin")
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref=None
+        )
+        assert resolved.source == "/path/to/local/plugin"
+        assert resolved.resolved_ref is None
+
+    def test_from_plugin_source_preserves_repo_path(self):
+        """Should preserve repo_path when redacting credentials."""
+        plugin_source = PluginSource(
+            source="https://token@github.com/org/monorepo.git",
+            ref="main",
+            repo_path="plugins/my-plugin",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123"
+        )
+        assert resolved.source == "https://****@github.com/org/monorepo.git"
+        assert resolved.repo_path == "plugins/my-plugin"
+
+    def test_to_plugin_source_uses_redacted_url(self):
+        """When converting back to PluginSource, should use the redacted URL."""
+        # Simulate a ResolvedPluginSource loaded from persistence
+        resolved = ResolvedPluginSource(
+            source="https://****@gitlab.com/org/repo.git",  # Already redacted
+            resolved_ref="abc123def456",
+            repo_path=None,
+            original_ref="main",
+        )
+        plugin_source = resolved.to_plugin_source()
+        assert plugin_source.source == "https://****@gitlab.com/org/repo.git"
+        assert plugin_source.ref == "abc123def456"  # Uses resolved ref, not original
+
+    def test_serialization_does_not_expose_credentials(self):
+        """Ensure JSON serialization doesn't expose credentials."""
+        plugin_source = PluginSource(
+            source="https://oauth2:SUPER_SECRET@gitlab.com/org/repo.git",
+            ref="main",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123"
+        )
+        json_str = resolved.model_dump_json()
+        assert "SUPER_SECRET" not in json_str
+        assert "****" in json_str

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -1,0 +1,197 @@
+"""Tests for URL credential redaction utilities."""
+
+from openhands.sdk.git.utils import redact_url_credentials  # re-exported for compat
+from openhands.sdk.plugin.types import PluginSource, ResolvedPluginSource
+from openhands.sdk.utils.redact import (
+    redact_url_credentials as redact_url_credentials_central,
+)
+
+
+class TestRedactUrlCredentials:
+    """Tests for redact_url_credentials function."""
+
+    def test_https_with_oauth2_token(self):
+        """Should redact oauth2 tokens in HTTPS URLs."""
+        url = "https://oauth2:SECRET_TOKEN@gitlab.com/org/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@gitlab.com/org/repo.git"
+        assert "SECRET_TOKEN" not in result
+
+    def test_https_with_username_password(self):
+        """Should redact username:password in HTTPS URLs."""
+        url = "https://user:password123@github.com/owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/owner/repo.git"
+        assert "user" not in result
+        assert "password123" not in result
+
+    def test_https_with_x_token_auth(self):
+        """Should redact x-token-auth credentials (Bitbucket style)."""
+        url = "https://x-token-auth:MY_TOKEN@bitbucket.org/team/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@bitbucket.org/team/repo.git"
+        assert "MY_TOKEN" not in result
+
+    def test_https_with_just_token(self):
+        """Should redact token-only auth (GitHub PAT style)."""
+        url = "https://ghp_xxxxxxxxxxxx@github.com/owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/owner/repo.git"
+        assert "ghp_xxxxxxxxxxxx" not in result
+
+    def test_https_without_credentials(self):
+        """Should not modify URLs without credentials."""
+        url = "https://github.com/owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == url
+
+    def test_http_with_credentials(self):
+        """Should redact credentials in HTTP URLs."""
+        url = "http://user:pass@internal-git.company.com/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "http://****@internal-git.company.com/repo.git"
+        assert "user" not in result
+        assert "pass" not in result
+
+    def test_ssh_url_unchanged(self):
+        """Should not modify SSH URLs (no embedded credentials)."""
+        url = "git@github.com:owner/repo.git"
+        result = redact_url_credentials(url)
+        assert result == url
+
+    def test_ssh_gitlab_url_unchanged(self):
+        """Should not modify GitLab SSH URLs."""
+        url = "git@gitlab.com:org/project.git"
+        result = redact_url_credentials(url)
+        assert result == url
+
+    def test_local_path_unchanged(self):
+        """Should not modify local paths."""
+        path = "/path/to/local/repo"
+        result = redact_url_credentials(path)
+        assert result == path
+
+    def test_github_shorthand_unchanged(self):
+        """Should not modify GitHub shorthand format (no credentials)."""
+        source = "github:owner/repo"
+        result = redact_url_credentials(source)
+        assert result == source
+
+    def test_preserves_port_in_url(self):
+        """Should preserve port numbers in URLs while redacting credentials."""
+        url = "https://user:pass@git.company.com:8443/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@git.company.com:8443/repo.git"
+        assert "8443" in result
+        assert "user" not in result
+
+    def test_preserves_path_with_subdirectories(self):
+        """Should preserve full path with subdirectories."""
+        url = "https://token@github.com/org/repo/tree/main/subdir"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/org/repo/tree/main/subdir"
+        assert "/org/repo/tree/main/subdir" in result
+
+    def test_empty_string(self):
+        """Should handle empty string."""
+        result = redact_url_credentials("")
+        assert result == ""
+
+    def test_special_characters_in_token(self):
+        """Should handle special characters in tokens."""
+        # URL-encoded special characters in credentials
+        url = "https://user%40domain:p%40ss%3Aword@github.com/repo.git"
+        result = redact_url_credentials(url)
+        assert result == "https://****@github.com/repo.git"
+        assert "user%40domain" not in result
+
+
+class TestResolvedPluginSourceCredentialRedaction:
+    """Tests for credential redaction in ResolvedPluginSource."""
+
+    def test_from_plugin_source_redacts_credentials(self):
+        """Should redact credentials when creating from PluginSource."""
+        plugin_source = PluginSource(
+            source="https://oauth2:SECRET_TOKEN@gitlab.com/org/repo.git",
+            ref="main",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123def456"
+        )
+        assert resolved.source == "https://****@gitlab.com/org/repo.git"
+        assert "SECRET_TOKEN" not in resolved.source
+        assert resolved.resolved_ref == "abc123def456"
+        assert resolved.original_ref == "main"
+
+    def test_from_plugin_source_preserves_url_without_credentials(self):
+        """Should not modify URLs without credentials."""
+        plugin_source = PluginSource(
+            source="https://github.com/owner/repo.git",
+            ref="v1.0.0",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123def456"
+        )
+        assert resolved.source == "https://github.com/owner/repo.git"
+        assert resolved.resolved_ref == "abc123def456"
+
+    def test_from_plugin_source_preserves_local_path(self):
+        """Should not modify local paths."""
+        plugin_source = PluginSource(source="/path/to/local/plugin")
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref=None
+        )
+        assert resolved.source == "/path/to/local/plugin"
+        assert resolved.resolved_ref is None
+
+    def test_from_plugin_source_preserves_repo_path(self):
+        """Should preserve repo_path when redacting credentials."""
+        plugin_source = PluginSource(
+            source="https://token@github.com/org/monorepo.git",
+            ref="main",
+            repo_path="plugins/my-plugin",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123"
+        )
+        assert resolved.source == "https://****@github.com/org/monorepo.git"
+        assert resolved.repo_path == "plugins/my-plugin"
+
+    def test_to_plugin_source_uses_redacted_url(self):
+        """When converting back to PluginSource, should use the redacted URL."""
+        # Simulate a ResolvedPluginSource loaded from persistence
+        resolved = ResolvedPluginSource(
+            source="https://****@gitlab.com/org/repo.git",  # Already redacted
+            resolved_ref="abc123def456",
+            repo_path=None,
+            original_ref="main",
+        )
+        plugin_source = resolved.to_plugin_source()
+        assert plugin_source.source == "https://****@gitlab.com/org/repo.git"
+        assert plugin_source.ref == "abc123def456"  # Uses resolved ref, not original
+
+    def test_serialization_does_not_expose_credentials(self):
+        """Ensure JSON serialization doesn't expose credentials."""
+        plugin_source = PluginSource(
+            source="https://oauth2:SUPER_SECRET@gitlab.com/org/repo.git",
+            ref="main",
+        )
+        resolved = ResolvedPluginSource.from_plugin_source(
+            plugin_source, resolved_ref="abc123"
+        )
+        json_str = resolved.model_dump_json()
+        assert "SUPER_SECRET" not in json_str
+        assert "****" in json_str
+
+
+class TestRedactUrlCredentialsCentralModule:
+    """Verify redact_url_credentials is accessible from the central redact module."""
+
+    def test_same_behaviour_as_git_utils(self):
+        url = "https://oauth2:SECRET@gitlab.com/org/repo.git"
+        assert redact_url_credentials(url) == redact_url_credentials_central(url)
+
+    def test_importable_from_sdk_utils_redact(self):
+        assert (
+            redact_url_credentials_central("https://t@host/r") == "https://****@host/r"
+        )


### PR DESCRIPTION
## Summary

Prevent git credentials embedded in `https://user:token@host` URLs from leaking into logs and persisted state across the plugin/extension stack.

- Moves `redact_url_credentials()` to the canonical `sdk/utils/redact.py` module (removes the local copy in `git/utils.py`, which re-exports it for callers like `cached_repo.py`)
- Applies redaction at all URL-logging sites: `extensions/fetch.py`, `extensions/installation/manager.py`, `plugin/source.py`, `plugin/loader.py`, `git/cached_repo.py`
- `ResolvedPluginSource.from_plugin_source()` stores only the redacted URL so credentials never reach persisted state
- Adds `TestRedactUrlCredentialsCentralModule` to verify the function is importable from the central module and has identical behaviour to the `git.utils` re-export

## How to Test

```bash
uv run pytest tests/sdk/git/test_url_redaction.py -v
# All 22 tests should pass
```
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ca9ffb1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ca9ffb1-python \
  ghcr.io/openhands/agent-server:ca9ffb1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ca9ffb1-golang-amd64
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-golang-amd64
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-golang-amd64
ghcr.io/openhands/agent-server:ca9ffb1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ca9ffb1-golang-arm64
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-golang-arm64
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-golang-arm64
ghcr.io/openhands/agent-server:ca9ffb1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ca9ffb1-java-amd64
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-java-amd64
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-java-amd64
ghcr.io/openhands/agent-server:ca9ffb1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ca9ffb1-java-arm64
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-java-arm64
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-java-arm64
ghcr.io/openhands/agent-server:ca9ffb1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ca9ffb1-python-amd64
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-python-amd64
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-python-amd64
ghcr.io/openhands/agent-server:ca9ffb1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ca9ffb1-python-arm64
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-python-arm64
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-python-arm64
ghcr.io/openhands/agent-server:ca9ffb1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ca9ffb1-golang
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-golang
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-golang
ghcr.io/openhands/agent-server:ca9ffb1-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ca9ffb1-java
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-java
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-java
ghcr.io/openhands/agent-server:ca9ffb1-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ca9ffb1-python
ghcr.io/openhands/agent-server:ca9ffb1197c737d77ff1df711006210c840b0bd6-python
ghcr.io/openhands/agent-server:fix-redact-plugin-url-credentials-python
ghcr.io/openhands/agent-server:ca9ffb1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ca9ffb1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ca9ffb1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->