### PR TITLE
Adjust RUNTIME_URL deprecation metadata for v1.15.0

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -59,8 +59,8 @@ def _default_web_url() -> str | None:
 
     warn_deprecated(
         "RUNTIME_URL environment variable",
-        deprecated_in="1.14.0",
-        removed_in="1.19.0",
+        deprecated_in="1.15.0",
+        removed_in="1.20.0",
         details="Use OH_WEB_URL instead.",
     )
     return legacy_web_url

--- a/tests/agent_server/test_api.py
+++ b/tests/agent_server/test_api.py
@@ -433,7 +433,7 @@ class TestConfigWebUrl:
             caught[0].message
         )
         assert "OH_WEB_URL" in str(caught[0].message)
-        assert "removed in 1.19.0" in str(caught[0].message)
+        assert "removed in 1.20.0" in str(caught[0].message)
 
     def test_web_url_prefers_oh_web_url_over_runtime_url(self):
         """Test that the canonical env var wins without warnings."""


### PR DESCRIPTION
## Summary
- bump the `RUNTIME_URL` deprecation metadata in `Config.web_url` to match the current SDK version on `main`
- move the removal target forward accordingly from `1.19.0` to `1.20.0`
- update the agent-server API test expectation for the warning text

## Why
PR #2429 merged after `v1.15.0` was tagged. A follow-up review comment on that merged PR asked for the deprecation window to be adjusted against the current SDK version and handled in a new PR from `main`.

## Validation
- `make build`
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/config.py tests/agent_server/test_api.py`
- `uv run pytest tests/agent_server/test_api.py`

## Reference
- follow-up to #2429
- compatibility introduced in #2423

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:90d11d8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-90d11d8-python \
  ghcr.io/openhands/agent-server:90d11d8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:90d11d8-golang-amd64
ghcr.io/openhands/agent-server:90d11d8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:90d11d8-golang-arm64
ghcr.io/openhands/agent-server:90d11d8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:90d11d8-java-amd64
ghcr.io/openhands/agent-server:90d11d8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:90d11d8-java-arm64
ghcr.io/openhands/agent-server:90d11d8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:90d11d8-python-amd64
ghcr.io/openhands/agent-server:90d11d8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:90d11d8-python-arm64
ghcr.io/openhands/agent-server:90d11d8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:90d11d8-golang
ghcr.io/openhands/agent-server:90d11d8-java
ghcr.io/openhands/agent-server:90d11d8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `90d11d8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `90d11d8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->