### PR TITLE
Remove multiswebench from CI eval workflow options

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -19,7 +19,6 @@ on:
                     - swebench
                     - swtbench
                     - commit0
-                    - multiswebench
                     - swebenchmultimodal
             sdk_ref:
                 description: SDK commit/ref to evaluate (must be a semantic version like v1.0.0 unless 'Allow unreleased branches' is checked)


### PR DESCRIPTION
## Summary

Remove `multiswebench` from the benchmark dropdown in the `run-eval.yml` workflow.

## Motivation

The multiswebench CI integration is not working properly and is delaying other development. The benchmark itself remains available in the [benchmarks repo](https://github.com/OpenHands/benchmarks) as a non-CI benchmark (like `openagentsafety` and `swebenchmultilingual`), but it should not be triggerable from CI actions.

## Changes

- Removed `multiswebench` from the `benchmark` choice options in `.github/workflows/run-eval.yml`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:74cae59-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-74cae59-python \
  ghcr.io/openhands/agent-server:74cae59-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:74cae59-golang-amd64
ghcr.io/openhands/agent-server:74cae59-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:74cae59-golang-arm64
ghcr.io/openhands/agent-server:74cae59-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:74cae59-java-amd64
ghcr.io/openhands/agent-server:74cae59-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:74cae59-java-arm64
ghcr.io/openhands/agent-server:74cae59-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:74cae59-python-amd64
ghcr.io/openhands/agent-server:74cae59-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:74cae59-python-arm64
ghcr.io/openhands/agent-server:74cae59-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:74cae59-golang
ghcr.io/openhands/agent-server:74cae59-java
ghcr.io/openhands/agent-server:74cae59-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `74cae59-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `74cae59-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->