### PR TITLE
Do not forward api_key to Bedrock calls

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -120,6 +120,16 @@ When reviewing code, provide constructive feedback:
 
 When adding non-Python files (JS, templates, etc.) loaded at runtime, add them to `openhands-agent-server/openhands/agent_server/agent-server.spec` using `collect_data_files`.
 
+# Bedrock + LiteLLM note
+
+- LiteLLM interprets the `api_key` parameter for Bedrock models as an **AWS bearer token**.
+  When using IAM/SigV4 auth (AWS credentials / profiles), do **not** forward `LLM.api_key`
+  to LiteLLM for Bedrock models, or Bedrock may return:
+  `Invalid API Key format: Must start with pre-defined prefix`.
+- If you need Bedrock bearer-token auth, set `AWS_BEARER_TOKEN_BEDROCK` in the environment
+  (instead of using `LLM_API_KEY`).
+
+
 </DEV_SETUP>
 
 <PR_ARTIFACTS>

--- a/openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/litellm_provider.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import warnings
+from typing import Any, cast
+
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    import litellm
+
+
+def infer_litellm_provider(*, model: str, api_base: str | None) -> str | None:
+    """Infer the LiteLLM provider for a given model.
+
+    This delegates to LiteLLM's provider inference logic (which includes model
+    list lookups like Bedrock's regional model identifiers).
+    """
+
+    try:
+        get_llm_provider = cast(Any, litellm).get_llm_provider
+        _model, provider, _dynamic_key, _api_base = get_llm_provider(
+            model=model,
+            custom_llm_provider=None,
+            api_base=api_base,
+            api_key=None,
+        )
+    except Exception:
+        return None
+
+    return provider

--- a/tests/sdk/llm/test_api_key_validation.py
+++ b/tests/sdk/llm/test_api_key_validation.py
@@ -72,6 +72,22 @@ def test_bedrock_model_with_none_api_key():
     assert llm.aws_region_name == "us-east-1"
 
 
+def test_bedrock_model_with_api_key_not_forwarded_to_litellm():
+    """Test that Bedrock models never forward LLM.api_key to LiteLLM.
+
+    LiteLLM interprets the Bedrock api_key parameter as an AWS bearer token.
+    Forwarding a non-Bedrock key (e.g. OpenAI/Anthropic) breaks IAM/SigV4 auth.
+    """
+
+    llm = LLM(
+        usage_id="test-llm",
+        model="us.anthropic.claude-3-sonnet-20240229-v1:0",
+        api_key=SecretStr("sk-ant-not-a-bedrock-key"),
+    )
+    assert llm.api_key is not None
+    assert llm._get_litellm_api_key_value() is None
+
+
 def test_non_bedrock_model_with_valid_key():
     """Test that non-Bedrock models work normally with valid API keys."""
     llm = LLM(


### PR DESCRIPTION
### Problem
When calling AWS Bedrock models via LiteLLM, any non-`None` `api_key` is treated as an AWS bearer token. If a user has a generic key stored (e.g. OpenAI/Anthropic) and selects a Bedrock model, forwarding that key makes Bedrock reject requests with:

`Invalid API Key format: Must start with pre-defined prefix`

### Fix
- Delegate provider inference to `litellm.get_llm_provider()` (via a small SDK utility).
- Suppress forwarding `LLM.api_key` to LiteLLM when the inferred provider is `bedrock` (so IAM/SigV4 auth works with AWS env/profile credentials).

### Tests
- Added regression test ensuring Bedrock never forwards `api_key`.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:67fee2b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-67fee2b-python \
  ghcr.io/openhands/agent-server:67fee2b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:67fee2b-golang-amd64
ghcr.io/openhands/agent-server:67fee2b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:67fee2b-golang-arm64
ghcr.io/openhands/agent-server:67fee2b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:67fee2b-java-amd64
ghcr.io/openhands/agent-server:67fee2b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:67fee2b-java-arm64
ghcr.io/openhands/agent-server:67fee2b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:67fee2b-python-amd64
ghcr.io/openhands/agent-server:67fee2b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:67fee2b-python-arm64
ghcr.io/openhands/agent-server:67fee2b-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:67fee2b-golang
ghcr.io/openhands/agent-server:67fee2b-java
ghcr.io/openhands/agent-server:67fee2b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `67fee2b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `67fee2b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->