### PR TITLE
fix(sdk): stop sending reasoning_effort to Kimi thinking

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
+from functools import cache
 
-from litellm.utils import supports_reasoning
+from litellm import get_supported_openai_params
 
 
 def model_matches(model: str, patterns: list[str]) -> bool:
@@ -54,24 +55,26 @@ class ModelFeatures:
 LITELLM_PROXY_PREFIX = "litellm_proxy/"
 
 
-def _supports_reasoning_effort(model: str | None) -> bool:
-    """Return True if the model supports reasoning_effort via LiteLLM.
-
-    We pass the full model string to LiteLLM so it can run its own provider
-    parsing logic (including nested provider paths like `openrouter/anthropic/...`
-    and other special cases).
-
-    We only strip our `litellm_proxy/` wrapper prefix, since it is not a real
-    LiteLLM provider.
-    """
+@cache
+def _normalized_supported_openai_params(model: str | None) -> frozenset[str]:
+    """Return LiteLLM-supported OpenAI params for a normalized model name."""
     if not model:
-        return False
+        return frozenset()
 
     normalized = model.strip().lower()
     if normalized.startswith(LITELLM_PROXY_PREFIX):
         normalized = normalized.removeprefix(LITELLM_PROXY_PREFIX)
 
-    return bool(supports_reasoning(model=normalized, custom_llm_provider=None))
+    params = get_supported_openai_params(
+        model=normalized,
+        custom_llm_provider=None,
+    )
+    return frozenset(params or ())
+
+
+def _supports_reasoning_effort(model: str | None) -> bool:
+    """Return True if LiteLLM says the model accepts reasoning_effort."""
+    return "reasoning_effort" in _normalized_supported_openai_params(model)
 
 
 EXTENDED_THINKING_MODELS: list[str] = [

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -60,6 +60,18 @@ def test_gpt5_uses_reasoning_effort_and_strips_temp_top_p():
     assert "top_p" not in out
 
 
+def test_kimi_k2_thinking_does_not_send_reasoning_effort():
+    llm = DummyLLM(
+        model="litellm_proxy/moonshot/kimi-k2-thinking",
+        temperature=1.0,
+        reasoning_effort="high",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    assert "reasoning_effort" not in out
+    assert out.get("temperature") == 1.0
+
+
 def test_gemini_2_5_pro_without_reasoning_effort_preserves_temp_and_top_p():
     llm = DummyLLM(model="gemini-2.5-pro", reasoning_effort=None)
     out = select_chat_options(llm, user_kwargs={}, has_tools=True)

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -45,6 +45,11 @@ def test_model_matches(name, pattern, expected):
         ("gemini-1.5-pro", False),
         # DeepSeek Reasoner
         ("deepseek/deepseek-reasoner", True),
+        # Moonshot Kimi thinking models expose reasoning content but do not
+        # accept the reasoning_effort parameter.
+        ("moonshot/kimi-k2.5", False),
+        ("moonshot/kimi-k2-thinking", False),
+        ("litellm_proxy/moonshot/kimi-k2-thinking", False),
         # OpenRouter docs list these as reasoning models, but LiteLLM capability
         # metadata does not currently mark them as reasoning-capable.
         ("openrouter/moonshotai/kimi-k2.5", False),


### PR DESCRIPTION
@enyst

## Summary
- stop treating Moonshot Kimi thinking models as `reasoning_effort`-capable
- derive `supports_reasoning_effort` from LiteLLM's supported OpenAI params instead of generic reasoning support
- add regressions for Kimi model feature detection and chat option normalization

## Context
Follow-up to the Kimi-K2 thinking failures discussed on the v1.14.1 release PR. The execution path was:
- `select_chat_options()` checks `get_features(...).supports_reasoning_effort`
- `get_features()` called `_supports_reasoning_effort()`
- that used `litellm.utils.supports_reasoning(...)`
- LiteLLM reports Moonshot Kimi thinking as a reasoning model, but it does not accept the `reasoning_effort` param
- the SDK then forwarded `reasoning_effort`, and LiteLLM rejected the request with `UnsupportedParamsError`

This change makes the gate match the param we actually send by checking LiteLLM's supported params table for `reasoning_effort`.

## Testing
- `uv run pytest tests/sdk/llm/test_model_features.py tests/sdk/llm/test_chat_options.py`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/model_features.py tests/sdk/llm/test_model_features.py tests/sdk/llm/test_chat_options.py`

## Notes
`LLM.drop_params` is still `True` by default. This fix is intentionally not relying on silent dropping; instead it prevents the SDK from sending a param that LiteLLM says the model does not support.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:47046e3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-47046e3-python \
  ghcr.io/openhands/agent-server:47046e3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:47046e3-golang-amd64
ghcr.io/openhands/agent-server:47046e3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:47046e3-golang-arm64
ghcr.io/openhands/agent-server:47046e3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:47046e3-java-amd64
ghcr.io/openhands/agent-server:47046e3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:47046e3-java-arm64
ghcr.io/openhands/agent-server:47046e3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:47046e3-python-amd64
ghcr.io/openhands/agent-server:47046e3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:47046e3-python-arm64
ghcr.io/openhands/agent-server:47046e3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:47046e3-golang
ghcr.io/openhands/agent-server:47046e3-java
ghcr.io/openhands/agent-server:47046e3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `47046e3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `47046e3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->