### PR TITLE
Show full dynamic context in SystemPromptEvent.visualize

### DIFF
--- a/openhands-sdk/openhands/sdk/event/llm_convertible/system.py
+++ b/openhands-sdk/openhands/sdk/event/llm_convertible/system.py
@@ -48,10 +48,7 @@ class SystemPromptEvent(LLMConvertibleEvent):
         content.append(self.system_prompt.text)
         if self.dynamic_context:
             content.append("\n\nDynamic Context:\n", style="bold italic")
-            context_preview = self.dynamic_context.text[:500]
-            if len(self.dynamic_context.text) > 500:
-                context_preview += "..."
-            content.append(context_preview)
+            content.append(self.dynamic_context.text)
         content.append(f"\n\nTools Available: {len(self.tools)}")
         for tool in self.tools:
             # Use ToolDefinition properties directly


### PR DESCRIPTION
## Summary

Remove the 500 character truncation limit for `dynamic_context` in the `SystemPromptEvent.visualize` method.

## Motivation

When debugging or developing with the SDK, it's useful to see the complete dynamic context to verify that everything is working correctly. The previous truncation to 500 characters made it difficult to inspect the full context being passed to the LLM.

## Changes

- Removed truncation logic that limited `dynamic_context` to 500 characters with "..." suffix
- Now displays the full `dynamic_context.text` content

## Before
```python
context_preview = self.dynamic_context.text[:500]
if len(self.dynamic_context.text) > 500:
    context_preview += "..."
content.append(context_preview)
```

## After
```python
content.append(self.dynamic_context.text)
```
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc68dcd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc68dcd-python \
  ghcr.io/openhands/agent-server:dc68dcd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc68dcd-golang-amd64
ghcr.io/openhands/agent-server:dc68dcd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc68dcd-golang-arm64
ghcr.io/openhands/agent-server:dc68dcd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc68dcd-java-amd64
ghcr.io/openhands/agent-server:dc68dcd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc68dcd-java-arm64
ghcr.io/openhands/agent-server:dc68dcd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc68dcd-python-amd64
ghcr.io/openhands/agent-server:dc68dcd-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:dc68dcd-python-arm64
ghcr.io/openhands/agent-server:dc68dcd-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:dc68dcd-golang
ghcr.io/openhands/agent-server:dc68dcd-java
ghcr.io/openhands/agent-server:dc68dcd-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc68dcd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc68dcd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->