### PR TITLE
feat(observability): support custom ports for self-hosted Laminar

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -24,7 +24,11 @@ def _get_int_env(key: str) -> int | None:
     """Read an environment variable as an optional int."""
     val = get_env(key)
     if val is not None and val != "":
-        return int(val)
+        try:
+            return int(val)
+        except ValueError:
+            logger.warning("%s must be an integer, got %r", key, val)
+            return None
     return None
 
 


### PR DESCRIPTION
## Summary

- Add `LMNR_HTTP_PORT` and `LMNR_GRPC_PORT` environment variables to configure custom ports for self-hosted Laminar instances
- Self-hosted Laminar uses port 8001 (gRPC) and 8000 (HTTP), but `maybe_init_laminar()` defaults to 8443/443 (cloud ports), making self-hosted setups unusable without workarounds
- Fully backward compatible: when unset, defaults remain unchanged

## Problem

When using a self-hosted Laminar instance (via `docker compose`), the gRPC port is `8001` and HTTP port is `8000`. However, `maybe_init_laminar()` calls `Laminar.initialize()` without port arguments, so it always defaults to the cloud ports (gRPC: 8443, HTTP: 443).

Current workarounds are unintuitive:
1. Pre-initialize `Laminar` before importing the SDK to prevent re-initialization
2. Use raw `OTEL_EXPORTER_OTLP_TRACES_*` environment variables instead of `LMNR_*` variables

## Solution

Read optional `LMNR_HTTP_PORT` and `LMNR_GRPC_PORT` environment variables and pass them to `Laminar.initialize()` on the Laminar backend path only. The OTEL backend path is unaffected since its ports are controlled by `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`.

### Usage

```env
LMNR_PROJECT_API_KEY=your_key
LMNR_BASE_URL=http://your-laminar-host
LMNR_HTTP_PORT=8000
LMNR_GRPC_PORT=8001
```

## Test plan

- [x] Verified with self-hosted Laminar (Docker Compose) — traces exported successfully
- [x] Without `LMNR_HTTP_PORT`/`LMNR_GRPC_PORT` set, behavior is identical to before (defaults to 443/8443)

🤖 Generated with [Claude Code](https://claude.com/claude-code)