### PR TITLE
Log response content when webhook posting fails

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -757,6 +757,7 @@ class ConversationWebhookSubscriber:
         conversation_data = conversation_info.model_dump(mode="json")
 
         # Retry logic
+        response = None
         for attempt in range(self.spec.num_retries + 1):
             try:
                 async with httpx.AsyncClient() as client:
@@ -780,10 +781,14 @@ class ConversationWebhookSubscriber:
                 if attempt < self.spec.num_retries:
                     await asyncio.sleep(self.spec.retry_delay)
                 else:
+                    # Log response content for debugging failures
+                    response_content = (
+                        response.text if response is not None else "No response"
+                    )
                     logger.error(
                         f"Failed to post conversation info to webhook "
                         f"{conversations_url} after {self.spec.num_retries + 1} "
-                        "attempts"
+                        f"attempts. Response: {response_content}"
                     )
 
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where `ConversationWebhookSubscriber` in `conversation_service.py` was not logging the response content when webhook requests failed with HTTP errors like 422. This made it difficult to debug why webhooks were failing.

The fix adds logging of `response.text` after all retries are exhausted, making it easier to diagnose webhook issues by seeing the actual error message from the server.

## Changes

- Added `response = None` before the retry loop to track the response object
- Modified the final error log to include `response.text` when available

Example of the new log output:
```
Failed to post conversation info to webhook https://.../conversations after 3 attempts. Response: {"detail":[{"type":"missing","loc":["query","conversation_id"],"msg":"Field required","input":null}]}
```

## Checklist

- [x] This is a small bug fix with minimal changes
- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?