### PR TITLE
fix(sdk): pin LiteLLM version exactly

### DIFF
--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -11,7 +11,7 @@ dependencies = [
     "fastmcp>=3.0.0",
     "filelock>=3.20.1",
     "httpx>=0.27.0",
-    "litellm>=1.80.10",
+    "litellm==1.80.10",
     "pydantic>=2.12.5",
     "python-frontmatter>=1.1.0",
     "python-json-logger>=3.3.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2404,7 +2404,7 @@ requires-dist = [
     { name = "fastmcp", specifier = ">=3.0.0" },
     { name = "filelock", specifier = ">=3.20.1" },
     { name = "httpx", specifier = ">=0.27.0" },
-    { name = "litellm", specifier = ">=1.80.10" },
+    { name = "litellm", specifier = "==1.80.10" },
     { name = "lmnr", specifier = ">=0.7.24" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },


### PR DESCRIPTION
## Summary

- pin `litellm` exactly to `1.80.10` in `openhands-sdk/pyproject.toml`
- update `uv.lock` to keep the workspace lock metadata aligned
- tighten unlocked installs such as `pip install openhands-sdk` against the malicious `litellm==1.82.8` wheel reported in `BerriAI/litellm#24512`

## Validation

- `uv run pre-commit run --files openhands-sdk/pyproject.toml uv.lock`
- `uv sync --frozen --group dev`

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ed2c02e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ed2c02e-python \
  ghcr.io/openhands/agent-server:ed2c02e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ed2c02e-golang-amd64
ghcr.io/openhands/agent-server:ed2c02e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ed2c02e-golang-arm64
ghcr.io/openhands/agent-server:ed2c02e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ed2c02e-java-amd64
ghcr.io/openhands/agent-server:ed2c02e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ed2c02e-java-arm64
ghcr.io/openhands/agent-server:ed2c02e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ed2c02e-python-amd64
ghcr.io/openhands/agent-server:ed2c02e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:ed2c02e-python-arm64
ghcr.io/openhands/agent-server:ed2c02e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:ed2c02e-golang
ghcr.io/openhands/agent-server:ed2c02e-java
ghcr.io/openhands/agent-server:ed2c02e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ed2c02e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ed2c02e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->