### PR TITLE
ci: block accidental package version bumps on non-release PRs

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -4,31 +4,14 @@ name: API breakage checks
 on:
     pull_request:
         branches: [main]
-        # This workflow serves two purposes:
-        # - On everyday PRs: ensure package versions are NOT bumped accidentally
-        # - On release PRs created by prepare-release.yml (rel-X.Y.Z branches):
-        #   run Griffe API breakage checks
+        # Only run on release PRs created by prepare-release.yml (rel-X.Y.Z branches)
+        # We enforce version-bump policy here, which does not apply to everyday PRs.
+        head-branches: [rel-*]
 
 jobs:
-    version-bump-guard:
-        name: Guard against accidental package version bumps
-        runs-on: ubuntu-latest
-        if: ${{ !startsWith(github.head_ref, 'rel-') }}
-        steps:
-            - name: Checkout
-              uses: actions/checkout@v5
-              with:
-                  fetch-depth: 0
-            - name: Check for version bumps
-              env:
-                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
-                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-              run: python3 .github/scripts/check_no_version_bump.py
-
     sdk-api:
         name: SDK programmatic API (Griffe)
         runs-on: ubuntu-latest
-        if: ${{ startsWith(github.head_ref, 'rel-') }}
         # Non-blocking for now — report failures but don't gate releases.
         # Remove continue-on-error once validated in production.
         continue-on-error: true

--- a/.github/workflows/version-bump-guard.yml
+++ b/.github/workflows/version-bump-guard.yml
@@ -1,0 +1,22 @@
+---
+name: Version bump guard
+
+on:
+    pull_request:
+        branches: [main]
+
+jobs:
+    version-bump-guard:
+        name: Guard against accidental package version bumps
+        runs-on: ubuntu-latest
+        if: ${{ !startsWith(github.head_ref, 'rel-') }}
+        steps:
+            - name: Checkout
+              uses: actions/checkout@v5
+              with:
+                  fetch-depth: 0
+            - name: Check for version bumps
+              env:
+                  BASE_SHA: ${{ github.event.pull_request.base.sha }}
+                  HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+              run: python3 .github/scripts/check_no_version_bump.py


### PR DESCRIPTION
## Summary

This adds a lightweight guard to prevent accidental bumps of package versions (`[project].version`) in the per-package `pyproject.toml` files on everyday PRs.

## How it works

- The existing Griffe workflow (`.github/workflows/api-breakage.yml`) is now triggered for all PRs to `main`.
- For **non-release** PRs (head ref not starting with `rel-`), it runs `.github/scripts/check_no_version_bump.py` to compare package versions between the PR base and head SHAs.
- For **release** PRs (`rel-*`), it keeps running the existing Griffe API breakage check (unchanged behavior).

If a version changes on a non-release PR, the check fails with a GitHub annotation pointing at the relevant `pyproject.toml`.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c336dbd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c336dbd-python \
  ghcr.io/openhands/agent-server:c336dbd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c336dbd-golang-amd64
ghcr.io/openhands/agent-server:c336dbd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c336dbd-golang-arm64
ghcr.io/openhands/agent-server:c336dbd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c336dbd-java-amd64
ghcr.io/openhands/agent-server:c336dbd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c336dbd-java-arm64
ghcr.io/openhands/agent-server:c336dbd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c336dbd-python-amd64
ghcr.io/openhands/agent-server:c336dbd-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c336dbd-python-arm64
ghcr.io/openhands/agent-server:c336dbd-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c336dbd-golang
ghcr.io/openhands/agent-server:c336dbd-java
ghcr.io/openhands/agent-server:c336dbd-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c336dbd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c336dbd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->