### PR TITLE
Add training data cutoff guidance to CURRENT_DATETIME section

### DIFF
--- a/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2
+++ b/openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2
@@ -1,6 +1,8 @@
 {% if current_datetime %}
 <CURRENT_DATETIME>
 The current date and time is: {{ current_datetime }}
+
+Note: Your training data may have a cutoff date earlier than the current date shown above. When evaluating dates, CVE identifiers (e.g., CVE-2026-*), security advisories, or other time-sensitive information, trust the system clock above rather than assumptions based on your training data. Information from years beyond your training cutoff is valid if the current date confirms we are in or past that year.
 </CURRENT_DATETIME>
 {% endif %}
 {% if repo_skills %}


### PR DESCRIPTION
## Problem

Agents may become suspicious of dates, CVE identifiers, or other time-sensitive information from years beyond the LLM's training data cutoff. For example, an agent trained on 2025 data might incorrectly flag CVE-2026-* identifiers as invalid or suspicious, even when the system clock shows we are in 2026.

Related issue: https://github.com/OpenHands/extensions/pull/116

## Solution

Added explicit guidance in the `<CURRENT_DATETIME>` section of the dynamic context telling the agent:
1. Its training data may have a cutoff date earlier than the current system clock
2. When evaluating time-sensitive information (CVEs, dates, security advisories), trust the system clock
3. Information from years beyond the training cutoff is valid if the current date confirms we are in that year

## Changes

Modified `openhands-sdk/openhands/sdk/context/prompts/templates/system_message_suffix.j2`:
- Added note about training data cutoff in the `<CURRENT_DATETIME>` section
- Instructs the agent to trust the system clock over training data assumptions

## Example Output

```xml
<CURRENT_DATETIME>
The current date and time is: 2026-03-22T18:24:56.703651

Note: Your training data may have a cutoff date earlier than the current date shown above. When evaluating dates, CVE identifiers (e.g., CVE-2026-*), security advisories, or Note: Your training data may have a cutoff date earlier than t raNote: YourassNote: Your training data may have a cutoff date earlier than the current date shown above. When evalutheNote: Your training data may have a cutoff date earlier than the current date s
#########################################################################################################time` is set
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:aec7ae8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-aec7ae8-python \
  ghcr.io/openhands/agent-server:aec7ae8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:aec7ae8-golang-amd64
ghcr.io/openhands/agent-server:aec7ae8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:aec7ae8-golang-arm64
ghcr.io/openhands/agent-server:aec7ae8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:aec7ae8-java-amd64
ghcr.io/openhands/agent-server:aec7ae8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:aec7ae8-java-arm64
ghcr.io/openhands/agent-server:aec7ae8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:aec7ae8-python-amd64
ghcr.io/openhands/agent-server:aec7ae8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:aec7ae8-python-arm64
ghcr.io/openhands/agent-server:aec7ae8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:aec7ae8-golang
ghcr.io/openhands/agent-server:aec7ae8-java
ghcr.io/openhands/agent-server:aec7ae8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `aec7ae8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `aec7ae8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->