### PR TITLE
Fix API breakage workflow exit codes

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -38,8 +38,9 @@ jobs:
               continue-on-error: ${{ !startsWith(github.head_ref, 'rel-') }}
               run: |
                   uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py 2>&1 | tee api-breakage.log
-                  echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-                  exit "${PIPESTATUS[0]}"
+                  exit_code=${PIPESTATUS[0]}
+                  echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+                  exit "${exit_code}"
 
             - name: Post REST API breakage report to PR
               if: ${{ always() && github.event_name == 'pull_request' }}

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -30,8 +30,9 @@ jobs:
               continue-on-error: ${{ !startsWith(github.head_ref, 'rel-') }}
               run: |
                   uv run python .github/scripts/check_sdk_api_breakage.py 2>&1 | tee api-breakage.log
-                  echo "exit_code=${PIPESTATUS[0]}" >> "$GITHUB_OUTPUT"
-                  exit "${PIPESTATUS[0]}"
+                  exit_code=${PIPESTATUS[0]}
+                  echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
+                  exit "${exit_code}"
             - name: Post API breakage report to PR
               if: ${{ always() && github.event_name == 'pull_request' }}
               uses: actions/github-script@v7


### PR DESCRIPTION
## Summary
- Preserve the API breakage workflows' exit codes by capturing PIPESTATUS before any subsequent commands.
- Apply the same fix to the OpenAPI (oasdiff) workflow.

## Context
A test-only PR (now closed) demonstrated that both workflows always exited 0 because PIPESTATUS was read after `echo`, so rel-* PRs did not actually fail on breakage. This PR applies the minimal fix directly on main.

## Testing
- uv run pre-commit run --files .github/workflows/api-breakage.yml
- uv run pre-commit run --files .github/workflows/agent-server-rest-api-breakage.yml

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6d97de0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6d97de0-python \
  ghcr.io/openhands/agent-server:6d97de0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6d97de0-golang-amd64
ghcr.io/openhands/agent-server:6d97de0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6d97de0-golang-arm64
ghcr.io/openhands/agent-server:6d97de0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6d97de0-java-amd64
ghcr.io/openhands/agent-server:6d97de0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6d97de0-java-arm64
ghcr.io/openhands/agent-server:6d97de0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6d97de0-python-amd64
ghcr.io/openhands/agent-server:6d97de0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:6d97de0-python-arm64
ghcr.io/openhands/agent-server:6d97de0-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:6d97de0-golang
ghcr.io/openhands/agent-server:6d97de0-java
ghcr.io/openhands/agent-server:6d97de0-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6d97de0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6d97de0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->