### PR TITLE
Normalize OpenAPI schema for oasdiff

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -172,15 +172,19 @@ def _normalize_openapi_for_oasdiff(schema: dict) -> dict:
 
     def _walk(node: object) -> None:
         if isinstance(node, dict):
-            if "exclusiveMinimum" in node and isinstance(
-                node["exclusiveMinimum"], (int, float)
+            if (
+                "exclusiveMinimum" in node
+                and isinstance(node["exclusiveMinimum"], (int, float))
+                and not isinstance(node["exclusiveMinimum"], bool)
             ):
                 value = node["exclusiveMinimum"]
                 if "minimum" not in node:
                     node["minimum"] = value
                 node["exclusiveMinimum"] = True
-            if "exclusiveMaximum" in node and isinstance(
-                node["exclusiveMaximum"], (int, float)
+            if (
+                "exclusiveMaximum" in node
+                and isinstance(node["exclusiveMaximum"], (int, float))
+                and not isinstance(node["exclusiveMaximum"], bool)
             ):
                 value = node["exclusiveMaximum"]
                 if "maximum" not in node:

--- a/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
+++ b/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
@@ -270,3 +270,17 @@ def test_normalize_openapi_preserves_boolean_exclusive():
 
     assert normalized["exclusiveMinimum"] is True
     assert normalized["minimum"] == 4
+
+
+def test_normalize_openapi_boolean_exclusive_without_minimum():
+    schema = {
+        "exclusiveMinimum": True,
+        "exclusiveMaximum": False,
+    }
+
+    normalized = _normalize_openapi_for_oasdiff(schema)
+
+    assert normalized["exclusiveMinimum"] is True
+    assert normalized["exclusiveMaximum"] is False
+    assert "minimum" not in normalized
+    assert "maximum" not in normalized


### PR DESCRIPTION
## Summary
- Normalize OpenAPI 3.1 numeric exclusiveMinimum/exclusiveMaximum values before running oasdiff.
- Eliminates oasdiff parse failures (exit code 102) so the breakage check reports real diffs.

## Context
oasdiff expects OpenAPI 3.0-style boolean exclusiveMinimum/exclusiveMaximum, but FastAPI emits numeric values in OpenAPI 3.1. This caused oasdiff to fail to parse the previous spec and emit exit code 102.

## Testing
- uv run pre-commit run --files .github/scripts/check_agent_server_rest_api_breakage.py
- PATH="$(pwd)/.agent_tmp/bin:$PATH" uv run python .github/scripts/check_agent_server_rest_api_breakage.py




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c6f2b72-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c6f2b72-python \
  ghcr.io/openhands/agent-server:c6f2b72-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c6f2b72-golang-amd64
ghcr.io/openhands/agent-server:c6f2b72-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c6f2b72-golang-arm64
ghcr.io/openhands/agent-server:c6f2b72-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c6f2b72-java-amd64
ghcr.io/openhands/agent-server:c6f2b72-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c6f2b72-java-arm64
ghcr.io/openhands/agent-server:c6f2b72-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c6f2b72-python-amd64
ghcr.io/openhands/agent-server:c6f2b72-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:c6f2b72-python-arm64
ghcr.io/openhands/agent-server:c6f2b72-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:c6f2b72-golang
ghcr.io/openhands/agent-server:c6f2b72-java
ghcr.io/openhands/agent-server:c6f2b72-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c6f2b72-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c6f2b72-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->