### PR TITLE
fix(ci): rename PAT secret to PAT_TOKEN

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -190,7 +190,7 @@ jobs:
             - name: Run task
               env:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
                   PYTHONPATH: ''
               run: |
                   echo "Running agent script: $AGENT_SCRIPT_URL"

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Add needs-triage label
               uses: actions/github-script@v8
               with:
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   script: |
                       // Get the issue details
                       const issue = context.payload.issue;

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Trigger docs repo sync
               uses: peter-evans/repository-dispatch@v4
               with:
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
                   repository: OpenHands/docs
                   event-type: update
                   client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
               if: steps.check-fork.outputs.is_fork == 'false'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Remove .pr/ directory
               id: remove

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -47,5 +47,5 @@ jobs:
                   # Review style: roasted (other option: standard)
                   review-style: roasted
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v5
               with:
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -69,7 +69,7 @@ jobs:
 
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  GH_TOKEN: ${{ secrets.PAT_TOKEN }}
               run: |
                   cat > pr_body.txt << 'EOF'
                   ## Release v${{ inputs.version }}

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -235,7 +235,7 @@ jobs:
               env:
                   DEFAULT_MODEL: ${{ steps.load-models.outputs.default_model }}
                   ALLOWED_MODEL_IDS_JSON: ${{ steps.load-models.outputs.allowed_model_ids }}
-                  PAT_TOKEN_DEFAULT: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  PAT_TOKEN_DEFAULT: ${{ secrets.PAT_TOKEN }}
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
             - uses: actions/stale@v10
               with:
-                  repo-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  repo-token: ${{ secrets.PAT_TOKEN }}
                   stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a 
                       comment, otherwise it will be closed in 10 days.
                   stale-pr-message: This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment,

--- a/.github/workflows/todo-management.yml
+++ b/.github/workflows/todo-management.yml
@@ -130,7 +130,7 @@ jobs:
               uses: actions/checkout@v5
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  token: ${{ secrets.PAT_TOKEN }}
 
             - name: Switch to feature branch with TODO management files
               run: |
@@ -170,7 +170,7 @@ jobs:
                   LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929
                   LLM_BASE_URL: https://llm-proxy.app.all-hands.dev
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+                  GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
                   TODO_FILE: ${{ matrix.todo.file }}
                   TODO_LINE: ${{ matrix.todo.line }}

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -24,7 +24,7 @@ jobs:
             (github.event.workflow_run.conclusion == 'success' &&
              github.event.workflow_run.event == 'release')
         env:
-            GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
+            GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         steps:
             - name: Checkout
               uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Renames `ALLHANDS_BOT_GITHUB_PAT` → `PAT_TOKEN` across all 10 workflow files (12 references)
- The old secret was removed/expired, causing all eval runs and other CI workflows to fail with "Missing PAT token"
- The new `PAT_TOKEN` secret has already been configured in repo settings

## Affected workflows
- `run-eval.yml` — eval dispatch (blocking all evaluations)
- `assign-reviews.yml`
- `auto-label-issues.yml`
- `deploy-docs.yml`
- `pr-artifacts.yml`
- `pr-review-by-openhands.yml`
- `prepare-release.yml`
- `stale.yml`
- `todo-management.yml`
- `version-bump-prs.yml`

## Test plan
- [ ] Merge and trigger an eval run to confirm the PAT_TOKEN secret is picked up
- [ ] Verify other workflows (stale, auto-label, etc.) still function

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0f75ac8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0f75ac8-python \
  ghcr.io/openhands/agent-server:0f75ac8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0f75ac8-golang-amd64
ghcr.io/openhands/agent-server:0f75ac8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0f75ac8-golang-arm64
ghcr.io/openhands/agent-server:0f75ac8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0f75ac8-java-amd64
ghcr.io/openhands/agent-server:0f75ac8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0f75ac8-java-arm64
ghcr.io/openhands/agent-server:0f75ac8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0f75ac8-python-amd64
ghcr.io/openhands/agent-server:0f75ac8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:0f75ac8-python-arm64
ghcr.io/openhands/agent-server:0f75ac8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:0f75ac8-golang
ghcr.io/openhands/agent-server:0f75ac8-java
ghcr.io/openhands/agent-server:0f75ac8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0f75ac8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0f75ac8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->