### PR TITLE
fix(workflow): remove unused DATASET/SPLIT env vars from run-eval workflow

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -113,8 +113,6 @@ on:
 env:
     EVAL_REPO: OpenHands/evaluation
     EVAL_WORKFLOW: eval-job.yml
-    DATASET: princeton-nlp/SWE-bench_Verified
-    SPLIT: test
 
 jobs:
     print-parameters:
@@ -154,8 +152,6 @@ jobs:
                   echo "=== Environment Variables ==="
                   echo "EVAL_REPO: ${{ env.EVAL_REPO }}"
                   echo "EVAL_WORKFLOW: ${{ env.EVAL_WORKFLOW }}"
-                  echo "DATASET: ${{ env.DATASET }}"
-                  echo "SPLIT: ${{ env.SPLIT }}"
                   echo ""
                   echo "=== Label (for PR events) ==="
                   echo "Label: ${{ github.event.label.name || 'N/A' }}"


### PR DESCRIPTION
## Summary

Removes the unused `DATASET` and `SPLIT` environment variables from the Run Eval workflow.

## Problem

The `print-parameters` job always printed:
```
DATASET: princeton-nlp/SWE-bench_Verified
SPLIT: test
```
regardless of which benchmark was selected (e.g., `commit0`, `gaia`), causing confusion.

## Solution

These variables were legacy leftovers from when the workflow only supported SWE-bench. They are not used by downstream evaluation jobs — the `benchmark` input is what drives the eval job. This PR removes them entirely.

Fixes #2503

@juanmichelini @simonrosenberg can you double check that this removal is not a problem? Thanks 
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:30a9add-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-30a9add-python \
  ghcr.io/openhands/agent-server:30a9add-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:30a9add-golang-amd64
ghcr.io/openhands/agent-server:30a9add-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:30a9add-golang-arm64
ghcr.io/openhands/agent-server:30a9add-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:30a9add-java-amd64
ghcr.io/openhands/agent-server:30a9add-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:30a9add-java-arm64
ghcr.io/openhands/agent-server:30a9add-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:30a9add-python-amd64
ghcr.io/openhands/agent-server:30a9add-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:30a9add-python-arm64
ghcr.io/openhands/agent-server:30a9add-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:30a9add-golang
ghcr.io/openhands/agent-server:30a9add-java
ghcr.io/openhands/agent-server:30a9add-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `30a9add-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `30a9add-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->