### PR TITLE
fix(ci): handle dict-valued json_schema_extra in API breakage checker

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -298,12 +298,79 @@ def ensure_griffe() -> None:
         raise SystemExit(1)
 
 
+def _strip_balanced_param(text: str, param: str) -> str:
+    """Remove a keyword parameter whose value may contain nested delimiters.
+
+    Handles values like ``json_schema_extra={'key': {'nested': True}}`` where a
+    simple regex cannot reliably match the balanced braces/parens/brackets.
+
+    Returns *text* with the ``param=<value>`` fragment (and any surrounding
+    comma) removed.
+    """
+    pattern = re.compile(rf",?\s*{re.escape(param)}\s*=\s*")
+    match = pattern.search(text)
+    if not match:
+        return text
+
+    start = match.start()
+    pos = match.end()
+    if pos >= len(text):
+        return text
+
+    # Track balanced delimiters to find where the value ends.
+    openers = {"(": ")", "[": "]", "{": "}"}
+    closers = {")", "]", "}"}
+    stack: list[str] = []
+    in_string: str | None = None
+
+    while pos < len(text):
+        ch = text[pos]
+
+        # Handle string literals (skip their contents).
+        if in_string:
+            if ch == "\\" and pos + 1 < len(text):
+                pos += 2
+                continue
+            if ch == in_string:
+                in_string = None
+            pos += 1
+            continue
+
+        if ch in ("'", '"'):
+            in_string = ch
+            pos += 1
+            continue
+
+        if ch in openers:
+            stack.append(openers[ch])
+            pos += 1
+            continue
+
+        if ch in closers:
+            if stack:
+                stack.pop()
+                pos += 1
+                if not stack:
+                    break
+                continue
+            # Unmatched closer — end of value.
+            break
+
+        # At depth 0, a comma or closing paren ends the value.
+        if not stack and ch in (",", ")"):
+            break
+
+        pos += 1
+
+    return text[:start] + text[pos:]
+
+
 def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
     """Check if the change is only in Field metadata (description, title, etc.).
 
-    Field metadata parameters like ``description``, ``title``, ``examples``, and
-    ``deprecated`` don't affect runtime behavior. Changes to these should not be
-    considered breaking API changes.
+    Field metadata parameters like ``description``, ``title``, ``examples``,
+    ``json_schema_extra``, and ``deprecated`` don't affect runtime behavior.
+    Changes to these should not be considered breaking API changes.
 
     Returns:
         True if both values are Field() calls and only metadata parameters differ.
@@ -314,21 +381,29 @@ def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
     if not (old_str.startswith("Field(") and new_str.startswith("Field(")):
         return False
 
-    # Metadata parameters that don't affect runtime behavior.
+    # Simple metadata parameters whose values are always plain quoted strings
+    # or simple literals.
     # See https://docs.pydantic.dev/latest/api/fields/#pydantic.fields.Field
-    metadata_patterns = {
+    simple_metadata_patterns = {
         "description": r'([\'"])([^\'"]*?)\1',
         "title": r'([\'"])([^\'"]*?)\1',
         "examples": r'([\'"])([^\'"]*?)\1',
-        "json_schema_extra": r'([\'"])([^\'"]*?)\1',
         "deprecated": r"(?:True|False|None|'[^']*'|\"[^\"]*\")",
     }
 
+    # Parameters whose values can be complex nested structures (dicts, function
+    # calls, etc.) and need balanced-delimiter parsing instead of a regex.
+    balanced_params = ("json_schema_extra",)
+
     def _normalize(value: str) -> str:
         normalized = value
-        for param, value_pattern in metadata_patterns.items():
+
+        for param, value_pattern in simple_metadata_patterns.items():
             pattern = rf",?\s*{param}\s*=\s*{value_pattern}"
             normalized = re.sub(pattern, "", normalized)
+
+        for param in balanced_params:
+            normalized = _strip_balanced_param(normalized, param)
 
         normalized = re.sub(r"\(\s*,", "(", normalized)
         normalized = re.sub(r",\s*\)", ")", normalized)

--- a/tests/ci_scripts/test_check_sdk_api_breakage.py
+++ b/tests/ci_scripts/test_check_sdk_api_breakage.py
@@ -480,6 +480,37 @@ def test_is_field_metadata_only_change_added_deprecated_kwarg():
     assert _is_field_metadata_only_change(old, new) is True
 
 
+def test_is_field_metadata_only_change_json_schema_extra_dict():
+    """Adding json_schema_extra with a dict value is metadata-only."""
+    old = "Field(default='claude-sonnet-4-20250514', description='Model name.')"
+    new = (
+        "Field(default='claude-sonnet-4-20250514', description='Model name.', "
+        "json_schema_extra={'openhands_settings': "
+        "{'label': None, 'prominence': 'critical', 'depends_on': []}})"
+    )
+    assert _is_field_metadata_only_change(old, new) is True
+
+
+def test_is_field_metadata_only_change_json_schema_extra_function_call():
+    """Adding json_schema_extra with a function call value is metadata-only."""
+    old = "Field(default=None, description='API key.')"
+    new = (
+        "Field(default=None, description='API key.', "
+        "json_schema_extra=field_meta(SettingProminence.CRITICAL, label='API Key'))"
+    )
+    assert _is_field_metadata_only_change(old, new) is True
+
+
+def test_is_field_metadata_only_change_json_schema_extra_with_real_change():
+    """json_schema_extra + real default change is NOT metadata-only."""
+    old = "Field(default='old-model', description='Model name.')"
+    new = (
+        "Field(default='new-model', description='Model name.', "
+        "json_schema_extra={'key': 'value'})"
+    )
+    assert _is_field_metadata_only_change(old, new) is False
+
+
 def test_field_deprecated_change_is_not_breaking(tmp_path):
     """Field deprecated metadata changes should not count as breaking changes."""
     old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
@@ -580,5 +611,56 @@ def test_field_description_change_is_not_breaking(tmp_path):
         _SDK_CFG,
     )
     # Field description changes should NOT count as breaking
+    assert total_breaks == 0
+    assert undeprecated == 0
+
+
+def test_field_json_schema_extra_dict_is_not_breaking(tmp_path):
+    """Adding json_schema_extra with a dict value should not be breaking."""
+    old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
+    new_pkg = _write_pkg_init(tmp_path, "new", ["Config"])
+
+    old_init = old_pkg / "__init__.py"
+    new_init = new_pkg / "__init__.py"
+
+    old_init.write_text(
+        old_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    model: str = Field(\n"
+        + "        default='claude-sonnet-4-20250514',\n"
+        + "        description='Model name.',\n"
+        + "    )\n"
+    )
+    new_init.write_text(
+        new_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    model: str = Field(\n"
+        + "        default='claude-sonnet-4-20250514',\n"
+        + "        description='Model name.',\n"
+        + "        json_schema_extra={\n"
+        + "            'settings': {\n"
+        + "                'label': None,\n"
+        + "                'prominence': 'critical',\n"
+        + "            }\n"
+        + "        },\n"
+        + "    )\n"
+    )
+
+    old_root = griffe.load(
+        "openhands.sdk",
+        search_paths=[str(tmp_path / "old")],
+    )
+    new_root = griffe.load(
+        "openhands.sdk",
+        search_paths=[str(tmp_path / "new")],
+    )
+
+    total_breaks, undeprecated = _prod._compute_breakages(
+        old_root,
+        new_root,
+        _SDK_CFG,
+    )
     assert total_breaks == 0
     assert undeprecated == 0


### PR DESCRIPTION
## Summary
- replace the regex-only `json_schema_extra` matcher with balanced-delimiter parsing
- treat dict-valued and function-call `json_schema_extra` Field metadata as non-breaking
- add regression tests for metadata-only and real-breaking cases

## Validation
- `make build`
- `uv run pre-commit run --files .github/scripts/check_sdk_api_breakage.py tests/ci_scripts/test_check_sdk_api_breakage.py`
- `uv run pytest tests/ci_scripts/test_check_sdk_api_breakage.py`