### PR TITLE
fix(ci): ignore added Field metadata in SDK API breakage check

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -314,7 +314,7 @@ def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
     if not (old_str.startswith("Field(") and new_str.startswith("Field(")):
         return False
 
-    # Metadata parameters that don't affect runtime behavior
+    # Metadata parameters that don't affect runtime behavior.
     # See https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field
     metadata_patterns = {
         "description": r'([\'"])([^\'"]*?)\1',
@@ -324,15 +324,19 @@ def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
         "deprecated": r"(?:True|False|None|'[^']*'|\"[^\"]*\")",
     }
 
-    old_normalized = old_str
-    new_normalized = new_str
+    def _normalize(value: str) -> str:
+        normalized = value
+        for param, value_pattern in metadata_patterns.items():
+            pattern = rf",?\s*{param}\s*=\s*{value_pattern}"
+            normalized = re.sub(pattern, "", normalized)
 
-    for param, value_pattern in metadata_patterns.items():
-        pattern = rf"{param}\s*=\s*{value_pattern}"
-        old_normalized = re.sub(pattern, f"{param}=PLACEHOLDER", old_normalized)
-        new_normalized = re.sub(pattern, f"{param}=PLACEHOLDER", new_normalized)
+        normalized = re.sub(r"\(\s*,", "(", normalized)
+        normalized = re.sub(r",\s*\)", ")", normalized)
+        normalized = re.sub(r",\s*,", ", ", normalized)
+        normalized = re.sub(r"\s+", " ", normalized)
+        return normalized.strip()
 
-    return old_normalized == new_normalized
+    return _normalize(old_str) == _normalize(new_str)
 
 
 def _collect_breakages_pairs(

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,10 @@ consult each relevant package-level AGENTS.md.
   [openhands-sdk/openhands/sdk/AGENTS.md](openhands-sdk/openhands/sdk/AGENTS.md).
   Public API removals require deprecation before removal, and breaking SDK API
   changes require at least a **MINOR** SemVer bump.
+- The SDK API breakage checker should treat metadata-only changes to
+  Pydantic `Field(...)` declarations as non-breaking, including adding,
+  removing, or editing `description`, `title`, `examples`,
+  `json_schema_extra`, and `deprecated` kwargs.
 - For public REST APIs, read
   [openhands-agent-server/AGENTS.md](openhands-agent-server/AGENTS.md).
   REST contract breaks need a deprecation notice and a runway of

--- a/tests/ci_scripts/test_check_sdk_api_breakage.py
+++ b/tests/ci_scripts/test_check_sdk_api_breakage.py
@@ -473,6 +473,13 @@ def test_is_field_metadata_only_change_deprecated_bool_only():
     assert _is_field_metadata_only_change(old, new) is True
 
 
+def test_is_field_metadata_only_change_added_deprecated_kwarg():
+    """Adding deprecated metadata should still be treated as metadata-only."""
+    old = "Field(default=False, description='old description')"
+    new = "Field(default=False, deprecated=True, description='new description')"
+    assert _is_field_metadata_only_change(old, new) is True
+
+
 def test_field_deprecated_change_is_not_breaking(tmp_path):
     """Field deprecated metadata changes should not count as breaking changes."""
     old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
@@ -492,6 +499,43 @@ def test_field_deprecated_change_is_not_breaking(tmp_path):
         + "\nfrom pydantic import BaseModel, Field\n\n"
         + "class Config(BaseModel):\n"
         + "    enabled: bool = Field(default=False, deprecated=True)\n"
+    )
+
+    old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])
+    new_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "new")])
+
+    total_breaks, undeprecated = _prod._compute_breakages(
+        old_root,
+        new_root,
+        _SDK_CFG,
+    )
+    assert total_breaks == 0
+    assert undeprecated == 0
+
+
+def test_field_added_deprecated_kwarg_is_not_breaking(tmp_path):
+    """Adding deprecated metadata should not count as a breaking change."""
+    old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
+    new_pkg = _write_pkg_init(tmp_path, "new", ["Config"])
+
+    old_init = old_pkg / "__init__.py"
+    new_init = new_pkg / "__init__.py"
+
+    old_init.write_text(
+        old_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    enabled: bool = Field(default=False, description='Old description')\n"
+    )
+    new_init.write_text(
+        new_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    enabled: bool = Field(\n"
+        + "        default=False,\n"
+        + "        deprecated=True,\n"
+        + "        description='New description',\n"
+        + "    )\n"
     )
 
     old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])


### PR DESCRIPTION
## Summary
- treat added or removed Pydantic `Field(...)` metadata kwargs as non-breaking in the SDK API breakage checker
- add regression coverage for `deprecated=True` being added to an existing field
- document the checker behavior in `AGENTS.md`

## Testing
- `uv run pytest tests/ci_scripts/test_check_sdk_api_breakage.py`
- `uv run pre-commit run --files .github/scripts/check_sdk_api_breakage.py tests/ci_scripts/test_check_sdk_api_breakage.py AGENTS.md`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7a4ace5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7a4ace5-python \
  ghcr.io/openhands/agent-server:7a4ace5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7a4ace5-golang-amd64
ghcr.io/openhands/agent-server:7a4ace5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7a4ace5-golang-arm64
ghcr.io/openhands/agent-server:7a4ace5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7a4ace5-java-amd64
ghcr.io/openhands/agent-server:7a4ace5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7a4ace5-java-arm64
ghcr.io/openhands/agent-server:7a4ace5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7a4ace5-python-amd64
ghcr.io/openhands/agent-server:7a4ace5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:7a4ace5-python-arm64
ghcr.io/openhands/agent-server:7a4ace5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:7a4ace5-golang
ghcr.io/openhands/agent-server:7a4ace5-java
ghcr.io/openhands/agent-server:7a4ace5-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7a4ace5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7a4ace5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->