### PR TITLE
feat: emit structured docker build telemetry

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -575,6 +575,7 @@ def _get_dockerfile_path(sdk_project_root: Path) -> Path:
         raise FileNotFoundError(f"Dockerfile not found at {dockerfile_path}")
     return dockerfile_path
 
+
 def _round_seconds(value: float) -> float:
     return round(value, 3)
 
@@ -683,6 +684,8 @@ def _parse_buildkit_telemetry(stderr: str) -> BuildTelemetry:
         telemetry.export_manifest_seconds
     )
     return telemetry
+
+
 # --- single entry point ---
 
 
@@ -698,7 +701,7 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
 
     telemetry = BuildTelemetry()
     build_context_started = time.monotonic()
-    ctx = _make_build_context(opts.sdk_project_root, opts.prebuilt_sdist)
+    ctx = _make_build_context(opts.sdk_project_root)
     telemetry.build_context_seconds = _round_seconds(
         time.monotonic() - build_context_started
     )

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -5,6 +5,7 @@ import subprocess
 from pathlib import Path
 from unittest.mock import patch
 
+
 BUILDKIT_STDERR_SAMPLE = "\n".join(
     [
         "#8 importing cache manifest from "
@@ -30,6 +31,8 @@ BUILDKIT_STDERR_SAMPLE = "\n".join(
         "",
     ]
 )
+
+
 def test_git_info_priority_sdk_sha():
     """Test that SDK_SHA takes priority over GITHUB_SHA and git commands."""
     from openhands.agent_server.docker.build import _git_info


### PR DESCRIPTION
## Summary
- add a non-breaking `build_with_telemetry()` API that returns tags plus parsed BuildKit phase timings
- preserve telemetry on failures via a `BuildCommandError` subclass
- cover cache import/export and image export parsing with focused tests

## Testing
- `uv run pytest tests/agent_server/test_docker_build.py`
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/docker/build.py tests/agent_server/test_docker_build.py`

## Notes
- supersedes the stacked telemetry PR so this change can merge independently against `main`

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7e44f3c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7e44f3c-python \
  ghcr.io/openhands/agent-server:7e44f3c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7e44f3c-golang-amd64
ghcr.io/openhands/agent-server:7e44f3c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7e44f3c-golang-arm64
ghcr.io/openhands/agent-server:7e44f3c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7e44f3c-java-amd64
ghcr.io/openhands/agent-server:7e44f3c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7e44f3c-java-arm64
ghcr.io/openhands/agent-server:7e44f3c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7e44f3c-python-amd64
ghcr.io/openhands/agent-server:7e44f3c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:7e44f3c-python-arm64
ghcr.io/openhands/agent-server:7e44f3c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:7e44f3c-golang
ghcr.io/openhands/agent-server:7e44f3c-java
ghcr.io/openhands/agent-server:7e44f3c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7e44f3c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7e44f3c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->