### PR TITLE
chore(uv): add 7-day exclude-newer guardrail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,6 +107,7 @@ When reviewing code, provide constructive feedback:
 - `AgentSettings.tools` is part of the exported settings schema so the schema stays aligned with the settings payload that round-trips through `AgentSettings` and drives `create_agent()`.
 - `AgentSettings.mcp_config` now uses FastMCP's typed `MCPConfig` at runtime. When serializing settings back to plain data (e.g. `model_dump()` or `create_agent()`), keep the output compact with `exclude_none=True, exclude_defaults=True` so callers still see the familiar `.mcp.json`-style dict shape.
 - AgentSkills progressive disclosure goes through `AgentContext.get_system_message_suffix()` into `<available_skills>`, and `openhands.sdk.context.skills.to_prompt()` truncates each prompt description to 1024 characters because the AgentSkills specification caps `description` at 1-1024 characters.
+- Workspace-wide uv resolver guardrails belong in the repository root `[tool.uv]` table. When `exclude-newer` is configured there, `uv lock` persists it into the root `uv.lock` `[options]` section as both an absolute cutoff and `exclude-newer-span`, and `uv sync --frozen` continues to use that locked workspace state.
 
 
 ## Package-specific guidance

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,8 +2,9 @@
 [tool.uv.workspace]
 members = ["openhands-sdk", "openhands-tools", "openhands-workspace", "openhands-agent-server"]
 
-# Security: Enforce minimum versions for transitive dependencies with known CVEs
+# Security: Apply workspace-wide dependency guardrails.
 [tool.uv]
+exclude-newer = "7 days"  # Avoid packages uploaded in the last 7 days.
 constraint-dependencies = [
     "starlette>=0.49.1",  # CVE-2025-62727
     "aiohttp>=3.13.3",  # CVE-2025-69223 + 7 others

--- a/uv.lock
+++ b/uv.lock
@@ -7,6 +7,10 @@ resolution-markers = [
     "python_full_version < '3.13'",
 ]
 
+[options]
+exclude-newer = "2026-03-25T15:01:42.994669841Z"
+exclude-newer-span = "P7D"
+
 [manifest]
 members = [
     "openhands-agent-server",


### PR DESCRIPTION
## Summary
- add a workspace-wide `exclude-newer = "7 days"` guardrail in the root `[tool.uv]` config
- refresh `uv.lock` so the shared workspace lockfile records the matching exclude-newer options
- record the workspace-level uv behavior in `AGENTS.md` for future contributors

## Why
This repository uses a single root uv workspace and shared `uv.lock`. Adding the guardrail at the root `[tool.uv]` level applies consistently to the workspace commands we already run from the repository root (`uv lock`, `uv sync`, CI installs, and `make build`) without changing package-local configuration.

I also verified that `origin/main`'s existing locked artifacts were already older than 7 days relative to the current system clock, so this change is forward-looking and does not force dependency churn.

## Validation
- `uv lock`
- `uv sync --frozen --group dev`
- `uv run pre-commit run --files pyproject.toml AGENTS.md`

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bc5f8ed3-a665-4e81-be89-2b67edd1e1d9)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:69c3e59-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-69c3e59-python \
  ghcr.io/openhands/agent-server:69c3e59-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:69c3e59-golang-amd64
ghcr.io/openhands/agent-server:69c3e59-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:69c3e59-golang-arm64
ghcr.io/openhands/agent-server:69c3e59-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:69c3e59-java-amd64
ghcr.io/openhands/agent-server:69c3e59-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:69c3e59-java-arm64
ghcr.io/openhands/agent-server:69c3e59-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:69c3e59-python-amd64
ghcr.io/openhands/agent-server:69c3e59-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:69c3e59-python-arm64
ghcr.io/openhands/agent-server:69c3e59-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:69c3e59-golang
ghcr.io/openhands/agent-server:69c3e59-java
ghcr.io/openhands/agent-server:69c3e59-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `69c3e59-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `69c3e59-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->