### PR TITLE
fix(conversation): sanitize remote error logging

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -2,7 +2,6 @@ import asyncio
 import bisect
 import json
 import os
-import re
 import threading
 import time
 import uuid
@@ -52,6 +51,7 @@ from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
+from openhands.sdk.utils.redact import http_error_log_content
 from openhands.sdk.workspace import LocalWorkspace, RemoteWorkspace
 
 
@@ -59,47 +59,6 @@ logger = get_logger(__name__)
 
 LEGACY_CONVERSATIONS_PATH = "/api/conversations"
 ACP_CONVERSATIONS_PATH = "/api/acp/conversations"
-_SECRET_KEY_PATTERN = re.compile(
-    r"(api[_-]?key|token|secret|password|authorization|auth)", re.IGNORECASE
-)
-_REDACT_ALL_VALUES_KEYS = {"environment", "env", "headers", "acp_env"}
-
-
-def _redact_content(value):
-    """Redact nested values while preserving key names where possible."""
-    if isinstance(value, Mapping):
-        return {k: _redact_content(v) for k, v in value.items()}
-    if isinstance(value, list):
-        return [_redact_content(item) for item in value]
-    return "<redacted>"
-
-
-def _sanitize_error_content(content):
-    """Recursively redact likely secrets from structured error payloads."""
-    if isinstance(content, Mapping):
-        sanitized = {}
-        for key, value in content.items():
-            key_str = str(key)
-            key_lower = key_str.lower()
-            if key_lower in _REDACT_ALL_VALUES_KEYS:
-                sanitized[key] = _redact_content(value)
-            elif _SECRET_KEY_PATTERN.search(key_str):
-                sanitized[key] = "<redacted>"
-            else:
-                sanitized[key] = _sanitize_error_content(value)
-        return sanitized
-    if isinstance(content, list):
-        return [_sanitize_error_content(item) for item in content]
-    return content
-
-
-def _http_error_log_content(response: httpx.Response):
-    """Return a sanitized representation of an HTTP error body for logs."""
-    try:
-        return _sanitize_error_content(response.json())
-    except Exception:
-        body_len = len(response.text or "")
-        return f"<non-JSON response body omitted ({body_len} chars)>"
 
 
 def _uses_acp_conversation_contract(agent: AgentBase) -> bool:
@@ -136,7 +95,7 @@ def _send_request(
         response.raise_for_status()
         return response
     except httpx.HTTPStatusError as e:
-        content = _http_error_log_content(e.response)
+        content = http_error_log_content(e.response)
         logger.error(
             "HTTP request failed (%d %s): %s",
             e.response.status_code,

--- a/openhands-sdk/openhands/sdk/secret/secrets.py
+++ b/openhands-sdk/openhands/sdk/secret/secrets.py
@@ -8,6 +8,7 @@ from pydantic import Field, SecretStr, field_serializer, field_validator
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
+from openhands.sdk.utils.redact import is_secret_key
 
 
 logger = get_logger(__name__)
@@ -62,7 +63,7 @@ class LookupSecret(SecretSource):
     def _validate_secrets(cls, headers: dict[str, str], info):
         result = {}
         for key, value in headers.items():
-            if _is_secret_header(key):
+            if is_secret_key(key):
                 secret_value = validate_secret(SecretStr(value), info)
                 # Skip headers with redacted/empty secret values
                 if secret_value is None:
@@ -79,7 +80,7 @@ class LookupSecret(SecretSource):
     def _serialize_secrets(self, headers: dict[str, str], info):
         result = {}
         for key, value in headers.items():
-            if _is_secret_header(key):
+            if is_secret_key(key):
                 secret_value = serialize_secret(SecretStr(value), info)
                 if secret_value is None:
                     logger.debug(
@@ -90,29 +91,6 @@ class LookupSecret(SecretSource):
             else:
                 result[key] = value
         return result
-
-
-# Patterns used for substring matching against header names (case-insensitive).
-# Headers containing any of these patterns will be redacted during serialization.
-# Examples: X-Access-Token, Cookie, Authorization, X-API-Key, X-API-Secret
-_SECRET_HEADERS = [
-    "AUTHORIZATION",
-    "COOKIE",
-    "CREDENTIAL",
-    "KEY",
-    "PASSWORD",
-    "SECRET",
-    "SESSION",
-    "TOKEN",
-]
-
-
-def _is_secret_header(key: str):
-    key = key.upper()
-    for secret in _SECRET_HEADERS:
-        if secret in key:
-            return True
-    return False
 
 
 # Type alias for secret values - can be a plain string or a SecretSource

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -1,0 +1,117 @@
+"""Utilities for redacting sensitive data from logs and error responses.
+
+This module provides a centralized, unified set of patterns and functions for
+detecting and redacting secret-bearing keys in structured data (JSON objects,
+headers, etc.). It's the single source of truth for secret key detection across
+the SDK.
+"""
+
+from collections.abc import Mapping
+from typing import Any
+
+import httpx
+
+
+# Patterns used for substring matching against key names (case-insensitive).
+# Keys containing any of these patterns will have their values redacted.
+# Examples: api_key, X-Access-Token, Authorization, password, secret
+# Note: We use "AUTHORIZATION" instead of "AUTH" to avoid false positives
+# like "Author" headers.
+SECRET_KEY_PATTERNS = frozenset(
+    {
+        "AUTHORIZATION",
+        "COOKIE",
+        "CREDENTIAL",
+        "KEY",
+        "PASSWORD",
+        "SECRET",
+        "SESSION",
+        "TOKEN",
+    }
+)
+
+# Keys that should have ALL nested values redacted (not just detected secret keys).
+# These typically contain environment variables or headers that may include secrets.
+REDACT_ALL_VALUES_KEYS = frozenset({"environment", "env", "headers", "acp_env"})
+
+
+def is_secret_key(key: str) -> bool:
+    """Check if a key name likely contains secret data.
+
+    Performs case-insensitive substring matching against known secret key patterns.
+
+    Args:
+        key: The key name to check (e.g., "api_key", "Authorization", "X-Token")
+
+    Returns:
+        True if the key matches any secret pattern, False otherwise
+
+    Examples:
+        >>> is_secret_key("api_key")
+        True
+        >>> is_secret_key("Authorization")
+        True
+        >>> is_secret_key("user_name")
+        False
+    """
+    key_upper = key.upper()
+    return any(pattern in key_upper for pattern in SECRET_KEY_PATTERNS)
+
+
+def _redact_all_values(value: Any) -> Any:
+    """Recursively redact all values while preserving structure (key names)."""
+    if isinstance(value, Mapping):
+        return {k: _redact_all_values(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_redact_all_values(item) for item in value]
+    return "<redacted>"
+
+
+def sanitize_dict(content: Any) -> Any:
+    """Recursively redact likely secrets from structured data.
+
+    This function walks through a nested dict/list structure and:
+    - Redacts values for keys matching SECRET_KEY_PATTERNS
+    - Redacts ALL nested values for keys in REDACT_ALL_VALUES_KEYS
+    - Leaves other values unchanged
+
+    Args:
+        content: A dict, list, or scalar value to sanitize
+
+    Returns:
+        A sanitized copy with secrets replaced by '<redacted>'
+    """
+    if isinstance(content, Mapping):
+        sanitized = {}
+        for key, value in content.items():
+            key_str = str(key)
+            key_lower = key_str.lower()
+            if key_lower in REDACT_ALL_VALUES_KEYS:
+                sanitized[key] = _redact_all_values(value)
+            elif is_secret_key(key_str):
+                sanitized[key] = "<redacted>"
+            else:
+                sanitized[key] = sanitize_dict(value)
+        return sanitized
+    if isinstance(content, list):
+        return [sanitize_dict(item) for item in content]
+    return content
+
+
+def http_error_log_content(response: httpx.Response) -> str | dict:
+    """Return a sanitized representation of an HTTP error body for logs.
+
+    For JSON responses, returns a sanitized dict with secrets redacted.
+    For non-JSON responses, returns a placeholder message with the body length.
+
+    Args:
+        response: The httpx.Response to extract error content from
+
+    Returns:
+        A sanitized dict or string safe for logging
+    """
+    try:
+        return sanitize_dict(response.json())
+    except Exception:
+        body_len = len(response.text or "")
+        return f"<non-JSON response body omitted ({body_len} chars)>"

--- a/tests/sdk/conversation/remote/test_remote_request_logging.py
+++ b/tests/sdk/conversation/remote/test_remote_request_logging.py
@@ -4,6 +4,112 @@ import httpx
 import pytest
 
 from openhands.sdk.conversation.impl.remote_conversation import _send_request
+from openhands.sdk.utils.redact import (
+    http_error_log_content,
+    is_secret_key,
+    sanitize_dict,
+)
+
+
+class TestIsSecretKey:
+    """Tests for the unified is_secret_key function."""
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "api_key",
+            "API_KEY",
+            "Api-Key",
+            "x-api-key",
+            "Authorization",
+            "AUTHORIZATION",
+            "x-access-token",
+            "X-Token",
+            "password",
+            "PASSWORD",
+            "user_password",
+            "secret",
+            "client_secret",
+            "Cookie",
+            "session_id",
+            "credential",
+        ],
+    )
+    def test_detects_secret_keys(self, key):
+        assert is_secret_key(key) is True
+
+    @pytest.mark.parametrize(
+        "key",
+        [
+            "user_name",
+            "email",
+            "status",
+            "detail",
+            "message",
+            "input",
+            "output",
+            "Author",  # Should NOT be redacted (false positive check)
+        ],
+    )
+    def test_ignores_non_secret_keys(self, key):
+        assert is_secret_key(key) is False
+
+
+class TestSanitizeDict:
+    """Tests for the sanitize_dict function."""
+
+    def test_redacts_secret_keys(self):
+        data = {"api_key": "my-secret", "name": "test"}
+        result = sanitize_dict(data)
+        assert result == {"api_key": "<redacted>", "name": "test"}
+
+    def test_redacts_all_values_in_environment_keys(self):
+        data = {
+            "environment": {"VAR1": "val1", "VAR2": "val2"},
+            "acp_env": {"NESTED": {"deep": "value"}},
+        }
+        result = sanitize_dict(data)
+        assert result["environment"] == {"VAR1": "<redacted>", "VAR2": "<redacted>"}
+        assert result["acp_env"] == {"NESTED": {"deep": "<redacted>"}}
+
+    def test_preserves_structure_in_lists(self):
+        data = [{"api_key": "secret"}, {"name": "test"}]
+        result = sanitize_dict(data)
+        assert result == [{"api_key": "<redacted>"}, {"name": "test"}]
+
+    def test_handles_nested_structures(self):
+        data = {
+            "detail": [
+                {
+                    "input": {
+                        "agent": {"llm": {"api_key": "secret"}},
+                        "headers": {"X-Token": "token123"},
+                    }
+                }
+            ]
+        }
+        result = sanitize_dict(data)
+        assert result["detail"][0]["input"]["agent"]["llm"]["api_key"] == "<redacted>"
+        assert result["detail"][0]["input"]["headers"] == {"X-Token": "<redacted>"}
+
+
+class TestHttpErrorLogContent:
+    """Tests for the http_error_log_content function."""
+
+    def test_sanitizes_json_response(self):
+        request = httpx.Request("POST", "http://example.com")
+        response = httpx.Response(
+            422, request=request, json={"api_key": "secret", "message": "error"}
+        )
+        result = http_error_log_content(response)
+        assert result == {"api_key": "<redacted>", "message": "error"}
+
+    def test_handles_non_json_response(self):
+        request = httpx.Request("GET", "http://example.com")
+        response = httpx.Response(500, request=request, text="Internal Server Error")
+        result = http_error_log_content(response)
+        assert "<non-JSON response body omitted" in result
+        assert "21 chars" in result
 
 
 def test_send_request_redacts_structured_error_content(caplog):


### PR DESCRIPTION
## Summary
- sanitize structured HTTP error bodies before logging them in `RemoteConversation`
- redact nested secret-bearing fields such as `api_key`, `environment`, `headers`, and `acp_env`
- omit raw non-JSON response bodies from logs
- add direct regression tests for structured and text error responses

## Why
`_send_request()` in `openhands.sdk.conversation.impl.remote_conversation` was logging raw error response bodies. Some server-side validation errors echo the original request body, which can include secret-bearing fields. This PR prevents those values from being written to logs while preserving enough structure to debug the failure.

## Changes
Based on code review feedback, the implementation was refactored to:
1. **Create centralized `utils/redact.py` module** - Single source of truth for secret key patterns and sanitization functions
2. **Unify secret detection** - `secrets.py` now imports `is_secret_key()` from the new module, eliminating duplicated patterns
3. **Add comprehensive tests** - Unit tests for `is_secret_key()`, `sanitize_dict()`, and `http_error_log_content()`

## Testing
```bash
uv run pytest tests/sdk/conversation/remote/test_remote_request_logging.py tests/sdk/conversation/test_secret_source.py -v
```

Refs: OpenHands/software-agent-sdk#2629

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c62a802-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c62a802-python \
  ghcr.io/openhands/agent-server:c62a802-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c62a802-golang-amd64
ghcr.io/openhands/agent-server:c62a802-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c62a802-golang-arm64
ghcr.io/openhands/agent-server:c62a802-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c62a802-java-amd64
ghcr.io/openhands/agent-server:c62a802-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c62a802-java-arm64
ghcr.io/openhands/agent-server:c62a802-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c62a802-python-amd64
ghcr.io/openhands/agent-server:c62a802-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c62a802-python-arm64
ghcr.io/openhands/agent-server:c62a802-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c62a802-golang
ghcr.io/openhands/agent-server:c62a802-java
ghcr.io/openhands/agent-server:c62a802-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c62a802-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c62a802-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->