### PR TITLE
Add TCP network transport to ACPAgent

### DIFF
--- a/examples/01_standalone_sdk/41_acp_agent_remote_example.py
+++ b/examples/01_standalone_sdk/41_acp_agent_remote_example.py
@@ -1,151 +1,51 @@
-"""Example: ACPAgent with TCP transport and APIRemoteWorkspace.
+"""Example: ACPAgent with TCP transport.
 
-This example demonstrates the real-world use case for ACPAgent's TCP transport
-mode: running inside a remote K8s pod (via APIRemoteWorkspace) that doesn't have
-Node.js installed, and connecting to an ACP server running as a separate service
-on the network.
+This example shows how to connect ACPAgent to an already-running ACP server
+over TCP, instead of spawning one as a subprocess.
 
-Architecture::
-
-    ┌─────────────────────┐       ┌──────────────────────┐
-    │  Local Machine       │       │  K8s Cluster          │
-    │                      │       │                       │
-    │  APIRemoteWorkspace ─┼──────>│  Runtime Pod          │
-    │  provisions pod     │       │  (agent-server image) │
-    │                      │       │                       │
-    │  Conversation        │       │  ACPAgent runs here   │
-    │  (RemoteConversation)│       │  connects via TCP ────┼──> ACP Server
-    └─────────────────────┘       │                       │    (separate pod
-                                   └──────────────────────┘     or sidecar)
-
-The ACPAgent is serialized and sent to the remote pod. Inside the pod, it
-connects to the ACP server over TCP instead of spawning it as a subprocess
-(since the pod image lacks Node.js / npx).
+Note: TCP is a *custom transport* — the ACP spec currently defines stdio
+(and draft Streamable HTTP).  The remote server must speak newline-delimited
+JSON-RPC over a TCP socket (stdio-style framing).
 
 Prerequisites:
-    - RUNTIME_API_KEY: API key for the OpenHands Runtime API
-    - ACP_HOST: Hostname of the ACP server (e.g. "acp-server.default.svc.cluster.local")
-    - ACP_PORT: Port of the ACP server (default: 4001)
-
-Optional:
-    - RUNTIME_API_URL: Runtime API URL (default: https://runtime.eval.all-hands.dev)
-    - SERVER_IMAGE: Custom agent-server image (default: main branch image)
+    - An ACP-compatible server listening on TCP with newline-delimited
+      JSON-RPC (e.g. a wrapper around claude-code-acp)
+    - ACP_HOST env var (hostname, e.g. "acp-server.internal")
+    - ACP_PORT env var (port, default 4001)
 
 Usage:
-    RUNTIME_API_KEY=... ACP_HOST=acp.internal ACP_PORT=4001 \\
+    ACP_HOST=localhost ACP_PORT=4001 \
         uv run python examples/01_standalone_sdk/41_acp_agent_remote_example.py
 """
 
 import os
-import sys
-import time
 
-from openhands.sdk import Conversation, RemoteConversation, get_logger
 from openhands.sdk.agent import ACPAgent
-from openhands.workspace import APIRemoteWorkspace
+from openhands.sdk.conversation import Conversation
 
 
-logger = get_logger(__name__)
+acp_host = os.environ["ACP_HOST"]
+acp_port = int(os.getenv("ACP_PORT", "4001"))
 
+agent = ACPAgent(acp_host=acp_host, acp_port=acp_port)
 
-def main() -> None:
-    # ── Validate required environment variables ──────────────────────────
-    runtime_api_key = os.getenv("RUNTIME_API_KEY")
-    if not runtime_api_key:
-        logger.error("RUNTIME_API_KEY is required to provision the remote runtime")
-        sys.exit(1)
+try:
+    cwd = os.getcwd()
+    conversation = Conversation(agent=agent, workspace=cwd)
 
-    acp_host = os.getenv("ACP_HOST")
-    if not acp_host:
-        logger.error(
-            "ACP_HOST is required (hostname of the running ACP server, "
-            "e.g. 'acp-server.default.svc.cluster.local')"
-        )
-        sys.exit(1)
-
-    acp_port = int(os.getenv("ACP_PORT", "4001"))
-
-    # ── Create the ACPAgent with TCP transport ───────────────────────────
-    # This agent will be serialized and sent to the remote pod.
-    # Inside the pod, it connects to the ACP server over the network.
-    agent = ACPAgent(
-        acp_host=acp_host,
-        acp_port=acp_port,
+    conversation.send_message(
+        "List the files in the current directory and write a short "
+        "summary of what you see into SUMMARY.md."
     )
-    logger.info(f"ACPAgent configured for TCP transport: {acp_host}:{acp_port}")
+    conversation.run()
 
-    # ── Provision a remote K8s pod via Runtime API ───────────────────────
-    server_image_sha = os.getenv("GITHUB_SHA") or "main"
-    server_image = os.getenv(
-        "SERVER_IMAGE",
-        f"ghcr.io/openhands/agent-server:{server_image_sha[:7]}-python-amd64",
+    # --- ask_agent: stateless side-question via fork_session ---
+    print("\n--- ask_agent ---")
+    response = conversation.ask_agent(
+        "Based on what you just saw, what is the most interesting file?"
     )
-    logger.info(f"Using server image: {server_image}")
+    print(f"ask_agent response: {response}")
+finally:
+    agent.close()
 
-    runtime_api_url = os.getenv("RUNTIME_API_URL", "https://runtime.eval.all-hands.dev")
-
-    with APIRemoteWorkspace(
-        runtime_api_url=runtime_api_url,
-        runtime_api_key=runtime_api_key,
-        server_image=server_image,
-        image_pull_policy="Always",
-    ) as workspace:
-        # Verify the remote runtime is alive
-        result = workspace.execute_command("echo 'Runtime is alive' && uname -a")
-        logger.info(f"Remote runtime: exit={result.exit_code}, stdout={result.stdout}")
-
-        # ── Create a RemoteConversation ──────────────────────────────────
-        # The Conversation factory detects the RemoteWorkspace and returns
-        # a RemoteConversation.  The ACPAgent is serialized to JSON and
-        # sent to the remote agent server running in the K8s pod.
-        received_events: list = []
-        last_event_time = {"ts": time.time()}
-
-        def on_event(event) -> None:
-            received_events.append(event)
-            last_event_time["ts"] = time.time()
-            logger.info(f"Event: {type(event).__name__}")
-
-        conversation = Conversation(
-            agent=agent,
-            workspace=workspace,
-            callbacks=[on_event],
-        )
-        assert isinstance(conversation, RemoteConversation), (
-            f"Expected RemoteConversation, got {type(conversation).__name__}"
-        )
-
-        try:
-            # ── First turn: ask the ACP-powered agent to explore ─────────
-            conversation.send_message(
-                "List the files in the current directory and write a short "
-                "summary of what you see into SUMMARY.md."
-            )
-            conversation.run()
-
-            # Wait for any trailing events
-            while time.time() - last_event_time["ts"] < 2.0:
-                time.sleep(0.1)
-
-            # ── Second turn: use ask_agent for a side-question ───────────
-            print("\n--- ask_agent (stateless side-question) ---")
-            response = conversation.ask_agent(
-                "Based on what you just saw, what is the most interesting file?"
-            )
-            print(f"ask_agent response: {response}")
-
-            # ── Print cost metrics ───────────────────────────────────────
-            cost = (
-                conversation.conversation_stats.get_combined_metrics().accumulated_cost
-            )
-            print(f"\nTotal cost: ${cost:.4f}")
-            print(f"Events received: {len(received_events)}")
-
-        finally:
-            conversation.close()
-
-    print("\nDone!")
-
-
-if __name__ == "__main__":
-    main()
+print("Done!")


### PR DESCRIPTION
## Summary
- Add TCP transport mode to ACPAgent so it can connect to an already-running ACP server over the network via `asyncio.open_connection(host, port)`, as an alternative to the existing subprocess mode
- Introduce `acp_host` and `acp_port` fields with a `@model_validator` ensuring exactly one transport (subprocess or TCP) is configured
- Refactor `_start_acp_server()` to branch on transport mode and update `_cleanup()` to close the TCP writer

## Motivation
When using `APIRemoteWorkspace`, the agent runs inside a remote K8s pod whose container image doesn't include Node.js or the ACP command. Rather than requiring custom container images, this lets ACPAgent connect to an ACP server running elsewhere on the network.

## Test plan
- [x] 4 new validation tests (TCP creation, both-set rejection, neither-set rejection, host-without-port rejection)
- [x] 2 new serialization tests (TCP round-trip, dict deserialization)
- [x] 1 new init state test (TCP transport connects with mocked executor)
- [x] 3 new cleanup tests (TCP writer close, skip process in TCP mode, error handling)
- [x] All 63 ACP agent tests pass
- [x] All 2343 SDK tests pass (no regressions)
- [x] `ruff check` and `ruff format --check` clean

> **Note:** This PR is stacked on `feat/acp-agent-ask-agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9d49428-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9d49428-python \
  ghcr.io/openhands/agent-server:9d49428-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9d49428-golang-amd64
ghcr.io/openhands/agent-server:9d49428-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9d49428-golang-arm64
ghcr.io/openhands/agent-server:9d49428-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9d49428-java-amd64
ghcr.io/openhands/agent-server:9d49428-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9d49428-java-arm64
ghcr.io/openhands/agent-server:9d49428-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9d49428-python-amd64
ghcr.io/openhands/agent-server:9d49428-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:9d49428-python-arm64
ghcr.io/openhands/agent-server:9d49428-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:9d49428-golang
ghcr.io/openhands/agent-server:9d49428-java
ghcr.io/openhands/agent-server:9d49428-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9d49428-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9d49428-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->