### PR TITLE
test(llm): lock in gpt-5.4 verified model coverage

### DIFF
--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -63,6 +63,8 @@ async def test_list_verified_models():
     assert response.models == VERIFIED_MODELS
     assert "openai" in response.models
     assert "anthropic" in response.models
+    assert "gpt-5.4" in response.models["openai"]
+    assert "gpt-5.4" in response.models["openhands"]
 
 
 def test_providers_endpoint_integration(client):

--- a/tests/sdk/llm/test_model_list.py
+++ b/tests/sdk/llm/test_model_list.py
@@ -83,6 +83,11 @@ def test_list_bedrock_models_with_boto3(monkeypatch):
     assert result == ["bedrock/anthropic.claude-3"]
 
 
+def test_gpt_5_4_is_listed_as_verified_for_openai_and_openhands():
+    assert "gpt-5.4" in VERIFIED_MODELS["openai"]
+    assert "gpt-5.4" in VERIFIED_OPENHANDS_MODELS
+
+
 def test_openhands_models_all_have_provider_list():
     """Every model in VERIFIED_OPENHANDS_MODELS must also appear in at least one
     provider-specific list so that the UI can display it under its actual provider.


### PR DESCRIPTION
## Summary

- add regression coverage asserting `gpt-5.4` remains in the OpenAI and OpenHands verified model lists
- verify the verified-models agent-server response continues to surface `gpt-5.4`
- closes #2682

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works? (not applicable)
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? (not applicable)
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? (not applicable)
- [ ] Is the github CI passing?

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e81ad79b-c5c7-4236-a4c3-dd3e0868273d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9a7584c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9a7584c-python \
  ghcr.io/openhands/agent-server:9a7584c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9a7584c-golang-amd64
ghcr.io/openhands/agent-server:9a7584c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9a7584c-golang-arm64
ghcr.io/openhands/agent-server:9a7584c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9a7584c-java-amd64
ghcr.io/openhands/agent-server:9a7584c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9a7584c-java-arm64
ghcr.io/openhands/agent-server:9a7584c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9a7584c-python-amd64
ghcr.io/openhands/agent-server:9a7584c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9a7584c-python-arm64
ghcr.io/openhands/agent-server:9a7584c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9a7584c-golang
ghcr.io/openhands/agent-server:9a7584c-java
ghcr.io/openhands/agent-server:9a7584c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9a7584c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9a7584c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->