### PR TITLE
Fix run-eval to use locked LiteLLM dependency

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -184,6 +184,12 @@ jobs:
               with:
                   python-version: '3.13'
 
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: latest
+                  python-version: '3.13'
+
             - name: Validate eval_limit
               if: github.event_name == 'workflow_dispatch'
               run: |
@@ -200,15 +206,15 @@ jobs:
               run: |
                   python3 .github/run-eval/validate_sdk_ref.py
 
-            - name: Install dependencies
+            - name: Sync locked workspace dependencies
               run: |
-                  pip install 'litellm>=1.81.0'
+                  uv sync --frozen
 
             - name: Load model IDs from Python script
               id: load-models
               run: |
                   # Extract all model IDs from resolve_model_config.py
-                  ALLOWED_MODEL_IDS=$(python3 << 'EOF'
+                  ALLOWED_MODEL_IDS=$(uv run python << 'EOF'
                   import sys
                   sys.path.insert(0, '.github/run-eval')
                   from resolve_model_config import MODELS
@@ -311,7 +317,7 @@ jobs:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY_EVAL }}
                   LLM_BASE_URL: https://llm-proxy.eval.all-hands.dev
               run: |
-                  python3 .github/run-eval/resolve_model_config.py
+                  uv run python .github/run-eval/resolve_model_config.py
 
             - name: Dispatch evaluation workflow
               env:


### PR DESCRIPTION
## Summary
- replace the ad hoc `pip install 'litellm>=1.81.0'` in `run-eval.yml` with the repo's locked `uv` environment
- run the model-resolution scripts through `uv run python` so they use the synced workspace environment
- keep the workflow aligned with the other CI jobs that already use `setup-uv` + `uv sync --frozen`

## Why
`run-eval.yml` was bypassing `uv.lock` and pulling the latest PyPI LiteLLM release at runtime. That is how the affected March 24, 2026 runs installed `litellm-1.82.8` even though the repository lockfile pins `litellm==1.80.10`.

Using `uv sync --frozen` keeps `run-eval` on the reviewed, locked dependency set and follows the same pattern used elsewhere in this repo.

## Validation
- `uv sync --frozen`
- `uv run python <<'EOF' ... import MODELS ... EOF`
- `MODEL_IDS=claude-sonnet-4-5-20250929 GITHUB_OUTPUT=/tmp/run-eval-output SKIP_PREFLIGHT=true uv run python .github/run-eval/resolve_model_config.py`
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8d844d1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8d844d1-python \
  ghcr.io/openhands/agent-server:8d844d1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8d844d1-golang-amd64
ghcr.io/openhands/agent-server:8d844d1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8d844d1-golang-arm64
ghcr.io/openhands/agent-server:8d844d1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8d844d1-java-amd64
ghcr.io/openhands/agent-server:8d844d1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8d844d1-java-arm64
ghcr.io/openhands/agent-server:8d844d1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8d844d1-python-amd64
ghcr.io/openhands/agent-server:8d844d1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:8d844d1-python-arm64
ghcr.io/openhands/agent-server:8d844d1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:8d844d1-golang
ghcr.io/openhands/agent-server:8d844d1-java
ghcr.io/openhands/agent-server:8d844d1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8d844d1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8d844d1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->