### PR TITLE
Handle fork PRs in API breakage workflows

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -42,8 +42,56 @@ jobs:
                   echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
                   exit "${exit_code}"
 
+            - name: Write REST API breakage summary
+              if: ${{ always() }}
+              env:
+                  EXIT_CODE: ${{ steps.api_breakage.outputs.exit_code }}
+                  IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+                  LOG_PATH: api-breakage.log
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  python3 <<'PY' >> "$GITHUB_STEP_SUMMARY"
+                  import os
+                  from pathlib import Path
+
+                  exit_code = int(os.environ.get('EXIT_CODE', '0') or '0')
+                  is_fork = os.environ.get('IS_FORK', 'false') == 'true'
+                  run_url = os.environ['RUN_URL']
+
+                  print('## Agent server REST API breakage checks (OpenAPI)')
+                  print()
+                  print(f"**Result:** {'✅ Passed' if exit_code == 0 else '❌ Failed'}")
+                  print()
+
+                  if is_fork:
+                      print(
+                          '_Fork PR detected: sticky PR comment was skipped because '
+                          'the GitHub token is read-only for `pull_request` workflows '
+                          'from forks._'
+                      )
+                      print()
+
+                  if exit_code != 0:
+                      try:
+                          log = Path(os.environ['LOG_PATH']).read_text()
+                      except Exception as exc:
+                          log = f'Unable to read log file: {exc}'
+
+                      excerpt = log[:1000].replace('```', '``\\`')
+                      print('<details><summary>Log excerpt (first 1000 characters)</summary>')
+                      print()
+                      print('```text')
+                      print(excerpt)
+                      print('```')
+                      print()
+                      print('</details>')
+                      print()
+
+                  print(f'[Action log]({run_url})')
+                  PY
+
             - name: Post REST API breakage report to PR
-              if: ${{ always() && github.event_name == 'pull_request' }}
+              if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
               uses: actions/github-script@v7
               env:
                   EXIT_CODE: ${{ steps.api_breakage.outputs.exit_code }}

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -37,8 +37,56 @@ jobs:
                   exit_code=${PIPESTATUS[0]}
                   echo "exit_code=${exit_code}" >> "$GITHUB_OUTPUT"
                   exit "${exit_code}"
+            - name: Write API breakage summary
+              if: ${{ always() }}
+              env:
+                  EXIT_CODE: ${{ steps.api_breakage.outputs.exit_code }}
+                  IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+                  LOG_PATH: api-breakage.log
+                  RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+              run: |
+                  python3 <<'PY' >> "$GITHUB_STEP_SUMMARY"
+                  import os
+                  from pathlib import Path
+
+                  exit_code = int(os.environ.get('EXIT_CODE', '0') or '0')
+                  is_fork = os.environ.get('IS_FORK', 'false') == 'true'
+                  run_url = os.environ['RUN_URL']
+
+                  print('## API breakage checks (Griffe)')
+                  print()
+                  print(f"**Result:** {'✅ Passed' if exit_code == 0 else '❌ Failed'}")
+                  print()
+
+                  if is_fork:
+                      print(
+                          '_Fork PR detected: sticky PR comment was skipped because '
+                          'the GitHub token is read-only for `pull_request` workflows '
+                          'from forks._'
+                      )
+                      print()
+
+                  if exit_code != 0:
+                      try:
+                          log = Path(os.environ['LOG_PATH']).read_text()
+                      except Exception as exc:
+                          log = f'Unable to read log file: {exc}'
+
+                      excerpt = log[:1000].replace('```', '``\\`')
+                      print('<details><summary>Log excerpt (first 1000 characters)</summary>')
+                      print()
+                      print('```text')
+                      print(excerpt)
+                      print('```')
+                      print()
+                      print('</details>')
+                      print()
+
+                  print(f'[Action log]({run_url})')
+                  PY
+
             - name: Post API breakage report to PR
-              if: ${{ always() && github.event_name == 'pull_request' }}
+              if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
               uses: actions/github-script@v7
               env:
                   EXIT_CODE: ${{ steps.api_breakage.outputs.exit_code }}


### PR DESCRIPTION
## Summary

- skip sticky API breakage PR comments on fork PRs
- add a GitHub Actions job summary for both API breakage workflows
- keep the existing sticky PR comment behavior for same-repo PRs

## Testing

- `uv run pre-commit run --files .github/workflows/api-breakage.yml .github/workflows/agent-server-rest-api-breakage.yml`

## Context

Refs #2407

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:28a4a68-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-28a4a68-python \
  ghcr.io/openhands/agent-server:28a4a68-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:28a4a68-golang-amd64
ghcr.io/openhands/agent-server:28a4a68-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:28a4a68-golang-arm64
ghcr.io/openhands/agent-server:28a4a68-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:28a4a68-java-amd64
ghcr.io/openhands/agent-server:28a4a68-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:28a4a68-java-arm64
ghcr.io/openhands/agent-server:28a4a68-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:28a4a68-python-amd64
ghcr.io/openhands/agent-server:28a4a68-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:28a4a68-python-arm64
ghcr.io/openhands/agent-server:28a4a68-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:28a4a68-golang
ghcr.io/openhands/agent-server:28a4a68-java
ghcr.io/openhands/agent-server:28a4a68-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `28a4a68-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `28a4a68-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->