### PR TITLE
fix: Include boto3 extra in agent-server Docker image

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -30,7 +30,7 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv python install 3.12 && uv venv --python 3.12 .venv && uv sync --frozen --no-editable --managed-python
+    uv python install 3.12 && uv venv --python 3.12 .venv && uv sync --frozen --no-editable --managed-python --extra boto3
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -41,7 +41,7 @@ ARG USERNAME UID GID
 
 # We need --dev for pyinstaller
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv sync --frozen --dev --no-editable
+    uv sync --frozen --dev --no-editable --extra boto3
 
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
     uv run pyinstaller openhands-agent-server/openhands/agent_server/agent-server.spec


### PR DESCRIPTION
## Summary

Fixes the `No module named 'boto3'` error when using AWS Bedrock models with the local GUI Docker deployment.

## Problem

Users running the OpenHands local GUI with Bedrock models encounter this error:

```
litellm.APIConnectionError: No module named 'boto3'
Traceback (most recent call last):
  File "litellm/main.py", line 3437, in completion
  File "litellm/llms/bedrock/chat/converse_handler.py", line 310, in completion
  File "litellm/llms/bedrock/base_aws_llm.py", line 255, in get_credentials
  File "litellm/llms/bedrock/base_aws_llm.py", line 894, in _auth_with_env_vars
ModuleNotFoundError: No module named 'boto3'
```

## Root Cause

The `boto3` package is defined as an **optional dependency** (extra) in `openhands-sdk/pyproject.toml`:

```toml
[project.optional-dependencies]
boto3 = ["boto3>=1.35.0"]
```

However, the Dockerfile's `uv sync` commands were not including the `--extra boto3` flag, so boto3 was never installed in the Docker image despite being present in `uv.lock`.

## Solution

Added `--extra boto3` to both `uv sync` commands in the Dockerfile:
1. In the `builder` stage (for source mode)
2. In the `binary-builder` stage (for binary mode)

This ensures boto3 and its dependencies (botocore, jmespath, s3transfer) are installed in all agent-server Docker image variants.

## Testing

This fix should be verified by building the Docker image and testing with a Bedrock model configuration.

@rbren can click here to [continue refining the PR](https://app.all-hands.dev/conversations/None)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2a71b3d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2a71b3d-python \
  ghcr.io/openhands/agent-server:2a71b3d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2a71b3d-golang-amd64
ghcr.io/openhands/agent-server:2a71b3d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2a71b3d-golang-arm64
ghcr.io/openhands/agent-server:2a71b3d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2a71b3d-java-amd64
ghcr.io/openhands/agent-server:2a71b3d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2a71b3d-java-arm64
ghcr.io/openhands/agent-server:2a71b3d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2a71b3d-python-amd64
ghcr.io/openhands/agent-server:2a71b3d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2a71b3d-python-arm64
ghcr.io/openhands/agent-server:2a71b3d-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2a71b3d-golang
ghcr.io/openhands/agent-server:2a71b3d-java
ghcr.io/openhands/agent-server:2a71b3d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2a71b3d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2a71b3d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->