### PR TITLE
docs(architecture): add in-repo SDK architecture constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,13 @@ consult each relevant package-level AGENTS.md.
 - Agent server: [openhands-agent-server/AGENTS.md](openhands-agent-server/AGENTS.md)
 - Eval config: [.github/run-eval/AGENTS.md](.github/run-eval/AGENTS.md)
 
+For deeper design invariants and package/component boundaries that would make
+AGENTS.md too heavy, also read the architecture docs in `docs/architecture/`:
+
+- Docs taxonomy and AGENTS map: [docs/architecture/README.md](docs/architecture/README.md)
+- Core SDK constraints: [docs/architecture/sdk.md](docs/architecture/sdk.md)
+- Runtime package constraints: [docs/architecture/runtime.md](docs/architecture/runtime.md)
+
 ## API compatibility pointers
 
 - For SDK Python API deprecation/removal policy, read

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -1,0 +1,55 @@
+# Architecture constraints docs
+
+This directory holds the **durable architecture contracts** for the monorepo.
+It complements the AGENTS files instead of replacing them.
+
+## What belongs in `AGENTS.md`
+
+AGENTS files are the **operational layer** for contributors and software agents:
+
+- how to build, test, lint, and validate changes
+- package-specific compatibility rules and workflows
+- review-time guardrails and common footguns
+- pointers to the next-closest guidance file
+
+AGENTS files should stay compact enough to load as working context.
+
+## What belongs in `docs/architecture/`
+
+These docs are the **design-constraint layer**:
+
+- package responsibilities and boundaries
+- invariants that should remain true across refactors
+- cross-package composition rules
+- first-level component maps with the contracts they are expected to uphold
+- OCL-like statements when the constraint is simple enough to formalize
+
+If a rule is too deep or too structural for an AGENTS file, it likely belongs here.
+
+## How the AGENTS files compose
+
+| File | Scope | Primary job | Relationship to these docs |
+| --- | --- | --- | --- |
+| [`AGENTS.md`](../../AGENTS.md) | Whole monorepo | Global workflow, repo memory, package map, compatibility policy | Entry point; links to the deeper docs in this directory |
+| [`openhands-sdk/openhands/sdk/AGENTS.md`](../../openhands-sdk/openhands/sdk/AGENTS.md) | Core SDK package | Public SDK API rules, event compatibility, docs workflow | Pairs with [`sdk.md`](./sdk.md) for architectural invariants |
+| [`openhands-sdk/openhands/sdk/subagent/AGENTS.md`](../../openhands-sdk/openhands/sdk/subagent/AGENTS.md) | Subagent loader | File-based agent precedence and schema invariants | A specialized deep-dive that supplements `sdk.md` |
+| [`openhands-tools/openhands/tools/AGENTS.md`](../../openhands-tools/openhands/tools/AGENTS.md) | Runtime tools package | Tool packaging, public surface, test expectations | Pairs with [`runtime.md`](./runtime.md) |
+| [`openhands-workspace/openhands/workspace/AGENTS.md`](../../openhands-workspace/openhands/workspace/AGENTS.md) | Deployable workspace backends | Workspace package API and backend change guardrails | Pairs with [`runtime.md`](./runtime.md) |
+| [`openhands-agent-server/AGENTS.md`](../../openhands-agent-server/AGENTS.md) | Agent server | REST/API compatibility and async-safety rules | Pairs with [`runtime.md`](./runtime.md) |
+| [`.github/run-eval/AGENTS.md`](../../.github/run-eval/AGENTS.md) | Eval model config | Evaluation model registry and test workflow | Summarized in [`runtime.md`](./runtime.md) |
+
+## Recommended reading order
+
+When changing code:
+
+1. Read the repository root [`AGENTS.md`](../../AGENTS.md).
+2. Read the closest package-level AGENTS file.
+3. Read the relevant architecture doc in this directory.
+4. Only then dive into source files and tests.
+
+That ordering keeps operational guidance in AGENTS and structural guidance here.
+
+## Documents in this directory
+
+- [`sdk.md`](./sdk.md): package-level constraints and first-level component map for `openhands-sdk/openhands/sdk`
+- [`runtime.md`](./runtime.md): package-level constraints and component maps for `openhands-tools`, `openhands-workspace`, `openhands-agent-server`, and eval config

--- a/docs/architecture/runtime.md
+++ b/docs/architecture/runtime.md
@@ -1,0 +1,107 @@
+# Runtime package architecture constraints
+
+This document captures the durable constraints for the runtime-oriented packages
+that sit next to the core SDK:
+
+- `openhands-tools/openhands/tools`
+- `openhands-workspace/openhands/workspace`
+- `openhands-agent-server/openhands/agent_server`
+- `.github/run-eval`
+
+## `openhands-tools`: tool implementations and presets
+
+### Package-level invariants
+
+- `openhands.tools.__all__` is the curated public surface of the published
+  `openhands-tools` distribution.
+- Tool implementations should expose typed action/observation schemas and
+  register through the SDK tool registry instead of relying on hidden globals.
+- Most tools split declarative registration (`definition.py`) from runtime
+  behavior (`impl.py`, `core.py`, or `executor.py`).
+- Tool descriptions and schemas are user-facing contracts; compatibility matters.
+- Heavy or optional dependencies should not leak into the default import surface
+  unnecessarily (for example, browser tools are intentionally not re-exported
+  from `openhands.tools.__init__`).
+
+### First-level component map
+
+| Component | Responsibility | Durable constraints / invariants |
+| --- | --- | --- |
+| `apply_patch/` | Structured patch application | Encapsulates patch parsing/application instead of scattering ad hoc text patch logic across agents. |
+| `browser_use/` | Browser automation and recording | Browser tools are optional/heavy; runtime assets and recordings are part of the package contract and must remain packaged when needed. |
+| `delegate/` | Multi-agent delegation | Delegation routes through registered subagent types and renders tool descriptions from registry/workspace context instead of hard-coding agent choices in prompts. |
+| `file_editor/` | High-signal file editing tool | Editing uses explicit commands (`view`, `create`, `str_replace`, `insert`, `undo_edit`), absolute paths, and exact-match semantics; resource declarations lock per target file so reads do not race partial writes. |
+| `gemini/` | Gemini-style file tool family | Provides an alternate file-editing surface as a bundle of distinct tools (`GEMINI_FILE_TOOLS`) instead of overloading the standard file editor. |
+| `glob/` | Filename/path discovery | Remains a read-only exploration tool rather than mutating workspace state. |
+| `grep/` | Content search | Remains a read-only exploration tool with results shaped for agent consumption. |
+| `planning_file_editor/` | Planning-only editor | Editing is restricted to `PLAN.md`; default location is `.agents_tmp/PLAN.md`, while legacy root-level `PLAN.md` is still honored for backward compatibility. |
+| `preset/` | Default agent and default tool bundles | Centralizes the opinionated built-in tool/agent set so other packages do not each invent their own defaults. |
+| `task/` | Blocking delegated task execution | Packages subagent task execution as a toolset instead of folding that orchestration into unrelated agent logic. |
+| `task_tracker/` | Structured task-list state for agents | Externalizes work planning into an explicit tool; if a save directory is configured, persistence is file-backed (`TASKS.json`) rather than hidden in prompt state. |
+| `terminal/` | Persistent shell execution | Session state persists across calls; long-running commands use soft timeouts and interactive follow-up; reset is explicit rather than silently replacing the session. |
+| `tom_consult/` | Optional Tom-based user-model consultation | Keeps this capability optional and isolated so core agents do not depend on Tom-specific runtime code. |
+| `utils/` | Shared tool helpers | Hosts reusable implementation helpers rather than duplicating timeout/process utilities in each tool package. |
+
+## `openhands-workspace`: deployable workspace backends
+
+### Package-level invariants
+
+- `openhands.workspace.__all__` is the published surface for deployable
+  workspace implementations.
+- Imports should stay lightweight; `DockerDevWorkspace` is lazy-loaded to avoid
+  build-time dependencies on plain import.
+- Backends remain compatible with SDK workspace types (`RemoteWorkspace`,
+  `TargetType`, `PlatformType`) rather than inventing parallel abstractions.
+- External side effects should stay behind explicit backend methods, not happen
+  at import time.
+
+### First-level component map
+
+| Component | Responsibility | Durable constraints / invariants |
+| --- | --- | --- |
+| `apptainer/` | Apptainer-backed execution | Provides a container workspace that still conforms to the shared workspace contract rather than a separate execution model. |
+| `cloud/` | OpenHands Cloud workspace | Represents cloud-hosted execution while preserving the SDK workspace interface expected by conversations and tools. |
+| `docker/` | Docker-backed workspaces and dev helpers | Docker support includes both runtime workspace logic and dev-oriented helpers, but the public import surface must stay lightweight. |
+| `remote_api/` | Runtime API remote workspace | Bridges the SDK's remote workspace abstraction to an API-driven backend instead of requiring conversation code to know transport details. |
+
+## `openhands-agent-server`: API/runtime host for conversations
+
+### Package-level invariants
+
+- The REST API under `/api/**` is public and backward compatibility matters.
+- REST contract breaks require deprecation notice plus a runway of five minor
+  releases before removal or mandatory replacement.
+- Async routes/services must not block the event loop while waiting on the
+  conversation state's synchronous FIFO lock.
+- Runtime-loaded non-Python assets belong in the PyInstaller spec when needed.
+
+### First-level component map
+
+| Module group | Responsibility | Durable constraints / invariants |
+| --- | --- | --- |
+| Bootstrap (`__main__.py`, `api.py`, `config.py`, `openapi.py`, `logging_config.py`, `middleware.py`, `dependencies.py`) | Server startup, dependency wiring, and HTTP surface setup | Startup/config code should assemble the server around SDK primitives rather than re-implementing agent logic. |
+| Conversation API (`conversation_router.py`, `conversation_router_acp.py`, `conversation_service.py`, `models.py`) | Conversation CRUD, lifecycle, and request/response modeling | Conversation services should preserve SDK conversation semantics; state mutation stays synchronized and persistence-aware. |
+| Event delivery (`event_router.py`, `event_service.py`, `pub_sub.py`, `sockets.py`) | Event streaming over HTTP/WebSocket/SSE-style channels | Delivery layers publish the existing event stream; they must not invent alternate authoritative state. |
+| Environment/file/tool routers (`bash_router.py`, `bash_service.py`, `desktop_router.py`, `desktop_service.py`, `file_router.py`, `git_router.py`, `hooks_router.py`, `hooks_service.py`, `llm_router.py`, `skills_router.py`, `skills_service.py`, `tool_router.py`, `server_details_router.py`, `vscode_router.py`, `vscode_service.py`) | API adapters around specific SDK/runtime capabilities | These modules expose bounded server-side capabilities; they should adapt SDK/runtime primitives, not fork their behavior. |
+| Support modules (`env_parser.py`, `tool_preload_service.py`, `utils.py`) | Shared runtime helpers | Shared support code should remain plumbing, not a second business-logic layer. |
+| Asset directories (`docker/`, `vscode_extensions/`) | Bundled runtime assets | Runtime assets are part of the packaged server and must stay aligned with the PyInstaller/data-file rules in the package AGENTS file. |
+
+## `.github/run-eval`: evaluation model registry and workflow bridge
+
+### Invariants
+
+- `resolve_model_config.py` is the source of truth for evaluation model entries.
+- Model configuration here must stay aligned with SDK LLM/model-feature support.
+- Existing working model configs should only be changed for a confirmed reason.
+- Structural integrity is guarded by tests in `tests/github_workflows/`.
+
+## Cross-package boundaries worth preserving
+
+- `openhands-tools` depends on the SDK tool abstractions; it should not bypass
+  them with package-private execution channels.
+- `openhands-workspace` implements concrete workspace backends but still speaks
+  the SDK workspace contract.
+- `openhands-agent-server` hosts conversations remotely; it should expose the SDK
+  model rather than redefining it.
+- `.github/run-eval` is operational glue around model definitions, not a second
+  LLM abstraction layer.

--- a/docs/architecture/sdk.md
+++ b/docs/architecture/sdk.md
@@ -1,0 +1,133 @@
+# Core SDK architecture constraints
+
+This document captures the structural contracts for the core package
+`openhands-sdk/openhands/sdk`.
+
+It is intentionally deeper than [`openhands-sdk/openhands/sdk/AGENTS.md`](../../openhands-sdk/openhands/sdk/AGENTS.md):
+that AGENTS file tells contributors **how to change** the SDK safely, while this
+page captures **what the SDK is trying to preserve**.
+
+## Package-level invariants
+
+### 1. Configuration is declarative; `ConversationState` is the mutable runtime hub
+
+The SDK is designed so that agents, tools specs, LLM configs, settings, plugin
+sources, and workspace configs are declarative Pydantic models.
+
+Durable constraint:
+
+- mutable execution status belongs in `ConversationState`; other objects may keep
+  private caches, but replay/persistence should not depend on those caches.
+
+OCL-like:
+
+- `context AgentBase inv Frozen: self.model_config.frozen = true`
+- `context Event inv Frozen: self.model_config.frozen = true`
+
+### 2. The event log is the execution trace
+
+Anything that must be auditable, replayable, or reconstructible for the LLM
+must appear in the event stream.
+
+Durable constraints:
+
+- events are immutable once emitted
+- mutations are expressed as new events, not edits in place
+- `LLMConvertibleEvent.events_to_messages(...)` is the canonical reconstruction
+  path from event history to LLM-visible message history
+
+### 3. Workspace choice controls local-vs-remote execution
+
+`Conversation(...)` and `Workspace(...)` are factories rather than separate user
+entrypoints.
+
+Durable constraints:
+
+- `Conversation(...)` returns `LocalConversation` unless the workspace is a
+  `RemoteWorkspace`
+- a remote conversation must not accept `persistence_dir`
+- `Workspace(host=...)` returns a remote workspace; otherwise it returns a local
+  workspace
+
+OCL-like:
+
+- `context Conversation::__new__ pre RemoteNoPersistence: workspace.oclIsKindOf(RemoteWorkspace) implies persistence_dir = null`
+- `context Workspace::__new__ post RemoteIffHost: (host <> null) implies result.oclIsKindOf(RemoteWorkspace)`
+
+### 4. Public Python API changes are governed from `openhands.sdk.__all__`
+
+The curated import surface in `openhands.sdk.__all__` is treated as public API.
+
+Durable constraints:
+
+- removing a public symbol requires deprecation first
+- breaking public SDK API changes require at least a MINOR version bump
+- persisted event schema changes must keep old conversations loadable
+
+### 5. Composition is additive, not ad hoc
+
+Plugins, MCP servers, skills, hooks, and subagents extend the SDK by composing
+well-defined seams instead of introducing package-specific side channels.
+
+Durable constraints:
+
+- plugins merge skills, MCP config, and hooks through the canonical loader
+- subagents register through the shared registry with explicit precedence rules
+- tools resolve from declarative `Tool(name=..., params=...)` specs through the
+  tool registry
+
+## Representative low-level invariants
+
+These are small enough to state directly.
+
+- `context ToolRegistry inv RegisteredNamesAreNonEmpty: name.trim().size() > 0`
+- `context resolve_tool pre Registered: tool_spec.name in registry`
+- `context ActionEvent inv BatchedThoughtOnlyFirst: shared_llm_response_id implies only_first_action_has_thought`
+- `context BaseConversation inv ConfirmationModeIff: is_confirmation_mode_active = (state.security_analyzer <> null and not state.confirmation_policy.oclIsKindOf(NeverConfirm))`
+
+## First-level component map
+
+| Component | Responsibility | Durable constraints / invariants |
+| --- | --- | --- |
+| `agent/` | Agent configuration, prompt assembly, action generation, and tool materialization | `AgentBase` is frozen and stateless by design; runtime tool instances live in private attrs; tool specs resolve through the registry; prompt construction separates mostly-static prompt material from per-conversation dynamic context. |
+| `context/` | Agent context, skills, and condensation helpers | Context enriches the agent without becoming a second state store; progressive disclosure flows through `AgentContext.get_system_message_suffix()`; skill prompt descriptions are truncated to the AgentSkills limit (1024 chars). |
+| `conversation/` | Conversation factories, orchestration, persistence, locking, and visualization | `ConversationState` is the mutable runtime hub; `Conversation(...)` chooses local vs remote from the workspace type; `ask_agent()` is contractually read-only; async code must not block the event loop on the synchronous state lock. |
+| `critic/` | Optional evaluation of actions/messages | Critic behavior is advisory to the agent loop, not a replacement for the event log or execution status; critic-related settings stay explicit in agent/settings models. |
+| `event/` | Event model hierarchy and event-to-LLM conversion | Events are frozen discriminated unions; parallel tool calls are represented as multiple action events that share one `llm_response_id`; only the first action in a batch may carry shared thought/reasoning payloads. |
+| `git/` | Typed git helpers used by higher-level features | Git interactions are isolated behind helper/models code instead of being spread through agent logic; callers should receive explicit errors rather than silent success on invalid repositories. |
+| `hooks/` | Conversation hook configuration and execution plumbing | Hook configuration is declarative; blocked actions/messages are surfaced through conversation state; plugin hook configs concatenate instead of overwriting each other. |
+| `io/` | Persistence/storage abstraction (`FileStore` and implementations) | Persistence is hidden behind an interface so conversations can use local or in-memory backends without changing orchestration semantics. |
+| `llm/` | LLM config, registry, message types, streaming, and provider-specific adaptation | All model/provider details are normalized into typed models here; message/content objects are the stable bridge between conversation history and provider APIs. |
+| `logger/` | Shared logging facade | Logging should be centralized here rather than configured ad hoc throughout the codebase. |
+| `mcp/` | Model Context Protocol integration | MCP servers are translated into ordinary tool definitions instead of special-cased agent logic; runtime config now uses typed `MCPConfig`, while serialized settings stay compact and dict-shaped. |
+| `observability/` | Optional telemetry/trace integration | Observability augments execution but must not become a behavioral dependency for core agent logic. |
+| `plugin/` | Plugin fetch/load/merge lifecycle | Plugin loading is canonicalized in `load_plugins(...)`; skills merge by name with later plugins winning, MCP config merges by key with later plugins winning, and hooks concatenate. |
+| `secret/` | Secret value handling | Secret values are modeled explicitly so persistence can either encrypt them with a cipher or redact them when no cipher is available. |
+| `security/` | Risk analysis and confirmation policies | Confirmation mode is active iff a security analyzer exists and the policy is not `NeverConfirm`; policy and analyzer remain explicit dependencies instead of hidden global settings. |
+| `settings/` | Structured settings models and schema export | `AgentSettings` plus `export_settings_schema()` are the canonical structured settings surface; `SettingsFieldSchema` intentionally omits a `required` flag; `AgentSettings.tools` and `mcp_config` stay aligned with the agent creation payload. |
+| `skills/` | Skill fetching/installation helpers | Skill fetching is a source-resolution/cache concern; prompt rendering and activation happen elsewhere, keeping skill acquisition separate from runtime context assembly. |
+| `subagent/` | Discovery and registration of Markdown/plugin/programmatic subagents | Registration is precedence-driven and registry-backed; programmatic registration wins absolutely, plugins and file-based agents are first-wins within the registry, and built-ins act as fallback. See the dedicated [`subagent` AGENTS guide](../../openhands-sdk/openhands/sdk/subagent/AGENTS.md). |
+| `testing/` | SDK test utilities | Test helpers support deterministic unit/integration tests but are not part of production execution paths. |
+| `tool/` | Tool specs, registry, base classes, and schema contracts | Tool resolution is name-based and registry-backed; unknown tools raise `KeyError`; factories must resolve to `Sequence[ToolDefinition]`; tool inputs/outputs are typed schemas rather than unstructured dictionaries. |
+| `utils/` | Shared primitives (cipher, deprecation, async helpers, JSON helpers, etc.) | Cross-cutting mechanics live here so core subsystems can reuse them without inventing parallel implementations; deprecation helpers are part of the SDK compatibility contract. |
+| `workspace/` | SDK workspace abstraction and factory | `working_dir` is normalized as workspace state rather than ambient process cwd; local pause/resume is a no-op while remote/container backends may implement it as an optional capability. |
+
+## Relationships worth preserving
+
+- `agent/` depends on `tool/`, `llm/`, `context/`, `mcp/`, and `critic/`, but
+  does not own persistence.
+- `conversation/` owns runtime coordination and persistence, but delegates agent
+  decisions to `agent/` and environment I/O to `workspace/`.
+- `event/` is the shared audit language between agent, conversation, hooks,
+  critic, and visualizers.
+- `settings/` is the canonical serialized configuration surface; it should not
+  diverge from the models required by `create_agent()`.
+- `plugin/`, `skills/`, and `subagent/` all extend the system through explicit
+  registries/loaders rather than bespoke imports.
+
+## Depth check
+
+If you are about to change one of these invariants, update both:
+
+1. the relevant AGENTS file, and
+2. this document (or a more specific architecture doc if one is added later).


### PR DESCRIPTION
## Summary

- add an in-repo `docs/architecture/` section for durable architecture constraints
- document the split between AGENTS operational guidance and deeper architecture docs
- capture package/component invariants for `openhands-sdk`, `openhands-tools`, `openhands-workspace`, `openhands-agent-server`, and `.github/run-eval`
- link the new architecture docs from the root `AGENTS.md`

Closes #1815.

_This PR description was created by an AI assistant (OpenHands) on behalf of the user._

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this? Not applicable; this is a documentation-only change.
- [x] If there is an example, have you run the example to make sure that it works? Not applicable; no examples were changed.
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? Not applicable; no runtime instructions were changed.
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? Not applicable; per the issue discussion, these architecture constraints now live in this repository under `docs/architecture/`.
- [x] Is the github CI passing? Yes; all checks were green at the time of update.
