### PR TITLE
fix: preserve classified step descriptions in BuildKit telemetry

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -722,7 +722,16 @@ def _parse_buildkit_telemetry(stderr: str) -> BuildTelemetry:
             )
             continue
 
-        step_descriptions[step] = message.removesuffix(" ...").strip()
+        # Only update step description if there isn't already a classified one.
+        # This prevents sub-operations (like "preparing build cache for export")
+        # from overwriting the main operation (like "exporting cache to registry").
+        new_desc = message.removesuffix(" ...").strip()
+        existing_desc = step_descriptions.get(step)
+        if (
+            existing_desc is None
+            or _classify_buildkit_description(existing_desc) is None
+        ):
+            step_descriptions[step] = new_desc
 
     telemetry.build_context_seconds = _round_seconds(telemetry.build_context_seconds)
     telemetry.buildx_wall_clock_seconds = _round_seconds(

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -885,6 +885,43 @@ def test_parse_buildkit_telemetry_extracts_phase_timings():
     assert telemetry.cached_step_count == 1
 
 
+def test_parse_buildkit_telemetry_cache_export_with_preparing_line():
+    """Test that cache export timing is captured when sub-operations appear.
+
+    This reproduces a bug where BuildKit outputs:
+        #33 exporting cache to registry
+        #33 preparing build cache for export
+        #33 DONE 36.2s
+
+    Previously, the second line overwrote step_descriptions["33"], causing
+    the DONE time to be attributed to "preparing build cache for export"
+    which wasn't classified as cache_export.
+
+    The fix ensures that once a step has a classified description
+    ("exporting cache to registry" -> cache_export), subsequent sub-operation
+    descriptions don't overwrite it.
+    """
+    from openhands.agent_server.docker.build import _parse_buildkit_telemetry
+
+    # Real-world BuildKit output pattern
+    stderr_with_preparing = "\n".join(
+        [
+            "#33 exporting cache to registry",
+            "#33 preparing build cache for export",
+            "#33 writing layer sha256:abc123 0.5s done",
+            "#33 preparing build cache for export 36.2s done",
+            "#33 DONE 36.2s",
+            "",
+        ]
+    )
+
+    telemetry = _parse_buildkit_telemetry(stderr_with_preparing)
+
+    # Should capture the cache export time because "exporting cache to registry"
+    # is preserved as the step description (not overwritten by "preparing...")
+    assert telemetry.cache_export_seconds == 36.2
+
+
 def test_build_with_telemetry_returns_parsed_buildkit_fields(tmp_path: Path):
     from openhands.agent_server.docker.build import (
         BuildOptions,


### PR DESCRIPTION
## Summary

Fixes a bug where `cache_export_seconds` was always `0.0` in build telemetry.

**Root cause:** When BuildKit exports cache to registry, it outputs multiple lines for the same step:
```
#33 exporting cache to registry
#33 preparing build cache for export
#33 DONE 36.2s
```

The second line was overwriting `step_descriptions["33"]`, so when the DONE line arrived, the description was "preparing build cache for export" which wasn't classified as `cache_export`.

**Fix:** Once a step has a classified description (like "exporting cache to registry" → `cache_export`), subsequent sub-operation descriptions don't overwrite it.

## Test plan

- [x] Added `test_parse_buildkit_telemetry_cache_export_with_preparing_line` to verify the fix
- [x] Existing telemetry tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)