### PR TITLE
feat: support reusing prebuilt SDK sdists

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -378,6 +378,14 @@ class BuildOptions(BaseModel):
         default_factory=_default_sdk_project_root,
         description="Path to OpenHands SDK root. Auto if None.",
     )
+    prebuilt_sdist: Path | None = Field(
+        default=None,
+        description=(
+            "Path to a pre-built SDK sdist tarball to reuse when creating the "
+            "clean Docker build context. If unset, the SDK will run "
+            "`uv build --sdist` itself."
+        ),
+    )
     sdk_version: str = Field(
         default=_DEFAULT_PACKAGE_VERSION,
         description=(
@@ -503,26 +511,37 @@ def _extract_tarball(tarball: Path, dest: Path) -> None:
         tar.extractall(path=".", filter="data")
 
 
-def _make_build_context(sdk_project_root: Path) -> Path:
+def _make_build_context(
+    sdk_project_root: Path,
+    prebuilt_sdist: Path | None = None,
+) -> Path:
     dockerfile_path = _get_dockerfile_path(sdk_project_root)
     tmp_root = Path(tempfile.mkdtemp(prefix="agent-build-", dir=None)).resolve()
-    sdist_dir = Path(tempfile.mkdtemp(prefix="agent-sdist-", dir=None)).resolve()
+    sdist_dir: Path | None = None
     try:
-        # sdists = _build_sdists(sdk_project_root, sdist_dir)
-        _run(
-            ["uv", "build", "--sdist", "--out-dir", str(sdist_dir.resolve())],
-            cwd=str(sdk_project_root.resolve()),
-        )
-        sdists = sorted(sdist_dir.glob("*.tar.gz"), key=lambda p: p.stat().st_mtime)
-        logger.info(
-            f"[build] Built {len(sdists)} sdists for "
-            f"clean context: {', '.join(str(s) for s in sdists)}"
-        )
-        assert len(sdists) == 1, "Expected exactly one sdist"
-        logger.debug(
-            f"[build] Extracting sdist {sdists[0]} to clean context {tmp_root}"
-        )
-        _extract_tarball(sdists[0], tmp_root)
+        if prebuilt_sdist is None:
+            sdist_dir = Path(
+                tempfile.mkdtemp(prefix="agent-sdist-", dir=None)
+            ).resolve()
+            _run(
+                ["uv", "build", "--sdist", "--out-dir", str(sdist_dir.resolve())],
+                cwd=str(sdk_project_root.resolve()),
+            )
+            sdists = sorted(sdist_dir.glob("*.tar.gz"), key=lambda p: p.stat().st_mtime)
+            logger.info(
+                f"[build] Built {len(sdists)} sdists for "
+                f"clean context: {', '.join(str(s) for s in sdists)}"
+            )
+            assert len(sdists) == 1, "Expected exactly one sdist"
+            sdist = sdists[0]
+        else:
+            sdist = Path(prebuilt_sdist).expanduser().resolve()
+            if not sdist.is_file():
+                raise FileNotFoundError(f"Pre-built sdist not found at {sdist}")
+            logger.info(f"[build] Reusing pre-built sdist for clean context: {sdist}")
+
+        logger.debug(f"[build] Extracting sdist {sdist} to clean context {tmp_root}")
+        _extract_tarball(sdist, tmp_root)
 
         # assert only one folder created
         entries = list(tmp_root.iterdir())
@@ -538,7 +557,8 @@ def _make_build_context(sdk_project_root: Path) -> Path:
         shutil.rmtree(tmp_root, ignore_errors=True)
         raise
     finally:
-        shutil.rmtree(sdist_dir, ignore_errors=True)
+        if sdist_dir is not None:
+            shutil.rmtree(sdist_dir, ignore_errors=True)
 
 
 def _active_buildx_driver() -> str | None:
@@ -701,7 +721,7 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
 
     telemetry = BuildTelemetry()
     build_context_started = time.monotonic()
-    ctx = _make_build_context(opts.sdk_project_root)
+    ctx = _make_build_context(opts.sdk_project_root, opts.prebuilt_sdist)
     telemetry.build_context_seconds = _round_seconds(
         time.monotonic() - build_context_started
     )
@@ -901,6 +921,12 @@ def main(argv: list[str]) -> int:
         help="Path to OpenHands SDK root (default: auto-detect).",
     )
     parser.add_argument(
+        "--prebuilt-sdist",
+        type=Path,
+        default=None,
+        help="Path to a pre-built SDK sdist tarball to reuse for the build context.",
+    )
+    parser.add_argument(
         "--build-ctx-only",
         action="store_true",
         help="Only create the clean build context directory and print its path.",
@@ -927,7 +953,7 @@ def main(argv: list[str]) -> int:
 
     # ---- build-ctx-only path ----
     if args.build_ctx_only:
-        ctx = _make_build_context(sdk_project_root)
+        ctx = _make_build_context(sdk_project_root, args.prebuilt_sdist)
         logger.info(f"[build] Clean build context (kept for debugging): {ctx}")
 
         # Create BuildOptions to generate tags
@@ -939,6 +965,7 @@ def main(argv: list[str]) -> int:
             platforms=[p.strip() for p in args.platforms.split(",") if p.strip()],  # type: ignore
             push=None,  # Not relevant for build-ctx-only
             sdk_project_root=sdk_project_root,
+            prebuilt_sdist=args.prebuilt_sdist,
             arch=args.arch or None,
             include_versioned_tag=args.versioned_tag,
         )
@@ -986,6 +1013,7 @@ def main(argv: list[str]) -> int:
         platforms=[p.strip() for p in args.platforms.split(",") if p.strip()],  # type: ignore
         push=push,
         sdk_project_root=sdk_project_root,
+        prebuilt_sdist=args.prebuilt_sdist,
         arch=args.arch or None,
         include_versioned_tag=args.versioned_tag,
     )

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+import tarfile
 from pathlib import Path
 from unittest.mock import patch
 
@@ -31,6 +32,18 @@ BUILDKIT_STDERR_SAMPLE = "\n".join(
         "",
     ]
 )
+
+
+def _create_fake_sdist(tmp_path: Path) -> Path:
+    src_root = tmp_path / "openhands-sdk-test"
+    src_root.mkdir()
+    (src_root / "README.md").write_text("fixture", encoding="utf-8")
+
+    tarball = tmp_path / "openhands-sdk-test.tar.gz"
+    with tarfile.open(tarball, "w:gz") as tar:
+        tar.add(src_root, arcname=src_root.name)
+
+    return tarball
 
 
 def test_git_info_priority_sdk_sha():
@@ -470,6 +483,160 @@ def test_versioned_tags_format_without_v_prefix():
     # Should be "1.2.0-python", not "v1.2.0-python"
     assert versioned_tags == ["1.2.0-python"]
     assert not any(tag.startswith("v") for tag in versioned_tags)
+
+
+def test_make_build_context_reuses_prebuilt_sdist_without_running_uv_build(
+    tmp_path: Path,
+):
+    from openhands.agent_server.docker.build import (
+        _default_sdk_project_root,
+        _make_build_context,
+    )
+
+    prebuilt_sdist = _create_fake_sdist(tmp_path)
+
+    with patch("openhands.agent_server.docker.build._run") as mock_run:
+        ctx = _make_build_context(
+            _default_sdk_project_root(),
+            prebuilt_sdist=prebuilt_sdist,
+        )
+
+    try:
+        mock_run.assert_not_called()
+        assert (ctx / "README.md").read_text(encoding="utf-8") == "fixture"
+        assert (ctx / "Dockerfile").exists()
+    finally:
+        if ctx.exists():
+            import shutil
+
+            shutil.rmtree(ctx, ignore_errors=True)
+
+
+def test_build_with_prebuilt_sdist_preserves_tags_and_docker_args(tmp_path: Path):
+    from openhands.agent_server.docker.build import (
+        BuildOptions,
+        _default_sdk_project_root,
+        build,
+    )
+
+    prebuilt_sdist = _create_fake_sdist(tmp_path)
+    ctx = tmp_path / "ctx"
+    ctx.mkdir()
+    docker_calls: list[tuple[list[str], str | None]] = []
+
+    def fake_run(cmd: list[str], cwd: str | None = None):
+        if cmd[:3] != ["docker", "buildx", "build"]:
+            raise AssertionError(f"unexpected command: {cmd}")
+        docker_calls.append((cmd, cwd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    opts = BuildOptions(
+        base_image="python:3.12",
+        custom_tags="python,java",
+        git_sha="abc1234567890",
+        git_ref="refs/heads/main",
+        sdk_version="1.2.0",
+        include_versioned_tag=True,
+        target="source-minimal",
+        push=False,
+        sdk_project_root=_default_sdk_project_root(),
+        prebuilt_sdist=prebuilt_sdist,
+    )
+
+    with (
+        patch(
+            "openhands.agent_server.docker.build._make_build_context", return_value=ctx
+        ) as mock_make_context,
+        patch("openhands.agent_server.docker.build._run", side_effect=fake_run),
+        patch(
+            "openhands.agent_server.docker.build._active_buildx_driver",
+            return_value="docker-container",
+        ),
+        patch(
+            "openhands.agent_server.docker.build._default_local_cache_dir",
+            return_value=tmp_path / "cache",
+        ),
+        patch("openhands.agent_server.docker.build.shutil.rmtree"),
+    ):
+        tags = build(opts)
+
+    assert tags == opts.all_tags
+    mock_make_context.assert_called_once_with(opts.sdk_project_root, prebuilt_sdist)
+    assert len(docker_calls) == 1
+    cmd, cwd = docker_calls[0]
+    assert cwd == str(ctx)
+    assert "--load" in cmd
+    assert "--target" in cmd and "source-minimal" in cmd
+    assert "--build-arg" in cmd
+    assert "BASE_IMAGE=python:3.12" in cmd
+    for tag in opts.all_tags:
+        assert tag in cmd
+
+
+def test_build_can_reuse_same_prebuilt_sdist_multiple_times(tmp_path: Path):
+    from openhands.agent_server.docker.build import (
+        BuildOptions,
+        _default_sdk_project_root,
+        build,
+    )
+
+    prebuilt_sdist = _create_fake_sdist(tmp_path)
+    docker_calls: list[tuple[list[str], str | None]] = []
+
+    def fake_run(cmd: list[str], cwd: str | None = None):
+        if cmd[:3] != ["docker", "buildx", "build"]:
+            raise AssertionError(f"unexpected command: {cmd}")
+        docker_calls.append((cmd, cwd))
+        return subprocess.CompletedProcess(cmd, 0, stdout="ok", stderr="")
+
+    def fake_make_context(*_args, **_kwargs):
+        idx = len(docker_calls)
+        ctx = tmp_path / f"ctx-{idx}"
+        ctx.mkdir()
+        return ctx
+
+    with (
+        patch(
+            "openhands.agent_server.docker.build._make_build_context",
+            side_effect=fake_make_context,
+        ),
+        patch("openhands.agent_server.docker.build._run", side_effect=fake_run),
+        patch(
+            "openhands.agent_server.docker.build._active_buildx_driver",
+            return_value="docker-container",
+        ),
+        patch(
+            "openhands.agent_server.docker.build._default_local_cache_dir",
+            return_value=tmp_path / "cache",
+        ),
+        patch("openhands.agent_server.docker.build.shutil.rmtree"),
+    ):
+        first_tags = build(
+            BuildOptions(
+                base_image="python:3.12",
+                custom_tags="python",
+                git_sha="abc1234567890",
+                git_ref="refs/heads/main",
+                push=False,
+                sdk_project_root=_default_sdk_project_root(),
+                prebuilt_sdist=prebuilt_sdist,
+            )
+        )
+        second_tags = build(
+            BuildOptions(
+                base_image="python:3.12",
+                custom_tags="java",
+                git_sha="abc1234567890",
+                git_ref="refs/heads/main",
+                push=False,
+                sdk_project_root=_default_sdk_project_root(),
+                prebuilt_sdist=prebuilt_sdist,
+            )
+        )
+
+    assert prebuilt_sdist.exists()
+    assert len(docker_calls) == 2
+    assert first_tags != second_tags
 
 
 def test_parse_buildkit_telemetry_extracts_phase_timings():


### PR DESCRIPTION
## Summary
- add `BuildOptions.prebuilt_sdist` as a public API for reusing a prebuilt SDK sdist
- teach `_make_build_context()` and the CLI to use a provided sdist instead of always running `uv build --sdist`
- add tests covering no redundant sdist build, preserved docker args/tags, and repeated sdist reuse

## Scope
This intentionally carries only the original prebuilt-sdist feature from #2399. It does not include the later BuildKit cache export changes.

## Validation
- `uv run pytest tests/agent_server/test_docker_build.py`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6c88624-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6c88624-python \
  ghcr.io/openhands/agent-server:6c88624-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6c88624-golang-amd64
ghcr.io/openhands/agent-server:6c88624-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6c88624-golang-arm64
ghcr.io/openhands/agent-server:6c88624-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6c88624-java-amd64
ghcr.io/openhands/agent-server:6c88624-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6c88624-java-arm64
ghcr.io/openhands/agent-server:6c88624-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6c88624-python-amd64
ghcr.io/openhands/agent-server:6c88624-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:6c88624-python-arm64
ghcr.io/openhands/agent-server:6c88624-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:6c88624-golang
ghcr.io/openhands/agent-server:6c88624-java
ghcr.io/openhands/agent-server:6c88624-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6c88624-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6c88624-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->