### PR TITLE
feat: Add structured output support for FinishTool

### DIFF
--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -21,6 +21,7 @@ from openhands.sdk.conversation import (
     ConversationExecutionStatus,
     LocalConversation,
     RemoteConversation,
+    get_structured_response,
 )
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.event import Event, HookExecutionEvent, LLMConvertibleEvent
@@ -167,5 +168,6 @@ __all__ = [
     "load_skills_from_dir",
     "load_user_skills",
     "page_iterator",
+    "get_structured_response",
     "__version__",
 ]

--- a/openhands-sdk/openhands/sdk/conversation/__init__.py
+++ b/openhands-sdk/openhands/sdk/conversation/__init__.py
@@ -9,7 +9,10 @@ from openhands.sdk.conversation.resource_lock_manager import (
     ResourceLockManager,
     ResourceLockTimeout,
 )
-from openhands.sdk.conversation.response_utils import get_agent_final_response
+from openhands.sdk.conversation.response_utils import (
+    get_agent_final_response,
+    get_structured_response,
+)
 from openhands.sdk.conversation.secret_registry import SecretRegistry
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
@@ -46,5 +49,6 @@ __all__ = [
     "RemoteConversation",
     "EventsListBase",
     "get_agent_final_response",
+    "get_structured_response",
     "WebSocketConnectionError",
 ]

--- a/openhands-sdk/openhands/sdk/conversation/response_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/response_utils.py
@@ -2,6 +2,8 @@
 
 from collections.abc import Sequence
 
+from pydantic import BaseModel
+
 from openhands.sdk.event import ActionEvent, MessageEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.llm.message import content_to_str
@@ -39,3 +41,49 @@ def get_agent_final_response(events: Sequence[Event]) -> str:
             text_parts = content_to_str(event.llm_message.content)
             return "".join(text_parts)
     return ""
+
+
+def get_structured_response[T: BaseModel](
+    events: Sequence[Event],
+    response_schema: type[T],
+) -> T | None:
+    """Extract and validate structured response from conversation events.
+
+    Searches backwards through events to find the last finish action from the
+    agent and validates its data against the provided Pydantic model.
+
+    Args:
+        events: List of conversation events to search through.
+        response_schema: The Pydantic model class to validate against.
+
+    Returns:
+        A validated instance of response_schema, or None if no valid
+        finish action is found.
+
+    Example:
+        ```python
+        from pydantic import BaseModel, Field
+        from openhands.sdk.conversation.response_utils import get_structured_response
+
+        class CodeReviewResult(BaseModel):
+            score: int = Field(description="Score from 1-10")
+            issues: list[str] = Field(description="Issues found")
+            can_merge: bool = Field(description="Ready to merge")
+
+        # After conversation completes
+        result = get_structured_response(conversation.events, CodeReviewResult)
+        if result:
+            print(f"Score: {result.score}, Can merge: {result.can_merge}")
+        ```
+    """
+    for event in reversed(events):
+        if (
+            isinstance(event, ActionEvent)
+            and event.source == "agent"
+            and event.tool_name == FinishTool.name
+            and event.action is not None
+        ):
+            # Extract action data and validate against schema
+            action_data = event.action.model_dump(exclude={"kind"})
+            return response_schema.model_validate(action_data)
+    return None

--- a/openhands-sdk/openhands/sdk/tool/builtins/finish.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/finish.py
@@ -1,7 +1,8 @@
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Self
+from typing import TYPE_CHECKING, Any, Self
 
-from pydantic import Field
+from pydantic import BaseModel, Field, create_model
+from pydantic.json_schema import SkipJsonSchema
 from rich.text import Text
 
 from openhands.sdk.tool.tool import (
@@ -57,44 +58,119 @@ The message should include:
 """
 
 
+def create_structured_finish_action(response_schema: type[BaseModel]) -> type[Action]:
+    """Create a FinishAction subclass with fields from the response schema.
+
+    This dynamically creates an Action class that includes all fields from
+    the provided Pydantic model, allowing the LLM to return structured output.
+
+    Args:
+        response_schema: A Pydantic model class defining the expected structure.
+
+    Returns:
+        A new Action subclass with fields from the response schema.
+    """
+    fields: dict[str, Any] = {}
+    for field_name, field_info in response_schema.model_fields.items():
+        annotation = response_schema.__annotations__.get(field_name)
+        fields[field_name] = (annotation, field_info)
+
+    structured_action: type[Action] = create_model(
+        f"Structured{response_schema.__name__}FinishAction",
+        __base__=Action,
+        **fields,
+    )
+    return structured_action
+
+
 class FinishExecutor(ToolExecutor):
     def __call__(
         self,
         action: FinishAction,
         conversation: "BaseConversation | None" = None,  # noqa: ARG002
     ) -> FinishObservation:
-        return FinishObservation.from_text(text=action.message)
+        # For structured actions, extract text from any 'message' or 'summary' field
+        # or use a JSON representation
+        if hasattr(action, "message"):
+            return FinishObservation.from_text(text=action.message)
+        else:
+            # For structured actions without a message field,
+            # return the action data as JSON
+            import json
+
+            return FinishObservation.from_text(
+                text=json.dumps(action.model_dump(exclude={"kind"}), indent=2)
+            )
 
 
 class FinishTool(ToolDefinition[FinishAction, FinishObservation]):
     """Tool for signaling the completion of a task or conversation."""
 
+    # Store response_schema for later retrieval (excluded from serialization)
+    response_schema: SkipJsonSchema[type[BaseModel] | None] = Field(
+        default=None, repr=False, exclude=True
+    )
+
     @classmethod
     def create(
         cls,
         conv_state: "ConversationState | None" = None,  # noqa: ARG003
+        response_schema: type[BaseModel] | None = None,
         **params,
     ) -> Sequence[Self]:
-        """Create FinishTool instance.
+        """Create FinishTool instance with optional structured output.
 
         Args:
             conv_state: Optional conversation state (not used by FinishTool).
+            response_schema: Optional Pydantic model class defining the expected
+                structure of the final response. When provided, the agent must
+                return data matching this schema instead of a simple message.
             **params: Additional parameters (none supported).
 
         Returns:
             A sequence containing a single FinishTool instance.
 
         Raises:
-            ValueError: If any parameters are provided.
+            ValueError: If any unsupported parameters are provided.
+
+        Example:
+            ```python
+            from pydantic import BaseModel, Field
+
+            class TaskResult(BaseModel):
+                success: bool = Field(description="Whether the task succeeded")
+                summary: str = Field(description="Summary of what was done")
+                files_changed: list[str] = Field(description="Files modified")
+
+            tools = [
+                Tool(name="FinishTool", params={"response_schema": TaskResult})
+            ]
+            ```
         """
         if params:
-            raise ValueError("FinishTool doesn't accept parameters")
+            raise ValueError(
+                f"FinishTool only accepts 'response_schema' parameter, got: {params}"
+            )
+
+        if response_schema is not None:
+            action_type = create_structured_finish_action(response_schema)
+            schema_json = response_schema.model_json_schema()
+            description = (
+                f"{TOOL_DESCRIPTION}\n\n"
+                f"You MUST provide output matching the following schema:\n"
+                f"{schema_json}"
+            )
+        else:
+            action_type = FinishAction
+            description = TOOL_DESCRIPTION
+
         return [
             cls(
-                action_type=FinishAction,
+                action_type=action_type,
                 observation_type=FinishObservation,
-                description=TOOL_DESCRIPTION,
+                description=description,
                 executor=FinishExecutor(),
+                response_schema=response_schema,
                 annotations=ToolAnnotations(
                     title="finish",
                     readOnlyHint=True,

--- a/tests/sdk/tool/test_finish_structured_output.py
+++ b/tests/sdk/tool/test_finish_structured_output.py
@@ -1,0 +1,323 @@
+"""Tests for FinishTool structured output functionality."""
+
+import pytest
+from pydantic import BaseModel, Field
+
+from openhands.sdk.conversation.response_utils import get_structured_response
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.tool.builtins.finish import (
+    FinishAction,
+    FinishObservation,
+    FinishTool,
+    create_structured_finish_action,
+)
+from openhands.sdk.tool.schema import Action
+
+
+class CodeReviewResult(BaseModel):
+    """Sample structured output schema for testing."""
+
+    score: int = Field(description="Score from 1-10")
+    issues_found: list[str] = Field(description="List of issues identified")
+    can_merge: bool = Field(description="Whether the code is ready to merge")
+
+
+class SimpleResult(BaseModel):
+    """Simple schema with minimal fields."""
+
+    success: bool = Field(description="Whether the task succeeded")
+    summary: str = Field(description="Summary of the result")
+
+
+def test_finish_tool_without_response_schema():
+    """Test that FinishTool without response_schema works as before."""
+    tools = FinishTool.create()
+    assert len(tools) == 1
+    tool = tools[0]
+
+    assert tool.action_type == FinishAction
+    assert tool.response_schema is None
+    assert "Signals the completion" in tool.description
+    assert "schema" not in tool.description.lower()
+
+
+def test_finish_tool_with_response_schema():
+    """Test that FinishTool with response_schema creates structured action."""
+    tools = FinishTool.create(response_schema=CodeReviewResult)
+    assert len(tools) == 1
+    tool = tools[0]
+
+    # Should have a dynamic action type
+    assert tool.action_type != FinishAction
+    assert "StructuredCodeReviewResultFinishAction" in tool.action_type.__name__
+    assert tool.response_schema == CodeReviewResult
+
+    # Description should include schema info
+    assert "schema" in tool.description.lower()
+    assert "score" in tool.description
+    assert "issues_found" in tool.description
+    assert "can_merge" in tool.description
+
+
+def test_finish_tool_rejects_unknown_params():
+    """Test that FinishTool raises error for unknown parameters."""
+    with pytest.raises(ValueError) as exc_info:
+        FinishTool.create(unknown_param="value")
+    assert "only accepts 'response_schema' parameter" in str(exc_info.value)
+
+
+def test_create_structured_finish_action():
+    """Test the helper function to create structured action types."""
+    action_type = create_structured_finish_action(CodeReviewResult)
+
+    # Should be a subclass of Action
+    assert issubclass(action_type, Action)
+
+    # Should have the schema fields
+    fields = action_type.model_fields
+    assert "score" in fields
+    assert "issues_found" in fields
+    assert "can_merge" in fields
+
+    # Should NOT have 'message' field (from FinishAction)
+    assert "message" not in fields
+
+
+def test_structured_action_validation():
+    """Test that structured actions can be instantiated and validated."""
+    action_type = create_structured_finish_action(CodeReviewResult)
+
+    # Create a valid action - using model_validate since fields are dynamic
+    action = action_type.model_validate(
+        {"score": 8, "issues_found": ["minor typo"], "can_merge": True}
+    )
+    action_data = action.model_dump(exclude={"kind"})
+
+    assert action_data["score"] == 8
+    assert action_data["issues_found"] == ["minor typo"]
+    assert action_data["can_merge"] is True
+
+
+def test_structured_action_schema():
+    """Test that structured action produces correct MCP schema."""
+    action_type = create_structured_finish_action(CodeReviewResult)
+    schema = action_type.to_mcp_schema()
+
+    assert "properties" in schema
+    props = schema["properties"]
+
+    assert "score" in props
+    assert props["score"]["type"] == "integer"
+
+    assert "issues_found" in props
+    assert props["issues_found"]["type"] == "array"
+
+    assert "can_merge" in props
+    assert props["can_merge"]["type"] == "boolean"
+
+
+def test_finish_executor_with_message_action():
+    """Test FinishExecutor handles FinishAction with message field."""
+    from openhands.sdk.tool.builtins.finish import FinishExecutor
+
+    executor = FinishExecutor()
+    action = FinishAction(message="Task completed!")
+    obs = executor(action)
+
+    assert isinstance(obs, FinishObservation)
+    assert obs.text == "Task completed!"
+
+
+def test_finish_executor_with_structured_action():
+    """Test FinishExecutor handles structured actions without message field."""
+    from openhands.sdk.tool.builtins.finish import FinishExecutor
+
+    action_type = create_structured_finish_action(SimpleResult)
+    action = action_type.model_validate(
+        {"success": True, "summary": "All tests passed"}
+    )
+
+    executor = FinishExecutor()
+    # Cast to FinishAction for type checking - executor handles both types
+    obs = executor(action)  # type: ignore[arg-type]
+
+    assert isinstance(obs, FinishObservation)
+    # Should contain JSON representation
+    assert "success" in obs.text
+    assert "true" in obs.text.lower()
+    assert "summary" in obs.text
+    assert "All tests passed" in obs.text
+
+
+def test_get_structured_response_with_structured_action():
+    """Test extracting structured response from events."""
+    action_type = create_structured_finish_action(CodeReviewResult)
+    action = action_type.model_validate(
+        {"score": 9, "issues_found": ["doc missing"], "can_merge": True}
+    )
+
+    tool_call = MessageToolCall(
+        id="test-call-id", name="finish", arguments="{}", origin="completion"
+    )
+    action_event = ActionEvent(
+        source="agent",
+        thought=[TextContent(text="Review complete")],
+        action=action,
+        tool_name="finish",
+        tool_call_id="test-call-id",
+        tool_call=tool_call,
+        llm_response_id="test-response-id",
+    )
+
+    events = [action_event]
+    result = get_structured_response(events, CodeReviewResult)
+
+    assert result is not None
+    assert result.score == 9
+    assert result.issues_found == ["doc missing"]
+    assert result.can_merge is True
+
+
+def test_get_structured_response_empty_events():
+    """Test get_structured_response with empty events list."""
+    result = get_structured_response([], CodeReviewResult)
+    assert result is None
+
+
+def test_get_structured_response_no_finish_action():
+    """Test get_structured_response when no finish action exists."""
+    # Create a non-finish action event
+    tool_call = MessageToolCall(
+        id="test-call-id", name="read_file", arguments="{}", origin="completion"
+    )
+    action_event = ActionEvent(
+        source="agent",
+        thought=[TextContent(text="Reading file")],
+        action=None,
+        tool_name="read_file",
+        tool_call_id="test-call-id",
+        tool_call=tool_call,
+        llm_response_id="test-response-id",
+    )
+
+    result = get_structured_response([action_event], CodeReviewResult)
+    assert result is None
+
+
+def test_get_structured_response_with_none_action():
+    """Test get_structured_response when finish action is None."""
+    tool_call = MessageToolCall(
+        id="test-call-id", name="finish", arguments="{}", origin="completion"
+    )
+    action_event = ActionEvent(
+        source="agent",
+        thought=[TextContent(text="Finishing")],
+        action=None,  # No executable action
+        tool_name="finish",
+        tool_call_id="test-call-id",
+        tool_call=tool_call,
+        llm_response_id="test-response-id",
+    )
+
+    result = get_structured_response([action_event], CodeReviewResult)
+    assert result is None
+
+
+def test_get_structured_response_finds_last_finish():
+    """Test get_structured_response returns the last finish action."""
+    action_type = create_structured_finish_action(SimpleResult)
+
+    # First finish action
+    action1 = action_type.model_validate(
+        {"success": False, "summary": "First attempt failed"}
+    )
+    tool_call1 = MessageToolCall(
+        id="call-1", name="finish", arguments="{}", origin="completion"
+    )
+    event1 = ActionEvent(
+        source="agent",
+        thought=[TextContent(text="First")],
+        action=action1,
+        tool_name="finish",
+        tool_call_id="call-1",
+        tool_call=tool_call1,
+        llm_response_id="resp-1",
+    )
+
+    # Second finish action (should be returned)
+    action2 = action_type.model_validate(
+        {"success": True, "summary": "Second attempt succeeded"}
+    )
+    tool_call2 = MessageToolCall(
+        id="call-2", name="finish", arguments="{}", origin="completion"
+    )
+    event2 = ActionEvent(
+        source="agent",
+        thought=[TextContent(text="Second")],
+        action=action2,
+        tool_name="finish",
+        tool_call_id="call-2",
+        tool_call=tool_call2,
+        llm_response_id="resp-2",
+    )
+
+    events = [event1, event2]
+    result = get_structured_response(events, SimpleResult)
+
+    assert result is not None
+    assert result.success is True
+    assert result.summary == "Second attempt succeeded"
+
+
+def test_finish_tool_serialization():
+    """Test that FinishTool with response_schema serializes correctly."""
+    tools = FinishTool.create(response_schema=CodeReviewResult)
+    tool = tools[0]
+
+    # response_schema should be excluded from serialization
+    dumped = tool.model_dump()
+    assert "response_schema" not in dumped
+
+
+def test_finish_tool_openai_tool_schema():
+    """Test the OpenAI tool schema includes structured fields."""
+    tools = FinishTool.create(response_schema=CodeReviewResult)
+    tool = tools[0]
+
+    openai_tool = tool.to_openai_tool()
+    fn = openai_tool["function"]
+    # Parameters is optional in the TypedDict but we know it's present
+    assert "parameters" in fn
+    params = fn["parameters"]  # type: ignore[typeddict-item]
+
+    # Should include the schema fields
+    props = params.get("properties", {})
+    assert "score" in props
+    assert "issues_found" in props
+    assert "can_merge" in props
+
+
+def test_finish_tool_backward_compatibility():
+    """Test that original FinishAction still works with get_agent_final_response."""
+    from openhands.sdk.conversation.response_utils import get_agent_final_response
+
+    # Create a classic finish action event
+    finish_action = FinishAction(message="Task completed successfully!")
+    tool_call = MessageToolCall(
+        id="test-call-id", name="finish", arguments="{}", origin="completion"
+    )
+    action_event = ActionEvent(
+        source="agent",
+        thought=[TextContent(text="Finishing")],
+        action=finish_action,
+        tool_name="finish",
+        tool_call_id="test-call-id",
+        tool_call=tool_call,
+        llm_response_id="test-response-id",
+    )
+
+    events = [action_event]
+    result = get_agent_final_response(events)
+
+    assert result == "Task completed successfully!"


### PR DESCRIPTION
## Summary

This PR adds first-class support for structured output in the SDK, addressing #2566.

### Changes

1. **`FinishTool.create()` now accepts a `response_schema` parameter**
   - Takes a Pydantic model class defining the expected structure of the final response
   - When provided, a dynamic `Action` type is created with fields from the schema
   - The LLM is guided to return data matching that schema via the tool description

2. **New `get_structured_response()` helper function**
   - Extracts and validates structured response from conversation events
   - Returns a typed instance of the provided schema
   - Exported from `openhands.sdk` for easy access

3. **Backward compatible**
   - Without `response_schema`, `FinishTool` behaves exactly as before with its `message` field

### Example Usage

```python
from pydantic import BaseModel, Field
from openhands.sdk import LLM, Agent, Conversation, Tool, get_structured_response

# Define the expected response structure
class CodeReviewResult(BaseModel):
    score: int = Field(description="Score from 1-10")
    issues_found: list[str] = Field(description="List of issues identified")
    can_merge: bool = Field(description="Whether the code is ready to merge")

# Create agent with structured finish tool
llm = LLM(model="anthropic/claude-sonnet-4-20250514")
agent = Agent(
    llm=llm,
    tools=[
        Tool(name="FileEditorTool"),
        Tool(name="FinishTool", params={"response_schema": CodeReviewResult}),
    ],
)

# Run conversation
conversation = Conversation(agent=agent, workspace="./my-repo")
conversation.send_message("Review the code in src/main.py")
conversation.run()

# Extract structured response
result = get_structured_response(conversation.events, CodeReviewResult)
if result:
    print(f"Score: {result.score}")
    print(f"Can merge: {result.can_merge}")
    for issue in result.issues_found:
        print(f"  - {issue}")
```

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

Fixes #2566

---

_This PR was created by an AI assistant (OpenHands) on behalf of @openhands._

@VascoSch92 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/24aa1ec0-1a47-4036-b9e5-59e9f5198fa9)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:773b670-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-773b670-python \
  ghcr.io/openhands/agent-server:773b670-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:773b670-golang-amd64
ghcr.io/openhands/agent-server:773b670-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:773b670-golang-arm64
ghcr.io/openhands/agent-server:773b670-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:773b670-java-amd64
ghcr.io/openhands/agent-server:773b670-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:773b670-java-arm64
ghcr.io/openhands/agent-server:773b670-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:773b670-python-amd64
ghcr.io/openhands/agent-server:773b670-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:773b670-python-arm64
ghcr.io/openhands/agent-server:773b670-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:773b670-golang
ghcr.io/openhands/agent-server:773b670-java
ghcr.io/openhands/agent-server:773b670-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `773b670-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `773b670-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->