### PR TITLE
build: move SDK SHA args after expensive layers for cache reuse

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -58,12 +58,6 @@ RUN test -x /agent-server/dist/openhands-agent-server
 FROM ${BASE_IMAGE} AS base-image-minimal
 ARG USERNAME UID GID PORT
 
-
-ARG OPENHANDS_BUILD_GIT_SHA=unknown
-ARG OPENHANDS_BUILD_GIT_REF=unknown
-ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
-ENV OPENHANDS_BUILD_GIT_REF=${OPENHANDS_BUILD_GIT_REF}
-
 # Install base packages and create user
 RUN set -eux; \
     # Install base packages (works for both Debian-based images)
@@ -103,6 +97,14 @@ RUN mkdir -p /etc/claude-code && \
 # NOTE: we should NOT include UV_PROJECT_ENVIRONMENT here,
 # since the agent might use it to perform other work (e.g. tools that use Python)
 COPY --from=ghcr.io/astral-sh/uv /uv /uvx /bin/
+
+# SDK version metadata — placed AFTER expensive RUN layers (apt-get, npm)
+# so that changing the SDK commit does not invalidate their cache.
+# This lets BuildKit reuse cached base layers across SDK commits.
+ARG OPENHANDS_BUILD_GIT_SHA=unknown
+ARG OPENHANDS_BUILD_GIT_REF=unknown
+ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
+ENV OPENHANDS_BUILD_GIT_REF=${OPENHANDS_BUILD_GIT_REF}
 
 USER ${USERNAME}
 WORKDIR /


### PR DESCRIPTION
## Summary

Move `OPENHANDS_BUILD_GIT_SHA`/`OPENHANDS_BUILD_GIT_REF` ARG/ENV declarations to **after** the expensive `apt-get` and `npm install` layers in the `base-image-minimal` Dockerfile stage.

Fixes [OpenHands/benchmarks#544](https://github.com/OpenHands/benchmarks/issues/544). Related to [OpenHands/benchmarks#531](https://github.com/OpenHands/benchmarks/issues/531).

## Problem

PR #2130 (`fd80128`) placed the ARG before apt-get:
```dockerfile
FROM ${BASE_IMAGE} AS base-image-minimal
ARG OPENHANDS_BUILD_GIT_SHA=unknown        # ← changes every SDK commit
ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
RUN apt-get update && apt-get install ...  # ← cache BUSTED by above
RUN npm install -g @zed-industries/...     # ← cache BUSTED too
```

Every SDK commit changes the SHA, which invalidates all downstream layers. BuildKit registry cache (`--cache-from type=registry`) stores layers keyed by their ancestor chain — the SHA in the chain means cached apt-get layers from prior builds no longer match. This forces `apt-get` (~103s) + `npm install` (~38s) to rebuild on **all 433 benchmark images** per SDK bump.

## Fix

```dockerfile
FROM ${BASE_IMAGE} AS base-image-minimal
RUN apt-get update && apt-get install ...  # ← cached across SDK commits
RUN npm install -g @zed-industries/...     # ← cached across SDK commits
ARG OPENHANDS_BUILD_GIT_SHA=unknown        # ← only invalidates layers after this point
ENV OPENHANDS_BUILD_GIT_SHA=${OPENHANDS_BUILD_GIT_SHA}
```

## Experimental validation

A/B test on CI with 4 django SWT-bench images ([benchmarks#544](https://github.com/OpenHands/benchmarks/issues/544)):

| Run | Dockerfile | apt-get cached? | Buildx p50 |
|-----|-----------|----------------|------------|
| [Seed #23343565318](https://github.com/OpenHands/benchmarks/actions/runs/23343565318) | ARG after (this PR), `cache-mode=max` | N/A (cold) | 149s |
| [Test #23343709061](https://github.com/OpenHands/benchmarks/actions/runs/23343709061) | ARG after, **different SDK SHA** | **3/4 CACHED** | 154s |
| [Baseline #23164396524](https://github.com/OpenHands/benchmarks/actions/runs/23164396524) | ARG before (current) | **0/414 CACHED** | 322s |

**2.1x faster** with this fix (154s vs 322s per image). At 433 images: recovers ~4 hours of wasted rebuilds per SDK bump.

## Test plan
- [x] A/B test: build with SDK commit A, rebuild same images with SDK commit B — apt-get layers are registry cache hits
- [ ] Full 433-image SWT-bench build to confirm at-scale improvement
- [ ] Verify `OPENHANDS_BUILD_GIT_SHA` env var is still set correctly in the final image