### PR TITLE
feat: add qwen tool preset (bash + str_replace aliases for Anthropic schema compatibility)

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -33,9 +33,9 @@ on:
                 type: string
             tool_preset:
                 description: >-
-                    Tool preset for file editing (default, gemini, gpt5, planning).
+                    Tool preset for file editing (default, gemini, gpt5, nemotron, planning, qwen).
                     'default' uses FileEditorTool, 'gemini' uses read_file/write_file/edit/list_directory,
-                    'gpt5' uses apply_patch tool.
+                    'gpt5' uses apply_patch tool, 'nemotron' and 'qwen' use bash/str_replace (Anthropic schema).
                 required: false
                 default: default
                 type: choice
@@ -43,7 +43,9 @@ on:
                     - default
                     - gemini
                     - gpt5
+                    - nemotron
                     - planning
+                    - qwen
     schedule:
         - cron: 30 22 * * * # Runs at 10:30pm UTC every day
 

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -93,7 +93,8 @@ on:
                 description: >-
                     Tool preset for file editing. 'default' uses FileEditorTool,
                     'gemini' uses read_file/write_file/edit/list_directory,
-                    'gpt5' uses apply_patch tool.
+                    'gpt5' uses apply_patch tool, 'nemotron' and 'qwen' use
+                    bash/str_replace (Anthropic schema).
                 required: false
                 default: default
                 type: choice
@@ -101,7 +102,9 @@ on:
                     - default
                     - gemini
                     - gpt5
+                    - nemotron
                     - planning
+                    - qwen
             agent_type:
                 description: >-
                     Agent type: 'default' for standard Agent,

--- a/openhands-tools/openhands/tools/nemotron/__init__.py
+++ b/openhands-tools/openhands/tools/nemotron/__init__.py
@@ -1,0 +1,73 @@
+"""Nemotron-compatible tools (Anthropic bash/str_replace schema).
+
+Nemotron-3 Super (nvidia/nemotron-3-super-120b-a12b) was fine-tuned on
+trajectories that use the Anthropic str_replace_based_edit_tool / bash
+tool schema. This module exposes those exact tool names so the model's
+calls succeed without any prompt engineering or model-side changes.
+
+  bash        → BashExecutor        (model calls "bash", not "terminal")
+  str_replace → StrReplaceExecutor  (model calls "str_replace", not "file_editor")
+
+Tools:
+    - bash: Run shell commands (Anthropic-compatible)
+    - str_replace: File viewing and editing operations (Anthropic-compatible)
+
+Usage:
+    To use Nemotron-compatible tools instead of the standard terminal/file_editor:
+
+    ```python
+    from openhands.tools.nemotron import NEMOTRON_TOOLS
+
+    agent = Agent(
+        llm=llm,
+        tools=[
+            *NEMOTRON_TOOLS,
+            Tool(name=TaskTrackerTool.name),
+        ],
+    )
+    ```
+
+    Or use the preset:
+
+    ```python
+    from openhands.tools.preset.nemotron import get_nemotron_agent
+
+    agent = get_nemotron_agent(llm=llm)
+    ```
+"""
+
+from openhands.sdk import Tool
+from openhands.tools.nemotron.bash import (
+    BashAction,
+    BashExecutor,
+    BashObservation,
+    BashTool,
+)
+from openhands.tools.nemotron.str_replace import (
+    StrReplaceAction,
+    StrReplaceExecutor,
+    StrReplaceObservation,
+    StrReplaceTool,
+)
+
+
+# Convenience list for easy replacement of terminal/file_editor tools
+NEMOTRON_TOOLS: list[Tool] = [
+    Tool(name=BashTool.name),
+    Tool(name=StrReplaceTool.name),
+]
+
+__all__ = [
+    # Convenience list
+    "NEMOTRON_TOOLS",
+    # Bash tool
+    "BashTool",
+    "BashAction",
+    "BashObservation",
+    "BashExecutor",
+    # StrReplace tool
+    "StrReplaceTool",
+    "StrReplaceAction",
+    "StrReplaceObservation",
+    "StrReplaceExecutor",
+]

--- a/openhands-tools/openhands/tools/nemotron/bash/__init__.py
+++ b/openhands-tools/openhands/tools/nemotron/bash/__init__.py
@@ -1,0 +1,15 @@
+# Core tool interface
+from openhands.tools.nemotron.bash.definition import (
+    BashAction,
+    BashObservation,
+    BashTool,
+)
+from openhands.tools.nemotron.bash.impl import BashExecutor
+
+
+__all__ = [
+    "BashTool",
+    "BashAction",
+    "BashObservation",
+    "BashExecutor",
+]

--- a/openhands-tools/openhands/tools/nemotron/bash/definition.py
+++ b/openhands-tools/openhands/tools/nemotron/bash/definition.py
@@ -1,0 +1,253 @@
+"""Bash tool definition (Nemotron/Anthropic-compatible).
+
+This is a thin wrapper around TerminalExecutor that exposes the tool as "bash"
+instead of "terminal", matching Anthropic's bash tool schema exactly.
+"""
+
+import os
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from pydantic import Field
+from rich.text import Text
+
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    register_tool,
+)
+from openhands.tools.terminal.constants import (
+    MAX_CMD_OUTPUT_SIZE,
+    NO_CHANGE_TIMEOUT_SECONDS,
+)
+from openhands.tools.terminal.metadata import CmdOutputMetadata
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+from openhands.sdk.llm import ImageContent, TextContent
+from openhands.sdk.utils import maybe_truncate
+
+
+class BashAction(Action):
+    """Schema for bash command execution (Anthropic-compatible).
+
+    This matches the Anthropic bash tool schema exactly:
+    - command: str (required)
+    """
+
+    command: str = Field(
+        description=(
+            "The bash command to execute. Can be empty string to view additional "
+            "logs when previous exit code is `-1`. Can be `C-c` (Ctrl+C) to "
+            "interrupt the currently running process. Note: You can only execute "
+            "one bash command at a time. If you need to run multiple commands "
+            "sequentially, you can use `&&` or `;` to chain them together."
+        )
+    )
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation with PS1-style bash prompt."""
+        content = Text()
+        content.append("$ ", style="bold green")
+        if self.command:
+            content.append(self.command, style="white")
+        else:
+            content.append("[empty command]", style="italic")
+        return content
+
+
+class BashObservation(Observation):
+    """A ToolResult that can be rendered as a CLI output."""
+
+    command: str | None = Field(
+        description=(
+            "The bash command that was executed. Can be empty string if the "
+            "observation is from a previous command that hit soft timeout and "
+            "is not yet finished."
+        ),
+    )
+    exit_code: int | None = Field(
+        default=None,
+        description=(
+            "The exit code of the command. -1 indicates the process hit the "
+            "soft timeout and is not yet finished."
+        ),
+    )
+    timeout: bool = Field(
+        default=False, description="Whether the command execution timed out."
+    )
+    metadata: CmdOutputMetadata = Field(
+        default_factory=CmdOutputMetadata,
+        description="Additional metadata captured from PS1 after command execution.",
+    )
+    full_output_save_dir: str | None = Field(
+        default=None,
+        description="Directory where full output files are saved",
+    )
+
+    @property
+    def command_id(self) -> int | None:
+        """Get the command ID from metadata."""
+        return self.metadata.pid
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent | ImageContent]:
+        llm_content: list[TextContent | ImageContent] = []
+
+        if self.is_error:
+            llm_content.append(TextContent(text=self.ERROR_MESSAGE_HEADER))
+
+        content_text = self.text
+
+        ret = f"{self.metadata.prefix}{content_text}{self.metadata.suffix}"
+        if self.metadata.working_dir:
+            ret += f"\n[Current working directory: {self.metadata.working_dir}]"
+        if self.metadata.py_interpreter_path:
+            ret += f"\n[Python interpreter: {self.metadata.py_interpreter_path}]"
+        if self.metadata.exit_code != -1:
+            ret += f"\n[Command finished with exit code {self.metadata.exit_code}]"
+
+        truncated_text = maybe_truncate(
+            content=ret,
+            truncate_after=MAX_CMD_OUTPUT_SIZE,
+            save_dir=self.full_output_save_dir,
+            tool_prefix="bash",
+        )
+        llm_content.append(TextContent(text=truncated_text))
+
+        return llm_content
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation with terminal-style output formatting."""
+        text = Text()
+
+        if self.is_error:
+            text.append("❌ ", style="red bold")
+            text.append(self.ERROR_MESSAGE_HEADER, style="bold red")
+
+        content_text = self.text
+
+        if content_text:
+            output_lines = content_text.split("\n")
+            for line in output_lines:
+                if line.strip():
+                    if any(
+                        keyword in line.lower()
+                        for keyword in ["error", "failed", "exception", "traceback"]
+                    ):
+                        text.append(line, style="red")
+                    elif any(
+                        keyword in line.lower() for keyword in ["warning", "warn"]
+                    ):
+                        text.append(line, style="yellow")
+                    elif line.startswith("+ "):
+                        text.append(line, style="cyan")
+                    else:
+                        text.append(line, style="white")
+                text.append("\n")
+
+        if hasattr(self, "metadata") and self.metadata:
+            if self.metadata.working_dir:
+                text.append("\n📁 ", style="blue")
+                text.append(
+                    f"Working directory: {self.metadata.working_dir}", style="blue"
+                )
+
+            if self.metadata.py_interpreter_path:
+                text.append("\n🐍 ", style="green")
+                text.append(
+                    f"Python interpreter: {self.metadata.py_interpreter_path}",
+                    style="green",
+                )
+
+            if (
+                hasattr(self.metadata, "exit_code")
+                and self.metadata.exit_code is not None
+            ):
+                if self.metadata.exit_code == 0:
+                    text.append("\n✅ ", style="green")
+                    text.append(f"Exit code: {self.metadata.exit_code}", style="green")
+                elif self.metadata.exit_code == -1:
+                    text.append("\n⏳ ", style="yellow")
+                    text.append("Process still running (soft timeout)", style="yellow")
+                else:
+                    text.append("\n❌ ", style="red")
+                    text.append(f"Exit code: {self.metadata.exit_code}", style="red")
+
+        return text
+
+
+TOOL_DESCRIPTION = f"""Run a shell command and return stdout/stderr.
+
+### Command Execution
+* One command at a time: You can only execute one bash command at a time. \
+If you need to run multiple commands sequentially, use `&&` or `;` to chain \
+them together.
+* Persistent session: Commands execute in a persistent shell session where \
+environment variables, virtual environments, and working directory persist \
+between commands.
+* Soft timeout: Commands have a soft timeout of {NO_CHANGE_TIMEOUT_SECONDS} \
+seconds, once that's reached, you have the option to continue or interrupt the \
+command.
+
+### Long-running Commands
+* For commands that may run indefinitely, run them in the background and \
+redirect output to a file, e.g. `python3 app.py > server.log 2>&1 &`.
+* If a bash command returns exit code `-1`, this means the process hit the \
+soft timeout and is not yet finished. Send empty `command` to retrieve \
+additional logs or send `C-c` to interrupt.
+
+### Output Handling
+* Output truncation: If the output exceeds a maximum length, it will be \
+truncated before being returned.
+"""
+
+
+class BashTool(ToolDefinition[BashAction, BashObservation]):
+    """Bash tool (Anthropic-compatible) that wraps TerminalExecutor."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: "ConversationState",
+    ) -> Sequence["BashTool"]:
+        """Initialize BashTool with executor parameters.
+
+        Args:
+            conv_state: Conversation state to get working directory from.
+        """
+        from openhands.tools.nemotron.bash.impl import BashExecutor
+
+        working_dir = conv_state.workspace.working_dir
+        if not os.path.isdir(working_dir):
+            raise ValueError(f"working_dir '{working_dir}' is not a valid directory")
+
+        executor = BashExecutor(
+            working_dir=working_dir,
+            full_output_save_dir=conv_state.env_observation_persistence_dir,
+        )
+
+        return [
+            cls(
+                action_type=BashAction,
+                observation_type=BashObservation,
+                description=TOOL_DESCRIPTION,
+                annotations=ToolAnnotations(
+                    title="bash",
+                    readOnlyHint=False,
+                    destructiveHint=True,
+                    idempotentHint=False,
+                    openWorldHint=True,
+                ),
+                executor=executor,
+            )
+        ]
+
+
+register_tool(BashTool.name, BashTool)

--- a/openhands-tools/openhands/tools/nemotron/bash/impl.py
+++ b/openhands-tools/openhands/tools/nemotron/bash/impl.py
@@ -1,0 +1,148 @@
+"""Bash executor implementation (Nemotron/Anthropic-compatible).
+
+This executor wraps TerminalExecutor to provide Anthropic-compatible bash tool.
+"""
+
+import json
+from typing import TYPE_CHECKING
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.tool import ToolExecutor
+from openhands.tools.nemotron.bash.definition import BashAction, BashObservation
+from openhands.tools.terminal.definition import TerminalAction
+from openhands.tools.terminal.terminal.factory import create_terminal_session
+from openhands.tools.terminal.terminal.terminal_session import TerminalSession
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation import LocalConversation
+
+
+logger = get_logger(__name__)
+
+
+class BashExecutor(ToolExecutor[BashAction, BashObservation]):
+    """Bash executor that wraps TerminalSession for Anthropic compatibility."""
+
+    session: TerminalSession
+
+    def __init__(
+        self,
+        working_dir: str,
+        full_output_save_dir: str | None = None,
+    ):
+        """Initialize BashExecutor.
+
+        Args:
+            working_dir: Working directory for bash commands
+            full_output_save_dir: Path to directory to save full output
+                                  logs and files, used when truncation is needed.
+        """
+        self.session = create_terminal_session(
+            work_dir=working_dir,
+            username=None,
+            no_change_timeout_seconds=None,
+            terminal_type=None,  # Auto-detect
+            shell_path=None,
+        )
+        self.session.initialize()
+        self.full_output_save_dir = full_output_save_dir
+        logger.info(f"BashExecutor initialized with working_dir: {working_dir}")
+
+    def _export_envs(
+        self, action: BashAction, conversation: "LocalConversation | None" = None
+    ) -> None:
+        if not action.command.strip():
+            return
+
+        env_vars = {}
+        if conversation is not None:
+            try:
+                secret_registry = conversation.state.secret_registry
+                env_vars = secret_registry.get_secrets_as_env_vars(action.command)
+            except Exception:
+                env_vars = {}
+
+        if not env_vars:
+            return
+
+        export_statements = []
+        for key, value in env_vars.items():
+            export_statements.append(f"export {key}={json.dumps(value)}")
+        exports_cmd = " && ".join(export_statements)
+
+        logger.debug(f"Exporting {len(env_vars)} environment variables before command")
+
+        _ = self.session.execute(
+            TerminalAction(
+                command=exports_cmd,
+                is_input=False,
+                timeout=None,
+            )
+        )
+
+    def __call__(
+        self,
+        action: BashAction,
+        conversation: "LocalConversation | None" = None,
+    ) -> BashObservation:
+        # Reset if session is closed
+        if self.session._closed:
+            original_work_dir = self.session.work_dir
+            self.session = create_terminal_session(
+                work_dir=original_work_dir,
+                username=None,
+                no_change_timeout_seconds=None,
+                terminal_type=None,
+                shell_path=None,
+            )
+            self.session.initialize()
+
+        # Export environment variables if needed
+        self._export_envs(action, conversation)
+
+        # Convert BashAction to TerminalAction
+        terminal_action = TerminalAction(
+            command=action.command,
+            is_input=False,
+            timeout=None,
+        )
+
+        # Execute using terminal session
+        terminal_obs = self.session.execute(terminal_action)
+
+        # Convert TerminalObservation to BashObservation
+        observation = BashObservation(
+            content=terminal_obs.content,
+            is_error=terminal_obs.is_error,
+            command=terminal_obs.command,
+            exit_code=terminal_obs.exit_code,
+            timeout=terminal_obs.timeout,
+            metadata=terminal_obs.metadata,
+            full_output_save_dir=self.full_output_save_dir,
+        )
+
+        # Apply automatic secrets masking
+        content_text = observation.text
+        if content_text and conversation is not None:
+            try:
+                secret_registry = conversation.state.secret_registry
+                masked_content = secret_registry.mask_secrets_in_output(content_text)
+                if masked_content:
+                    data = observation.model_dump(
+                        exclude={"content", "full_output_save_dir"}
+                    )
+                    return BashObservation.from_text(
+                        text=masked_content,
+                        full_output_save_dir=self.full_output_save_dir,
+                        **data,
+                    )
+            except Exception:
+                pass
+
+        return observation
+
+    def close(self) -> None:
+        """Close the terminal session and clean up resources."""
+        if hasattr(self, "session"):
+            self.session.close()

--- a/openhands-tools/openhands/tools/nemotron/str_replace/__init__.py
+++ b/openhands-tools/openhands/tools/nemotron/str_replace/__init__.py
@@ -1,0 +1,15 @@
+# Core tool interface
+from openhands.tools.nemotron.str_replace.definition import (
+    StrReplaceAction,
+    StrReplaceObservation,
+    StrReplaceTool,
+)
+from openhands.tools.nemotron.str_replace.impl import StrReplaceExecutor
+
+
+__all__ = [
+    "StrReplaceTool",
+    "StrReplaceAction",
+    "StrReplaceObservation",
+    "StrReplaceExecutor",
+]

--- a/openhands-tools/openhands/tools/nemotron/str_replace/definition.py
+++ b/openhands-tools/openhands/tools/nemotron/str_replace/definition.py
@@ -1,0 +1,262 @@
+"""String replace tool definition (Nemotron/Anthropic-compatible).
+
+This is a thin wrapper around FileEditorExecutor that exposes the tool as
+"str_replace" instead of "file_editor", matching Anthropic's
+str_replace_based_edit_tool schema exactly.
+"""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Literal
+
+from pydantic import Field, PrivateAttr
+from rich.text import Text
+
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    register_tool,
+)
+from openhands.tools.file_editor.utils.diff import visualize_diff
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+
+CommandLiteral = Literal["view", "create", "str_replace", "insert", "undo_edit"]
+
+
+class StrReplaceAction(Action):
+    """Schema for str_replace operations (Anthropic-compatible).
+
+    This matches Anthropic's str_replace_based_edit_tool schema.
+    """
+
+    command: CommandLiteral = Field(
+        description=(
+            'The commands to run. Allowed options are: "view", "create", '
+            '"str_replace", "insert", "undo_edit".'
+        )
+    )
+    path: str = Field(description="Absolute path to file or directory.")
+    file_text: str | None = Field(
+        default=None,
+        description=(
+            "Required parameter of `create` command, with the content of "
+            "the file to be created."
+        ),
+    )
+    old_str: str | None = Field(
+        default=None,
+        description=(
+            "Required parameter of `str_replace` command containing the "
+            "string in `path` to replace."
+        ),
+    )
+    new_str: str | None = Field(
+        default=None,
+        description=(
+            "Optional parameter of `str_replace` command containing the "
+            "new string (if not given, no string will be added). Required parameter "
+            "of `insert` command containing the string to insert."
+        ),
+    )
+    insert_line: int | None = Field(
+        default=None,
+        ge=0,
+        description=(
+            "Required parameter of `insert` command. The `new_str` will "
+            "be inserted AFTER the line `insert_line` of `path`."
+        ),
+    )
+    view_range: list[int] | None = Field(
+        default=None,
+        description=(
+            "Optional parameter of `view` command when `path` points to a "
+            "file. If none is given, the full file is shown. If provided, the file "
+            "will be shown in the indicated line number range, e.g. [11, 12] will "
+            "show lines 11 and 12. Indexing at 1 to start. Setting `[start_line, "
+            "-1]` shows all lines from `start_line` to the end of the file."
+        ),
+    )
+
+
+class StrReplaceObservation(Observation):
+    """A ToolResult that can be rendered as a CLI output."""
+
+    command: CommandLiteral = Field(
+        description=(
+            "The command that was run: `view`, `create`, `str_replace`, "
+            "`insert`, or `undo_edit`."
+        )
+    )
+
+    path: str | None = Field(default=None, description="The file path that was edited.")
+    prev_exist: bool = Field(
+        default=True,
+        description=(
+            "Indicates if the file previously existed. If not, it was created."
+        ),
+    )
+    old_content: str | None = Field(
+        default=None, description="The content of the file before the edit."
+    )
+    new_content: str | None = Field(
+        default=None, description="The content of the file after the edit."
+    )
+
+    _diff_cache: Text | None = PrivateAttr(default=None)
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation of this observation."""
+        text = Text()
+
+        if self.is_error:
+            text.append("❌ ", style="red bold")
+            text.append(self.ERROR_MESSAGE_HEADER, style="bold red")
+
+        if not self._has_meaningful_diff:
+            return super().visualize
+
+        assert self.path is not None, "path should be set for meaningful diff"
+        if not self._diff_cache:
+            change_applied = self.command != "view" and not self.is_error
+            self._diff_cache = visualize_diff(
+                self.path,
+                self.old_content,
+                self.new_content,
+                n_context_lines=2,
+                change_applied=change_applied,
+            )
+
+        text.append(self._diff_cache)
+        return text
+
+    @property
+    def _has_meaningful_diff(self) -> bool:
+        """Check if there's a meaningful diff to display."""
+        if self.is_error:
+            return False
+
+        if not self.path:
+            return False
+
+        if self.command not in ("create", "str_replace", "insert", "undo_edit"):
+            return False
+
+        if self.command == "create" and self.new_content and not self.prev_exist:
+            return True
+
+        if self.command in ("str_replace", "insert", "undo_edit"):
+            if self.old_content is not None and self.new_content is not None:
+                return self.old_content != self.new_content
+
+        return False
+
+
+TOOL_DESCRIPTION = """View, create and edit plain-text files.
+
+* State is persistent across command calls and discussions with the user
+* If `path` is a text file, `view` displays the result of applying `cat -n`. \
+If `path` is a directory, `view` lists non-hidden files and directories up to \
+2 levels deep
+* The `create` command cannot be used if the specified `path` already exists \
+as a file
+* If a `command` generates a long output, it will be truncated and marked with \
+`<response clipped>`
+* The `undo_edit` command will revert the last edit made to the file at `path`
+* This tool can be used for creating and editing files in plain-text format.
+
+
+Before using this tool:
+1. Use the view tool to understand the file's contents and context
+2. Verify the directory path is correct (only applicable when creating new files):
+   - Use the view tool to verify the parent directory exists and is the correct \
+location
+
+When making edits:
+   - Ensure the edit results in idiomatic, correct code
+   - Do not leave the code in a broken state
+   - Always use absolute file paths (starting with /)
+
+CRITICAL REQUIREMENTS FOR USING THIS TOOL:
+
+1. EXACT MATCHING: The `old_str` parameter must match EXACTLY one or more \
+consecutive lines from the file, including all whitespace and indentation. \
+The tool will fail if `old_str` matches multiple locations or doesn't match \
+exactly with the file content.
+
+2. UNIQUENESS: The `old_str` must uniquely identify a single instance in the file:
+   - Include sufficient context before and after the change point (3-5 lines \
+recommended)
+   - If not unique, the replacement will not be performed
+
+3. REPLACEMENT: The `new_str` parameter should contain the edited lines that \
+replace the `old_str`. Both strings must be different.
+
+Remember: when making multiple file edits in a row to the same file, you should \
+prefer to send all edits in a single message with multiple calls to this tool, \
+rather than multiple messages with a single call each.
+"""
+
+
+class StrReplaceTool(ToolDefinition[StrReplaceAction, StrReplaceObservation]):
+    """String replace tool (Anthropic-compatible) that wraps FileEditorExecutor."""
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: "ConversationState",
+    ) -> Sequence["StrReplaceTool"]:
+        """Initialize StrReplaceTool with a FileEditorExecutor.
+
+        Args:
+            conv_state: Conversation state to get working directory from.
+        """
+        from openhands.tools.nemotron.str_replace.impl import StrReplaceExecutor
+
+        executor = StrReplaceExecutor(workspace_root=conv_state.workspace.working_dir)
+
+        description_lines = TOOL_DESCRIPTION.split("\n")
+        base_description = "\n".join(description_lines[:2])
+        remaining_description = "\n".join(description_lines[2:])
+
+        if conv_state.agent.llm.vision_is_active():
+            tool_description = (
+                f"{base_description}\n"
+                "* If `path` is an image file (.png, .jpg, .jpeg, .gif, .webp, "
+                ".bmp), `view` displays the image content\n"
+                f"{remaining_description}"
+            )
+        else:
+            tool_description = TOOL_DESCRIPTION
+
+        working_dir = conv_state.workspace.working_dir
+        enhanced_description = (
+            f"{tool_description}\n\n"
+            f"Your current working directory is: {working_dir}\n"
+            f"When exploring project structure, start with this directory "
+            f"instead of the root filesystem."
+        )
+
+        return [
+            cls(
+                action_type=StrReplaceAction,
+                observation_type=StrReplaceObservation,
+                description=enhanced_description,
+                annotations=ToolAnnotations(
+                    title="str_replace",
+                    readOnlyHint=False,
+                    destructiveHint=True,
+                    idempotentHint=False,
+                    openWorldHint=False,
+                ),
+                executor=executor,
+            )
+        ]
+
+
+register_tool(StrReplaceTool.name, StrReplaceTool)

--- a/openhands-tools/openhands/tools/nemotron/str_replace/impl.py
+++ b/openhands-tools/openhands/tools/nemotron/str_replace/impl.py
@@ -1,0 +1,85 @@
+"""String replace executor implementation (Nemotron/Anthropic-compatible).
+
+This executor wraps FileEditorExecutor to provide Anthropic-compatible
+str_replace tool functionality.
+"""
+
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from openhands.sdk.tool import ToolExecutor
+from openhands.tools.file_editor.editor import FileEditor
+from openhands.tools.file_editor.exceptions import ToolError
+from openhands.tools.nemotron.str_replace.definition import (
+    StrReplaceAction,
+    StrReplaceObservation,
+)
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation import LocalConversation
+
+
+class StrReplaceExecutor(ToolExecutor[StrReplaceAction, StrReplaceObservation]):
+    """String replace executor that wraps FileEditor for Anthropic compatibility."""
+
+    def __init__(
+        self,
+        workspace_root: str | None = None,
+        allowed_edits_files: list[str] | None = None,
+    ):
+        self.editor: FileEditor = FileEditor(workspace_root=workspace_root)
+        self.allowed_edits_files: set[Path] | None = (
+            {Path(f).resolve() for f in allowed_edits_files}
+            if allowed_edits_files
+            else None
+        )
+
+    def __call__(
+        self,
+        action: StrReplaceAction,
+        conversation: "LocalConversation | None" = None,  # noqa: ARG002
+    ) -> StrReplaceObservation:
+        # Enforce allowed_edits_files restrictions
+        if self.allowed_edits_files is not None and action.command != "view":
+            action_path = Path(action.path).resolve()
+            if action_path not in self.allowed_edits_files:
+                return StrReplaceObservation.from_text(
+                    text=(
+                        f"Operation '{action.command}' is not allowed "
+                        f"on file '{action_path}'. "
+                        f"Only the following files can be edited: "
+                        f"{sorted(str(p) for p in self.allowed_edits_files)}"
+                    ),
+                    command=action.command,
+                    is_error=True,
+                )
+
+        result: StrReplaceObservation | None = None
+        try:
+            # Call the FileEditor and convert the result
+            file_editor_result = self.editor(
+                command=action.command,
+                path=action.path,
+                file_text=action.file_text,
+                view_range=action.view_range,
+                old_str=action.old_str,
+                new_str=action.new_str,
+                insert_line=action.insert_line,
+            )
+            # Convert FileEditorObservation to StrReplaceObservation
+            result = StrReplaceObservation(
+                content=file_editor_result.content,
+                is_error=file_editor_result.is_error,
+                command=file_editor_result.command,
+                path=file_editor_result.path,
+                prev_exist=file_editor_result.prev_exist,
+                old_content=file_editor_result.old_content,
+                new_content=file_editor_result.new_content,
+            )
+        except ToolError as e:
+            result = StrReplaceObservation.from_text(
+                text=e.message, command=action.command, is_error=True
+            )
+        assert result is not None, "str_replace should always return a result"
+        return result

--- a/openhands-tools/openhands/tools/preset/__init__.py
+++ b/openhands-tools/openhands/tools/preset/__init__.py
@@ -21,7 +21,9 @@ Notes:
 from .default import get_default_agent, register_builtins_agents
 from .gemini import get_gemini_agent, get_gemini_tools
 from .gpt5 import get_gpt5_agent
+from .nemotron import get_nemotron_agent, get_nemotron_tools
 from .planning import get_planning_agent
+from .qwen import get_qwen_agent, get_qwen_tools
 
 
 __all__ = [
@@ -29,6 +31,10 @@ __all__ = [
     "get_gemini_agent",
     "get_gemini_tools",
     "get_gpt5_agent",
+    "get_nemotron_agent",
+    "get_nemotron_tools",
     "get_planning_agent",
+    "get_qwen_agent",
+    "get_qwen_tools",
     "register_builtins_agents",
 ]

--- a/openhands-tools/openhands/tools/preset/nemotron.py
+++ b/openhands-tools/openhands/tools/preset/nemotron.py
@@ -1,0 +1,94 @@
+"""Nemotron-3 Super preset configuration for OpenHands agents.
+
+Nemotron-3 Super (nvidia/nemotron-3-super-120b-a12b) was fine-tuned on
+trajectories that use the Anthropic str_replace_based_edit_tool / bash
+tool schema. This preset exposes those exact tool names so the model's
+calls succeed without any prompt engineering or model-side changes.
+
+  bash        → BashExecutor        (model calls "bash", not "terminal")
+  str_replace → StrReplaceExecutor  (model calls "str_replace", not "file_editor")
+  task_tracker, finish, think — unchanged; model already calls these correctly.
+"""
+
+from openhands.sdk import Agent
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.context.condenser.base import CondenserBase
+from openhands.sdk.llm.llm import LLM
+from openhands.sdk.logger import get_logger
+from openhands.sdk.tool import Tool
+
+
+logger = get_logger(__name__)
+
+
+def register_nemotron_tools(enable_browser: bool = True) -> None:
+    """Register the nemotron set of tools."""
+    from openhands.tools.nemotron import BashTool, StrReplaceTool
+    from openhands.tools.task_tracker import TaskTrackerTool
+
+    logger.debug(f"Tool: {BashTool.name} registered.")
+    logger.debug(f"Tool: {StrReplaceTool.name} registered.")
+    logger.debug(f"Tool: {TaskTrackerTool.name} registered.")
+
+    if enable_browser:
+        from openhands.tools.browser_use import BrowserToolSet
+
+        logger.debug(f"Tool: {BrowserToolSet.name} registered.")
+
+
+def get_nemotron_tools(
+    enable_browser: bool = True,
+) -> list[Tool]:
+    """Get the nemotron set of tool specifications.
+
+    This uses Anthropic-compatible tool names (bash, str_replace) instead
+    of the default OpenHands names (terminal, file_editor).
+
+    Args:
+        enable_browser: Whether to include browser tools.
+    """
+    register_nemotron_tools(enable_browser=enable_browser)
+
+    from openhands.tools.nemotron import BashTool, StrReplaceTool
+    from openhands.tools.task_tracker import TaskTrackerTool
+
+    tools = [
+        Tool(name=BashTool.name),
+        Tool(name=StrReplaceTool.name),
+        Tool(name=TaskTrackerTool.name),
+    ]
+    if enable_browser:
+        from openhands.tools.browser_use import BrowserToolSet
+
+        tools.append(Tool(name=BrowserToolSet.name))
+    return tools
+
+
+def get_nemotron_condenser(llm: LLM) -> CondenserBase:
+    """Get the default condenser for nemotron preset."""
+    condenser = LLMSummarizingCondenser(llm=llm, max_size=80, keep_first=4)
+    return condenser
+
+
+def get_nemotron_agent(
+    llm: LLM,
+    cli_mode: bool = False,
+) -> Agent:
+    """Get an agent with Nemotron-compatible tools: bash, str_replace.
+
+    Args:
+        llm: The LLM to use for the agent.
+        cli_mode: Whether to run in CLI mode (disables browser tools).
+    """
+    tools = get_nemotron_tools(
+        enable_browser=not cli_mode,
+    )
+    agent = Agent(
+        llm=llm,
+        tools=tools,
+        system_prompt_kwargs={"cli_mode": cli_mode},
+        condenser=get_nemotron_condenser(
+            llm=llm.model_copy(update={"usage_id": "condenser"})
+        ),
+    )
+    return agent

--- a/openhands-tools/openhands/tools/preset/qwen.py
+++ b/openhands-tools/openhands/tools/preset/qwen.py
@@ -1,0 +1,96 @@
+"""Qwen preset configuration for OpenHands agents.
+
+Qwen 3.5 Flash and similar models use the Anthropic str_replace_based_edit_tool
+schema (same as Nemotron). This preset exposes tools under the names the model expects.
+
+  bash        → BashExecutor        (model calls "bash", not "terminal")
+  str_replace → StrReplaceExecutor  (model calls "str_replace", not "file_editor")
+  task_tracker, finish, think — unchanged; model already calls these correctly.
+"""
+
+from openhands.sdk import Agent
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
+from openhands.sdk.context.condenser.base import CondenserBase
+from openhands.sdk.llm.llm import LLM
+from openhands.sdk.logger import get_logger
+from openhands.sdk.tool import Tool
+
+
+logger = get_logger(__name__)
+
+
+def register_qwen_tools(enable_browser: bool = True) -> None:
+    """Register the qwen set of tools.
+
+    Qwen uses the same tool names as Nemotron (Anthropic schema),
+    so we reuse the Nemotron tools.
+    """
+    from openhands.tools.nemotron import BashTool, StrReplaceTool
+    from openhands.tools.task_tracker import TaskTrackerTool
+
+    logger.debug(f"Tool: {BashTool.name} registered.")
+    logger.debug(f"Tool: {StrReplaceTool.name} registered.")
+    logger.debug(f"Tool: {TaskTrackerTool.name} registered.")
+
+    if enable_browser:
+        from openhands.tools.browser_use import BrowserToolSet
+
+        logger.debug(f"Tool: {BrowserToolSet.name} registered.")
+
+
+def get_qwen_tools(
+    enable_browser: bool = True,
+) -> list[Tool]:
+    """Get the qwen set of tool specifications.
+
+    This uses Anthropic-compatible tool names (bash, str_replace) instead
+    of the default OpenHands names (terminal, file_editor).
+
+    Args:
+        enable_browser: Whether to include browser tools.
+    """
+    register_qwen_tools(enable_browser=enable_browser)
+
+    from openhands.tools.nemotron import BashTool, StrReplaceTool
+    from openhands.tools.task_tracker import TaskTrackerTool
+
+    tools = [
+        Tool(name=BashTool.name),
+        Tool(name=StrReplaceTool.name),
+        Tool(name=TaskTrackerTool.name),
+    ]
+    if enable_browser:
+        from openhands.tools.browser_use import BrowserToolSet
+
+        tools.append(Tool(name=BrowserToolSet.name))
+    return tools
+
+
+def get_qwen_condenser(llm: LLM) -> CondenserBase:
+    """Get the default condenser for qwen preset."""
+    condenser = LLMSummarizingCondenser(llm=llm, max_size=80, keep_first=4)
+    return condenser
+
+
+def get_qwen_agent(
+    llm: LLM,
+    cli_mode: bool = False,
+) -> Agent:
+    """Get an agent with Qwen-compatible tools: bash, str_replace.
+
+    Args:
+        llm: The LLM to use for the agent.
+        cli_mode: Whether to run in CLI mode (disables browser tools).
+    """
+    tools = get_qwen_tools(
+        enable_browser=not cli_mode,
+    )
+    agent = Agent(
+        llm=llm,
+        tools=tools,
+        system_prompt_kwargs={"cli_mode": cli_mode},
+        condenser=get_qwen_condenser(
+            llm=llm.model_copy(update={"usage_id": "condenser"})
+        ),
+    )
+    return agent

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -29,7 +29,7 @@ from tests.integration.early_stopper import EarlyStopperBase, EarlyStopResult
 
 
 # Tool preset type for selecting which file editing toolset to use
-ToolPresetType = Literal["default", "gemini", "gpt5", "planning"]
+ToolPresetType = Literal["default", "gemini", "gpt5", "nemotron", "planning", "qwen"]
 
 
 def get_tools_for_preset(
@@ -38,7 +38,8 @@ def get_tools_for_preset(
     """Get the list of tools for the given preset.
 
     Args:
-        preset: The tool preset to use (default, gemini, gpt5, or planning).
+        preset: The tool preset to use (default, gemini, gpt5, nemotron,
+            planning, qwen).
         enable_browser: Whether to include browser tools.
 
     Returns:
@@ -53,11 +54,19 @@ def get_tools_for_preset(
             from openhands.tools.preset.gpt5 import get_gpt5_tools
 
             return get_gpt5_tools(enable_browser=enable_browser)
+        case "nemotron":
+            from openhands.tools.preset.nemotron import get_nemotron_tools
+
+            return get_nemotron_tools(enable_browser=enable_browser)
         case "planning":
             from openhands.tools.preset.planning import get_planning_tools
 
             # Planning preset is read-only and doesn't support browser tools
             return get_planning_tools()
+        case "qwen":
+            from openhands.tools.preset.qwen import get_qwen_tools
+
+            return get_qwen_tools(enable_browser=enable_browser)
         case "default":
             from openhands.tools.preset.default import get_default_tools
 

--- a/tests/integration/run_infer.py
+++ b/tests/integration/run_infer.py
@@ -455,13 +455,14 @@ def main():
     parser.add_argument(
         "--tool-preset",
         type=str,
-        choices=["default", "gemini", "gpt5", "planning"],
+        choices=["default", "gemini", "gpt5", "nemotron", "planning", "qwen"],
         default="default",
         help=(
             "Tool preset to use for file editing (default: 'default'). "
             "'default' uses FileEditorTool (claude-style), "
             "'gemini' uses read_file/write_file/edit/list_directory tools, "
             "'gpt5' uses apply_patch tool, "
+            "'nemotron' and 'qwen' use bash/str_replace (Anthropic schema), "
             "'planning' uses planning-specific tools."
         ),
     )

--- a/tests/integration/test_tool_presets.py
+++ b/tests/integration/test_tool_presets.py
@@ -59,6 +59,19 @@ def test_get_tools_for_preset_gpt5():
     assert "file_editor" not in tool_names
 
 
+def test_get_tools_for_preset_nemotron():
+    """Test that nemotron preset returns Anthropic-compatible tools."""
+    tools = get_tools_for_preset("nemotron", enable_browser=False)
+    tool_names = {t.name for t in tools}
+
+    assert "bash" in tool_names
+    assert "str_replace" in tool_names
+    assert "task_tracker" in tool_names
+    # Default terminal and file_editor should NOT be present
+    assert "terminal" not in tool_names
+    assert "file_editor" not in tool_names
+
+
 def test_get_tools_for_preset_planning():
     """Test that planning preset returns read-only tools."""
     tools = get_tools_for_preset("planning", enable_browser=False)
@@ -73,6 +86,19 @@ def test_get_tools_for_preset_planning():
     assert "browser_navigate" not in tool_names
 
 
+def test_get_tools_for_preset_qwen():
+    """Test that qwen preset returns Anthropic-compatible tools."""
+    tools = get_tools_for_preset("qwen", enable_browser=False)
+    tool_names = {t.name for t in tools}
+
+    assert "bash" in tool_names
+    assert "str_replace" in tool_names
+    assert "task_tracker" in tool_names
+    # Default terminal and file_editor should NOT be present
+    assert "terminal" not in tool_names
+    assert "file_editor" not in tool_names
+
+
 def test_get_tools_for_preset_invalid():
     """Test that invalid preset raises ValueError."""
     with pytest.raises(ValueError, match="Unknown `preset` parameter"):
@@ -83,7 +109,14 @@ def test_get_tools_for_preset_invalid():
 def test_tool_preset_type_literal_values():
     """Verify ToolPresetType includes all expected values."""
     # This is a compile-time check but we document expected values here
-    valid_presets: list[ToolPresetType] = ["default", "gemini", "gpt5", "planning"]
+    valid_presets: list[ToolPresetType] = [
+        "default",
+        "gemini",
+        "gpt5",
+        "nemotron",
+        "planning",
+        "qwen",
+    ]
     for preset in valid_presets:
         # Should not raise
         tools = get_tools_for_preset(preset, enable_browser=False)
@@ -104,12 +137,19 @@ def test_run_infer_argparse_accepts_all_tool_presets():
     parser.add_argument(
         "--tool-preset",
         type=str,
-        choices=["default", "gemini", "gpt5", "planning"],
+        choices=["default", "gemini", "gpt5", "nemotron", "planning", "qwen"],
         default="default",
     )
 
     # Test each valid preset value
-    valid_presets: list[ToolPresetType] = ["default", "gemini", "gpt5", "planning"]
+    valid_presets: list[ToolPresetType] = [
+        "default",
+        "gemini",
+        "gpt5",
+        "nemotron",
+        "planning",
+        "qwen",
+    ]
 
     for preset in valid_presets:
         # This should not raise an error

--- a/tests/tools/nemotron/__init__.py
+++ b/tests/tools/nemotron/__init__.py
@@ -1,0 +1,1 @@
+# Tests for Nemotron-compatible tools

--- a/tests/tools/nemotron/bash/__init__.py
+++ b/tests/tools/nemotron/bash/__init__.py
@@ -1,0 +1,1 @@
+# Tests for Nemotron bash tool

--- a/tests/tools/nemotron/bash/test_bash.py
+++ b/tests/tools/nemotron/bash/test_bash.py
@@ -1,0 +1,92 @@
+"""Tests for Nemotron bash tool."""
+
+from openhands.tools.nemotron.bash.definition import BashAction, BashTool
+from openhands.tools.nemotron.bash.impl import BashExecutor
+
+
+def test_bash_tool_name():
+    """Test that BashTool has the correct name."""
+    assert BashTool.name == "bash"
+
+
+def test_bash_basic_command(tmp_path):
+    """Test basic command execution."""
+    executor = BashExecutor(working_dir=str(tmp_path))
+    action = BashAction(command="echo hello")
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert "hello" in obs.text
+
+
+def test_bash_exit_code(tmp_path):
+    """Test that exit codes are captured."""
+    executor = BashExecutor(working_dir=str(tmp_path))
+
+    # Successful command
+    action = BashAction(command="true")
+    obs = executor(action)
+    assert obs.exit_code == 0
+
+    # Failing command - use a subshell to avoid killing the session
+    action = BashAction(command="(exit 42)")
+    obs = executor(action)
+    assert obs.exit_code == 42
+
+
+def test_bash_working_directory(tmp_path):
+    """Test that working directory is set correctly."""
+    executor = BashExecutor(working_dir=str(tmp_path))
+    action = BashAction(command="pwd")
+    obs = executor(action)
+
+    assert str(tmp_path) in obs.text
+
+
+def test_bash_environment_persistence(tmp_path):
+    """Test that environment variables persist across commands."""
+    executor = BashExecutor(working_dir=str(tmp_path))
+
+    # Set environment variable
+    action = BashAction(command="export MY_VAR=test123")
+    executor(action)
+
+    # Check it persists
+    action = BashAction(command="echo $MY_VAR")
+    obs = executor(action)
+
+    assert "test123" in obs.text
+
+
+def test_bash_file_operations(tmp_path):
+    """Test file operations through bash."""
+    executor = BashExecutor(working_dir=str(tmp_path))
+
+    # Create a file
+    action = BashAction(command="echo 'test content' > test.txt")
+    executor(action)
+
+    # Read it back
+    action = BashAction(command="cat test.txt")
+    obs = executor(action)
+
+    assert "test content" in obs.text
+
+    # Verify file exists
+    assert (tmp_path / "test.txt").exists()
+
+
+def test_bash_action_visualize():
+    """Test BashAction visualization."""
+    action = BashAction(command="ls -la")
+    viz = action.visualize
+
+    assert "$ " in viz.plain
+    assert "ls -la" in viz.plain
+
+
+def test_bash_executor_close(tmp_path):
+    """Test that executor can be closed without errors."""
+    executor = BashExecutor(working_dir=str(tmp_path))
+    executor.close()
+    # Should not raise

--- a/tests/tools/nemotron/str_replace/__init__.py
+++ b/tests/tools/nemotron/str_replace/__init__.py
@@ -1,0 +1,1 @@
+# Tests for Nemotron str_replace tool

--- a/tests/tools/nemotron/str_replace/test_str_replace.py
+++ b/tests/tools/nemotron/str_replace/test_str_replace.py
@@ -1,0 +1,145 @@
+"""Tests for Nemotron str_replace tool."""
+
+from openhands.tools.nemotron.str_replace.definition import (
+    StrReplaceAction,
+    StrReplaceTool,
+)
+from openhands.tools.nemotron.str_replace.impl import StrReplaceExecutor
+
+
+def test_str_replace_tool_name():
+    """Test that StrReplaceTool has the correct name."""
+    assert StrReplaceTool.name == "str_replace"
+
+
+def test_str_replace_view_file(tmp_path):
+    """Test viewing a file."""
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def foo():\n    return 'hello'\n")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(command="view", path=str(test_file))
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert "def foo():" in obs.text
+
+
+def test_str_replace_view_directory(tmp_path):
+    """Test viewing a directory."""
+    (tmp_path / "file1.txt").write_text("content1")
+    (tmp_path / "file2.py").write_text("content2")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(command="view", path=str(tmp_path))
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert "file1.txt" in obs.text
+    assert "file2.py" in obs.text
+
+
+def test_str_replace_create_file(tmp_path):
+    """Test creating a new file."""
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(
+        command="create", path=str(tmp_path / "new.py"), file_text="print('hello')\n"
+    )
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert (tmp_path / "new.py").exists()
+    assert (tmp_path / "new.py").read_text() == "print('hello')\n"
+
+
+def test_str_replace_basic_replacement(tmp_path):
+    """Test basic find/replace."""
+    test_file = tmp_path / "test.py"
+    test_file.write_text("def foo():\n    return 'old'\n")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(
+        command="str_replace",
+        path=str(test_file),
+        old_str="'old'",
+        new_str="'new'",
+    )
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert test_file.read_text() == "def foo():\n    return 'new'\n"
+
+
+def test_str_replace_string_not_found(tmp_path):
+    """Test error when old_str is not found."""
+    test_file = tmp_path / "test.txt"
+    test_file.write_text("hello world\n")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(
+        command="str_replace",
+        path=str(test_file),
+        old_str="goodbye",
+        new_str="farewell",
+    )
+    obs = executor(action)
+
+    assert obs.is_error
+
+
+def test_str_replace_insert(tmp_path):
+    """Test inserting text after a line."""
+    test_file = tmp_path / "test.py"
+    test_file.write_text("line1\nline2\nline3\n")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(
+        command="insert",
+        path=str(test_file),
+        insert_line=1,
+        new_str="inserted",
+    )
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert test_file.read_text() == "line1\ninserted\nline2\nline3\n"
+
+
+def test_str_replace_undo_edit(tmp_path):
+    """Test undoing the last edit."""
+    test_file = tmp_path / "test.py"
+    test_file.write_text("original content\n")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+
+    # Make an edit
+    action = StrReplaceAction(
+        command="str_replace",
+        path=str(test_file),
+        old_str="original",
+        new_str="modified",
+    )
+    executor(action)
+    assert test_file.read_text() == "modified content\n"
+
+    # Undo the edit
+    action = StrReplaceAction(command="undo_edit", path=str(test_file))
+    obs = executor(action)
+
+    assert not obs.is_error
+    assert test_file.read_text() == "original content\n"
+
+
+def test_str_replace_create_existing_file_error(tmp_path):
+    """Test error when trying to create file that already exists."""
+    test_file = tmp_path / "existing.py"
+    test_file.write_text("old content\n")
+
+    executor = StrReplaceExecutor(workspace_root=str(tmp_path))
+    action = StrReplaceAction(
+        command="create", path=str(test_file), file_text="new content\n"
+    )
+    obs = executor(action)
+
+    assert obs.is_error
+    assert "already exists" in obs.text.lower()

--- a/tests/tools/nemotron/test_nemotron_preset.py
+++ b/tests/tools/nemotron/test_nemotron_preset.py
@@ -1,0 +1,33 @@
+"""Tests for Nemotron preset."""
+
+from openhands.tools.nemotron import NEMOTRON_TOOLS, BashTool, StrReplaceTool
+from openhands.tools.preset.nemotron import get_nemotron_tools
+
+
+def test_nemotron_tools_list():
+    """Test that NEMOTRON_TOOLS contains the expected tools."""
+    tool_names = {t.name for t in NEMOTRON_TOOLS}
+    assert "bash" in tool_names
+    assert "str_replace" in tool_names
+
+
+def test_get_nemotron_tools_returns_correct_tools():
+    """Test that get_nemotron_tools returns the expected tools."""
+    tools = get_nemotron_tools(enable_browser=False)
+    tool_names = {t.name for t in tools}
+
+    assert "bash" in tool_names
+    assert "str_replace" in tool_names
+    assert "task_tracker" in tool_names
+    # Should not have browser tools when disabled
+    assert "browser_use" not in tool_names
+
+
+def test_bash_tool_name_is_bash():
+    """Test that BashTool name is 'bash' (not 'terminal')."""
+    assert BashTool.name == "bash"
+
+
+def test_str_replace_tool_name_is_str_replace():
+    """Test that StrReplaceTool name is 'str_replace' (not 'file_editor')."""
+    assert StrReplaceTool.name == "str_replace"

--- a/tests/tools/test_qwen_preset.py
+++ b/tests/tools/test_qwen_preset.py
@@ -1,0 +1,66 @@
+"""Test Qwen preset."""
+
+from pydantic import SecretStr
+
+from openhands.sdk import Agent
+from openhands.sdk.llm import LLM
+from openhands.tools.nemotron import BashTool, StrReplaceTool
+from openhands.tools.preset.qwen import get_qwen_agent, get_qwen_tools
+from openhands.tools.task_tracker import TaskTrackerTool
+
+
+def test_get_qwen_tools_basic():
+    """Test that get_qwen_tools returns the correct tools."""
+    tools = get_qwen_tools(enable_browser=False)
+
+    # Should have bash, str_replace, and task_tracker
+    assert len(tools) == 3
+
+    tool_names = {tool.name for tool in tools}
+    assert tool_names == {
+        BashTool.name,
+        StrReplaceTool.name,
+        TaskTrackerTool.name,
+    }
+
+
+def test_get_qwen_tools_with_browser():
+    """Test that get_qwen_tools includes browser tools when enabled."""
+    tools = get_qwen_tools(enable_browser=True)
+
+    # Should have bash, str_replace, task_tracker, and browser_tool_set
+    assert len(tools) == 4
+
+    tool_names = {tool.name for tool in tools}
+    assert "browser_tool_set" in tool_names
+    assert BashTool.name in tool_names
+    assert StrReplaceTool.name in tool_names
+    assert TaskTrackerTool.name in tool_names
+
+
+def test_get_qwen_agent():
+    """Test that get_qwen_agent creates an agent with the correct tools."""
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test")
+    agent = get_qwen_agent(llm=llm, cli_mode=True)
+
+    assert isinstance(agent, Agent)
+    assert len(agent.tools) == 3
+
+    tool_names = {tool.name for tool in agent.tools}
+    assert tool_names == {
+        BashTool.name,
+        StrReplaceTool.name,
+        TaskTrackerTool.name,
+    }
+
+
+def test_qwen_tools_use_anthropic_names():
+    """Test that Qwen preset uses Anthropic-compatible tool names."""
+    tools = get_qwen_tools(enable_browser=False)
+    tool_names = {tool.name for tool in tools}
+
+    # Verify it uses "bash" and "str_replace" (not "terminal" and "file_editor")
+    assert "bash" in tool_names
+    assert "str_replace" in tool_names
+    assert "terminal" not in tool_names
+    assert "file_editor" not in tool_names


### PR DESCRIPTION
## Summary

This PR implements tool presets for models that were fine-tuned on Anthropic's `str_replace_based_edit_tool` / `bash` schema, addressing the tool name mismatches that were causing high error rates (42-96%) in Qwen 3.5 Flash evaluations.

**Fixes #2555**

## Problem Context

Evaluation runs of `dashscope/qwen3.5-flash-2026-02-23` showed high conversation error rates due to tool name mismatches:

| Benchmark | Error Rate | Tool-Name Errors |
|-----------|------------|------------------|
| SWE-Bench | 62.0% | `str_replace` not found (60%) |
| SWT-Bench | 79.5% | `str_replace` not found (42%) |
| Commit0 | 75.0% | `str_replace` not found (56%) |
| SWE-Bench Multimodal | 96.1% | `str_replace` not found (7%) |

The model was fine-tuned on Anthropic's tool schema where:
- Shell execution is a tool named `bash` (not `terminal`)
- File editing is a tool named `str_replace` (not a sub-command of `file_editor`)

The model's behavior is correct for that schema. The parameters it passes (`path`, `old_str`, `new_str`, `command`, `file_text`) are semantically correct and map 1-to-1 to existing OpenHands tool arguments — only the tool names differ.

## Solution

### Implementation Approach

Created tool wrappers that expose existing functionality under Anthropic-compatible names:

1. **Nemotron Tools** (`openhands-tools/openhands/tools/nemotron/`):
   - `BashTool`: Wraps `TerminalExecutor`, exposes as "bash"
   - `StrReplaceTool`: Wraps `FileEditorExecutor`, exposes as "str_replace"

2. **Nemotron Preset** (`openhands-tools/openhands/tools/preset/nemotron.py`):
   - Uses bash + str_replace + task_tracker
   - Designed for NVIDIA Nemotron-3 Super models

3. **Qwen Preset** (`openhands-tools/openhands/tools/preset/qwen.py`):
   - Reuses Nemotron tools (same Anthropic schema)
   - Designed for Qwen 3.5 Flash and similar models

### Key Changes

- **Tools**:
  - Added `openhands-tools/openhands/tools/nemotron/` with bash and str_replace wrappers
  - Updated `openhands-tools/openhands/tools/preset/__init__.py` to export new presets

- **Workflows**:
  - Updated `.github/workflows/run-eval.yml` to add `nemotron` and `qwen` tool preset options
  - Updated `.github/workflows/integration-runner.yml` to add `nemotron` and `qwen` tool preset options

- **Integration Tests**:
  - Updated `tests/integration/base.py` to include `nemotron` and `qwen` in `ToolPresetType`
  - Updated `tests/integration/run_infer.py` argparse choices
  - Added tests in `tests/integration/test_tool_presets.py`

- **Unit Tests**:
  - Added comprehensive tests in `tests/tools/nemotron/` for bash and str_replace tools
  - Added tests in `tests/tools/test_qwen_preset.py`

## Expected Impact

| Metric | Before (default preset) | After (qwen/nemotron preset) |
|--------|-------------------------|------------------------------|
| Tool-name errors | 42-60% of conversations | ~0% |
| `stuck` conversations | High | ~0% |

## Testing

- ✅ All existing tests pass
- ✅ New unit tests for Nemotron tools (21 tests)
- ✅ New unit tests for Qwen preset (4 tests)
- ✅ Updated integration tests (10 tests)
- ✅ Pre-commit hooks pass

To test with evaluations:
```bash
# Use qwen preset for Qwen 3.5 Flash
TOOL_PRESET=qwen

# Or use nemotron preset for Nemotron models
TOOL_PRESET=nemotron
```

## Notes

- `task_tracker`, `finish`, and `think` do not need aliasing — models use those names correctly
- No system-prompt changes needed; the fix is entirely in the tool name exposed in the schema
- The same tools work for both Nemotron and Qwen since they're both trained on Anthropic schema
- This provides a reusable solution for future models trained on the same schema

## Follow-up Work

As mentioned in the issue, we'll also need:
- [ ] PR in OpenHands/evaluation repo to use the new preset
- [ ] PR in OpenHands/benchmarks repo to use the new preset

These can be done after this PR merges and we validate the implementation with eval runs.

## Related

- Supersedes #2554 (Nemotron preset PR)
- Related to #2553 (Nemotron issue)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a3ccab7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a3ccab7-python \
  ghcr.io/openhands/agent-server:a3ccab7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a3ccab7-golang-amd64
ghcr.io/openhands/agent-server:a3ccab7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a3ccab7-golang-arm64
ghcr.io/openhands/agent-server:a3ccab7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a3ccab7-java-amd64
ghcr.io/openhands/agent-server:a3ccab7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a3ccab7-java-arm64
ghcr.io/openhands/agent-server:a3ccab7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a3ccab7-python-amd64
ghcr.io/openhands/agent-server:a3ccab7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:a3ccab7-python-arm64
ghcr.io/openhands/agent-server:a3ccab7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:a3ccab7-golang
ghcr.io/openhands/agent-server:a3ccab7-java
ghcr.io/openhands/agent-server:a3ccab7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a3ccab7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a3ccab7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->