### PR TITLE
fix: add diagnostics for preflight proxy failures

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -405,8 +405,8 @@ def _check_proxy_reachable(base_url: str, timeout: int = 10) -> tuple[bool, str]
     Tests TCP connectivity with a short timeout so we fail fast with a clear
     message instead of hanging for 60s on each model check.
     """
-    import urllib.request
     import urllib.error
+    import urllib.request
 
     health_url = f"{base_url.rstrip('/')}/health"
     try:
@@ -475,9 +475,7 @@ def run_preflight_check(models: list[dict[str, Any]]) -> bool:
         print(f"✓ All {len(models)} model(s) passed preflight check\n", flush=True)
     else:
         print("✗ Some models failed preflight check", flush=True)
-        print(
-            "Evaluation aborted to avoid wasting compute resources.\n", flush=True
-        )
+        print("Evaluation aborted to avoid wasting compute resources.\n", flush=True)
 
     return all_passed
 


### PR DESCRIPTION
## Summary
- When the LiteLLM proxy is down, `resolve_model_config.py` hangs silently until GH Actions kills it with SIGTERM (exit 143), producing **zero output** — making it impossible to diagnose why eval runs fail
- Add SIGTERM signal handler that prints proxy URL and diagnostic message before exiting
- Add fast HTTP health check (`GET /health`, 10s timeout) before attempting model completions — fails immediately with a clear error instead of hanging for 60s per model
- Flush all output so GH Actions logs show progress even if the process is killed mid-flight

## Context
Multiple eval runs failed today with `exit code 143` at the "Resolve model configurations" step. The only visible info was the step name — no error message, no URL, no indication of what went wrong. This was caused by the LiteLLM proxy being temporarily unreachable.

## Test plan
- [ ] Verify existing preflight checks still pass when proxy is up
- [ ] Verify clear error message when proxy is down (e.g., `LLM_BASE_URL=http://localhost:1`)
- [ ] Verify SIGTERM handler prints diagnostic before exit

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f9c1867-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f9c1867-python \
  ghcr.io/openhands/agent-server:f9c1867-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f9c1867-golang-amd64
ghcr.io/openhands/agent-server:f9c1867-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f9c1867-golang-arm64
ghcr.io/openhands/agent-server:f9c1867-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f9c1867-java-amd64
ghcr.io/openhands/agent-server:f9c1867-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f9c1867-java-arm64
ghcr.io/openhands/agent-server:f9c1867-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f9c1867-python-amd64
ghcr.io/openhands/agent-server:f9c1867-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:f9c1867-python-arm64
ghcr.io/openhands/agent-server:f9c1867-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:f9c1867-golang
ghcr.io/openhands/agent-server:f9c1867-java
ghcr.io/openhands/agent-server:f9c1867-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f9c1867-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f9c1867-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->