### PR TITLE
Add dashscope/qwen3.6-plus to resolve_model_config.py

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -88,6 +88,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "qwen3.6-plus": {
+        "id": "qwen3.6-plus",
+        "display_name": "Qwen3.6 Plus",
+        "llm_config": {
+            "model": "litellm_proxy/dashscope/qwen3.6-plus",
+            "temperature": 0.0,
+        },
+    },
     "claude-4.5-opus": {
         "id": "claude-4.5-opus",
         "display_name": "Claude 4.5 Opus",

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -570,3 +570,13 @@ def test_converse_nemotron_super_3_120b_config():
         model["llm_config"]["model"] == "litellm_proxy/converse-nemotron-super-3-120b"
     )
     assert model["llm_config"]["temperature"] == 0.0
+
+
+def test_qwen3_6_plus_config():
+    """Test that qwen3.6-plus has correct configuration."""
+    model = MODELS["qwen3.6-plus"]
+
+    assert model["id"] == "qwen3.6-plus"
+    assert model["display_name"] == "Qwen3.6 Plus"
+    assert model["llm_config"]["model"] == "litellm_proxy/dashscope/qwen3.6-plus"
+    assert model["llm_config"]["temperature"] == 0.0


### PR DESCRIPTION
## Fixes #2680

## Summary

This PR adds the `qwen3.6-plus` model to `resolve_model_config.py`, following the existing pattern for dashscope models.

## Changes

- Added model configuration for `qwen3.6-plus` in `.github/run-eval/resolve_model_config.py`
- Added corresponding test in `tests/github_workflows/test_resolve_model_config.py`

## Model Configuration

```python
"qwen3.6-plus": {
    "id": "qwen3.6-plus",
    "display_name": "Qwen3.6 Plus",
    "llm_config": {
        "model": "litellm_proxy/dashscope/qwen3.6-plus",
        "temperature": 0.0,
    },
},
```

## Testing

- All Pydantic validation tests pass
- New model configuration test added and passing

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/86371e1f-8671-4107-93e9-944ba78d1809)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5cae72c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5cae72c-python \
  ghcr.io/openhands/agent-server:5cae72c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5cae72c-golang-amd64
ghcr.io/openhands/agent-server:5cae72c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5cae72c-golang-arm64
ghcr.io/openhands/agent-server:5cae72c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5cae72c-java-amd64
ghcr.io/openhands/agent-server:5cae72c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5cae72c-java-arm64
ghcr.io/openhands/agent-server:5cae72c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5cae72c-python-amd64
ghcr.io/openhands/agent-server:5cae72c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5cae72c-python-arm64
ghcr.io/openhands/agent-server:5cae72c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5cae72c-golang
ghcr.io/openhands/agent-server:5cae72c-java
ghcr.io/openhands/agent-server:5cae72c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5cae72c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5cae72c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->