### PR TITLE
fix(workspace): avoid logging forwarded env values

### DIFF
--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -212,7 +212,16 @@ class APIRemoteWorkspace(RemoteWorkspace):
             payload["resource_factor"] = self.resource_factor
 
         logger.info(f"Starting runtime with {self.server_image}")
-        logger.info(f"Payload: {payload}")
+        logger.info(
+            "Runtime start payload: image=%s session_id=%s image_pull_policy=%s "
+            "runtime_class=%s resource_factor=%s environment_keys=%s",
+            payload["image"],
+            payload["session_id"],
+            payload["image_pull_policy"],
+            payload.get("runtime_class"),
+            payload.get("resource_factor", 1),
+            sorted(environment),
+        )
         resp = self._send_api_request(
             "POST",
             f"{self.runtime_api_url}/start",

--- a/tests/workspace/test_api_remote_workspace.py
+++ b/tests/workspace/test_api_remote_workspace.py
@@ -241,3 +241,49 @@ def test_forward_env_empty_list_results_in_empty_environment():
 
         workspace._runtime_id = None
         workspace.cleanup()
+
+
+def test_start_runtime_logs_environment_keys_without_values(caplog):
+    """Test that start-runtime logs do not include forwarded env values."""
+    from openhands.workspace import APIRemoteWorkspace
+
+    with patch.dict(
+        os.environ,
+        {
+            "SECRET_TOKEN": "super-secret-value",
+            "ANOTHER_SECRET": "another-secret-value",
+        },
+    ):
+        with patch.object(
+            APIRemoteWorkspace, "_start_or_attach_to_runtime"
+        ) as mock_attach:
+            mock_attach.return_value = None
+
+            workspace = APIRemoteWorkspace(
+                runtime_api_url="https://example.com",
+                runtime_api_key="test-key",
+                server_image="test-image",
+                forward_env=["SECRET_TOKEN", "ANOTHER_SECRET"],
+            )
+
+            mock_response = MagicMock()
+            mock_response.json.return_value = {
+                "runtime_id": "test-id",
+                "url": "https://test-runtime.com",
+                "session_api_key": "test-key",
+            }
+
+            with patch.object(
+                workspace, "_send_api_request", return_value=mock_response
+            ):
+                with caplog.at_level("INFO"):
+                    workspace._start_runtime()
+
+            log_text = "\n".join(record.getMessage() for record in caplog.records)
+            assert "super-secret-value" not in log_text
+            assert "another-secret-value" not in log_text
+            assert "Runtime start payload:" in log_text
+            assert "environment_keys=['ANOTHER_SECRET', 'SECRET_TOKEN']" in log_text
+
+            workspace._runtime_id = None
+            workspace.cleanup()


### PR DESCRIPTION
## Summary
- stop logging the raw runtime start payload in `APIRemoteWorkspace`
- log only safe runtime metadata plus forwarded environment keys
- add a regression test that verifies forwarded env values never appear in logs

## Why
`APIRemoteWorkspace._start_runtime()` was logging `Payload: {payload}` after copying forwarded host env vars into `payload["environment"]`. That exposed secrets such as `LMNR_PROJECT_API_KEY` and provider API keys when instance logs were published in evaluation artifacts.

## Testing
- `PYTHONPATH="/Users/simonrosenberg/tmp/software-agent-sdk-sec-leak-fix/openhands-workspace:/Users/simonrosenberg/tmp/software-agent-sdk-sec-leak-fix/openhands-sdk:/Users/simonrosenberg/tmp/software-agent-sdk-sec-leak-fix/openhands-agent-server" pytest tests/workspace/test_api_remote_workspace.py`

Refs: OpenHands/software-agent-sdk#2629

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cd14202-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cd14202-python \
  ghcr.io/openhands/agent-server:cd14202-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cd14202-golang-amd64
ghcr.io/openhands/agent-server:cd14202-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cd14202-golang-arm64
ghcr.io/openhands/agent-server:cd14202-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cd14202-java-amd64
ghcr.io/openhands/agent-server:cd14202-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cd14202-java-arm64
ghcr.io/openhands/agent-server:cd14202-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cd14202-python-amd64
ghcr.io/openhands/agent-server:cd14202-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cd14202-python-arm64
ghcr.io/openhands/agent-server:cd14202-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cd14202-golang
ghcr.io/openhands/agent-server:cd14202-java
ghcr.io/openhands/agent-server:cd14202-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cd14202-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cd14202-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->