### PR TITLE
fix(ci): allow additive response oneOf expansion in oasdiff checker

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -25,11 +25,19 @@ Policies enforced:
      declare a scheduled removal version that has been reached by the current
      package version.
 
-3) No in-place contract breakage
+3) Additive response oneOf/anyOf expansion is allowed
+   - Adding new members to ``oneOf`` or ``anyOf`` discriminated unions in response
+     schemas is a normal evolution for extensible event-stream APIs.  Clients MUST
+     handle unknown discriminator values gracefully (skip/ignore).
+   - oasdiff flags ``response-body-one-of-added`` and
+     ``response-property-one-of-added`` as ERR; this script downgrades them to
+     informational notices.
+
+4) No in-place contract breakage
    - Breaking REST contract changes that are not removals of previously-deprecated
-     operations fail the check. REST clients need 5 minor releases of runway, so
-     incompatible replacements must ship additively or behind a versioned contract
-     until the scheduled removal version.
+     operations or additive oneOf expansions fail the check. REST clients need 5
+     minor releases of runway, so incompatible replacements must ship additively or
+     behind a versioned contract until the scheduled removal version.
 
 If the baseline release schema can't be generated (e.g., missing tag / repo issues),
 the script emits a warning and exits successfully to avoid flaky CI.
@@ -410,11 +418,32 @@ def _validate_removed_operations(
     return errors
 
 
+# oasdiff rule IDs for additive oneOf/anyOf expansion in response schemas.
+# These are flagged as ERR by oasdiff but are expected evolution for extensible
+# discriminated-union APIs (e.g. the events endpoint).  We downgrade them to
+# informational notices so they don't block CI.
+_ADDITIVE_RESPONSE_ONEOF_IDS = frozenset(
+    {
+        "response-body-one-of-added",
+        "response-property-one-of-added",
+        # anyOf variants are already INFO in oasdiff and won't appear in the
+        # breaking list, but include them for completeness / future-proofing.
+        "response-body-any-of-added",
+        "response-property-any-of-added",
+    }
+)
+
+
 def _split_breaking_changes(
     breaking_changes: list[dict],
-) -> tuple[list[dict], list[dict]]:
-    """Split oasdiff results into removals and all other breakages."""
+) -> tuple[list[dict], list[dict], list[dict]]:
+    """Split oasdiff results into three buckets.
+
+    Returns:
+        (removed_operations, additive_response_oneof, other_breaking_changes)
+    """
     removed_operations: list[dict] = []
+    additive_response_oneof: list[dict] = []
     other_breaking_changes: list[dict] = []
 
     for change in breaking_changes:
@@ -431,9 +460,13 @@ def _split_breaking_changes(
             )
             continue
 
+        if change_id in _ADDITIVE_RESPONSE_ONEOF_IDS:
+            additive_response_oneof.append(change)
+            continue
+
         other_breaking_changes.append(change)
 
-    return removed_operations, other_breaking_changes
+    return removed_operations, additive_response_oneof, other_breaking_changes
 
 
 def _normalize_openapi_for_oasdiff(schema: dict) -> dict:
@@ -570,9 +603,11 @@ def main() -> int:
                 "in JSON format. There may be warnings only."
             )
     else:
-        removed_operations, other_breaking_changes = _split_breaking_changes(
-            breaking_changes
-        )
+        (
+            removed_operations,
+            additive_response_oneof,
+            other_breaking_changes,
+        ) = _split_breaking_changes(breaking_changes)
         removal_errors = _validate_removed_operations(
             removed_operations,
             prev_schema,
@@ -582,11 +617,22 @@ def main() -> int:
         for error in removal_errors:
             print(f"::error title={PYPI_DISTRIBUTION} REST API::{error}")
 
+        if additive_response_oneof:
+            print(
+                f"\n::notice title={PYPI_DISTRIBUTION} REST API::"
+                "Additive oneOf/anyOf expansion detected in response schemas. "
+                "This is expected for extensible discriminated-union APIs and "
+                "does not break backward compatibility."
+            )
+            for item in additive_response_oneof:
+                print(f"  - {item.get('text', str(item))}")
+
         if other_breaking_changes:
             print(
                 "::error "
                 f"title={PYPI_DISTRIBUTION} REST API::Detected breaking REST API "
-                "changes other than removing previously-deprecated operations. "
+                "changes other than removing previously-deprecated operations "
+                "or additive response oneOf expansions. "
                 "REST contract changes must preserve compatibility for 5 minor "
                 "releases; keep the old contract available until its scheduled "
                 "removal version."
@@ -599,7 +645,8 @@ def main() -> int:
         if not (removal_errors or other_breaking_changes):
             print(
                 "Breaking changes are limited to previously-deprecated operations "
-                "whose scheduled removal versions have been reached."
+                "whose scheduled removal versions have been reached, and/or "
+                "additive response oneOf expansions."
             )
         else:
             return 1

--- a/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
+++ b/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
@@ -408,6 +408,112 @@ def test_main_rejects_non_removal_breakage_even_with_newer_version(monkeypatch, 
     assert "other than removing previously-deprecated operations" in captured.out
 
 
+def test_split_breaking_changes_separates_three_buckets():
+    changes = [
+        {
+            "id": "removed-operation",
+            "details": {"path": "/foo", "method": "get", "deprecated": True},
+            "text": "removed GET /foo",
+        },
+        {
+            "id": "response-property-one-of-added",
+            "details": {},
+            "text": "added '#/components/schemas/NewTool' to response oneOf",
+        },
+        {
+            "id": "response-body-one-of-added",
+            "details": {},
+            "text": "added body oneOf member",
+        },
+        {
+            "id": "response-body-changed",
+            "details": {},
+            "text": "response body changed",
+        },
+    ]
+    removed, additive_oneof, other = _prod._split_breaking_changes(changes)
+    assert len(removed) == 1
+    assert removed[0]["path"] == "/foo"
+    assert len(additive_oneof) == 2
+    assert additive_oneof[0]["id"] == "response-property-one-of-added"
+    assert additive_oneof[1]["id"] == "response-body-one-of-added"
+    assert len(other) == 1
+    assert other[0]["id"] == "response-body-changed"
+
+
+def test_main_passes_when_only_additive_oneof(monkeypatch, capsys):
+    monkeypatch.setattr(_prod, "_read_version_from_pyproject", lambda _path: "1.15.0")
+    monkeypatch.setattr(
+        _prod, "_get_baseline_version", lambda _distribution, _current: "1.14.0"
+    )
+    monkeypatch.setattr(_prod, "_find_sdk_deprecated_fastapi_routes", lambda _root: [])
+    monkeypatch.setattr(_prod, "_generate_current_openapi", lambda: {"paths": {}})
+    monkeypatch.setattr(_prod, "_find_deprecation_policy_errors", lambda _schema: [])
+    monkeypatch.setattr(
+        _prod, "_generate_openapi_for_git_ref", lambda _ref: {"paths": {}}
+    )
+    monkeypatch.setattr(_prod, "_normalize_openapi_for_oasdiff", lambda schema: schema)
+    monkeypatch.setattr(
+        _prod,
+        "_run_oasdiff_breakage_check",
+        lambda _prev, _cur: (
+            [
+                {
+                    "id": "response-property-one-of-added",
+                    "details": {},
+                    "text": "added NewTool to response oneOf",
+                }
+            ],
+            1,
+        ),
+    )
+
+    assert _prod.main() == 0
+
+    captured = capsys.readouterr()
+    assert "Additive oneOf/anyOf expansion detected" in captured.out
+    assert "additive response oneOf expansions" in captured.out
+
+
+def test_main_fails_when_additive_oneof_mixed_with_real_breakage(monkeypatch, capsys):
+    monkeypatch.setattr(_prod, "_read_version_from_pyproject", lambda _path: "1.15.0")
+    monkeypatch.setattr(
+        _prod, "_get_baseline_version", lambda _distribution, _current: "1.14.0"
+    )
+    monkeypatch.setattr(_prod, "_find_sdk_deprecated_fastapi_routes", lambda _root: [])
+    monkeypatch.setattr(_prod, "_generate_current_openapi", lambda: {"paths": {}})
+    monkeypatch.setattr(_prod, "_find_deprecation_policy_errors", lambda _schema: [])
+    monkeypatch.setattr(
+        _prod, "_generate_openapi_for_git_ref", lambda _ref: {"paths": {}}
+    )
+    monkeypatch.setattr(_prod, "_normalize_openapi_for_oasdiff", lambda schema: schema)
+    monkeypatch.setattr(
+        _prod,
+        "_run_oasdiff_breakage_check",
+        lambda _prev, _cur: (
+            [
+                {
+                    "id": "response-property-one-of-added",
+                    "details": {},
+                    "text": "added NewTool to response oneOf",
+                },
+                {
+                    "id": "response-body-changed",
+                    "details": {},
+                    "text": "response body changed",
+                },
+            ],
+            1,
+        ),
+    )
+
+    assert _prod.main() == 1
+
+    captured = capsys.readouterr()
+    assert "Additive oneOf/anyOf expansion detected" in captured.out
+    assert "other than removing previously-deprecated operations" in captured.out
+
+
 def test_normalize_openapi_converts_numeric_exclusive_bounds():
     schema = {
         "components": {


### PR DESCRIPTION
## Summary

The oasdiff breaking-change checker now classifies additive `oneOf`/`anyOf` expansion in response schemas as **informational notices** rather than errors.

## Motivation

oasdiff flags `response-body-one-of-added` and `response-property-one-of-added` as `ERR`, because a strict/generated client with an exhaustive match on discriminator values would choke on an unknown type.

However, the events endpoint is fundamentally an **extensible discriminated union**. Every time we add a new tool type, action type, or observation type, the response schema grows. This is the standard evolution pattern for event-stream APIs (GitHub webhooks, Stripe events, etc.). Blocking these expansions in CI means the system can't grow without a false-positive failure.

The right contract for consumers: **handle unknown discriminator values gracefully** (skip/ignore).

## What changed

`_split_breaking_changes` now returns three buckets instead of two:

1. **Removed operations** — validated against deprecation runway (unchanged)
2. **Additive response oneOf/anyOf expansion** — logged as `::notice`, does not fail CI (new)
3. **Other breaking changes** — fails CI (unchanged)

Rule IDs downgraded:
- `response-body-one-of-added`
- `response-property-one-of-added`
- `response-body-any-of-added` (future-proofing)
- `response-property-any-of-added` (future-proofing)

## What is NOT allowed

- Removing a `oneOf` member from a response (narrows what clients can expect)
- Adding to request `oneOf` if it changes required input semantics
- Any change that modifies the shape of an existing schema member
- All existing deprecation runway policies remain intact

## Tests

Added 3 new tests:
- `test_split_breaking_changes_separates_three_buckets` — unit test for the three-way split
- `test_main_passes_when_only_additive_oneof` — CI passes when the only breaking change is additive oneOf
- `test_main_fails_when_additive_oneof_mixed_with_real_breakage` — CI still fails when real breakage is mixed in

All 21 tests pass.

Closes #2491 (originated from the review discussion there)
