### PR TITLE
ci: Gate API breakage failures on release PRs

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -4,9 +4,6 @@ name: API breakage checks
 on:
     pull_request:
         branches: [main]
-        # Only run on release PRs created by prepare-release.yml (rel-X.Y.Z branches)
-        # We enforce version-bump policy here, which does not apply to everyday PRs.
-        head-branches: [rel-*]
 
 jobs:
     sdk-api:
@@ -15,9 +12,6 @@ jobs:
         permissions:
             contents: read
             pull-requests: write
-        # Non-blocking for now — report failures but don't gate releases.
-        # Remove continue-on-error once validated in production.
-        continue-on-error: true
         steps:
             - name: Checkout
               uses: actions/checkout@v5
@@ -31,7 +25,9 @@ jobs:
               run: uv sync --frozen --group dev
             - name: Run SDK API breakage check
               id: api_breakage
-              continue-on-error: true
+              # Release PRs (rel-*) must block on breakage.
+              # Other PRs should still report failures via PR comment, but not gate merges.
+              continue-on-error: ${{ !startsWith(github.head_ref, 'rel-') }}
               run: |
                   uv run python .github/scripts/check_sdk_api_breakage.py 2>&1 | tee api-breakage.log
                   echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
This updates the API breakage workflow so that:

- PRs with head branch `rel-*` are **blocking** (API breakage check failures fail the workflow)
- Other PRs to `main` still run the check and post the PR comment report, but the failure is **non-blocking** via `continue-on-error` on the check step.

Note: `head-branches` filtering is not supported for `pull_request`, so gating is done via `github.head_ref` instead.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6baa6d7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6baa6d7-python \
  ghcr.io/openhands/agent-server:6baa6d7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6baa6d7-golang-amd64
ghcr.io/openhands/agent-server:6baa6d7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6baa6d7-golang-arm64
ghcr.io/openhands/agent-server:6baa6d7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6baa6d7-java-amd64
ghcr.io/openhands/agent-server:6baa6d7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6baa6d7-java-arm64
ghcr.io/openhands/agent-server:6baa6d7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6baa6d7-python-amd64
ghcr.io/openhands/agent-server:6baa6d7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6baa6d7-python-arm64
ghcr.io/openhands/agent-server:6baa6d7-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6baa6d7-golang
ghcr.io/openhands/agent-server:6baa6d7-java
ghcr.io/openhands/agent-server:6baa6d7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6baa6d7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6baa6d7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->