### PR TITLE
feat(tools/grep): declare resources for parallel execution

### DIFF
--- a/openhands-tools/openhands/tools/grep/definition.py
+++ b/openhands-tools/openhands/tools/grep/definition.py
@@ -68,21 +68,15 @@ class GrepTool(ToolDefinition[GrepAction, GrepObservation]):
     """A ToolDefinition subclass that automatically initializes a GrepExecutor."""
 
     def declared_resources(self, action: Action) -> DeclaredResources:
-        """Declare resource usage based on the active backend.
+        """Declare resource usage for parallel execution.
 
-        With ripgrep, each call spawns an independent subprocess — safe for
-        lock-free parallel execution. The grep fallback may have
-        platform-specific limitations, so concurrent calls are serialized
-        via the tool-wide mutex.
+        Both backends (ripgrep and regular grep) spawn independent
+        subprocesses with no shared mutable state, so all grep calls
+        are safe to run lock-free in parallel.
         """
         if not isinstance(action, GrepAction):
             raise TypeError(f"Expected GrepAction, got {type(action).__name__}")
-        # Import here to avoid circular imports (definition ↔ impl)
-        from openhands.tools.grep.impl import GrepExecutor
-
-        if isinstance(self.executor, GrepExecutor) and self.executor.is_parallel_safe():
-            return DeclaredResources(keys=(), declared=True)
-        return DeclaredResources(keys=(), declared=False)
+        return DeclaredResources(keys=(), declared=True)
 
     @classmethod
     def create(

--- a/openhands-tools/openhands/tools/grep/impl.py
+++ b/openhands-tools/openhands/tools/grep/impl.py
@@ -38,14 +38,6 @@ class GrepExecutor(ToolExecutor[GrepAction, GrepObservation]):
         if not self._ripgrep_available:
             _log_ripgrep_fallback_warning("grep", "regular grep command")
 
-    def is_parallel_safe(self) -> bool:
-        """Whether the executor is safe for lock-free parallel execution.
-
-        True when ripgrep is available (independent subprocesses).
-        False for the grep fallback (may have platform-specific limitations).
-        """
-        return self._ripgrep_available
-
     def __call__(
         self,
         action: GrepAction,

--- a/tests/tools/grep/test_grep_executor.py
+++ b/tests/tools/grep/test_grep_executor.py
@@ -189,11 +189,11 @@ def test_grep_executor_invalid_regex():
         assert "Invalid regex pattern" in observation.text
 
 
-def test_grep_executor_concurrent_with_ripgrep():
-    """Test that concurrent ripgrep-based grep calls return correct results.
+def test_grep_executor_concurrent():
+    """Test that concurrent grep calls return correct results.
 
-    Ripgrep spawns independent subprocesses with their own working directory,
-    so concurrent calls are inherently thread-safe.
+    Both backends spawn independent subprocesses, so concurrent calls
+    are inherently thread-safe.
     """
     import threading
 
@@ -209,8 +209,6 @@ def test_grep_executor_concurrent_with_ripgrep():
             (dir_b / f"beta_{i}.txt").write_text(f"hello_beta {i}")
 
         executor = GrepExecutor(working_dir=temp_dir)
-        if not executor.is_parallel_safe():
-            pytest.skip("ripgrep not installed")
 
         results: list[tuple[str, list[str]]] = []
         results_lock = threading.Lock()

--- a/tests/tools/grep/test_grep_tool.py
+++ b/tests/tools/grep/test_grep_tool.py
@@ -14,7 +14,6 @@ from openhands.sdk.llm import LLM
 from openhands.sdk.tool.tool import DeclaredResources
 from openhands.sdk.workspace import LocalWorkspace
 from openhands.tools.grep import GrepAction, GrepObservation, GrepTool
-from openhands.tools.grep.impl import GrepExecutor
 
 
 def _create_test_conv_state(temp_dir: str) -> ConversationState:
@@ -293,55 +292,18 @@ def test_grep_tool_to_llm_content_error():
         "custom-path-with-include",
     ],
 )
-def test_grep_tool_declared_resources_with_ripgrep(pattern, path, include):
-    """Test that GrepTool declares no resources when ripgrep is available."""
+def test_grep_tool_declared_resources(pattern, path, include):
+    """Test that GrepTool declares parallel-safe resources for all backends."""
     with tempfile.TemporaryDirectory() as temp_dir:
         conv_state = _create_test_conv_state(temp_dir)
         tools = GrepTool.create(conv_state)
         tool = tools[0]
-
-        assert isinstance(tool.executor, GrepExecutor)
-        if not tool.executor.is_parallel_safe():
-            pytest.skip("ripgrep not installed")
 
         action = GrepAction(pattern=pattern, path=path, include=include)
         resources = tool.declared_resources(action)
 
         assert isinstance(resources, DeclaredResources)
         assert resources.declared is True
-        assert resources.keys == ()
-
-
-@pytest.mark.parametrize(
-    "pattern, path, include",
-    [
-        ("log.*Error", None, None),
-        ("function\\s+\\w+", "/some/custom/path", None),
-        ("TODO", None, "*.py"),
-        ("import", "/another/path", "*.{ts,tsx}"),
-    ],
-    ids=[
-        "regex-no-path",
-        "regex-custom-path",
-        "simple-with-include",
-        "custom-path-with-include",
-    ],
-)
-def test_grep_tool_declared_resources_without_ripgrep(pattern, path, include):
-    """Test that GrepTool falls back to tool-wide mutex when ripgrep is unavailable."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        conv_state = _create_test_conv_state(temp_dir)
-        tools = GrepTool.create(conv_state)
-        tool = tools[0]
-
-        assert isinstance(tool.executor, GrepExecutor)
-        tool.executor._ripgrep_available = False  # force fallback path
-
-        action = GrepAction(pattern=pattern, path=path, include=include)
-        resources = tool.declared_resources(action)
-
-        assert isinstance(resources, DeclaredResources)
-        assert resources.declared is False
         assert resources.keys == ()
 
 


### PR DESCRIPTION
## Summary

- Override declared_resources() on GrepTool to return DeclaredResources(keys=(), declared=True), opting the tool into lock-free parallel execution instead of the default tool-wide mutex.
- Add parametrized tests for the new declared_resources override and a concurrency test for the executor.

## Context

Without an explicit declared_resources() override, the parallel executor falls back to a tool:grep mutex that serializes all grep calls, even when they target unrelated directories.

Unlike the glob tool — where the Python glob fallback relies on os.chdir() (process-global state) and genuinely requires serialization — both grep backends (ripgrep and regular grep) spawn independent subprocesses via subprocess.run with no shared mutable state. This means all grep calls are inherently safe to run concurrently, regardless of which backend is active, and no is_parallel_safe() check is needed.

## Benchmark

```
         Benchmarking 1 chains          
┏━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━┓
┃ Chain                 ┃        Calls ┃
┡━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━┩
│ tool-grep             │           20 │
└───────────────────────┴──────────────┘
```

main

```
                                    Benchmark Results                                     
┏━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Chain          ┃   W ┃     Wall (s) ┃    Speedup ┃    Mem (MB) ┃    Errors ┃    Unique ┃
┡━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
│ tool-grep      │   1 │        4.617 │      1.00x │         1.4 │         0 │       1/3 │
│ tool-grep      │   2 │        4.678 │      0.99x │         1.4 │         0 │       1/3 │
│ tool-grep      │   4 │        4.634 │      1.00x │         1.4 │         0 │       1/3 │
│ tool-grep      │   8 │        4.726 │      0.98x │         1.4 │         0 │       1/3 │
└────────────────┴─────┴──────────────┴────────────┴─────────────┴───────────┴───────────┘
```

this branch

```
                                   Benchmark Results                                     
┏━━━━━━━━━━━━━━━━┳━━━━━┳━━━━━━━━━━━━━━┳━━━━━━━━━━━━┳━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━┓
┃ Chain          ┃   W ┃     Wall (s) ┃    Speedup ┃    Mem (MB) ┃    Errors ┃    Unique ┃
┡━━━━━━━━━━━━━━━━╇━━━━━╇━━━━━━━━━━━━━━╇━━━━━━━━━━━━╇━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━┩
│ tool-grep      │   1 │        4.770 │      1.00x │         1.4 │         0 │       1/3 │
│ tool-grep      │   2 │        2.714 │      1.76x │         1.5 │         0 │       1/3 │
│ tool-grep      │   4 │        1.669 │      2.87x │         1.6 │         0 │       1/3 │
│ tool-grep      │   8 │        1.465 │      3.26x │         1.9 │         0 │       1/3 │
└────────────────┴─────┴──────────────┴────────────┴─────────────┴───────────┴───────────┘
```

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [x] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e26ba8a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e26ba8a-python \
  ghcr.io/openhands/agent-server:e26ba8a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e26ba8a-golang-amd64
ghcr.io/openhands/agent-server:e26ba8a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e26ba8a-golang-arm64
ghcr.io/openhands/agent-server:e26ba8a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e26ba8a-java-amd64
ghcr.io/openhands/agent-server:e26ba8a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e26ba8a-java-arm64
ghcr.io/openhands/agent-server:e26ba8a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e26ba8a-python-amd64
ghcr.io/openhands/agent-server:e26ba8a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e26ba8a-python-arm64
ghcr.io/openhands/agent-server:e26ba8a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e26ba8a-golang
ghcr.io/openhands/agent-server:e26ba8a-java
ghcr.io/openhands/agent-server:e26ba8a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e26ba8a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e26ba8a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->