### PR TITLE
feat(sdk/subagent): working_dir in file-based agents

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -373,10 +373,7 @@ class LocalConversation(BaseConversation):
 
         # Register file-based agents defined in plugins
         if all_plugin_agents:
-            register_plugin_agents(
-                agents=all_plugin_agents,
-                work_dir=self.workspace.working_dir,
-            )
+            register_plugin_agents(agents=all_plugin_agents)
 
         # Combine explicit hook_config with plugin hooks
         # Explicit hooks run first (before plugin hooks)

--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -158,7 +158,6 @@ def _get_profile_store() -> LLMProfileStore:
 
 def agent_definition_to_factory(
     agent_def: AgentDefinition,
-    work_dir: str | Path | None = None,
 ) -> Callable[["LLM"], "Agent"]:
     """Create an agent factory closure from an `AgentDefinition`.
 
@@ -168,6 +167,7 @@ def agent_definition_to_factory(
     - Tool names from `agent_def.tools` are mapped to `Tool` objects.
     - Skill names from `agent_def.skills` are resolved to `Skill` objects
       from project and user skill directories (project takes priority).
+      The project directory is taken from `agent_def.working_dir`.
     - The system prompt is set as the `system_message_suffix` on the
       `AgentContext`.
     - `model: inherit` preserves the parent LLM; an explicit model name
@@ -178,8 +178,6 @@ def agent_definition_to_factory(
 
     Args:
         agent_def: The agent definition to convert.
-        work_dir: Project directory for resolving skill names. If None,
-            only user-level skills are searched.
 
     Raises:
         ValueError: If a tool or skill is not found.
@@ -191,7 +189,10 @@ def agent_definition_to_factory(
         from openhands.sdk.context.skills import load_available_skills
 
         available = load_available_skills(
-            work_dir, include_user=True, include_project=True, include_public=False
+            agent_def.working_dir,
+            include_user=True,
+            include_project=True,
+            include_public=False,
         )
 
         for name in agent_def.skills:
@@ -286,7 +287,10 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
 
     registered: list[str] = []
     for agent_def in deduplicated:
-        factory = agent_definition_to_factory(agent_def, work_dir=work_dir)
+        # Set working_dir from the project if not explicitly defined
+        if agent_def.working_dir is None:
+            agent_def = agent_def.model_copy(update={"working_dir": str(work_dir)})
+        factory = agent_definition_to_factory(agent_def)
         was_registered = register_agent_if_absent(
             name=agent_def.name,
             factory_func=factory,
@@ -304,7 +308,6 @@ def register_file_agents(work_dir: str | Path) -> list[str]:
 
 def register_plugin_agents(
     agents: list[AgentDefinition],
-    work_dir: str | Path | None = None,
 ) -> list[str]:
     """Register plugin-provided agent definitions into the delegate registry.
 
@@ -313,17 +316,18 @@ def register_plugin_agents(
     ``Plugin.agents`` list (which is loaded but not currently registered) into
     the delegate registry.
 
+    Skill resolution uses each agent definition's ``working_dir`` if set;
+    otherwise only user-level skills are searched.
+
     Args:
         agents: Agent definitions collected from loaded plugins.
-        work_dir: Project directory for resolving skill names in agent
-            definitions. If None, only user-level skills are searched.
 
     Returns:
         List of agent names that were actually registered.
     """
     registered: list[str] = []
     for agent_def in agents:
-        factory = agent_definition_to_factory(agent_def, work_dir=work_dir)
+        factory = agent_definition_to_factory(agent_def)
         was_registered = register_agent_if_absent(
             name=agent_def.name,
             factory_func=factory,

--- a/openhands-sdk/openhands/sdk/subagent/schema.py
+++ b/openhands-sdk/openhands/sdk/subagent/schema.py
@@ -18,6 +18,7 @@ KNOWN_FIELDS: Final[set[str]] = {
     "tools",
     "skills",
     "max_iteration_per_run",
+    "working_dir",
 }
 
 
@@ -54,6 +55,16 @@ def _extract_skills(fm: dict[str, object]) -> list[str]:
     else:
         skills = []
     return skills
+
+
+def _extract_working_dir(fm: dict[str, object]) -> str | None:
+    """Extract working directory from frontmatter."""
+    working_dir_raw = fm.get("working_dir")
+    if working_dir_raw is None:
+        return working_dir_raw
+    if isinstance(working_dir_raw, str):
+        return working_dir_raw
+    raise ValueError(f"working_dir must be a str or None, got {type(working_dir_raw)}")
 
 
 def _extract_examples(description: str) -> list[str]:
@@ -102,6 +113,11 @@ class AgentDefinition(BaseModel):
         default_factory=list,
         description="Examples of when to use this agent (for triggering)",
     )
+    working_dir: str | None = Field(
+        default=None,
+        description="Working directory for the subagent. "
+        "If None, inherits the parent conversation's working directory.",
+    )
     max_iteration_per_run: int | None = Field(
         default=None,
         description="Maximum iterations per run. "
@@ -147,6 +163,7 @@ class AgentDefinition(BaseModel):
         tools: list[str] = _extract_tools(fm)
         skills: list[str] = _extract_skills(fm)
         max_iteration_per_run: int | None = _extract_max_iteration_per_run(fm)
+        working_dir = _extract_working_dir(fm)
 
         # Extract whenToUse examples from description
         when_to_use_examples = _extract_examples(description)
@@ -161,6 +178,7 @@ class AgentDefinition(BaseModel):
             color=color,
             tools=tools,
             skills=skills,
+            working_dir=working_dir,
             max_iteration_per_run=max_iteration_per_run,
             system_prompt=content,
             source=str(agent_path),

--- a/openhands-tools/openhands/tools/delegate/impl.py
+++ b/openhands-tools/openhands/tools/delegate/impl.py
@@ -144,10 +144,18 @@ class DelegateExecutor(ToolExecutor):
                 if parent_visualizer is not None:
                     sub_visualizer = parent_visualizer.create_sub_visualizer(agent_id)
 
+                # Use working_dir from agent definition if set,
+                # otherwise inherit from parent
+                effective_workspace = (
+                    factory.definition.working_dir
+                    if factory.definition.working_dir
+                    else workspace_path
+                )
+
                 # Use max_iteration_per_run from agent definition if set
                 conv_kwargs: dict = {
                     "agent": worker_agent,
-                    "workspace": workspace_path,
+                    "workspace": effective_workspace,
                     "visualizer": sub_visualizer,
                 }
 

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -160,11 +160,19 @@ class TaskManager:
                 f"Available tasks: {', '.join(sorted(self._tasks))}"
             )
 
-        worker_agent = self._get_sub_agent(subagent_type)
+        factory = get_agent_factory(subagent_type)
+        worker_agent = self._get_sub_agent_from_factory(factory)
         conversation_id = self._tasks[resume].conversation_id
+
+        # Use working_dir from agent definition if set,
+        # otherwise inherit from parent
+        workspace = (
+            factory.definition.working_dir
+            or self.parent_conversation.state.workspace.working_dir
+        )
         conversation = LocalConversation(
             agent=worker_agent,
-            workspace=self.parent_conversation.state.workspace.working_dir,
+            workspace=workspace,
             persistence_dir=self._tmp_dir,
             conversation_id=conversation_id,
             delete_on_close=False,
@@ -214,6 +222,7 @@ class TaskManager:
             task_id=task_id,
             worker_agent=worker_agent,
             conversation_id=conversation_id,
+            working_dir=factory.definition.working_dir,
         )
 
         self._tasks[task_id] = Task(
@@ -231,9 +240,14 @@ class TaskManager:
         task_id: str,
         conversation_id: uuid.UUID,
         worker_agent: Agent,
+        working_dir: str | None = None,
     ) -> LocalConversation:
         parent = self.parent_conversation
         parent_visualizer = parent._visualizer
+
+        # Use working_dir from agent definition if set,
+        # otherwise inherit from parent
+        workspace = working_dir or parent.state.workspace.working_dir
 
         visualizer = None
         if parent_visualizer is not None:
@@ -242,7 +256,7 @@ class TaskManager:
 
         return LocalConversation(
             agent=worker_agent,
-            workspace=parent.state.workspace.working_dir,
+            workspace=workspace,
             visualizer=visualizer,
             persistence_dir=self._tmp_dir,
             conversation_id=conversation_id,

--- a/tests/sdk/subagent/test_subagent_registry.py
+++ b/tests/sdk/subagent/test_subagent_registry.py
@@ -114,7 +114,7 @@ def test_register_plugin_agents(tmp_path: Path) -> None:
         system_prompt="Plugin prompt.",
     )
 
-    registered = register_plugin_agents([plugin_agent], work_dir=tmp_path)
+    registered = register_plugin_agents([plugin_agent])
 
     assert registered == ["plugin-agent"]
     factory = get_agent_factory("plugin-agent")
@@ -141,7 +141,7 @@ def test_register_plugin_agents_skips_existing(tmp_path: Path) -> None:
         system_prompt="",
     )
 
-    registered = register_plugin_agents([plugin_agent], work_dir=tmp_path)
+    registered = register_plugin_agents([plugin_agent])
     assert registered == []
     # Programmatic version still there
     factory = get_agent_factory("my-agent")
@@ -258,9 +258,10 @@ def test_agent_definition_to_factory_with_skills(tmp_path: Path) -> None:
         tools=[],
         skills=["test-skill"],
         system_prompt="You are a skilled agent.",
+        working_dir=str(tmp_path),
     )
 
-    factory = agent_definition_to_factory(agent_def, work_dir=tmp_path)
+    factory = agent_definition_to_factory(agent_def)
     llm = _make_test_llm()
     agent = factory(llm)
 
@@ -284,9 +285,10 @@ def test_agent_definition_to_factory_skills_only_no_prompt(tmp_path: Path) -> No
         tools=[],
         skills=["only-skill"],
         system_prompt="",
+        working_dir=str(tmp_path),
     )
 
-    factory = agent_definition_to_factory(agent_def, work_dir=tmp_path)
+    factory = agent_definition_to_factory(agent_def)
     llm = _make_test_llm()
     agent = factory(llm)
 
@@ -343,10 +345,11 @@ def test_agent_definition_to_factory_skills_project_over_user(tmp_path: Path) ->
     agent_def = AgentDefinition(
         name="priority-agent",
         skills=["shared-skill"],
+        working_dir=str(tmp_path),
     )
 
     with patch("openhands.sdk.context.skills.skill.Path.home", return_value=user_home):
-        factory = agent_definition_to_factory(agent_def, work_dir=tmp_path)
+        factory = agent_definition_to_factory(agent_def)
 
     llm = _make_test_llm()
     agent = factory(llm)


### PR DESCRIPTION
## Summary

Add `working_dir` to `AgentDefinition`
                                                                                                                                                                                                                    Move the subagent working directory configuration into AgentDefinition so it can be set at agent definition time — either programmatically or via markdown frontmatter.

In this way you can define agents which have access to a very specific part of the repo (for example the front-end).

## Changes
- Add working_dir field to AgentDefinition (defaults to None, inheriting from parent)
- DelegateExecutor and TaskManager use definition.working_dir when spawning subagent conversations, falling back to the parent's workspace
- Remove work_dir parameter from register_plugin_agents — skill resolution now falls back to agent_def.working_dir

## Usage

```python
  AgentDefinition(name="my_agent", working_dir="/some/path", ...)
```

or

```text
  ---
  name: my_agent
  working_dir: /some/path
  ---
```

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:242a637-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-242a637-python \
  ghcr.io/openhands/agent-server:242a637-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:242a637-golang-amd64
ghcr.io/openhands/agent-server:242a637-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:242a637-golang-arm64
ghcr.io/openhands/agent-server:242a637-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:242a637-java-amd64
ghcr.io/openhands/agent-server:242a637-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:242a637-java-arm64
ghcr.io/openhands/agent-server:242a637-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:242a637-python-amd64
ghcr.io/openhands/agent-server:242a637-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:242a637-python-arm64
ghcr.io/openhands/agent-server:242a637-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:242a637-golang
ghcr.io/openhands/agent-server:242a637-java
ghcr.io/openhands/agent-server:242a637-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `242a637-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `242a637-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->