### PR TITLE
feat(workflow): Expected instance_ids format (no spaces)

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -194,6 +194,17 @@ jobs:
                     exit 1
                   fi
 
+            - name: Validate instance_ids (no spaces allowed)
+              if: github.event_name == 'workflow_dispatch' && github.event.inputs.instance_ids != ''
+              run: |
+                  INSTANCE_IDS="${{ github.event.inputs.instance_ids }}"
+                  if [[ "$INSTANCE_IDS" =~ [[:space:]] ]]; then
+                    echo "::error::instance_ids must not contain spaces. Use comma-separated values without spaces."
+                    echo "Got: '$INSTANCE_IDS'"
+                    echo "Example: 'django__django-11583,django__django-12345'"
+                    exit 1
+                  fi
+
             - name: Validate SDK reference (semantic version check)
               if: github.event_name == 'workflow_dispatch'
               env:


### PR DESCRIPTION
## Summary
Documents the expected format for `instance_ids` input to prevent Helm deploy failures.

## Problem
When instance IDs are passed with spaces (e.g., `2d83110e, 2a649bb1, 6359a0b1`), the Helm deploy step fails because spaces cause shell word-splitting issues.

## Solution
Update the `instance_ids` input description to clearly state:
- Values should be comma-separated with **no spaces**
- Provide an example: `"django__django-11583,django__django-12345"`
- Clarify that leaving it empty evaluates all instances up to `eval_limit`
- Fail as fast as possible

Fixes OpenHands/evaluation#327


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0ec9f6a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0ec9f6a-python \
  ghcr.io/openhands/agent-server:0ec9f6a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0ec9f6a-golang-amd64
ghcr.io/openhands/agent-server:0ec9f6a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0ec9f6a-golang-arm64
ghcr.io/openhands/agent-server:0ec9f6a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0ec9f6a-java-amd64
ghcr.io/openhands/agent-server:0ec9f6a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0ec9f6a-java-arm64
ghcr.io/openhands/agent-server:0ec9f6a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0ec9f6a-python-amd64
ghcr.io/openhands/agent-server:0ec9f6a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:0ec9f6a-python-arm64
ghcr.io/openhands/agent-server:0ec9f6a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:0ec9f6a-golang
ghcr.io/openhands/agent-server:0ec9f6a-java
ghcr.io/openhands/agent-server:0ec9f6a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0ec9f6a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0ec9f6a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->