### PR TITLE
ci: skip api breakage check when prev lacks __all__

### DIFF
--- a/tests/ci_scripts/test_check_sdk_api_breakage.py
+++ b/tests/ci_scripts/test_check_sdk_api_breakage.py
@@ -210,6 +210,23 @@ def test_removed_public_method_with_deprecation_is_not_undeprecated(tmp_path):
     assert undeprecated == 0
 
 
+def test_missing_all_in_previous_release_skips_breakage_check(tmp_path):
+    """If previous release lacks __all__, skip instead of failing workflow."""
+    old_pkg = tmp_path / "old" / "openhands" / "sdk"
+    old_pkg.mkdir(parents=True)
+    (tmp_path / "old" / "openhands" / "__init__.py").write_text("")
+    (old_pkg / "__init__.py").write_text("# no __all__ in previous release\n")
+
+    _write_pkg_init(tmp_path, "new", ["Foo"])
+
+    old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])
+    new_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "new")])
+
+    total_breaks, undeprecated = _prod._compute_breakages(old_root, new_root, _SDK_CFG)
+    assert total_breaks == 0
+    assert undeprecated == 0
+
+
 def test_parse_version_simple():
     v = _parse_version("1.2.3")
     assert v.major == 1


### PR DESCRIPTION
## Problem
The `API breakage checks` workflow can fail on PRs when the *previous* PyPI release of a package did not define a statically-evaluable `__all__` (e.g. `openhands-tools` prior to adopting curated exports).

This causes:
```
Failed to compute breakages: Expected __all__ to be defined on the public module
```
…which fails the entire workflow even though we cannot compute meaningful breakages.

## Fix
In `.github/scripts/check_sdk_api_breakage.py`, treat missing/unstatically-evaluable `__all__` in the **previous release** as a transitional case:
- still require `__all__` in the current code (new version)
- but **skip** breakage comparison if the previous release lacks it

## Tests
- Added unit test: `test_missing_all_in_previous_release_skips_breakage_check`
- `uv run pytest tests/ci_scripts/test_check_sdk_api_breakage.py -q`


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b918be0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b918be0-python \
  ghcr.io/openhands/agent-server:b918be0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b918be0-golang-amd64
ghcr.io/openhands/agent-server:b918be0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b918be0-golang-arm64
ghcr.io/openhands/agent-server:b918be0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b918be0-java-amd64
ghcr.io/openhands/agent-server:b918be0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b918be0-java-arm64
ghcr.io/openhands/agent-server:b918be0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b918be0-python-amd64
ghcr.io/openhands/agent-server:b918be0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b918be0-python-arm64
ghcr.io/openhands/agent-server:b918be0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b918be0-golang
ghcr.io/openhands/agent-server:b918be0-java
ghcr.io/openhands/agent-server:b918be0-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b918be0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b918be0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->