### PR TITLE
feat(agent-server): add persistent named settings for LLM profiles, agents, and secrets

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -33,6 +33,8 @@ from openhands.agent_server.server_details_router import (
     mark_initialization_complete,
     server_details_router,
 )
+from openhands.agent_server.settings_router import settings_router
+from openhands.agent_server.settings_service import get_default_settings_service
 from openhands.agent_server.skills_router import skills_router
 from openhands.agent_server.sockets import sockets_router
 from openhands.agent_server.tool_preload_service import get_tool_preload_service
@@ -47,98 +49,104 @@ logger = get_logger(__name__)
 
 @asynccontextmanager
 async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
-    service = get_default_conversation_service()
-    vscode_service = get_vscode_service()
-    desktop_service = get_desktop_service()
-    tool_preload_service = get_tool_preload_service()
+    # Initialize settings service first (needed by conversation service)
+    settings_service = get_default_settings_service()
+    async with settings_service:
+        api.state.settings_service = settings_service
+        logger.info("Settings service initialized successfully")
 
-    # Define async functions for starting each service
-    async def start_vscode_service():
-        if vscode_service is not None:
-            vscode_started = await vscode_service.start()
-            if vscode_started:
-                logger.info("VSCode service started successfully")
+        service = get_default_conversation_service()
+        vscode_service = get_vscode_service()
+        desktop_service = get_desktop_service()
+        tool_preload_service = get_tool_preload_service()
+
+        # Define async functions for starting each service
+        async def start_vscode_service():
+            if vscode_service is not None:
+                vscode_started = await vscode_service.start()
+                if vscode_started:
+                    logger.info("VSCode service started successfully")
+                else:
+                    logger.warning(
+                        "VSCode service failed to start, continuing without VSCode"
+                    )
             else:
-                logger.warning(
-                    "VSCode service failed to start, continuing without VSCode"
-                )
-        else:
-            logger.info("VSCode service is disabled")
+                logger.info("VSCode service is disabled")
 
-    async def start_desktop_service():
-        if desktop_service is not None:
-            desktop_started = await desktop_service.start()
-            if desktop_started:
-                logger.info("Desktop service started successfully")
+        async def start_desktop_service():
+            if desktop_service is not None:
+                desktop_started = await desktop_service.start()
+                if desktop_started:
+                    logger.info("Desktop service started successfully")
+                else:
+                    logger.warning(
+                        "Desktop service failed to start, continuing without desktop"
+                    )
             else:
-                logger.warning(
-                    "Desktop service failed to start, continuing without desktop"
-                )
-        else:
-            logger.info("Desktop service is disabled")
+                logger.info("Desktop service is disabled")
 
-    async def start_tool_preload_service():
-        if tool_preload_service is not None:
-            tool_preload_started = await tool_preload_service.start()
-            if tool_preload_started:
-                logger.info("Tool preload service started successfully")
+        async def start_tool_preload_service():
+            if tool_preload_service is not None:
+                tool_preload_started = await tool_preload_service.start()
+                if tool_preload_started:
+                    logger.info("Tool preload service started successfully")
+                else:
+                    logger.warning("Tool preload service failed to start - skipping")
             else:
-                logger.warning("Tool preload service failed to start - skipping")
-        else:
-            logger.info("Tool preload service is disabled")
+                logger.info("Tool preload service is disabled")
 
-    # Start all services concurrently
-    results = await asyncio.gather(
-        start_vscode_service(),
-        start_desktop_service(),
-        start_tool_preload_service(),
-        return_exceptions=True,
-    )
-
-    # Check for any exceptions during initialization
-    exceptions = [r for r in results if isinstance(r, Exception)]
-    if exceptions:
-        logger.error(
-            "Service initialization failed with %d exception(s): %s",
-            len(exceptions),
-            exceptions,
+        # Start all services concurrently
+        results = await asyncio.gather(
+            start_vscode_service(),
+            start_desktop_service(),
+            start_tool_preload_service(),
+            return_exceptions=True,
         )
-        # Re-raise the first exception to prevent server from starting
-        raise RuntimeError(
-            f"Server initialization failed with {len(exceptions)} exception(s)"
-        ) from exceptions[0]
 
-    # Mark initialization as complete - now the /ready endpoint will return 200
-    # and Kubernetes readiness probes will pass
-    mark_initialization_complete()
-    logger.info("Server initialization complete - ready to serve requests")
-
-    async with service:
-        # Store the initialized service in app state for dependency injection
-        api.state.conversation_service = service
-        try:
-            yield
-        finally:
-            # Define async functions for stopping each service
-            async def stop_vscode_service():
-                if vscode_service is not None:
-                    await vscode_service.stop()
-
-            async def stop_desktop_service():
-                if desktop_service is not None:
-                    await desktop_service.stop()
-
-            async def stop_tool_preload_service():
-                if tool_preload_service is not None:
-                    await tool_preload_service.stop()
-
-            # Stop all services concurrently
-            await asyncio.gather(
-                stop_vscode_service(),
-                stop_desktop_service(),
-                stop_tool_preload_service(),
-                return_exceptions=True,
+        # Check for any exceptions during initialization
+        exceptions = [r for r in results if isinstance(r, Exception)]
+        if exceptions:
+            logger.error(
+                "Service initialization failed with %d exception(s): %s",
+                len(exceptions),
+                exceptions,
             )
+            # Re-raise the first exception to prevent server from starting
+            raise RuntimeError(
+                f"Server initialization failed with {len(exceptions)} exception(s)"
+            ) from exceptions[0]
+
+        # Mark initialization as complete - now the /ready endpoint will return 200
+        # and Kubernetes readiness probes will pass
+        mark_initialization_complete()
+        logger.info("Server initialization complete - ready to serve requests")
+
+        async with service:
+            # Store the initialized service in app state for dependency injection
+            api.state.conversation_service = service
+            try:
+                yield
+            finally:
+                # Define async functions for stopping each service
+                async def stop_vscode_service():
+                    if vscode_service is not None:
+                        await vscode_service.stop()
+
+                async def stop_desktop_service():
+                    if desktop_service is not None:
+                        await desktop_service.stop()
+
+                async def stop_tool_preload_service():
+                    if tool_preload_service is not None:
+                        await tool_preload_service.stop()
+
+                # Stop all services concurrently
+                await asyncio.gather(
+                    stop_vscode_service(),
+                    stop_desktop_service(),
+                    stop_tool_preload_service(),
+                    return_exceptions=True,
+                )
 
 
 def _get_root_path(config: Config) -> str:
@@ -210,6 +218,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(skills_router)
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
+    api_router.include_router(settings_router)
     app.include_router(api_router)
     app.include_router(sockets_router)
 

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -112,6 +112,13 @@ class Config(BaseModel):
             "The location of the directory where conversations and events are stored."
         ),
     )
+    settings_path: Path = Field(
+        default=Path("workspace/settings"),
+        description=(
+            "The location of the directory where persistent settings are stored, "
+            "including LLM profiles, agent configurations, and secret bundles."
+        ),
+    )
     bash_events_dir: Path = Field(
         default=Path("workspace/bash_events"),
         description=(

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -9,6 +9,7 @@ from pydantic import SecretStr
 from openhands.agent_server.conversation_service import (
     ConversationContractMismatchError,
     ConversationService,
+    SettingsReferenceError,
 )
 from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.models import (
@@ -130,7 +131,10 @@ async def batch_get_conversations(
 
 @conversation_router.post(
     "",
-    responses={409: {"description": "Conversation contract mismatch"}},
+    responses={
+        400: {"description": "Bad request (e.g., missing agent or invalid reference)"},
+        409: {"description": "Conversation contract mismatch"},
+    },
 )
 async def start_conversation(
     request: Annotated[
@@ -139,9 +143,19 @@ async def start_conversation(
     response: Response,
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> ConversationInfo:
-    """Start a conversation in the local environment."""
+    """Start a conversation in the local environment.
+
+    The agent can be provided either inline via 'agent' or by reference via
+    'agent_name'. Similarly, secrets can be provided inline or referenced via
+    'secrets_name'. An LLM profile can be applied via 'llm_profile_name'.
+    """
     try:
         info, is_new = await conversation_service.start_conversation(request)
+    except SettingsReferenceError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     except ConversationContractMismatchError as e:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/openhands-agent-server/openhands/agent_server/conversation_router_acp.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router_acp.py
@@ -6,7 +6,10 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from pydantic import SecretStr
 
-from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.conversation_service import (
+    ConversationService,
+    SettingsReferenceError,
+)
 from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.models import (
     ACPConversationInfo,
@@ -118,7 +121,12 @@ async def batch_get_acp_conversations(
     return await conversation_service.batch_get_acp_conversations(ids)
 
 
-@conversation_router_acp.post("")
+@conversation_router_acp.post(
+    "",
+    responses={
+        400: {"description": "Bad request (e.g., missing agent or invalid reference)"},
+    },
+)
 async def start_acp_conversation(
     request: Annotated[
         StartACPConversationRequest,
@@ -127,7 +135,18 @@ async def start_acp_conversation(
     response: Response,
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> ACPConversationInfo:
-    """Start a conversation using the ACP-capable contract."""
-    info, is_new = await conversation_service.start_acp_conversation(request)
+    """Start a conversation using the ACP-capable contract.
+
+    The agent can be provided either inline via 'agent' or by reference via
+    'agent_name'. Similarly, secrets can be provided inline or referenced via
+    'secrets_name'. An LLM profile can be applied via 'llm_profile_name'.
+    """
+    try:
+        info, is_new = await conversation_service.start_acp_conversation(request)
+    except SettingsReferenceError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        ) from e
     response.status_code = status.HTTP_201_CREATED if is_new else status.HTTP_200_OK
     return info

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -14,6 +14,7 @@ from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import (
     ACPConversationInfo,
     ACPConversationPage,
+    ACPEnabledAgent,
     ConversationInfo,
     ConversationPage,
     ConversationSortOrder,
@@ -24,6 +25,7 @@ from openhands.agent_server.models import (
 )
 from openhands.agent_server.pub_sub import Subscriber
 from openhands.agent_server.server_details_router import update_last_execution_time
+from openhands.agent_server.settings_service import SettingsService
 from openhands.agent_server.utils import safe_rmtree, utc_now
 from openhands.sdk import LLM, Agent, Event, Message
 from openhands.sdk.conversation.state import (
@@ -32,6 +34,7 @@ from openhands.sdk.conversation.state import (
 )
 from openhands.sdk.event import MessageEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+from openhands.sdk.secret import SecretSource
 from openhands.sdk.utils.cipher import Cipher
 
 
@@ -129,6 +132,102 @@ def _register_agent_definitions(
     )
 
 
+class SettingsReferenceError(ValueError):
+    """Raised when a referenced setting does not exist."""
+
+
+def _resolve_agent_and_llm(
+    request: StartConversationRequest | StartACPConversationRequest,
+    settings_service: SettingsService | None,
+) -> ACPEnabledAgent:
+    """Resolve agent and LLM references from the request.
+
+    Priority order:
+    1. Inline agent takes precedence over agent_name
+    2. If no agent specified, look up agent_name
+    3. If agent has no LLM, use llm_profile_name to provide one
+
+    Returns the resolved agent configuration.
+    """
+    agent: ACPEnabledAgent | None = request.agent
+
+    # Resolve agent by name if not provided inline
+    if agent is None and request.agent_name:
+        if settings_service is None:
+            raise SettingsReferenceError(
+                f"Cannot resolve agent_name '{request.agent_name}': "
+                "settings service not available"
+            )
+        named_agent = settings_service.get_agent(request.agent_name)
+        if named_agent is None:
+            raise SettingsReferenceError(
+                f"Agent '{request.agent_name}' not found in settings"
+            )
+        agent = named_agent.agent
+        logger.debug(f"Resolved agent from settings: {request.agent_name}")
+
+    if agent is None:
+        raise SettingsReferenceError(
+            "Either 'agent' (inline) or 'agent_name' (reference) must be provided"
+        )
+
+    # Resolve LLM profile if needed
+    if request.llm_profile_name:
+        if settings_service is None:
+            raise SettingsReferenceError(
+                f"Cannot resolve llm_profile_name '{request.llm_profile_name}': "
+                "settings service not available"
+            )
+        named_profile = settings_service.get_llm_profile(request.llm_profile_name)
+        if named_profile is None:
+            raise SettingsReferenceError(
+                f"LLM profile '{request.llm_profile_name}' not found in settings"
+            )
+
+        # Apply LLM profile to agent if agent doesn't have one configured
+        if isinstance(agent, Agent):
+            if agent.llm is None or agent.llm.api_key is None:
+                agent = agent.model_copy(update={"llm": named_profile.llm})
+                logger.debug(
+                    f"Applied LLM profile '{request.llm_profile_name}' to agent"
+                )
+        # For ACPAgent, check if it needs LLM (implementation depends on ACPAgent)
+
+    return agent
+
+
+def _resolve_secrets(
+    request: StartConversationRequest | StartACPConversationRequest,
+    settings_service: SettingsService | None,
+) -> dict[str, SecretSource]:
+    """Resolve and merge secrets from inline and referenced bundles.
+
+    Priority: inline secrets take precedence over secrets from secrets_name.
+    """
+    merged_secrets: dict[str, SecretSource] = {}
+
+    # First, apply secrets from referenced bundle (lower priority)
+    if request.secrets_name:
+        if settings_service is None:
+            raise SettingsReferenceError(
+                f"Cannot resolve secrets_name '{request.secrets_name}': "
+                "settings service not available"
+            )
+        named_secrets = settings_service.get_secrets(request.secrets_name)
+        if named_secrets is None:
+            raise SettingsReferenceError(
+                f"Secrets bundle '{request.secrets_name}' not found in settings"
+            )
+        merged_secrets.update(named_secrets.secrets)
+        logger.debug(f"Loaded {len(named_secrets.secrets)} secrets from bundle")
+
+    # Then, apply inline secrets (higher priority, overrides)
+    if request.secrets:
+        merged_secrets.update(request.secrets)
+
+    return merged_secrets
+
+
 @dataclass
 class ConversationService:
     """
@@ -137,6 +236,7 @@ class ConversationService:
     """
 
     conversations_dir: Path = field()
+    settings_service: SettingsService | None = field(default=None)
     webhook_specs: list[WebhookSpec] = field(default_factory=list)
     session_api_key: str | None = field(default=None)
     cipher: Cipher | None = None
@@ -412,10 +512,14 @@ class ConversationService:
             )
             return conversation_info, False
 
+        # Resolve agent and LLM from references (if provided)
+        resolved_agent = _resolve_agent_and_llm(request, self.settings_service)
+
+        # Resolve and merge secrets
+        resolved_secrets = _resolve_secrets(request, self.settings_service)
+
         # Dynamically register tools from client's registry
         if request.tool_module_qualnames:
-            import importlib
-
             for tool_name, module_qualname in request.tool_module_qualnames.items():
                 try:
                     # Import the module to trigger tool auto-registration
@@ -456,9 +560,25 @@ class ConversationService:
         # serialize to plain strings. Pass expose_secrets=True so StaticSecret values
         # are preserved through the round-trip; the dict is only used in-process to
         # construct StoredConversation, not sent over the network.
+        #
+        # Build the stored conversation with resolved agent and secrets
+        # Exclude fields that we're overriding with resolved values
+        request_data = request.model_dump(
+            mode="json",
+            context={"expose_secrets": True},
+            exclude={
+                "agent",
+                "agent_name",
+                "llm_profile_name",
+                "secrets",
+                "secrets_name",
+            },
+        )
         stored = StoredConversation(
             id=conversation_id,
-            **request.model_dump(mode="json", context={"expose_secrets": True}),
+            agent=resolved_agent,
+            secrets=resolved_secrets,
+            **request_data,
         )
         event_service = await self._start_event_service(stored)
         initial_message = request.initial_message
@@ -705,9 +825,12 @@ class ConversationService:
         )
 
     @classmethod
-    def get_instance(cls, config: Config) -> "ConversationService":
+    def get_instance(
+        cls, config: Config, settings_service: SettingsService | None = None
+    ) -> "ConversationService":
         return ConversationService(
             conversations_dir=config.conversations_path,
+            settings_service=settings_service,
             webhook_specs=config.webhooks,
             session_api_key=(
                 config.session_api_keys[0] if config.session_api_keys else None
@@ -968,10 +1091,10 @@ def get_default_conversation_service() -> ConversationService:
     if _conversation_service:
         return _conversation_service
 
-    from openhands.agent_server.config import (
-        get_default_config,
-    )
+    from openhands.agent_server.config import get_default_config
+    from openhands.agent_server.settings_service import get_default_settings_service
 
     config = get_default_config()
-    _conversation_service = ConversationService.get_instance(config)
+    settings_service = get_default_settings_service()
+    _conversation_service = ConversationService.get_instance(config, settings_service)
     return _conversation_service

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -108,6 +108,13 @@ class _StartConversationRequestBase(BaseModel):
         default_factory=dict,
         description="Secrets available in the conversation",
     )
+    secrets_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of a stored secrets bundle to use. If provided, these secrets "
+            "are merged with any inline secrets (inline takes precedence)."
+        ),
+    )
     tool_module_qualnames: dict[str, str] = Field(
         default_factory=dict,
         description=(
@@ -155,24 +162,75 @@ class StartConversationRequest(_StartConversationRequestBase):
     """Payload to create a new conversation.
 
     Contains an Agent configuration along with conversation-specific options.
+
+    The agent can be provided either:
+    - Inline via the `agent` field
+    - By reference via `agent_name` (referencing a stored agent configuration)
+
+    If both are provided, the inline agent takes precedence.
+    Similarly, `llm_profile_name` can provide an LLM configuration that will be
+    used if the inline agent doesn't specify an LLM.
     """
 
-    agent: Agent
+    agent: Agent | None = Field(
+        default=None,
+        description="Inline agent configuration. If not provided, agent_name is used.",
+    )
+    agent_name: str | None = Field(
+        default=None,
+        description="Name of a stored agent configuration to use.",
+    )
+    llm_profile_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of a stored LLM profile to use. If provided and the agent "
+            "doesn't have an LLM configured, this profile's LLM will be used."
+        ),
+    )
 
 
 class StartACPConversationRequest(_StartConversationRequestBase):
-    """Payload to create a conversation with ACP-capable agent support."""
+    """Payload to create a conversation with ACP-capable agent support.
 
-    agent: ACPEnabledAgent
+    The agent can be provided either:
+    - Inline via the `agent` field
+    - By reference via `agent_name` (referencing a stored agent configuration)
+
+    If both are provided, the inline agent takes precedence.
+    Similarly, `llm_profile_name` can provide an LLM configuration.
+    """
+
+    agent: ACPEnabledAgent | None = Field(
+        default=None,
+        description="Inline agent configuration. If not provided, agent_name is used.",
+    )
+    agent_name: str | None = Field(
+        default=None,
+        description="Name of a stored agent configuration to use.",
+    )
+    llm_profile_name: str | None = Field(
+        default=None,
+        description=(
+            "Name of a stored LLM profile to use. If provided and the agent "
+            "doesn't have an LLM configured, this profile's LLM will be used."
+        ),
+    )
 
 
 class StoredConversation(StartACPConversationRequest):
     """Stored details about a conversation.
 
     Extends StartConversationRequest with server-assigned fields.
+    The agent field is required (not optional) in stored conversations
+    because references have already been resolved.
     """
 
     id: OpenHandsUUID
+    # Override to make agent required (references are resolved before storage)
+    agent: ACPEnabledAgent = Field(  # type: ignore[assignment]
+        ...,
+        description="The resolved agent configuration (references resolved).",
+    )
     title: str | None = Field(
         default=None, description="User-defined title for the conversation"
     )

--- a/openhands-agent-server/openhands/agent_server/settings_models.py
+++ b/openhands-agent-server/openhands/agent_server/settings_models.py
@@ -1,0 +1,226 @@
+"""Models for persistent named settings in agent-server.
+
+These models define the schema for named, reusable configurations that can be
+referenced when starting conversations, rather than providing them inline each time.
+"""
+
+import re
+from datetime import datetime
+
+from pydantic import BaseModel, Field, field_validator
+
+from openhands.agent_server.models import ACPEnabledAgent
+from openhands.agent_server.utils import utc_now
+from openhands.sdk import LLM, Agent
+from openhands.sdk.secret import SecretSource
+
+
+# Name validation pattern - alphanumeric, underscores, hyphens
+_NAME_PATTERN = re.compile(r"^[a-zA-Z0-9_-]+$")
+
+
+def _validate_name(name: str) -> str:
+    """Validate that a name contains only allowed characters."""
+    if not _NAME_PATTERN.match(name):
+        raise ValueError(
+            "Name must contain only alphanumeric characters, underscores, and hyphens"
+        )
+    return name
+
+
+class NamedLLMProfile(BaseModel):
+    """A named, reusable LLM configuration.
+
+    Example:
+        POST /settings/llm-profiles
+        {
+            "name": "my-claude",
+            "llm": {
+                "model": "claude-sonnet-4-20250514",
+                "api_key": "sk-..."
+            }
+        }
+    """
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Unique identifier for this LLM profile",
+    )
+    llm: LLM = Field(description="The LLM configuration")
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+
+class NamedAgent(BaseModel):
+    """A named, reusable agent configuration.
+
+    Example:
+        POST /settings/agents
+        {
+            "name": "my-agent",
+            "agent": {
+                "llm": {"model": "claude-sonnet-4-20250514", "api_key": "sk-..."},
+                "tools": [{"name": "TerminalTool"}, {"name": "FileEditorTool"}]
+            }
+        }
+    """
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Unique identifier for this agent configuration",
+    )
+    agent: ACPEnabledAgent = Field(description="The agent configuration")
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+
+class NamedSecrets(BaseModel):
+    """A named bundle of secrets that can be referenced in conversations.
+
+    Example:
+        POST /settings/secrets
+        {
+            "name": "my-api-keys",
+            "secrets": {
+                "GITHUB_TOKEN": {"kind": "StaticSecret", "value": "ghp_..."},
+                "OPENAI_API_KEY": {"kind": "StaticSecret", "value": "sk-..."}
+            }
+        }
+    """
+
+    name: str = Field(
+        min_length=1,
+        max_length=100,
+        description="Unique identifier for this secrets bundle",
+    )
+    secrets: dict[str, SecretSource] = Field(
+        default_factory=dict,
+        description="Dictionary of secret name to secret source",
+    )
+    created_at: datetime = Field(default_factory=utc_now)
+    updated_at: datetime = Field(default_factory=utc_now)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+
+# Request/Response models for the REST API
+
+
+class CreateLLMProfileRequest(BaseModel):
+    """Request to create a new LLM profile."""
+
+    name: str = Field(min_length=1, max_length=100)
+    llm: LLM
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+
+class CreateAgentRequest(BaseModel):
+    """Request to create a new agent configuration."""
+
+    name: str = Field(min_length=1, max_length=100)
+    agent: ACPEnabledAgent
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+
+class CreateSecretsRequest(BaseModel):
+    """Request to create a new secrets bundle."""
+
+    name: str = Field(min_length=1, max_length=100)
+    secrets: dict[str, SecretSource] = Field(default_factory=dict)
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        return _validate_name(v)
+
+
+class SettingsListResponse(BaseModel):
+    """Response containing a list of setting names."""
+
+    names: list[str] = Field(default_factory=list)
+
+
+class LLMProfileInfo(BaseModel):
+    """Public info about an LLM profile (without sensitive data)."""
+
+    name: str
+    model: str
+    base_url: str | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_named_profile(cls, profile: NamedLLMProfile) -> "LLMProfileInfo":
+        return cls(
+            name=profile.name,
+            model=profile.llm.model,
+            base_url=profile.llm.base_url,
+            created_at=profile.created_at,
+            updated_at=profile.updated_at,
+        )
+
+
+class AgentInfo(BaseModel):
+    """Public info about an agent configuration."""
+
+    name: str
+    llm_model: str | None = None
+    tool_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_named_agent(cls, agent: NamedAgent) -> "AgentInfo":
+        llm_model = None
+        tool_count = 0
+        if isinstance(agent.agent, Agent):
+            llm_model = agent.agent.llm.model if agent.agent.llm else None
+            tool_count = len(agent.agent.tools) if agent.agent.tools else 0
+        return cls(
+            name=agent.name,
+            llm_model=llm_model,
+            tool_count=tool_count,
+            created_at=agent.created_at,
+            updated_at=agent.updated_at,
+        )
+
+
+class SecretsInfo(BaseModel):
+    """Public info about a secrets bundle (without actual secret values)."""
+
+    name: str
+    secret_names: list[str] = Field(default_factory=list)
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_named_secrets(cls, secrets: NamedSecrets) -> "SecretsInfo":
+        return cls(
+            name=secrets.name,
+            secret_names=list(secrets.secrets.keys()),
+            created_at=secrets.created_at,
+            updated_at=secrets.updated_at,
+        )

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -1,0 +1,283 @@
+"""REST API router for managing persistent settings.
+
+Provides endpoints for CRUD operations on:
+- LLM profiles: Named, reusable LLM configurations
+- Agents: Named, reusable agent configurations
+- Secrets: Named bundles of secrets
+"""
+
+from fastapi import APIRouter, Depends, HTTPException, status
+
+from openhands.agent_server.models import Success
+from openhands.agent_server.settings_models import (
+    AgentInfo,
+    CreateAgentRequest,
+    CreateLLMProfileRequest,
+    CreateSecretsRequest,
+    LLMProfileInfo,
+    NamedAgent,
+    NamedLLMProfile,
+    NamedSecrets,
+    SecretsInfo,
+    SettingsListResponse,
+)
+from openhands.agent_server.settings_service import SettingsService
+
+
+settings_router = APIRouter(prefix="/settings", tags=["Settings"])
+
+
+# Dependency to get the settings service
+def get_settings_service() -> SettingsService:
+    from openhands.agent_server.settings_service import get_default_settings_service
+
+    return get_default_settings_service()
+
+
+# === LLM Profiles ===
+
+
+@settings_router.get("/llm-profiles")
+async def list_llm_profiles(
+    service: SettingsService = Depends(get_settings_service),
+) -> SettingsListResponse:
+    """List all stored LLM profile names."""
+    names = service.list_llm_profiles()
+    return SettingsListResponse(names=names)
+
+
+@settings_router.get(
+    "/llm-profiles/{name}",
+    responses={404: {"description": "LLM profile not found"}},
+)
+async def get_llm_profile(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> NamedLLMProfile:
+    """Get an LLM profile by name.
+
+    Returns the full profile configuration including the LLM settings.
+    Note: API keys and other secrets are encrypted in storage but returned
+    in their encrypted form for security.
+    """
+    profile = service.get_llm_profile(name)
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"LLM profile '{name}' not found",
+        )
+    return profile
+
+
+@settings_router.get("/llm-profiles/{name}/info")
+async def get_llm_profile_info(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> LLMProfileInfo:
+    """Get public info about an LLM profile (without sensitive data)."""
+    profile = service.get_llm_profile(name)
+    if profile is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"LLM profile '{name}' not found",
+        )
+    return LLMProfileInfo.from_named_profile(profile)
+
+
+@settings_router.post("/llm-profiles", status_code=status.HTTP_201_CREATED)
+async def create_llm_profile(
+    request: CreateLLMProfileRequest,
+    service: SettingsService = Depends(get_settings_service),
+) -> NamedLLMProfile:
+    """Create or update an LLM profile.
+
+    If a profile with the given name already exists, it will be updated.
+    """
+    profile = NamedLLMProfile(name=request.name, llm=request.llm)
+    if not service.create_llm_profile(profile):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create LLM profile",
+        )
+    return profile
+
+
+@settings_router.delete(
+    "/llm-profiles/{name}",
+    responses={404: {"description": "LLM profile not found"}},
+)
+async def delete_llm_profile(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> Success:
+    """Delete an LLM profile by name."""
+    if not service.delete_llm_profile(name):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"LLM profile '{name}' not found",
+        )
+    return Success()
+
+
+# === Agents ===
+
+
+@settings_router.get("/agents")
+async def list_agents(
+    service: SettingsService = Depends(get_settings_service),
+) -> SettingsListResponse:
+    """List all stored agent names."""
+    names = service.list_agents()
+    return SettingsListResponse(names=names)
+
+
+@settings_router.get(
+    "/agents/{name}",
+    responses={404: {"description": "Agent not found"}},
+)
+async def get_agent(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> NamedAgent:
+    """Get an agent configuration by name."""
+    agent = service.get_agent(name)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Agent '{name}' not found",
+        )
+    return agent
+
+
+@settings_router.get("/agents/{name}/info")
+async def get_agent_info(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> AgentInfo:
+    """Get public info about an agent configuration."""
+    agent = service.get_agent(name)
+    if agent is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Agent '{name}' not found",
+        )
+    return AgentInfo.from_named_agent(agent)
+
+
+@settings_router.post("/agents", status_code=status.HTTP_201_CREATED)
+async def create_agent(
+    request: CreateAgentRequest,
+    service: SettingsService = Depends(get_settings_service),
+) -> NamedAgent:
+    """Create or update an agent configuration.
+
+    If an agent with the given name already exists, it will be updated.
+    """
+    agent = NamedAgent(name=request.name, agent=request.agent)
+    if not service.create_agent(agent):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create agent",
+        )
+    return agent
+
+
+@settings_router.delete(
+    "/agents/{name}",
+    responses={404: {"description": "Agent not found"}},
+)
+async def delete_agent(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> Success:
+    """Delete an agent configuration by name."""
+    if not service.delete_agent(name):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Agent '{name}' not found",
+        )
+    return Success()
+
+
+# === Secrets ===
+
+
+@settings_router.get("/secrets")
+async def list_secrets(
+    service: SettingsService = Depends(get_settings_service),
+) -> SettingsListResponse:
+    """List all stored secrets bundle names."""
+    names = service.list_secrets()
+    return SettingsListResponse(names=names)
+
+
+@settings_router.get(
+    "/secrets/{name}",
+    responses={404: {"description": "Secrets bundle not found"}},
+)
+async def get_secrets(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> NamedSecrets:
+    """Get a secrets bundle by name.
+
+    Note: Secret values are encrypted in storage. The returned structure
+    includes the encrypted values.
+    """
+    secrets = service.get_secrets(name)
+    if secrets is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Secrets bundle '{name}' not found",
+        )
+    return secrets
+
+
+@settings_router.get("/secrets/{name}/info")
+async def get_secrets_info(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> SecretsInfo:
+    """Get public info about a secrets bundle (keys only, no values)."""
+    secrets = service.get_secrets(name)
+    if secrets is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Secrets bundle '{name}' not found",
+        )
+    return SecretsInfo.from_named_secrets(secrets)
+
+
+@settings_router.post("/secrets", status_code=status.HTTP_201_CREATED)
+async def create_secrets(
+    request: CreateSecretsRequest,
+    service: SettingsService = Depends(get_settings_service),
+) -> NamedSecrets:
+    """Create or update a secrets bundle.
+
+    If a bundle with the given name already exists, it will be updated.
+    """
+    secrets = NamedSecrets(name=request.name, secrets=request.secrets)
+    if not service.create_secrets(secrets):
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Failed to create secrets bundle",
+        )
+    return secrets
+
+
+@settings_router.delete(
+    "/secrets/{name}",
+    responses={404: {"description": "Secrets bundle not found"}},
+)
+async def delete_secrets(
+    name: str,
+    service: SettingsService = Depends(get_settings_service),
+) -> Success:
+    """Delete a secrets bundle by name."""
+    if not service.delete_secrets(name):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Secrets bundle '{name}' not found",
+        )
+    return Success()

--- a/openhands-agent-server/openhands/agent_server/settings_service.py
+++ b/openhands-agent-server/openhands/agent_server/settings_service.py
@@ -1,0 +1,256 @@
+"""Service for managing persistent settings in agent-server.
+
+This service provides CRUD operations for named LLM profiles, agent configurations,
+and secret bundles, using file-based persistence similar to conversations.
+"""
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TypeVar
+
+from pydantic import BaseModel
+
+from openhands.agent_server.settings_models import (
+    NamedAgent,
+    NamedLLMProfile,
+    NamedSecrets,
+)
+from openhands.agent_server.utils import safe_rmtree, utc_now
+from openhands.sdk.utils.cipher import Cipher
+
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T", NamedLLMProfile, NamedAgent, NamedSecrets)
+
+
+@dataclass
+class SettingsService:
+    """Service for managing persistent named settings.
+
+    Settings are stored as JSON files in subdirectories:
+    - {settings_dir}/llm_profiles/{name}.json
+    - {settings_dir}/agents/{name}.json
+    - {settings_dir}/secrets/{name}.json
+    """
+
+    settings_dir: Path
+    cipher: Cipher | None = None
+    _initialized: bool = field(default=False, init=False)
+
+    # Cached settings (loaded on startup)
+    _llm_profiles: dict[str, NamedLLMProfile] = field(default_factory=dict, init=False)
+    _agents: dict[str, NamedAgent] = field(default_factory=dict, init=False)
+    _secrets: dict[str, NamedSecrets] = field(default_factory=dict, init=False)
+
+    @property
+    def llm_profiles_dir(self) -> Path:
+        return self.settings_dir / "llm_profiles"
+
+    @property
+    def agents_dir(self) -> Path:
+        return self.settings_dir / "agents"
+
+    @property
+    def secrets_dir(self) -> Path:
+        return self.settings_dir / "secrets"
+
+    def _ensure_dirs(self) -> None:
+        """Create settings directories if they don't exist."""
+        self.settings_dir.mkdir(parents=True, exist_ok=True)
+        self.llm_profiles_dir.mkdir(exist_ok=True)
+        self.agents_dir.mkdir(exist_ok=True)
+        self.secrets_dir.mkdir(exist_ok=True)
+
+    def _load_item(self, path: Path, model_class: type[T], context: str) -> T | None:
+        """Load a single item from a JSON file."""
+        try:
+            json_str = path.read_text()
+            return model_class.model_validate_json(
+                json_str,
+                context={"cipher": self.cipher},
+            )
+        except Exception:
+            logger.exception(f"Error loading {context} from {path}")
+            return None
+
+    def _save_item(self, item: BaseModel, path: Path, context: str) -> bool:
+        """Save an item to a JSON file."""
+        try:
+            json_str = item.model_dump_json(
+                indent=2,
+                context={"cipher": self.cipher},
+            )
+            path.write_text(json_str)
+            return True
+        except Exception:
+            logger.exception(f"Error saving {context} to {path}")
+            return False
+
+    def _load_all(self) -> None:
+        """Load all settings from disk into memory."""
+        # Load LLM profiles
+        if self.llm_profiles_dir.exists():
+            for file in self.llm_profiles_dir.glob("*.json"):
+                profile = self._load_item(
+                    file, NamedLLMProfile, f"LLM profile {file.stem}"
+                )
+                if profile:
+                    self._llm_profiles[profile.name] = profile
+
+        # Load agents
+        if self.agents_dir.exists():
+            for file in self.agents_dir.glob("*.json"):
+                agent = self._load_item(file, NamedAgent, f"Agent {file.stem}")
+                if agent:
+                    self._agents[agent.name] = agent
+
+        # Load secrets
+        if self.secrets_dir.exists():
+            for file in self.secrets_dir.glob("*.json"):
+                secrets = self._load_item(file, NamedSecrets, f"Secrets {file.stem}")
+                if secrets:
+                    self._secrets[secrets.name] = secrets
+
+        logger.info(
+            f"Loaded {len(self._llm_profiles)} LLM profiles, "
+            f"{len(self._agents)} agents, {len(self._secrets)} secret bundles"
+        )
+
+    # LLM Profile operations
+
+    def list_llm_profiles(self) -> list[str]:
+        """List all LLM profile names."""
+        return list(self._llm_profiles.keys())
+
+    def get_llm_profile(self, name: str) -> NamedLLMProfile | None:
+        """Get an LLM profile by name."""
+        return self._llm_profiles.get(name)
+
+    def create_llm_profile(self, profile: NamedLLMProfile) -> bool:
+        """Create or update an LLM profile."""
+        # Update timestamp if it already exists
+        if profile.name in self._llm_profiles:
+            profile.updated_at = utc_now()
+
+        path = self.llm_profiles_dir / f"{profile.name}.json"
+        if self._save_item(profile, path, f"LLM profile {profile.name}"):
+            self._llm_profiles[profile.name] = profile
+            return True
+        return False
+
+    def delete_llm_profile(self, name: str) -> bool:
+        """Delete an LLM profile by name."""
+        if name not in self._llm_profiles:
+            return False
+
+        path = self.llm_profiles_dir / f"{name}.json"
+        if safe_rmtree(path, f"LLM profile {name}"):
+            del self._llm_profiles[name]
+            return True
+        return False
+
+    # Agent operations
+
+    def list_agents(self) -> list[str]:
+        """List all agent names."""
+        return list(self._agents.keys())
+
+    def get_agent(self, name: str) -> NamedAgent | None:
+        """Get an agent configuration by name."""
+        return self._agents.get(name)
+
+    def create_agent(self, agent: NamedAgent) -> bool:
+        """Create or update an agent configuration."""
+        if agent.name in self._agents:
+            agent.updated_at = utc_now()
+
+        path = self.agents_dir / f"{agent.name}.json"
+        if self._save_item(agent, path, f"Agent {agent.name}"):
+            self._agents[agent.name] = agent
+            return True
+        return False
+
+    def delete_agent(self, name: str) -> bool:
+        """Delete an agent configuration by name."""
+        if name not in self._agents:
+            return False
+
+        path = self.agents_dir / f"{name}.json"
+        if safe_rmtree(path, f"Agent {name}"):
+            del self._agents[name]
+            return True
+        return False
+
+    # Secrets operations
+
+    def list_secrets(self) -> list[str]:
+        """List all secrets bundle names."""
+        return list(self._secrets.keys())
+
+    def get_secrets(self, name: str) -> NamedSecrets | None:
+        """Get a secrets bundle by name."""
+        return self._secrets.get(name)
+
+    def create_secrets(self, secrets: NamedSecrets) -> bool:
+        """Create or update a secrets bundle."""
+        if secrets.name in self._secrets:
+            secrets.updated_at = utc_now()
+
+        path = self.secrets_dir / f"{secrets.name}.json"
+        if self._save_item(secrets, path, f"Secrets {secrets.name}"):
+            self._secrets[secrets.name] = secrets
+            return True
+        return False
+
+    def delete_secrets(self, name: str) -> bool:
+        """Delete a secrets bundle by name."""
+        if name not in self._secrets:
+            return False
+
+        path = self.secrets_dir / f"{name}.json"
+        if safe_rmtree(path, f"Secrets {name}"):
+            del self._secrets[name]
+            return True
+        return False
+
+    # Lifecycle methods
+
+    async def __aenter__(self) -> "SettingsService":
+        """Initialize the service and load settings from disk."""
+        self._ensure_dirs()
+        self._load_all()
+        self._initialized = True
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        """Clean up resources."""
+        self._initialized = False
+
+    @classmethod
+    def get_instance(
+        cls, settings_dir: Path, cipher: Cipher | None = None
+    ) -> "SettingsService":
+        """Create a new SettingsService instance."""
+        return cls(settings_dir=settings_dir, cipher=cipher)
+
+
+# Global singleton
+_settings_service: SettingsService | None = None
+
+
+def get_default_settings_service() -> SettingsService:
+    """Get the default settings service singleton."""
+    global _settings_service
+    if _settings_service is not None:
+        return _settings_service
+
+    from openhands.agent_server.config import get_default_config
+
+    config = get_default_config()
+    _settings_service = SettingsService.get_instance(
+        settings_dir=config.settings_path,
+        cipher=config.cipher,
+    )
+    return _settings_service

--- a/tests/agent_server/test_settings_references.py
+++ b/tests/agent_server/test_settings_references.py
@@ -1,0 +1,220 @@
+"""Tests for settings reference resolution in conversation creation."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.agent_server.conversation_service import (
+    SettingsReferenceError,
+    _resolve_agent_and_llm,
+    _resolve_secrets,
+)
+from openhands.agent_server.models import StartConversationRequest
+from openhands.agent_server.settings_models import (
+    NamedAgent,
+    NamedLLMProfile,
+    NamedSecrets,
+)
+from openhands.agent_server.settings_service import SettingsService
+from openhands.sdk import LLM, Agent
+from openhands.sdk.secret import StaticSecret
+from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.workspace import LocalWorkspace
+
+
+@pytest.fixture
+def settings_dir():
+    """Create a temporary directory for settings."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
+
+
+@pytest.fixture
+def cipher():
+    """Create a cipher for encryption."""
+    return Cipher("test-secret-key-12345")
+
+
+@pytest.fixture
+async def settings_service(settings_dir, cipher):
+    """Create an initialized settings service with test data."""
+    service = SettingsService(settings_dir=settings_dir, cipher=cipher)
+    async with service:
+        # Add some test profiles
+        llm_profile = NamedLLMProfile(
+            name="test-llm-profile",
+            llm=LLM(model="gpt-4o", api_key=SecretStr("profile-key")),
+        )
+        service.create_llm_profile(llm_profile)
+
+        agent = NamedAgent(
+            name="test-agent",
+            agent=Agent(
+                llm=LLM(
+                    model="claude-sonnet-4-20250514", api_key=SecretStr("agent-key")
+                ),
+                tools=[],
+            ),
+        )
+        service.create_agent(agent)
+
+        secrets = NamedSecrets(
+            name="test-secrets",
+            secrets={
+                "GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp_test")),
+            },
+        )
+        service.create_secrets(secrets)
+
+        yield service
+
+
+def _create_request(
+    agent: Agent | None = None,
+    agent_name: str | None = None,
+    llm_profile_name: str | None = None,
+    secrets: dict | None = None,
+    secrets_name: str | None = None,
+) -> StartConversationRequest:
+    """Helper to create request with minimal required fields."""
+    return StartConversationRequest(
+        workspace=LocalWorkspace(working_dir="workspace/project"),
+        agent=agent,
+        agent_name=agent_name,
+        llm_profile_name=llm_profile_name,
+        secrets=secrets or {},
+        secrets_name=secrets_name,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resolve_inline_agent(settings_service):
+    """Test that inline agent takes precedence."""
+    inline_agent = Agent(llm=LLM(model="inline-model"), tools=[])
+    request = _create_request(agent=inline_agent)
+
+    resolved = _resolve_agent_and_llm(request, settings_service)
+    assert resolved.llm.model == "inline-model"
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_by_name(settings_service):
+    """Test resolving agent by reference name."""
+    request = _create_request(agent_name="test-agent")
+
+    resolved = _resolve_agent_and_llm(request, settings_service)
+    assert resolved.llm.model == "claude-sonnet-4-20250514"
+
+
+@pytest.mark.asyncio
+async def test_resolve_agent_not_found(settings_service):
+    """Test error when referenced agent doesn't exist."""
+    request = _create_request(agent_name="nonexistent")
+
+    with pytest.raises(SettingsReferenceError, match="not found"):
+        _resolve_agent_and_llm(request, settings_service)
+
+
+@pytest.mark.asyncio
+async def test_resolve_missing_agent_and_name():
+    """Test error when neither agent nor agent_name provided."""
+    request = StartConversationRequest(
+        workspace=LocalWorkspace(working_dir="workspace/project"),
+        agent=None,
+        agent_name=None,
+    )
+
+    with pytest.raises(SettingsReferenceError, match="must be provided"):
+        _resolve_agent_and_llm(request, None)
+
+
+@pytest.mark.asyncio
+async def test_resolve_llm_profile(settings_service):
+    """Test applying LLM profile to agent without LLM."""
+    # Agent without LLM
+    agent = Agent(llm=LLM(model="needs-key"), tools=[])
+    request = _create_request(agent=agent, llm_profile_name="test-llm-profile")
+
+    resolved = _resolve_agent_and_llm(request, settings_service)
+    # LLM profile should be applied since agent's LLM has no api_key
+    assert resolved.llm.model == "gpt-4o"
+
+
+@pytest.mark.asyncio
+async def test_resolve_llm_profile_not_found(settings_service):
+    """Test error when LLM profile doesn't exist."""
+    agent = Agent(llm=LLM(model="test"), tools=[])
+    request = _create_request(agent=agent, llm_profile_name="nonexistent")
+
+    with pytest.raises(SettingsReferenceError, match="not found"):
+        _resolve_agent_and_llm(request, settings_service)
+
+
+@pytest.mark.asyncio
+async def test_resolve_secrets_inline_only(settings_service):
+    """Test resolving only inline secrets."""
+    request = _create_request(
+        agent=Agent(llm=LLM(model="test"), tools=[]),
+        secrets={"MY_SECRET": StaticSecret(value=SecretStr("inline"))},
+    )
+
+    resolved = _resolve_secrets(request, settings_service)
+    assert "MY_SECRET" in resolved
+    assert len(resolved) == 1
+
+
+@pytest.mark.asyncio
+async def test_resolve_secrets_by_name(settings_service):
+    """Test resolving secrets by reference name."""
+    request = _create_request(
+        agent=Agent(llm=LLM(model="test"), tools=[]),
+        secrets_name="test-secrets",
+    )
+
+    resolved = _resolve_secrets(request, settings_service)
+    assert "GITHUB_TOKEN" in resolved
+
+
+@pytest.mark.asyncio
+async def test_resolve_secrets_merge_with_precedence(settings_service):
+    """Test that inline secrets override referenced secrets."""
+    request = _create_request(
+        agent=Agent(llm=LLM(model="test"), tools=[]),
+        secrets_name="test-secrets",
+        secrets={
+            "GITHUB_TOKEN": StaticSecret(value=SecretStr("inline-override")),
+            "NEW_SECRET": StaticSecret(value=SecretStr("new")),
+        },
+    )
+
+    resolved = _resolve_secrets(request, settings_service)
+    # Check inline override took precedence
+    github_secret = resolved["GITHUB_TOKEN"]
+    assert isinstance(github_secret, StaticSecret)
+    assert github_secret.value is not None
+    assert github_secret.value.get_secret_value() == "inline-override"
+    # Check new secret was added
+    assert "NEW_SECRET" in resolved
+
+
+@pytest.mark.asyncio
+async def test_resolve_secrets_not_found(settings_service):
+    """Test error when secrets bundle doesn't exist."""
+    request = _create_request(
+        agent=Agent(llm=LLM(model="test"), tools=[]),
+        secrets_name="nonexistent",
+    )
+
+    with pytest.raises(SettingsReferenceError, match="not found"):
+        _resolve_secrets(request, settings_service)
+
+
+@pytest.mark.asyncio
+async def test_resolve_without_settings_service():
+    """Test error when settings service is None but references are used."""
+    request = _create_request(agent_name="some-agent")
+
+    with pytest.raises(SettingsReferenceError, match="not available"):
+        _resolve_agent_and_llm(request, None)

--- a/tests/agent_server/test_settings_service.py
+++ b/tests/agent_server/test_settings_service.py
@@ -1,0 +1,195 @@
+"""Tests for the settings service."""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.agent_server.settings_models import (
+    NamedAgent,
+    NamedLLMProfile,
+    NamedSecrets,
+)
+from openhands.agent_server.settings_service import SettingsService
+from openhands.sdk import LLM, Agent
+from openhands.sdk.secret import StaticSecret
+from openhands.sdk.utils.cipher import Cipher
+
+
+@pytest.fixture
+def settings_dir():
+    """Create a temporary directory for settings."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        yield Path(temp_dir)
+
+
+@pytest.fixture
+def cipher():
+    """Create a cipher for encryption."""
+    return Cipher("test-secret-key-12345")
+
+
+@pytest.fixture
+async def settings_service(settings_dir, cipher):
+    """Create an initialized settings service."""
+    service = SettingsService(settings_dir=settings_dir, cipher=cipher)
+    async with service:
+        yield service
+
+
+@pytest.fixture
+def sample_llm():
+    """Create a sample LLM configuration."""
+    return LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test-api-key"),
+        usage_id="test-usage",
+    )
+
+
+@pytest.fixture
+def sample_agent(sample_llm):
+    """Create a sample agent configuration."""
+    return Agent(llm=sample_llm, tools=[])
+
+
+@pytest.mark.asyncio
+async def test_llm_profile_crud(settings_service, sample_llm):
+    """Test CRUD operations for LLM profiles."""
+    # Create
+    profile = NamedLLMProfile(name="my-claude", llm=sample_llm)
+    assert settings_service.create_llm_profile(profile)
+
+    # Read
+    retrieved = settings_service.get_llm_profile("my-claude")
+    assert retrieved is not None
+    assert retrieved.name == "my-claude"
+    assert retrieved.llm.model == "gpt-4o"
+
+    # List
+    names = settings_service.list_llm_profiles()
+    assert "my-claude" in names
+
+    # Delete
+    assert settings_service.delete_llm_profile("my-claude")
+    assert settings_service.get_llm_profile("my-claude") is None
+
+
+@pytest.mark.asyncio
+async def test_agent_crud(settings_service, sample_agent):
+    """Test CRUD operations for agent configurations."""
+    # Create
+    agent = NamedAgent(name="my-agent", agent=sample_agent)
+    assert settings_service.create_agent(agent)
+
+    # Read
+    retrieved = settings_service.get_agent("my-agent")
+    assert retrieved is not None
+    assert retrieved.name == "my-agent"
+
+    # List
+    names = settings_service.list_agents()
+    assert "my-agent" in names
+
+    # Delete
+    assert settings_service.delete_agent("my-agent")
+    assert settings_service.get_agent("my-agent") is None
+
+
+@pytest.mark.asyncio
+async def test_secrets_crud(settings_service):
+    """Test CRUD operations for secrets bundles."""
+    # Create
+    secrets = NamedSecrets(
+        name="my-api-keys",
+        secrets={
+            "GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp_test123")),
+            "OPENAI_KEY": StaticSecret(value=SecretStr("sk-test456")),
+        },
+    )
+    assert settings_service.create_secrets(secrets)
+
+    # Read
+    retrieved = settings_service.get_secrets("my-api-keys")
+    assert retrieved is not None
+    assert retrieved.name == "my-api-keys"
+    assert "GITHUB_TOKEN" in retrieved.secrets
+    assert "OPENAI_KEY" in retrieved.secrets
+
+    # List
+    names = settings_service.list_secrets()
+    assert "my-api-keys" in names
+
+    # Delete
+    assert settings_service.delete_secrets("my-api-keys")
+    assert settings_service.get_secrets("my-api-keys") is None
+
+
+@pytest.mark.asyncio
+async def test_persistence(settings_dir, cipher, sample_llm):
+    """Test that settings persist across service restarts."""
+    # Create and save
+    service1 = SettingsService(settings_dir=settings_dir, cipher=cipher)
+    async with service1:
+        profile = NamedLLMProfile(name="persistent-profile", llm=sample_llm)
+        service1.create_llm_profile(profile)
+
+    # Reload and verify
+    service2 = SettingsService(settings_dir=settings_dir, cipher=cipher)
+    async with service2:
+        retrieved = service2.get_llm_profile("persistent-profile")
+        assert retrieved is not None
+        assert retrieved.name == "persistent-profile"
+
+
+@pytest.mark.asyncio
+async def test_update_existing(settings_service, sample_llm):
+    """Test updating an existing profile."""
+    # Create initial
+    profile1 = NamedLLMProfile(name="updatable", llm=sample_llm)
+    settings_service.create_llm_profile(profile1)
+    initial_updated_at = profile1.updated_at
+
+    # Update with new config
+    new_llm = LLM(model="claude-sonnet-4-20250514", api_key=SecretStr("new-key"))
+    profile2 = NamedLLMProfile(name="updatable", llm=new_llm)
+    settings_service.create_llm_profile(profile2)
+
+    # Verify update
+    retrieved = settings_service.get_llm_profile("updatable")
+    assert retrieved is not None
+    assert retrieved.llm.model == "claude-sonnet-4-20250514"
+    # updated_at should be different (newer)
+    assert retrieved.updated_at >= initial_updated_at
+
+
+@pytest.mark.asyncio
+async def test_delete_nonexistent(settings_service):
+    """Test deleting a nonexistent item returns False."""
+    assert not settings_service.delete_llm_profile("nonexistent")
+    assert not settings_service.delete_agent("nonexistent")
+    assert not settings_service.delete_secrets("nonexistent")
+
+
+@pytest.mark.asyncio
+async def test_name_validation():
+    """Test that invalid names are rejected."""
+    with pytest.raises(ValueError, match="alphanumeric"):
+        NamedLLMProfile(
+            name="invalid name with spaces",
+            llm=LLM(model="test"),
+        )
+
+    with pytest.raises(ValueError, match="alphanumeric"):
+        NamedLLMProfile(
+            name="invalid/name",
+            llm=LLM(model="test"),
+        )
+
+    # Valid names should work
+    profile = NamedLLMProfile(
+        name="valid-name_123",
+        llm=LLM(model="test"),
+    )
+    assert profile.name == "valid-name_123"


### PR DESCRIPTION
## Summary

This PR adds file-based persistence for commonly-used configurations that can be referenced when starting conversations, rather than providing them inline each time.

Addresses the need to replace our current "Local GUI" with a thin frontend that talks to an AgentServer - lack of persistent settings was the main blocker (would have required localStorage).

## New Features

### 1. Settings REST API (`/api/settings`)

New endpoints for managing reusable configurations:

**LLM Profiles:**
- `GET /api/settings/llm-profiles` - List all profile names
- `GET /api/settings/llm-profiles/{name}` - Get a profile
- `GET /api/settings/llm-profiles/{name}/info` - Get profile info (without secrets)
- `POST /api/settings/llm-profiles` - Create/update a profile
- `DELETE /api/settings/llm-profiles/{name}` - Delete a profile

**Agent Configurations:**
- `GET /api/settings/agents` - List all agent names
- `GET /api/settings/agents/{name}` - Get an agent config
- `GET /api/settings/agents/{name}/info` - Get agent info
- `POST /api/settings/agents` - Create/update an agent config
- `DELETE /api/settings/agents/{name}` - Delete an agent config

**Secret Bundles:**
- `GET /api/settings/secrets` - List all secret bundle names
- `GET /api/settings/secrets/{name}` - Get a secrets bundle
- `GET /api/settings/secrets/{name}/info` - Get bundle info (key names only)
- `POST /api/settings/secrets` - Create/update a secrets bundle
- `DELETE /api/settings/secrets/{name}` - Delete a secrets bundle

### 2. Reference Support in Conversation Creation

`StartConversationRequest` now supports these optional fields:
- `agent_name`: Reference a stored agent configuration
- `llm_profile_name`: Apply a stored LLM profile to the agent
- `secrets_name`: Merge secrets from a stored bundle with inline secrets

Example usage:
```json
POST /api/conversations
{
  "workspace": {"kind": "LocalWorkspace", "working_dir": "workspace/project"},
  "agent_name": "my-default-agent",
  "secrets_name": "my-api-keys"
}
```

### 3. File-based Persistence

Settings are stored in `workspace/settings/` (configurable via `OH_SETTINGS_PATH`):
- `settings/llm_profiles/{name}.json`
- `settings/agents/{name}.json`
- `settings/secrets/{name}.json`

Secrets are encrypted using the same cipher as conversations (via `OH_SECRET_KEY`).

## Backward Compatibility

- ✅ All existing APIs work unchanged
- ✅ Inline configurations take precedence over references
- ✅ The `agent` field is still accepted (and takes precedence over `agent_name`)
- ✅ Secrets are merged: referenced bundle + inline (inline takes precedence)

## Design Decisions

1. **Client still chooses explicitly**: The client references stored settings at conversation start, maintaining clear control
2. **File-level persistence**: Same approach as conversations/trajectories - simple and consistent
3. **Uses SDK classes**: `LLM`, `Agent`, `SecretSource` - no new schema
4. **References resolved before storage**: `StoredConversation` always has resolved agent/secrets

## Testing

- `test_settings_service.py` - 7 tests for CRUD operations
- `test_settings_references.py` - 11 tests for reference resolution
- All existing tests continue to pass
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1d905fb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1d905fb-python \
  ghcr.io/openhands/agent-server:1d905fb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1d905fb-golang-amd64
ghcr.io/openhands/agent-server:1d905fb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1d905fb-golang-arm64
ghcr.io/openhands/agent-server:1d905fb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1d905fb-java-amd64
ghcr.io/openhands/agent-server:1d905fb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1d905fb-java-arm64
ghcr.io/openhands/agent-server:1d905fb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1d905fb-python-amd64
ghcr.io/openhands/agent-server:1d905fb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:1d905fb-python-arm64
ghcr.io/openhands/agent-server:1d905fb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:1d905fb-golang
ghcr.io/openhands/agent-server:1d905fb-java
ghcr.io/openhands/agent-server:1d905fb-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1d905fb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1d905fb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->