### PR TITLE
feat(sdk/subagent): condenser for subagents

### DIFF
--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -245,10 +245,21 @@ def agent_definition_to_factory(
                 )
             tools.append(Tool(name=tool_name))
 
+        # Build condenser if configured
+        condenser = None
+        if agent_def.condenser:
+            from openhands.sdk.context.condenser import LLMSummarizingCondenser
+
+            condenser = LLMSummarizingCondenser(
+                llm=llm.model_copy(update={"usage_id": "condenser"}),
+                **agent_def.condenser,
+            )
+
         return Agent(
             llm=llm,
             tools=tools,
             agent_context=agent_context,
+            condenser=condenser,
         )
 
     return _factory

--- a/openhands-sdk/openhands/sdk/subagent/schema.py
+++ b/openhands-sdk/openhands/sdk/subagent/schema.py
@@ -19,6 +19,7 @@ KNOWN_FIELDS: Final[set[str]] = {
     "skills",
     "max_iteration_per_run",
     "profile_store_dir",
+    "condenser",
 }
 
 
@@ -55,6 +56,35 @@ def _extract_skills(fm: dict[str, object]) -> list[str]:
     else:
         skills = []
     return skills
+
+
+_CONDENSER_VALID_KEYS: Final[set[str]] = {
+    "max_size",
+    "max_tokens",
+    "keep_first",
+    "minimum_progress",
+    "hard_context_reset_max_retries",
+    "hard_context_reset_context_scaling",
+}
+
+
+def _extract_condenser(fm: dict[str, object]) -> dict[str, Any] | None:
+    """Extract condenser configuration from frontmatter."""
+    condenser_raw = fm.get("condenser")
+    if condenser_raw is None:
+        return None
+    if not isinstance(condenser_raw, dict):
+        raise ValueError(
+            f"condenser must be a mapping of configuration parameters, "
+            f"got {type(condenser_raw)}"
+        )
+    unknown_keys = set(condenser_raw.keys()) - _CONDENSER_VALID_KEYS
+    if unknown_keys:
+        raise ValueError(
+            f"Unknown condenser parameter(s): {sorted(unknown_keys)}. "
+            f"Valid parameters are: {sorted(_CONDENSER_VALID_KEYS)}"
+        )
+    return condenser_raw
 
 
 def _extract_profile_store_dir(fm: dict[str, object]) -> str | None:
@@ -121,6 +151,13 @@ class AgentDefinition(BaseModel):
         "It must be strictly positive, or None for default.",
         gt=0,
     )
+    condenser: dict[str, Any] | None = Field(
+        default=None,
+        description="Condenser configuration for this agent. "
+        "Parameters are passed to LLMSummarizingCondenser (e.g., max_size, ...). "
+        "The condenser LLM is inherited from the agent's LLM.",
+        examples=[{"max_size": 100, "keep_first": 2}],
+    )
     profile_store_dir: str | None = Field(
         default=None,
         description="Path to the directory where LLM profiles are stored. "
@@ -139,6 +176,7 @@ class AgentDefinition(BaseModel):
         - description: Description with optional <example> tags for triggering
         - tools (optional): List of allowed tools
         - skills (optional): Comma-separated skill names or list of skill names
+        - condenser (optional): Condenser configuration (e.g., max_size, keep_first)
         - model (optional): Model profile to use (default: 'inherit')
         - color (optional): Display color
         - max_iterations_per_run: Max iteration per run
@@ -165,6 +203,7 @@ class AgentDefinition(BaseModel):
         tools: list[str] = _extract_tools(fm)
         skills: list[str] = _extract_skills(fm)
         max_iteration_per_run: int | None = _extract_max_iteration_per_run(fm)
+        condenser: dict[str, Any] | None = _extract_condenser(fm)
         profile_store_dir: str | None = _extract_profile_store_dir(fm)
 
         # Extract whenToUse examples from description
@@ -181,6 +220,7 @@ class AgentDefinition(BaseModel):
             tools=tools,
             skills=skills,
             max_iteration_per_run=max_iteration_per_run,
+            condenser=condenser,
             profile_store_dir=profile_store_dir,
             system_prompt=content,
             source=str(agent_path),

--- a/tests/sdk/subagent/test_subagent_schema.py
+++ b/tests/sdk/subagent/test_subagent_schema.py
@@ -3,7 +3,11 @@ from pathlib import Path
 import pytest
 from pydantic import ValidationError
 
-from openhands.sdk.subagent.schema import AgentDefinition, _extract_examples
+from openhands.sdk.subagent.schema import (
+    _CONDENSER_VALID_KEYS,
+    AgentDefinition,
+    _extract_examples,
+)
 
 
 class TestAgentDefinition:
@@ -318,6 +322,113 @@ Content.
         """Test that profile_store_dir defaults to None on direct construction."""
         agent = AgentDefinition(name="test")
         assert agent.profile_store_dir is None
+
+    def test_condenser_default_none(self):
+        """Test that condenser defaults to None on direct construction."""
+        agent = AgentDefinition(name="test")
+        assert agent.condenser is None
+
+    def test_condenser_as_dict(self):
+        """Test creating AgentDefinition with condenser as dict."""
+        config = {"max_size": 100, "keep_first": 2}
+        agent = AgentDefinition(name="condensed-agent", condenser=config)
+        assert agent.condenser == config
+
+    def test_load_condenser_from_frontmatter(self, tmp_path: Path):
+        """Test loading condenser from YAML frontmatter."""
+        agent_md = tmp_path / "condensed.md"
+        agent_md.write_text(
+            """---
+name: condensed-agent
+condenser:
+  max_size: 100
+  keep_first: 3
+---
+
+You are an agent with condensation.
+"""
+        )
+
+        agent = AgentDefinition.load(agent_md)
+        assert agent.condenser is not None
+        assert agent.condenser["max_size"] == 100
+        assert agent.condenser["keep_first"] == 3
+
+    def test_load_condenser_not_in_metadata(self, tmp_path: Path):
+        """Test that condenser doesn't leak into metadata."""
+        agent_md = tmp_path / "agent.md"
+        agent_md.write_text(
+            """---
+name: agent
+condenser:
+  max_size: 50
+custom_field: value
+---
+
+Prompt.
+"""
+        )
+        agent = AgentDefinition.load(agent_md)
+        assert "condenser" not in agent.metadata
+        assert agent.metadata.get("custom_field") == "value"
+
+    def test_load_condenser_non_dict_raises(self, tmp_path: Path):
+        """Test that non-dict condenser value raises ValueError."""
+        agent_md = tmp_path / "bad-condenser.md"
+        agent_md.write_text(
+            """---
+name: bad-condenser
+condenser: true
+---
+
+Prompt.
+"""
+        )
+        with pytest.raises(ValueError, match="must be a mapping"):
+            AgentDefinition.load(agent_md)
+
+    def test_load_condenser_unknown_key_raises(self, tmp_path: Path):
+        """Test that unknown condenser parameters raise ValueError."""
+        agent_md = tmp_path / "bad-condenser.md"
+        agent_md.write_text(
+            """---
+name: bad-condenser
+condenser:
+  max_size: 100
+  bogus_param: 42
+---
+
+Prompt.
+"""
+        )
+        with pytest.raises(ValueError, match="Unknown condenser parameter"):
+            AgentDefinition.load(agent_md)
+
+    def test_load_without_condenser(self, tmp_path: Path):
+        """Test that loading from file without condenser gives None."""
+        agent_md = tmp_path / "agent.md"
+        agent_md.write_text(
+            """---
+name: no-condenser
+---
+
+Prompt.
+"""
+        )
+        agent = AgentDefinition.load(agent_md)
+        assert agent.condenser is None
+
+    def test_condenser_valid_keys_match_llm_summarizing_condenser(self):
+        """Ensure _CONDENSER_VALID_KEYS stays in sync with LLMSummarizingCondenser."""
+        from openhands.sdk.context.condenser import LLMSummarizingCondenser
+
+        # Get all user-configurable fields (exclude 'llm' which is inherited)
+        condenser_fields = set(LLMSummarizingCondenser.model_fields.keys()) - {"llm"}
+        assert _CONDENSER_VALID_KEYS == condenser_fields, (
+            f"_CONDENSER_VALID_KEYS is out of sync with LLMSummarizingCondenser. "
+            f"Missing: {condenser_fields - _CONDENSER_VALID_KEYS}, "
+            f"Extra: {_CONDENSER_VALID_KEYS - condenser_fields}"
+        )
 
 
 class TestExtractExamples:


### PR DESCRIPTION
## Summary

(ref #2186 )

Allow subagents defined via Markdown files to declare a condenser configuration. The condenser LLM is inherited from the agent's own LLM at factory time — the definition only stores the tuning parameters (e.g., max_size, keep_first).

## Changes
### openhands-sdk/openhands/sdk/subagent/schema.py
  - Added condenser: dict[str, Any] | None field to AgentDefinition
  - Added _extract_condenser() with key validation against _CONDENSER_VALID_KEYS
  - Unknown keys produce a clear error listing valid parameters
  
### openhands-sdk/openhands/sdk/subagent/registry.py
- In agent_definition_to_factory, constructs an LLMSummarizingCondenser from the config when present, inheriting the agent's LLM with usage_id: "condenser"

### tests/sdk/subagent/test_subagent_schema.py
- 8 new tests: default None, dict construction, YAML frontmatter loading, metadata exclusion, unknown key rejection, non-dict value rejection, absent field, and a sync test that verifies _CONDENSER_VALID_KEYS
  matches LLMSummarizingCondenser.model_fields to prevent drift

## Usage

```text
  ---
  name: long-running-agent
  condenser:
    max_size: 100
    keep_first: 3
  ---

  You are an agent that handles long tasks.
```

## Design decisions

  - Config-only in definition, object in factory: The AgentDefinition stores a plain dict since the condenser needs an LLM instance which is only available at factory time. This mirrors how model: inherit works.
  - Key validation at parse time: Unknown keys are rejected early during load() rather than deferring to Pydantic at construction time, giving clearer errors tied to the source file.
  - Value validation deferred: Value types (e.g., max_size must be int > 0) are validated by Pydantic when LLMSummarizingCondenser is constructed — no need to duplicate those constraints.
  - Sync test guards against drift: test_condenser_valid_keys_match_llm_summarizing_condenser will fail if LLMSummarizingCondenser fields change without updating _CONDENSER_VALID_KEYS.


## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:37c2787-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-37c2787-python \
  ghcr.io/openhands/agent-server:37c2787-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:37c2787-golang-amd64
ghcr.io/openhands/agent-server:37c2787-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:37c2787-golang-arm64
ghcr.io/openhands/agent-server:37c2787-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:37c2787-java-amd64
ghcr.io/openhands/agent-server:37c2787-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:37c2787-java-arm64
ghcr.io/openhands/agent-server:37c2787-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:37c2787-python-amd64
ghcr.io/openhands/agent-server:37c2787-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:37c2787-python-arm64
ghcr.io/openhands/agent-server:37c2787-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:37c2787-golang
ghcr.io/openhands/agent-server:37c2787-java
ghcr.io/openhands/agent-server:37c2787-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `37c2787-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `37c2787-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->