### PR TITLE
fix(tools): add vision note to planning file editor

### DIFF
--- a/openhands-tools/openhands/tools/planning_file_editor/definition.py
+++ b/openhands-tools/openhands/tools/planning_file_editor/definition.py
@@ -45,18 +45,13 @@ class PlanningFileEditorObservation(FileEditorObservation):
     """
 
 
-TOOL_DESCRIPTION = (
-    FILE_EDITOR_TOOL_DESCRIPTION
-    + """
-
-IMPORTANT RESTRICTION FOR PLANNING AGENT:
+PLANNING_RESTRICTIONS = """IMPORTANT RESTRICTION FOR PLANNING AGENT:
 * You can VIEW any file in the workspace using the 'view' command
 * You can ONLY EDIT the PLAN.md file (all other edit operations will be rejected)
 * PLAN.md is automatically initialized with section headers at the workspace root
 * All editing commands (create, str_replace, insert, undo_edit) are restricted to PLAN.md only
 * The PLAN.md file already contains the required section structure - you just need to fill in the content
-"""  # noqa
-)
+"""  # noqa: E501
 
 
 class PlanningFileEditorTool(
@@ -129,9 +124,25 @@ class PlanningFileEditorTool(
             plan_path=plan_path,
         )
 
+        description_lines = FILE_EDITOR_TOOL_DESCRIPTION.split("\n")
+        base_description = "\n".join(description_lines[:2])
+        remaining_description = "\n".join(description_lines[2:])
+
+        if conv_state.agent.llm.vision_is_active():
+            file_editor_description = (
+                f"{base_description}\n"
+                "* If `path` is an image file (.png, .jpg, .jpeg, .gif, .webp, "
+                ".bmp), `view` displays the image content\n"
+                f"{remaining_description}"
+            )
+        else:
+            file_editor_description = FILE_EDITOR_TOOL_DESCRIPTION
+
+        tool_description = f"{file_editor_description}\n\n{PLANNING_RESTRICTIONS}"
+
         # Add working directory information to the tool description
         enhanced_description = (
-            f"{TOOL_DESCRIPTION}\n\n"
+            f"{tool_description}\n\n"
             f"Your current working directory: {working_dir}\n"
             f"Your PLAN.md location: {plan_path}\n"
             f"This plan file will be accessible to other agents in the workflow."


### PR DESCRIPTION
## Summary
- include the vision image-view bullet in planning_file_editor description when vision is enabled
- build description dynamically to mirror file_editor behavior

Fixes #2357
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b8f9c70-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b8f9c70-python \
  ghcr.io/openhands/agent-server:b8f9c70-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b8f9c70-golang-amd64
ghcr.io/openhands/agent-server:b8f9c70-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b8f9c70-golang-arm64
ghcr.io/openhands/agent-server:b8f9c70-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b8f9c70-java-amd64
ghcr.io/openhands/agent-server:b8f9c70-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b8f9c70-java-arm64
ghcr.io/openhands/agent-server:b8f9c70-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b8f9c70-python-amd64
ghcr.io/openhands/agent-server:b8f9c70-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:b8f9c70-python-arm64
ghcr.io/openhands/agent-server:b8f9c70-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:b8f9c70-golang
ghcr.io/openhands/agent-server:b8f9c70-java
ghcr.io/openhands/agent-server:b8f9c70-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b8f9c70-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b8f9c70-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->