### PR TITLE
feat(tools): add codebase_search and github_codebase_search tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,27 @@ print("All done!")
 
 For installation instructions and detailed setup, see the [Getting Started Guide](https://docs.openhands.dev/sdk/getting-started).
 
+### Codebase Search (Optional)
+
+Add natural-language code search to your agent with [Morph's WarpGrep](https://morphllm.com). Requires a `MORPH_API_KEY` ([get one here](https://morphllm.com/dashboard/api-keys)) and Node.js 18+.
+
+```python
+from openhands.tools.codebase_search import register_codebase_search_tools
+
+register_codebase_search_tools()
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        # ... your other tools ...
+        Tool(name="codebase_search"),           # search local repos
+        Tool(name="github_codebase_search"),    # search public GitHub repos
+    ],
+)
+```
+
+See [`examples/01_standalone_sdk/45_codebase_search.py`](examples/01_standalone_sdk/45_codebase_search.py) for a full working example.
+
 ## Documentation
 
 For detailed documentation, tutorials, and API reference, visit:

--- a/examples/01_standalone_sdk/45_codebase_search.py
+++ b/examples/01_standalone_sdk/45_codebase_search.py
@@ -1,0 +1,53 @@
+"""Codebase search using Morph's WarpGrep.
+
+Natural-language code search backed by an LLM sub-agent that uses ripgrep,
+file reads, and directory listing under the hood.  Two tools are provided:
+
+  - ``codebase_search``          — search a local repository
+  - ``github_codebase_search``   — search a public GitHub repository
+
+Requirements:
+  - MORPH_API_KEY  : Get from https://morphllm.com/dashboard/api-keys
+  - LLM_API_KEY    : Your LLM provider API key
+  - Node.js 18+    : Required by the MCP server (``npx``)
+"""
+
+import os
+
+from openhands.sdk import LLM, Agent, Conversation, Tool
+from openhands.tools.codebase_search import register_codebase_search_tools
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalTool
+
+# 1. Register the Morph search tools (explicit, not automatic)
+register_codebase_search_tools()
+
+# 2. Configure the LLM
+llm = LLM(
+    model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+    api_key=os.getenv("LLM_API_KEY"),
+    base_url=os.getenv("LLM_BASE_URL", None),
+)
+
+# 3. Build the agent with search + editing tools
+agent = Agent(
+    llm=llm,
+    tools=[
+        Tool(name=TerminalTool.name),
+        Tool(name=FileEditorTool.name),
+        # Morph search tools — pass api_key here or set MORPH_API_KEY env var
+        Tool(name="codebase_search"),
+        Tool(name="github_codebase_search"),
+    ],
+)
+
+# 4. Run a conversation
+cwd = os.getcwd()
+conversation = Conversation(agent=agent, workspace=cwd)
+conversation.send_message(
+    "Use codebase_search to find how errors are handled in this project, "
+    "then summarize what you found."
+)
+conversation.run()
+
+print(f"EXAMPLE_COST: {llm.metrics.accumulated_cost}")

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -86,7 +86,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-install ACP servers for ACPAgent support (Claude Code + Codex)
-# and Morph MCP server for codebase_search / github_codebase_search tools.
+# and Morph WarpGrep SDK for codebase_search / github_codebase_search tools.
 # Install Node.js/npm if not present (SWE-bench base images may lack them)
 RUN set -eux; \
     if ! command -v npm >/dev/null 2>&1; then \
@@ -94,7 +94,7 @@ RUN set -eux; \
         apt-get install -y --no-install-recommends nodejs && \
         rm -rf /var/lib/apt/lists/*; \
     fi; \
-    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp @morphllm/morphmcp
+    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp @morphllm/morphsdk
 
 # Configure Claude Code managed settings for headless operation:
 # Allow all tool permissions (no human in the loop to approve).

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -86,6 +86,7 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-install ACP servers for ACPAgent support (Claude Code + Codex)
+# and Morph MCP server for codebase_search / github_codebase_search tools.
 # Install Node.js/npm if not present (SWE-bench base images may lack them)
 RUN set -eux; \
     if ! command -v npm >/dev/null 2>&1; then \
@@ -93,7 +94,7 @@ RUN set -eux; \
         apt-get install -y --no-install-recommends nodejs && \
         rm -rf /var/lib/apt/lists/*; \
     fi; \
-    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp
+    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp @morphllm/morphmcp
 
 # Configure Claude Code managed settings for headless operation:
 # Allow all tool permissions (no human in the loop to approve).

--- a/openhands-agent-server/openhands/agent_server/tool_router.py
+++ b/openhands-agent-server/openhands/agent_server/tool_router.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter
 
 from openhands.sdk.tool.registry import list_registered_tools
+from openhands.tools.codebase_search import register_codebase_search_tools
 from openhands.tools.preset.default import register_default_tools
 from openhands.tools.preset.gemini import register_gemini_tools
 from openhands.tools.preset.planning import register_planning_tools
@@ -12,6 +13,7 @@ tool_router = APIRouter(prefix="/tools", tags=["Tools"])
 register_default_tools(enable_browser=True)
 register_gemini_tools(enable_browser=True)
 register_planning_tools()
+register_codebase_search_tools()
 
 
 # Tool listing

--- a/openhands-tools/openhands/tools/__init__.py
+++ b/openhands-tools/openhands/tools/__init__.py
@@ -18,6 +18,7 @@ from ``openhands.tools.browser_use``.
 
 from importlib.metadata import PackageNotFoundError, version
 
+from openhands.tools.codebase_search import register_codebase_search_tools
 from openhands.tools.delegate import DelegationVisualizer
 from openhands.tools.file_editor import FileEditorTool
 from openhands.tools.preset.default import (
@@ -39,6 +40,7 @@ except PackageNotFoundError:
 __all__ = [
     "__version__",
     "DelegationVisualizer",
+    "register_codebase_search_tools",
     "FileEditorTool",
     "TaskTrackerTool",
     "TerminalTool",

--- a/openhands-tools/openhands/tools/codebase_search/__init__.py
+++ b/openhands-tools/openhands/tools/codebase_search/__init__.py
@@ -1,0 +1,15 @@
+"""Codebase search tools powered by Morph's WarpGrep.
+
+Provides natural-language code search via the ``@morphllm/morphmcp`` MCP server.
+Two tools are registered:
+
+- ``codebase_search`` — search a local repository
+- ``github_codebase_search`` — search a public GitHub repository
+
+Requires ``MORPH_API_KEY`` (get one at https://morphllm.com/dashboard/api-keys)
+and Node.js 18+ (for the MCP server process).
+"""
+
+from openhands.tools.codebase_search.definition import register_codebase_search_tools
+
+__all__ = ["register_codebase_search_tools"]

--- a/openhands-tools/openhands/tools/codebase_search/__init__.py
+++ b/openhands-tools/openhands/tools/codebase_search/__init__.py
@@ -1,15 +1,28 @@
-"""Codebase search tools powered by Morph's WarpGrep.
+"""Codebase search tools powered by Morph's WarpGrep SDK.
 
-Provides natural-language code search via the ``@morphllm/morphmcp`` MCP server.
 Two tools are registered:
 
 - ``codebase_search`` — search a local repository
 - ``github_codebase_search`` — search a public GitHub repository
 
-Requires ``MORPH_API_KEY`` (get one at https://morphllm.com/dashboard/api-keys)
-and Node.js 18+ (for the MCP server process).
+Requires ``MORPH_API_KEY`` (get one at https://morphllm.com/dashboard/api-keys),
+Node.js 18+, and ``@morphllm/morphsdk`` (``npm install -g @morphllm/morphsdk``).
 """
 
-from openhands.tools.codebase_search.definition import register_codebase_search_tools
+from openhands.tools.codebase_search.definition import (
+    CodebaseSearchAction,
+    CodebaseSearchObservation,
+    CodebaseSearchTool,
+    GitHubCodebaseSearchAction,
+    GitHubCodebaseSearchTool,
+    register_codebase_search_tools,
+)
 
-__all__ = ["register_codebase_search_tools"]
+__all__ = [
+    "CodebaseSearchAction",
+    "CodebaseSearchObservation",
+    "CodebaseSearchTool",
+    "GitHubCodebaseSearchAction",
+    "GitHubCodebaseSearchTool",
+    "register_codebase_search_tools",
+]

--- a/openhands-tools/openhands/tools/codebase_search/bridge.js
+++ b/openhands-tools/openhands/tools/codebase_search/bridge.js
@@ -1,0 +1,52 @@
+#!/usr/bin/env node
+/**
+ * Bridge script that wraps @morphllm/morphsdk for use from Python.
+ *
+ * Reads a single JSON object from stdin, calls the appropriate SDK method,
+ * and writes the result as JSON to stdout.
+ *
+ * Input schema:
+ *   { "type": "local"|"github", "query": "...", "repo_path": "...", "owner_repo": "...", "github_url": "...", "branch": "..." }
+ *
+ * Output schema:
+ *   { "success": bool, "contexts": [...], "summary": "...", "error": "..." }
+ */
+
+const { WarpGrepClient } = require("@morphllm/morphsdk/tools/warp-grep");
+
+async function main() {
+  // Read JSON from stdin
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  const input = JSON.parse(Buffer.concat(chunks).toString());
+
+  const client = new WarpGrepClient({
+    morphApiKey: process.env.MORPH_API_KEY,
+    morphApiUrl: process.env.MORPH_API_URL || undefined,
+    timeout: Number(process.env.MORPH_WARP_GREP_TIMEOUT) || undefined,
+  });
+
+  let result;
+  if (input.type === "github") {
+    const github = input.github_url || input.owner_repo || "";
+    result = await client.searchGitHub({
+      searchTerm: input.query,
+      github,
+      branch: input.branch || undefined,
+    });
+  } else {
+    result = await client.execute({
+      searchTerm: input.query,
+      repoRoot: input.repo_path || ".",
+    });
+  }
+
+  process.stdout.write(JSON.stringify(result));
+}
+
+main().catch((err) => {
+  process.stdout.write(
+    JSON.stringify({ success: false, error: err.message || String(err) })
+  );
+  process.exit(0); // exit clean so Python gets the JSON
+});

--- a/openhands-tools/openhands/tools/codebase_search/definition.py
+++ b/openhands-tools/openhands/tools/codebase_search/definition.py
@@ -1,0 +1,134 @@
+"""Codebase search tool registration backed by @morphllm/morphmcp.
+
+This module registers ``codebase_search`` and ``github_codebase_search`` as
+native OpenHands tools. Under the hood they are MCP tools served by the
+``@morphllm/morphmcp`` npm package (started via ``npx``).
+
+The ``edit_file`` tool exposed by the same MCP server is intentionally
+filtered out to avoid conflicts with the built-in ``FileEditorTool``.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Sequence
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.utils import create_mcp_tools
+from openhands.sdk.tool import ToolDefinition, register_tool
+
+logger = get_logger(__name__)
+
+# ── Shared MCP client cache ────────────────────────────────────────────
+# Both resolvers share a single MCP server process per API key so that
+# agents using both tools don't spawn two ``npx`` processes.
+_lock = threading.Lock()
+_morph_clients: dict[str, tuple[object, list[ToolDefinition]]] = {}
+
+_SEARCH_TOOL_NAMES = frozenset({"codebase_search", "github_codebase_search"})
+
+
+def _validate_api_key(params: dict) -> str:
+    """Return a validated MORPH_API_KEY or raise with a helpful message."""
+    api_key: str | None = params.get("api_key") or os.environ.get("MORPH_API_KEY")
+    if not api_key:
+        raise ValueError(
+            "MORPH_API_KEY is required for codebase_search.\n"
+            "Set it as an environment variable:\n"
+            "  export MORPH_API_KEY=sk-morph-...\n"
+            "Or pass it in Tool params:\n"
+            "  Tool(name='codebase_search', params={'api_key': 'sk-morph-...'})\n\n"
+            "Get your key at https://morphllm.com/dashboard/api-keys"
+        )
+    return api_key
+
+
+def _get_morph_search_tools(
+    api_key: str,
+    api_url: str | None = None,
+    timeout_ms: int | None = None,
+) -> list[ToolDefinition]:
+    """Start (or reuse) the Morph MCP server and return search tools only."""
+    with _lock:
+        if api_key in _morph_clients:
+            _, tools = _morph_clients[api_key]
+            return tools
+
+    # Build environment for the MCP server process
+    env: dict[str, str] = {"MORPH_API_KEY": api_key}
+    if api_url or os.environ.get("MORPH_API_URL"):
+        env["MORPH_API_URL"] = api_url or os.environ["MORPH_API_URL"]
+    if timeout_ms or os.environ.get("MORPH_WARP_GREP_TIMEOUT"):
+        env["MORPH_WARP_GREP_TIMEOUT"] = str(
+            timeout_ms or os.environ["MORPH_WARP_GREP_TIMEOUT"]
+        )
+
+    mcp_config = {
+        "mcpServers": {
+            "morph": {
+                "command": "npx",
+                "args": ["-y", "@morphllm/morphmcp"],
+                "env": env,
+            }
+        }
+    }
+
+    # Timeout for the MCP handshake (seconds).  The WarpGrep model timeout
+    # (MORPH_WARP_GREP_TIMEOUT) is separate and controls per-search duration
+    # inside the MCP server.
+    handshake_timeout = 60.0
+
+    client = create_mcp_tools(mcp_config, timeout=handshake_timeout)
+    search_tools: list[ToolDefinition] = [
+        t for t in client if t.name in _SEARCH_TOOL_NAMES
+    ]
+
+    logger.info(
+        f"Morph MCP server started — exposing tools: "
+        f"{[t.name for t in search_tools]}"
+    )
+
+    with _lock:
+        _morph_clients[api_key] = (client, search_tools)
+
+    return search_tools
+
+
+# ── Resolvers ───────────────────────────────────────────────────────────
+
+def _codebase_search_resolver(
+    params: dict, conv_state: object  # noqa: ARG001
+) -> Sequence[ToolDefinition]:
+    api_key = _validate_api_key(params)
+    tools = _get_morph_search_tools(
+        api_key=api_key,
+        api_url=params.get("api_url"),
+        timeout_ms=params.get("timeout"),
+    )
+    return [t for t in tools if t.name == "codebase_search"]
+
+
+def _github_codebase_search_resolver(
+    params: dict, conv_state: object  # noqa: ARG001
+) -> Sequence[ToolDefinition]:
+    api_key = _validate_api_key(params)
+    tools = _get_morph_search_tools(
+        api_key=api_key,
+        api_url=params.get("api_url"),
+        timeout_ms=params.get("timeout"),
+    )
+    return [t for t in tools if t.name == "github_codebase_search"]
+
+
+# ── Public registration ─────────────────────────────────────────────────
+
+def register_codebase_search_tools() -> None:
+    """Register ``codebase_search`` and ``github_codebase_search`` tools.
+
+    Call this once before creating an Agent that uses these tools.
+    Registration is explicit (not at import time) to avoid starting MCP
+    server processes when the module is merely imported.
+    """
+    register_tool("codebase_search", _codebase_search_resolver)
+    register_tool("github_codebase_search", _github_codebase_search_resolver)

--- a/openhands-tools/openhands/tools/codebase_search/definition.py
+++ b/openhands-tools/openhands/tools/codebase_search/definition.py
@@ -1,22 +1,34 @@
 """Codebase search tool registration backed by @morphllm/morphmcp.
 
 This module registers ``codebase_search`` and ``github_codebase_search`` as
-native OpenHands tools. Under the hood they are MCP tools served by the
+native OpenHands tools.  Under the hood they are MCP tools served by the
 ``@morphllm/morphmcp`` npm package (started via ``npx``).
 
 The ``edit_file`` tool exposed by the same MCP server is intentionally
 filtered out to avoid conflicts with the built-in ``FileEditorTool``.
+
+.. note::
+    Unlike most tools that subclass :class:`ToolDefinition` and implement
+    ``create()``, these tools use **callable resolver functions** registered
+    directly with :func:`register_tool`.  The registry invokes them as
+    ``factory(conv_state=conv_state, **params)``; see
+    :func:`_resolver_from_callable` in ``openhands.sdk.tool.registry``.
 """
 
 from __future__ import annotations
 
+import atexit
 import os
 import threading
 from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp.utils import create_mcp_tools
 from openhands.sdk.tool import ToolDefinition, register_tool
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
 
 logger = get_logger(__name__)
 
@@ -24,7 +36,7 @@ logger = get_logger(__name__)
 # Both resolvers share a single MCP server process per API key so that
 # agents using both tools don't spawn two ``npx`` processes.
 _lock = threading.Lock()
-_morph_clients: dict[str, tuple[object, list[ToolDefinition]]] = {}
+_morph_clients: dict[tuple[str, str | None, int | None], tuple[object, list[ToolDefinition]]] = {}
 
 _SEARCH_TOOL_NAMES = frozenset({"codebase_search", "github_codebase_search"})
 
@@ -50,55 +62,72 @@ def _get_morph_search_tools(
     timeout_ms: int | None = None,
 ) -> list[ToolDefinition]:
     """Start (or reuse) the Morph MCP server and return search tools only."""
+    cache_key = (api_key, api_url, timeout_ms)
+
     with _lock:
-        if api_key in _morph_clients:
-            _, tools = _morph_clients[api_key]
+        if cache_key in _morph_clients:
+            _, tools = _morph_clients[cache_key]
             return tools
 
-    # Build environment for the MCP server process
-    env: dict[str, str] = {"MORPH_API_KEY": api_key}
-    if api_url or os.environ.get("MORPH_API_URL"):
-        env["MORPH_API_URL"] = api_url or os.environ["MORPH_API_URL"]
-    if timeout_ms or os.environ.get("MORPH_WARP_GREP_TIMEOUT"):
-        env["MORPH_WARP_GREP_TIMEOUT"] = str(
-            timeout_ms or os.environ["MORPH_WARP_GREP_TIMEOUT"]
-        )
+        # Build environment for the MCP server process
+        env: dict[str, str] = {"MORPH_API_KEY": api_key}
+        if api_url or os.environ.get("MORPH_API_URL"):
+            env["MORPH_API_URL"] = api_url or os.environ["MORPH_API_URL"]
+        if timeout_ms or os.environ.get("MORPH_WARP_GREP_TIMEOUT"):
+            env["MORPH_WARP_GREP_TIMEOUT"] = str(
+                timeout_ms or os.environ["MORPH_WARP_GREP_TIMEOUT"]
+            )
 
-    mcp_config = {
-        "mcpServers": {
-            "morph": {
-                "command": "npx",
-                "args": ["-y", "@morphllm/morphmcp"],
-                "env": env,
+        mcp_config = {
+            "mcpServers": {
+                "morph": {
+                    "command": "npx",
+                    "args": ["-y", "@morphllm/morphmcp"],
+                    "env": env,
+                }
             }
         }
-    }
 
-    # Timeout for the MCP handshake (seconds).  The WarpGrep model timeout
-    # (MORPH_WARP_GREP_TIMEOUT) is separate and controls per-search duration
-    # inside the MCP server.
-    handshake_timeout = 60.0
+        # Timeout for the MCP handshake (seconds).  The WarpGrep model timeout
+        # (MORPH_WARP_GREP_TIMEOUT) is separate and controls per-search duration
+        # inside the MCP server.
+        handshake_timeout = 60.0
 
-    client = create_mcp_tools(mcp_config, timeout=handshake_timeout)
-    search_tools: list[ToolDefinition] = [
-        t for t in client if t.name in _SEARCH_TOOL_NAMES
-    ]
+        client = create_mcp_tools(mcp_config, timeout=handshake_timeout)
+        search_tools: list[ToolDefinition] = [
+            t for t in client if t.name in _SEARCH_TOOL_NAMES
+        ]
 
-    logger.info(
-        f"Morph MCP server started — exposing tools: "
-        f"{[t.name for t in search_tools]}"
-    )
+        logger.info(
+            "Morph MCP server started — exposing tools: %s",
+            [t.name for t in search_tools],
+        )
 
+        _morph_clients[cache_key] = (client, search_tools)
+        return search_tools
+
+
+# ── MCP client cleanup ─────────────────────────────────────────────────
+
+def _cleanup_morph_clients() -> None:
+    """Close all cached MCP clients on process exit."""
     with _lock:
-        _morph_clients[api_key] = (client, search_tools)
+        for client, _ in _morph_clients.values():
+            try:
+                client.sync_close()
+            except Exception:
+                pass
+        _morph_clients.clear()
 
-    return search_tools
+
+atexit.register(_cleanup_morph_clients)
 
 
 # ── Resolvers ───────────────────────────────────────────────────────────
 
 def _codebase_search_resolver(
-    params: dict, conv_state: object  # noqa: ARG001
+    conv_state: "ConversationState | None" = None,  # noqa: ARG001
+    **params: Any,
 ) -> Sequence[ToolDefinition]:
     api_key = _validate_api_key(params)
     tools = _get_morph_search_tools(
@@ -110,7 +139,8 @@ def _codebase_search_resolver(
 
 
 def _github_codebase_search_resolver(
-    params: dict, conv_state: object  # noqa: ARG001
+    conv_state: "ConversationState | None" = None,  # noqa: ARG001
+    **params: Any,
 ) -> Sequence[ToolDefinition]:
     api_key = _validate_api_key(params)
     tools = _get_morph_search_tools(

--- a/openhands-tools/openhands/tools/codebase_search/definition.py
+++ b/openhands-tools/openhands/tools/codebase_search/definition.py
@@ -1,50 +1,124 @@
-"""Codebase search tool registration backed by @morphllm/morphmcp.
+"""Codebase search tools powered by Morph's WarpGrep SDK.
 
-This module registers ``codebase_search`` and ``github_codebase_search`` as
-native OpenHands tools.  Under the hood they are MCP tools served by the
-``@morphllm/morphmcp`` npm package (started via ``npx``).
-
-The ``edit_file`` tool exposed by the same MCP server is intentionally
-filtered out to avoid conflicts with the built-in ``FileEditorTool``.
-
-.. note::
-    Unlike most tools that subclass :class:`ToolDefinition` and implement
-    ``create()``, these tools use **callable resolver functions** registered
-    directly with :func:`register_tool`.  The registry invokes them as
-    ``factory(conv_state=conv_state, **params)``; see
-    :func:`_resolver_from_callable` in ``openhands.sdk.tool.registry``.
+Registers ``codebase_search`` and ``github_codebase_search`` as native
+OpenHands tools.  Each tool calls ``@morphllm/morphsdk`` via a small
+Node.js bridge script (``bridge.js``), which handles the multi-turn
+WarpGrep agent loop internally and returns aggregated results.
 """
 
 from __future__ import annotations
 
-import atexit
+import json
 import os
-import threading
+import subprocess
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from pydantic import Field
+
 from openhands.sdk.logger import get_logger
-from openhands.sdk.mcp.utils import create_mcp_tools
-from openhands.sdk.tool import ToolDefinition, register_tool
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    ToolExecutor,
+    register_tool,
+)
 
 if TYPE_CHECKING:
+    from openhands.sdk.conversation import LocalConversation
     from openhands.sdk.conversation.state import ConversationState
 
 logger = get_logger(__name__)
 
-# ── Shared MCP client cache ────────────────────────────────────────────
-# Both resolvers share a single MCP server process per API key so that
-# agents using both tools don't spawn two ``npx`` processes.
-_lock = threading.Lock()
-_morph_clients: dict[tuple[str, str | None, int | None], tuple[object, list[ToolDefinition]]] = {}
+_BRIDGE_SCRIPT = Path(__file__).parent / "bridge.js"
 
-_SEARCH_TOOL_NAMES = frozenset({"codebase_search", "github_codebase_search"})
+_CODEBASE_SEARCH_DESCRIPTION = """\
+Search the local codebase using natural language. This tool uses a \
+specialised code-search sub-agent (WarpGrep) that runs ripgrep and file \
+reads internally, then returns the most relevant code snippets.
+
+Pass a natural-language question — do NOT pass regex or symbol-only queries.
+
+Good: "Where does authentication get handled?"
+Bad:  "auth()" or "grep -r auth"
+"""
+
+_GITHUB_CODEBASE_SEARCH_DESCRIPTION = """\
+Search a public GitHub repository using natural language. Provide either \
+a full GitHub URL or an owner/repo shorthand (e.g. "expressjs/express"). \
+The tool clones and searches the repo remotely — no local checkout needed.
+
+Pass a natural-language question — do NOT pass regex or symbol-only queries.
+"""
 
 
-def _validate_api_key(params: dict) -> str:
+# ── Actions ─────────────────────────────────────────────────────────────
+
+
+class CodebaseSearchAction(Action):
+    """Search a local repository with a natural-language query."""
+
+    search_string: str = Field(
+        description=(
+            "Natural-language question about the code you want to understand. "
+            "Good: 'Where does auth get handled?' "
+            "Bad: 'auth()'"
+        ),
+    )
+    repo_path: str = Field(
+        description="Absolute path to the repository root to search.",
+    )
+
+
+class GitHubCodebaseSearchAction(Action):
+    """Search a public GitHub repository with a natural-language query."""
+
+    search_string: str = Field(
+        description=(
+            "Natural-language question about the code you want to understand. "
+            "Good: 'Where does auth get handled?' "
+            "Bad: 'auth()'"
+        ),
+    )
+    github_url: str | None = Field(
+        default=None,
+        description=(
+            "Full GitHub URL (e.g. 'https://github.com/expressjs/express'). "
+            "Provide either github_url or owner_repo."
+        ),
+    )
+    owner_repo: str | None = Field(
+        default=None,
+        description=(
+            "Repository shorthand (e.g. 'expressjs/express'). "
+            "Provide either github_url or owner_repo."
+        ),
+    )
+    branch: str | None = Field(
+        default=None,
+        description="Branch to search. Defaults to the repo's default branch.",
+    )
+
+
+# ── Observations ────────────────────────────────────────────────────────
+
+
+class CodebaseSearchObservation(Observation):
+    """Results from a codebase search."""
+
+    pass  # Uses base Observation's text field
+
+
+# ── Executors ───────────────────────────────────────────────────────────
+
+
+def _validate_api_key(api_key: str | None) -> str:
     """Return a validated MORPH_API_KEY or raise with a helpful message."""
-    api_key: str | None = params.get("api_key") or os.environ.get("MORPH_API_KEY")
-    if not api_key:
+    key = api_key or os.environ.get("MORPH_API_KEY")
+    if not key:
         raise ValueError(
             "MORPH_API_KEY is required for codebase_search.\n"
             "Set it as an environment variable:\n"
@@ -53,112 +127,191 @@ def _validate_api_key(params: dict) -> str:
             "  Tool(name='codebase_search', params={'api_key': 'sk-morph-...'})\n\n"
             "Get your key at https://morphllm.com/dashboard/api-keys"
         )
-    return api_key
+    return key
 
 
-def _get_morph_search_tools(
-    api_key: str,
-    api_url: str | None = None,
-    timeout_ms: int | None = None,
-) -> list[ToolDefinition]:
-    """Start (or reuse) the Morph MCP server and return search tools only."""
-    cache_key = (api_key, api_url, timeout_ms)
+def _run_bridge(payload: dict, api_key: str) -> dict:
+    """Call the Node.js bridge script and return parsed JSON."""
+    env = {**os.environ, "MORPH_API_KEY": api_key}
 
-    with _lock:
-        if cache_key in _morph_clients:
-            _, tools = _morph_clients[cache_key]
-            return tools
+    try:
+        proc = subprocess.run(
+            ["node", str(_BRIDGE_SCRIPT)],
+            input=json.dumps(payload),
+            capture_output=True,
+            text=True,
+            timeout=120,
+            env=env,
+        )
+    except FileNotFoundError:
+        raise ValueError(
+            "Node.js is required for codebase_search but 'node' was not found.\n"
+            "Install Node.js 18+ from https://nodejs.org/"
+        )
+    except subprocess.TimeoutExpired:
+        return {"success": False, "error": "Search timed out after 120 seconds."}
 
-        # Build environment for the MCP server process
-        env: dict[str, str] = {"MORPH_API_KEY": api_key}
-        if api_url or os.environ.get("MORPH_API_URL"):
-            env["MORPH_API_URL"] = api_url or os.environ["MORPH_API_URL"]
-        if timeout_ms or os.environ.get("MORPH_WARP_GREP_TIMEOUT"):
-            env["MORPH_WARP_GREP_TIMEOUT"] = str(
-                timeout_ms or os.environ["MORPH_WARP_GREP_TIMEOUT"]
-            )
-
-        mcp_config = {
-            "mcpServers": {
-                "morph": {
-                    "command": "npx",
-                    "args": ["-y", "@morphllm/morphmcp"],
-                    "env": env,
-                }
+    if proc.returncode != 0 and not proc.stdout.strip():
+        stderr = proc.stderr.strip()
+        # Check for missing SDK
+        if "Cannot find module" in stderr or "MODULE_NOT_FOUND" in stderr:
+            return {
+                "success": False,
+                "error": (
+                    "@morphllm/morphsdk is not installed. Run:\n"
+                    "  npm install -g @morphllm/morphsdk"
+                ),
             }
-        }
+        return {"success": False, "error": stderr[:500] if stderr else "Bridge process failed."}
 
-        # Timeout for the MCP handshake (seconds).  The WarpGrep model timeout
-        # (MORPH_WARP_GREP_TIMEOUT) is separate and controls per-search duration
-        # inside the MCP server.
-        handshake_timeout = 60.0
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return {"success": False, "error": f"Invalid JSON from bridge: {proc.stdout[:200]}"}
 
-        client = create_mcp_tools(mcp_config, timeout=handshake_timeout)
-        search_tools: list[ToolDefinition] = [
-            t for t in client if t.name in _SEARCH_TOOL_NAMES
+
+def _format_result(result: dict) -> str:
+    """Format a WarpGrep result dict into readable text for the LLM."""
+    if not result.get("success"):
+        return f"Search failed: {result.get('error', 'Unknown error')}"
+
+    contexts = result.get("contexts", [])
+    if not contexts:
+        return "No relevant code found."
+
+    parts: list[str] = []
+    if result.get("summary"):
+        parts.append(result["summary"])
+        parts.append("")
+
+    for ctx in contexts:
+        file_path = ctx.get("file", "unknown")
+        content = ctx.get("content", "")
+        if content:
+            parts.append(f"--- {file_path} ---")
+            parts.append(content)
+            parts.append("")
+
+    return "\n".join(parts).strip()
+
+
+class CodebaseSearchExecutor(ToolExecutor[CodebaseSearchAction, CodebaseSearchObservation]):
+    """Execute local codebase search via the Morph SDK."""
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    def __call__(
+        self,
+        action: CodebaseSearchAction,
+        conversation: LocalConversation | None = None,
+    ) -> CodebaseSearchObservation:
+        result = _run_bridge(
+            {"type": "local", "query": action.search_string, "repo_path": action.repo_path},
+            self._api_key,
+        )
+        return CodebaseSearchObservation.from_text(text=_format_result(result))
+
+
+class GitHubCodebaseSearchExecutor(ToolExecutor[GitHubCodebaseSearchAction, CodebaseSearchObservation]):
+    """Execute GitHub codebase search via the Morph SDK."""
+
+    def __init__(self, api_key: str) -> None:
+        self._api_key = api_key
+
+    def __call__(
+        self,
+        action: GitHubCodebaseSearchAction,
+        conversation: LocalConversation | None = None,
+    ) -> CodebaseSearchObservation:
+        result = _run_bridge(
+            {
+                "type": "github",
+                "query": action.search_string,
+                "github_url": action.github_url,
+                "owner_repo": action.owner_repo,
+                "branch": action.branch,
+            },
+            self._api_key,
+        )
+        return CodebaseSearchObservation.from_text(text=_format_result(result))
+
+
+# ── Tool Definitions ────────────────────────────────────────────────────
+
+
+class CodebaseSearchTool(ToolDefinition[CodebaseSearchAction, CodebaseSearchObservation]):
+    """Local codebase search powered by Morph WarpGrep."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: ConversationState,
+        api_key: str | None = None,
+        **kwargs: Any,
+    ) -> Sequence[CodebaseSearchTool]:
+        key = _validate_api_key(api_key)
+        working_dir = conv_state.workspace.working_dir
+        description = (
+            f"{_CODEBASE_SEARCH_DESCRIPTION}\n"
+            f"Your current working directory is: {working_dir}"
+        )
+        return [
+            cls(
+                description=description,
+                action_type=CodebaseSearchAction,
+                observation_type=CodebaseSearchObservation,
+                executor=CodebaseSearchExecutor(api_key=key),
+                annotations=ToolAnnotations(
+                    title="codebase_search",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
+            )
         ]
 
-        logger.info(
-            "Morph MCP server started — exposing tools: %s",
-            [t.name for t in search_tools],
-        )
 
-        _morph_clients[cache_key] = (client, search_tools)
-        return search_tools
+class GitHubCodebaseSearchTool(ToolDefinition[GitHubCodebaseSearchAction, CodebaseSearchObservation]):
+    """GitHub codebase search powered by Morph WarpGrep."""
 
+    name = "github_codebase_search"  # override auto-naming of "git_hub_codebase_search"
 
-# ── MCP client cleanup ─────────────────────────────────────────────────
-
-def _cleanup_morph_clients() -> None:
-    """Close all cached MCP clients on process exit."""
-    with _lock:
-        for client, _ in _morph_clients.values():
-            try:
-                client.sync_close()
-            except Exception:
-                pass
-        _morph_clients.clear()
-
-
-atexit.register(_cleanup_morph_clients)
-
-
-# ── Resolvers ───────────────────────────────────────────────────────────
-
-def _codebase_search_resolver(
-    conv_state: "ConversationState | None" = None,  # noqa: ARG001
-    **params: Any,
-) -> Sequence[ToolDefinition]:
-    api_key = _validate_api_key(params)
-    tools = _get_morph_search_tools(
-        api_key=api_key,
-        api_url=params.get("api_url"),
-        timeout_ms=params.get("timeout"),
-    )
-    return [t for t in tools if t.name == "codebase_search"]
+    @classmethod
+    def create(
+        cls,
+        conv_state: ConversationState,
+        api_key: str | None = None,
+        **kwargs: Any,
+    ) -> Sequence[GitHubCodebaseSearchTool]:
+        key = _validate_api_key(api_key)
+        return [
+            cls(
+                description=_GITHUB_CODEBASE_SEARCH_DESCRIPTION,
+                action_type=GitHubCodebaseSearchAction,
+                observation_type=CodebaseSearchObservation,
+                executor=GitHubCodebaseSearchExecutor(api_key=key),
+                annotations=ToolAnnotations(
+                    title="github_codebase_search",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
+            )
+        ]
 
 
-def _github_codebase_search_resolver(
-    conv_state: "ConversationState | None" = None,  # noqa: ARG001
-    **params: Any,
-) -> Sequence[ToolDefinition]:
-    api_key = _validate_api_key(params)
-    tools = _get_morph_search_tools(
-        api_key=api_key,
-        api_url=params.get("api_url"),
-        timeout_ms=params.get("timeout"),
-    )
-    return [t for t in tools if t.name == "github_codebase_search"]
+# ── Registration ────────────────────────────────────────────────────────
 
-
-# ── Public registration ─────────────────────────────────────────────────
 
 def register_codebase_search_tools() -> None:
     """Register ``codebase_search`` and ``github_codebase_search`` tools.
 
     Call this once before creating an Agent that uses these tools.
-    Registration is explicit (not at import time) to avoid starting MCP
-    server processes when the module is merely imported.
+    Registration is explicit (not at import time) to avoid import-time
+    side-effects.
     """
-    register_tool("codebase_search", _codebase_search_resolver)
-    register_tool("github_codebase_search", _github_codebase_search_resolver)
+    register_tool(CodebaseSearchTool.name, CodebaseSearchTool)
+    register_tool(GitHubCodebaseSearchTool.name, GitHubCodebaseSearchTool)

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -51,6 +51,8 @@ _EXCLUDED_EXAMPLES = {
     "examples/01_standalone_sdk/16_llm_security_analyzer.py",
     "examples/01_standalone_sdk/27_observability_laminar.py",
     "examples/01_standalone_sdk/35_subscription_login.py",
+    # Requires a running Morph MCP server and MORPH_API_KEY
+    "examples/01_standalone_sdk/45_codebase_search.py",
     # Requires interactive input() which fails in CI with EOFError
     "examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py",
 }


### PR DESCRIPTION
## Summary

- Register Morph's WarpGrep as native OpenHands tools via the `@morphllm/morphmcp` MCP server
- Users add `Tool(name="codebase_search")` to their agent like any other tool — MCP plumbing is internal
- Two separate tool registrations (`codebase_search` + `github_codebase_search`) sharing one MCP server process
- `edit_file` from the MCP server is filtered out to avoid conflict with `FileEditorTool`
- Clear `ValueError` with dashboard link when `MORPH_API_KEY` is missing
- Pre-installs `@morphllm/morphmcp` in Docker image for fast cold starts

### Usage

```python
from openhands.tools.codebase_search import register_codebase_search_tools

register_codebase_search_tools()

agent = Agent(
    llm=llm,
    tools=[
        Tool(name="codebase_search"),           # search local repos
        Tool(name="github_codebase_search"),    # search public GitHub repos
    ],
)
```

Requires `MORPH_API_KEY` env var (or passed via `Tool(name="codebase_search", params={"api_key": "sk-..."})`) and Node.js 18+.

## Test plan

- [x] Import and registration verified locally
- [x] Both tools appear in `list_registered_tools()`
- [x] Missing `MORPH_API_KEY` raises `ValueError` with instructions + dashboard link
- [x] Top-level `from openhands.tools import register_codebase_search_tools` works
- [ ] End-to-end test with `MORPH_API_KEY` set against a real repo
- [ ] Docker image build with `@morphllm/morphmcp` pre-installed

🤖 Generated with [Claude Code](https://claude.com/claude-code)