### PR TITLE
fix(terminal): use dedicated tmux socket to isolate from user sessions

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -42,7 +42,8 @@ class TmuxTerminal(TerminalInterface):
             return
 
         env = sanitized_env()
-        self.server = libtmux.Server(environment=env)
+        # Use a dedicated socket to isolate OpenHands sessions from the user's tmux
+        self.server = libtmux.Server(socket_name="openhands", environment=env)
         _shell_command = "/bin/bash"
         if self.username in ["root", "openhands"]:
             # This starts a non-login (new) shell for the given user


### PR DESCRIPTION
## Summary

When users run the OpenHands CLI inside their own tmux session, the agent's tmux sessions would appear in and interfere with the user's tmux setup. This happens because the `libtmux.Server()` was being created without a socket name, causing it to use the default tmux socket.

This PR fixes the issue by using a dedicated socket name `openhands` for all OpenHands tmux sessions. This ensures:
- Agent sessions won't appear in user's `tmux list-sessions`
- Commands like `tmux kill-server` from the agent won't affect user sessions
- User's tmux environment stays clean and uncluttered

### Changes
- Added `socket_name="openhands"` parameter to `libtmux.Server()` initialization in `TmuxTerminal`

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - No new tests needed - this is a configuration change that uses existing libtmux functionality. The existing tmux terminal tests continue to pass.
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - no examples affected
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - Verified manually that separate sockets work: `tmux -L openhands list-sessions` shows only openhands sessions while `tmux list-sessions` shows only user sessions
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - internal implementation detail, no user-facing documentation needed
- [ ] Is the github CI passing?
  - Waiting for CI

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:47cb75a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-47cb75a-python \
  ghcr.io/openhands/agent-server:47cb75a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:47cb75a-golang-amd64
ghcr.io/openhands/agent-server:47cb75a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:47cb75a-golang-arm64
ghcr.io/openhands/agent-server:47cb75a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:47cb75a-java-amd64
ghcr.io/openhands/agent-server:47cb75a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:47cb75a-java-arm64
ghcr.io/openhands/agent-server:47cb75a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:47cb75a-python-amd64
ghcr.io/openhands/agent-server:47cb75a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:47cb75a-python-arm64
ghcr.io/openhands/agent-server:47cb75a-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:47cb75a-golang
ghcr.io/openhands/agent-server:47cb75a-java
ghcr.io/openhands/agent-server:47cb75a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `47cb75a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `47cb75a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->