### PR TITLE
fix(docker): bundle Python runtime for portable /agent-server

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -20,6 +20,12 @@ ARG PORT=8000
 # Docker-in-Docker) reject dlopen() on such libraries with:
 #   "cannot enable executable stack as shared object requires: Invalid argument"
 # Debian's CPython packages do not have this issue.
+#
+# PORTABILITY: After the venv is built we bundle the interpreter, stdlib,
+# and libpython into /agent-server/.python/ and repoint the venv at it.
+# This makes /agent-server fully self-contained — downstream consumers
+# (e.g. eval images) can COPY it onto any base image without needing a
+# compatible system Python.
 ####################################################################################
 FROM python:3.13-bookworm AS builder
 ARG USERNAME UID GID
@@ -39,6 +45,51 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
     uv venv --python-preference only-system .venv && uv sync --frozen --no-editable --extra boto3
+
+# Bundle the Python runtime inside /agent-server so that the entire directory
+# is self-contained and portable.  Eval images (and any other consumer) can
+# COPY /agent-server onto *any* base image without requiring that base image
+# to ship a compatible system Python.
+#
+# What we copy:
+#   .python/bin/python3.13     – the interpreter binary
+#   .python/lib/python3.13/    – the standard library (minus tests)
+#   .python/lib/libpython*.so* – shared libraries (Debian builds --enable-shared)
+#
+# We then repoint the venv's symlinks and pyvenv.cfg at the bundled copy.
+RUN set -eux; \
+    REAL_PYTHON=$(readlink -f .venv/bin/python3); \
+    PY_VER=$("${REAL_PYTHON}" -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')"); \
+    PYTHON_PREFIX=$("${REAL_PYTHON}" -c "import sys; print(sys.base_prefix)"); \
+    # --- copy interpreter binary ------------------------------------------------- \
+    mkdir -p .python/bin; \
+    cp "${REAL_PYTHON}" ".python/bin/python${PY_VER}"; \
+    ln -s "python${PY_VER}" .python/bin/python3; \
+    ln -s "python${PY_VER}" .python/bin/python; \
+    # --- copy standard library (skip test suite to save ~30 MB) ------------------ \
+    mkdir -p .python/lib; \
+    cp -a "${PYTHON_PREFIX}/lib/python${PY_VER}" ".python/lib/python${PY_VER}"; \
+    rm -rf ".python/lib/python${PY_VER}/test" \
+           ".python/lib/python${PY_VER}/tests" \
+           ".python/lib/python${PY_VER}/idle_test" \
+           ".python/lib/python${PY_VER}/idlelib"; \
+    # --- copy shared libraries (libpython) --------------------------------------- \
+    for lib in "${PYTHON_PREFIX}"/lib/libpython*.so*; do \
+        [ -e "$lib" ] && cp -a "$lib" .python/lib/; \
+    done; \
+    # --- repoint venv at the bundled Python -------------------------------------- \
+    for f in .venv/bin/python*; do \
+        [ -L "$f" ] || continue; \
+        name=$(basename "$f"); \
+        rm "$f"; \
+        ln -s "../../.python/bin/${name}" "$f"; \
+    done; \
+    # Ensure canonical names resolve (some venvs only create python3 + python) \
+    [ -L .venv/bin/python ] || ln -s "../../.python/bin/python" .venv/bin/python; \
+    [ -L .venv/bin/python3 ] || ln -s "../../.python/bin/python3" .venv/bin/python3; \
+    sed -i "s|^home = .*|home = /agent-server/.python/bin|" .venv/pyvenv.cfg; \
+    # --- quick smoke-test inside the builder ------------------------------------- \
+    .venv/bin/python -c "import sys; print('bundled python:', sys.executable, sys.version)"
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -272,11 +323,14 @@ EXPOSE ${PORT} ${NOVNC_PORT}
 FROM base-image AS source
 ARG USERNAME
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
+# Bundled Python's libpython*.so lives under /agent-server/.python/lib
+ENV LD_LIBRARY_PATH=/agent-server/.python/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENTRYPOINT ["/agent-server/.venv/bin/python", "-m", "openhands.agent_server"]
 
 FROM base-image-minimal AS source-minimal
 ARG USERNAME
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
+ENV LD_LIBRARY_PATH=/agent-server/.python/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}
 ENTRYPOINT ["/agent-server/.venv/bin/python", "-m", "openhands.agent_server"]
 
 ############################


### PR DESCRIPTION
## Summary

- Bundle the Python interpreter, stdlib, and libpython from the builder stage into `/agent-server/.python/` and repoint the venv symlinks at it
- This makes `/agent-server` fully self-contained — eval images can COPY it onto any base image without needing Python at `/usr/local/bin/python3`
- Keeps `--python-preference only-system` to avoid the seccomp/executable-stack issue with python-build-standalone

## Problem

SDK v1.15.0 (commit 06b91863) switched from uv-managed Python to `--python-preference only-system`, which creates a venv with symlinks to `/usr/local/bin/python3` (from the `python:3.13-bookworm` builder). When this venv is COPYed onto commit0 base images (Ubuntu 22.04, Python at `/usr/bin/python3`), the symlink is broken and the container fails to start:

```
exec: "/agent-server/.venv/bin/python": stat /usr/local/bin/python3: no such file or directory
```

This causes all commit0 evaluation pods to get stuck in "pending" status (OpenHands/benchmarks#607).

SWE-bench was unaffected because its base images derive from Python Docker images that have `/usr/local/bin/python3`.

## Test plan

- [x] Built image locally with commit0 base (`docker.io/wentingzhao/tinydb:v0`) — container starts and Python resolves correctly
- [x] Verified venv symlinks point to bundled `.python/` directory
- [x] Confirmed bundled Python runs: `Python: /agent-server/.venv/bin/python 3.13.12`
- [ ] Rebuild commit0 eval images and run evaluation

Fixes OpenHands/benchmarks#607

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d7b6700-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d7b6700-python \
  ghcr.io/openhands/agent-server:d7b6700-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d7b6700-golang-amd64
ghcr.io/openhands/agent-server:d7b6700-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d7b6700-golang-arm64
ghcr.io/openhands/agent-server:d7b6700-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d7b6700-java-amd64
ghcr.io/openhands/agent-server:d7b6700-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d7b6700-java-arm64
ghcr.io/openhands/agent-server:d7b6700-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d7b6700-python-amd64
ghcr.io/openhands/agent-server:d7b6700-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d7b6700-python-arm64
ghcr.io/openhands/agent-server:d7b6700-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d7b6700-golang
ghcr.io/openhands/agent-server:d7b6700-java
ghcr.io/openhands/agent-server:d7b6700-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d7b6700-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d7b6700-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->