### PR TITLE
Run API breakage checks on push to main

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -2,6 +2,8 @@
 name: REST API breakage checks
 
 on:
+    push:
+        branches: [main]
     pull_request:
         branches: [main]
 

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -2,6 +2,8 @@
 name: Python API breakage checks
 
 on:
+    push:
+        branches: [main]
     pull_request:
         branches: [main]
 
@@ -28,8 +30,9 @@ jobs:
               # Let this step fail so CI is visibly red on breakage.
               # Later reporting steps still run because they use if: always().
               env:
-                  ACP_VERSION_CHECK_BASE_REF: ${{ github.base_ref }}
-                  ACP_VERSION_CHECK_SKIP: ${{ contains(github.event.pull_request.body, 'skip-acp-check') }}
+                  ACP_VERSION_CHECK_BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.before }}
+                  ACP_VERSION_CHECK_SKIP: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', 'skip-acp-check') 
+                      }}
               run: |
                   uv run python .github/scripts/check_sdk_api_breakage.py 2>&1 | tee api-breakage.log
                   exit_code=${PIPESTATUS[0]}


### PR DESCRIPTION
## Summary

This PR updates the Python API breakage and REST API breakage workflows so they run on both:
- `pull_request` targeting `main`
- `push` to `main`

It also makes the Python API workflow's ACP version-check inputs safe for push events by using the previous pushed commit as the base reference and guarding the PR-body skip token lookup.

Closes #2436.

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this? Not applicable; this is a workflow-only change, and I validated it with `uv run pre-commit run --files .github/workflows/api-breakage.yml .github/workflows/agent-server-rest-api-breakage.yml`.
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9e3f6e8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9e3f6e8-python \
  ghcr.io/openhands/agent-server:9e3f6e8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9e3f6e8-golang-amd64
ghcr.io/openhands/agent-server:9e3f6e8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9e3f6e8-golang-arm64
ghcr.io/openhands/agent-server:9e3f6e8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9e3f6e8-java-amd64
ghcr.io/openhands/agent-server:9e3f6e8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9e3f6e8-java-arm64
ghcr.io/openhands/agent-server:9e3f6e8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9e3f6e8-python-amd64
ghcr.io/openhands/agent-server:9e3f6e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:9e3f6e8-python-arm64
ghcr.io/openhands/agent-server:9e3f6e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:9e3f6e8-golang
ghcr.io/openhands/agent-server:9e3f6e8-java
ghcr.io/openhands/agent-server:9e3f6e8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9e3f6e8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9e3f6e8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->