### PR TITLE
fix(ci): ignore Field deprecated metadata in API breakage check

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -301,9 +301,9 @@ def ensure_griffe() -> None:
 def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
     """Check if the change is only in Field metadata (description, title, etc.).
 
-    Field metadata parameters like ``description``, ``title``, and ``examples``
-    don't affect runtime behavior - they're documentation-only. Changes to these
-    should not be considered breaking API changes.
+    Field metadata parameters like ``description``, ``title``, ``examples``, and
+    ``deprecated`` don't affect runtime behavior. Changes to these should not be
+    considered breaking API changes.
 
     Returns:
         True if both values are Field() calls and only metadata parameters differ.
@@ -316,14 +316,19 @@ def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
 
     # Metadata parameters that don't affect runtime behavior
     # See https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field
-    metadata_params = ["description", "title", "examples", "json_schema_extra"]
+    metadata_patterns = {
+        "description": r'([\'"])([^\'"]*?)\1',
+        "title": r'([\'"])([^\'"]*?)\1',
+        "examples": r'([\'"])([^\'"]*?)\1',
+        "json_schema_extra": r'([\'"])([^\'"]*?)\1',
+        "deprecated": r"(?:True|False|None|'[^']*'|\"[^\"]*\")",
+    }
 
     old_normalized = old_str
     new_normalized = new_str
 
-    for param in metadata_params:
-        # Pattern to match param='...' or param="..." with simple string values
-        pattern = rf'{param}\s*=\s*([\'"])([^\'"]*?)\1'
+    for param, value_pattern in metadata_patterns.items():
+        pattern = rf"{param}\s*=\s*{value_pattern}"
         old_normalized = re.sub(pattern, f"{param}=PLACEHOLDER", old_normalized)
         new_normalized = re.sub(pattern, f"{param}=PLACEHOLDER", new_normalized)
 

--- a/tests/ci_scripts/test_check_sdk_api_breakage.py
+++ b/tests/ci_scripts/test_check_sdk_api_breakage.py
@@ -466,6 +466,46 @@ def test_is_field_metadata_only_change_long_description():
     assert _is_field_metadata_only_change(old, new) is True
 
 
+def test_is_field_metadata_only_change_deprecated_bool_only():
+    """Changing only Field deprecated metadata is detected as metadata-only."""
+    old = "Field(default=False, deprecated=False)"
+    new = "Field(default=False, deprecated=True)"
+    assert _is_field_metadata_only_change(old, new) is True
+
+
+def test_field_deprecated_change_is_not_breaking(tmp_path):
+    """Field deprecated metadata changes should not count as breaking changes."""
+    old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
+    new_pkg = _write_pkg_init(tmp_path, "new", ["Config"])
+
+    old_init = old_pkg / "__init__.py"
+    new_init = new_pkg / "__init__.py"
+
+    old_init.write_text(
+        old_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    enabled: bool = Field(default=False, deprecated=False)\n"
+    )
+    new_init.write_text(
+        new_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    enabled: bool = Field(default=False, deprecated=True)\n"
+    )
+
+    old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])
+    new_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "new")])
+
+    total_breaks, undeprecated = _prod._compute_breakages(
+        old_root,
+        new_root,
+        _SDK_CFG,
+    )
+    assert total_breaks == 0
+    assert undeprecated == 0
+
+
 def test_field_description_change_is_not_breaking(tmp_path):
     """Field description changes should not be counted as breaking changes."""
     old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])


### PR DESCRIPTION
## Summary
- treat `Field(..., deprecated=...)` changes as metadata-only in the Python API breakage checker
- keep `deprecated=True/False` annotations from being reported as structural breakages by Griffe-based API comparisons
- add targeted tests covering both the helper logic and end-to-end breakage computation

## Rationale:

This is necessary because of course when we want to deprecate a field, we add `deprecated=True`, that in itself should not be marked by the Griffe workflow as a breakage, it's not a breakage.

## Testing
- `uv run pytest tests/ci_scripts/test_check_sdk_api_breakage.py -q`
- `uv run pre-commit run --files .github/scripts/check_sdk_api_breakage.py tests/ci_scripts/test_check_sdk_api_breakage.py`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc49c4e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc49c4e-python \
  ghcr.io/openhands/agent-server:dc49c4e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc49c4e-golang-amd64
ghcr.io/openhands/agent-server:dc49c4e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc49c4e-golang-arm64
ghcr.io/openhands/agent-server:dc49c4e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc49c4e-java-amd64
ghcr.io/openhands/agent-server:dc49c4e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc49c4e-java-arm64
ghcr.io/openhands/agent-server:dc49c4e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc49c4e-python-amd64
ghcr.io/openhands/agent-server:dc49c4e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:dc49c4e-python-arm64
ghcr.io/openhands/agent-server:dc49c4e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:dc49c4e-golang
ghcr.io/openhands/agent-server:dc49c4e-java
ghcr.io/openhands/agent-server:dc49c4e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc49c4e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc49c4e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->