### PR TITLE
Remove stale Python API workflow env

### DIFF
--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -23,12 +23,11 @@ jobs:
                   enable-cache: true
             - name: Install workspace deps (dev)
               run: uv sync --frozen --group dev
-            - name: Run SDK API breakage check
+            - name: Run Python API breakage check
               id: api_breakage
               # Let this step fail so CI is visibly red on breakage.
               # Later reporting steps still run because they use if: always().
               env:
-                  SDK_INCLUDE_PATHS: openhands.sdk
                   ACP_VERSION_CHECK_BASE_REF: ${{ github.base_ref }}
                   ACP_VERSION_CHECK_SKIP: ${{ contains(github.event.pull_request.body, 'skip-acp-check') }}
               run: |


### PR DESCRIPTION
## Summary
- remove the unused `SDK_INCLUDE_PATHS` environment variable from `api-breakage.yml`
- align the step label with the current user-facing `Python API` naming

## Context
`SDK_INCLUDE_PATHS` is currently set in the workflow, but `check_sdk_api_breakage.py` does not read it.

This PR removes that stale workflow configuration and does one adjacent low-risk cleanup: renaming the step from `Run SDK API breakage check` to `Run Python API breakage check` so the workflow wording is consistent.

## Testing
- `uv run pre-commit run --files .github/workflows/api-breakage.yml`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f6e0275-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f6e0275-python \
  ghcr.io/openhands/agent-server:f6e0275-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f6e0275-golang-amd64
ghcr.io/openhands/agent-server:f6e0275-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f6e0275-golang-arm64
ghcr.io/openhands/agent-server:f6e0275-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f6e0275-java-amd64
ghcr.io/openhands/agent-server:f6e0275-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f6e0275-java-arm64
ghcr.io/openhands/agent-server:f6e0275-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f6e0275-python-amd64
ghcr.io/openhands/agent-server:f6e0275-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:f6e0275-python-arm64
ghcr.io/openhands/agent-server:f6e0275-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:f6e0275-golang
ghcr.io/openhands/agent-server:f6e0275-java
ghcr.io/openhands/agent-server:f6e0275-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f6e0275-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f6e0275-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->