### PR TITLE
fix: cherry-pick cache_export_seconds telemetry fix to main

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -689,7 +689,16 @@ def _parse_buildkit_telemetry(stderr: str) -> BuildTelemetry:
             )
             continue
 
-        step_descriptions[step] = message.removesuffix(" ...").strip()
+        # Only update step description if there isn't already a classified one.
+        # This prevents sub-operations (like "preparing build cache for export")
+        # from overwriting the main operation (like "exporting cache to registry").
+        new_desc = message.removesuffix(" ...").strip()
+        existing_desc = step_descriptions.get(step)
+        if (
+            existing_desc is None
+            or _classify_buildkit_description(existing_desc) is None
+        ):
+            step_descriptions[step] = new_desc
 
     telemetry.build_context_seconds = _round_seconds(telemetry.build_context_seconds)
     telemetry.buildx_wall_clock_seconds = _round_seconds(

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -655,6 +655,43 @@ def test_parse_buildkit_telemetry_extracts_phase_timings():
     assert telemetry.cached_step_count == 1
 
 
+def test_parse_buildkit_telemetry_cache_export_with_preparing_line():
+    """Test that cache export timing is captured when sub-operations appear.
+
+    This reproduces a bug where BuildKit outputs:
+        #33 exporting cache to registry
+        #33 preparing build cache for export
+        #33 DONE 36.2s
+
+    Previously, the second line overwrote step_descriptions["33"], causing
+    the DONE time to be attributed to "preparing build cache for export"
+    which wasn't classified as cache_export.
+
+    The fix ensures that once a step has a classified description
+    ("exporting cache to registry" -> cache_export), subsequent sub-operation
+    descriptions don't overwrite it.
+    """
+    from openhands.agent_server.docker.build import _parse_buildkit_telemetry
+
+    # Real-world BuildKit output pattern
+    stderr_with_preparing = "\n".join(
+        [
+            "#33 exporting cache to registry",
+            "#33 preparing build cache for export",
+            "#33 writing layer sha256:abc123 0.5s done",
+            "#33 preparing build cache for export 36.2s done",
+            "#33 DONE 36.2s",
+            "",
+        ]
+    )
+
+    telemetry = _parse_buildkit_telemetry(stderr_with_preparing)
+
+    # Should capture the cache export time because "exporting cache to registry"
+    # is preserved as the step description (not overwritten by "preparing...")
+    assert telemetry.cache_export_seconds == 36.2
+
+
 def test_build_with_telemetry_returns_parsed_buildkit_fields(tmp_path: Path):
     from openhands.agent_server.docker.build import (
         BuildOptions,


### PR DESCRIPTION
## Summary

Cherry-picks the fix from PR #2478 onto main.

PR #2478 fixed a bug where `cache_export_seconds` was always `0.0` in build telemetry. The root cause: when BuildKit exports cache to registry, it outputs multiple lines for the same step:

```
#33 exporting cache to registry
#33 preparing build cache for export
#33 DONE 36.2s
```

The second line overwrote `step_descriptions["33"]`, so when the DONE line arrived, the description was "preparing build cache for export" which wasn't classified as `cache_export`.

**The fix:** Once a step has a classified description (like "exporting cache to registry" → `cache_export`), subsequent sub-operation descriptions don't overwrite it.

## Why this PR exists

PR #2478 was accidentally merged into `feat/build-phase-telemetry` (a stale feature branch) instead of `main`. The telemetry feature itself was landed on main via a separate PR #2422, but the bug fix never made it. As a result, all current image builds report `cache_export_seconds: 0.0`, making it impossible to measure the actual impact of cache export on build times.

This is blocking the investigation in [benchmarks#531](https://github.com/OpenHands/benchmarks/issues/531) — we need working telemetry to determine whether `--cache-to mode=max` vs `mode=off` has a measurable cost.

## Test plan

- [x] Clean cherry-pick, no conflicts
- [x] Includes the test `test_parse_buildkit_telemetry_cache_export_with_preparing_line` from #2478
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9ed3e03-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9ed3e03-python \
  ghcr.io/openhands/agent-server:9ed3e03-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9ed3e03-golang-amd64
ghcr.io/openhands/agent-server:9ed3e03-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9ed3e03-golang-arm64
ghcr.io/openhands/agent-server:9ed3e03-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9ed3e03-java-amd64
ghcr.io/openhands/agent-server:9ed3e03-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9ed3e03-java-arm64
ghcr.io/openhands/agent-server:9ed3e03-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9ed3e03-python-amd64
ghcr.io/openhands/agent-server:9ed3e03-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:9ed3e03-python-arm64
ghcr.io/openhands/agent-server:9ed3e03-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:9ed3e03-golang
ghcr.io/openhands/agent-server:9ed3e03-java
ghcr.io/openhands/agent-server:9ed3e03-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9ed3e03-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9ed3e03-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->