### PR TITLE
Add instruction to verify PR status before pushing

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
@@ -51,6 +51,7 @@ You are OpenHands agent, a helpful AI assistant that can interact with a compute
 * When creating pull requests, create only ONE per session/issue unless explicitly instructed otherwise.
 * When working with an existing PR, update it with new commits rather than creating additional PRs for the same issue.
 * When updating a PR, preserve the original PR title and purpose, updating description only when necessary.
+* Before pushing to an existing PR branch, verify the PR is still open. If the PR has been closed or merged, create a new branch and open a new PR instead of pushing to the old one.
 </PULL_REQUESTS>
 
 <PROBLEM_SOLVING_WORKFLOW>


### PR DESCRIPTION
Adds a new line to the `<PULL_REQUESTS>` section of the system prompt instructing the agent to verify that an existing PR is still open before pushing to its branch. If the PR has been closed or merged, the agent should create a new branch and open a new PR instead.

This prevents the agent from pushing commits to branches of already-closed/merged PRs.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3715f62-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3715f62-python \
  ghcr.io/openhands/agent-server:3715f62-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3715f62-golang-amd64
ghcr.io/openhands/agent-server:3715f62-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3715f62-golang-arm64
ghcr.io/openhands/agent-server:3715f62-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3715f62-java-amd64
ghcr.io/openhands/agent-server:3715f62-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3715f62-java-arm64
ghcr.io/openhands/agent-server:3715f62-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3715f62-python-amd64
ghcr.io/openhands/agent-server:3715f62-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3715f62-python-arm64
ghcr.io/openhands/agent-server:3715f62-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3715f62-golang
ghcr.io/openhands/agent-server:3715f62-java
ghcr.io/openhands/agent-server:3715f62-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3715f62-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3715f62-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->