### PR TITLE
fix(sdk/subagent): fix get_factory_info()

### DIFF
--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -282,17 +282,10 @@ def get_factory_info() -> str:
     with _registry_lock:
         user_factories = dict(_agent_factories)
 
-    info_lines = []
-    info_lines.append(
-        "- **default**: Default general-purpose agent (used when no agent type is provided)"  # noqa: E501
-    )
-
     if not user_factories:
-        info_lines.append(
-            "- No user-registered agents yet. Call register_agent(...) to add custom agents."  # noqa: E501
-        )
-        return "\n".join(info_lines)
+        return "- No user-registered agents yet. Call register_agent(...) to add custom agents."  # noqa: E501
 
+    info_lines = []
     for name, factory in sorted(user_factories.items()):
         info_lines.append(f"- **{name}**: {factory.description}")
 

--- a/openhands-tools/openhands/tools/preset/subagents/default.md
+++ b/openhands-tools/openhands/tools/preset/subagents/default.md
@@ -1,6 +1,6 @@
 ---
 name: default
-description: Default general-purpose agent
+description: Default general-purpose agent (used when no agent type is provided)
 tools:
   - terminal
   - file_editor

--- a/openhands-tools/openhands/tools/preset/subagents/default_cli.md
+++ b/openhands-tools/openhands/tools/preset/subagents/default_cli.md
@@ -1,6 +1,6 @@
 ---
 name: default cli mode
-description: Default general-purpose agent
+description: Default general-purpose agent (used when no agent type is provided)
 tools:
   - terminal
   - file_editor

--- a/tests/sdk/subagent/test_subagent_registry.py
+++ b/tests/sdk/subagent/test_subagent_registry.py
@@ -241,7 +241,6 @@ def test_agent_definition_to_factory_no_system_prompt() -> None:
 def test_factory_info() -> None:
     """get_factory_info returns formatted listing of registered agents."""
     info = get_factory_info()
-    assert "default" in info
     assert "No user-registered agents" in info
 
     # Register some agents
@@ -255,7 +254,6 @@ def test_factory_info() -> None:
     register_agent(name="beta-agent", factory_func=factory_b, description="Beta desc")
 
     info = get_factory_info()
-    assert "default" in info
     assert "No user-registered agents" not in info
     assert "**alpha-agent**: Alpha desc" in info
     assert "**beta-agent**: Beta desc" in info


### PR DESCRIPTION
## Summary

This fixes `get_factory_info()` so the default agent's description is defined in one place (its frontmatter) rather than being duplicated as a special case in the registry code.
                                                                                     
- Remove the hardcoded "default" agent entry from get_factory_info() output, so it only lists user-registered agents                                                                                               
- Move the "used when no agent type is provided" description into the actual default agent definition files (default.md, default_cli.md) where it belongs                                                          
- Simplify early return when no user agents are registered

## Note
This is a beaviouhr change but it is not a problem as we give the default agent to the DelegateTool always, i.e., there is no change in this sense.

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7d01015-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7d01015-python \
  ghcr.io/openhands/agent-server:7d01015-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7d01015-golang-amd64
ghcr.io/openhands/agent-server:7d01015-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7d01015-golang-arm64
ghcr.io/openhands/agent-server:7d01015-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7d01015-java-amd64
ghcr.io/openhands/agent-server:7d01015-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7d01015-java-arm64
ghcr.io/openhands/agent-server:7d01015-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7d01015-python-amd64
ghcr.io/openhands/agent-server:7d01015-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:7d01015-python-arm64
ghcr.io/openhands/agent-server:7d01015-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:7d01015-golang
ghcr.io/openhands/agent-server:7d01015-java
ghcr.io/openhands/agent-server:7d01015-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7d01015-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7d01015-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->