### PR TITLE
fix: always install Node 22 for ACP packages in agent-server images

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -93,14 +93,32 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-install ACP servers for ACPAgent support (Claude Code, Codex, Gemini CLI)
-# Always install Node.js 22+ even if an older version exists (e.g. SWE-bench
-# images ship NVM-managed Node 8-14 which cannot run modern ACP packages).
+# Install Node.js 22 to a dedicated prefix so ACP packages get a modern runtime
+# WITHOUT overwriting the repo-specific Node.js that test suites depend on.
+# SWE-bench images ship NVM/apt-managed Node 8-14 which cannot run ACP packages.
+ENV ACP_NODE_DIR=/opt/acp-node
 RUN set -eux; \
-    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-    apt-get install -y --no-install-recommends nodejs && \
-    rm -rf /var/lib/apt/lists/* && \
-    node --version && \
-    npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp @google/gemini-cli
+    ARCH=$(dpkg --print-architecture); \
+    case "$ARCH" in amd64) NARCH=x64;; arm64) NARCH=arm64;; *) NARCH=$ARCH;; esac; \
+    mkdir -p "$ACP_NODE_DIR"; \
+    curl -fsSL "https://nodejs.org/dist/v22.14.0/node-v22.14.0-linux-${NARCH}.tar.xz" \
+      | tar -xJ --strip-components=1 -C "$ACP_NODE_DIR"; \
+    "$ACP_NODE_DIR/bin/node" --version; \
+    "$ACP_NODE_DIR/bin/npm" install -g \
+      @zed-industries/claude-agent-acp \
+      @zed-industries/codex-acp \
+      @google/gemini-cli; \
+    # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
+    # This ensures the ACP binary's #!/usr/bin/env node shebang resolves to
+    # Node 22, while the repo's own node (NVM/system) stays untouched for tests.
+    for bin in claude-agent-acp codex-acp gemini; do \
+      if [ -e "$ACP_NODE_DIR/bin/$bin" ]; then \
+        printf '#!/bin/sh\nPATH="%s/bin:$PATH" exec "%s/bin/%s" "$@"\n' \
+          "$ACP_NODE_DIR" "$ACP_NODE_DIR" "$bin" \
+          > /usr/local/bin/"$bin"; \
+        chmod +x /usr/local/bin/"$bin"; \
+      fi; \
+    done
 
 # Configure Claude Code managed settings for headless operation:
 # Allow all tool permissions (no human in the loop to approve).

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -93,13 +93,13 @@ RUN set -eux; \
     rm -rf /var/lib/apt/lists/*
 
 # Pre-install ACP servers for ACPAgent support (Claude Code, Codex, Gemini CLI)
-# Install Node.js/npm if not present (SWE-bench base images may lack them)
+# Always install Node.js 22+ even if an older version exists (e.g. SWE-bench
+# images ship NVM-managed Node 8-14 which cannot run modern ACP packages).
 RUN set -eux; \
-    if ! command -v npm >/dev/null 2>&1; then \
-        curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
-        apt-get install -y --no-install-recommends nodejs && \
-        rm -rf /var/lib/apt/lists/*; \
-    fi; \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
+    rm -rf /var/lib/apt/lists/* && \
+    node --version && \
     npm install -g @zed-industries/claude-agent-acp @zed-industries/codex-acp @google/gemini-cli
 
 # Configure Claude Code managed settings for headless operation:

--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -70,11 +70,7 @@ class APIRemoteWorkspace(RemoteWorkspace):
         gt=0,
     )
     api_timeout: float = Field(
-        default=600.0,
-        description="Timeout in seconds for reading HTTP responses from the "
-        "agent-server. Must be long enough for conversation creation, which "
-        "triggers lazy agent initialisation (ACP subprocess startup, model "
-        "config loading, etc.).",
+        default=60.0, description="API request timeout (seconds)"
     )
     keep_alive: bool = Field(default=False, description="Keep runtime alive on cleanup")
     pause_on_close: bool = Field(

--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -70,7 +70,11 @@ class APIRemoteWorkspace(RemoteWorkspace):
         gt=0,
     )
     api_timeout: float = Field(
-        default=60.0, description="API request timeout (seconds)"
+        default=600.0,
+        description="Timeout in seconds for reading HTTP responses from the "
+        "agent-server. Must be long enough for conversation creation, which "
+        "triggers lazy agent initialisation (ACP subprocess startup, model "
+        "config loading, etc.).",
     )
     keep_alive: bool = Field(default=False, description="Keep runtime alive on cleanup")
     pause_on_close: bool = Field(


### PR DESCRIPTION
## Summary

- **Always install Node.js 22** from nodesource in the agent-server Dockerfile, removing the conditional `if ! command -v npm` check
- SWE-bench base images ship with NVM-managed old Node.js (v8–v14) that already have `npm` in PATH, causing the conditional to skip Node 22 installation
- ACP packages (`claude-agent-acp`, `codex-acp`, `gemini-cli`) installed into old Node.js crash with `SyntaxError` on modern ES module syntax (e.g. `import ... with { type: "json" }`)
- This is the root cause of ACP agent failures on swebenchmultimodal (and potentially other SWE-bench benchmarks)

## Root cause analysis

The Dockerfile had:
```dockerfile
if ! command -v npm >/dev/null 2>&1; then
    # install Node 22
fi
npm install -g @zed-industries/claude-agent-acp ...
```

SWE-bench images are built from repos that often include `.nvmrc` or NVM-managed Node.js versions:
- **p5.js**: Node 14.17.3
- **marked**: Node 12.22.12  
- **wp-calypso**: Node 8.9.3
- **react-pdf**: Node 8.17.0

Since `npm` exists in PATH via the old Node.js, the conditional skipped Node 22 installation. ACP packages were installed into the old Node.js and crashed immediately on startup.

**Chart.js** (Node 21.6.2) worked because its Node.js version is new enough.

## Related

- Root cause tracked in OpenHands/runtime-api#458
- ACP client EOF handling fix: agentclientprotocol/python-sdk#86

## Test plan

- [ ] Build an agent-server image from a SWE-bench base that has old Node.js (e.g. p5.js with Node 14)
- [ ] Verify `node --version` shows v22.x inside the built image
- [ ] Verify `claude-agent-acp` starts without SyntaxError
- [ ] Run swebenchmultimodal eval with ACP agent on previously-failing instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:612ef5a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-612ef5a-python \
  ghcr.io/openhands/agent-server:612ef5a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:612ef5a-golang-amd64
ghcr.io/openhands/agent-server:612ef5a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:612ef5a-golang-arm64
ghcr.io/openhands/agent-server:612ef5a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:612ef5a-java-amd64
ghcr.io/openhands/agent-server:612ef5a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:612ef5a-java-arm64
ghcr.io/openhands/agent-server:612ef5a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:612ef5a-python-amd64
ghcr.io/openhands/agent-server:612ef5a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:612ef5a-python-arm64
ghcr.io/openhands/agent-server:612ef5a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:612ef5a-golang
ghcr.io/openhands/agent-server:612ef5a-java
ghcr.io/openhands/agent-server:612ef5a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `612ef5a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `612ef5a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->