### PR TITLE
fix(tools): share browser executor across subagents to prevent CDP port conflicts

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -2,7 +2,9 @@
 
 import base64
 import hashlib
+import logging
 import os
+import threading
 from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, ClassVar, Literal, Self
@@ -19,6 +21,8 @@ from openhands.sdk.tool import (
 )
 from openhands.sdk.utils import DEFAULT_TEXT_CONTENT_LIMIT, maybe_truncate
 
+
+_logger = logging.getLogger(__name__)
 
 # Lazy import to avoid hanging during module import
 if TYPE_CHECKING:
@@ -782,6 +786,7 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
     # Shared executor: reuse a single Chromium/CDP instance across parent
     # and subagents to avoid CDP port conflicts in sandbox containers.
     _shared_executor: ClassVar["BrowserToolExecutor | None"] = None
+    _shared_executor_lock: ClassVar[threading.Lock] = threading.Lock()
 
     @classmethod
     def create(
@@ -793,26 +798,35 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
         # avoid hanging during module import
         import sys
 
-        if cls._shared_executor is not None:
-            executor = cls._shared_executor
-        elif sys.platform == "win32":
-            from openhands.tools.browser_use.impl_windows import (
-                WindowsBrowserToolExecutor,
-            )
+        with cls._shared_executor_lock:
+            if cls._shared_executor is not None:
+                if executor_config:
+                    _logger.warning(
+                        "BrowserToolSet.create() called with executor_config but a "
+                        "shared executor already exists. The config %s will be "
+                        "ignored. This typically happens when a subagent requests "
+                        "browser tools — it reuses the parent's browser session.",
+                        list(executor_config.keys()),
+                    )
+                executor = cls._shared_executor
+            elif sys.platform == "win32":
+                from openhands.tools.browser_use.impl_windows import (
+                    WindowsBrowserToolExecutor,
+                )
 
-            executor = WindowsBrowserToolExecutor(
-                full_output_save_dir=conv_state.env_observation_persistence_dir,
-                **executor_config,
-            )
-            cls._shared_executor = executor
-        else:
-            from openhands.tools.browser_use.impl import BrowserToolExecutor
+                executor = WindowsBrowserToolExecutor(
+                    full_output_save_dir=conv_state.env_observation_persistence_dir,
+                    **executor_config,
+                )
+                cls._shared_executor = executor
+            else:
+                from openhands.tools.browser_use.impl import BrowserToolExecutor
 
-            executor = BrowserToolExecutor(
-                full_output_save_dir=conv_state.env_observation_persistence_dir,
-                **executor_config,
-            )
-            cls._shared_executor = executor
+                executor = BrowserToolExecutor(
+                    full_output_save_dir=conv_state.env_observation_persistence_dir,
+                    **executor_config,
+                )
+                cls._shared_executor = executor
 
         # Each tool.create() returns a Sequence[Self], so we flatten the results
         tools: list[ToolDefinition[BrowserAction, BrowserObservation]] = []

--- a/tests/tools/browser_use/test_browser_toolset.py
+++ b/tests/tools/browser_use/test_browser_toolset.py
@@ -174,6 +174,43 @@ def test_browser_toolset_shared_executor_reset():
         assert executor1 is not executor2
 
 
+def test_browser_toolset_warns_when_config_ignored(caplog):
+    """
+    Test that a warning is logged when a second create()
+    passes config that gets ignored.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+
+        # First call sets up the shared executor
+        BrowserToolSet.create(conv_state=conv_state)
+
+        # Second call with different config should warn
+        with caplog.at_level(
+            "WARNING", logger="openhands.tools.browser_use.definition"
+        ):
+            BrowserToolSet.create(conv_state=conv_state, headless=False)
+
+        assert any("shared executor already exists" in msg for msg in caplog.messages)
+
+
+def test_browser_toolset_no_warning_when_no_config(caplog):
+    """Test that no warning is logged when a second create() passes no extra config."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+
+        BrowserToolSet.create(conv_state=conv_state)
+
+        with caplog.at_level(
+            "WARNING", logger="openhands.tools.browser_use.definition"
+        ):
+            BrowserToolSet.create(conv_state=conv_state)
+
+        assert not any(
+            "shared executor already exists" in msg for msg in caplog.messages
+        )
+
+
 def test_browser_toolset_create_tools_can_generate_mcp_schema():
     """Test that tools from BrowserToolSet.create() can generate MCP schemas."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
## Summary
- Subagents each launched their own Chromium process via BrowserToolSet.create(), causing CDP port conflicts in sandbox containers where the parent agent's Chromium already occupies the debugging port
- Make BrowserToolExecutor a singleton at the BrowserToolSet class level so parent and subagents share a single Chromium instance

## Problem

When a subagent is spawned, it resolves its tools independently — including browser_tool_set. Each call to BrowserToolSet.create() constructed a new BrowserToolExecutor, which launched a new Chromium process and tried to connect via CDP.

In sandbox containers, this fails because:
1. The parent agent's Chromium already holds the CDP debugging port
2. The subagent's Chromium either can't bind the port (→ _cdp_client_root stays None → AssertionError: Root CDP client not initialized) or connects to the parent's /json/version endpoint and hijacks its session (→ tab conflicts, "Failed to open new tab - no browser is open" on cleanup)

```text
  Code path:
  Subagent tool resolution
    → BrowserToolSet.create()
      → new BrowserToolExecutor()
        → _ensure_initialized()
          → BrowserSession.start()
            → launches new Chromium on same CDP port
              → port conflict / session hijack
```

## Fix

Add a ClassVar _shared_executor to BrowserToolSet. The first create() call (parent agent) creates and caches the executor. All subsequent calls (subagents) reuse it. One Chromium process, one CDP connection, no port conflict.

The change is 4 lines in definition.py.

## Test plan
- test_browser_toolset_create_multiple_calls_share_executor — two create() calls return the same executor instance
- test_browser_toolset_shared_executor_survives_multiple_subagents — parent + 3 subagents all share one executor
- test_browser_toolset_shared_executor_reset — resetting _shared_executor allows creating a fresh executor
- All existing test_browser_toolset.py tests pass (autouse fixture resets singleton between tests)

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fd7cd24-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fd7cd24-python \
  ghcr.io/openhands/agent-server:fd7cd24-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fd7cd24-golang-amd64
ghcr.io/openhands/agent-server:fd7cd24-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fd7cd24-golang-arm64
ghcr.io/openhands/agent-server:fd7cd24-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fd7cd24-java-amd64
ghcr.io/openhands/agent-server:fd7cd24-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fd7cd24-java-arm64
ghcr.io/openhands/agent-server:fd7cd24-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fd7cd24-python-amd64
ghcr.io/openhands/agent-server:fd7cd24-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:fd7cd24-python-arm64
ghcr.io/openhands/agent-server:fd7cd24-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:fd7cd24-golang
ghcr.io/openhands/agent-server:fd7cd24-java
ghcr.io/openhands/agent-server:fd7cd24-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fd7cd24-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fd7cd24-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->