### PR TITLE
fix: Return empty summary for think/file_editor tools when LLM doesn't provide one

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -708,6 +708,11 @@ class Agent(CriticMixin, AgentBase):
         security_risk = risk.SecurityRisk(raw)
         return security_risk
 
+    # Tools where empty summary is preferred over raw JSON default.
+    # Frontend shows translated titles ("Thinking", "Reading <path>") for these.
+    # See: https://github.com/OpenHands/OpenHands/issues/13690
+    _EMPTY_SUMMARY_TOOLS = frozenset({"think", "file_editor"})
+
     def _extract_summary(self, tool_name: str, arguments: dict) -> str:
         """Extract and validate the summary field from tool arguments.
 
@@ -727,6 +732,11 @@ class Agent(CriticMixin, AgentBase):
         # If valid summary provided by LLM, use it
         if summary is not None and isinstance(summary, str) and summary.strip():
             return summary
+
+        # Return empty for tools where frontend provides better titles
+        # (e.g., "Thinking" for think, "Reading <path>" for file_editor)
+        if tool_name in self._EMPTY_SUMMARY_TOOLS:
+            return ""
 
         # Generate default summary: {tool_name}: {arguments}
         args_str = json.dumps(arguments)

--- a/tests/sdk/agent/test_extract_summary.py
+++ b/tests/sdk/agent/test_extract_summary.py
@@ -43,3 +43,51 @@ def test_extract_summary(agent, summary_value, expected_result):
     result = agent._extract_summary("test_tool", arguments)
     assert result == expected_result
     assert "summary" not in arguments
+
+
+@pytest.mark.parametrize(
+    "tool_name,arguments",
+    [
+        ("think", {"thought": "analyzing the problem"}),
+        ("file_editor", {"command": "view", "path": "/workspace/file.py"}),
+    ],
+)
+def test_extract_summary_returns_empty_for_frontend_handled_tools(
+    agent, tool_name, arguments
+):
+    """Test that tools with frontend translations return empty summary.
+
+    Frontend displays translated titles like "Thinking" and "Reading <path>"
+    for these tools, which is better than raw JSON.
+    See: https://github.com/OpenHands/OpenHands/issues/13690
+    """
+    original_args = arguments.copy()
+
+    result = agent._extract_summary(tool_name, arguments)
+
+    assert result == ""
+    assert "summary" not in arguments
+    assert arguments == original_args
+
+
+@pytest.mark.parametrize(
+    "tool_name,arguments,summary",
+    [
+        ("think", {"thought": "analyzing the problem"}, "Planning approach"),
+        (
+            "file_editor",
+            {"command": "view", "path": "/workspace/file.py"},
+            "Read config",
+        ),
+    ],
+)
+def test_extract_summary_uses_llm_provided_for_frontend_handled_tools(
+    agent, tool_name, arguments, summary
+):
+    """Test that LLM-provided summaries are still used for frontend-handled tools."""
+    arguments["summary"] = summary
+
+    result = agent._extract_summary(tool_name, arguments)
+
+    assert result == summary
+    assert "summary" not in arguments


### PR DESCRIPTION
## Summary

This PR fixes the summary display issue for `think` and `file_editor` tools where raw JSON was shown instead of frontend-provided translations.

**Fixes:** OpenHands/OpenHands#13690

## Problem

When the LLM doesn't provide a summary, the SDK generates a default in the format `{tool_name}: {arguments}`:
- `think: {"thought": "The user is asking about..."}`
- `file_editor: {"command": "view", "path": "/workspace/..."}`

The frontend already has translated titles for these tools:
- "Thinking" for think tool
- "Reading <path>" / "Editing <path>" for file_editor

## Solution

Return empty string for `think` and `file_editor` tools when the LLM doesn't provide a summary. This allows the frontend to display its translated titles instead.

## Code Changes

**`openhands-sdk/openhands/sdk/agent/agent.py`:**
```python
# Tools where empty summary is preferred over raw JSON default.
# Frontend shows translated titles ("Thinking", "Reading <path>") for these.
# See: https://github.com/OpenHands/OpenHands/issues/13690
_EMPTY_SUMMARY_TOOLS = frozenset({"think", "file_editor"})

def _extract_summary(self, tool_name: str, arguments: dict) -> str:
    summary = arguments.pop("summary", None)
    if summary is not None and isinstance(summary, str) and summary.strip():
        return summary

    # Return empty for tools where frontend provides better titles
    if tool_name in self._EMPTY_SUMMARY_TOOLS:
        return ""

    args_str = json.dumps(arguments)
    return f"{tool_name}: {args_str}"
```

## Tests

- `test_extract_summary_returns_empty_for_frontend_handled_tools`: Verifies empty string for think and file_editor
- `test_extract_summary_uses_llm_provided_for_frontend_handled_tools`: Verifies LLM-provided summaries are still used

---

*This PR was created by an AI assistant (OpenHands).*
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d637e4f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d637e4f-python \
  ghcr.io/openhands/agent-server:d637e4f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d637e4f-golang-amd64
ghcr.io/openhands/agent-server:d637e4f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d637e4f-golang-arm64
ghcr.io/openhands/agent-server:d637e4f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d637e4f-java-amd64
ghcr.io/openhands/agent-server:d637e4f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d637e4f-java-arm64
ghcr.io/openhands/agent-server:d637e4f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d637e4f-python-amd64
ghcr.io/openhands/agent-server:d637e4f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d637e4f-python-arm64
ghcr.io/openhands/agent-server:d637e4f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d637e4f-golang
ghcr.io/openhands/agent-server:d637e4f-java
ghcr.io/openhands/agent-server:d637e4f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d637e4f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d637e4f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->