### PR TITLE
Enforce OpenAPI endpoint deprecations in REST API checks

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -2,20 +2,27 @@
 """REST API breakage detection for openhands-agent-server using oasdiff.
 
 This script compares the current OpenAPI schema for the agent-server REST API against
-the most recent published version on PyPI, using oasdiff for breaking change detection.
+an already-published release. The baseline version is selected from PyPI, but the
+baseline schema is generated from the matching git tag under the current workspace's
+locked dependency set. This keeps the comparison focused on API changes in our code,
+not schema drift from newer FastAPI/Pydantic releases.
 
-Policies enforced (mirrors the SDK's Griffe checks, but for REST):
+Policies enforced:
 
-1) Deprecation-before-removal
+1) Deprecation metadata for REST endpoints
+   - Endpoints documented as deprecated in their OpenAPI description must also be
+     marked `deprecated: true` in the generated schema.
+
+2) Deprecation-before-removal
    - If a REST operation (path + HTTP method) is removed, it must have been marked
      `deprecated: true` in the baseline release.
 
-2) MINOR version bump
+3) MINOR version bump
    - If a breaking REST change is detected, the current version must be at least a
      MINOR bump compared to the baseline release.
 
-If the baseline release schema can't be fetched (e.g., network / PyPI issues), the
-script emits a warning and exits successfully to avoid flaky CI.
+If the baseline release schema can't be generated (e.g., missing tag / repo issues),
+the script emits a warning and exits successfully to avoid flaky CI.
 """
 
 from __future__ import annotations
@@ -34,6 +41,33 @@ from packaging import version as pkg_version
 REPO_ROOT = Path(__file__).resolve().parents[2]
 AGENT_SERVER_PYPROJECT = REPO_ROOT / "openhands-agent-server" / "pyproject.toml"
 PYPI_DISTRIBUTION = "openhands-agent-server"
+HTTP_METHODS = {
+    "get",
+    "put",
+    "post",
+    "delete",
+    "patch",
+    "options",
+    "head",
+    "trace",
+}
+OPENAPI_PROGRAM = """
+import json
+import sys
+from pathlib import Path
+
+source_tree = Path(sys.argv[1])
+sys.path = [
+    str(source_tree / "openhands-agent-server"),
+    str(source_tree / "openhands-sdk"),
+    str(source_tree / "openhands-tools"),
+    str(source_tree / "openhands-workspace"),
+] + sys.path
+
+from openhands.agent_server.api import create_app
+
+print(json.dumps(create_app().openapi()))
+"""
 
 
 def _read_version_from_pyproject(pyproject: Path) -> str:
@@ -81,85 +115,88 @@ def _get_baseline_version(distribution: str, current: str) -> str | None:
     return max(older, key=pkg_version.parse)
 
 
-def _generate_current_openapi() -> dict:
-    from openhands.agent_server.api import create_app
+def _generate_openapi_from_source_tree(source_tree: Path, label: str) -> dict | None:
+    try:
+        result = subprocess.run(
+            [sys.executable, "-c", OPENAPI_PROGRAM, str(source_tree)],
+            check=True,
+            capture_output=True,
+            text=True,
+            cwd=source_tree,
+        )
+        return json.loads(result.stdout)
+    except subprocess.CalledProcessError as exc:
+        output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
+        excerpt = output.strip()[-1000:]
+        print(
+            f"::warning title={PYPI_DISTRIBUTION} REST API::Failed to generate "
+            f"OpenAPI schema for {label}: {exc}\n{excerpt}"
+        )
+        return None
+    except Exception as exc:
+        print(
+            f"::warning title={PYPI_DISTRIBUTION} REST API::Failed to generate "
+            f"OpenAPI schema for {label}: {exc}"
+        )
+        return None
 
-    return create_app().openapi()
+
+def _generate_current_openapi() -> dict | None:
+    return _generate_openapi_from_source_tree(REPO_ROOT, "current workspace")
 
 
-def _generate_openapi_for_version(version: str) -> dict | None:
-    """Generate OpenAPI schema for a published agent-server version.
-
-    Returns None on failure so callers can treat it as a best-effort comparison.
-    """
-
+def _generate_openapi_for_git_ref(git_ref: str) -> dict | None:
     with tempfile.TemporaryDirectory(prefix="agent-server-openapi-") as tmp:
-        venv_dir = Path(tmp) / ".venv"
-        python = venv_dir / "bin" / "python"
+        source_tree = Path(tmp)
 
         try:
-            subprocess.run(
-                [
-                    "uv",
-                    "venv",
-                    str(venv_dir),
-                    "--python",
-                    sys.executable,
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
-            openhands_packages = (
-                "openhands-agent-server",
-                "openhands-sdk",
-                "openhands-tools",
-                "openhands-workspace",
-            )
-            packages = [f"{name}=={version}" for name in openhands_packages]
-
-            subprocess.run(
-                [
-                    "uv",
-                    "pip",
-                    "install",
-                    "--python",
-                    str(python),
-                    *packages,
-                ],
-                check=True,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.STDOUT,
-                text=True,
-            )
-
-            program = (
-                "import json; "
-                "from openhands.agent_server.api import create_app; "
-                "print(json.dumps(create_app().openapi()))"
-            )
-            result = subprocess.run(
-                [str(python), "-c", program],
+            archive = subprocess.run(
+                ["git", "-C", str(REPO_ROOT), "archive", git_ref],
                 check=True,
                 capture_output=True,
-                text=True,
             )
-            return json.loads(result.stdout)
+            subprocess.run(
+                ["tar", "-x", "-C", str(source_tree)],
+                check=True,
+                input=archive.stdout,
+                capture_output=True,
+            )
         except subprocess.CalledProcessError as exc:
-            output = (exc.stdout or "") + ("\n" + exc.stderr if exc.stderr else "")
-            excerpt = output.strip()[-1000:]
+            output = (exc.stdout or b"") + (b"\n" + exc.stderr if exc.stderr else b"")
+            excerpt = output.decode(errors="replace").strip()[-1000:]
             print(
-                f"::warning title={PYPI_DISTRIBUTION} REST API::Failed to generate "
-                f"OpenAPI schema for v{version}: {exc}\n{excerpt}"
+                f"::warning title={PYPI_DISTRIBUTION} REST API::Failed to extract "
+                f"source for {git_ref}: {exc}\n{excerpt}"
             )
             return None
-        except Exception as exc:
-            print(
-                f"::warning title={PYPI_DISTRIBUTION} REST API::Failed to generate "
-                f"OpenAPI schema for v{version}: {exc}"
+
+        return _generate_openapi_from_source_tree(source_tree, git_ref)
+
+
+def _find_deprecation_policy_errors(schema: dict) -> list[str]:
+    errors: list[str] = []
+
+    for path, path_item in schema.get("paths", {}).items():
+        if not isinstance(path_item, dict):
+            continue
+
+        for method, operation in path_item.items():
+            if method not in HTTP_METHODS or not isinstance(operation, dict):
+                continue
+
+            description = operation.get("description") or ""
+            if "deprecated since" not in description.lower():
+                continue
+
+            if operation.get("deprecated") is True:
+                continue
+
+            errors.append(
+                f"{method.upper()} {path} documents deprecation in its "
+                "description but is not marked deprecated=true in OpenAPI."
             )
-            return None
+
+    return errors
 
 
 def _normalize_openapi_for_oasdiff(schema: dict) -> dict:
@@ -262,11 +299,19 @@ def main() -> int:
         )
         return 0
 
-    prev_schema = _generate_openapi_for_version(baseline_version)
-    if prev_schema is None:
-        return 0
+    baseline_git_ref = f"v{baseline_version}"
 
     current_schema = _generate_current_openapi()
+    if current_schema is None:
+        return 1
+
+    deprecation_policy_errors = _find_deprecation_policy_errors(current_schema)
+    for error in deprecation_policy_errors:
+        print(f"::error title={PYPI_DISTRIBUTION} REST API::{error}")
+
+    prev_schema = _generate_openapi_for_git_ref(baseline_git_ref)
+    if prev_schema is None:
+        return 0 if not deprecation_policy_errors else 1
 
     prev_schema = _normalize_openapi_for_oasdiff(prev_schema)
     current_schema = _normalize_openapi_for_oasdiff(current_schema)
@@ -291,63 +336,51 @@ def main() -> int:
                 f"oasdiff returned exit code {exit_code} but no breaking changes "
                 "in JSON format. There may be warnings only."
             )
-        return 0
+    else:
+        removed_operations = []
 
-    removed_operations = []
-    other_breakage = []
+        for change in breaking_changes:
+            change_id = change.get("id", "")
+            details = change.get("details", {})
 
-    for change in breaking_changes:
-        change_id = change.get("id", "")
-        text = change.get("text", "")
-        details = change.get("details", {})
+            if "removed" in change_id.lower() and "operation" in change_id.lower():
+                removed_operations.append(
+                    {
+                        "path": details.get("path", ""),
+                        "method": details.get("method", ""),
+                        "deprecated": details.get("deprecated", False),
+                    }
+                )
 
-        if "removed" in change_id.lower() and "operation" in change_id.lower():
-            path = details.get("path", "")
-            method = details.get("method", "")
-            operation_id = details.get("operationId", "")
-            deprecated = details.get("deprecated", False)
+        undeprecated_removals = [
+            op for op in removed_operations if not op.get("deprecated", False)
+        ]
 
-            removed_operations.append(
-                {
-                    "path": path,
-                    "method": method,
-                    "operationId": operation_id,
-                    "deprecated": deprecated,
-                }
-            )
-        else:
-            other_breakage.append(text)
-
-    undeprecated_removals = [
-        op for op in removed_operations if not op.get("deprecated", False)
-    ]
-
-    if undeprecated_removals:
         for op in undeprecated_removals:
             print(
-                f"::error "
-                f"title={PYPI_DISTRIBUTION} REST API::Removed {op['method'].upper()} "
-                f"{op['path']} without prior deprecation (deprecated=true)."
+                f"::error title={PYPI_DISTRIBUTION} REST API::Removed "
+                f"{op['method'].upper()} {op['path']} without prior deprecation "
+                "(deprecated=true)."
             )
 
-    has_breaking = bool(breaking_changes)
+        if not _is_minor_or_major_bump(current_version, baseline_version):
+            print(
+                "::error "
+                f"title={PYPI_DISTRIBUTION} REST API::Breaking REST API change "
+                f"detected without MINOR version bump ({baseline_version} -> "
+                f"{current_version})."
+            )
 
-    if has_breaking and not _is_minor_or_major_bump(current_version, baseline_version):
-        print(
-            "::error "
-            f"title={PYPI_DISTRIBUTION} REST API::Breaking REST API change detected "
-            f"without MINOR version bump ({baseline_version} -> {current_version})."
-        )
-
-    if has_breaking:
         print("\nBreaking REST API changes detected compared to baseline release:")
         for text in breaking_changes:
             print(f"- {text.get('text', str(text))}")
 
-    errors = bool(undeprecated_removals) or (
-        has_breaking and not _is_minor_or_major_bump(current_version, baseline_version)
-    )
-    return 1 if errors else 0
+        if undeprecated_removals or not _is_minor_or_major_bump(
+            current_version, baseline_version
+        ):
+            return 1
+
+    return 1 if deprecation_policy_errors else 0
 
 
 if __name__ == "__main__":

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -20,7 +20,6 @@ from openhands.agent_server.conversation_service import get_default_conversation
 from openhands.agent_server.models import ExecuteBashRequest, Success
 from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils.deprecation import deprecated
 
 
 logger = get_logger(__name__)
@@ -110,21 +109,18 @@ async def upload_file_query(
     return await _upload_file(path, file)
 
 
-@file_router.post("/upload/{path:path}")
-@deprecated(
-    deprecated_in="1.15.0",
-    removed_in="1.20.0",
-    details=(
-        "Use the /file/upload endpoint with a query parameter for the path "
-        "instead of a path parameter. This allows for better handling of "
-        "complex paths and is more consistent with other endpoints."
-    ),
-)
+@file_router.post("/upload/{path:path}", deprecated=True)
 async def upload_file_path(
     path: Annotated[str, FastApiPath(alias="path", description="Absolute file path.")],
     file: Annotated[UploadFile, File(...)],
 ) -> Success:
-    """Upload a file using path parameter (legacy, for backwards compatibility)."""
+    """Upload a file using path parameter (legacy, for backwards compatibility).
+
+    Deprecated since v1.15.0 and scheduled for removal in v1.20.0.
+
+    Prefer `/file/upload?path=...` to avoid path-encoding issues and align with
+    other file endpoints.
+    """
     return await _upload_file(path, file)
 
 
@@ -136,20 +132,17 @@ async def download_file_query(
     return await _download_file(path)
 
 
-@file_router.get("/download/{path:path}")
-@deprecated(
-    deprecated_in="1.15.0",
-    removed_in="1.20.0",
-    details=(
-        "Use the /file/download endpoint with a query parameter for the path "
-        "instead of a path parameter. This allows for better handling of "
-        "complex paths and is more consistent with other endpoints."
-    ),
-)
+@file_router.get("/download/{path:path}", deprecated=True)
 async def download_file_path(
     path: Annotated[str, FastApiPath(description="Absolute file path.")],
 ) -> FileResponse:
-    """Download a file using path parameter (legacy, for backwards compatibility)."""
+    """Download a file using path parameter (legacy, for backwards compatibility).
+
+    Deprecated since v1.15.0 and scheduled for removal in v1.20.0.
+
+    Prefer `/file/download?path=...` to avoid path-encoding issues and align with
+    other file endpoints.
+    """
     return await _download_file(path)
 
 

--- a/openhands-agent-server/openhands/agent_server/git_router.py
+++ b/openhands-agent-server/openhands/agent_server/git_router.py
@@ -10,7 +10,6 @@ from openhands.agent_server.server_details_router import update_last_execution_t
 from openhands.sdk.git.git_changes import get_git_changes
 from openhands.sdk.git.git_diff import get_git_diff
 from openhands.sdk.git.models import GitChange, GitDiff
-from openhands.sdk.utils.deprecation import deprecated
 
 
 git_router = APIRouter(prefix="/git", tags=["Git"])
@@ -39,18 +38,15 @@ async def git_changes_query(
     return await _get_git_changes(path)
 
 
-@git_router.get("/changes/{path:path}")
-@deprecated(
-    deprecated_in="1.15.0",
-    removed_in="1.20.0",
-    details=(
-        "Use the /git/changes endpoint with a query parameter for the path "
-        "instead of a path parameter. This allows for better handling of "
-        "complex paths and is more consistent with other endpoints."
-    ),
-)
+@git_router.get("/changes/{path:path}", deprecated=True)
 async def git_changes_path(path: str) -> list[GitChange]:
-    """Get git changes using path parameter (legacy, for backwards compatibility)."""
+    """Get git changes using path parameter (legacy, for backwards compatibility).
+
+    Deprecated since v1.15.0 and scheduled for removal in v1.20.0.
+
+    Prefer `/git/changes?path=...` to avoid path-encoding issues and align with
+    other Git endpoints.
+    """
     return await _get_git_changes(path)
 
 
@@ -62,16 +58,13 @@ async def git_diff_query(
     return await _get_git_diff(path)
 
 
-@git_router.get("/diff/{path:path}")
-@deprecated(
-    deprecated_in="1.15.0",
-    removed_in="1.20.0",
-    details=(
-        "Use the /git/diff endpoint with a query parameter for the path "
-        "instead of a path parameter. This allows for better handling of "
-        "complex paths and is more consistent with other endpoints."
-    ),
-)
+@git_router.get("/diff/{path:path}", deprecated=True)
 async def git_diff_path(path: str) -> GitDiff:
-    """Get git diff using path parameter (legacy, for backwards compatibility)."""
+    """Get git diff using path parameter (legacy, for backwards compatibility).
+
+    Deprecated since v1.15.0 and scheduled for removal in v1.20.0.
+
+    Prefer `/git/diff?path=...` to avoid path-encoding issues and align with
+    other Git endpoints.
+    """
     return await _get_git_diff(path)

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -306,3 +306,18 @@ def test_download_file_with_special_characters_in_path(client, tmp_path):
 
     assert response.status_code == 200
     assert response.content == b"special path content"
+
+
+def test_file_legacy_routes_are_deprecated_in_openapi(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    openapi_schema = response.json()
+
+    upload_operation = openapi_schema["paths"]["/api/file/upload/{path}"]["post"]
+    assert upload_operation.get("deprecated") is True
+    assert "Deprecated since v1.15.0" in upload_operation["description"]
+
+    download_operation = openapi_schema["paths"]["/api/file/download/{path}"]["get"]
+    assert download_operation.get("deprecated") is True
+    assert "Deprecated since v1.15.0" in download_operation["description"]

--- a/tests/agent_server/test_git_router.py
+++ b/tests/agent_server/test_git_router.py
@@ -305,3 +305,18 @@ async def test_git_changes_with_complex_paths(client):
         assert response_data[0]["path"] == "src/deep/nested/file.py"
         assert response_data[1]["path"] == "file with spaces.txt"
         assert response_data[2]["path"] == "special-chars_file@123.py"
+
+
+def test_git_legacy_routes_are_deprecated_in_openapi(client):
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    openapi_schema = response.json()
+
+    changes_operation = openapi_schema["paths"]["/api/git/changes/{path}"]["get"]
+    assert changes_operation.get("deprecated") is True
+    assert "Deprecated since v1.15.0" in changes_operation["description"]
+
+    diff_operation = openapi_schema["paths"]["/api/git/diff/{path}"]["get"]
+    assert diff_operation.get("deprecated") is True
+    assert "Deprecated since v1.15.0" in diff_operation["description"]

--- a/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
+++ b/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
@@ -1,8 +1,4 @@
-"""Tests for agent-server REST API breakage check script.
-
-We import the production script via a file-based module load so tests remain coupled
-to real behavior.
-"""
+"""Tests for agent-server REST API breakage check script."""
 
 from __future__ import annotations
 
@@ -20,7 +16,6 @@ def _load_prod_module():
     spec = importlib.util.spec_from_file_location(name, script_path)
     assert spec and spec.loader
     mod = importlib.util.module_from_spec(spec)
-    # Register so @dataclass can resolve the module's __dict__
     sys.modules[name] = mod
     spec.loader.exec_module(mod)
     return mod
@@ -28,12 +23,10 @@ def _load_prod_module():
 
 _prod = _load_prod_module()
 
-OperationKey = _prod.OperationKey
-_compute_breakages = _prod._compute_breakages
-_get_previous_version = _prod._get_previous_version
+_find_deprecation_policy_errors = _prod._find_deprecation_policy_errors
+_get_baseline_version = _prod._get_baseline_version
 _is_minor_or_major_bump = _prod._is_minor_or_major_bump
 _normalize_openapi_for_oasdiff = _prod._normalize_openapi_for_oasdiff
-_resolve_ref = _prod._resolve_ref
 
 
 def _schema_with_operation(path: str, method: str, operation: dict) -> dict:
@@ -47,158 +40,54 @@ def _schema_with_operation(path: str, method: str, operation: dict) -> dict:
     }
 
 
-def test_removed_operation_is_breaking_and_requires_deprecation():
-    prev_schema = _schema_with_operation(
+def test_find_deprecation_policy_errors_requires_openapi_deprecated_flag():
+    schema = _schema_with_operation(
         "/foo",
         "get",
         {
-            "deprecated": False,
+            "description": (
+                "Deprecated since v1.2.3 and scheduled for removal in v1.5.0."
+            ),
             "responses": {},
         },
     )
-    current_schema = {"openapi": "3.0.0", "paths": {}}
 
-    reasons, undeprecated = _compute_breakages(prev_schema, current_schema)
+    assert _find_deprecation_policy_errors(schema) == [
+        "GET /foo documents deprecation in its description but is not marked "
+        "deprecated=true in OpenAPI."
+    ]
 
-    assert any("Removed operations" in reason for reason in reasons)
-    assert set(undeprecated) == {OperationKey(method="get", path="/foo")}
 
-
-def test_removed_deprecated_operation_is_still_breaking_but_allowed():
-    prev_schema = _schema_with_operation(
+def test_find_deprecation_policy_errors_accepts_deprecated_operations():
+    schema = _schema_with_operation(
         "/foo",
         "get",
         {
             "deprecated": True,
+            "description": (
+                "Deprecated since v1.2.3 and scheduled for removal in v1.5.0."
+            ),
             "responses": {},
         },
     )
-    current_schema = {"openapi": "3.0.0", "paths": {}}
 
-    reasons, undeprecated = _compute_breakages(prev_schema, current_schema)
-
-    assert any("Removed operations" in reason for reason in reasons)
-    assert undeprecated == []
+    assert _find_deprecation_policy_errors(schema) == []
 
 
-def test_new_required_parameter_is_breaking():
-    prev_schema = _schema_with_operation("/foo", "get", {"responses": {}})
-    current_schema = _schema_with_operation(
+def test_find_deprecation_policy_errors_ignores_non_deprecated_operations():
+    schema = _schema_with_operation(
         "/foo",
         "get",
         {
-            "parameters": [
-                {
-                    "name": "x",
-                    "in": "query",
-                    "required": True,
-                }
-            ],
+            "description": "Current endpoint.",
             "responses": {},
         },
     )
 
-    reasons, _undeprecated = _compute_breakages(prev_schema, current_schema)
-
-    assert any("new required params" in reason for reason in reasons)
+    assert _find_deprecation_policy_errors(schema) == []
 
 
-def test_request_body_becoming_required_is_breaking():
-    prev_schema = _schema_with_operation(
-        "/foo",
-        "post",
-        {
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {"type": "object"},
-                    }
-                },
-            },
-            "responses": {},
-        },
-    )
-
-    current_schema = _schema_with_operation(
-        "/foo",
-        "post",
-        {
-            "requestBody": {
-                "required": True,
-                "content": {
-                    "application/json": {
-                        "schema": {"type": "object"},
-                    }
-                },
-            },
-            "responses": {},
-        },
-    )
-
-    reasons, _undeprecated = _compute_breakages(prev_schema, current_schema)
-
-    assert any("request body became required" in reason for reason in reasons)
-
-
-def test_new_required_json_fields_in_request_body_are_breaking():
-    prev_schema = _schema_with_operation(
-        "/foo",
-        "post",
-        {
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "type": "object",
-                            "required": ["a"],
-                        },
-                    }
-                },
-            },
-            "responses": {},
-        },
-    )
-
-    current_schema = _schema_with_operation(
-        "/foo",
-        "post",
-        {
-            "requestBody": {
-                "content": {
-                    "application/json": {
-                        "schema": {
-                            "type": "object",
-                            "required": ["a", "b"],
-                        },
-                    }
-                },
-            },
-            "responses": {},
-        },
-    )
-
-    reasons, _undeprecated = _compute_breakages(prev_schema, current_schema)
-
-    assert any("new required JSON fields" in reason for reason in reasons)
-    assert any("b" in reason for reason in reasons)
-
-
-def test_resolve_ref_circuit_breaker_handles_cycles():
-    spec = {
-        "components": {
-            "schemas": {
-                "A": {"$ref": "#/components/schemas/B"},
-                "B": {"$ref": "#/components/schemas/A"},
-            }
-        }
-    }
-
-    resolved = _resolve_ref({"$ref": "#/components/schemas/A"}, spec, max_depth=5)
-
-    assert isinstance(resolved, dict)
-
-
-def test_get_previous_version_warns_and_returns_none_when_pypi_fails(
+def test_get_baseline_version_warns_and_returns_none_when_pypi_fails(
     monkeypatch, capsys
 ):
     def _raise(_distribution: str) -> dict:  # pragma: no cover
@@ -206,7 +95,7 @@ def test_get_previous_version_warns_and_returns_none_when_pypi_fails(
 
     monkeypatch.setattr(_prod, "_fetch_pypi_metadata", _raise)
 
-    assert _get_previous_version("some-dist", "1.0.0") is None
+    assert _get_baseline_version("some-dist", "1.0.0") is None
 
     captured = capsys.readouterr()
     assert "::warning" in captured.out
@@ -270,17 +159,3 @@ def test_normalize_openapi_preserves_boolean_exclusive():
 
     assert normalized["exclusiveMinimum"] is True
     assert normalized["minimum"] == 4
-
-
-def test_normalize_openapi_boolean_exclusive_without_minimum():
-    schema = {
-        "exclusiveMinimum": True,
-        "exclusiveMaximum": False,
-    }
-
-    normalized = _normalize_openapi_for_oasdiff(schema)
-
-    assert normalized["exclusiveMinimum"] is True
-    assert normalized["exclusiveMaximum"] is False
-    assert "minimum" not in normalized
-    assert "maximum" not in normalized


### PR DESCRIPTION
## Summary

Fix the agent-server REST API deprecation policy so deprecated endpoints are actually marked as deprecated in OpenAPI, and make the REST API breakage check compare schemas under the same dependency environment.

This follow-up was prompted by the false-positive breakage investigation in #2404.

## Changes

### REST routes
- Replace SDK `@deprecated(...)` usage on deprecated FastAPI file/git endpoints with FastAPI `deprecated=True`
- Keep explicit deprecation/removal notes in route docstrings so the OpenAPI descriptions remain user-visible
- Add OpenAPI tests verifying the legacy file/git routes are marked deprecated

### Breakage check script
- Enforce that endpoints documenting deprecation in their OpenAPI description are also marked `deprecated: true`
- Generate the baseline OpenAPI schema from the matching git tag (`v<baseline_version>`) instead of reinstalling the published package with floating transitive dependencies
- Generate both baseline and current schemas under the current workspace dependency set so framework drift does not look like an API breakage

## Why

We found two policy gaps while reviewing #2404:
1. Deprecated REST endpoints could be documented as deprecated without appearing deprecated in OpenAPI
2. The breakage check could report false positives because the baseline schema was generated under a different FastAPI/Pydantic version than the current workspace

## Testing

- `uv run pre-commit run --files .github/scripts/check_agent_server_rest_api_breakage.py openhands-agent-server/openhands/agent_server/file_router.py openhands-agent-server/openhands/agent_server/git_router.py tests/agent_server/test_file_router.py tests/agent_server/test_git_router.py tests/ci_scripts/test_check_agent_server_rest_api_breakage.py`
- `uv run pytest tests/agent_server/test_file_router.py tests/agent_server/test_git_router.py tests/ci_scripts/test_check_agent_server_rest_api_breakage.py`
- `PATH="$PWD/.agent_tmp/bin:$PATH" uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py`

## Reference

- Original investigation / discovery: #2404

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:12e68ba-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-12e68ba-python \
  ghcr.io/openhands/agent-server:12e68ba-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:12e68ba-golang-amd64
ghcr.io/openhands/agent-server:12e68ba-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:12e68ba-golang-arm64
ghcr.io/openhands/agent-server:12e68ba-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:12e68ba-java-amd64
ghcr.io/openhands/agent-server:12e68ba-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:12e68ba-java-arm64
ghcr.io/openhands/agent-server:12e68ba-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:12e68ba-python-amd64
ghcr.io/openhands/agent-server:12e68ba-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:12e68ba-python-arm64
ghcr.io/openhands/agent-server:12e68ba-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:12e68ba-golang
ghcr.io/openhands/agent-server:12e68ba-java
ghcr.io/openhands/agent-server:12e68ba-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `12e68ba-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `12e68ba-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->