### PR TITLE
fix: override server_image default to None in DockerDevWorkspace

### DIFF
--- a/openhands-workspace/openhands/workspace/docker/dev_workspace.py
+++ b/openhands-workspace/openhands/workspace/docker/dev_workspace.py
@@ -28,6 +28,13 @@ class DockerDevWorkspace(DockerWorkspace):
             result = workspace.execute_command("ls -la")
     """
 
+    # Override parent's server_image default to None so that callers
+    # providing base_image don't need to explicitly pass server_image=None.
+    server_image: str | None = Field(
+        default=None,
+        description="Pre-built agent server image. Mutually exclusive with base_image.",
+    )
+
     # Add base_image support
     base_image: str | None = Field(
         default=None,


### PR DESCRIPTION
## Summary
- `DockerDevWorkspace` inherits `server_image`'s default of `"ghcr.io/openhands/agent-server:latest-python"` from `DockerWorkspace`, causing the `_validate_images` validator to reject any instance constructed with only `base_image` (both fields are non-None).
- Override the `server_image` field default to `None` in `DockerDevWorkspace` so callers can use `base_image` without needing to explicitly pass `server_image=None`.
- This is the SDK-side fix for the workaround applied downstream in [OpenHands/benchmarks@63cb3a1](https://github.com/OpenHands/benchmarks/commit/63cb3a1e59bf95b09a49f3e5068f176793e05ab1).

Fixes #2242

## Breaking change note

`DockerDevWorkspace()` called **without** `base_image` previously inherited the parent's `server_image` default (`"ghcr.io/openhands/agent-server:latest-python"`) and passed validation. After this change, it will raise a `ValueError` since both fields default to `None`.

This is unlikely to affect anyone in practice — using `DockerDevWorkspace` without `base_image` is not a meaningful use case (you'd use `DockerWorkspace` directly instead). All existing usages in the SDK and benchmarks repos pass `base_image` explicitly. The previous behavior was accidentally permissive, not intentional.

## Test plan
- [ ] Existing tests pass (`test_docker_dev_workspace_has_build_fields`, `test_docker_dev_workspace_import`, etc.)
- [ ] `DockerDevWorkspace(base_image="python:3.13")` no longer raises a validation error
- [ ] `DockerDevWorkspace(server_image="ghcr.io/openhands/agent-server:latest")` still works
- [ ] `DockerDevWorkspace()` (neither field) raises a validation error as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e27b76e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e27b76e-python \
  ghcr.io/openhands/agent-server:e27b76e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e27b76e-golang-amd64
ghcr.io/openhands/agent-server:e27b76e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e27b76e-golang-arm64
ghcr.io/openhands/agent-server:e27b76e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e27b76e-java-amd64
ghcr.io/openhands/agent-server:e27b76e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e27b76e-java-arm64
ghcr.io/openhands/agent-server:e27b76e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e27b76e-python-amd64
ghcr.io/openhands/agent-server:e27b76e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:e27b76e-python-arm64
ghcr.io/openhands/agent-server:e27b76e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:e27b76e-golang
ghcr.io/openhands/agent-server:e27b76e-java
ghcr.io/openhands/agent-server:e27b76e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e27b76e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e27b76e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->