### PR TITLE
Fix LiteLLM cost tracking for provider-prefixed models

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/telemetry.py
@@ -271,9 +271,10 @@ class Telemetry(BaseModel):
 
         # move on to litellm cost calculator
         # Handle model name properly - if it doesn't contain "/", use as-is
-        model_parts = self.model_name.split("/")
-        if len(model_parts) > 1:
-            extra_kwargs["model"] = "/".join(model_parts[1:])
+        if "/" in self.model_name:
+            provider, bare = self.model_name.split("/", 1)
+            extra_kwargs["model"] = bare
+            extra_kwargs["custom_llm_provider"] = provider
         else:
             extra_kwargs["model"] = self.model_name
         try:


### PR DESCRIPTION
## Summary
Fixes missing cost tracking in `Conversation.run()` when using provider-prefixed model names (e.g. `vertex_ai/claude-sonnet-4-5@...`, `azure/gpt-5.2-chat`).
Previously, telemetry’s LiteLLM cost fallback stripped the provider and passed only the bare model name to `litellm_completion_cost()`, causing LiteLLM to warn `“LLM Provider NOT provided”` and return None for cost. This PR preserves the provider by passing `custom_llm_provider=<provider>` and `model=<bare_model>` to LiteLLM’s cost calculator.

Also adds regression tests to ensure provider and model are propagated correctly for cost calculation.

[fill in a summary of this PR]

## Checklist

- [✔ ] If the PR is changing/adding functionality, are there tests to reflect this?
- - Added unit tests in tests/sdk/test_telemetry.py that assert litellm_completion_cost() is called with custom_llm_provider and the correct bare model (covers Vertex AI + Azure).
- [ ✔] If there is an example, have you run the example to make sure that it works?
- - Conducted Experiment before and after doing the suggested changes, cost is getting reflected in telemetry logs for model names with provided which was showing $0.00 before making suggested changes.
- [ ✔] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- - Ran local checks per DEVELOPMENT.md: make format, make lint, uv run pre-commit run --all-files, and uv run pytest.
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- - N/A (bugfix; no user-facing docs update required).
- [ ] Is the github CI passing?
- - I did the pre-commit checks and all the offline checks, not sure which additional workflow I need to execute.
