### PR TITLE
feat(tool/file_editor): file editor resources

### DIFF
--- a/openhands-tools/openhands/tools/file_editor/definition.py
+++ b/openhands-tools/openhands/tools/file_editor/definition.py
@@ -1,6 +1,7 @@
 """String replace editor tool implementation."""
 
 from collections.abc import Sequence
+from pathlib import Path
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field, PrivateAttr
@@ -201,7 +202,8 @@ class FileEditorTool(ToolDefinition[FileEditorAction, FileEditorObservation]):
         *different* files run in parallel.
         """
         assert isinstance(action, FileEditorAction)
-        return DeclaredResources(keys=(f"file:{action.path}",), declared=True)
+        normalized_path = Path(action.path).resolve()
+        return DeclaredResources(keys=(f"file:{normalized_path}",), declared=True)
 
     @classmethod
     def create(

--- a/tests/tools/file_editor/test_file_editor_tool.py
+++ b/tests/tools/file_editor/test_file_editor_tool.py
@@ -2,6 +2,7 @@
 
 import os
 import tempfile
+from pathlib import Path
 from uuid import uuid4
 
 import pytest
@@ -234,8 +235,9 @@ def test_declared_resources_locks_on_file_path(command):
     with tempfile.TemporaryDirectory() as temp_dir:
         tool = FileEditorTool.create(_create_test_conv_state(temp_dir))[0]
         action = FileEditorAction(command=command, path="/a.py")
+        expected_path = Path("/a.py").resolve()
         assert tool.declared_resources(action) == DeclaredResources(
-            keys=("file:/a.py",), declared=True
+            keys=(f"file:{expected_path}",), declared=True
         )
 
 
@@ -259,6 +261,35 @@ def test_declared_resources_same_path_same_key_across_commands():
             FileEditorAction(command="str_replace", path="/a.py")
         )
         assert r1.keys == r2.keys
+
+
+def test_declared_resources_normalizes_dotdot_paths():
+    """Paths with '..' that resolve to the same file produce the same key."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tool = FileEditorTool.create(_create_test_conv_state(temp_dir))[0]
+        r1 = tool.declared_resources(FileEditorAction(command="view", path="/a/c.py"))
+        r2 = tool.declared_resources(
+            FileEditorAction(command="view", path="/a/b/../c.py")
+        )
+        assert r1.keys == r2.keys
+
+
+def test_declared_resources_normalizes_dot_paths():
+    """Paths with '.' that resolve to the same file produce the same key."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tool = FileEditorTool.create(_create_test_conv_state(temp_dir))[0]
+        r1 = tool.declared_resources(FileEditorAction(command="view", path="/a/c.py"))
+        r2 = tool.declared_resources(FileEditorAction(command="view", path="/a/./c.py"))
+        assert r1.keys == r2.keys
+
+
+def test_declared_resources_normalizes_relative_paths():
+    """Relative paths are resolved to absolute path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        tool = FileEditorTool.create(_create_test_conv_state(temp_dir))[0]
+        r1 = tool.declared_resources(FileEditorAction(command="view", path="a.py"))
+        expected_path = Path("a.py").resolve()
+        assert r1.keys == (f"file:{expected_path}",)
 
 
 def test_file_editor_tool_image_viewing_line_with_vision_enabled():


### PR DESCRIPTION
## Summary

This PR is part of issue #2530.

We have added specific resource declarations for the `FileEditorTool`.

I didn't see a significant speedup from parallelization with this tool, as the `FileEditorTool` is heavy on Python code, which remains blocked by the GIL.

However, adding these declarations improves performance when working alongside other tools (such as MCP servers).

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a3f948b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a3f948b-python \
  ghcr.io/openhands/agent-server:a3f948b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a3f948b-golang-amd64
ghcr.io/openhands/agent-server:a3f948b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a3f948b-golang-arm64
ghcr.io/openhands/agent-server:a3f948b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a3f948b-java-amd64
ghcr.io/openhands/agent-server:a3f948b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a3f948b-java-arm64
ghcr.io/openhands/agent-server:a3f948b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a3f948b-python-amd64
ghcr.io/openhands/agent-server:a3f948b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a3f948b-python-arm64
ghcr.io/openhands/agent-server:a3f948b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a3f948b-golang
ghcr.io/openhands/agent-server:a3f948b-java
ghcr.io/openhands/agent-server:a3f948b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a3f948b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a3f948b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->