### PR TITLE
chore: remove INSTALL_BOTO3 and INSTALL_ACP build args

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -30,9 +30,8 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-sdk ./openhands-sdk
 COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
-ARG INSTALL_BOTO3=true
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv python install 3.13 && uv venv --python 3.13 .venv && uv sync --frozen --no-editable --managed-python $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3")
+    uv python install 3.13 && uv venv --python 3.13 .venv && uv sync --frozen --no-editable --managed-python --extra boto3
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -41,10 +40,9 @@ RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
 FROM builder AS binary-builder
 ARG USERNAME UID GID
 
-ARG INSTALL_BOTO3=true
 # We need --dev for pyinstaller
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv sync --frozen --dev --no-editable $([ "$INSTALL_BOTO3" = "true" ] && echo "--extra boto3")
+    uv sync --frozen --dev --no-editable --extra boto3
 
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
     uv run pyinstaller openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -83,17 +81,13 @@ RUN set -eux; \
 
 # Pre-install ACP servers for ACPAgent support (Claude Code + Codex)
 # Install Node.js/npm if not present (SWE-bench base images may lack them)
-# Set INSTALL_ACP=false to skip ACP installation (e.g. for benchmark images)
-ARG INSTALL_ACP=true
 RUN set -eux; \
     if ! command -v npm >/dev/null 2>&1; then \
         curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
         apt-get install -y --no-install-recommends nodejs && \
         rm -rf /var/lib/apt/lists/*; \
     fi; \
-    if [ "$INSTALL_ACP" = "true" ]; then \
-        npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp; \
-    fi
+    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp
 
 # Configure Claude Code managed settings for headless operation:
 # Allow all tool permissions (no human in the loop to approve).

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -405,10 +405,7 @@ class BuildOptions(BaseModel):
     )
     extra_build_args: dict[str, str] = Field(
         default_factory=dict,
-        description=(
-            "Additional Docker build args to pass to buildx. "
-            "For example, {'INSTALL_ACP': 'false'} to skip ACP installation."
-        ),
+        description="Additional Docker build args to pass to buildx.",
     )
 
     @property


### PR DESCRIPTION
## Summary
- Remove `ARG INSTALL_BOTO3` from Dockerfile — always install the `boto3` extra
- Remove `ARG INSTALL_ACP` from Dockerfile — always install ACP servers
- Clean up stale `INSTALL_ACP` example in `BuildOptions.extra_build_args` description

All images now unconditionally include boto3 and ACP deps. The conditional ARGs added unnecessary complexity for negligible size savings.

Closes #2569

## Test plan
- [ ] CI builds the Docker image successfully without the removed ARGs
- [ ] Benchmark images include boto3 and ACP deps as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:16ad7b5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-16ad7b5-python \
  ghcr.io/openhands/agent-server:16ad7b5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:16ad7b5-golang-amd64
ghcr.io/openhands/agent-server:16ad7b5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:16ad7b5-golang-arm64
ghcr.io/openhands/agent-server:16ad7b5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:16ad7b5-java-amd64
ghcr.io/openhands/agent-server:16ad7b5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:16ad7b5-java-arm64
ghcr.io/openhands/agent-server:16ad7b5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:16ad7b5-python-amd64
ghcr.io/openhands/agent-server:16ad7b5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:16ad7b5-python-arm64
ghcr.io/openhands/agent-server:16ad7b5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:16ad7b5-golang
ghcr.io/openhands/agent-server:16ad7b5-java
ghcr.io/openhands/agent-server:16ad7b5-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `16ad7b5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `16ad7b5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->