### PR TITLE
Pass workflow run ID to evaluation job

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -354,6 +354,7 @@ jobs:
                   echo "Dispatching evaluation workflow with SDK commit: $SDK_SHA (benchmark: $BENCHMARK, eval branch: $EVAL_BRANCH, benchmarks branch: $BENCHMARKS_BRANCH, tool preset: $TOOL_PRESET)"
                   PAYLOAD=$(jq -n \
                     --arg sdk "$SDK_SHA" \
+                    --arg sdk_run_id "${{ github.run_id }}" \
                     --arg eval_limit "$EVAL_LIMIT" \
                     --argjson models "$MODELS_JSON" \
                     --arg ref "$EVAL_BRANCH" \
@@ -370,7 +371,7 @@ jobs:
                     --arg agent_type "$AGENT_TYPE" \
                     --arg partial_archive_url "$PARTIAL_ARCHIVE_URL" \
                     --arg triggered_by "$TRIGGERED_BY" \
-                    '{ref: $ref, inputs: {sdk_commit: $sdk, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries, tool_preset: $tool_preset, agent_type: $agent_type, partial_archive_url: $partial_archive_url, triggered_by: $triggered_by}}')
+                    '{ref: $ref, inputs: {sdk_commit: $sdk, sdk_workflow_run_id: $sdk_run_id, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries, tool_preset: $tool_preset, agent_type: $agent_type, partial_archive_url: $partial_archive_url, triggered_by: $triggered_by}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
                     -H "Authorization: token $PAT_TOKEN" \
                     -H "Accept: application/vnd.github+json" \


### PR DESCRIPTION
## Summary

This PR passes the software-agent-sdk workflow run ID to the evaluation workflow when dispatching evaluation jobs. This enables the evaluation repo to save the SDK workflow run ID in params.json for easier retriggering and debugging.

## Changes

- Add `sdk_workflow_run_id` parameter to the dispatch payload in `.github/workflows/run-eval.yml`
- Pass `github.run_id` as the value for this parameter

## Related Issue

Related to OpenHands/evaluation#364

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this? - No tests needed, workflow change only
- [x] If there is an example, have you run the example to make sure that it works? - N/A
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? - N/A
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? - Not significant enough for docs
- [ ] Is the github CI passing? - Will check after PR creation
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:73130e7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-73130e7-python \
  ghcr.io/openhands/agent-server:73130e7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:73130e7-golang-amd64
ghcr.io/openhands/agent-server:73130e7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:73130e7-golang-arm64
ghcr.io/openhands/agent-server:73130e7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:73130e7-java-amd64
ghcr.io/openhands/agent-server:73130e7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:73130e7-java-arm64
ghcr.io/openhands/agent-server:73130e7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:73130e7-python-amd64
ghcr.io/openhands/agent-server:73130e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-amd64
ghcr.io/openhands/agent-server:73130e7-python-arm64
ghcr.io/openhands/agent-server:73130e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-arm64
ghcr.io/openhands/agent-server:73130e7-golang
ghcr.io/openhands/agent-server:73130e7-java
ghcr.io/openhands/agent-server:73130e7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `73130e7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `73130e7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->