### PR TITLE
feat(docker): make boto3 installation optional via build arg

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -30,8 +30,9 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-sdk ./openhands-sdk
 COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
+ARG INSTALL_BOTO3=true
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv python install 3.13 && uv venv --python 3.13 .venv && uv sync --frozen --no-editable --managed-python --extra boto3
+    uv python install 3.13 && uv venv --python 3.13 .venv && uv sync --frozen --no-editable --managed-python $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3")
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -40,9 +41,10 @@ RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
 FROM builder AS binary-builder
 ARG USERNAME UID GID
 
+ARG INSTALL_BOTO3=true
 # We need --dev for pyinstaller
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv sync --frozen --dev --no-editable --extra boto3
+    uv sync --frozen --dev --no-editable $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3")
 
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
     uv run pyinstaller openhands-agent-server/openhands/agent_server/agent-server.spec


### PR DESCRIPTION
## Summary

- Adds `INSTALL_BOTO3=true` build arg to `builder` and `binary-builder` Dockerfile stages
- When set to `false`, `--extra boto3` is omitted from `uv sync`, skipping boto3/botocore installation
- The runtime already handles this gracefully — `_get_boto3()` in `unverified_models.py` uses lazy import with fallback

## Non-breaking

- Defaults to `true` — existing builds produce identical images
- boto3 is already declared as an optional extra in `openhands-sdk/pyproject.toml`
- Runtime already degrades gracefully when boto3 is absent (Bedrock model listing skipped with warning)

## Test plan

- [ ] Build with default args → boto3 installed (same as before)
- [ ] Build with `--build-arg INSTALL_BOTO3=false` → boto3/botocore not installed
- [ ] Verify agent-server starts and operates correctly without boto3 (non-Bedrock models)

Ref: https://github.com/OpenHands/benchmarks/issues/537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:48ba39c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-48ba39c-python \
  ghcr.io/openhands/agent-server:48ba39c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:48ba39c-golang-amd64
ghcr.io/openhands/agent-server:48ba39c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:48ba39c-golang-arm64
ghcr.io/openhands/agent-server:48ba39c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:48ba39c-java-amd64
ghcr.io/openhands/agent-server:48ba39c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:48ba39c-java-arm64
ghcr.io/openhands/agent-server:48ba39c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:48ba39c-python-amd64
ghcr.io/openhands/agent-server:48ba39c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:48ba39c-python-arm64
ghcr.io/openhands/agent-server:48ba39c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:48ba39c-golang
ghcr.io/openhands/agent-server:48ba39c-java
ghcr.io/openhands/agent-server:48ba39c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `48ba39c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `48ba39c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->