### PR TITLE
ci: detect ACP minor version bumps

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -32,6 +32,7 @@ import ast
 import json
 import os
 import re
+import subprocess
 import sys
 import tomllib
 import urllib.request
@@ -40,6 +41,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from packaging import version as pkg_version
+from packaging.requirements import Requirement
 
 
 @dataclass(frozen=True)
@@ -81,6 +83,11 @@ PACKAGES: tuple[PackageConfig, ...] = (
     ),
 )
 
+ACP_DEPENDENCY = "agent-client-protocol"
+ACP_SKIP_ENV = "ACP_VERSION_CHECK_SKIP"
+ACP_SKIP_TOKEN = "skip-acp-check"
+ACP_BASE_REF_ENV = "ACP_VERSION_CHECK_BASE_REF"
+
 
 def read_version_from_pyproject(path: str) -> str:
     """Read the version string from a pyproject.toml file."""
@@ -91,6 +98,140 @@ def read_version_from_pyproject(path: str) -> str:
     if not v:
         raise SystemExit(f"Could not read version from {path}")
     return str(v)
+
+
+def _read_pyproject(path: str) -> dict:
+    with open(path, "rb") as f:
+        return tomllib.load(f)
+
+
+def _bool_env(name: str) -> bool:
+    value = os.environ.get(name, "").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def _get_dependency_spec(project_data: dict, dependency: str) -> str | None:
+    deps = project_data.get("project", {}).get("dependencies", [])
+    for dep in deps:
+        if dep.startswith(dependency):
+            return dep
+    return None
+
+
+def _min_version_from_requirement(req_str: str) -> pkg_version.Version | None:
+    try:
+        req = Requirement(req_str)
+    except Exception as exc:
+        print(
+            f"::warning title=ACP version::Unable to parse requirement "
+            f"'{req_str}': {exc}"
+        )
+        return None
+
+    lower_bounds: list[pkg_version.Version] = []
+    for spec in req.specifier:
+        if spec.operator in {">=", ">", "==", "~="}:
+            try:
+                lower_bounds.append(_parse_version(spec.version))
+            except Exception as exc:
+                print(
+                    f"::warning title=ACP version::Unable to parse version "
+                    f"'{spec.version}' from '{req_str}': {exc}"
+                )
+
+    if not lower_bounds:
+        return None
+
+    return max(lower_bounds)
+
+
+def _git_show_file(ref: str, rel_path: str) -> str | None:
+    for candidate in (f"origin/{ref}", ref):
+        result = subprocess.run(
+            ["git", "show", f"{candidate}:{rel_path}"],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            return result.stdout
+    return None
+
+
+def _load_base_pyproject(base_ref: str) -> dict | None:
+    rel_path = "openhands-sdk/pyproject.toml"
+    content = _git_show_file(base_ref, rel_path)
+    if content is None:
+        print(
+            f"::warning title=ACP version::Unable to read {rel_path} from "
+            f"{base_ref}; skipping ACP version check"
+        )
+        return None
+    try:
+        return tomllib.loads(content)
+    except tomllib.TOMLDecodeError as exc:
+        print(
+            f"::warning title=ACP version::Failed to parse {rel_path} from "
+            f"{base_ref}: {exc}"
+        )
+        return None
+
+
+def _check_acp_version_bump(repo_root: str) -> int:
+    if _bool_env(ACP_SKIP_ENV):
+        print(
+            f"::notice title=ACP version::Skipping ACP version check because "
+            f"{ACP_SKIP_ENV} is set (token: [{ACP_SKIP_TOKEN}])."
+        )
+        return 0
+
+    base_ref = os.environ.get(ACP_BASE_REF_ENV) or os.environ.get("GITHUB_BASE_REF")
+    if not base_ref:
+        print(
+            "::warning title=ACP version::No base ref found; skipping ACP version check"
+        )
+        return 0
+
+    base_data = _load_base_pyproject(base_ref)
+    if base_data is None:
+        return 0
+
+    current_data = _read_pyproject(
+        os.path.join(repo_root, "openhands-sdk", "pyproject.toml")
+    )
+    old_req = _get_dependency_spec(base_data, ACP_DEPENDENCY)
+    new_req = _get_dependency_spec(current_data, ACP_DEPENDENCY)
+
+    if not old_req or not new_req:
+        print(
+            f"::warning title=ACP version::Unable to locate {ACP_DEPENDENCY} "
+            "dependency in pyproject.toml; skipping ACP version check"
+        )
+        return 0
+
+    old_min = _min_version_from_requirement(old_req)
+    new_min = _min_version_from_requirement(new_req)
+
+    if old_min is None or new_min is None:
+        print(
+            f"::warning title=ACP version::Unable to parse {ACP_DEPENDENCY} "
+            "minimum version; skipping ACP version check"
+        )
+        return 0
+
+    if new_min <= old_min:
+        return 0
+
+    if new_min.major != old_min.major or new_min.minor != old_min.minor:
+        print(
+            "::error title=ACP version::Detected "
+            f"{ACP_DEPENDENCY} minor/major version bump "
+            f"({old_req} -> {new_req}). If intentional, add "
+            f"[{ACP_SKIP_TOKEN}] to the PR description to bypass."
+        )
+        return 1
+
+    return 0
 
 
 def _parse_version(v: str) -> pkg_version.Version:
@@ -657,11 +798,12 @@ def _check_package(griffe_module, repo_root: str, cfg: PackageConfig) -> int:
 
 def main() -> int:
     """Main entry point for API breakage detection."""
+    repo_root = os.getcwd()
+    rc = _check_acp_version_bump(repo_root)
+
     ensure_griffe()
     import griffe
 
-    repo_root = os.getcwd()
-    rc = 0
     for cfg in PACKAGES:
         print(f"\n{'=' * 60}")
         print(f"Checking {cfg.distribution} ({cfg.package})")

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -28,6 +28,10 @@ jobs:
               # Release PRs (rel-*) must block on breakage.
               # Other PRs should still report failures via PR comment, but not gate merges.
               continue-on-error: ${{ !startsWith(github.head_ref, 'rel-') }}
+              env:
+                  SDK_INCLUDE_PATHS: openhands.sdk
+                  ACP_VERSION_CHECK_BASE_REF: ${{ github.base_ref }}
+                  ACP_VERSION_CHECK_SKIP: ${{ contains(github.event.pull_request.body, 'skip-acp-check') }}
               run: |
                   uv run python .github/scripts/check_sdk_api_breakage.py 2>&1 | tee api-breakage.log
                   exit_code=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary
- add ACP minor/major bump detection for agent-client-protocol in the Griffe check
- surface ACP bump errors in the API breakage job without stopping other checks
- allow opt-out via `[skip-acp-check]` in the PR description

## Why
ACP minor/major version bumps can introduce protocol changes that break downstream ACP clients (CLI, external integrations). This makes the bump highly review-sensitive, so we want CI to flag it loudly and require an explicit acknowledgment when the upgrade is intentional.

## Fixes
- Fixes #2343

## Testing
- `uv run pre-commit run --files .github/scripts/check_sdk_api_breakage.py .github/workflows/api-breakage.yml`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0acdc06-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0acdc06-python \
  ghcr.io/openhands/agent-server:0acdc06-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0acdc06-golang-amd64
ghcr.io/openhands/agent-server:0acdc06-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0acdc06-golang-arm64
ghcr.io/openhands/agent-server:0acdc06-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0acdc06-java-amd64
ghcr.io/openhands/agent-server:0acdc06-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0acdc06-java-arm64
ghcr.io/openhands/agent-server:0acdc06-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0acdc06-python-amd64
ghcr.io/openhands/agent-server:0acdc06-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:0acdc06-python-arm64
ghcr.io/openhands/agent-server:0acdc06-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:0acdc06-golang
ghcr.io/openhands/agent-server:0acdc06-java
ghcr.io/openhands/agent-server:0acdc06-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0acdc06-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0acdc06-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->