### PR TITLE
chore: remove outdated INSTALL_ACP example from build.py docstring

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -403,13 +403,6 @@ class BuildOptions(BaseModel):
             "(e.g., at each release)."
         ),
     )
-    extra_build_args: dict[str, str] = Field(
-        default_factory=dict,
-        description=(
-            "Additional Docker build args to pass to buildx. "
-            "For example, {'INSTALL_ACP': 'false'} to skip ACP installation."
-        ),
-    )
 
     @property
     def short_sha(self) -> str:
@@ -773,9 +766,6 @@ def build_with_telemetry(opts: BuildOptions) -> BuildResult:
         "--build-arg",
         f"OPENHANDS_BUILD_GIT_REF={opts.git_ref}",
     ]
-    for key, value in opts.extra_build_args.items():
-        args += ["--build-arg", f"{key}={value}"]
-
     if push:
         args += ["--platform", ",".join(opts.platforms), "--push"]
     else:


### PR DESCRIPTION
## Summary

This PR removes `extra_build_args` from `BuildOptions` entirely. 

The `INSTALL_BOTO3` and `INSTALL_ACP` build args were already removed from the Dockerfile (boto3 and ACP deps are now always installed unconditionally as of Release v1.15.0). The `extra_build_args` field was only ever used to pass these now-defunct build args, so it can be removed.

**Related PRs:**
- Benchmarks PR removing `LIGHTWEIGHT_BUILD_ARGS`: https://github.com/OpenHands/benchmarks/pull/572

**Note:** This is a breaking change for the benchmarks repo, but [benchmarks PR #572](https://github.com/OpenHands/benchmarks/pull/572) is already open to remove the `extra_build_args` usage there. These PRs should be merged in coordination.

Closes #2569

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this? (N/A - removing unused field)
- [x] If there is an example, have you run the example to make sure that it works? (N/A)
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? (N/A)
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? (N/A - internal cleanup)
- [x] Is the github CI passing?
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:96f99ad-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-96f99ad-python \
  ghcr.io/openhands/agent-server:96f99ad-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:96f99ad-golang-amd64
ghcr.io/openhands/agent-server:96f99ad-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:96f99ad-golang-arm64
ghcr.io/openhands/agent-server:96f99ad-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:96f99ad-java-amd64
ghcr.io/openhands/agent-server:96f99ad-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:96f99ad-java-arm64
ghcr.io/openhands/agent-server:96f99ad-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:96f99ad-python-amd64
ghcr.io/openhands/agent-server:96f99ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:96f99ad-python-arm64
ghcr.io/openhands/agent-server:96f99ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:96f99ad-golang
ghcr.io/openhands/agent-server:96f99ad-java
ghcr.io/openhands/agent-server:96f99ad-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `96f99ad-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `96f99ad-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->