### PR TITLE
docs: link CLI bridge RFC to SDK flexibility umbrella

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,7 +106,7 @@ When reviewing code, provide constructive feedback:
 - `SettingsFieldSchema` intentionally does not export a `required` flag. If a consumer needs nullability semantics, inspect the underlying Python typing rather than inferring from SDK defaults.
 - `AgentSettings.tools` is part of the exported settings schema so the schema stays aligned with the settings payload that round-trips through `AgentSettings` and drives `create_agent()`.
 - `AgentSettings.mcp_config` now uses FastMCP's typed `MCPConfig` at runtime. When serializing settings back to plain data (e.g. `model_dump()` or `create_agent()`), keep the output compact with `exclude_none=True, exclude_defaults=True` so callers still see the familiar `.mcp.json`-style dict shape.
-
+- OpenHands-CLI#574 ("Bridge — Unified Server-Client Architecture for CLI ↔ Cloud") belongs in the SDK flexibility umbrella alongside LLM switching and teleport: it keeps the runtime local behind a local `openhands-agent-server`, while teleport moves or restores a conversation across runtimes.
 
 ## Package-specific guidance
 When reviewing or modifying code, read the closest AGENTS file for the


### PR DESCRIPTION
## Summary

- add a repo memory note that OpenHands-CLI#574 belongs in the SDK flexibility umbrella
- record the distinction between Bridge/local agent-server work and conversation teleport
- note that issue #1562 was updated separately with the new third category and an explanatory reply

Closes #1562.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this? (Not applicable: docs-only AGENTS.md update.)
- [x] If there is an example, have you run the example to make sure that it works? (Not applicable.)
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? (Not applicable.)
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? (Not applicable.)
- [ ] Is the github CI passing?


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/673fad42-c190-4c32-bf0e-a3bcd1978a12)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a16951c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a16951c-python \
  ghcr.io/openhands/agent-server:a16951c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a16951c-golang-amd64
ghcr.io/openhands/agent-server:a16951c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a16951c-golang-arm64
ghcr.io/openhands/agent-server:a16951c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a16951c-java-amd64
ghcr.io/openhands/agent-server:a16951c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a16951c-java-arm64
ghcr.io/openhands/agent-server:a16951c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a16951c-python-amd64
ghcr.io/openhands/agent-server:a16951c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a16951c-python-arm64
ghcr.io/openhands/agent-server:a16951c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a16951c-golang
ghcr.io/openhands/agent-server:a16951c-java
ghcr.io/openhands/agent-server:a16951c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a16951c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a16951c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->