### PR TITLE
docs(review): flag too-new package uploads in reviewer prompt

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -45,7 +45,7 @@ Examples of straightforward and low-risk PRs you should approve (non-exhaustive)
 - **Documentation-only changes**: Docstring updates, clarifying notes, API documentation improvements
 - **Simple additions**: Adding entries to lists/dictionaries following existing patterns
 - **Test-only changes**: Adding or updating tests without changing production code
-- **Dependency updates**: Version bumps with passing CI
+- **Dependency updates**: Version bumps with passing CI, unless the updated package is newer than the repo's 7-day freshness guardrail described in the Security section below
 
 ### When NOT to APPROVE - Blocking Issues
 
@@ -54,6 +54,7 @@ Examples of straightforward and low-risk PRs you should approve (non-exhaustive)
 - **Package version bumps in non-release PRs**: If any `pyproject.toml` file has changes to the `version` field (e.g., `version = "1.12.0"` → `version = "1.13.0"`), and the PR is NOT explicitly a release PR (title/description doesn't indicate it's a release), **DO NOT APPROVE**. Version numbers should only be changed in dedicated release PRs managed by maintainers.
   - Check: Look for changes to `version = "..."` in any `*/pyproject.toml` files
   - Exception: PRs with titles like "release: v1.x.x" or "chore: bump version to 1.x.x" from maintainers
+- **Too-new dependency uploads**: If a dependency bump pulls in a package uploaded within the repo's 7-day freshness window, **DO NOT APPROVE**. See the Security section below for the exact review instructions and the Dependabot / `tool.uv.exclude-newer` caveat.
 
 Examples:
 - A PR adding a new model to `resolve_model_config.py` or `verified_models.py` with corresponding test updates
@@ -70,6 +71,30 @@ Use COMMENT when you have feedback or concerns:
 - Minor style preferences
 
 If there are significant issues, leave detailed comments explaining the concerns—but let a human maintainer decide whether to block the PR.
+
+## Security
+
+### Dependency freshness / supply-chain guardrail
+
+This repository intentionally uses a workspace-wide `uv` resolver guardrail:
+
+- Root `pyproject.toml`: `[tool.uv] exclude-newer = "7 days"`
+
+**Important:** Dependabot does **not** currently honor that `uv` guardrail when it opens `uv.lock` update PRs for this repo's workspace setup. A Dependabot PR can therefore bump to a version that was uploaded **less than 7 days ago**, even though a local `uv lock` would normally exclude it.
+
+When reviewing dependency update PRs (`uv.lock`, `pyproject.toml`, `requirements*.txt`, etc.), explicitly check for **too-new package uploads**:
+
+1. Check the package upload timestamp on the package index.
+2. For `uv.lock`, use the per-file `upload-time` metadata in the changed package entry.
+3. Treat `upload-time` as the upload time of that specific distribution file to the package index (for example, the wheel uploaded to PyPI) — not the Git tag time or GitHub release time.
+4. Compare that timestamp against the current date and the repo's 7-day freshness window.
+
+If the updated package was uploaded **within the last 7 days**, treat it as a real security / supply-chain concern:
+
+- Do **NOT** approve the PR.
+- Leave a **COMMENT** review that clearly calls out the package name, version, upload time, and that it is newer than the repo's 7-day guardrail.
+- Explain that this can happen because Dependabot currently ignores `tool.uv.exclude-newer` for this repo's workspace updates.
+- Ask a human maintainer to decide whether to wait until the package ages past the guardrail or to merge intentionally despite the freshness risk.
 
 ## Core Principles
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,6 +108,7 @@ When reviewing code, provide constructive feedback:
 - `AgentSettings.mcp_config` now uses FastMCP's typed `MCPConfig` at runtime. When serializing settings back to plain data (e.g. `model_dump()` or `create_agent()`), keep the output compact with `exclude_none=True, exclude_defaults=True` so callers still see the familiar `.mcp.json`-style dict shape.
 - AgentSkills progressive disclosure goes through `AgentContext.get_system_message_suffix()` into `<available_skills>`, and `openhands.sdk.context.skills.to_prompt()` truncates each prompt description to 1024 characters because the AgentSkills specification caps `description` at 1-1024 characters.
 - Workspace-wide uv resolver guardrails belong in the repository root `[tool.uv]` table. When `exclude-newer` is configured there, `uv lock` persists it into the root `uv.lock` `[options]` section as both an absolute cutoff and `exclude-newer-span`, and `uv sync --frozen` continues to use that locked workspace state.
+- `pr-review-by-openhands` delegates to `OpenHands/extensions/plugins/pr-review@main`. Repo-specific reviewer instructions live in `.agents/skills/custom-codereview-guide.md`, and because task-trigger matching is substring-based, that `/codereview` skill is also auto-injected for the workflow's `/codereview-roasted` prompt.
 
 
 ## Package-specific guidance


### PR DESCRIPTION
## Summary
- add a `Security` section to the repo-specific PR review guidance in `.agents/skills/custom-codereview-guide.md`
- tell the reviewer agent to treat dependency uploads newer than the repo's 7-day `uv` freshness guardrail as a non-approvable supply-chain concern
- document that Dependabot currently ignores `tool.uv.exclude-newer` for this repo's `uv.lock` workspace updates
- record how the repo-specific review skill is injected into the `pr-review-by-openhands` workflow prompt

## Validation
- `uv run pre-commit run --files AGENTS.md .agents/skills/custom-codereview-guide.md`

## Context
This follows up on the review discussion around PR #2643 and the existing Dependabot/uv workspace tracking issue #2510.
For review, non-binding suggestions simplifying the text while still keeping the intent are welcome.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e33cb909-55b7-4787-bb8b-d4e583b554b6)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:53bcb3b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-53bcb3b-python \
  ghcr.io/openhands/agent-server:53bcb3b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:53bcb3b-golang-amd64
ghcr.io/openhands/agent-server:53bcb3b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:53bcb3b-golang-arm64
ghcr.io/openhands/agent-server:53bcb3b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:53bcb3b-java-amd64
ghcr.io/openhands/agent-server:53bcb3b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:53bcb3b-java-arm64
ghcr.io/openhands/agent-server:53bcb3b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:53bcb3b-python-amd64
ghcr.io/openhands/agent-server:53bcb3b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:53bcb3b-python-arm64
ghcr.io/openhands/agent-server:53bcb3b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:53bcb3b-golang
ghcr.io/openhands/agent-server:53bcb3b-java
ghcr.io/openhands/agent-server:53bcb3b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `53bcb3b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `53bcb3b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->