### PR TITLE
refactor: deprecate delete_on_close in LocalConversation

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -74,7 +74,6 @@ class Conversation:
             type[ConversationVisualizerBase] | ConversationVisualizerBase | None
         ) = DefaultConversationVisualizer,
         secrets: dict[str, SecretValue] | dict[str, str] | None = None,
-        delete_on_close: bool = False,
     ) -> "LocalConversation": ...
 
     @overload
@@ -163,5 +162,4 @@ class Conversation:
             workspace=workspace,
             persistence_dir=persistence_dir,
             secrets=secrets,
-            delete_on_close=delete_on_close,
         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -53,6 +53,7 @@ from openhands.sdk.subagent import (
 )
 from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.deprecation import warn_deprecated
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -71,7 +72,6 @@ class LocalConversation(BaseConversation):
     llm_registry: LLMRegistry
     _cleanup_initiated: bool
     _hook_processor: HookEventProcessor | None
-    delete_on_close: bool = True
     # Plugin lazy loading state
     _plugin_specs: list[PluginSource] | None
     _resolved_plugins: list[ResolvedPluginSource] | None
@@ -97,7 +97,6 @@ class LocalConversation(BaseConversation):
             type[ConversationVisualizerBase] | ConversationVisualizerBase | None
         ) = DefaultConversationVisualizer,
         secrets: Mapping[str, SecretValue] | None = None,
-        delete_on_close: bool = True,
         cipher: Cipher | None = None,
         **_: object,
     ):
@@ -139,6 +138,17 @@ class LocalConversation(BaseConversation):
                    decrypted when loading. If not provided, secrets are redacted
                    (lost) on serialization.
         """
+        if "delete_on_close" in _:
+            warn_deprecated(
+                "LocalConversation(delete_on_close=...)",
+                deprecated_in="1.11.5",
+                removed_in="1.14.0",
+                details=(
+                    "delete_on_close has no effect on LocalConversation. "
+                    "Tool executors are now always cleaned up on close()."
+                ),
+            )
+
         super().__init__()  # Initialize with span tracking
         # Mark cleanup as initiated as early as possible to avoid races or partially
         # initialized instances during interpreter shutdown.
@@ -259,7 +269,6 @@ class LocalConversation(BaseConversation):
 
         atexit.register(self.close)
         self._start_observability_span(str(desired_id))
-        self.delete_on_close = delete_on_close
 
     @property
     def id(self) -> ConversationID:
@@ -767,8 +776,8 @@ class LocalConversation(BaseConversation):
         except AttributeError:
             # Object may be partially constructed; span fields may be missing.
             pass
-        # Always close tool executors to release OS resources (browser
-        # processes, terminal sessions, etc.), regardless of delete_on_close.
+        # Close tool executors to release OS resources (browser
+        # processes, terminal sessions, etc.).
         try:
             tools_map = self.agent.tools_map
         except (AttributeError, RuntimeError):

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -167,7 +167,6 @@ class TaskManager:
             workspace=self.parent_conversation.state.workspace.working_dir,
             persistence_dir=self._tmp_dir,
             conversation_id=conversation_id,
-            delete_on_close=False,
         )
 
         self._tasks[resume] = self._tasks[resume].model_copy(
@@ -247,7 +246,6 @@ class TaskManager:
             persistence_dir=self._tmp_dir,
             conversation_id=conversation_id,
             max_iteration_per_run=max_iteration_per_run,
-            delete_on_close=False,
         )
 
     def _get_sub_agent(self, subagent_type: str) -> Agent:

--- a/tests/sdk/conversation/test_conversation_factory.py
+++ b/tests/sdk/conversation/test_conversation_factory.py
@@ -1,9 +1,11 @@
 """Tests for Conversation factory functionality."""
 
 import uuid
+import warnings
 from unittest.mock import Mock, patch
 
 import pytest
+from deprecation import DeprecatedWarning
 from pydantic import SecretStr
 
 from openhands.sdk import Agent, Conversation
@@ -117,3 +119,29 @@ def test_conversation_factory_type_inference(mock_ws_client, agent, remote_works
 
     assert isinstance(local_conv, LocalConversation)
     assert isinstance(remote_conv, RemoteConversation)
+
+
+def test_local_conversation_delete_on_close_emits_deprecation(agent):
+    """Passing delete_on_close to LocalConversation emits a deprecation warning."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        conv = LocalConversation(agent=agent, workspace="", delete_on_close=True)
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecatedWarning)
+    ]
+    assert len(deprecation_warnings) == 1
+    assert "delete_on_close" in str(deprecation_warnings[0].message)
+    assert not hasattr(conv, "delete_on_close")
+
+
+def test_local_conversation_no_deprecation_without_delete_on_close(agent):
+    """No deprecation warning when delete_on_close is not passed."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        LocalConversation(agent=agent, workspace="")
+
+    deprecation_warnings = [
+        w for w in caught if issubclass(w.category, DeprecatedWarning)
+    ]
+    assert len(deprecation_warnings) == 0

--- a/tests/sdk/conversation/test_repo_root_project_skills.py
+++ b/tests/sdk/conversation/test_repo_root_project_skills.py
@@ -58,7 +58,6 @@ def test_system_prompt_includes_repo_root_agents_md_when_workdir_is_subdir(
         agent=agent,
         workspace=subdir,
         persistence_dir=tmp_path / "conversation",
-        delete_on_close=True,
     )
     conversation.send_message("hi")
 

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -35,7 +35,6 @@ def _make_parent_conversation(tmp_path: Path) -> LocalConversation:
         agent=agent,
         workspace=str(tmp_path),
         visualizer=None,
-        delete_on_close=False,
     )
 
 

--- a/tests/tools/terminal/test_conversation_cleanup.py
+++ b/tests/tools/terminal/test_conversation_cleanup.py
@@ -34,10 +34,7 @@ def test_conversation_close_calls_executor_close(mock_llm):
             llm=mock_llm,
             tools=[Tool(name="test_terminal")],
         )
-        # delete_on_close=True is required to trigger executor cleanup
-        conversation = Conversation(
-            agent=agent, workspace=temp_dir, delete_on_close=True
-        )
+        conversation = Conversation(agent=agent, workspace=temp_dir)
 
         # Trigger lazy agent initialization to create tools
         conversation._ensure_agent_ready()
@@ -70,10 +67,7 @@ def test_conversation_del_calls_close(mock_llm):
             llm=mock_llm,
             tools=[Tool(name="test_terminal")],
         )
-        # delete_on_close=True is required to trigger executor cleanup
-        conversation = Conversation(
-            agent=agent, workspace=temp_dir, delete_on_close=True
-        )
+        conversation = Conversation(agent=agent, workspace=temp_dir)
 
         # Trigger lazy agent initialization to create tools
         conversation._ensure_agent_ready()


### PR DESCRIPTION
## Summary

After PR #2316 made tool executor cleanup unconditional in `LocalConversation.close()`, the `delete_on_close` field became dead code in `LocalConversation`. This PR properly deprecates it following the SDK's deprecation policy.

Follows up on [this review comment](https://github.com/OpenHands/software-agent-sdk/pull/2316#discussion_r2126523780) from @xingyaoww.

### Changes

- **Remove** `delete_on_close` class attribute and `self.delete_on_close` assignment from `LocalConversation`
- **Emit `DeprecatedWarning`** when `delete_on_close` is passed as a kwarg to `LocalConversation.__init__` (absorbed by the existing `**_` catch-all for backward compatibility)
- **Stop passing** `delete_on_close` from `Conversation` factory to `LocalConversation`
- **Remove** `delete_on_close=False` from `TaskManager`'s `LocalConversation` calls
- **Update tests** to remove `delete_on_close` references
- **Add deprecation warning tests**

> **Note:** `delete_on_close` remains active in `RemoteConversation` where it controls server-side resource deletion via the DELETE API call.

## Test plan

- All existing tests pass (50 tests across cleanup, factory, task manager, and skills tests)
- New tests verify the deprecation warning is emitted when `delete_on_close` is passed to `LocalConversation` and not emitted when omitted
- Pre-commit checks (ruff, pyright, pycodestyle) all pass
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2003c08-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2003c08-python \
  ghcr.io/openhands/agent-server:2003c08-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2003c08-golang-amd64
ghcr.io/openhands/agent-server:2003c08-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2003c08-golang-arm64
ghcr.io/openhands/agent-server:2003c08-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2003c08-java-amd64
ghcr.io/openhands/agent-server:2003c08-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2003c08-java-arm64
ghcr.io/openhands/agent-server:2003c08-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2003c08-python-amd64
ghcr.io/openhands/agent-server:2003c08-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:2003c08-python-arm64
ghcr.io/openhands/agent-server:2003c08-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:2003c08-golang
ghcr.io/openhands/agent-server:2003c08-java
ghcr.io/openhands/agent-server:2003c08-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2003c08-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2003c08-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->