### PR TITLE
DRAFT: Fix malformed JSON from literal \\n/\\t/\\r outside string values

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -11,6 +11,7 @@ from openhands.sdk.agent.utils import (
     make_llm_completion,
     prepare_llm_messages,
     sanitize_json_control_chars,
+    strip_literal_escape_sequences,
 )
 from openhands.sdk.conversation import (
     ConversationCallbackType,
@@ -588,6 +589,9 @@ class Agent(CriticMixin, AgentBase):
             # Sanitize raw control characters (U+0000–U+001F) that some
             # models emit as literal bytes instead of JSON escape sequences.
             sanitized_args = sanitize_json_control_chars(tool_call.arguments)
+            # Strip literal \n / \t / \r sequences that some models
+            # (e.g. Qwen3.5-Flash) place outside of JSON string values.
+            sanitized_args = strip_literal_escape_sequences(sanitized_args)
             arguments = json.loads(sanitized_args)
 
             # Fix malformed arguments (e.g., JSON strings for list/dict fields)

--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -55,6 +55,56 @@ def sanitize_json_control_chars(raw: str) -> str:
     return _CONTROL_CHAR_RE.sub(_escape_control_char, raw)
 
 
+# The set of letters that, when preceded by a bare backslash outside a JSON
+# string, form an escape-like sequence the model intended as whitespace.
+_WHITESPACE_ESCAPE_LETTERS = frozenset("ntr")
+
+
+def strip_literal_escape_sequences(raw: str) -> str:
+    r"""Replace literal ``\n`` / ``\t`` / ``\r`` outside JSON strings with spaces.
+
+    Some models (e.g. Qwen3.5-Flash) emit the two-character sequences
+    ``\n``, ``\t``, or ``\r`` *outside* of JSON string values.  Standard
+    JSON only allows backslash escapes inside quoted strings, so
+    ``json.loads`` rejects these bare sequences.
+
+    This function walks the string while tracking whether the current
+    position is inside a quoted string and replaces those sequences with
+    a single space when they appear outside a string.
+    """  # noqa: E501
+    result: list[str] = []
+    in_string = False
+    i = 0
+    length = len(raw)
+    while i < length:
+        ch = raw[i]
+        if in_string:
+            result.append(ch)
+            if ch == "\\":
+                # Escaped character inside string – copy it verbatim
+                i += 1
+                if i < length:
+                    result.append(raw[i])
+            elif ch == '"':
+                in_string = False
+        else:
+            if ch == '"':
+                in_string = True
+                result.append(ch)
+            elif (
+                ch == "\\"
+                and i + 1 < length
+                and raw[i + 1] in _WHITESPACE_ESCAPE_LETTERS
+            ):
+                # Bare \n / \t / \r outside a string → whitespace
+                result.append(" ")
+                i += 1  # skip the letter after the backslash
+            else:
+                result.append(ch)
+        i += 1
+    return "".join(result)
+
+
 def fix_malformed_tool_arguments(
     arguments: dict[str, Any], action_type: type[Action]
 ) -> dict[str, Any]:

--- a/tests/sdk/agent/test_strip_literal_escape_sequences.py
+++ b/tests/sdk/agent/test_strip_literal_escape_sequences.py
@@ -1,0 +1,71 @@
+"""Tests for strip_literal_escape_sequences helper function.
+
+Verifies that literal backslash-letter escape sequences (``\\n``, ``\\t``,
+``\\r``) appearing *outside* of JSON string values are replaced with spaces,
+while identical sequences inside strings are left untouched.
+"""
+
+import json
+
+from openhands.sdk.agent.utils import strip_literal_escape_sequences
+
+
+def test_valid_json_unchanged():
+    """Already-valid JSON passes through unmodified."""
+    raw = '{"command": "echo hello", "path": "/tmp"}'
+    assert strip_literal_escape_sequences(raw) == raw
+
+
+def test_literal_newline_outside_string():
+    r"""Bare ``\n`` between values is replaced with a space."""
+    raw = r'{"view_range": \n[2142, 2250]\n\n}'
+    result = strip_literal_escape_sequences(raw)
+    parsed = json.loads(result)
+    assert parsed["view_range"] == [2142, 2250]
+
+
+def test_qwen_realistic_example():
+    r"""Full realistic payload from Qwen3.5-Flash (issue #2488)."""
+    raw = (
+        r'{"command": "view", "path": "/workspace/django/query.py",'
+        r' "view_range": \n[2142, 2250]\n\n}'
+    )
+    result = strip_literal_escape_sequences(raw)
+    parsed = json.loads(result)
+    assert parsed["command"] == "view"
+    assert parsed["path"] == "/workspace/django/query.py"
+    assert parsed["view_range"] == [2142, 2250]
+
+
+def test_escape_inside_string_preserved():
+    r"""``\n`` inside a quoted string must NOT be touched."""
+    raw = r'{"text": "line1\nline2"}'
+    assert strip_literal_escape_sequences(raw) == raw
+    parsed = json.loads(raw)
+    assert parsed["text"] == "line1\nline2"
+
+
+def test_escaped_quote_inside_string():
+    r"""Escaped quotes inside strings don't confuse the tracker."""
+    raw = r'{"text": "say \"hello\nworld\""}'
+    assert strip_literal_escape_sequences(raw) == raw
+
+
+def test_tab_and_return_outside_string():
+    r"""Bare ``\t`` and ``\r`` outside strings are also replaced."""
+    raw = r'{"a":\t1,\r"b": 2}'
+    result = strip_literal_escape_sequences(raw)
+    parsed = json.loads(result)
+    assert parsed["a"] == 1
+    assert parsed["b"] == 2
+
+
+def test_empty_string():
+    assert strip_literal_escape_sequences("") == ""
+
+
+def test_no_strings_at_all():
+    r"""Bare escape in a string with no quotes (degenerate input)."""
+    raw = r"\n\t\r"
+    result = strip_literal_escape_sequences(raw)
+    assert result == "   "


### PR DESCRIPTION
## Summary

Fixes #2488

Some models (e.g. Qwen3.5-Flash) emit literal backslash-letter escape sequences (`\n`, `\t`, `\r`) **outside** of JSON string values in tool call arguments. Standard JSON only permits backslash escapes inside quoted strings, so `json.loads()` rejects them with `Expecting value` errors.

Example of what the model emits:
```
{"command": "view", "path": "/workspace/django/query.py", "view_range": \n[2142, 2250]\n\n}
```

## Changes

**`openhands-sdk/openhands/sdk/agent/utils.py`** — Add `strip_literal_escape_sequences()`, a minimal state-machine that walks the raw arguments string, tracks whether the current position is inside a JSON quoted string, and replaces bare `\n` / `\t` / `\r` outside strings with a single space.

**`openhands-sdk/openhands/sdk/agent/agent.py`** — Call the new function right after `sanitize_json_control_chars()` and before `json.loads()` in the tool-call processing pipeline.

**`tests/sdk/agent/test_strip_literal_escape_sequences.py`** — 8 tests covering:
- Valid JSON passes through unchanged
- The exact Qwen3.5-Flash payload from the issue
- Escape sequences inside JSON strings are preserved
- Escaped quotes inside strings don't confuse the tracker
- `\t` and `\r` outside strings are also handled
- Edge cases (empty string, no strings)

## Design rationale

The fix is applied at the same sanitization point where `sanitize_json_control_chars` already runs — this is the natural place for pre-parse cleanup of LLM-produced JSON. The state machine approach correctly distinguishes between `\n` inside strings (valid JSON escape = must keep) and outside strings (invalid = replace with whitespace).
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:05a6773-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-05a6773-python \
  ghcr.io/openhands/agent-server:05a6773-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:05a6773-golang-amd64
ghcr.io/openhands/agent-server:05a6773-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:05a6773-golang-arm64
ghcr.io/openhands/agent-server:05a6773-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:05a6773-java-amd64
ghcr.io/openhands/agent-server:05a6773-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:05a6773-java-arm64
ghcr.io/openhands/agent-server:05a6773-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:05a6773-python-amd64
ghcr.io/openhands/agent-server:05a6773-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:05a6773-python-arm64
ghcr.io/openhands/agent-server:05a6773-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:05a6773-golang
ghcr.io/openhands/agent-server:05a6773-java
ghcr.io/openhands/agent-server:05a6773-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `05a6773-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `05a6773-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->