### PR TITLE
fix(agent-server): sanitize 422 error responses to prevent secret leakage

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -1,7 +1,8 @@
 import asyncio
 import traceback
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
+from typing import Any
 from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
@@ -254,7 +255,7 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
             return RedirectResponse(url="/static/", status_code=302)
 
 
-def _sanitize_validation_errors(errors: list[dict]) -> list[dict]:
+def _sanitize_validation_errors(errors: Sequence[Any]) -> list[dict]:
     """Sanitize validation error details to remove sensitive input values.
 
     FastAPI's default 422 response includes the raw request ``input`` in each

--- a/tests/agent_server/test_validation_error_sanitization.py
+++ b/tests/agent_server/test_validation_error_sanitization.py
@@ -14,9 +14,7 @@ from pydantic import BaseModel
 from openhands.agent_server.api import (
     _add_exception_handlers,
     _sanitize_validation_errors,
-    create_app,
 )
-from openhands.agent_server.config import Config
 
 
 # ---------------------------------------------------------------------------
@@ -137,7 +135,9 @@ class TestSanitizeValidationErrors:
         original_api_key = original_errors[0]["input"]["agent"]["llm"]["api_key"]
         _sanitize_validation_errors(original_errors)
         # Original should be untouched
-        assert original_errors[0]["input"]["agent"]["llm"]["api_key"] == original_api_key
+        assert (
+            original_errors[0]["input"]["agent"]["llm"]["api_key"] == original_api_key
+        )
 
     def test_redacts_multiple_secret_patterns(self):
         """Various secret key patterns should all be redacted."""


### PR DESCRIPTION
## Summary
- Add a custom `RequestValidationError` handler to the agent server that sanitizes sensitive fields before returning 422 responses
- Reuses `sanitize_dict` from `openhands.sdk.utils.redact` (the same module introduced in #2631) for consistent redaction patterns
- Redacts `api_key`, `acp_env`, tokens, passwords, authorization headers, and other secret-bearing fields from the `input` field in validation error details

## Why
FastAPI's default 422 handler echoes the raw request body inside the `detail[].input` field. When a `StartConversationRequest` (or `StartACPConversationRequest`) payload fails validation, secret-bearing fields like `agent.llm.api_key` and `agent.acp_env` would be included in the error response body. This is defense-in-depth complementing the SDK-side fix in #2631.

**Not actively exploited** — all observed 422s had `api_key: None` and `acp_env: {}`. But if a run with populated `acp_env` hits a 422, real credentials would be included in the error response.

Refs: OpenHands/evaluation#385

## Changes
- **`openhands-agent-server/openhands/agent_server/api.py`**: Added `_sanitize_validation_errors()` helper and `RequestValidationError` exception handler that sanitizes the `input` field in each validation error before returning the 422 response
- **`tests/agent_server/test_validation_error_sanitization.py`**: 12 tests covering unit tests for the sanitization helper and integration tests with a real FastAPI test client

## Test plan
- [x] Unit tests for `_sanitize_validation_errors` — verifies redaction of `api_key`, `acp_env`, multiple secret patterns, preservation of non-secret fields, handling of missing/scalar inputs, and non-mutation of originals
- [x] Integration tests via `TestClient` — verifies end-to-end 422 responses are sanitized, error structure is preserved, valid requests are unaffected, and non-JSON bodies are handled

```bash
uv run pytest tests/agent_server/test_validation_error_sanitization.py -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e3c4c5c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e3c4c5c-python \
  ghcr.io/openhands/agent-server:e3c4c5c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e3c4c5c-golang-amd64
ghcr.io/openhands/agent-server:e3c4c5c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e3c4c5c-golang-arm64
ghcr.io/openhands/agent-server:e3c4c5c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e3c4c5c-java-amd64
ghcr.io/openhands/agent-server:e3c4c5c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e3c4c5c-java-arm64
ghcr.io/openhands/agent-server:e3c4c5c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e3c4c5c-python-amd64
ghcr.io/openhands/agent-server:e3c4c5c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e3c4c5c-python-arm64
ghcr.io/openhands/agent-server:e3c4c5c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e3c4c5c-golang
ghcr.io/openhands/agent-server:e3c4c5c-java
ghcr.io/openhands/agent-server:e3c4c5c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e3c4c5c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e3c4c5c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->