### PR TITLE
fix(sdk): handle newlines in JSON-stringified dict arguments

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -99,7 +99,10 @@ def fix_malformed_tool_arguments(
         if any(exp in (list, dict) for exp in expected_origins):
             # Try to parse the string as JSON
             try:
-                parsed_value = json.loads(value)
+                # `strict=False` allows control characters (e.g. newlines) that
+                # the outer json.loads decoded from escape sequences.
+                # https://docs.python.org/3/library/json.html#json.JSONDecoder
+                parsed_value = json.loads(value, strict=False)
                 # json.loads() returns dict, list, str, int, float, bool, or None
                 # Only use parsed value if it matches expected collection types
                 if isinstance(parsed_value, (list, dict)):


### PR DESCRIPTION
## Summary

The PR closes #2216 

- Fix `DelegateAction` validation failure when LLMs serialize the tasks dict as a `JSON` string containing newlines
- Use `json.loads(value, strict=False)` in `fix_malformed_tool_arguments` to accept control characters that the outer JSON parse decoded from escape sequences

## Root cause
When an `LLM` sends tasks as a `JSON` string (not an object), `\n` escapes in the outer `JSON` become real newline characters after `json.loads`. The inner `json.loads` then rejects these raw control characters, `fix_malformed_tool_arguments` silently swallows the error, and `DelegateAction.model_validate` fails with `dict_type`.

## Test plan
- New test `test_issue_2216` reproduces the exact error from the issue (failing with the same error if no fix in place)
- All 16 existing `test_fix_malformed_tool_arguments` tests pass

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1e0a0d8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1e0a0d8-python \
  ghcr.io/openhands/agent-server:1e0a0d8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1e0a0d8-golang-amd64
ghcr.io/openhands/agent-server:1e0a0d8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1e0a0d8-golang-arm64
ghcr.io/openhands/agent-server:1e0a0d8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1e0a0d8-java-amd64
ghcr.io/openhands/agent-server:1e0a0d8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1e0a0d8-java-arm64
ghcr.io/openhands/agent-server:1e0a0d8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1e0a0d8-python-amd64
ghcr.io/openhands/agent-server:1e0a0d8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:1e0a0d8-python-arm64
ghcr.io/openhands/agent-server:1e0a0d8-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:1e0a0d8-golang
ghcr.io/openhands/agent-server:1e0a0d8-java
ghcr.io/openhands/agent-server:1e0a0d8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1e0a0d8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1e0a0d8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->