### PR TITLE
Fix Qwen3.5-Flash low submission rate: improve JSON arg parsing and add corrective feedback

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -432,6 +432,33 @@ class Agent(CriticMixin, AgentBase):
             state.execution_status = ConversationExecutionStatus.FINISHED
             return
 
+        # When the LLM produced no tool call and no user-facing content,
+        # inject corrective feedback so the model knows it must act.
+        # This prevents the monologue stuck-detector from firing when the
+        # model simply forgot to emit a function call (common with Qwen,
+        # which sometimes places tool-call XML inside reasoning_content).
+        if not has_content:
+            logger.warning(
+                "LLM response contained no tool call and no content"
+                " - sending corrective feedback"
+            )
+            nudge = MessageEvent(
+                source="user",
+                llm_message=Message(
+                    role="user",
+                    content=[
+                        TextContent(
+                            text=(
+                                "Your last response did not include a "
+                                "function call or a message. Please "
+                                "use a tool to proceed with the task."
+                            )
+                        )
+                    ],
+                ),
+            )
+            on_event(nudge)
+
     def _requires_user_confirmation(
         self, state: ConversationState, action_events: list[ActionEvent]
     ) -> bool:
@@ -585,10 +612,17 @@ class Agent(CriticMixin, AgentBase):
         # Validate arguments
         security_risk: risk.SecurityRisk = risk.SecurityRisk.UNKNOWN
         try:
-            # Sanitize raw control characters (U+0000–U+001F) that some
-            # models emit as literal bytes instead of JSON escape sequences.
-            sanitized_args = sanitize_json_control_chars(tool_call.arguments)
-            arguments = json.loads(sanitized_args)
+            # Try parsing arguments as-is first.  Raw newlines / tabs are
+            # legal JSON whitespace and many models emit them between tokens
+            # (e.g. Qwen: "view_range": \n[1, 100]\n).  sanitize_json_
+            # control_chars would escape those to \\n, which breaks parsing.
+            # Fall back to sanitization only when the raw string is invalid
+            # (handles models that emit raw control chars *inside* strings).
+            try:
+                arguments = json.loads(tool_call.arguments)
+            except json.JSONDecodeError:
+                sanitized_args = sanitize_json_control_chars(tool_call.arguments)
+                arguments = json.loads(sanitized_args)
 
             # Fix malformed arguments (e.g., JSON strings for list/dict fields)
             arguments = fix_malformed_tool_arguments(arguments, tool.action_type)

--- a/tests/sdk/agent/test_tool_call_recovery.py
+++ b/tests/sdk/agent/test_tool_call_recovery.py
@@ -1,0 +1,291 @@
+"""Tests for tool call argument parsing and empty-response recovery.
+
+Covers two fixes for the Qwen3.5-Flash stuck conversation issue:
+
+1. JSON argument parsing: raw json.loads first, sanitize_json_control_chars
+   as fallback (fixes literal \\n whitespace being incorrectly escaped).
+
+2. Corrective feedback: when the LLM produces no tool call and no content,
+   inject a user message so the model can self-correct instead of silently
+   looping into the monologue stuck detector.
+"""
+
+import json
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Self
+from unittest.mock import patch
+
+from litellm import ChatCompletionMessageToolCall
+from litellm.types.utils import (
+    Choices,
+    Function,
+    Message as LiteLLMMessage,
+    ModelResponse,
+)
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.event import ActionEvent, AgentErrorEvent, MessageEvent
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
+from openhands.sdk.tool.tool import ToolDefinition
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+
+# ── minimal tool ─────────────────────────────────────────────────────────
+
+
+class _ViewAction(Action):
+    command: str
+    path: str
+    view_range: list[int] | None = None
+
+
+class _ViewObs(Observation):
+    output: str
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        return [TextContent(text=self.output)]
+
+
+class _ViewExec(ToolExecutor[_ViewAction, _ViewObs]):
+    def __call__(self, action: _ViewAction, conversation=None) -> _ViewObs:
+        return _ViewObs(output=f"viewed {action.path}")
+
+
+class _ViewTool(ToolDefinition[_ViewAction, _ViewObs]):
+    name = "view_tool"
+
+    @classmethod
+    def create(cls, conv_state: "ConversationState | None" = None) -> Sequence[Self]:
+        return [
+            cls(
+                description="View a file",
+                action_type=_ViewAction,
+                observation_type=_ViewObs,
+                executor=_ViewExec(),
+            )
+        ]
+
+
+register_tool("ViewTool", _ViewTool)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────
+
+
+def _make_agent(*, with_tool: bool = True) -> Agent:
+    llm = LLM(
+        model="test-model",
+        usage_id="test-llm",
+        api_key=SecretStr("test-key"),
+        base_url="http://test",
+    )
+    tools = [Tool(name="ViewTool")] if with_tool else []
+    return Agent(llm=llm, tools=tools)
+
+
+def _model_response(
+    content: str | None,
+    tool_calls: list[ChatCompletionMessageToolCall] | None = None,
+    *,
+    response_id: str = "resp-1",
+    reasoning_content: str | None = None,
+) -> ModelResponse:
+    msg = LiteLLMMessage(
+        role="assistant",
+        content=content,
+        tool_calls=tool_calls,
+    )
+    if reasoning_content is not None:
+        msg.reasoning_content = reasoning_content  # type: ignore[attr-defined]
+    return ModelResponse(
+        id=response_id,
+        choices=[Choices(index=0, message=msg, finish_reason="stop")],
+        created=0,
+        model="test-model",
+        object="chat.completion",
+    )
+
+
+# ── Fix 1: JSON argument parsing ────────────────────────────────────────
+
+
+def test_newline_whitespace_in_arguments_parses_ok():
+    """Arguments with raw newlines as JSON whitespace should parse directly.
+
+    Qwen3.5-Flash emits arguments like:
+        "view_range": \\n[1, 100]\\n\\n
+    After API JSON decoding the \\n become 0x0A — valid JSON whitespace.
+    """
+    args_with_newlines = (
+        '{"command": "view", "path": "/workspace/test.py", '
+        '"view_range": \n[1, 100]\n\n}'
+    )
+    assert json.loads(args_with_newlines) is not None  # sanity
+
+    agent = _make_agent()
+    conv = Conversation(agent=agent)
+
+    resp = _model_response(
+        content="Viewing file",
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id="call_1",
+                type="function",
+                function=Function(
+                    name="view_tool",
+                    arguments=args_with_newlines,
+                ),
+            )
+        ],
+    )
+
+    events: list[object] = []
+    with patch("openhands.sdk.llm.llm.litellm_completion", return_value=resp):
+        conv.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="View file.")],
+            )
+        )
+        agent.step(conv, on_event=events.append)
+
+    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    error_events = [e for e in events if isinstance(e, AgentErrorEvent)]
+    assert len(action_events) >= 1, (
+        f"Expected ActionEvent, got errors: {[e.error for e in error_events]}"
+    )
+    assert action_events[0].action is not None
+    assert isinstance(action_events[0].action, _ViewAction)
+
+
+def test_control_chars_in_string_values_still_sanitized():
+    """Raw 0x0A inside a JSON string value triggers fallback sanitization."""
+    args_raw = '{"command": "view", "path": "/workspace/test\n.py"}'
+    # This is invalid JSON (raw newline inside string)
+    try:
+        json.loads(args_raw)
+        # If this doesn't raise, the test premise is wrong
+        assert False, "Expected json.loads to fail"
+    except json.JSONDecodeError:
+        pass
+
+    agent = _make_agent()
+    conv = Conversation(agent=agent)
+
+    resp = _model_response(
+        content="Viewing file",
+        tool_calls=[
+            ChatCompletionMessageToolCall(
+                id="call_2",
+                type="function",
+                function=Function(
+                    name="view_tool",
+                    arguments=args_raw,
+                ),
+            )
+        ],
+    )
+
+    events: list[object] = []
+    with patch("openhands.sdk.llm.llm.litellm_completion", return_value=resp):
+        conv.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="View file.")],
+            )
+        )
+        agent.step(conv, on_event=events.append)
+
+    # After sanitization fallback the action is still created
+    action_events = [e for e in events if isinstance(e, ActionEvent)]
+    assert len(action_events) >= 1
+    assert action_events[0].action is not None
+
+
+# ── Fix 2: Corrective feedback on empty response ────────────────────────
+
+
+def test_reasoning_only_response_injects_nudge():
+    """When LLM returns reasoning but no tool call / content, inject nudge."""
+    agent = _make_agent(with_tool=False)
+    conv = Conversation(agent=agent)
+
+    resp = _model_response(
+        content="",
+        reasoning_content="Let me think about this...",
+    )
+
+    events: list[object] = []
+    with patch("openhands.sdk.llm.llm.litellm_completion", return_value=resp):
+        conv.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="Fix the bug.")],
+            )
+        )
+        agent.step(conv, on_event=events.append)
+
+    agent_msgs = [
+        e for e in events if isinstance(e, MessageEvent) and e.source == "agent"
+    ]
+    user_nudges = [
+        e for e in events if isinstance(e, MessageEvent) and e.source == "user"
+    ]
+    assert len(agent_msgs) == 1
+    assert len(user_nudges) == 1
+    nudge_text = user_nudges[0].llm_message.content[0]
+    assert isinstance(nudge_text, TextContent)
+    assert "function call" in nudge_text.text
+
+
+def test_content_response_does_not_inject_nudge():
+    """When LLM produces meaningful content, no nudge should be injected."""
+    agent = _make_agent(with_tool=False)
+    conv = Conversation(agent=agent)
+
+    resp = _model_response(content="Here is my analysis of the bug...")
+
+    events: list[object] = []
+    with patch("openhands.sdk.llm.llm.litellm_completion", return_value=resp):
+        conv.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="Fix the bug.")],
+            )
+        )
+        agent.step(conv, on_event=events.append)
+
+    user_nudges = [
+        e for e in events if isinstance(e, MessageEvent) and e.source == "user"
+    ]
+    assert len(user_nudges) == 0
+
+
+def test_completely_empty_response_injects_nudge():
+    """Completely empty responses (no reasoning, no content) get a nudge."""
+    agent = _make_agent(with_tool=False)
+    conv = Conversation(agent=agent)
+
+    resp = _model_response(content="")
+
+    events: list[object] = []
+    with patch("openhands.sdk.llm.llm.litellm_completion", return_value=resp):
+        conv.send_message(
+            Message(
+                role="user",
+                content=[TextContent(text="Fix the bug.")],
+            )
+        )
+        agent.step(conv, on_event=events.append)
+
+    user_nudges = [
+        e for e in events if isinstance(e, MessageEvent) and e.source == "user"
+    ]
+    assert len(user_nudges) == 1


### PR DESCRIPTION
## Summary

Fixes the root causes of **426/500 stuck conversations** in Qwen3.5-Flash SWE-bench evaluations, where only 74 out of 500 instances were submitted.

Addresses [openhands-index-results#714](https://github.com/OpenHands/openhands-index-results/issues/714).

## Root Cause Analysis

Analysis of 170 sampled stuck conversations identified three failure mechanisms:

| Cause | % of stuck | Description |
|-------|-----------|-------------|
| **Empty messages** | 91% | Model places tool calls in `reasoning_content` instead of proper function calls → 3 consecutive empty responses → monologue stuck detector fires |
| **Malformed JSON** | 8% | Literal `\n` (newline bytes) in function call arguments as JSON whitespace, but `sanitize_json_control_chars` escapes them to `\\n`, breaking parsing |
| **Tool hallucination** | 1% | Model calls `str_replace` instead of `str_replace_editor` |

## Changes

### Fix 1: JSON argument parsing order (`agent.py`)

**Before:** Always applied `sanitize_json_control_chars()` before `json.loads()`. This escaped raw newlines (valid JSON whitespace between tokens) into `\\n`, which made previously-valid JSON invalid.

**After:** Try `json.loads()` on raw arguments first. Only fall back to `sanitize_json_control_chars()` when the raw string fails to parse. This correctly handles:
- Newlines as whitespace (Qwen pattern): parsed directly ✅
- Raw control chars inside string values (kimi-k2.5 pattern): sanitized on fallback ✅

### Fix 2: Corrective feedback on empty responses (`agent.py`)

**Before:** When the LLM produced no tool call and no content (reasoning-only or truly empty), the agent silently emitted a `MessageEvent` and continued the loop. After 3 consecutive such responses, the monologue stuck detector would fire and terminate the conversation.

**After:** After emitting the agent's empty `MessageEvent`, inject a user-role nudge message:
> "Your last response did not include a function call or a message. Please use a tool to proceed with the task."

This:
- Breaks the monologue chain (user message resets the stuck detector counter)
- Gives the model actionable corrective feedback
- Follows the same pattern used for `FunctionCallValidationError` recovery

## Tests

Added `tests/sdk/agent/test_tool_call_recovery.py` with 5 tests:
- `test_newline_whitespace_in_arguments_parses_ok` — validates Fix 1
- `test_control_chars_in_string_values_still_sanitized` — validates fallback path still works
- `test_reasoning_only_response_injects_nudge` — validates Fix 2
- `test_content_response_does_not_inject_nudge` — no false positives
- `test_completely_empty_response_injects_nudge` — edge case

All 237 agent tests pass, including existing `test_sanitize_json_control_chars` and `test_stuck_detector` suites.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bc108a2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bc108a2-python \
  ghcr.io/openhands/agent-server:bc108a2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bc108a2-golang-amd64
ghcr.io/openhands/agent-server:bc108a2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bc108a2-golang-arm64
ghcr.io/openhands/agent-server:bc108a2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bc108a2-java-amd64
ghcr.io/openhands/agent-server:bc108a2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bc108a2-java-arm64
ghcr.io/openhands/agent-server:bc108a2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bc108a2-python-amd64
ghcr.io/openhands/agent-server:bc108a2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:bc108a2-python-arm64
ghcr.io/openhands/agent-server:bc108a2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:bc108a2-golang
ghcr.io/openhands/agent-server:bc108a2-java
ghcr.io/openhands/agent-server:bc108a2-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bc108a2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bc108a2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->