### PR TITLE
feat(agent-server): expose settings schema

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -33,6 +33,7 @@ from openhands.agent_server.server_details_router import (
     mark_initialization_complete,
     server_details_router,
 )
+from openhands.agent_server.settings_router import settings_router
 from openhands.agent_server.skills_router import skills_router
 from openhands.agent_server.sockets import sockets_router
 from openhands.agent_server.tool_preload_service import get_tool_preload_service
@@ -210,6 +211,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(skills_router)
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
+    api_router.include_router(settings_router)
     app.include_router(api_router)
     app.include_router(sockets_router)
 

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -1,0 +1,19 @@
+from functools import lru_cache
+
+from fastapi import APIRouter
+
+from openhands.sdk.settings import AgentSettings, SettingsSchema
+
+
+settings_router = APIRouter(prefix="/settings", tags=["Settings"])
+
+
+@lru_cache(maxsize=1)
+def _get_agent_settings_schema() -> SettingsSchema:
+    return AgentSettings.export_schema()
+
+
+@settings_router.get("/schema", response_model=SettingsSchema)
+async def get_agent_settings_schema() -> SettingsSchema:
+    """Return the schema used to render AgentSettings-based settings forms."""
+    return _get_agent_settings_schema()

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -1,0 +1,26 @@
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+
+
+def test_get_agent_settings_schema():
+    client = TestClient(create_app(Config(static_files_path=None, session_api_keys=[])))
+
+    response = client.get("/api/settings/schema")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["model_name"] == "AgentSettings"
+
+    section_keys = [section["key"] for section in body["sections"]]
+    assert "llm" in section_keys
+    assert "condenser" in section_keys
+    assert "verification" in section_keys
+
+    verification_section = next(
+        section for section in body["sections"] if section["key"] == "verification"
+    )
+    verification_field_keys = {field["key"] for field in verification_section["fields"]}
+    assert "verification.confirmation_mode" in verification_field_keys
+    assert "verification.security_analyzer" in verification_field_keys


### PR DESCRIPTION
## Summary
- add an SDK-owned `GET /api/settings/schema` endpoint in `openhands-agent-server`
- register the new router in the agent server API app
- add focused test coverage for the exported AgentSettings schema route

## Details
- serve the schema through a dedicated `settings_router` so agent-server clients can discover the SDK-owned settings model over HTTP
- cache the exported schema with `lru_cache(maxsize=1)` so repeated requests reuse the same serialized structure
- keep the change additive by wiring the new router into the existing `/api` FastAPI surface without altering other routes

## Testing
- `uv run --group dev pytest tests/agent_server/test_settings_router.py -q`
- `uv run --group dev ruff check openhands-agent-server/openhands/agent_server/api.py openhands-agent-server/openhands/agent_server/settings_router.py tests/agent_server/test_settings_router.py`
- `uv run --group dev ruff format --check openhands-agent-server/openhands/agent_server/api.py openhands-agent-server/openhands/agent_server/settings_router.py tests/agent_server/test_settings_router.py`

## Evidence

**Verification link:** [View conversation](https://app.all-hands.dev/conversations/91ee1ba943c14482a4e31b1d97ff8c5a)

**Before (origin/main):**
```bash
$ uv run python - <<'PY'
from fastapi.testclient import TestClient
from openhands.agent_server.api import create_app
from openhands.agent_server.config import Config
client = TestClient(create_app(Config(session_api_keys=[])))
resp = client.get('/api/settings/schema')
print('status:', resp.status_code)
print('body:', resp.json())
PY
status: 404
body: {'detail': 'Not Found'}
```

**After (this PR):**
```bash
$ uv run python - <<'PY'
from fastapi.testclient import TestClient
from openhands.agent_server.api import create_app
from openhands.agent_server.config import Config
client = TestClient(create_app(Config(session_api_keys=[])))
resp = client.get('/api/settings/schema')
body = resp.json()
print('status:', resp.status_code)
print('keys:', sorted(body.keys()))
print('section_count:', len(body.get('sections', [])))
print('first_section:', body.get('sections', [{}])[0].get('key'))
PY
status: 200
keys: ['model_name', 'sections']
section_count: 4
first_section: general
```

_This evidence was gathered by an AI assistant (OpenHands) on behalf of the user._

## Checklist
- [x] CI passing
- [x] Tests are minimal and pass
- [x] No unnecessary code
- [x] Evidence from live run (with conversation link if available)
- [x] All review comments resolved
- [x] Documentation updated (not applicable)

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/625f793d-6314-403e-87b3-1a92ea2c0d6f)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ac188c9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ac188c9-python \
  ghcr.io/openhands/agent-server:ac188c9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ac188c9-golang-amd64
ghcr.io/openhands/agent-server:ac188c9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ac188c9-golang-arm64
ghcr.io/openhands/agent-server:ac188c9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ac188c9-java-amd64
ghcr.io/openhands/agent-server:ac188c9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ac188c9-java-arm64
ghcr.io/openhands/agent-server:ac188c9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ac188c9-python-amd64
ghcr.io/openhands/agent-server:ac188c9-nikolaik_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ac188c9-python-arm64
ghcr.io/openhands/agent-server:ac188c9-nikolaik_python-nodejs_tag_python3.13-nodejs22-slim-arm64
```
<!-- AGENT_SERVER_IMAGES_END -->
