### PR TITLE
fix: preflight check now validates reasoning_content for thinking models

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -330,8 +330,14 @@ def check_model(
             **kwargs,
         )
 
-        response_content = response.choices[0].message.content if response.choices else None
-        reasoning_content = response.choices[0].message.reasoning_content if response.choices else None
+        response_content = (
+            response.choices[0].message.content if response.choices else None
+        )
+        reasoning_content = (
+            getattr(response.choices[0].message, "reasoning_content", None)
+            if response.choices
+            else None
+        )
 
         if response_content or reasoning_content:
             return True, f"✓ {display_name}: OK"

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -297,7 +297,9 @@ class TestTestModel:
             "llm_config": {"model": "litellm_proxy/test-model"},
         }
         mock_response = MagicMock()
-        mock_response.choices = [MagicMock(message=MagicMock(content=""))]
+        mock_response.choices = [
+            MagicMock(message=MagicMock(content="", reasoning_content=None))
+        ]
 
         with patch("litellm.completion", return_value=mock_response):
             success, message = test_model(model_config, "test-key", "https://test.com")
@@ -305,6 +307,48 @@ class TestTestModel:
         assert success is False
         assert "✗" in message
         assert "Empty response" in message
+
+    def test_thinking_model_success(self):
+        """Test that a thinking model with only reasoning_content passes."""
+        model_config = {
+            "display_name": "Thinking Model",
+            "llm_config": {"model": "litellm_proxy/thinking-model"},
+        }
+        mock_response = MagicMock()
+        mock_response.choices = [
+            MagicMock(
+                message=MagicMock(content="", reasoning_content="Let me think...")
+            )
+        ]
+
+        with patch("litellm.completion", return_value=mock_response):
+            success, message = test_model(model_config, "test-key", "https://test.com")
+
+        assert success is True
+        assert "✓" in message
+
+    def test_model_without_reasoning_content_attribute(self):
+        """Test that models whose Message object lacks reasoning_content don't raise."""
+        from types import SimpleNamespace
+
+        model_config = {
+            "display_name": "Standard Model",
+            "llm_config": {"model": "litellm_proxy/standard-model"},
+        }
+        mock_response = MagicMock()
+        # SimpleNamespace has only the attributes we give it - no reasoning_content
+        message = SimpleNamespace(content="2")
+        choice = MagicMock()
+        choice.message = message
+        mock_response.choices = [choice]
+
+        with patch("litellm.completion", return_value=mock_response):
+            success, message_str = test_model(
+                model_config, "test-key", "https://test.com"
+            )
+
+        assert success is True
+        assert "✓" in message_str
 
     def test_timeout_error(self):
         """Test that timeout errors are handled correctly."""


### PR DESCRIPTION
Fixes #2419

## Problem

The preflight LLM check fails for thinking models like NVIDIA Nemotron-3 Super 120B. When `enable_thinking: true` is set in the model config, the model puts all its output into `reasoning_content` rather than `content`. The preflight check only validated `content`, so it always saw an empty response and aborted the evaluation.

## Change

Also check `reasoning_content` alongside `content`:

```python
response_content = response.choices[0].message.content if response.choices else None
reasoning_content = response.choices[0].message.reasoning_content if response.choices else None

if response_content or reasoning_content:
```


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d3fcdec-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d3fcdec-python \
  ghcr.io/openhands/agent-server:d3fcdec-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d3fcdec-golang-amd64
ghcr.io/openhands/agent-server:d3fcdec-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d3fcdec-golang-arm64
ghcr.io/openhands/agent-server:d3fcdec-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d3fcdec-java-amd64
ghcr.io/openhands/agent-server:d3fcdec-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d3fcdec-java-arm64
ghcr.io/openhands/agent-server:d3fcdec-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d3fcdec-python-amd64
ghcr.io/openhands/agent-server:d3fcdec-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:d3fcdec-python-arm64
ghcr.io/openhands/agent-server:d3fcdec-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:d3fcdec-golang
ghcr.io/openhands/agent-server:d3fcdec-java
ghcr.io/openhands/agent-server:d3fcdec-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d3fcdec-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d3fcdec-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->