### PR TITLE
fix: strip deployment prefixes from LiteLLM proxy model names

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -54,6 +54,9 @@ class ModelFeatures:
 
 LITELLM_PROXY_PREFIX = "litellm_proxy/"
 
+# Common deployment path prefixes used in LiteLLM proxy configurations
+DEPLOYMENT_PREFIXES = ("prod/", "dev/", "staging/", "test/")
+
 
 @cache
 def _normalized_supported_openai_params(model: str | None) -> frozenset[str]:
@@ -64,6 +67,12 @@ def _normalized_supported_openai_params(model: str | None) -> frozenset[str]:
     normalized = model.strip().lower()
     if normalized.startswith(LITELLM_PROXY_PREFIX):
         normalized = normalized.removeprefix(LITELLM_PROXY_PREFIX)
+
+    # Strip common deployment path prefixes (e.g., "prod/claude-opus-4-5" → "claude-opus-4-5")
+    for prefix in DEPLOYMENT_PREFIXES:
+        if normalized.startswith(prefix):
+            normalized = normalized.removeprefix(prefix)
+            break
 
     params = get_supported_openai_params(
         model=normalized,

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -68,7 +68,7 @@ def _normalized_supported_openai_params(model: str | None) -> frozenset[str]:
     if normalized.startswith(LITELLM_PROXY_PREFIX):
         normalized = normalized.removeprefix(LITELLM_PROXY_PREFIX)
 
-    # Strip common deployment path prefixes (e.g., "prod/claude-opus-4-5" → "claude-opus-4-5")
+    # Strip deployment prefixes (e.g., "prod/", "dev/", "staging/", "test/")
     for prefix in DEPLOYMENT_PREFIXES:
         if normalized.startswith(prefix):
             normalized = normalized.removeprefix(prefix)

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -61,6 +61,11 @@ def test_model_matches(name, pattern, expected):
         ("litellm_proxy/gpt-5", True),
         ("litellm_proxy/claude-opus-4-5", True),
         ("litellm_proxy/gemini-3-flash-preview", True),
+        # LiteLLM proxy with deployment path prefixes (prod/, dev/, staging/, test/)
+        ("litellm_proxy/prod/claude-opus-4-5-20251101", True),
+        ("litellm_proxy/dev/claude-opus-4-5", True),
+        ("litellm_proxy/staging/gpt-5", True),
+        ("litellm_proxy/test/o1", True),
         ("unknown-model", False),
     ],
 )


### PR DESCRIPTION
## Summary

When using models via LiteLLM proxy with deployment path prefixes (e.g., `litellm_proxy/prod/claude-opus-4-5-20251101`), the SDK now correctly strips prefixes like `prod/`, `dev/`, `staging/`, and `test/` before querying LiteLLM for model capabilities.

## Problem

Users with LiteLLM proxy configurations using deployment paths encountered:
```
AnthropicException - {"type":"error","error":{"type":"invalid_request_error",
"message":"`temperature` and `top_p` cannot both be specified for this model."}}
```

**Root cause:** `_normalized_supported_openai_params()` stripped `litellm_proxy/` but left deployment prefixes like `prod/`. LiteLLM doesn't recognize `prod/claude-opus-4-5-20251101` as a valid model, so `supports_reasoning_effort` returned `False`, and temp/top_p weren't stripped from requests.

## Fix

Added stripping of common deployment path prefixes (`prod/`, `dev/`, `staging/`, `test/`) in `_normalized_supported_openai_params()`.

**Before:**
```
litellm_proxy/prod/claude-opus-4-5-20251101
  → strips litellm_proxy/
  → prod/claude-opus-4-5-20251101
  → LiteLLM returns 0 params
  → supports_reasoning_effort = False ❌
```

**After:**
```
litellm_proxy/prod/claude-opus-4-5-20251101
  → strips litellm_proxy/
  → strips prod/
  → claude-opus-4-5-20251101
  → LiteLLM returns params
  → supports_reasoning_effort = True ✅
```

## Testing

Added test cases for deployment prefix handling:
- `litellm_proxy/prod/claude-opus-4-5-20251101`
- `litellm_proxy/dev/claude-opus-4-5`
- `litellm_proxy/staging/gpt-5`
- `litellm_proxy/test/o1`

All 139 tests pass.

Fixes #2686

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/922f74d8-b1d9-40ca-b758-887b8ceadf11)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5716d75-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5716d75-python \
  ghcr.io/openhands/agent-server:5716d75-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5716d75-golang-amd64
ghcr.io/openhands/agent-server:5716d75-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5716d75-golang-arm64
ghcr.io/openhands/agent-server:5716d75-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5716d75-java-amd64
ghcr.io/openhands/agent-server:5716d75-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5716d75-java-arm64
ghcr.io/openhands/agent-server:5716d75-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5716d75-python-amd64
ghcr.io/openhands/agent-server:5716d75-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5716d75-python-arm64
ghcr.io/openhands/agent-server:5716d75-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5716d75-golang
ghcr.io/openhands/agent-server:5716d75-java
ghcr.io/openhands/agent-server:5716d75-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5716d75-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5716d75-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->