### PR TITLE
feat: lightweight benchmark images (merge #2535 + #2536 + #2537)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -31,8 +31,12 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
 ARG INSTALL_BOTO3=true
+ARG INSTALL_BROWSER=true
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv python install 3.13 && uv venv --python 3.13 .venv && uv sync --frozen --no-editable --managed-python $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3")
+    uv python install 3.13 && uv venv --python 3.13 .venv && \
+    uv sync --frozen --no-editable --managed-python \
+        $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3") \
+        $([ "$INSTALL_BROWSER" = "true" ] && echo "--extra browser")
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -42,9 +46,12 @@ FROM builder AS binary-builder
 ARG USERNAME UID GID
 
 ARG INSTALL_BOTO3=true
+ARG INSTALL_BROWSER=true
 # We need --dev for pyinstaller
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv sync --frozen --dev --no-editable $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3")
+    uv sync --frozen --dev --no-editable \
+        $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3") \
+        $([ "$INSTALL_BROWSER" = "true" ] && echo "--extra browser")
 
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
     uv run pyinstaller openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -86,12 +93,12 @@ RUN set -eux; \
 # Set INSTALL_ACP=false to skip ACP installation (e.g. for benchmark images)
 ARG INSTALL_ACP=true
 RUN set -eux; \
-    if ! command -v npm >/dev/null 2>&1; then \
-        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-        apt-get install -y --no-install-recommends nodejs && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi; \
     if [ "$INSTALL_ACP" = "true" ]; then \
+        if ! command -v npm >/dev/null 2>&1; then \
+            curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+            apt-get install -y --no-install-recommends nodejs && \
+            rm -rf /var/lib/apt/lists/*; \
+        fi; \
         npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp; \
     fi
 

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -395,6 +395,13 @@ class BuildOptions(BaseModel):
             "(e.g., at each release)."
         ),
     )
+    extra_build_args: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Additional Docker build args to pass to buildx. "
+            "For example, {'INSTALL_ACP': 'false'} to skip ACP installation."
+        ),
+    )
 
     @property
     def short_sha(self) -> str:
@@ -751,6 +758,8 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
         "--build-arg",
         f"OPENHANDS_BUILD_GIT_REF={opts.git_ref}",
     ]
+    for key, value in opts.extra_build_args.items():
+        args += ["--build-arg", f"{key}={value}"]
     if push:
         args += ["--platform", ",".join(opts.platforms), "--push"]
     else:

--- a/openhands-tools/openhands/tools/preset/default.py
+++ b/openhands-tools/openhands/tools/preset/default.py
@@ -16,6 +16,20 @@ from openhands.sdk.tool import Tool
 logger = get_logger(__name__)
 
 
+def _try_import_browser_toolset() -> type | None:
+    """Import BrowserToolSet if available, else log and return None."""
+    try:
+        from openhands.tools.browser_use import BrowserToolSet
+
+        return BrowserToolSet
+    except ImportError:
+        logger.warning(
+            "browser-use is not installed. Browser tools are unavailable. "
+            "Install with: pip install openhands-tools[browser]"
+        )
+        return None
+
+
 def register_default_tools(enable_browser: bool = True) -> None:
     """Register the default set of tools."""
     # Tools are now automatically registered when imported
@@ -28,9 +42,9 @@ def register_default_tools(enable_browser: bool = True) -> None:
     logger.debug(f"Tool: {TaskTrackerTool.name} registered.")
 
     if enable_browser:
-        from openhands.tools.browser_use import BrowserToolSet
-
-        logger.debug(f"Tool: {BrowserToolSet.name} registered.")
+        BrowserToolSet = _try_import_browser_toolset()
+        if BrowserToolSet:
+            logger.debug(f"Tool: {BrowserToolSet.name} registered.")
 
 
 def get_default_tools(
@@ -54,9 +68,9 @@ def get_default_tools(
         Tool(name=TaskTrackerTool.name),
     ]
     if enable_browser:
-        from openhands.tools.browser_use import BrowserToolSet
-
-        tools.append(Tool(name=BrowserToolSet.name))
+        BrowserToolSet = _try_import_browser_toolset()
+        if BrowserToolSet:
+            tools.append(Tool(name=BrowserToolSet.name))
     return tools
 
 

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -11,10 +11,12 @@ dependencies = [
     "cachetools",
     "libtmux>=0.53.0",
     "pydantic>=2.11.7",
-    "browser-use>=0.8.0",
     "func-timeout>=4.3.5",
     "tom-swe>=1.0.3",
 ]
+
+[project.optional-dependencies]
+browser = ["browser-use>=0.8.0"]
 
 [project.urls]
 Source = "https://github.com/OpenHands/software-agent-sdk"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ dev = [
     "streamlit>=1.49.1",
     "pytest-timeout>=2.4.0",
     "griffe[pypi]>=2.0.0",
+    "browser-use>=0.8.0",  # Optional dep of openhands-tools; needed for tests/type-checking
 ]
 
 # Ruff configuration

--- a/tests/tools/test_optional_browser.py
+++ b/tests/tools/test_optional_browser.py
@@ -1,0 +1,49 @@
+"""Tests for optional browser-use dependency handling."""
+
+import logging
+from unittest.mock import patch
+
+from openhands.tools.preset.default import (
+    get_default_tools,
+    register_default_tools,
+)
+
+
+def test_register_default_tools_browser_disabled():
+    """When enable_browser=False, no browser import is attempted."""
+    register_default_tools(enable_browser=False)
+
+
+def test_register_default_tools_browser_enabled():
+    """When enable_browser=True and browser-use is installed, tools are registered."""
+    register_default_tools(enable_browser=True)
+
+
+def test_get_default_tools_without_browser():
+    """When enable_browser=False, returns only non-browser tools."""
+    tools = get_default_tools(enable_browser=False)
+    assert len(tools) == 3  # terminal, file_editor, task_tracker
+
+
+def test_get_default_tools_with_browser():
+    """Browser tool included when browser-use is installed."""
+    tools = get_default_tools(enable_browser=True)
+    assert len(tools) == 4  # terminal, file_editor, task_tracker, browser
+
+
+def test_get_default_tools_browser_missing_fallback(caplog):
+    """Degrades gracefully when browser-use is missing."""
+    original_import = __builtins__.__import__
+
+    def mock_import(name, *args, **kwargs):
+        if "browser_use" in name:
+            raise ImportError("No module named 'browser_use'")
+        return original_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=mock_import):
+        with caplog.at_level(logging.WARNING):
+            tools = get_default_tools(enable_browser=True)
+
+    # Should return only non-browser tools (no crash)
+    assert len(tools) == 3
+    assert "browser-use is not installed" in caplog.text

--- a/uv.lock
+++ b/uv.lock
@@ -26,6 +26,7 @@ constraints = [
 
 [manifest.dependency-groups]
 dev = [
+    { name = "browser-use", specifier = ">=0.8.0" },
     { name = "griffe", extras = ["pypi"], specifier = ">=2.0.0" },
     { name = "packaging", specifier = ">=24.2" },
     { name = "pre-commit", specifier = ">=4.3.0" },
@@ -1272,6 +1273,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/44/69/9b804adb5fd0671f367781560eb5eb586c4d495277c93bde4307b9e28068/greenlet-3.2.4-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:3b67ca49f54cede0186854a008109d6ee71f66bd57bb36abd6d0a0267b540cdd", size = 274079, upload-time = "2025-08-07T13:15:45.033Z" },
     { url = "https://files.pythonhosted.org/packages/46/e9/d2a80c99f19a153eff70bc451ab78615583b8dac0754cfb942223d2c1a0d/greenlet-3.2.4-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ddf9164e7a5b08e9d22511526865780a576f19ddd00d62f8a665949327fde8bb", size = 640997, upload-time = "2025-08-07T13:42:56.234Z" },
     { url = "https://files.pythonhosted.org/packages/3b/16/035dcfcc48715ccd345f3a93183267167cdd162ad123cd93067d86f27ce4/greenlet-3.2.4-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:f28588772bb5fb869a8eb331374ec06f24a83a9c25bfa1f38b6993afe9c1e968", size = 655185, upload-time = "2025-08-07T13:45:27.624Z" },
+    { url = "https://files.pythonhosted.org/packages/31/da/0386695eef69ffae1ad726881571dfe28b41970173947e7c558d9998de0f/greenlet-3.2.4-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:5c9320971821a7cb77cfab8d956fa8e39cd07ca44b6070db358ceb7f8797c8c9", size = 649926, upload-time = "2025-08-07T13:53:15.251Z" },
     { url = "https://files.pythonhosted.org/packages/68/88/69bf19fd4dc19981928ceacbc5fd4bb6bc2215d53199e367832e98d1d8fe/greenlet-3.2.4-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c60a6d84229b271d44b70fb6e5fa23781abb5d742af7b808ae3f6efd7c9c60f6", size = 651839, upload-time = "2025-08-07T13:18:30.281Z" },
     { url = "https://files.pythonhosted.org/packages/19/0d/6660d55f7373b2ff8152401a83e02084956da23ae58cddbfb0b330978fe9/greenlet-3.2.4-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3b3812d8d0c9579967815af437d96623f45c0f2ae5f04e366de62a12d83a8fb0", size = 607586, upload-time = "2025-08-07T13:18:28.544Z" },
     { url = "https://files.pythonhosted.org/packages/8e/1a/c953fdedd22d81ee4629afbb38d2f9d71e37d23caace44775a3a969147d4/greenlet-3.2.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:abbf57b5a870d30c4675928c37278493044d7c14378350b3aa5d484fa65575f0", size = 1123281, upload-time = "2025-08-07T13:42:39.858Z" },
@@ -1282,6 +1284,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/49/e8/58c7f85958bda41dafea50497cbd59738c5c43dbbea5ee83d651234398f4/greenlet-3.2.4-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:1a921e542453fe531144e91e1feedf12e07351b1cf6c9e8a3325ea600a715a31", size = 272814, upload-time = "2025-08-07T13:15:50.011Z" },
     { url = "https://files.pythonhosted.org/packages/62/dd/b9f59862e9e257a16e4e610480cfffd29e3fae018a68c2332090b53aac3d/greenlet-3.2.4-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cd3c8e693bff0fff6ba55f140bf390fa92c994083f838fece0f63be121334945", size = 641073, upload-time = "2025-08-07T13:42:57.23Z" },
     { url = "https://files.pythonhosted.org/packages/f7/0b/bc13f787394920b23073ca3b6c4a7a21396301ed75a655bcb47196b50e6e/greenlet-3.2.4-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:710638eb93b1fa52823aa91bf75326f9ecdfd5e0466f00789246a5280f4ba0fc", size = 655191, upload-time = "2025-08-07T13:45:29.752Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/d6/6adde57d1345a8d0f14d31e4ab9c23cfe8e2cd39c3baf7674b4b0338d266/greenlet-3.2.4-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:c5111ccdc9c88f423426df3fd1811bfc40ed66264d35aa373420a34377efc98a", size = 649516, upload-time = "2025-08-07T13:53:16.314Z" },
     { url = "https://files.pythonhosted.org/packages/7f/3b/3a3328a788d4a473889a2d403199932be55b1b0060f4ddd96ee7cdfcad10/greenlet-3.2.4-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d76383238584e9711e20ebe14db6c88ddcedc1829a9ad31a584389463b5aa504", size = 652169, upload-time = "2025-08-07T13:18:32.861Z" },
     { url = "https://files.pythonhosted.org/packages/ee/43/3cecdc0349359e1a527cbf2e3e28e5f8f06d3343aaf82ca13437a9aa290f/greenlet-3.2.4-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:23768528f2911bcd7e475210822ffb5254ed10d71f4028387e5a99b4c6699671", size = 610497, upload-time = "2025-08-07T13:18:31.636Z" },
     { url = "https://files.pythonhosted.org/packages/b8/19/06b6cf5d604e2c382a6f31cafafd6f33d5dea706f4db7bdab184bad2b21d/greenlet-3.2.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:00fadb3fedccc447f517ee0d3fd8fe49eae949e1cd0f6a611818f4f6fb7dc83b", size = 1121662, upload-time = "2025-08-07T13:42:41.117Z" },
@@ -1292,6 +1295,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/22/5c/85273fd7cc388285632b0498dbbab97596e04b154933dfe0f3e68156c68c/greenlet-3.2.4-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:49a30d5fda2507ae77be16479bdb62a660fa51b1eb4928b524975b3bde77b3c0", size = 273586, upload-time = "2025-08-07T13:16:08.004Z" },
     { url = "https://files.pythonhosted.org/packages/d1/75/10aeeaa3da9332c2e761e4c50d4c3556c21113ee3f0afa2cf5769946f7a3/greenlet-3.2.4-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:299fd615cd8fc86267b47597123e3f43ad79c9d8a22bebdce535e53550763e2f", size = 686346, upload-time = "2025-08-07T13:42:59.944Z" },
     { url = "https://files.pythonhosted.org/packages/c0/aa/687d6b12ffb505a4447567d1f3abea23bd20e73a5bed63871178e0831b7a/greenlet-3.2.4-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:c17b6b34111ea72fc5a4e4beec9711d2226285f0386ea83477cbb97c30a3f3a5", size = 699218, upload-time = "2025-08-07T13:45:30.969Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/8b/29aae55436521f1d6f8ff4e12fb676f3400de7fcf27fccd1d4d17fd8fecd/greenlet-3.2.4-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:b4a1870c51720687af7fa3e7cda6d08d801dae660f75a76f3845b642b4da6ee1", size = 694659, upload-time = "2025-08-07T13:53:17.759Z" },
     { url = "https://files.pythonhosted.org/packages/92/2e/ea25914b1ebfde93b6fc4ff46d6864564fba59024e928bdc7de475affc25/greenlet-3.2.4-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:061dc4cf2c34852b052a8620d40f36324554bc192be474b9e9770e8c042fd735", size = 695355, upload-time = "2025-08-07T13:18:34.517Z" },
     { url = "https://files.pythonhosted.org/packages/72/60/fc56c62046ec17f6b0d3060564562c64c862948c9d4bc8aa807cf5bd74f4/greenlet-3.2.4-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:44358b9bf66c8576a9f57a590d5f5d6e72fa4228b763d0e43fee6d3b06d3a337", size = 657512, upload-time = "2025-08-07T13:18:33.969Z" },
     { url = "https://files.pythonhosted.org/packages/23/6e/74407aed965a4ab6ddd93a7ded3180b730d281c77b765788419484cdfeef/greenlet-3.2.4-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:2917bdf657f5859fbf3386b12d68ede4cf1f04c90c3a6bc1f013dd68a22e2269", size = 1612508, upload-time = "2025-11-04T12:42:23.427Z" },
@@ -2421,7 +2425,6 @@ source = { editable = "openhands-tools" }
 dependencies = [
     { name = "bashlex" },
     { name = "binaryornot" },
-    { name = "browser-use" },
     { name = "cachetools" },
     { name = "func-timeout" },
     { name = "libtmux" },
@@ -2430,11 +2433,16 @@ dependencies = [
     { name = "tom-swe" },
 ]
 
+[package.optional-dependencies]
+browser = [
+    { name = "browser-use" },
+]
+
 [package.metadata]
 requires-dist = [
     { name = "bashlex", specifier = ">=0.18" },
     { name = "binaryornot", specifier = ">=0.4.4" },
-    { name = "browser-use", specifier = ">=0.8.0" },
+    { name = "browser-use", marker = "extra == 'browser'", specifier = ">=0.8.0" },
     { name = "cachetools" },
     { name = "func-timeout", specifier = ">=4.3.5" },
     { name = "libtmux", specifier = ">=0.53.0" },
@@ -2442,6 +2450,7 @@ requires-dist = [
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "tom-swe", specifier = ">=1.0.3" },
 ]
+provides-extras = ["browser"]
 
 [[package]]
 name = "openhands-workspace"


### PR DESCRIPTION
## Summary

Merges the three optional dependency PRs into a single branch for benchmark image builds:

- **#2535** — `INSTALL_ACP=false` skips npm ACP packages + nodejs install (~32s/image)
- **#2536** — `INSTALL_BOTO3=false` skips botocore/boto3 (~80MB, ~5-10s/image)
- **#2537** — `INSTALL_BROWSER=false` skips browser-use + playwright (~300-500MB)

### Additional changes in this merge PR

1. **Dockerfile conflict resolution**: Combined the `INSTALL_BOTO3` and `INSTALL_BROWSER` args in both `builder` and `binary-builder` stages using `$([ "$X" = "true" ] && echo "...")` pattern
2. **Skip nodejs entirely when `INSTALL_ACP=false`**: Moved the nodesource/nodejs conditional install inside the ACP guard so we don't install nodejs when ACP isn't needed
3. **`BuildOptions.extra_build_args`**: Added a `dict[str, str]` field to `BuildOptions` (in `build.py`) that gets threaded into the `docker buildx build` command. This lets callers (like the benchmarks repo) pass `INSTALL_ACP=false` etc. without hardcoding in the SDK

### Impact (measured from 433-image build logs)

| Dependency | Per-image saving | Cumulative (433 imgs) |
|---|---|---|
| npm ACP + nodejs | ~32s install + ~4s export/push | **4.5h** |
| browser-use + playwright | ~15s export/push | **1.8h** |
| boto3/botocore | ~3s export/push | **0.4h** |
| **Total** | **~54s/image** | **~6.7h cumulative** |

Wall-clock estimate: **~1.9h saved** (at 3.5x effective parallelism), plus reduced disk pressure from smaller images.

All three build args default to `true`, so existing users see no change.

## Test plan

- [ ] Build a test image with all flags `false`: `docker buildx build --build-arg INSTALL_ACP=false --build-arg INSTALL_BOTO3=false --build-arg INSTALL_BROWSER=false --target source-minimal .`
- [ ] Build a test image with all flags `true` (default): verify no regression
- [ ] Run SWT-bench benchmark build with lightweight flags via benchmarks repo PR
- [ ] Verify browser-use graceful degradation via `tests/tools/test_optional_browser.py`

Supersedes #2516.
Depends on: #2535, #2536, #2537

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dcb136a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dcb136a-python \
  ghcr.io/openhands/agent-server:dcb136a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dcb136a-golang-amd64
ghcr.io/openhands/agent-server:dcb136a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dcb136a-golang-arm64
ghcr.io/openhands/agent-server:dcb136a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dcb136a-java-amd64
ghcr.io/openhands/agent-server:dcb136a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dcb136a-java-arm64
ghcr.io/openhands/agent-server:dcb136a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dcb136a-python-amd64
ghcr.io/openhands/agent-server:dcb136a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:dcb136a-python-arm64
ghcr.io/openhands/agent-server:dcb136a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:dcb136a-golang
ghcr.io/openhands/agent-server:dcb136a-java
ghcr.io/openhands/agent-server:dcb136a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dcb136a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dcb136a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->