### PR TITLE
Make API breakage workflows fail loudly

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -33,9 +33,8 @@ jobs:
 
             - name: Run agent server REST API breakage check
               id: api_breakage
-              # Release PRs (rel-*) must block on breakage.
-              # Other PRs should still report failures via PR comment, but not gate merges.
-              continue-on-error: ${{ !startsWith(github.head_ref, 'rel-') }}
+              # Let this step fail so CI is visibly red on breakage.
+              # Later reporting steps still run because they use if: always().
               run: |
                   uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py 2>&1 | tee api-breakage.log
                   exit_code=${PIPESTATUS[0]}

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -25,9 +25,8 @@ jobs:
               run: uv sync --frozen --group dev
             - name: Run SDK API breakage check
               id: api_breakage
-              # Release PRs (rel-*) must block on breakage.
-              # Other PRs should still report failures via PR comment, but not gate merges.
-              continue-on-error: ${{ !startsWith(github.head_ref, 'rel-') }}
+              # Let this step fail so CI is visibly red on breakage.
+              # Later reporting steps still run because they use if: always().
               env:
                   SDK_INCLUDE_PATHS: openhands.sdk
                   ACP_VERSION_CHECK_BASE_REF: ${{ github.base_ref }}


### PR DESCRIPTION
## Summary
- make the Griffe API breakage workflow fail the job when the check fails
- make the OpenAPI breakage workflow fail the job when the check fails
- keep the existing sticky PR comments and step summaries by leaving the reporting steps on `if: always()`

## Context
Today both workflows can post a PR comment saying `Failed` while the workflow still appears green in CI because the actual breakage-check step uses `continue-on-error` for non-release branches.

This change removes that behavior so failures are more visible in CI, while keeping these checks optional unless branch protection marks them as required.

## Testing
- `uv run pre-commit run --files .github/workflows/api-breakage.yml .github/workflows/agent-server-rest-api-breakage.yml`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:17a6eaf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-17a6eaf-python \
  ghcr.io/openhands/agent-server:17a6eaf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:17a6eaf-golang-amd64
ghcr.io/openhands/agent-server:17a6eaf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:17a6eaf-golang-arm64
ghcr.io/openhands/agent-server:17a6eaf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:17a6eaf-java-amd64
ghcr.io/openhands/agent-server:17a6eaf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:17a6eaf-java-arm64
ghcr.io/openhands/agent-server:17a6eaf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:17a6eaf-python-amd64
ghcr.io/openhands/agent-server:17a6eaf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:17a6eaf-python-arm64
ghcr.io/openhands/agent-server:17a6eaf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:17a6eaf-golang
ghcr.io/openhands/agent-server:17a6eaf-java
ghcr.io/openhands/agent-server:17a6eaf-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `17a6eaf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `17a6eaf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->