### PR TITLE
add ability to run chrome as root

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -250,15 +250,14 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
             # Chromium refuses to run as root with sandboxing enabled.
             # Disable the sandbox when running as root so CHROME_DOCKER_ARGS
             # (--no-sandbox, --disable-setuid-sandbox, etc.) are applied.
-            # SECURITY: Running Chrome as root without a sandbox is risky - a compromised
-            # browser process would have full root access. Only do this in controlled environments.
+            # SECURITY: Running Chrome as root without a sandbox is risky
+            # - a compromised browser has full root access. Use only in
+            # controlled environments.
             running_as_root = os.getuid() == 0
             if running_as_root:
-                logger.info(
                 logger.warning(
-                    "Running as root - disabling Chromium sandbox (required for root). "
-                    "WARNING: This reduces security isolation."
-                )
+                    "Running as root - disabling Chromium sandbox "
+                    "(required for root). This reduces security isolation."
                 )
 
             self._config = {

--- a/tests/tools/browser_use/test_browser_initialization.py
+++ b/tests/tools/browser_use/test_browser_initialization.py
@@ -89,6 +89,7 @@ class TestBrowserInitialization:
                 "openhands.tools.browser_use.impl.CustomBrowserUseServer",
                 return_value=mock_server,
             ),
+            patch("os.getuid", return_value=1000),  # Non-root user
         ):
             executor = BrowserToolExecutor(
                 headless=False,
@@ -101,6 +102,7 @@ class TestBrowserInitialization:
                 "headless": False,
                 "allowed_domains": ["example.com"],
                 "executable_path": "/usr/bin/chromium",
+                "chromium_sandbox": True,  # Enabled for non-root
                 "custom_param": "test",
             }
 


### PR DESCRIPTION
## Summary

Apparently chrome sandbox doesn't work if you're running as root

Confirmed that with this change I can browse as root

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:196536f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-196536f-python \
  ghcr.io/openhands/agent-server:196536f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:196536f-golang-amd64
ghcr.io/openhands/agent-server:196536f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:196536f-golang-arm64
ghcr.io/openhands/agent-server:196536f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:196536f-java-amd64
ghcr.io/openhands/agent-server:196536f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:196536f-java-arm64
ghcr.io/openhands/agent-server:196536f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:196536f-python-amd64
ghcr.io/openhands/agent-server:196536f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:196536f-python-arm64
ghcr.io/openhands/agent-server:196536f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:196536f-golang
ghcr.io/openhands/agent-server:196536f-java
ghcr.io/openhands/agent-server:196536f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `196536f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `196536f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->