### PR TITLE
CI: simplify pr-review gating and skip forks

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -21,11 +21,6 @@ jobs:
         if: |
             github.event.pull_request.head.repo.full_name == github.repository &&
             (
-                github.event.pull_request.author_association == 'OWNER' ||
-                github.event.pull_request.author_association == 'MEMBER' ||
-                github.event.pull_request.author_association == 'COLLABORATOR'
-            ) &&
-            (
                 (github.event.action == 'opened' && github.event.pull_request.draft == false) ||
                 github.event.action == 'ready_for_review' ||
                 (github.event.action == 'labeled' && github.event.label.name == 'review-this') ||


### PR DESCRIPTION
Adjust the PR review workflow to match desired behavior:

- Keep trigger on `pull_request` (not `pull_request_target`)
- Skip fork PRs via `head.repo.full_name == github.repository`
- Remove `author_association` gating

Co-authored-by: openhands <openhands@all-hands.dev>
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:454832f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-454832f-python \
  ghcr.io/openhands/agent-server:454832f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:454832f-golang-amd64
ghcr.io/openhands/agent-server:454832f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:454832f-golang-arm64
ghcr.io/openhands/agent-server:454832f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:454832f-java-amd64
ghcr.io/openhands/agent-server:454832f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:454832f-java-arm64
ghcr.io/openhands/agent-server:454832f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:454832f-python-amd64
ghcr.io/openhands/agent-server:454832f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:454832f-python-arm64
ghcr.io/openhands/agent-server:454832f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:454832f-golang
ghcr.io/openhands/agent-server:454832f-java
ghcr.io/openhands/agent-server:454832f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `454832f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `454832f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->