### PR TITLE
Add NVIDIA Nemotron-3 Super 120B model to resolve_model_config.py

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -238,6 +238,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "nemotron-3-super-120b-a12b-free": {
+        "id": "nemotron-3-super-120b-a12b-free",
+        "display_name": "NVIDIA Nemotron-3 Super 120B",
+        "llm_config": {
+            "model": "litellm_proxy/openrouter/nvidia/nemotron-3-super-120b-a12b:free",
+            "temperature": 0.0,
+        },
+    },
 }
 
 

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -501,3 +501,16 @@ def test_gpt_5_4_config():
     assert model["display_name"] == "GPT-5.4"
     assert model["llm_config"]["model"] == "litellm_proxy/openai/gpt-5.4"
     assert model["llm_config"]["reasoning_effort"] == "high"
+
+
+def test_nemotron_3_super_120b_a12b_free_config():
+    """Test that nemotron-3-super-120b-a12b-free has correct configuration."""
+    model = MODELS["nemotron-3-super-120b-a12b-free"]
+
+    assert model["id"] == "nemotron-3-super-120b-a12b-free"
+    assert model["display_name"] == "NVIDIA Nemotron-3 Super 120B"
+    assert (
+        model["llm_config"]["model"]
+        == "litellm_proxy/openrouter/nvidia/nemotron-3-super-120b-a12b:free"
+    )
+    assert model["llm_config"]["temperature"] == 0.0


### PR DESCRIPTION
## Summary
Adds the `nemotron-3-super-120b-a12b-free` model (NVIDIA Nemotron-3 Super 120B) to resolve_model_config.py.

## Changes
- Added `nemotron-3-super-120b-a12b-free` to MODELS dictionary in `.github/run-eval/resolve_model_config.py`
- Added `test_nemotron_3_super_120b_a12b_free_config()` test function in `tests/github_workflows/test_resolve_model_config.py`

## Configuration
- **Model ID**: `nemotron-3-super-120b-a12b-free`
- **Provider**: OpenRouter (NVIDIA)
- **Model Path**: `litellm_proxy/openrouter/nvidia/nemotron-3-super-120b-a12b:free`
- **Temperature**: `0.0` - Standard deterministic setting for consistent evaluation results
- **Display Name**: NVIDIA Nemotron-3 Super 120B

## Model Details
This model is based on the NVIDIA Nemotron-3 Super, a hybrid Mamba-Transformer-MoE architecture designed for agentic reasoning tasks. For more details, see the [NVIDIA blog post](https://developer.nvidia.com/blog/introducing-nemotron-3-super-an-open-hybrid-mamba-transformer-moe-for-agentic-reasoning/?nvid=nv-int-bnr-167561).

## Testing
✅ Pre-commit checks passed
✅ Unit test for model configuration passed: `test_nemotron_3_super_120b_a12b_free_config`
✅ All models validation test passed: `test_all_models_valid_with_pydantic`

Fixes #2389
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1996a00-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1996a00-python \
  ghcr.io/openhands/agent-server:1996a00-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1996a00-golang-amd64
ghcr.io/openhands/agent-server:1996a00-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1996a00-golang-arm64
ghcr.io/openhands/agent-server:1996a00-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1996a00-java-amd64
ghcr.io/openhands/agent-server:1996a00-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1996a00-java-arm64
ghcr.io/openhands/agent-server:1996a00-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1996a00-python-amd64
ghcr.io/openhands/agent-server:1996a00-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:1996a00-python-arm64
ghcr.io/openhands/agent-server:1996a00-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:1996a00-golang
ghcr.io/openhands/agent-server:1996a00-java
ghcr.io/openhands/agent-server:1996a00-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1996a00-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1996a00-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->