### PR TITLE
Add gpt-5.3-codex model configuration

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -135,6 +135,11 @@ MODELS = {
             "reasoning_effort": "high",
         },
     },
+    "gpt-5.3-codex": {
+        "id": "gpt-5.3-codex",
+        "display_name": "GPT-5.3 Codex",
+        "llm_config": {"model": "litellm_proxy/gpt-5.3-codex"},
+    },
     "minimax-m2": {
         "id": "minimax-m2",
         "display_name": "MiniMax M2",

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -15,9 +15,9 @@ run_eval_path = Path(__file__).parent.parent.parent / ".github" / "run-eval"
 sys.path.append(str(run_eval_path))
 from resolve_model_config import (  # noqa: E402  # type: ignore[import-not-found]
     MODELS,
+    check_model,
     find_models_by_id,
     run_preflight_check,
-    test_model,
 )
 
 
@@ -112,8 +112,8 @@ def test_find_models_by_id_single_model():
         result = find_models_by_id(model_ids)
 
     assert len(result) == 1
-    assert result[0]["id"] == "claude-sonnet-4-5-20250929"
-    assert result[0]["display_name"] == "Claude Sonnet 4.5"
+    assert result[0]["id"] == "gpt-4"
+    assert result[0]["display_name"] == "GPT-4"
 
 
 def test_find_models_by_id_multiple_models():
@@ -129,8 +129,8 @@ def test_find_models_by_id_multiple_models():
         result = find_models_by_id(model_ids)
 
     assert len(result) == 2
-    assert result[0]["id"] == "claude-sonnet-4-5-20250929"
-    assert result[1]["id"] == "deepseek-chat"
+    assert result[0]["id"] == "gpt-4"
+    assert result[1]["id"] == "claude-3"
 
 
 def test_find_models_by_id_preserves_order():
@@ -197,11 +197,11 @@ def test_find_models_by_id_preserves_full_config():
         result = find_models_by_id(model_ids)
 
     assert len(result) == 1
-    assert result[0]["id"] == "claude-sonnet-4-5-20250929"
-    assert (
-        result[0]["llm_config"]["model"] == "litellm_proxy/claude-sonnet-4-5-20250929"
-    )
-    assert result[0]["llm_config"]["temperature"] == 0.0
+    assert result[0]["id"] == "custom-model"
+    assert result[0]["llm_config"]["model"] == "custom-model"
+    assert result[0]["llm_config"]["api_key"] == "test-key"
+    assert result[0]["llm_config"]["base_url"] == "https://example.com"
+    assert result[0]["extra_field"] == "should be preserved"
 
 
 def test_all_models_valid_with_pydantic():
@@ -240,6 +240,15 @@ def test_gpt_5_2_high_reasoning_config():
     assert model["llm_config"]["reasoning_effort"] == "high"
 
 
+def test_gpt_5_3_codex_config():
+    """Test that gpt-5.3-codex has correct configuration."""
+    model = MODELS["gpt-5.3-codex"]
+
+    assert model["id"] == "gpt-5.3-codex"
+    assert model["display_name"] == "GPT-5.3 Codex"
+    assert model["llm_config"]["model"] == "litellm_proxy/gpt-5.3-codex"
+
+
 def test_gpt_oss_20b_config():
     """Test that gpt-oss-20b has correct configuration."""
     model = MODELS["gpt-oss-20b"]
@@ -262,8 +271,8 @@ def test_glm_5_config():
 # Tests for preflight check functionality
 
 
-class TestTestModel:
-    """Tests for the test_model function."""
+class TestCheckModel:
+    """Tests for the check_model function."""
 
     def test_successful_response(self):
         """Test that a successful model response returns True."""
@@ -275,7 +284,7 @@ class TestTestModel:
         mock_response.choices = [MagicMock(message=MagicMock(content="OK"))]
 
         with patch("litellm.completion", return_value=mock_response):
-            success, message = test_model(model_config, "test-key", "https://test.com")
+            success, message = check_model(model_config, "test-key", "https://test.com")
 
         assert success is True
         assert "✓" in message
@@ -291,7 +300,7 @@ class TestTestModel:
         mock_response.choices = [MagicMock(message=MagicMock(content=""))]
 
         with patch("litellm.completion", return_value=mock_response):
-            success, message = test_model(model_config, "test-key", "https://test.com")
+            success, message = check_model(model_config, "test-key", "https://test.com")
 
         assert success is False
         assert "✗" in message
@@ -312,7 +321,7 @@ class TestTestModel:
                 message="Timeout", model="test-model", llm_provider="test"
             ),
         ):
-            success, message = test_model(model_config, "test-key", "https://test.com")
+            success, message = check_model(model_config, "test-key", "https://test.com")
 
         assert success is False
         assert "✗" in message
@@ -333,7 +342,7 @@ class TestTestModel:
                 message="Connection failed", llm_provider="test", model="test-model"
             ),
         ):
-            success, message = test_model(model_config, "test-key", "https://test.com")
+            success, message = check_model(model_config, "test-key", "https://test.com")
 
         assert success is False
         assert "✗" in message
@@ -354,7 +363,7 @@ class TestTestModel:
                 "Model not found", llm_provider="test", model="test-model"
             ),
         ):
-            success, message = test_model(model_config, "test-key", "https://test.com")
+            success, message = check_model(model_config, "test-key", "https://test.com")
 
         assert success is False
         assert "✗" in message
@@ -374,7 +383,7 @@ class TestTestModel:
         mock_response.choices = [MagicMock(message=MagicMock(content="OK"))]
 
         with patch("litellm.completion", return_value=mock_response) as mock_completion:
-            test_model(model_config, "test-key", "https://test.com")
+            check_model(model_config, "test-key", "https://test.com")
 
         mock_completion.assert_called_once()
         call_kwargs = mock_completion.call_args[1]


### PR DESCRIPTION
## Summary

This PR adds support for the gpt-5.3-codex model to the evaluation system by adding it to the MODELS dictionary in `resolve_model_config.py`.

Changes include:
- Added gpt-5.3-codex model configuration to the MODELS dictionary
- Added test case for gpt-5.3-codex to validate its configuration
- Fixed test import issue (test_model → check_model) 
- Fixed incorrect assertions in existing tests that were checking wrong model IDs

Fixes #2285

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
  - Yes, added `test_gpt_5_3_codex_config()` test
- [x] If there is an example, have you run the example to make sure that it works?
  - N/A - This is a configuration change, not an example
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
  - Yes, ran all tests in `test_resolve_model_config.py` and they pass
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
  - N/A - This is a minor configuration addition, no documentation update needed
- [ ] Is the github CI passing?
  - Will be verified after PR creation
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:009e72e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-009e72e-python \
  ghcr.io/openhands/agent-server:009e72e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:009e72e-golang-amd64
ghcr.io/openhands/agent-server:009e72e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:009e72e-golang-arm64
ghcr.io/openhands/agent-server:009e72e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:009e72e-java-amd64
ghcr.io/openhands/agent-server:009e72e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:009e72e-java-arm64
ghcr.io/openhands/agent-server:009e72e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:009e72e-python-amd64
ghcr.io/openhands/agent-server:009e72e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:009e72e-python-arm64
ghcr.io/openhands/agent-server:009e72e-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:009e72e-golang
ghcr.io/openhands/agent-server:009e72e-java
ghcr.io/openhands/agent-server:009e72e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `009e72e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `009e72e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->