### PR TITLE
fix(llm): add provider-specific verified model lists for gemini, deepseek, moonshot, minimax

### DIFF
--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -52,6 +52,12 @@ This file (`resolve_model_config.py`) defines models available for evaluation. M
    - `openhands-sdk/openhands/sdk/llm/utils/model_prompt_spec.py` - GPT models only (variant detection)
    - `openhands-sdk/openhands/sdk/llm/utils/verified_models.py` - Production-ready models
 
+   > ⚠️ **When editing `verified_models.py`**: If you add a model to `VERIFIED_OPENHANDS_MODELS`,
+   > you **must also** add it to its provider-specific list (e.g. `VERIFIED_ANTHROPIC_MODELS`,
+   > `VERIFIED_GEMINI_MODELS`, `VERIFIED_MOONSHOT_MODELS`, etc.).
+   > If no list exists for the provider yet, create one and add it to the `VERIFIED_MODELS` dict.
+   > This ensures the model appears under its actual provider in the UI, not just under "openhands".
+
 ## Step 1: Add to resolve_model_config.py
 
 Add entry to `MODELS` dictionary:

--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -45,6 +45,23 @@ VERIFIED_MISTRAL_MODELS = [
     "devstral-medium-2512",
 ]
 
+VERIFIED_GEMINI_MODELS = [
+    "gemini-3-pro-preview",
+]
+
+VERIFIED_DEEPSEEK_MODELS = [
+    "deepseek-chat",
+]
+
+VERIFIED_MOONSHOT_MODELS = [
+    "kimi-k2-thinking",
+    "kimi-k2.5",
+]
+
+VERIFIED_MINIMAX_MODELS = [
+    "minimax-m2.5",
+]
+
 VERIFIED_OPENHANDS_MODELS = [
     "claude-opus-4-6",
     "claude-sonnet-4-5-20250929",
@@ -69,4 +86,8 @@ VERIFIED_MODELS = {
     "anthropic": VERIFIED_ANTHROPIC_MODELS,
     "openai": VERIFIED_OPENAI_MODELS,
     "mistral": VERIFIED_MISTRAL_MODELS,
+    "gemini": VERIFIED_GEMINI_MODELS,
+    "deepseek": VERIFIED_DEEPSEEK_MODELS,
+    "moonshot": VERIFIED_MOONSHOT_MODELS,
+    "minimax": VERIFIED_MINIMAX_MODELS,
 }

--- a/tests/sdk/llm/test_model_list.py
+++ b/tests/sdk/llm/test_model_list.py
@@ -5,6 +5,10 @@ from openhands.sdk.llm.utils.unverified_models import (
     _list_bedrock_foundation_models,
     get_unverified_models,
 )
+from openhands.sdk.llm.utils.verified_models import (
+    VERIFIED_MODELS,
+    VERIFIED_OPENHANDS_MODELS,
+)
 
 
 def test_organize_models_and_providers():
@@ -77,3 +81,19 @@ def test_list_bedrock_models_with_boto3(monkeypatch):
     result = _list_bedrock_foundation_models("us-east-1", "key", "secret")
 
     assert result == ["bedrock/anthropic.claude-3"]
+
+
+def test_openhands_models_all_have_provider_list():
+    """Every model in VERIFIED_OPENHANDS_MODELS must also appear in at least one
+    provider-specific list so that the UI can display it under its actual provider.
+    """
+    provider_models = set()
+    for provider, models in VERIFIED_MODELS.items():
+        if provider == "openhands":
+            continue
+        provider_models.update(models)
+
+    missing = [m for m in VERIFIED_OPENHANDS_MODELS if m not in provider_models]
+    assert not missing, (
+        f"Models in VERIFIED_OPENHANDS_MODELS missing from any provider list: {missing}"
+    )


### PR DESCRIPTION
## Summary

Fixes #2385

Models in `VERIFIED_OPENHANDS_MODELS` were appearing in the OpenHands verified models UI but not under their actual provider, because no provider-specific list existed for `gemini`, `deepseek`, `moonshot` (Kimi), and `minimax`.

## Diagnosis

The following models were in `VERIFIED_OPENHANDS_MODELS` but had no corresponding provider list:
- `gemini-3-pro-preview` → no `gemini` list
- `deepseek-chat` → no `deepseek` list
- `kimi-k2-thinking`, `kimi-k2.5` → no `moonshot` list
- `minimax-m2.5` → no `minimax` list

(The original reporter's example `claude-sonnet-4-6` was already fixed in #2104.)

## Changes

### `openhands-sdk/openhands/sdk/llm/utils/verified_models.py`
- Added `VERIFIED_GEMINI_MODELS = ["gemini-3-pro-preview"]`
- Added `VERIFIED_DEEPSEEK_MODELS = ["deepseek-chat"]`
- Added `VERIFIED_MOONSHOT_MODELS = ["kimi-k2-thinking", "kimi-k2.5"]`
- Added `VERIFIED_MINIMAX_MODELS = ["minimax-m2.5"]`
- Registered all new lists in `VERIFIED_MODELS` dict

### `tests/sdk/llm/test_model_list.py`
- Added `test_openhands_models_all_have_provider_list` — ensures every model in `VERIFIED_OPENHANDS_MODELS` also appears in at least one provider-specific list, preventing this class of regression.

### `.github/run-eval/ADDINGMODEL.md`
- Added a clear warning in the "Files to Modify" section explaining that when a model is added to `VERIFIED_OPENHANDS_MODELS`, it **must also** be added to its provider-specific list (creating a new one if needed).

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6294ebb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6294ebb-python \
  ghcr.io/openhands/agent-server:6294ebb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6294ebb-golang-amd64
ghcr.io/openhands/agent-server:6294ebb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6294ebb-golang-arm64
ghcr.io/openhands/agent-server:6294ebb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6294ebb-java-amd64
ghcr.io/openhands/agent-server:6294ebb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6294ebb-java-arm64
ghcr.io/openhands/agent-server:6294ebb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6294ebb-python-amd64
ghcr.io/openhands/agent-server:6294ebb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:6294ebb-python-arm64
ghcr.io/openhands/agent-server:6294ebb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:6294ebb-golang
ghcr.io/openhands/agent-server:6294ebb-java
ghcr.io/openhands/agent-server:6294ebb-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6294ebb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6294ebb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->