### PR TITLE
fix: pin runtime base image digest to unblock binary builds

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -3,7 +3,10 @@
 # NOTE: LC_ALL/LANG must be set to C.UTF-8 for libtmux to work correctly with
 # PyInstaller builds. Without proper locale, tmux converts UTF-8 separator
 # characters to underscores, breaking libtmux's format parsing.
-ARG BASE_IMAGE=nikolaik/python-nodejs:python3.13-nodejs22
+# Pinned to last known working digest (2025-03-23, glibc 2.41-12+deb13u1).
+# glibc deb13u2 breaks PyInstaller binaries by rejecting PT_GNU_STACK RWX
+# on libpython3.13.so.1.0. See OpenHands/benchmarks#573.
+ARG BASE_IMAGE=nikolaik/python-nodejs:python3.13-nodejs22@sha256:93e0bac86ea94f9956dc43c515cf77c2356a85de27128df4225de8c0b79425b2
 ARG USERNAME=openhands
 ARG UID=10001
 ARG GID=10001


### PR DESCRIPTION
## Summary

- Pins `nikolaik/python-nodejs:python3.13-nodejs22` to the last known working digest (`sha256:93e0bac...`, glibc `2.41-12+deb13u1`)
- One-line fix to unblock all GAIA evaluations (100% error rate since Mar 25)

## Root cause

The upstream base image was rebuilt between Mar 23–25, pulling in glibc `2.41-12+deb13u2` (Debian Trixie). This glibc patch tightened NX-stack enforcement — the dynamic linker now rejects `libpython3.13.so.1.0` which has `PT_GNU_STACK RWX`, causing every PyInstaller binary to crash with `[PYI-37:ERROR] cannot enable executable stack`.

No SDK code changed between the last successful build and the failing one. The Dockerfile, PyInstaller spec, and Python version are identical.

| | Working (Mar 23) | Broken (Mar 25) |
|---|---|---|
| **Image digest** | `sha256:93e0bac86ea9...` | `sha256:ba34d3dc43ac...` |
| **glibc** | `2.41-12+deb13u1` | `2.41-12+deb13u2` |

## Test plan

- [ ] Build a `binary` target image and verify the agent server starts on a sysbox-runc node
- [ ] Run a GAIA evaluation and confirm instances complete

Fixes OpenHands/benchmarks#573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c08d156-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c08d156-python \
  ghcr.io/openhands/agent-server:c08d156-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c08d156-golang-amd64
ghcr.io/openhands/agent-server:c08d156-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c08d156-golang-arm64
ghcr.io/openhands/agent-server:c08d156-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c08d156-java-amd64
ghcr.io/openhands/agent-server:c08d156-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c08d156-java-arm64
ghcr.io/openhands/agent-server:c08d156-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c08d156-python-amd64
ghcr.io/openhands/agent-server:c08d156-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:c08d156-python-arm64
ghcr.io/openhands/agent-server:c08d156-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:c08d156-golang
ghcr.io/openhands/agent-server:c08d156-java
ghcr.io/openhands/agent-server:c08d156-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c08d156-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c08d156-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->