### PR TITLE
add test for hanging command

### DIFF
--- a/tests/agent_server/test_long_running_commands.py
+++ b/tests/agent_server/test_long_running_commands.py
@@ -50,7 +50,7 @@ async def test_long_running_command_respects_timeout(bash_service):
 # ---------------------------------------------------------------------------
 def test_server_stays_responsive_during_long_command():
     """While /execute_bash_command is blocked on a slow task,
-    other endpoints (e.g. /info) must still respond promptly."""
+    other endpoints (e.g. /health) must still respond promptly."""
 
     from openhands.agent_server.api import create_app
     from openhands.agent_server.config import Config
@@ -60,8 +60,8 @@ def test_server_stays_responsive_during_long_command():
 
     # Use a real TestClient (runs the ASGI app in a thread)
     with TestClient(app, raise_server_exceptions=False) as client:
-        # Sanity: server is up
-        r = client.get("/info")
+        # Sanity: server is up (use /health which always returns 200)
+        r = client.get("/health")
         assert r.status_code == 200
 
         # Fire a 5-second command with a 2-second timeout via the sync endpoint.


### PR DESCRIPTION
## Summary

I suspect long-running commands are hanging the agent-server. Adding tests to validate/refute.

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b31153f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b31153f-python \
  ghcr.io/openhands/agent-server:b31153f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b31153f-golang-amd64
ghcr.io/openhands/agent-server:b31153f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b31153f-golang-arm64
ghcr.io/openhands/agent-server:b31153f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b31153f-java-amd64
ghcr.io/openhands/agent-server:b31153f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b31153f-java-arm64
ghcr.io/openhands/agent-server:b31153f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b31153f-python-amd64
ghcr.io/openhands/agent-server:b31153f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:b31153f-python-arm64
ghcr.io/openhands/agent-server:b31153f-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:b31153f-golang
ghcr.io/openhands/agent-server:b31153f-java
ghcr.io/openhands/agent-server:b31153f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b31153f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b31153f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->