### PR TITLE
fix(acp): retry transient ACP server errors (JSON-RPC -32603)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -940,7 +940,10 @@ class ACPAgent(AgentBase):
                     # Retry transient server errors (e.g. "Internal Server
                     # Error" from Gemini).  These are JSON-RPC -32603 errors
                     # that indicate a server-side failure, not a client bug.
-                    if e.code in _RETRIABLE_SERVER_ERROR_CODES and attempt < max_retries:
+                    if (
+                        e.code in _RETRIABLE_SERVER_ERROR_CODES
+                        and attempt < max_retries
+                    ):
                         delay = _ACP_PROMPT_RETRY_DELAYS[
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
                         ]

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -1709,10 +1709,12 @@ class TestACPPromptRetry:
         assert (
             conversation.state.execution_status == ConversationExecutionStatus.FINISHED
         )
-        assert "Success after server error retry" in events[0].llm_message.content[0].text
+        assert (
+            "Success after server error retry" in events[0].llm_message.content[0].text
+        )
 
     def test_no_retry_on_non_retriable_acp_error(self, tmp_path):
-        """ACP errors with non-retriable codes (e.g. -32600 Invalid request) fail immediately."""
+        """Non-retriable ACP error codes fail immediately."""
         from acp.exceptions import RequestError as ACPRequestError
 
         agent = _make_agent()


### PR DESCRIPTION
## Summary

When the ACP server returns a JSON-RPC Internal Error (`-32603`), the SDK now retries the prompt with exponential backoff instead of immediately failing the conversation.

**Context**: In the commit0 ACP Gemini evaluation run ([benchmarks#627](https://github.com/OpenHands/benchmarks/issues/627)), the majority of failures are transient server errors from Gemini:

- `ACPPromptError: Internal Server Error` — Gemini returns HTTP 500 via JSON-RPC `-32603`
- `ACPPromptError: Model stream ended with malformed function call` — transient model output issue
- `Server disconnected without sending a response` — transport drop (already retried)
- `Remote conversation ended with error` — generic fallback

The first two errors surface as `acp.exceptions.RequestError` which is a plain `Exception`, **not** one of the `_RETRIABLE_CONNECTION_ERRORS` (`OSError`, `ConnectionError`, etc.). So the SDK immediately fails the conversation without retrying, even though these are transient server-side errors.

The benchmarks retry loop does catch these and retries the entire instance (new runtime + new conversation), but that's much more expensive than retrying just the ACP prompt within the same session.

## What changed

- **`acp_agent.py`**: Added `ACPRequestError` (aliased from `acp.exceptions.RequestError`) to the retry loop in `step()`. Only server-side error codes are retried (currently `-32603` = JSON-RPC "Internal error"). Client errors like `-32600` ("Invalid request") are still raised immediately.
- **`_RETRIABLE_SERVER_ERROR_CODES`**: New `frozenset` constant defining which JSON-RPC error codes are transient. This is separate from `_RETRIABLE_CONNECTION_ERRORS` because the error type and semantics are different (application-level JSON-RPC vs transport-level connection).
- **Tests**: 3 new tests covering retry-then-success, no-retry for non-retriable codes, and max-retries-exhausted.

## Error flow before/after

| Error | Exception Type | Before | After |
|-------|---------------|--------|-------|
| `Internal Server Error` | `RequestError(-32603)` | Immediate fail → tear down conversation | Retry up to 3x with 5/15/30s backoff |
| `Invalid request` | `RequestError(-32600)` | Immediate fail | Immediate fail (unchanged) |
| `Connection reset` | `ConnectionError` | Retry 3x | Retry 3x (unchanged) |
| `Timeout` | `TimeoutError` | Immediate fail | Immediate fail (unchanged) |

## Test plan

- [x] `test_retry_on_acp_server_error_then_success` — first attempt raises `-32603`, second succeeds
- [x] `test_no_retry_on_non_retriable_acp_error` — `-32600` fails immediately (1 attempt)
- [x] `test_max_retries_exceeded_acp_server_error` — 4 total attempts, then raises
- [x] All existing retry tests still pass (111/111)

Closes https://github.com/OpenHands/benchmarks/issues/627

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3ebd9d9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3ebd9d9-python \
  ghcr.io/openhands/agent-server:3ebd9d9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3ebd9d9-golang-amd64
ghcr.io/openhands/agent-server:3ebd9d9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3ebd9d9-golang-arm64
ghcr.io/openhands/agent-server:3ebd9d9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3ebd9d9-java-amd64
ghcr.io/openhands/agent-server:3ebd9d9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3ebd9d9-java-arm64
ghcr.io/openhands/agent-server:3ebd9d9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3ebd9d9-python-amd64
ghcr.io/openhands/agent-server:3ebd9d9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3ebd9d9-python-arm64
ghcr.io/openhands/agent-server:3ebd9d9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3ebd9d9-golang
ghcr.io/openhands/agent-server:3ebd9d9-java
ghcr.io/openhands/agent-server:3ebd9d9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3ebd9d9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3ebd9d9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->