### PR TITLE
feat(sdk): merge MCP config from user-level skills into agent

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/skills/__init__.py
@@ -2,6 +2,7 @@ from openhands.sdk.context.skills.exceptions import SkillValidationError
 from openhands.sdk.context.skills.skill import (
     Skill,
     SkillResources,
+    collect_mcp_config,
     load_available_skills,
     load_project_skills,
     load_public_skills,
@@ -29,6 +30,7 @@ __all__ = [
     "KeywordTrigger",
     "TaskTrigger",
     "SkillKnowledge",
+    "collect_mcp_config",
     "load_available_skills",
     "load_skills_from_dir",
     "load_user_skills",

--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -2,7 +2,7 @@ import io
 import json
 import re
 from pathlib import Path
-from typing import Annotated, ClassVar, Literal, Union
+from typing import Annotated, Any, ClassVar, Literal, Union
 from xml.sax.saxutils import escape as xml_escape
 
 import frontmatter
@@ -1150,3 +1150,20 @@ def to_prompt(skills: list[Skill], max_description_length: int = 200) -> str:
 
     lines.append("</available_skills>")
     return "\n".join(lines)
+
+
+def collect_mcp_config(skills: list[Skill]) -> dict[str, Any]:
+    """Collect and merge MCP configs from skills that have mcp_tools.
+
+    Later skills override earlier ones by server name, consistent with
+    plugin merge semantics.
+    """
+    merged: dict[str, Any] = {}
+    for skill in skills:
+        if not skill.mcp_tools:
+            continue
+        servers = skill.mcp_tools.get("mcpServers", {})
+        if not servers:
+            continue
+        merged.setdefault("mcpServers", {}).update(servers)
+    return merged

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context.prompts.prompt import render_template
+from openhands.sdk.context.skills import collect_mcp_config
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.exceptions import ConversationRunError
 from openhands.sdk.conversation.secret_registry import SecretValue
@@ -455,6 +456,25 @@ class LocalConversation(BaseConversation):
 
             # Load plugins first (merges skills, MCP config, hooks)
             self._ensure_plugins_loaded()
+
+            # Merge MCP configs from already-loaded skills into the agent.
+            # Skills are loaded into agent_context by AgentContext._load_auto_skills
+            # and by _ensure_plugins_loaded, so we reuse them rather than re-reading
+            # the filesystem. Skill MCP has lower priority than the agent's existing
+            # mcp_config (which already includes plugin overrides).
+            if self.agent.agent_context:
+                skill_mcp = collect_mcp_config(self.agent.agent_context.skills)
+                if skill_mcp:
+                    skill_servers = skill_mcp.get("mcpServers", {})
+                    agent_servers = self.agent.mcp_config.get("mcpServers", {})
+                    merged_mcp = dict(self.agent.mcp_config)
+                    merged_mcp["mcpServers"] = {
+                        **skill_servers,
+                        **agent_servers,
+                    }
+                    self.agent = self.agent.model_copy(
+                        update={"mcp_config": merged_mcp}
+                    )
 
             # register file-based agents
             self._register_file_based_agents()

--- a/tests/sdk/context/skill/test_collect_mcp_config.py
+++ b/tests/sdk/context/skill/test_collect_mcp_config.py
@@ -1,0 +1,49 @@
+"""Tests for collect_mcp_config."""
+
+from openhands.sdk.context.skills import Skill, collect_mcp_config
+
+
+def _skill(name: str, mcp_tools: dict | None = None) -> Skill:
+    return Skill(name=name, content="placeholder", mcp_tools=mcp_tools)
+
+
+def test_merges_servers_from_multiple_skills():
+    skills = [
+        _skill("a", {"mcpServers": {"s1": {"command": "cmd1"}}}),
+        _skill("b", {"mcpServers": {"s2": {"command": "cmd2"}}}),
+    ]
+    result = collect_mcp_config(skills)
+    assert result == {
+        "mcpServers": {
+            "s1": {"command": "cmd1"},
+            "s2": {"command": "cmd2"},
+        }
+    }
+
+
+def test_later_skills_override_by_server_name():
+    skills = [
+        _skill("a", {"mcpServers": {"s1": {"command": "old"}}}),
+        _skill("b", {"mcpServers": {"s1": {"command": "new"}}}),
+    ]
+    result = collect_mcp_config(skills)
+    assert result == {"mcpServers": {"s1": {"command": "new"}}}
+
+
+def test_skips_skills_without_mcp_tools():
+    skills = [
+        _skill("no-mcp"),
+        _skill("has-mcp", {"mcpServers": {"s1": {"command": "cmd1"}}}),
+        _skill("empty-mcp", {"mcpServers": {}}),
+    ]
+    result = collect_mcp_config(skills)
+    assert result == {"mcpServers": {"s1": {"command": "cmd1"}}}
+
+
+def test_returns_empty_dict_when_no_skills_have_mcp():
+    skills = [_skill("a"), _skill("b")]
+    assert collect_mcp_config(skills) == {}
+
+
+def test_returns_empty_dict_for_empty_list():
+    assert collect_mcp_config([]) == {}


### PR DESCRIPTION
## Problem

Skills loaded from `~/.agents/skills/` (and `~/.openhands/skills/`) can include `.mcp.json` files that define MCP server configurations. These configs are stored on `Skill.mcp_tools` but never merged into the agent's `mcp_config` for standalone user skills — they're effectively unused.

## Solution

Automatically merge MCP configs from user-level skills into the agent's `mcp_config` during conversation initialization:

1. **`collect_mcp_config(skills)`** — new utility in `skill.py` that collects and merges `mcpServers` from all skills that have `mcp_tools`. Later skills override earlier ones by server name, consistent with plugin merge semantics.

2. **`_ensure_agent_ready()`** in `LocalConversation` now calls `load_user_skills()` + `collect_mcp_config()` after plugin loading, merging skill MCP servers into the agent. Skill configs have **lower priority** than explicit `Agent.mcp_config` (using `{**skill_servers, **agent_servers}` ordering), so agent-level config always wins on conflict.

## Example usage

```
# ~/.agents/skills/my-tool/SKILL.md
# ~/.agents/skills/my-tool/.mcp.json
{
  "mcpServers": {
    "my-server": { "command": "npx", "args": ["-y", "my-mcp-server"] }
  }
}
```

The MCP server is automatically available to the agent without passing `mcp_config` programmatically.

## Backward compatibility

- No changes to existing APIs or behavior
- Skills without `.mcp.json` are unaffected
- Explicit `Agent.mcp_config` always takes precedence over skill configs
- Errors during skill MCP loading are caught and logged (non-fatal)
