### PR TITLE
revert(docker): restore managed Python instead of --python-preference only-system

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -12,18 +12,11 @@ ARG PORT=8000
 ####################################################################################
 # Builder (source mode)
 # We copy source + build a venv here for local dev and debugging.
-#
-# NOTE: We use the base image's system Python (--python-preference only-system)
-# instead of uv-managed python-build-standalone. The python-build-standalone
-# builds ship libpython with an executable stack (PT_GNU_STACK PF_X).
-# Docker containers running under seccomp restrictions (e.g. GitHub Actions
-# Docker-in-Docker) reject dlopen() on such libraries with:
-#   "cannot enable executable stack as shared object requires: Invalid argument"
-# Debian's CPython packages do not have this issue.
 ####################################################################################
 FROM python:3.13-bookworm AS builder
 ARG USERNAME UID GID
 ENV UV_PROJECT_ENVIRONMENT=/agent-server/.venv
+ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 
 COPY --from=ghcr.io/astral-sh/uv /uv /uvx /bin/
 
@@ -38,7 +31,7 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv venv --python-preference only-system .venv && uv sync --frozen --no-editable --extra boto3
+    uv python install 3.13 && uv venv --python 3.13 .venv && uv sync --frozen --no-editable --managed-python --extra boto3
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -271,11 +264,13 @@ EXPOSE ${PORT} ${NOVNC_PORT}
 ############################
 FROM base-image AS source
 ARG USERNAME
+ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
 ENTRYPOINT ["/agent-server/.venv/bin/python", "-m", "openhands.agent_server"]
 
 FROM base-image-minimal AS source-minimal
 ARG USERNAME
+ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 COPY --chown=${USERNAME}:${USERNAME} --from=builder /agent-server /agent-server
 ENTRYPOINT ["/agent-server/.venv/bin/python", "-m", "openhands.agent_server"]
 


### PR DESCRIPTION
## Summary

Reverts the Docker builder from `uv venv --python-preference only-system` back to `uv python install 3.13` + `--managed-python`, restoring venv portability for `source`/`source-minimal` image targets.

### Problem

Commits `3192b084` and `29b76b66` switched the builder to use the system Python from `python:3.13-bookworm` instead of uv-managed python-build-standalone. This creates a `.venv` whose `pyvenv.cfg` `home` points to the builder image's `/usr/local/bin`, which may not exist in the target base image. This breaks downstream consumers like commit0 whose base images have different filesystem layouts (#2687).

### Fix

Restore the managed-python approach where `UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python` bundles the interpreter inside `/agent-server/`, so it gets copied along with the rest of the venv into the final image — making source/source-minimal fully portable.

### Notes on the execstack concern

The `--python-preference only-system` change was originally motivated by python-build-standalone's `PT_GNU_STACK PF_X` (executable stack) causing `dlopen()` failures in Docker-in-Docker with seccomp. However:

- The CI `server.yml` workflow builds the `binary` target (PyInstaller), not `source`/`source-minimal`
- The execstack issue was triggered by a Docker build cache invalidation, suggesting it may have been a transient BuildKit/seccomp configuration issue rather than a fundamental incompatibility
- If the execstack issue resurfaces, a targeted fix (e.g., `execstack -c` on the managed Python's libpython) would be preferable to breaking venv portability

Fixes #2687

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/c980c93d-aa7e-4fc5-8625-2c228910db46)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5883d39-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5883d39-python \
  ghcr.io/openhands/agent-server:5883d39-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5883d39-golang-amd64
ghcr.io/openhands/agent-server:5883d39-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5883d39-golang-arm64
ghcr.io/openhands/agent-server:5883d39-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5883d39-java-amd64
ghcr.io/openhands/agent-server:5883d39-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5883d39-java-arm64
ghcr.io/openhands/agent-server:5883d39-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5883d39-python-amd64
ghcr.io/openhands/agent-server:5883d39-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5883d39-python-arm64
ghcr.io/openhands/agent-server:5883d39-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5883d39-golang
ghcr.io/openhands/agent-server:5883d39-java
ghcr.io/openhands/agent-server:5883d39-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5883d39-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5883d39-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->