### PR TITLE
Fix apptainer workspace cleanup: kill zombie child processes.

### DIFF
--- a/openhands-workspace/openhands/workspace/apptainer/workspace.py
+++ b/openhands-workspace/openhands/workspace/apptainer/workspace.py
@@ -1,6 +1,7 @@
 """Apptainer-based remote workspace implementation."""
 
 import os
+import signal
 import subprocess
 import sys
 import threading
@@ -282,12 +283,13 @@ class ApptainerWorkspace(RemoteWorkspace):
             str(self.host_port),
         ]
 
-        # Start the server process in the background
+        # Start the server process in the background in separate process group
         self._process = subprocess.Popen(
             server_cmd,
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
+            start_new_session=True,
         )
 
         # Optionally stream logs in background
@@ -364,12 +366,15 @@ class ApptainerWorkspace(RemoteWorkspace):
             if self._process:
                 try:
                     logger.info("Terminating Apptainer process...")
-                    self._process.terminate()
+                    pgid = os.getpgid(self._process.pid)
+                    os.killpg(pgid, signal.SIGTERM)
                     self._process.wait(timeout=5)
                 except Exception as e:
                     logger.warning("Error terminating process: %s", e)
                     try:
-                        self._process.kill()
+                        pgid = os.getpgid(self._process.pid)
+                        os.killpg(pgid, signal.SIGKILL)
+                        self._process.wait(timeout=2)
                     except Exception:
                         pass
 


### PR DESCRIPTION
## Summary

This PR fixes the logic for cleaning up an Apptainer workspace instance. Currently [self._process](https://github.com/OpenHands/software-agent-sdk/blob/20ff7ba8efb089a9d1bae943d43410b6a6758126/openhands-workspace/openhands/workspace/apptainer/workspace.py#L286) inherits the same process group as that of the parent process. As a result, when we cleanup and terminate this process [here](https://github.com/OpenHands/software-agent-sdk/blob/20ff7ba8efb089a9d1bae943d43410b6a6758126/openhands-workspace/openhands/workspace/apptainer/workspace.py#L367), the child processes spawned by the `apptainer run` command are not killed (for e.g. processes responsible for overlaying file-system) which causes them to become zombie processes. 

This is particularly problematic for situations where the same machine spins up O(1K-10K) apptainer instances, for e.g. during rollouts for RL training. This PR fixes this issue by making two changes - 
- start self._process as a new session which ensures that self._process is the leader of its process group which also means that the PID of this process will also be the process group ID
- during cleanup, instead of using process.terminate(), send an OS signal (SIGTERM/SIGKILL) through os.killpg(<PID of self._process == PID of this group>) to kill the entire process group including the child processes spawned by self._process.

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?
