### PR TITLE
feat(docker): add extra_build_args to BuildOptions

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -395,6 +395,13 @@ class BuildOptions(BaseModel):
             "(e.g., at each release)."
         ),
     )
+    extra_build_args: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Additional Docker build args to pass to buildx. "
+            "For example, {'INSTALL_ACP': 'false'} to skip ACP installation."
+        ),
+    )
 
     @property
     def short_sha(self) -> str:
@@ -751,6 +758,8 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
         "--build-arg",
         f"OPENHANDS_BUILD_GIT_REF={opts.git_ref}",
     ]
+    for key, value in opts.extra_build_args.items():
+        args += ["--build-arg", f"{key}={value}"]
     if push:
         args += ["--platform", ",".join(opts.platforms), "--push"]
     else:


### PR DESCRIPTION
## Summary

- Add `extra_build_args: dict[str, str]` field to `BuildOptions` so callers can pass additional Docker build args to buildx
- This complements the Dockerfile ARGs added in #2535 (`INSTALL_ACP`) and #2536 (`INSTALL_BOTO3`), which are already on main but had no way to be controlled from the Python build API
- Extracted from #2538 (the umbrella lightweight-images PR) so the benchmarks repo can use it immediately against SDK main

## Changes

`openhands-agent-server/openhands/agent_server/docker/build.py`:
- New `extra_build_args` field on `BuildOptions` (default: empty dict)
- Loop over `extra_build_args` to append `--build-arg key=value` to the buildx command

## Test plan

- [ ] Existing tests pass (no behavior change when `extra_build_args` is empty)
- [ ] Benchmark image build with `extra_build_args={"INSTALL_ACP": "false", "INSTALL_BOTO3": "false"}` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8a09254-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8a09254-python \
  ghcr.io/openhands/agent-server:8a09254-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8a09254-golang-amd64
ghcr.io/openhands/agent-server:8a09254-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8a09254-golang-arm64
ghcr.io/openhands/agent-server:8a09254-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8a09254-java-amd64
ghcr.io/openhands/agent-server:8a09254-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8a09254-java-arm64
ghcr.io/openhands/agent-server:8a09254-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8a09254-python-amd64
ghcr.io/openhands/agent-server:8a09254-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:8a09254-python-arm64
ghcr.io/openhands/agent-server:8a09254-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:8a09254-golang
ghcr.io/openhands/agent-server:8a09254-java
ghcr.io/openhands/agent-server:8a09254-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8a09254-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8a09254-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->