### PR TITLE
fix(ci): switch Gemini defaults to 3.1 Pro

### DIFF
--- a/.github/workflows/api-compliance-runner.yml
+++ b/.github/workflows/api-compliance-runner.yml
@@ -18,7 +18,7 @@ on:
 
 env:
     # Default models to test (matches DEFAULT_MODELS in run_compliance.py)
-    DEFAULT_MODELS: claude-sonnet-4-5,gpt-5.2,gemini-3-pro
+    DEFAULT_MODELS: claude-sonnet-4-5,gpt-5.2,gemini-3.1-pro
 
 jobs:
     run-compliance-tests:

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -50,7 +50,7 @@ on:
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
     # Default models for scheduled/label-triggered runs (subset of models from resolve_model_config.py)
-    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v3.2-reasoner,kimi-k2-thinking,gemini-3-pro
+    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v3.2-reasoner,kimi-k2-thinking,gemini-3.1-pro
 
 jobs:
     setup-matrix:

--- a/tests/integration/api_compliance/run_compliance.py
+++ b/tests/integration/api_compliance/run_compliance.py
@@ -56,8 +56,8 @@ DEFAULT_MODELS: dict[str, dict[str, Any]] = {
         "model": "litellm_proxy/openai/gpt-5.2-2025-12-11",
         "_display": "gpt",
     },
-    "gemini-3-pro": {
-        "model": "litellm_proxy/gemini-3-pro-preview",
+    "gemini-3.1-pro": {
+        "model": "litellm_proxy/gemini-3.1-pro-preview",
         "_display": "gemini",
     },
 }


### PR DESCRIPTION
## Summary
- switch integration workflow defaults from `gemini-3-pro` to `gemini-3.1-pro`
- switch API compliance defaults to `gemini-3.1-pro`
- align API compliance model config with `litellm_proxy/gemini-3.1-pro-preview`

## Context
Google's current official 3.1 Pro model name is `gemini-3.1-pro-preview`, while the older `gemini-3-pro-preview` page is marked shut down. This follow-up keeps the existing legacy config intact but moves CI defaults to the exact 3.1 model name already present in the repo model registry.

Related to release PR #2614.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b7db09b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b7db09b-python \
  ghcr.io/openhands/agent-server:b7db09b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b7db09b-golang-amd64
ghcr.io/openhands/agent-server:b7db09b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b7db09b-golang-arm64
ghcr.io/openhands/agent-server:b7db09b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b7db09b-java-amd64
ghcr.io/openhands/agent-server:b7db09b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b7db09b-java-arm64
ghcr.io/openhands/agent-server:b7db09b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b7db09b-python-amd64
ghcr.io/openhands/agent-server:b7db09b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b7db09b-python-arm64
ghcr.io/openhands/agent-server:b7db09b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b7db09b-golang
ghcr.io/openhands/agent-server:b7db09b-java
ghcr.io/openhands/agent-server:b7db09b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b7db09b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b7db09b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->