### PR TITLE
fix(sdk): revert agent-client-protocol to optional [acp] extra

### DIFF
--- a/examples/01_standalone_sdk/40_acp_agent_example.py
+++ b/examples/01_standalone_sdk/40_acp_agent_example.py
@@ -8,6 +8,7 @@ and leaves the main conversation untouched.
 Prerequisites:
     - Node.js / npx available
     - Claude Code CLI authenticated (or CLAUDE_API_KEY set)
+    - pip install 'openhands-sdk[acp]'
 
 Usage:
     uv run python examples/01_standalone_sdk/40_acp_agent_example.py

--- a/openhands-sdk/openhands/sdk/agent/__init__.py
+++ b/openhands-sdk/openhands/sdk/agent/__init__.py
@@ -15,7 +15,14 @@ if TYPE_CHECKING:
 # that previously defaulted.
 def __getattr__(name: str):
     if name == "ACPAgent":
-        from openhands.sdk.agent.acp_agent import ACPAgent
+        try:
+            from openhands.sdk.agent.acp_agent import ACPAgent
+        except ImportError:
+            raise ImportError(
+                "The 'agent-client-protocol' package is required for ACPAgent. "
+                "Install it with: pip install 'openhands-sdk[acp]' or "
+                "pip install agent-client-protocol"
+            ) from None
 
         return ACPAgent
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -5,7 +5,6 @@ description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"
 dependencies = [
-    "agent-client-protocol>=0.8.1",
     "deprecation>=2.1.0",
     "fakeredis[lua]>=2.32.1",  # Explicit dependency for docket/fastmcp background tasks
     "fastmcp>=3.0.0",
@@ -27,6 +26,7 @@ Documentation = "https://docs.openhands.dev/sdk"
 "Bug Tracker" = "https://github.com/OpenHands/software-agent-sdk/issues"
 
 [project.optional-dependencies]
+acp = ["agent-client-protocol>=0.8.1"]
 boto3 = ["boto3>=1.35.0"]
 
 [build-system]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ openhands-agent-server = { workspace = true }
 
 [dependency-groups]
 dev = [
+    "agent-client-protocol>=0.8.1",  # Optional SDK extra; included for ACP tests
     "pre-commit>=4.3.0",
     "packaging>=24.2",
     "psutil>=7.0.0",

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -9,15 +9,22 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from openhands.sdk.agent.acp_agent import ACPAgent, _OpenHandsACPBridge
-from openhands.sdk.agent.base import AgentBase
-from openhands.sdk.conversation.state import (
+
+pytest.importorskip("acp", reason="agent-client-protocol not installed")
+
+from openhands.sdk.agent.acp_agent import ACPAgent, _OpenHandsACPBridge  # noqa: E402
+from openhands.sdk.agent.base import AgentBase  # noqa: E402
+from openhands.sdk.conversation.state import (  # noqa: E402
     ConversationExecutionStatus,
     ConversationState,
 )
-from openhands.sdk.event import ACPToolCallEvent, MessageEvent, SystemPromptEvent
-from openhands.sdk.llm import Message, TextContent
-from openhands.sdk.workspace.local import LocalWorkspace
+from openhands.sdk.event import (  # noqa: E402
+    ACPToolCallEvent,
+    MessageEvent,
+    SystemPromptEvent,
+)
+from openhands.sdk.llm import Message, TextContent  # noqa: E402
+from openhands.sdk.workspace.local import LocalWorkspace  # noqa: E402
 
 
 # ---------------------------------------------------------------------------

--- a/uv.lock
+++ b/uv.lock
@@ -25,6 +25,7 @@ constraints = [
 
 [manifest.dependency-groups]
 dev = [
+    { name = "agent-client-protocol", specifier = ">=0.8.1" },
     { name = "griffe", extras = ["pypi"], specifier = ">=2.0.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
@@ -2377,7 +2378,6 @@ name = "openhands-sdk"
 version = "1.12.0"
 source = { editable = "openhands-sdk" }
 dependencies = [
-    { name = "agent-client-protocol" },
     { name = "deprecation" },
     { name = "fakeredis", extra = ["lua"] },
     { name = "fastmcp" },
@@ -2393,13 +2393,16 @@ dependencies = [
 ]
 
 [package.optional-dependencies]
+acp = [
+    { name = "agent-client-protocol" },
+]
 boto3 = [
     { name = "boto3" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "agent-client-protocol", specifier = ">=0.8.1" },
+    { name = "agent-client-protocol", marker = "extra == 'acp'", specifier = ">=0.8.1" },
     { name = "boto3", marker = "extra == 'boto3'", specifier = ">=1.35.0" },
     { name = "deprecation", specifier = ">=2.1.0" },
     { name = "fakeredis", extras = ["lua"], specifier = ">=2.32.1" },
@@ -2414,7 +2417,7 @@ requires-dist = [
     { name = "tenacity", specifier = ">=9.1.2" },
     { name = "websockets", specifier = ">=12" },
 ]
-provides-extras = ["boto3"]
+provides-extras = ["acp", "boto3"]
 
 [[package]]
 name = "openhands-tools"


### PR DESCRIPTION
## Summary

- Moves `agent-client-protocol` from a hard required dependency back to an optional extra (`pip install openhands-sdk[acp]`)
- SDK consumers who don't use ACPAgent are no longer forced to pull in `agent-client-protocol>=0.8.1`, unblocking downstream repos (e.g. the CLI) that pin `agent-client-protocol<0.8.0`
- The lazy `__getattr__` import in `__init__.py` now catches `ImportError` and provides a clear install instruction

## Context

Commit `e9cbac0` (Feb 20) promoted `agent-client-protocol` from an `[acp]` optional extra to a hard required dependency. This created a version conflict: the CLI pins `agent-client-protocol>=0.7.0,<0.8.0` while the SDK now requires `>=0.8.1`. These constraints are mutually exclusive, preventing the CLI from upgrading to SDK v1.12.0+.

## Changes

| File | Change |
|------|--------|
| `openhands-sdk/pyproject.toml` | Move `agent-client-protocol>=0.8.1` from `dependencies` to `[project.optional-dependencies] acp` |
| `openhands-sdk/.../agent/__init__.py` | Catch `ImportError` in `__getattr__` with helpful install message |
| `tests/sdk/agent/test_acp_agent.py` | Add `pytest.importorskip("acp")` to skip when not installed |
| `examples/.../40_acp_agent_example.py` | Add install prerequisite note |
| `pyproject.toml` (root) | Add `agent-client-protocol` to dev deps so CI tests still run |
| `uv.lock` | Regenerated |

## Test plan

- [x] All 61 ACP agent tests pass (`pytest tests/sdk/agent/test_acp_agent.py`)
- [x] All 201 agent tests pass (`pytest tests/sdk/agent/`)
- [x] All pre-commit hooks pass (ruff, pycodestyle, pyright, import rules)
- [ ] CI passes
- [ ] Verify CLI can install SDK without pulling in ACP: `pip install openhands-sdk` should succeed without `agent-client-protocol`
- [ ] Verify `from openhands.sdk.agent import ACPAgent` raises clear `ImportError` when ACP not installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)