### PR TITLE
Fix: Add tags to root endpoint for OpenAPI spec

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -229,7 +229,7 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
         and config.static_files_path.is_dir()
     ):
         # Map the root path to server info if there are no static files
-        app.get("/")(get_server_info)
+        app.get("/", tags=["Server Details"])(get_server_info)
         return
 
     # Mount static files directory


### PR DESCRIPTION
## Summary

The root `/` endpoint was missing OpenAPI tags, causing it to appear under a default "API Reference" category in generated docs instead of "Server Details" where it belongs.

## Changes

Added `tags=["Server Details"]` to the root endpoint registration in `api.py`.

## Before
The root endpoint appeared under a confusing "API Reference" category in the docs navigation.

## After
The root endpoint correctly appears under "Server Details" along with other server status endpoints (`/alive`, `/health`, `/server_info`).

## Related
This fix is needed to properly generate the OpenAPI spec for the docs: https://github.com/OpenHands/docs/pull/397
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bbcec22-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bbcec22-python \
  ghcr.io/openhands/agent-server:bbcec22-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bbcec22-golang-amd64
ghcr.io/openhands/agent-server:bbcec22-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bbcec22-golang-arm64
ghcr.io/openhands/agent-server:bbcec22-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bbcec22-java-amd64
ghcr.io/openhands/agent-server:bbcec22-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bbcec22-java-arm64
ghcr.io/openhands/agent-server:bbcec22-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bbcec22-python-amd64
ghcr.io/openhands/agent-server:bbcec22-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:bbcec22-python-arm64
ghcr.io/openhands/agent-server:bbcec22-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:bbcec22-golang
ghcr.io/openhands/agent-server:bbcec22-java
ghcr.io/openhands/agent-server:bbcec22-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bbcec22-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bbcec22-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->