### PR TITLE
fix(Makefile): help and pre-commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ YELLOW := \033[33m
 RED := \033[31m
 CYAN := \033[36m
 RESET := \033[0m
+UNDERLINE := \033[4m
 
 # Required uv version
 REQUIRED_UV_VERSION := 0.8.13
@@ -50,6 +51,11 @@ lint:
 	@uv run ruff check --fix
 	@$(ECHO) "$(GREEN)Linting completed.$(RESET)"
 
+pre-commit:
+	@$(ECHO) "$(YELLOW)Run pre-commit...$(RESET)"
+	uv run pre-commit run --all-files
+	@$(ECHO) "$(GREEN)Pre-commit run successfully.$(RESET)"
+
 clean:
 	@$(ECHO) "$(YELLOW)Cleaning up cache files...$(RESET)"
 	@find . -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
@@ -61,12 +67,18 @@ clean:
 # Show help
 help:
 	@$(ECHO) "$(CYAN)OpenHands V1 Makefile$(RESET)"
-	@$(ECHO) "Available targets:"
-	@$(ECHO) "  $(GREEN)build$(RESET)        - Setup development environment (install deps + hooks)"
-	@$(ECHO) "  $(GREEN)format$(RESET)       - Format code with uv format"
-	@$(ECHO) "  $(GREEN)lint$(RESET)         - Lint code with ruff"
-	@$(ECHO) "  $(GREEN)clean$(RESET)        - Clean up cache files"
-	@$(ECHO) "  $(GREEN)help$(RESET)         - Show this help message"
+	@$(ECHO) ""
+	@$(ECHO) "$(UNDERLINE)Usage:$(RESET) make <COMMAND>"
+	@$(ECHO) ""
+	@$(ECHO) "$(UNDERLINE)Commands:$(RESET)"
+	@$(ECHO) "  $(GREEN)build$(RESET)                Setup development environment (install deps + hooks)"
+	@$(ECHO) "  $(GREEN)build-server$(RESET)         Build agent-server executable"
+	@$(ECHO) "  $(GREEN)test-server-schema$(RESET)   Test server schema"
+	@$(ECHO) "  $(GREEN)format$(RESET)               Format code with uv format"
+	@$(ECHO) "  $(GREEN)lint$(RESET)                 Lint code with ruff"
+	@$(ECHO) "  $(GREEN)pre-commit$(RESET)           Run the pre-commit"
+	@$(ECHO) "  $(GREEN)clean$(RESET)                Clean up cache files"
+	@$(ECHO) "  $(GREEN)help$(RESET)                 Show this help message"
 
 build-server: check-uv-version
 	@$(ECHO) "$(CYAN)Building agent-server executable...$(RESET)"


### PR DESCRIPTION
## Summary

Just a couple of things:
- complete `make help`
- restyling of `make help`
- add `make pre-commit`

<img width="745" height="286" alt="Screenshot 2026-02-21 at 23 52 22" src="https://github.com/user-attachments/assets/aa8886af-d0a8-4102-a416-f9d61a3e1cb4" />


## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3a65494-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3a65494-python \
  ghcr.io/openhands/agent-server:3a65494-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3a65494-golang-amd64
ghcr.io/openhands/agent-server:3a65494-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3a65494-golang-arm64
ghcr.io/openhands/agent-server:3a65494-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3a65494-java-amd64
ghcr.io/openhands/agent-server:3a65494-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3a65494-java-arm64
ghcr.io/openhands/agent-server:3a65494-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3a65494-python-amd64
ghcr.io/openhands/agent-server:3a65494-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:3a65494-python-arm64
ghcr.io/openhands/agent-server:3a65494-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:3a65494-golang
ghcr.io/openhands/agent-server:3a65494-java
ghcr.io/openhands/agent-server:3a65494-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3a65494-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3a65494-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->