### PR TITLE
refactor(sdk/context/skills): refactoring loading skills

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -683,33 +683,10 @@ def load_user_skills() -> list[Skill]:
         List of Skill objects loaded from user directories.
         Returns empty list if no skills found or loading fails.
     """
-    all_skills = []
-    seen_names = set()
+    all_skills: list[Skill] = []
+    seen_names: set[str] = set()
 
-    for skills_dir in USER_SKILLS_DIRS:
-        if not skills_dir.exists():
-            logger.debug(f"User skills directory does not exist: {skills_dir}")
-            continue
-
-        try:
-            logger.debug(f"Loading user skills from {skills_dir}")
-            repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
-                skills_dir
-            )
-
-            # Merge all skill categories
-            for skills_dict in [repo_skills, knowledge_skills, agent_skills]:
-                for name, skill in skills_dict.items():
-                    if name not in seen_names:
-                        all_skills.append(skill)
-                        seen_names.add(name)
-                    else:
-                        logger.warning(
-                            f"Skipping duplicate skill '{name}' from {skills_dir}"
-                        )
-
-        except Exception as e:
-            logger.warning(f"Failed to load user skills from {skills_dir}: {str(e)}")
+    _load_and_merge_from_dirs(USER_SKILLS_DIRS, seen_names, all_skills, "user skills")
 
     logger.debug(
         f"Loaded {len(all_skills)} user skills: {[s.name for s in all_skills]}"
@@ -745,6 +722,44 @@ def _merge_loaded_skills(
                 seen_names.add(name)
             else:
                 logger.warning(f"Skipping duplicate skill '{name}' from {source_dir}")
+
+
+def _load_and_merge_from_dirs(
+    dirs: list[Path],
+    seen_names: set[str],
+    all_skills: list[Skill],
+    source_label: str,
+) -> None:
+    """Load skills from multiple directories, merging with deduplication.
+
+    For each directory that exists, loads all skills via load_skills_from_dir()
+    and merges them into all_skills, skipping duplicates based on seen_names.
+    Earlier directories take precedence for duplicate names.
+
+    Args:
+        dirs: List of directories to search for skills.
+        seen_names: Set of already-seen skill names (mutated in place).
+        all_skills: Accumulator list of skills (mutated in place).
+        source_label: Human-readable label for log messages (e.g. "user skills").
+    """
+    for skills_dir in dirs:
+        if not skills_dir.exists():
+            logger.debug(f"{source_label} directory does not exist: {skills_dir}")
+            continue
+
+        try:
+            logger.debug(f"Loading {source_label} from {skills_dir}")
+            repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
+                skills_dir
+            )
+            _merge_loaded_skills(
+                source_dir=skills_dir,
+                loaded_skills=[repo_skills, knowledge_skills, agent_skills],
+                seen_names=seen_names,
+                all_skills=all_skills,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to load {source_label} from {skills_dir}: {str(e)}")
 
 
 def load_project_skills(work_dir: str | Path) -> list[Skill]:
@@ -815,30 +830,9 @@ def load_project_skills(work_dir: str | Path) -> list[Skill]:
             root / ".openhands" / "microagents",  # Legacy support
         ]
 
-        for project_skills_dir in project_skills_dirs:
-            if not project_skills_dir.exists():
-                logger.debug(
-                    f"Project skills directory does not exist: {project_skills_dir}"
-                )
-                continue
-
-            try:
-                logger.debug(f"Loading project skills from {project_skills_dir}")
-                repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(
-                    project_skills_dir
-                )
-
-                _merge_loaded_skills(
-                    source_dir=project_skills_dir,
-                    loaded_skills=[repo_skills, knowledge_skills, agent_skills],
-                    seen_names=seen_names,
-                    all_skills=all_skills,
-                )
-
-            except Exception as e:
-                logger.warning(
-                    f"Failed to load project skills from {project_skills_dir}: {str(e)}"
-                )
+        _load_and_merge_from_dirs(
+            project_skills_dirs, seen_names, all_skills, "project skills"
+        )
 
     logger.debug(
         f"Loaded {len(all_skills)} project skills: {[s.name for s in all_skills]}"


### PR DESCRIPTION
## Summary

Small refactor of how we loading skills.
In this way it is easy to maintain. 
No API change here. 

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.12-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.12-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dd29cfe-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dd29cfe-python \
  ghcr.io/openhands/agent-server:dd29cfe-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dd29cfe-golang-amd64
ghcr.io/openhands/agent-server:dd29cfe-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dd29cfe-golang-arm64
ghcr.io/openhands/agent-server:dd29cfe-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dd29cfe-java-amd64
ghcr.io/openhands/agent-server:dd29cfe-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dd29cfe-java-arm64
ghcr.io/openhands/agent-server:dd29cfe-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dd29cfe-python-amd64
ghcr.io/openhands/agent-server:dd29cfe-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-amd64
ghcr.io/openhands/agent-server:dd29cfe-python-arm64
ghcr.io/openhands/agent-server:dd29cfe-nikolaik_s_python-nodejs_tag_python3.12-nodejs22-arm64
ghcr.io/openhands/agent-server:dd29cfe-golang
ghcr.io/openhands/agent-server:dd29cfe-java
ghcr.io/openhands/agent-server:dd29cfe-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dd29cfe-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dd29cfe-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->