### PR TITLE
feat(docker): make ACP npm package installation optional via build arg

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -81,13 +81,17 @@ RUN set -eux; \
 
 # Pre-install ACP servers for ACPAgent support (Claude Code + Codex)
 # Install Node.js/npm if not present (SWE-bench base images may lack them)
+# Set INSTALL_ACP=false to skip ACP installation (e.g. for benchmark images)
+ARG INSTALL_ACP=true
 RUN set -eux; \
     if ! command -v npm >/dev/null 2>&1; then \
         curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
         apt-get install -y --no-install-recommends nodejs && \
         rm -rf /var/lib/apt/lists/*; \
     fi; \
-    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp
+    if [ "$INSTALL_ACP" = "true" ]; then \
+        npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp; \
+    fi
 
 # Configure Claude Code managed settings for headless operation:
 # Allow all tool permissions (no human in the loop to approve).


### PR DESCRIPTION
## Summary

- Adds `INSTALL_ACP=true` build arg to the `base-image-minimal` Dockerfile stage
- When set to `false`, skips `npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp`
- Saves ~38s per image build for use cases that don't need ACP (e.g. SWT-bench benchmarks)

## Non-breaking

Defaults to `true` — existing builds produce identical images. Only callers that explicitly pass `--build-arg INSTALL_ACP=false` are affected.

## Test plan

- [ ] Build with default args → ACP packages installed (same as before)
- [ ] Build with `--build-arg INSTALL_ACP=false` → ACP packages skipped
- [ ] Verify agent-server starts correctly in both cases

Ref: https://github.com/OpenHands/benchmarks/issues/537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:360c8aa-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-360c8aa-python \
  ghcr.io/openhands/agent-server:360c8aa-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:360c8aa-golang-amd64
ghcr.io/openhands/agent-server:360c8aa-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:360c8aa-golang-arm64
ghcr.io/openhands/agent-server:360c8aa-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:360c8aa-java-amd64
ghcr.io/openhands/agent-server:360c8aa-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:360c8aa-java-arm64
ghcr.io/openhands/agent-server:360c8aa-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:360c8aa-python-amd64
ghcr.io/openhands/agent-server:360c8aa-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:360c8aa-python-arm64
ghcr.io/openhands/agent-server:360c8aa-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:360c8aa-golang
ghcr.io/openhands/agent-server:360c8aa-java
ghcr.io/openhands/agent-server:360c8aa-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `360c8aa-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `360c8aa-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->