### PR TITLE
chore: redistribute AGENTS guidance

### DIFF
--- a/.github/run-eval/AGENTS.md
+++ b/.github/run-eval/AGENTS.md
@@ -1,5 +1,7 @@
 # Model Configuration for OpenHands SDK
 
+See the [project root AGENTS.md](../../AGENTS.md) for repository-wide policies and workflows.
+
 This directory contains model configuration and evaluation setup for the OpenHands SDK.
 
 ## Key Files

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,6 +100,17 @@ When reviewing code, provide constructive feedback:
 
 **Next Steps**: [Clear action items]
 </ROLE>
+
+## Package-specific guidance
+When working inside a package or domain, read the closest AGENTS file.
+
+- SDK: [openhands-sdk/openhands/sdk/AGENTS.md](openhands-sdk/openhands/sdk/AGENTS.md)
+- Subagents: [openhands-sdk/openhands/sdk/subagent/AGENTS.md](openhands-sdk/openhands/sdk/subagent/AGENTS.md)
+- Tools: [openhands-tools/openhands/tools/AGENTS.md](openhands-tools/openhands/tools/AGENTS.md)
+- Workspace: [openhands-workspace/openhands/workspace/AGENTS.md](openhands-workspace/openhands/workspace/AGENTS.md)
+- Agent server: [openhands-agent-server/AGENTS.md](openhands-agent-server/AGENTS.md)
+- Eval config: [.github/run-eval/AGENTS.md](.github/run-eval/AGENTS.md)
+
 <DEV_SETUP>
 - Make sure you `make build` to configure the dependencies first
 - We use pre-commit hooks `.pre-commit-config.yaml` that includes:
@@ -115,19 +126,6 @@ When reviewing code, provide constructive feedback:
 - If it is just code, you can modify it so it spans multiple lines.
 - If it is a single-line string, you can break it into a multi-line string by doing "ABC" -> ("A"\n"B"\n"C")
 - If it is a long multi-line string (e.g., docstring), you should just add type ignore AFTER the ending """. You should NEVER ADD IT INSIDE the docstring.
-
-# PyInstaller Data Files
-
-When adding non-Python files (JS, templates, etc.) loaded at runtime, add them to `openhands-agent-server/openhands/agent_server/agent-server.spec` using `collect_data_files`.
-
-# Bedrock + LiteLLM note
-
-- LiteLLM interprets the `api_key` parameter for Bedrock models as an **AWS bearer token**.
-  When using IAM/SigV4 auth (AWS credentials / profiles), do **not** forward `LLM.api_key`
-  to LiteLLM for Bedrock models, or Bedrock may return:
-  `Invalid API Key format: Must start with pre-defined prefix`.
-- If you need Bedrock bearer-token auth, set `AWS_BEARER_TOKEN_BEDROCK` in the environment
-  (instead of using `LLM_API_KEY`).
 
 
 </DEV_SETUP>
@@ -251,82 +249,6 @@ gh run rerun <RUN_ID> --repo <OWNER>/<REPO> --failed
 - Prefer accessing typed attributes directly. If necessary, convert inputs up front into a canonical shape; avoid purely hypothetical fallbacks.
 - Use real newlines in commit messages; do not write literal "\n".
 
-## Event Type Deprecation Policy
-
-When modifying event types (e.g., `TextContent`, `Message`, or any Pydantic model used in event serialization), follow these guidelines to ensure backward compatibility:
-
-### Critical Requirement: Old Events Must Always Load
-
-**Old events should ALWAYS load without error.** Production systems may resume conversations that contain events serialized with older SDK versions. Breaking changes to event schemas will cause production failures.
-
-**Important**: Deprecated field handlers are **permanent** and should never be removed. They ensure old conversations can always be loaded, regardless of when they were created.
-
-### When Removing a Field from an Event Type
-
-1. **Never use `extra="forbid"` without a deprecation handler** - This will reject old events that contain removed fields.
-
-2. **Add a model validator to handle deprecated fields** using the `handle_deprecated_model_fields` utility:
-   ```python
-   from openhands.sdk.utils.deprecation import handle_deprecated_model_fields
-
-   class MyModel(BaseModel):
-       model_config = ConfigDict(extra="forbid")
-
-       # Deprecated fields that are silently removed for backward compatibility
-       # when loading old events. These are kept permanently.
-       _DEPRECATED_FIELDS: ClassVar[tuple[str, ...]] = ("old_field_name",)
-
-       @model_validator(mode="before")
-       @classmethod
-       def _handle_deprecated_fields(cls, data: Any) -> Any:
-           """Remove deprecated fields for backward compatibility with old events."""
-           return handle_deprecated_model_fields(data, cls._DEPRECATED_FIELDS)
-   ```
-
-3. **Write tests that verify both old and new event formats load correctly**:
-   - Test that old format (with deprecated field) loads successfully
-   - Test that new format (without deprecated field) works
-   - Test that loading a sequence of mixed old/new events works
-
-### Test Naming Convention for Event Backward Compatibility Tests
-
-**The version in the test name should be the LAST version where a particular event structure exists.**
-
-For example, if `enable_truncation` was removed in v1.11.1, the test should be named `test_v1_10_0_...` (the last version with that field).
-
-This convention:
-- Makes it clear which version's format is being tested
-- Avoids duplicate tests for the same structure across multiple versions
-- Documents when a field was last present in the schema
-
-Example test names:
-- `test_v1_10_0_text_content_with_enable_truncation` - Tests the last version with `enable_truncation`
-- `test_v1_9_0_message_with_deprecated_fields` - Tests the last version with Message deprecated fields
-- `test_text_content_current_format` - Tests the current format (no version needed)
-
-### Example: See `TextContent` and `Message` in `openhands/sdk/llm/message.py`
-
-These classes demonstrate the proper pattern for handling deprecated fields while maintaining backward compatibility with persisted events.
-
-## Public API Removal Policy
-
-Symbols exported via `openhands.sdk.__all__` are the SDK's public surface. Two CI policies govern changes:
-
-1. **Deprecation before removal** – before removing a public API object, it must have been marked deprecated for at least one release using the canonical helpers in `openhands.sdk.utils.deprecation`.
-
-   This applies to:
-   - Removing a symbol from `openhands.sdk.__all__`.
-   - Removing a public class member (method/property/attribute) from a class that is exported via `openhands.sdk.__all__`.
-
-   Acceptable deprecation markers:
-   - `@deprecated(deprecated_in=..., removed_in=...)` decorator for functions/classes/methods
-   - `warn_deprecated(feature, deprecated_in=..., removed_in=...)` for runtime paths (e.g., attribute accessors). For members, use a qualified feature name like `"LLM.some_method"`.
-
-   Note: Deprecating a class counts as deprecating its members for the purposes of member removal.
-
-2. **MINOR version bump** – any breaking change (removal or structural) requires at least a MINOR version bump.
-
-These are enforced by `check_sdk_api_breakage.py` (runs on release PRs). Deprecation deadlines are separately enforced by `check_deprecations.py` (runs on every PR).
 </CODE>
 
 <TESTING>
@@ -345,32 +267,6 @@ Behavior tests (prefix `b##_*`) in `tests/integration/tests/` are designed to ve
 
 Before adding or modifying behavior tests, review `tests/integration/BEHAVIOR_TESTS.md` for the latest workflow, expectations, and examples.
 </TESTING>
-
-<DOCUMENTATION_WORKFLOW>
-# Documentation Repository
-
-Documentation lives in **github.com/OpenHands/docs** under the `sdk/` folder. When adding features or modifying APIs, you MUST update documentation there.
-
-## Workflow
-
-1. Clone docs repo: `git clone https://github.com/OpenHands/docs.git /workspace/project/openhands-docs`
-2. Create matching branch in both repos
-3. Update documentation in `openhands-docs/sdk/` folder
-4. **If you are creating a PR to `OpenHands/agent-sdk`**, you must also create a corresponding PR to `OpenHands/docs` with documentation updates in the `sdk/` folder
-5. Cross-reference both PRs in their descriptions
-
-Example:
-```bash
-cd /workspace/project/openhands-docs
-git checkout -b <feature-name>
-# Edit files in sdk/ folder
-git add sdk/
-git commit -m "Document <feature>
-
-Co-authored-by: openhands <openhands@all-hands.dev>"
-git push -u origin <feature-name>
-```
-</DOCUMENTATION_WORKFLOW>
 
 <AGENT_TMP_DIRECTORY>
 # Agent Temporary Directory Convention
@@ -400,29 +296,13 @@ Note: This is separate from `persistence_dir` which is used for conversation sta
 - Run tests: `uv run pytest`
 - Build agent-server: `make build-server` (output: `dist/agent-server/`)
 - Clean caches: `make clean`
-- Run an example: `uv run python examples/01_standalone_sdk/main.py`
+- Run SDK examples: see [openhands-sdk/openhands/sdk/AGENTS.md](openhands-sdk/openhands/sdk/AGENTS.md).
 </QUICK_COMMANDS>
-
-<RUNNING_EXAMPLES>
-# Running SDK Examples
-
-When implementing or modifying examples in `examples/`, always verify they work before committing:
-
-```bash
-# Run examples using the All-Hands LLM proxy
-LLM_BASE_URL="https://llm-proxy.eval.all-hands.dev" LLM_API_KEY="$LLM_API_KEY" \
-  uv run python examples/01_standalone_sdk/<example_name>.py
-```
-
-The `LLM_API_KEY` environment variable may be available in the OpenHands development environment and works with the All-Hands LLM proxy (`llm-proxy.eval.all-hands.dev` OR `llm-proxy.app.all-hands.dev`). Please consult the human user for the LLM key if it is not found.
-
-For examples that use the critic model (e.g., `34_critic_example.py`), the critic is auto-configured when using the All-Hands LLM proxy - no additional setup needed.
-</RUNNING_EXAMPLES>
 
 <REPO_CONFIG_NOTES>
 - Ruff: `line-length = 88`, `target-version = "py312"` (see `pyproject.toml`).
 - Ruff ignores `ARG` (unused arguments) under `tests/**/*.py` to allow pytest fixtures.
-- Repository guidance lives in `AGENTS.md` (loaded as a third-party skill file).
+- Repository guidance lives in the project root AGENTS.md (loaded as a third-party skill file).
 </REPO_CONFIG_NOTES>
 
 </REPO>

--- a/openhands-agent-server/AGENTS.md
+++ b/openhands-agent-server/AGENTS.md
@@ -1,11 +1,18 @@
 # openhands-agent-server
 
+See the [project root AGENTS.md](../AGENTS.md) for repository-wide policies and workflows.
+
 ## Development
 
 This package lives in the monorepo root. Typical commands (run from repo root):
 
 - Install deps: `make build`
 - Run agent-server tests: `uv run pytest tests/agent_server`
+
+## PyInstaller data files
+
+When adding non-Python files (JS, templates, etc.) loaded at runtime, add them to `openhands-agent-server/openhands/agent_server/agent-server.spec` using `collect_data_files`.
+
 
 ## REST API compatibility & deprecation policy
 

--- a/openhands-sdk/openhands/sdk/AGENTS.md
+++ b/openhands-sdk/openhands/sdk/AGENTS.md
@@ -1,5 +1,7 @@
 # Package Guidelines
 
+See the [project root AGENTS.md](../../../AGENTS.md) for repository-wide policies and workflows.
+
 ## Package Structure & Module Organization
 
 - This directory (`openhands-sdk/openhands/sdk/`) contains the core Python SDK under the `openhands.sdk.*` namespace.
@@ -25,6 +27,130 @@
 
 - Prefer real code paths over mocks; introduce fixtures in `tests/conftest.py` when setup is repeated.
 - Keep tests minimal and focused on the changed behavior; avoid adding broad integration tests unless required.
+
+## Bedrock + LiteLLM note
+
+- LiteLLM interprets the `api_key` parameter for Bedrock models as an **AWS bearer token**.
+  When using IAM/SigV4 auth (AWS credentials / profiles), do **not** forward `LLM.api_key`
+  to LiteLLM for Bedrock models, or Bedrock may return:
+  `Invalid API Key format: Must start with pre-defined prefix`.
+- If you need Bedrock bearer-token auth, set `AWS_BEARER_TOKEN_BEDROCK` in the environment
+  (instead of using `LLM_API_KEY`).
+
+## Event Type Deprecation Policy
+
+When modifying event types (e.g., `TextContent`, `Message`, or any Pydantic model used in event serialization), follow these guidelines to ensure backward compatibility:
+
+### Critical Requirement: Old Events Must Always Load
+
+**Old events should ALWAYS load without error.** Production systems may resume conversations that contain events serialized with older SDK versions. Breaking changes to event schemas will cause production failures.
+
+**Important**: Deprecated field handlers are **permanent** and should never be removed. They ensure old conversations can always be loaded, regardless of when they were created.
+
+### When Removing a Field from an Event Type
+
+1. **Never use `extra="forbid"` without a deprecation handler** - This will reject old events that contain removed fields.
+
+2. **Add a model validator to handle deprecated fields** using the `handle_deprecated_model_fields` utility:
+   ```python
+   from openhands.sdk.utils.deprecation import handle_deprecated_model_fields
+
+   class MyModel(BaseModel):
+       model_config = ConfigDict(extra="forbid")
+
+       # Deprecated fields that are silently removed for backward compatibility
+       # when loading old events. These are kept permanently.
+       _DEPRECATED_FIELDS: ClassVar[tuple[str, ...]] = ("old_field_name",)
+
+       @model_validator(mode="before")
+       @classmethod
+       def _handle_deprecated_fields(cls, data: Any) -> Any:
+           """Remove deprecated fields for backward compatibility with old events."""
+           return handle_deprecated_model_fields(data, cls._DEPRECATED_FIELDS)
+   ```
+
+3. **Write tests that verify both old and new event formats load correctly**:
+   - Test that old format (with deprecated field) loads successfully
+   - Test that new format (without deprecated field) works
+   - Test that loading a sequence of mixed old/new events works
+
+### Test Naming Convention for Event Backward Compatibility Tests
+
+**The version in the test name should be the LAST version where a particular event structure exists.**
+
+For example, if `enable_truncation` was removed in v1.11.1, the test should be named `test_v1_10_0_...` (the last version with that field).
+
+This convention:
+- Makes it clear which version's format is being tested
+- Avoids duplicate tests for the same structure across multiple versions
+- Documents when a field was last present in the schema
+
+Example test names:
+- `test_v1_10_0_text_content_with_enable_truncation` - Tests the last version with `enable_truncation`
+- `test_v1_9_0_message_with_deprecated_fields` - Tests the last version with Message deprecated fields
+- `test_text_content_current_format` - Tests the current format (no version needed)
+
+### Example: See `TextContent` and `Message` in `openhands/sdk/llm/message.py`
+
+These classes demonstrate the proper pattern for handling deprecated fields while maintaining backward compatibility with persisted events.
+
+## Public API Removal Policy
+
+Symbols exported via `openhands.sdk.__all__` are the SDK's public surface. Two CI policies govern changes:
+
+1. **Deprecation before removal** – before removing a public API object, it must have been marked deprecated for at least one release using the canonical helpers in `openhands.sdk.utils.deprecation`.
+
+   This applies to:
+   - Removing a symbol from `openhands.sdk.__all__`.
+   - Removing a public class member (method/property/attribute) from a class that is exported via `openhands.sdk.__all__`.
+
+   Acceptable deprecation markers:
+   - `@deprecated(deprecated_in=..., removed_in=...)` decorator for functions/classes/methods
+   - `warn_deprecated(feature, deprecated_in=..., removed_in=...)` for runtime paths (e.g., attribute accessors). For members, use a qualified feature name like `"LLM.some_method"`.
+
+   Note: Deprecating a class counts as deprecating its members for the purposes of member removal.
+
+2. **MINOR version bump** – any breaking change (removal or structural) requires at least a MINOR version bump.
+
+These are enforced by `check_sdk_api_breakage.py` (runs on release PRs). Deprecation deadlines are separately enforced by `check_deprecations.py` (runs on every PR).
+
+## Documentation workflow
+
+Documentation lives in **github.com/OpenHands/docs** under the `sdk/` folder. When adding features or modifying APIs, you MUST update documentation there.
+
+### Workflow
+
+1. Clone docs repo: `git clone https://github.com/OpenHands/docs.git /workspace/project/openhands-docs`
+2. Create matching branch in both repos
+3. Update documentation in `openhands-docs/sdk/` folder
+4. **If you are creating a PR to `OpenHands/agent-sdk`**, you must also create a corresponding PR to `OpenHands/docs` with documentation updates in the `sdk/` folder
+5. Cross-reference both PRs in their descriptions
+
+Example:
+```bash
+cd /workspace/project/openhands-docs
+git checkout -b <feature-name>
+# Edit files in sdk/ folder
+git add sdk/
+git commit -m "Document <feature>
+
+Co-authored-by: openhands <openhands@all-hands.dev>"
+git push -u origin <feature-name>
+```
+
+## Running SDK examples
+
+When implementing or modifying examples in `examples/`, always verify they work before committing:
+
+```bash
+# Run examples using the All-Hands LLM proxy
+LLM_BASE_URL="https://llm-proxy.eval.all-hands.dev" LLM_API_KEY="$LLM_API_KEY" \
+  uv run python examples/01_standalone_sdk/<example_name>.py
+```
+
+The `LLM_API_KEY` environment variable may be available in the OpenHands development environment and works with the All-Hands LLM proxy (`llm-proxy.eval.all-hands.dev` OR `llm-proxy.app.all-hands.dev`). Please consult the human user for the LLM key if it is not found.
+
+For examples that use the critic model (e.g., `34_critic_example.py`), the critic is auto-configured when using the All-Hands LLM proxy - no additional setup needed.
 
 ## Commit & Pull Request Guidelines
 

--- a/openhands-sdk/openhands/sdk/subagent/AGENTS.md
+++ b/openhands-sdk/openhands/sdk/subagent/AGENTS.md
@@ -1,5 +1,7 @@
 # Subagent loader (file-based agents): design + invariants
 
+See the [project root AGENTS.md](../../../../AGENTS.md) for repository-wide policies and workflows.
+
 This package (`openhands.sdk.subagent`) centralizes **subagent discovery** and **registration**.
 It exists so that contributors (human or agentic) can answer:
 

--- a/openhands-tools/openhands/tools/AGENTS.md
+++ b/openhands-tools/openhands/tools/AGENTS.md
@@ -1,5 +1,7 @@
 # Package Guidelines
 
+See the [project root AGENTS.md](../../../AGENTS.md) for repository-wide policies and workflows.
+
 ## Package Structure & Module Organization
 
 - This directory (`openhands-tools/openhands/tools/`) contains runtime tool implementations under the `openhands.tools.*` namespace.

--- a/openhands-workspace/openhands/workspace/AGENTS.md
+++ b/openhands-workspace/openhands/workspace/AGENTS.md
@@ -1,5 +1,7 @@
 # Package Guidelines
 
+See the [project root AGENTS.md](../../../AGENTS.md) for repository-wide policies and workflows.
+
 ## Package Structure & Module Organization
 
 - This directory (`openhands-workspace/openhands/workspace/`) contains workspace implementations under the `openhands.workspace.*` namespace (Docker, Apptainer, cloud, and API-remote).


### PR DESCRIPTION
## Summary
- add package-specific guidance links to the project root AGENTS.md
- move SDK and agent-server specific policies into their package AGENTS.md files
- link package AGENTS.md files back to the project root AGENTS.md

## Testing
- uv run pre-commit run --files AGENTS.md openhands-sdk/openhands/sdk/AGENTS.md openhands-sdk/openhands/sdk/subagent/AGENTS.md openhands-tools/openhands/tools/AGENTS.md openhands-workspace/openhands/workspace/AGENTS.md openhands-agent-server/AGENTS.md .github/run-eval/AGENTS.md
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:87c5225-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-87c5225-python \
  ghcr.io/openhands/agent-server:87c5225-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:87c5225-golang-amd64
ghcr.io/openhands/agent-server:87c5225-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:87c5225-golang-arm64
ghcr.io/openhands/agent-server:87c5225-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:87c5225-java-amd64
ghcr.io/openhands/agent-server:87c5225-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:87c5225-java-arm64
ghcr.io/openhands/agent-server:87c5225-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:87c5225-python-amd64
ghcr.io/openhands/agent-server:87c5225-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:87c5225-python-arm64
ghcr.io/openhands/agent-server:87c5225-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:87c5225-golang
ghcr.io/openhands/agent-server:87c5225-java
ghcr.io/openhands/agent-server:87c5225-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `87c5225-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `87c5225-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->