### PR TITLE
feat: support pre-built base images for faster rebuilds

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -9,13 +9,6 @@ ARG UID=10001
 ARG GID=10001
 ARG PORT=8000
 
-# Pre-built base overrides: when set to an image reference (e.g.,
-# ghcr.io/openhands/eval-base:tag), the final target pulls the pre-built
-# base from the registry instead of building base-image-minimal from scratch.
-# Default values reference the build stages defined below.
-ARG SOURCE_MINIMAL_BASE=base-image-minimal
-ARG SOURCE_BASE=base-image
-
 ####################################################################################
 # Builder (source mode)
 # We copy source + build a venv here for local dev and debugging.
@@ -251,13 +244,13 @@ EXPOSE ${PORT} ${NOVNC_PORT}
 # Target A: source
 # Local dev and debugging mode: copy source + venv from builder
 ############################
-FROM ${SOURCE_BASE} AS source
+FROM base-image AS source
 ARG USERNAME
 ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
 ENTRYPOINT ["/agent-server/.venv/bin/python", "-m", "openhands.agent_server"]
 
-FROM ${SOURCE_MINIMAL_BASE} AS source-minimal
+FROM base-image-minimal AS source-minimal
 ARG USERNAME
 ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -28,7 +28,7 @@ import tomllib
 from contextlib import chdir
 from pathlib import Path
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, Field, field_validator
 
 from openhands.sdk.logger import IN_CI, get_logger, rolling_log_view
 from openhands.sdk.workspace import PlatformType, TargetType
@@ -410,16 +410,6 @@ class BuildOptions(BaseModel):
             "For example, {'INSTALL_ACP': 'false'} to skip ACP installation."
         ),
     )
-    prebuilt_base: str | None = Field(
-        default=None,
-        description=(
-            "Pre-built base image to use instead of building base-image-minimal "
-            "from scratch. When set, the Dockerfile's SOURCE_MINIMAL_BASE / "
-            "SOURCE_BASE ARG is overridden, skipping the base-image-minimal "
-            "build stage entirely. Only applies to source-minimal and source "
-            "targets; raises ValueError for other targets."
-        ),
-    )
 
     @property
     def short_sha(self) -> str:
@@ -431,15 +421,6 @@ class BuildOptions(BaseModel):
         if v not in VALID_TARGETS:
             raise ValueError(f"target must be one of {sorted(VALID_TARGETS)}")
         return v
-
-    @model_validator(mode="after")
-    def _validate_prebuilt_base(self) -> "BuildOptions":
-        if self.prebuilt_base and self.target not in ("source-minimal", "source"):
-            raise ValueError(
-                f"prebuilt_base is only supported for source-minimal and source "
-                f"targets, got target={self.target}"
-            )
-        return self
 
     @property
     def custom_tag_list(self) -> list[str]:
@@ -794,17 +775,6 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
     ]
     for key, value in opts.extra_build_args.items():
         args += ["--build-arg", f"{key}={value}"]
-
-    # When a pre-built base is provided, override the Dockerfile ARG so the
-    # final target pulls the cached base from the registry instead of building
-    # base-image-minimal from scratch.
-    if opts.prebuilt_base:
-        target_arg = {
-            "source-minimal": "SOURCE_MINIMAL_BASE",
-            "source": "SOURCE_BASE",
-        }.get(opts.target)
-        if target_arg:
-            args += ["--build-arg", f"{target_arg}={opts.prebuilt_base}"]
 
     if push:
         args += ["--platform", ",".join(opts.platforms), "--push"]


### PR DESCRIPTION
## Summary
Add explicit Docker build targets that support phased benchmark image builds.

This PR adds support for building these stages directly from the SDK Dockerfile:
- `base-image-minimal`
- `base-image`
- `builder`

It also keeps the base-only build path efficient by using an empty build context for targets that do not need the SDK source tree.

## What This Enables
The benchmarks repo can use the SDK Dockerfile as the source of truth for the shared image components:

1. build and push one shared `builder` image keyed by SDK SHA
2. build and push per-instance `base-image-minimal` images keyed by SWE-bench instance tag
3. assemble final benchmark images in the benchmarks repo from those prebuilt pieces

This keeps the SDK side focused on exposing the reusable build primitives, while the benchmarks repo owns orchestration.

## Changes
- Add `builder`, `base-image-minimal`, and `base-image` as valid build targets in [`build.py`](https://github.com/OpenHands/software-agent-sdk/pull/2542/files)
- Add the same targets to `TargetType`
- Use an empty temp-dir build context for base-only targets instead of building an SDK sdist unnecessarily
- Keep the normal image targets and default Dockerfile behavior unchanged

## Backward Compatibility
Existing builds for the standard targets continue to work as before. This PR extends the target surface; it does not replace the normal build flow.

## Dependency
Used by:
- OpenHands/benchmarks#555

## Validation
- Python API breakage checks passed
- REST API breakage checks passed
- Type checks passed








<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f3c8e24-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f3c8e24-python \
  ghcr.io/openhands/agent-server:f3c8e24-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f3c8e24-golang-amd64
ghcr.io/openhands/agent-server:f3c8e24-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f3c8e24-golang-arm64
ghcr.io/openhands/agent-server:f3c8e24-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f3c8e24-java-amd64
ghcr.io/openhands/agent-server:f3c8e24-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f3c8e24-java-arm64
ghcr.io/openhands/agent-server:f3c8e24-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f3c8e24-python-amd64
ghcr.io/openhands/agent-server:f3c8e24-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:f3c8e24-python-arm64
ghcr.io/openhands/agent-server:f3c8e24-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:f3c8e24-golang
ghcr.io/openhands/agent-server:f3c8e24-java
ghcr.io/openhands/agent-server:f3c8e24-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f3c8e24-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f3c8e24-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->