### PR TITLE
fix(ci): allow additive response oneOf expansion in oasdiff checker

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -426,8 +426,9 @@ _ADDITIVE_RESPONSE_ONEOF_IDS = frozenset(
     {
         "response-body-one-of-added",
         "response-property-one-of-added",
-        # anyOf variants are already INFO in oasdiff and won't appear in the
-        # breaking list, but include them for completeness / future-proofing.
+        # Keep the anyOf variants here too so that if oasdiff ever reports them
+        # as breakages, additive response-union expansion gets the same
+        # downgrade without further script changes.
         "response-body-any-of-added",
         "response-property-any-of-added",
     }

--- a/openhands-agent-server/openhands/agent_server/README.md
+++ b/openhands-agent-server/openhands/agent_server/README.md
@@ -152,6 +152,18 @@ This provides a complete reference for all available endpoints, request/response
 - **`POST /conversations/{conversation_id}/events`**: Send a message to the agent
 - **`WebSocket /conversations/{conversation_id}/events/socket`**: Real-time event streaming
 
+### Event schema compatibility
+
+The event endpoints use extensible discriminated unions in their OpenAPI
+response schemas. New event, action, observation, or tool variants may be added
+over time as the platform grows.
+
+If you build a generated or hand-written client, treat discriminator values
+such as `kind` as open-ended: **skip or ignore unknown variants instead of
+assuming the current set is exhaustive**. This keeps clients
+forward-compatible when the server starts returning newer event types.
+
+
 ## WebSocket Communication
 
 The server supports WebSocket connections for real-time communication with agents:

--- a/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
+++ b/tests/ci_scripts/test_check_agent_server_rest_api_breakage.py
@@ -426,6 +426,11 @@ def test_split_breaking_changes_separates_three_buckets():
             "text": "added body oneOf member",
         },
         {
+            "id": "response-body-any-of-added",
+            "details": {},
+            "text": "added body anyOf member",
+        },
+        {
             "id": "response-body-changed",
             "details": {},
             "text": "response body changed",
@@ -434,9 +439,11 @@ def test_split_breaking_changes_separates_three_buckets():
     removed, additive_oneof, other = _prod._split_breaking_changes(changes)
     assert len(removed) == 1
     assert removed[0]["path"] == "/foo"
-    assert len(additive_oneof) == 2
-    assert additive_oneof[0]["id"] == "response-property-one-of-added"
-    assert additive_oneof[1]["id"] == "response-body-one-of-added"
+    assert {change["id"] for change in additive_oneof} == {
+        "response-property-one-of-added",
+        "response-body-one-of-added",
+        "response-body-any-of-added",
+    }
     assert len(other) == 1
     assert other[0]["id"] == "response-body-changed"
 


### PR DESCRIPTION
## Summary

The oasdiff breaking-change checker now classifies additive `oneOf`/`anyOf` expansion in response schemas as **informational notices** rather than errors.

## Motivation

oasdiff flags `response-body-one-of-added` and `response-property-one-of-added` as `ERR`, because a strict/generated client with an exhaustive match on discriminator values would choke on an unknown type.

However, the events endpoint is fundamentally an **extensible discriminated union**. Every time we add a new tool type, action type, or observation type, the response schema grows. This is the standard evolution pattern for event-stream APIs (GitHub webhooks, Stripe events, etc.). Blocking these expansions in CI means the system can't grow without a false-positive failure.

The right contract for consumers: **handle unknown discriminator values gracefully** (skip/ignore).

## What changed

`_split_breaking_changes` now returns three buckets instead of two:

1. **Removed operations** — validated against deprecation runway (unchanged)
2. **Additive response oneOf/anyOf expansion** — logged as `::notice`, does not fail CI (new)
3. **Other breaking changes** — fails CI (unchanged)

Rule IDs downgraded:
- `response-body-one-of-added`
- `response-property-one-of-added`
- `response-body-any-of-added` (future-proofing)
- `response-property-any-of-added` (future-proofing)

## What is NOT allowed

- Removing a `oneOf` member from a response (narrows what clients can expect)
- Adding to request `oneOf` if it changes required input semantics
- Any change that modifies the shape of an existing schema member
- All existing deprecation runway policies remain intact

## Tests

Added 3 new tests:
- `test_split_breaking_changes_separates_three_buckets` — unit test for the three-way split
- `test_main_passes_when_only_additive_oneof` — CI passes when the only breaking change is additive oneOf
- `test_main_fails_when_additive_oneof_mixed_with_real_breakage` — CI still fails when real breakage is mixed in

All 21 tests pass.

Closes #2491 (originated from the review discussion there)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d81d0fc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d81d0fc-python \
  ghcr.io/openhands/agent-server:d81d0fc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d81d0fc-golang-amd64
ghcr.io/openhands/agent-server:d81d0fc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d81d0fc-golang-arm64
ghcr.io/openhands/agent-server:d81d0fc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d81d0fc-java-amd64
ghcr.io/openhands/agent-server:d81d0fc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d81d0fc-java-arm64
ghcr.io/openhands/agent-server:d81d0fc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d81d0fc-python-amd64
ghcr.io/openhands/agent-server:d81d0fc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:d81d0fc-python-arm64
ghcr.io/openhands/agent-server:d81d0fc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:d81d0fc-golang
ghcr.io/openhands/agent-server:d81d0fc-java
ghcr.io/openhands/agent-server:d81d0fc-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d81d0fc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d81d0fc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->