### PR TITLE
Warn users when tmux is not installed for better terminal stability

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/factory.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/factory.py
@@ -2,6 +2,7 @@
 
 import platform
 import subprocess
+import warnings
 from typing import Literal
 
 from openhands.sdk.logger import get_logger
@@ -120,6 +121,13 @@ def create_terminal_session(
                 SubprocessTerminal,
             )
 
-            logger.info("Auto-detected: Using SubprocessTerminal (tmux not available)")
+            _tmux_warning = (
+                "tmux is not installed. Falling back to subprocess-based"
+                " terminal, which may be less stable. For best agent"
+                " performance, install tmux (e.g. `apt-get install tmux`"
+                " or `brew install tmux`)."
+            )
+            logger.warning(_tmux_warning)
+            warnings.warn(_tmux_warning, stacklevel=2)
             terminal = SubprocessTerminal(work_dir, username, shell_path)
             return TerminalSession(terminal, no_change_timeout_seconds)

--- a/tests/tools/terminal/test_session_factory.py
+++ b/tests/tools/terminal/test_session_factory.py
@@ -1,6 +1,7 @@
 """Tests for session factory and auto-detection logic."""
 
 import tempfile
+import warnings
 from unittest.mock import patch
 
 import pytest
@@ -84,6 +85,26 @@ def test_auto_detection_unix(mock_system):
             assert isinstance(session, TerminalSession)
             assert isinstance(session.terminal, SubprocessTerminal)
             session.close()
+
+
+@patch("platform.system")
+def test_warning_when_tmux_not_available(mock_system):
+    """Test that a warning is emitted when tmux is not installed."""
+    mock_system.return_value = "Linux"
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        with patch(
+            "openhands.tools.terminal.terminal.factory._is_tmux_available",
+            return_value=False,
+        ):
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                session = create_terminal_session(work_dir=temp_dir)
+                session.close()
+
+            assert len(w) == 1
+            assert "tmux is not installed" in str(w[0].message)
+            assert "install tmux" in str(w[0].message)
 
 
 def test_session_parameters_passed():


### PR DESCRIPTION
## Summary

When running the SDK in environments without tmux (e.g., GitHub CI), the terminal auto-detection silently falls back to the subprocess-based backend, which can be less stable. This PR adds a visible warning when that fallback occurs, guiding users to install tmux for best agent performance.

**Changes:**
- **`factory.py`**: In the auto-detect path, when tmux is not available, emit both a `logger.warning()` and a `warnings.warn()` with an actionable message (including install commands for apt and brew). The warning only fires on auto-detect — not when the user explicitly requests `terminal_type="subprocess"`.
- **`test_session_factory.py`**: Added `test_warning_when_tmux_not_available` to verify the warning is emitted with the expected content.

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3b0c05e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3b0c05e-python \
  ghcr.io/openhands/agent-server:3b0c05e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3b0c05e-golang-amd64
ghcr.io/openhands/agent-server:3b0c05e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3b0c05e-golang-arm64
ghcr.io/openhands/agent-server:3b0c05e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3b0c05e-java-amd64
ghcr.io/openhands/agent-server:3b0c05e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3b0c05e-java-arm64
ghcr.io/openhands/agent-server:3b0c05e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3b0c05e-python-amd64
ghcr.io/openhands/agent-server:3b0c05e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:3b0c05e-python-arm64
ghcr.io/openhands/agent-server:3b0c05e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:3b0c05e-golang
ghcr.io/openhands/agent-server:3b0c05e-java
ghcr.io/openhands/agent-server:3b0c05e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3b0c05e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3b0c05e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->