### PR TITLE
RFC: Unified Settings Architecture for SDK, CLI, and GUI

### DIFF
--- a/.pr/design.md
+++ b/.pr/design.md
@@ -1,0 +1,557 @@
+# OpenHands Settings Architecture Proposal
+
+## Executive Summary
+
+This document proposes a unified settings architecture where the **SDK's Pydantic models become the single source of truth** for all configuration. Client projects (CLI, GUI) will automatically derive their settings UI and CLI arguments from these models, ensuring instant propagation of new settings.
+
+## Current State Analysis
+
+### 1. SDK (software-agent-sdk)
+
+The SDK has well-defined Pydantic models:
+
+**LLM (`openhands/sdk/llm/llm.py`)**
+- ~50+ fields with `Field()` definitions
+- Examples: `model`, `api_key`, `base_url`, `temperature`, `max_output_tokens`, `reasoning_effort`, etc.
+
+**AgentBase (`openhands/sdk/agent/base.py`)**
+- ~15 fields for agent configuration
+- Examples: `llm`, `tools`, `condenser`, `critic`, `agent_context`, etc.
+
+**Conversation**
+- ~10+ parameters for conversation setup
+- Examples: `workspace`, `persistence_dir`, `max_iteration_per_run`, `stuck_detection`, etc.
+
+All settings use Pydantic's `Field()` with descriptions, defaults, and validation constraints.
+
+### 2. CLI (openhands-cli)
+
+The CLI maintains **separate** settings models:
+
+**Separate Models (`stores/cli_settings.py`)**
+```python
+class CriticSettings(BaseModel):
+    enable_critic: bool = True
+    enable_iterative_refinement: bool = False
+    critic_threshold: float = DEFAULT_CRITIC_THRESHOLD
+    # ... more fields
+```
+
+**Manual Agent Building (`stores/agent_store.py`)**
+```python
+llm = LLM(
+    model=model,
+    api_key=llm_api_key,
+    base_url=base_url,
+    usage_id="agent",
+)
+```
+
+**Hardcoded UI (`tui/modals/settings/`)**
+- Settings forms are manually defined in Python
+- Each new SDK setting requires manual UI updates
+
+**Manual Argparse (`argparsers/`)**
+- Command-line arguments are manually defined
+- No connection to SDK field definitions
+
+### 3. GUI (openhands/openhands)
+
+**Legacy V0 (`core/config/`)**
+- `LLMConfig`, `AgentConfig` - duplicates SDK models
+- Marked for deprecation
+
+**V1 App Server (`app_server/`)**
+- Moving toward SDK-based configuration
+- Uses `OpenHandsModel` from SDK
+
+**Separate Settings Model (`storage/data_models/settings.py`)**
+```python
+class Settings(BaseModel):
+    language: str | None = None
+    llm_model: str | None = None
+    llm_api_key: SecretStr | None = None
+    # ... duplicated from SDK
+```
+
+## Problem Statement
+
+Settings are defined in **three places** with manual synchronization:
+
+```
+┌─────────────────┐     manual sync     ┌─────────────────┐
+│   SDK Models    │ ◄─────────────────► │   CLI Models    │
+│ (LLM, Agent)    │                     │ (CliSettings)   │
+└────────┬────────┘                     └────────┬────────┘
+         │                                       │
+         │ manual sync                           │ manual sync
+         │                                       │
+         ▼                                       ▼
+┌─────────────────┐                     ┌─────────────────┐
+│   GUI Models    │                     │   CLI UI/Args   │
+│   (Settings)    │                     │   (hardcoded)   │
+└─────────────────┘                     └─────────────────┘
+```
+
+**Consequences:**
+1. New SDK settings require manual updates in CLI and GUI
+2. Settings descriptions may drift between projects
+3. Validation logic is duplicated
+4. High maintenance burden for new features
+
+## Proposed Architecture
+
+### Goal: Zero-Latency Settings Propagation
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    SDK (Source of Truth)                     │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  Pydantic Models with UI Metadata                    │    │
+│  │  - LLM: model, api_key, temperature, ...            │    │
+│  │  - Agent: tools, condenser, critic, ...             │    │
+│  │  - Conversation: workspace, stuck_detection, ...    │    │
+│  └─────────────────────────────────────────────────────┘    │
+│                            │                                 │
+│                            ▼                                 │
+│  ┌─────────────────────────────────────────────────────┐    │
+│  │  Settings Schema Export API                          │    │
+│  │  - JSON Schema generation                           │    │
+│  │  - UI hints and metadata                            │    │
+│  │  - Grouping and categorization                      │    │
+│  └─────────────────────────────────────────────────────┘    │
+└─────────────────────────────────────────────────────────────┘
+                             │
+              ┌──────────────┼──────────────┐
+              │              │              │
+              ▼              ▼              ▼
+       ┌──────────┐   ┌──────────┐   ┌──────────┐
+       │   CLI    │   │   GUI    │   │  Other   │
+       │ (auto-   │   │ (auto-   │   │ Clients  │
+       │  gen UI) │   │  gen UI) │   │          │
+       └──────────┘   └──────────┘   └──────────┘
+```
+
+### Key Components
+
+#### 1. UI Metadata in SDK Field Definitions
+
+Enhance Pydantic `Field()` definitions with UI hints:
+
+```python
+# openhands/sdk/llm/llm.py
+
+class LLM(BaseModel):
+    model: str = Field(
+        default="claude-sonnet-4-20250514",
+        description="The language model to use for completions.",
+        json_schema_extra={
+            # UI Configuration
+            "ui_type": "select",           # text, password, select, number, toggle
+            "ui_group": "Model",           # Grouping for UI tabs/sections
+            "ui_order": 1,                 # Display order within group
+            
+            # CLI Configuration  
+            "cli_flags": ["--model", "-m"],
+            "cli_group": "LLM Options",
+            
+            # Environment Variable
+            "env_var": "LLM_MODEL",
+            
+            # Dynamic choices (optional)
+            "choices_provider": "get_model_recommendations",
+            
+            # Visibility
+            "advanced": False,             # Show in basic/advanced mode
+        }
+    )
+    
+    api_key: str | SecretStr | None = Field(
+        default=None,
+        description="API key for authentication.",
+        json_schema_extra={
+            "ui_type": "password",
+            "ui_group": "Authentication",
+            "ui_order": 1,
+            "cli_flags": ["--api-key"],
+            "env_var": "LLM_API_KEY",
+            "required_if_no_default": True,
+        }
+    )
+    
+    temperature: float | None = Field(
+        default=None,
+        ge=0,
+        le=2,
+        description="Sampling temperature (0-2). Higher values = more random.",
+        json_schema_extra={
+            "ui_type": "slider",
+            "ui_group": "Generation",
+            "ui_order": 1,
+            "advanced": True,
+            "cli_flags": ["--temperature"],
+        }
+    )
+```
+
+#### 2. Settings Schema Export API
+
+Add a settings module to the SDK that exports schemas:
+
+```python
+# openhands/sdk/settings/__init__.py
+
+from typing import TypedDict
+from openhands.sdk import LLM, AgentBase
+from openhands.sdk.conversation import Conversation
+
+class FieldMetadata(TypedDict, total=False):
+    name: str
+    type: str
+    description: str
+    default: any
+    required: bool
+    # UI metadata
+    ui_type: str
+    ui_group: str
+    ui_order: int
+    advanced: bool
+    # CLI metadata
+    cli_flags: list[str]
+    cli_group: str
+    # Environment variable
+    env_var: str
+    # Validation
+    minimum: float | None
+    maximum: float | None
+    choices: list[str] | None
+    choices_provider: str | None
+
+
+class SettingsCategory(TypedDict):
+    name: str
+    description: str
+    fields: list[FieldMetadata]
+
+
+def get_llm_settings_schema() -> SettingsCategory:
+    """Extract settings schema from LLM model."""
+    ...
+
+def get_agent_settings_schema() -> SettingsCategory:
+    """Extract settings schema from Agent model."""
+    ...
+
+def get_conversation_settings_schema() -> SettingsCategory:
+    """Extract settings schema from Conversation model."""
+    ...
+
+def get_all_settings_schemas() -> dict[str, SettingsCategory]:
+    """Get all configurable settings from SDK models."""
+    return {
+        "llm": get_llm_settings_schema(),
+        "agent": get_agent_settings_schema(),
+        "conversation": get_conversation_settings_schema(),
+    }
+
+# Export version for compatibility checking
+SETTINGS_SCHEMA_VERSION = "1.0.0"
+```
+
+#### 3. Settings Form Generator Library
+
+A library that generates UI components from schemas:
+
+```python
+# openhands/sdk/settings/generators.py (or separate package)
+
+import argparse
+from typing import Protocol
+
+class FormGenerator(Protocol):
+    """Protocol for form generators."""
+    
+    def generate(self, schema: SettingsCategory) -> any:
+        """Generate form from schema."""
+        ...
+
+
+class ArgparseGenerator:
+    """Generate argparse arguments from settings schema."""
+    
+    def generate(self, schema: SettingsCategory) -> argparse.ArgumentParser:
+        parser = argparse.ArgumentParser()
+        
+        for field in schema["fields"]:
+            flags = field.get("cli_flags", [f"--{field['name'].replace('_', '-')}"])
+            
+            kwargs = {
+                "help": field.get("description"),
+                "default": field.get("default"),
+            }
+            
+            # Handle type conversion
+            field_type = field.get("type")
+            if field_type == "boolean":
+                kwargs["action"] = "store_true"
+            elif field_type == "integer":
+                kwargs["type"] = int
+            elif field_type == "number":
+                kwargs["type"] = float
+            elif field.get("choices"):
+                kwargs["choices"] = field["choices"]
+            
+            # Handle required fields
+            if field.get("required"):
+                kwargs["required"] = True
+            
+            parser.add_argument(*flags, **kwargs)
+        
+        return parser
+
+
+class TextualFormGenerator:
+    """Generate Textual TUI forms from settings schema."""
+    
+    def generate(self, schema: SettingsCategory):
+        """Generate Textual widgets for settings form."""
+        from textual.containers import Container
+        from textual.widgets import Input, Select, Switch, Label
+        
+        widgets = []
+        
+        for field in sorted(schema["fields"], key=lambda f: f.get("ui_order", 999)):
+            ui_type = field.get("ui_type", "text")
+            
+            label = Label(field.get("description", field["name"]))
+            
+            if ui_type == "password":
+                widget = Input(password=True, id=field["name"])
+            elif ui_type == "select":
+                choices = field.get("choices", [])
+                widget = Select(
+                    [(c, c) for c in choices],
+                    id=field["name"],
+                )
+            elif ui_type == "toggle":
+                widget = Switch(id=field["name"])
+            elif ui_type == "number" or ui_type == "slider":
+                widget = Input(type="number", id=field["name"])
+            else:
+                widget = Input(id=field["name"])
+            
+            widgets.extend([label, widget])
+        
+        return Container(*widgets)
+
+
+class ReactFormGenerator:
+    """Generate React form definition (JSON) from settings schema."""
+    
+    def generate(self, schema: SettingsCategory) -> dict:
+        """Generate JSON schema for react-jsonschema-form or similar."""
+        form_schema = {
+            "type": "object",
+            "properties": {},
+            "required": [],
+        }
+        
+        ui_schema = {}
+        
+        for field in schema["fields"]:
+            name = field["name"]
+            
+            # JSON Schema property
+            prop = {"title": field.get("description", name)}
+            
+            field_type = field.get("type")
+            if field_type == "boolean":
+                prop["type"] = "boolean"
+            elif field_type == "integer":
+                prop["type"] = "integer"
+            elif field_type == "number":
+                prop["type"] = "number"
+            else:
+                prop["type"] = "string"
+            
+            if field.get("choices"):
+                prop["enum"] = field["choices"]
+            
+            if field.get("minimum") is not None:
+                prop["minimum"] = field["minimum"]
+            if field.get("maximum") is not None:
+                prop["maximum"] = field["maximum"]
+            
+            form_schema["properties"][name] = prop
+            
+            if field.get("required"):
+                form_schema["required"].append(name)
+            
+            # UI Schema
+            ui_type = field.get("ui_type")
+            if ui_type == "password":
+                ui_schema[name] = {"ui:widget": "password"}
+            elif ui_type == "slider":
+                ui_schema[name] = {"ui:widget": "range"}
+        
+        return {"schema": form_schema, "uiSchema": ui_schema}
+```
+
+#### 4. Client Integration
+
+**CLI Integration:**
+
+```python
+# openhands_cli/setup.py (updated)
+
+from openhands.sdk.settings import get_llm_settings_schema
+from openhands.sdk.settings.generators import ArgparseGenerator
+
+def create_llm_parser() -> argparse.ArgumentParser:
+    """Create argparse for LLM settings from SDK schema."""
+    schema = get_llm_settings_schema()
+    generator = ArgparseGenerator()
+    return generator.generate(schema)
+```
+
+**TUI Integration:**
+
+```python
+# openhands_cli/tui/modals/settings/components/settings_tab.py (updated)
+
+from openhands.sdk.settings import get_llm_settings_schema, get_agent_settings_schema
+from openhands.sdk.settings.generators import TextualFormGenerator
+
+class SettingsTab(Container):
+    def compose(self) -> ComposeResult:
+        generator = TextualFormGenerator()
+        
+        # LLM Settings
+        llm_schema = get_llm_settings_schema()
+        yield Static("LLM Settings", classes="section-header")
+        yield generator.generate(llm_schema)
+        
+        # Agent Settings
+        agent_schema = get_agent_settings_schema()
+        yield Static("Agent Settings", classes="section-header")
+        yield generator.generate(agent_schema)
+```
+
+**GUI Integration:**
+
+```python
+# Frontend can fetch schema via API endpoint
+
+# openhands/app_server/settings_router.py
+from fastapi import APIRouter
+from openhands.sdk.settings import get_all_settings_schemas, SETTINGS_SCHEMA_VERSION
+
+router = APIRouter()
+
+@router.get("/api/settings/schema")
+async def get_settings_schema():
+    """Return settings schema for frontend form generation."""
+    return {
+        "version": SETTINGS_SCHEMA_VERSION,
+        "schemas": get_all_settings_schemas(),
+    }
+```
+
+### Implementation Plan
+
+#### Phase 1: SDK Schema Infrastructure (Week 1-2)
+1. Add `json_schema_extra` metadata to LLM fields
+2. Add `json_schema_extra` metadata to Agent fields  
+3. Create `openhands.sdk.settings` module with schema extraction
+4. Add unit tests for schema generation
+
+#### Phase 2: Form Generators (Week 3)
+1. Implement `ArgparseGenerator`
+2. Implement `TextualFormGenerator`
+3. Implement `ReactFormGenerator` (JSON output)
+4. Add tests for generators
+
+#### Phase 3: CLI Migration (Week 4)
+1. Update CLI to use generated argparse
+2. Update TUI settings modal to use generated forms
+3. Remove hardcoded settings definitions
+4. Ensure backward compatibility
+
+#### Phase 4: GUI Migration (Week 5)
+1. Add `/api/settings/schema` endpoint
+2. Update frontend to use dynamic form generation
+3. Remove hardcoded settings forms
+4. Test cross-version compatibility
+
+#### Phase 5: Documentation & Polish (Week 6)
+1. Document how to add new settings
+2. Create migration guide for existing settings
+3. Add schema versioning and deprecation support
+4. Performance optimization
+
+### Migration Example: Adding a New Setting
+
+**Before (current approach):**
+1. Add field to SDK model
+2. Manually add to CLI's `CliSettings` model
+3. Manually update CLI's settings UI
+4. Manually add CLI argument
+5. Manually update GUI's Settings model
+6. Manually update frontend form
+7. Write documentation
+
+**After (proposed approach):**
+1. Add field to SDK model with `json_schema_extra`
+2. Done! (CLI and GUI automatically pick up the new field)
+
+```python
+# Just add this to SDK:
+new_setting: int = Field(
+    default=10,
+    description="A new configurable setting",
+    json_schema_extra={
+        "ui_type": "number",
+        "ui_group": "Advanced",
+        "cli_flags": ["--new-setting"],
+        "env_var": "NEW_SETTING",
+    }
+)
+# CLI and GUI automatically show the new setting!
+```
+
+### Benefits
+
+1. **Single Source of Truth**: SDK Pydantic models are authoritative
+2. **Zero-Latency Propagation**: New settings appear everywhere instantly
+3. **Consistent Validation**: Same Pydantic validation in all clients
+4. **Reduced Duplication**: No need to maintain parallel model definitions
+5. **Better Documentation**: Field descriptions are always in sync
+6. **Type Safety**: Schema generation preserves type information
+7. **Testability**: Schema can be validated programmatically
+
+### Risks and Mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Breaking existing CLI/GUI | Use schema versioning, gradual rollout |
+| Performance overhead | Cache generated schemas |
+| Complex UI requirements | Allow UI overrides where needed |
+| Dynamic choices | Support `choices_provider` functions |
+| Validation edge cases | Keep Pydantic validators, enhance at generator level |
+
+### Open Questions
+
+1. **Where should generators live?** SDK, separate package, or in clients?
+   - Recommendation: SDK exports schema, clients can use shared generator library
+   
+2. **How to handle client-specific settings?** (e.g., CLI's `auto_open_plan_panel`)
+   - Recommendation: Client-specific settings remain in client, only shared settings come from SDK
+   
+3. **Version compatibility between SDK and clients?**
+   - Recommendation: Schema version + graceful degradation for unknown fields
+
+## Conclusion
+
+This architecture eliminates the manual synchronization burden and ensures that any new setting added to the SDK automatically appears in all client applications. The implementation is incremental and backward-compatible, allowing gradual migration of existing settings.
+
+The key insight is that **Pydantic models already contain all the information needed** to generate UIs - we just need to add UI hints and create the generation machinery.

--- a/.pr/poc_settings_schema.py
+++ b/.pr/poc_settings_schema.py
@@ -1,0 +1,512 @@
+"""
+Proof of Concept: Unified Settings Schema
+
+This module demonstrates how SDK Pydantic models can be the single source of truth
+for settings, with automatic schema generation for CLI and GUI.
+
+Run with: python settings_schema.py
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+from typing import Any, TypedDict, get_type_hints, get_origin, get_args, Literal
+
+from pydantic import BaseModel, Field, SecretStr
+
+
+# =============================================================================
+# PART 1: SDK Model Definitions (Enhanced with UI Metadata)
+# =============================================================================
+
+class LLMConfig(BaseModel):
+    """LLM configuration - single source of truth for LLM settings."""
+    
+    model: str = Field(
+        default="claude-sonnet-4-20250514",
+        description="The language model to use for completions.",
+        json_schema_extra={
+            "ui_type": "select",
+            "ui_group": "Model",
+            "ui_order": 1,
+            "cli_flags": ["--model", "-m"],
+            "env_var": "LLM_MODEL",
+            "advanced": False,
+            # Dynamic choices could be loaded from a provider
+            "choices": [
+                "claude-sonnet-4-20250514",
+                "claude-opus-4-20250514", 
+                "gpt-4o",
+                "gpt-4o-mini",
+            ],
+        }
+    )
+    
+    api_key: str | SecretStr | None = Field(
+        default=None,
+        description="API key for authentication with the LLM provider.",
+        json_schema_extra={
+            "ui_type": "password",
+            "ui_group": "Authentication",
+            "ui_order": 1,
+            "cli_flags": ["--api-key"],
+            "env_var": "LLM_API_KEY",
+            "advanced": False,
+        }
+    )
+    
+    base_url: str | None = Field(
+        default=None,
+        description="Custom base URL for the API (for proxies or self-hosted models).",
+        json_schema_extra={
+            "ui_type": "text",
+            "ui_group": "Authentication",
+            "ui_order": 2,
+            "cli_flags": ["--base-url"],
+            "env_var": "LLM_BASE_URL",
+            "advanced": True,
+        }
+    )
+    
+    temperature: float | None = Field(
+        default=None,
+        ge=0,
+        le=2,
+        description="Sampling temperature (0-2). Higher values make output more random.",
+        json_schema_extra={
+            "ui_type": "slider",
+            "ui_group": "Generation",
+            "ui_order": 1,
+            "cli_flags": ["--temperature"],
+            "advanced": True,
+        }
+    )
+    
+    max_output_tokens: int | None = Field(
+        default=None,
+        ge=1,
+        description="Maximum number of tokens in the response.",
+        json_schema_extra={
+            "ui_type": "number",
+            "ui_group": "Generation",
+            "ui_order": 2,
+            "cli_flags": ["--max-tokens"],
+            "advanced": True,
+        }
+    )
+    
+    caching_prompt: bool = Field(
+        default=True,
+        description="Enable prompt caching for faster responses.",
+        json_schema_extra={
+            "ui_type": "toggle",
+            "ui_group": "Performance",
+            "ui_order": 1,
+            "cli_flags": ["--cache-prompts/--no-cache-prompts"],
+            "advanced": True,
+        }
+    )
+    
+    reasoning_effort: Literal["low", "medium", "high", "none"] | None = Field(
+        default=None,
+        description="Effort level for reasoning models (low/medium/high/none).",
+        json_schema_extra={
+            "ui_type": "select",
+            "ui_group": "Generation",
+            "ui_order": 3,
+            "cli_flags": ["--reasoning-effort"],
+            "advanced": True,
+            "choices": ["low", "medium", "high", "none"],
+        }
+    )
+
+
+class AgentConfig(BaseModel):
+    """Agent configuration - single source of truth for agent settings."""
+    
+    enable_browsing: bool = Field(
+        default=True,
+        description="Enable web browsing capabilities.",
+        json_schema_extra={
+            "ui_type": "toggle",
+            "ui_group": "Tools",
+            "ui_order": 1,
+            "cli_flags": ["--browsing/--no-browsing"],
+            "advanced": False,
+        }
+    )
+    
+    enable_jupyter: bool = Field(
+        default=True,
+        description="Enable Jupyter notebook tool.",
+        json_schema_extra={
+            "ui_type": "toggle",
+            "ui_group": "Tools",
+            "ui_order": 2,
+            "cli_flags": ["--jupyter/--no-jupyter"],
+            "advanced": False,
+        }
+    )
+    
+    enable_stuck_detection: bool = Field(
+        default=True,
+        description="Automatically detect when agent is stuck in a loop.",
+        json_schema_extra={
+            "ui_type": "toggle",
+            "ui_group": "Behavior",
+            "ui_order": 1,
+            "cli_flags": ["--stuck-detection/--no-stuck-detection"],
+            "advanced": True,
+        }
+    )
+
+
+class ConversationConfig(BaseModel):
+    """Conversation configuration."""
+    
+    max_iteration_per_run: int = Field(
+        default=500,
+        ge=1,
+        description="Maximum iterations per agent run.",
+        json_schema_extra={
+            "ui_type": "number",
+            "ui_group": "Limits",
+            "ui_order": 1,
+            "cli_flags": ["--max-iterations"],
+            "advanced": True,
+        }
+    )
+    
+    enable_condenser: bool = Field(
+        default=True,
+        description="Enable conversation condensation to manage context window.",
+        json_schema_extra={
+            "ui_type": "toggle",
+            "ui_group": "Memory",
+            "ui_order": 1,
+            "cli_flags": ["--condenser/--no-condenser"],
+            "advanced": False,
+        }
+    )
+
+
+# =============================================================================
+# PART 2: Schema Extraction
+# =============================================================================
+
+class FieldMetadata(TypedDict, total=False):
+    """Metadata for a single settings field."""
+    name: str
+    type: str
+    description: str
+    default: Any
+    required: bool
+    # UI metadata
+    ui_type: str
+    ui_group: str
+    ui_order: int
+    advanced: bool
+    # CLI metadata
+    cli_flags: list[str]
+    # Environment variable
+    env_var: str
+    # Validation
+    minimum: float | None
+    maximum: float | None
+    choices: list[str] | None
+
+
+class SettingsCategory(TypedDict):
+    """A category of settings."""
+    name: str
+    description: str
+    fields: list[FieldMetadata]
+
+
+def extract_field_metadata(model_class: type[BaseModel]) -> list[FieldMetadata]:
+    """Extract field metadata from a Pydantic model."""
+    fields = []
+    
+    for field_name, field_info in model_class.model_fields.items():
+        metadata: FieldMetadata = {
+            "name": field_name,
+            "description": field_info.description or "",
+            "default": field_info.default if field_info.default is not None else None,
+            "required": field_info.is_required(),
+        }
+        
+        # Extract type information
+        annotation = field_info.annotation
+        origin = get_origin(annotation)
+        
+        if annotation == bool:
+            metadata["type"] = "boolean"
+        elif annotation == int:
+            metadata["type"] = "integer"
+        elif annotation in (float, int | None):
+            metadata["type"] = "number"
+        elif origin is Literal:
+            metadata["type"] = "string"
+            metadata["choices"] = list(get_args(annotation))
+        else:
+            metadata["type"] = "string"
+        
+        # Extract validation constraints
+        for constraint in field_info.metadata:
+            if hasattr(constraint, 'ge'):
+                metadata["minimum"] = constraint.ge
+            if hasattr(constraint, 'le'):
+                metadata["maximum"] = constraint.le
+        
+        # Extract UI metadata from json_schema_extra
+        extra = field_info.json_schema_extra or {}
+        if isinstance(extra, dict):
+            for key in ["ui_type", "ui_group", "ui_order", "advanced", 
+                       "cli_flags", "env_var", "choices"]:
+                if key in extra:
+                    metadata[key] = extra[key]
+        
+        fields.append(metadata)
+    
+    return fields
+
+
+def get_settings_schema(model_class: type[BaseModel], name: str) -> SettingsCategory:
+    """Get settings schema for a model."""
+    return {
+        "name": name,
+        "description": model_class.__doc__ or "",
+        "fields": extract_field_metadata(model_class),
+    }
+
+
+def get_all_settings_schemas() -> dict[str, SettingsCategory]:
+    """Get all settings schemas from SDK models."""
+    return {
+        "llm": get_settings_schema(LLMConfig, "LLM Settings"),
+        "agent": get_settings_schema(AgentConfig, "Agent Settings"),
+        "conversation": get_settings_schema(ConversationConfig, "Conversation Settings"),
+    }
+
+
+# =============================================================================
+# PART 3: Form Generators
+# =============================================================================
+
+class ArgparseGenerator:
+    """Generate argparse arguments from settings schema."""
+    
+    def generate(self, schemas: dict[str, SettingsCategory]) -> argparse.ArgumentParser:
+        """Generate a complete argument parser from schemas."""
+        parser = argparse.ArgumentParser(
+            description="OpenHands CLI (auto-generated from SDK schema)"
+        )
+        
+        for category_name, category in schemas.items():
+            group = parser.add_argument_group(category["name"])
+            
+            for field in category["fields"]:
+                flags = field.get("cli_flags", [f"--{field['name'].replace('_', '-')}"])
+                
+                # Skip if no CLI flags defined
+                if not flags:
+                    continue
+                
+                kwargs: dict[str, Any] = {
+                    "help": field.get("description"),
+                    "default": field.get("default"),
+                    "dest": field["name"],
+                }
+                
+                field_type = field.get("type")
+                
+                # Handle boolean flags
+                if field_type == "boolean":
+                    # Check if flag uses the /--no- pattern
+                    if any("/" in f for f in flags):
+                        flag = flags[0].split("/")[0]
+                        kwargs["action"] = "store_true"
+                        kwargs["dest"] = field["name"]
+                        group.add_argument(flag, **kwargs)
+                        continue
+                    else:
+                        kwargs["action"] = "store_true"
+                elif field_type == "integer":
+                    kwargs["type"] = int
+                elif field_type == "number":
+                    kwargs["type"] = float
+                
+                # Handle choices
+                if field.get("choices"):
+                    kwargs["choices"] = field["choices"]
+                
+                group.add_argument(*flags, **kwargs)
+        
+        return parser
+
+
+class TextualFormGenerator:
+    """Generate Textual TUI form descriptions from settings schema."""
+    
+    def generate(self, schemas: dict[str, SettingsCategory]) -> str:
+        """Generate a description of what the Textual form would look like."""
+        output = []
+        
+        for category_name, category in schemas.items():
+            output.append(f"\n=== {category['name']} ===")
+            output.append(f"Description: {category['description']}")
+            
+            # Group fields by ui_group
+            groups: dict[str, list[FieldMetadata]] = {}
+            for field in category["fields"]:
+                group = field.get("ui_group", "Other")
+                if group not in groups:
+                    groups[group] = []
+                groups[group].append(field)
+            
+            for group_name, fields in groups.items():
+                output.append(f"\n  [{group_name}]")
+                
+                for field in sorted(fields, key=lambda f: f.get("ui_order", 999)):
+                    ui_type = field.get("ui_type", "text")
+                    advanced = "🔧" if field.get("advanced") else ""
+                    
+                    output.append(f"    {advanced}{field['name']}: {ui_type}")
+                    output.append(f"      → {field.get('description', 'No description')}")
+                    if field.get("default") is not None:
+                        output.append(f"      Default: {field['default']}")
+                    if field.get("choices"):
+                        output.append(f"      Choices: {field['choices']}")
+        
+        return "\n".join(output)
+
+
+class ReactFormGenerator:
+    """Generate React-compatible form schema from settings schema."""
+    
+    def generate(self, schemas: dict[str, SettingsCategory]) -> dict:
+        """Generate JSON schema for react-jsonschema-form."""
+        form_schemas = {}
+        
+        for category_name, category in schemas.items():
+            schema = {
+                "type": "object",
+                "title": category["name"],
+                "description": category["description"],
+                "properties": {},
+                "required": [],
+            }
+            
+            ui_schema = {}
+            
+            for field in category["fields"]:
+                name = field["name"]
+                
+                prop: dict[str, Any] = {
+                    "title": name.replace("_", " ").title(),
+                    "description": field.get("description"),
+                }
+                
+                field_type = field.get("type")
+                if field_type == "boolean":
+                    prop["type"] = "boolean"
+                elif field_type == "integer":
+                    prop["type"] = "integer"
+                elif field_type == "number":
+                    prop["type"] = "number"
+                else:
+                    prop["type"] = "string"
+                
+                if field.get("choices"):
+                    prop["enum"] = field["choices"]
+                
+                if field.get("minimum") is not None:
+                    prop["minimum"] = field["minimum"]
+                if field.get("maximum") is not None:
+                    prop["maximum"] = field["maximum"]
+                
+                if field.get("default") is not None:
+                    prop["default"] = field["default"]
+                
+                schema["properties"][name] = prop
+                
+                if field.get("required"):
+                    schema["required"].append(name)
+                
+                # UI Schema
+                ui_type = field.get("ui_type")
+                if ui_type == "password":
+                    ui_schema[name] = {"ui:widget": "password"}
+                elif ui_type == "slider":
+                    ui_schema[name] = {"ui:widget": "range"}
+                elif ui_type == "toggle":
+                    ui_schema[name] = {"ui:widget": "checkbox"}
+            
+            form_schemas[category_name] = {
+                "schema": schema,
+                "uiSchema": ui_schema,
+            }
+        
+        return form_schemas
+
+
+# =============================================================================
+# PART 4: Demo
+# =============================================================================
+
+def main():
+    print("=" * 70)
+    print("PROOF OF CONCEPT: Unified Settings Schema")
+    print("=" * 70)
+    
+    # Get all schemas
+    schemas = get_all_settings_schemas()
+    
+    # 1. Show raw schema
+    print("\n1. RAW SCHEMA (JSON)")
+    print("-" * 40)
+    print(json.dumps(schemas, indent=2, default=str)[:2000] + "...\n")
+    
+    # 2. Generate argparse
+    print("\n2. AUTO-GENERATED ARGPARSE")
+    print("-" * 40)
+    argparse_gen = ArgparseGenerator()
+    parser = argparse_gen.generate(schemas)
+    parser.print_help()
+    
+    # 3. Show Textual form structure
+    print("\n3. TEXTUAL TUI FORM STRUCTURE")
+    print("-" * 40)
+    textual_gen = TextualFormGenerator()
+    print(textual_gen.generate(schemas))
+    
+    # 4. Show React form schema
+    print("\n4. REACT FORM SCHEMA (JSON)")
+    print("-" * 40)
+    react_gen = ReactFormGenerator()
+    react_schemas = react_gen.generate(schemas)
+    print(json.dumps(react_schemas["llm"]["schema"], indent=2)[:1500] + "...\n")
+    
+    print("\n" + "=" * 70)
+    print("SUMMARY")
+    print("=" * 70)
+    print("""
+This POC demonstrates:
+
+1. SDK models define settings with UI metadata in json_schema_extra
+2. Schema extraction pulls all metadata from Pydantic models
+3. Generators create CLI/TUI/GUI forms from the schema
+
+Benefits:
+- Adding a new field to the SDK model automatically appears in CLI/GUI
+- Descriptions and validation are consistent everywhere
+- No manual synchronization needed
+
+To add a new setting:
+  Just add a Field to the model with json_schema_extra metadata!
+""")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

This PR proposes an architecture where **SDK Pydantic models become the single source of truth** for all configuration settings. Client projects (CLI, GUI) would automatically derive their settings UI and CLI arguments from these models, ensuring instant propagation of new settings.

## Problem Statement

Currently, settings are defined in **three places** with manual synchronization:

1. **SDK**: `LLM` (~50+ fields), `AgentBase` (~15 fields) - canonical Pydantic models
2. **CLI**: Separate `CliSettings`, hardcoded TUI forms, manual argparse definitions
3. **GUI**: Separate `Settings` model, hardcoded frontend forms

When a new setting is added to the SDK, it must be manually:
- Added to CLI's settings models
- Added to TUI settings forms
- Added to CLI argument parser
- Added to GUI settings model
- Added to frontend settings form

This creates significant maintenance burden and causes settings to drift between projects.

## Proposed Solution

### 1. Enhance SDK Field definitions with UI metadata

```python
model: str = Field(
    default="claude-sonnet-4-20250514",
    description="The language model to use.",
    json_schema_extra={
        "ui_type": "select",
        "ui_group": "Model",
        "cli_flags": ["--model", "-m"],
        "env_var": "LLM_MODEL",
    }
)
```

### 2. Schema Export API in SDK

```python
from openhands.sdk.settings import get_all_settings_schemas
schemas = get_all_settings_schemas()  # Returns structured metadata
```

### 3. Form Generators

- `ArgparseGenerator` → Auto-generates CLI arguments
- `TextualFormGenerator` → Auto-generates TUI forms  
- `ReactFormGenerator` → Auto-generates GUI forms (JSON schema)

## Benefits

- **Zero-latency propagation**: New SDK settings appear in CLI/GUI automatically
- **Consistent validation**: Same Pydantic validation everywhere
- **Reduced duplication**: No parallel model definitions to maintain
- **Better documentation**: Field descriptions always in sync

## Contents

- **`.pr/design.md`**: Detailed architecture proposal with implementation plan
- **`.pr/poc_settings_schema.py`**: Working proof of concept

### Run the POC

```bash
uv run python .pr/poc_settings_schema.py
```

This demonstrates:
1. Schema extraction from Pydantic models
2. Auto-generated argparse CLI
3. Auto-generated TUI form structure
4. Auto-generated React form schema (JSON)

## Implementation Plan

| Phase | Duration | Description |
|-------|----------|-------------|
| 1 | Week 1-2 | Add `json_schema_extra` metadata to SDK models |
| 2 | Week 3 | Implement form generators |
| 3 | Week 4 | Migrate CLI to use generated forms/argparse |
| 4 | Week 5 | Migrate GUI to use schema for form generation |
| 5 | Week 6 | Documentation and polish |

## Questions for Discussion

1. Where should the form generators live? (SDK, separate package, or in clients?)
2. How to handle client-specific settings that don't belong in SDK?
3. Schema versioning strategy for compatibility between SDK and clients?

## Related Repositories

- [openhands-cli](https://github.com/OpenHands/openhands-cli)
- [openhands](https://github.com/OpenHands/openhands)

---

Note: This is an RFC (Request for Comments) - the `.pr/` directory contains design documents and POC code for review, not production code.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b6c400f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b6c400f-python \
  ghcr.io/openhands/agent-server:b6c400f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b6c400f-golang-amd64
ghcr.io/openhands/agent-server:b6c400f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b6c400f-golang-arm64
ghcr.io/openhands/agent-server:b6c400f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b6c400f-java-amd64
ghcr.io/openhands/agent-server:b6c400f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b6c400f-java-arm64
ghcr.io/openhands/agent-server:b6c400f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b6c400f-python-amd64
ghcr.io/openhands/agent-server:b6c400f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b6c400f-python-arm64
ghcr.io/openhands/agent-server:b6c400f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b6c400f-golang
ghcr.io/openhands/agent-server:b6c400f-java
ghcr.io/openhands/agent-server:b6c400f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b6c400f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b6c400f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->