### PR TITLE
fix(examples): emit EXAMPLE_COST for marketplace demo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -297,6 +297,7 @@ Note: This is separate from `persistence_dir` which is used for conversation sta
 - Build agent-server: `make build-server` (output: `dist/agent-server/`)
 - Clean caches: `make clean`
 - Run SDK examples: see [openhands-sdk/openhands/sdk/AGENTS.md](openhands-sdk/openhands/sdk/AGENTS.md).
+- The example workflow runs `uv run pytest tests/examples/test_examples.py --run-examples`; each successful example must print an `EXAMPLE_COST: ...` line to stdout (use `EXAMPLE_COST: 0` for non-LLM examples).
 - Conversation plugins passed via `plugins=[...]` are lazy-loaded on the first `send_message()` or `run()`, so example code should inspect plugin-added skills or `resolved_plugins` only after that first interaction.
 </QUICK_COMMANDS>
 

--- a/examples/01_standalone_sdk/43_mixed_marketplace_skills/main.py
+++ b/examples/01_standalone_sdk/43_mixed_marketplace_skills/main.py
@@ -116,3 +116,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    print("EXAMPLE_COST: 0")


### PR DESCRIPTION
## Summary
- move the marketplace demo `EXAMPLE_COST` fix onto its own branch
- keep release PR #2378 limited to the release commit
- apply the previously removed change from 21704dcf70bb269352de9cb62d601aa73a168049 on top of `main`

## Testing
- not run (branch split / PR management only)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b737441-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b737441-python \
  ghcr.io/openhands/agent-server:b737441-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b737441-golang-amd64
ghcr.io/openhands/agent-server:b737441-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b737441-golang-arm64
ghcr.io/openhands/agent-server:b737441-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b737441-java-amd64
ghcr.io/openhands/agent-server:b737441-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b737441-java-arm64
ghcr.io/openhands/agent-server:b737441-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b737441-python-amd64
ghcr.io/openhands/agent-server:b737441-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:b737441-python-arm64
ghcr.io/openhands/agent-server:b737441-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:b737441-golang
ghcr.io/openhands/agent-server:b737441-java
ghcr.io/openhands/agent-server:b737441-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b737441-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b737441-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->