### PR TITLE
fix: support custom user skills dirs via env var and API parameter

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -74,6 +74,14 @@ class SkillsRequest(BaseModel):
     project_dir: str | None = Field(
         default=None, description="Workspace directory path for project skills"
     )
+    user_skills_dirs: list[str] | None = Field(
+        default=None,
+        description=(
+            "Additional directories to search for user skills. "
+            "Useful when user skills are mounted at a custom path "
+            "inside the agent-server container."
+        ),
+    )
     org_config: OrgConfig | None = Field(
         default=None, description="Organization skills configuration"
     )
@@ -154,6 +162,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
         org_name=org_name,
         sandbox_exposed_urls=sandbox_urls,
         marketplace_path=request.marketplace_path,
+        user_skills_dirs=request.user_skills_dirs,
     )
 
     # Convert Skill objects to SkillInfo for response

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -17,6 +17,7 @@ sandbox < public < user < org < project
 import shutil
 import subprocess
 import tempfile
+from collections.abc import Sequence
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -286,6 +287,7 @@ def load_all_skills(
     org_name: str | None = None,
     sandbox_exposed_urls: list[ExposedUrlData] | None = None,
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
+    user_skills_dirs: Sequence[str | Path] | None = None,
 ) -> SkillLoadResult:
     """Load and merge skills from all configured sources.
 
@@ -308,6 +310,9 @@ def load_all_skills(
         sandbox_exposed_urls: List of exposed URLs from sandbox.
         marketplace_path: Relative marketplace JSON path for public skills.
             Pass None to load all public skills without marketplace filtering.
+        user_skills_dirs: Additional directories to search for user skills.
+            Useful when user skills are mounted at a custom path inside
+            the agent-server container.
 
     Returns:
         SkillLoadResult containing merged skills and source counts.
@@ -331,6 +336,7 @@ def load_all_skills(
         include_project=False,
         include_public=load_public,
         marketplace_path=marketplace_path,
+        user_skills_dirs=user_skills_dirs,
     )
     sources["sdk_base"] = len(sdk_base)
     skill_lists.append(list(sdk_base.values()))

--- a/openhands-sdk/openhands/sdk/context/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/skills/__init__.py
@@ -2,6 +2,7 @@ from openhands.sdk.context.skills.exceptions import SkillValidationError
 from openhands.sdk.context.skills.skill import (
     Skill,
     SkillResources,
+    get_user_skills_dirs,
     load_available_skills,
     load_project_skills,
     load_public_skills,
@@ -29,6 +30,7 @@ __all__ = [
     "KeywordTrigger",
     "TaskTrigger",
     "SkillKnowledge",
+    "get_user_skills_dirs",
     "load_available_skills",
     "load_skills_from_dir",
     "load_user_skills",

--- a/openhands-sdk/openhands/sdk/context/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/context/skills/skill.py
@@ -1,6 +1,8 @@
 import io
 import json
+import os
 import re
+from collections.abc import Sequence
 from pathlib import Path
 from typing import Annotated, ClassVar, Literal, Union
 from xml.sax.saxutils import escape as xml_escape
@@ -719,14 +721,67 @@ USER_SKILLS_DIRS = [
     Path.home() / ".openhands" / "microagents",  # Legacy support
 ]
 
+# Environment variable for specifying additional user skill directories.
+# When the agent-server runs inside a container, the host's skill directories
+# are not visible. Use this env var (colon-separated paths on Linux/macOS,
+# semicolon-separated on Windows) to tell the agent-server where user skills
+# have been mounted.
+USER_SKILLS_DIRS_ENV = "OPENHANDS_USER_SKILLS_DIRS"
 
-def load_user_skills() -> list[Skill]:
+
+def get_user_skills_dirs(
+    extra_dirs: Sequence[str | Path] | None = None,
+) -> list[Path]:
+    """Build the full list of user skill directories to search.
+
+    Merges default paths, environment variable paths, and explicit extras.
+    Priority (highest first): *extra_dirs* → env-var dirs → defaults.
+
+    Args:
+        extra_dirs: Additional directories to search (highest priority).
+
+    Returns:
+        Ordered list of directories to search for user skills.
+    """
+    dirs: list[Path] = []
+
+    # 1. Explicit extra dirs (highest priority)
+    if extra_dirs:
+        for p in extra_dirs:
+            dirs.append(Path(p) if isinstance(p, str) else p)
+
+    # 2. Environment variable dirs
+    env_value = os.environ.get(USER_SKILLS_DIRS_ENV, "")
+    if env_value:
+        for raw in env_value.split(os.pathsep):
+            raw = raw.strip()
+            if raw:
+                dirs.append(Path(raw))
+
+    # 3. Defaults (lowest priority)
+    dirs.extend(USER_SKILLS_DIRS)
+
+    return dirs
+
+
+def load_user_skills(
+    extra_dirs: Sequence[str | Path] | None = None,
+) -> list[Skill]:
     """Load skills from user's home directory.
 
     Searches for skills in ~/.agents/skills/, ~/.openhands/skills/, and
     ~/.openhands/microagents/ (legacy). Skills from all directories are merged,
-    with earlier entries in USER_SKILLS_DIRS taking precedence for duplicate
-    names.
+    with earlier entries taking precedence for duplicate names.
+
+    Additional directories can be supplied via the *extra_dirs* argument
+    (highest priority) or the ``OPENHANDS_USER_SKILLS_DIRS`` environment
+    variable (colon-separated paths). This is useful when the agent-server
+    runs inside a container where the host's home directory is not visible:
+    mount the user skills at an arbitrary path and point to it.
+
+    Args:
+        extra_dirs: Additional directories to search for user skills.
+            These take highest precedence over env-var and default paths.
 
     Returns:
         List of Skill objects loaded from user directories.
@@ -735,7 +790,8 @@ def load_user_skills() -> list[Skill]:
     all_skills: list[Skill] = []
     seen_names: set[str] = set()
 
-    _load_and_merge_from_dirs(USER_SKILLS_DIRS, seen_names, all_skills, "user skills")
+    dirs = get_user_skills_dirs(extra_dirs)
+    _load_and_merge_from_dirs(dirs, seen_names, all_skills, "user skills")
 
     logger.debug(
         f"Loaded {len(all_skills)} user skills: {[s.name for s in all_skills]}"
@@ -1079,6 +1135,7 @@ def load_available_skills(
     include_project: bool = False,
     include_public: bool = False,
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
+    user_skills_dirs: Sequence[str | Path] | None = None,
 ) -> dict[str, Skill]:
     """Load and merge skills from SDK-level sources with consistent precedence.
 
@@ -1097,6 +1154,9 @@ def load_available_skills(
         include_public: Load public skills from the OpenHands extensions repo.
         marketplace_path: Relative marketplace JSON path to use for public skills.
             Pass None to load all public skills without marketplace filtering.
+        user_skills_dirs: Additional directories to search for user skills.
+            Useful when the agent-server runs inside a container and user
+            skills are mounted at a custom path.
 
     Returns:
         Dict mapping skill name → Skill, with higher-precedence sources
@@ -1113,7 +1173,7 @@ def load_available_skills(
 
     if include_user:
         try:
-            for s in load_user_skills():
+            for s in load_user_skills(extra_dirs=user_skills_dirs):
                 available[s.name] = s
         except Exception as e:
             logger.warning(f"Failed to load user skills: {e}")

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -357,6 +357,21 @@ class TestLoadAllSkills:
             assert len(shared_skills) == 1
             assert shared_skills[0].content == "project"
 
+    def test_load_all_skills_passes_user_skills_dirs(self):
+        """Test that user_skills_dirs is forwarded to load_available_skills."""
+        with patch(self._PATCH_TARGET, side_effect=[{}, {}]) as mock_avail:
+            load_all_skills(
+                load_public=False,
+                load_user=True,
+                load_project=False,
+                load_org=False,
+                user_skills_dirs=["/mounted/skills"],
+            )
+
+        # sdk_base call should have user_skills_dirs
+        sdk_base_call = mock_avail.call_args_list[0]
+        assert sdk_base_call.kwargs["user_skills_dirs"] == ["/mounted/skills"]
+
 
 class TestSyncPublicSkills:
     """Tests for sync_public_skills function."""

--- a/tests/sdk/context/skill/test_load_user_skills.py
+++ b/tests/sdk/context/skill/test_load_user_skills.py
@@ -1,5 +1,6 @@
 """Tests for load_user_skills functionality."""
 
+import os
 import tempfile
 from pathlib import Path
 
@@ -9,8 +10,10 @@ from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.context.skills import (
     KeywordTrigger,
     Skill,
+    get_user_skills_dirs,
     load_user_skills,
 )
+from openhands.sdk.context.skills.skill import USER_SKILLS_DIRS_ENV
 
 
 @pytest.fixture
@@ -304,5 +307,130 @@ def test_agent_context_explicit_skill_takes_precedence(temp_user_skills_dir):
         assert len(context.skills) == 1
         # Explicit skill should be used, not the user skill
         assert context.skills[0].content == "Explicit skill content."
+    finally:
+        skill.USER_SKILLS_DIRS = original_dirs
+
+
+# --- Tests for extra_dirs / env var support ---
+
+
+def test_get_user_skills_dirs_defaults():
+    """Test that default dirs are returned when no extras are given."""
+    from openhands.sdk.context.skills import skill
+
+    # Temporarily clear env var to isolate test
+    old_env = os.environ.pop(USER_SKILLS_DIRS_ENV, None)
+    try:
+        dirs = get_user_skills_dirs()
+        assert dirs == skill.USER_SKILLS_DIRS
+    finally:
+        if old_env is not None:
+            os.environ[USER_SKILLS_DIRS_ENV] = old_env
+
+
+def test_get_user_skills_dirs_with_extra_dirs(tmp_path):
+    """Test that extra_dirs are prepended (highest priority)."""
+    old_env = os.environ.pop(USER_SKILLS_DIRS_ENV, None)
+    try:
+        extra = tmp_path / "custom_skills"
+        dirs = get_user_skills_dirs(extra_dirs=[str(extra)])
+        assert dirs[0] == extra
+    finally:
+        if old_env is not None:
+            os.environ[USER_SKILLS_DIRS_ENV] = old_env
+
+
+def test_get_user_skills_dirs_with_env_var(tmp_path, monkeypatch):
+    """Test that OPENHANDS_USER_SKILLS_DIRS env var paths are included."""
+    env_dir = tmp_path / "env_skills"
+    monkeypatch.setenv(USER_SKILLS_DIRS_ENV, str(env_dir))
+
+    dirs = get_user_skills_dirs()
+    # env var dirs come after extra_dirs (if any) but before defaults
+    assert env_dir in dirs
+    from openhands.sdk.context.skills import skill
+
+    # env var dirs should appear before the defaults
+    env_idx = dirs.index(env_dir)
+    default_idx = dirs.index(skill.USER_SKILLS_DIRS[0])
+    assert env_idx < default_idx
+
+
+def test_get_user_skills_dirs_priority(tmp_path, monkeypatch):
+    """Test priority: extra_dirs > env var > defaults."""
+    extra_dir = tmp_path / "extra"
+    env_dir = tmp_path / "env"
+    monkeypatch.setenv(USER_SKILLS_DIRS_ENV, str(env_dir))
+
+    dirs = get_user_skills_dirs(extra_dirs=[str(extra_dir)])
+    assert dirs[0] == extra_dir
+    assert dirs[1] == env_dir
+
+
+def test_load_user_skills_with_extra_dirs(tmp_path):
+    """Test load_user_skills loads from extra_dirs."""
+    from openhands.sdk.context.skills import skill
+
+    extra_dir = tmp_path / "extra_skills"
+    extra_dir.mkdir()
+    (extra_dir / "extra_skill.md").write_text(
+        "---\nname: extra_skill\n---\nExtra skill content."
+    )
+
+    original_dirs = skill.USER_SKILLS_DIRS
+    try:
+        # Point defaults to nonexistent dirs so only extra_dirs matters
+        skill.USER_SKILLS_DIRS = [tmp_path / "nonexistent"]
+        skills = load_user_skills(extra_dirs=[str(extra_dir)])
+        assert len(skills) == 1
+        assert skills[0].name == "extra_skill"
+        assert skills[0].content == "Extra skill content."
+    finally:
+        skill.USER_SKILLS_DIRS = original_dirs
+
+
+def test_load_user_skills_with_env_var(tmp_path, monkeypatch):
+    """Test load_user_skills loads from OPENHANDS_USER_SKILLS_DIRS env var."""
+    from openhands.sdk.context.skills import skill
+
+    env_dir = tmp_path / "env_skills"
+    env_dir.mkdir()
+    (env_dir / "env_skill.md").write_text(
+        "---\nname: env_skill\n---\nEnv skill content."
+    )
+
+    monkeypatch.setenv(USER_SKILLS_DIRS_ENV, str(env_dir))
+
+    original_dirs = skill.USER_SKILLS_DIRS
+    try:
+        # Point defaults to nonexistent dirs so only env var matters
+        skill.USER_SKILLS_DIRS = [tmp_path / "nonexistent"]
+        skills = load_user_skills()
+        assert len(skills) == 1
+        assert skills[0].name == "env_skill"
+        assert skills[0].content == "Env skill content."
+    finally:
+        skill.USER_SKILLS_DIRS = original_dirs
+
+
+def test_load_user_skills_extra_dirs_take_precedence(tmp_path):
+    """Test that extra_dirs skills override default dir skills."""
+    from openhands.sdk.context.skills import skill
+
+    default_dir = tmp_path / "default"
+    default_dir.mkdir()
+    (default_dir / "shared.md").write_text("---\nname: shared\n---\nDefault version.")
+
+    extra_dir = tmp_path / "extra"
+    extra_dir.mkdir()
+    (extra_dir / "shared.md").write_text("---\nname: shared\n---\nExtra version.")
+
+    original_dirs = skill.USER_SKILLS_DIRS
+    try:
+        skill.USER_SKILLS_DIRS = [default_dir]
+        skills = load_user_skills(extra_dirs=[str(extra_dir)])
+        assert len(skills) == 1
+        assert skills[0].name == "shared"
+        assert skills[0].content == "Extra version."
     finally:
         skill.USER_SKILLS_DIRS = original_dirs


### PR DESCRIPTION
## Summary

Fixes #2417

When the agent-server runs inside a container, the host's `~/.openhands/skills/` directory is not visible, making user skills inaccessible. This PR adds two complementary mechanisms for specifying additional user skill directories:

### 1. `OPENHANDS_USER_SKILLS_DIRS` environment variable

A path-separated list of additional directories to search for user skills. The container can be started with this env var pointing to mounted paths:

```bash
# Mount user skills and set the env var
docker run -v ~/.openhands/skills:/mounted/skills \
  -e OPENHANDS_USER_SKILLS_DIRS=/mounted/skills \
  agent-server
```

### 2. `user_skills_dirs` API parameter

The `/skills` endpoint now accepts an optional `user_skills_dirs` list, allowing the app-server to tell the agent-server where user skills have been mounted:

```json
{
  "load_user": true,
  "user_skills_dirs": ["/mounted/user-skills"]
}
```

### Priority order

Both mechanisms are additive — they prepend to the default search paths with proper precedence:

1. **`extra_dirs` (API parameter)** — highest priority
2. **`OPENHANDS_USER_SKILLS_DIRS` env var**
3. **Default paths** (`~/.agents/skills/`, `~/.openhands/skills/`, `~/.openhands/microagents/`) — lowest priority

### Changes

- **`openhands-sdk/openhands/sdk/context/skills/skill.py`**: Added `get_user_skills_dirs()`, `USER_SKILLS_DIRS_ENV` constant, and `extra_dirs` parameter to `load_user_skills()` and `user_skills_dirs` to `load_available_skills()`
- **`openhands-agent-server/openhands/agent_server/skills_service.py`**: Thread `user_skills_dirs` through `load_all_skills()`
- **`openhands-agent-server/openhands/agent_server/skills_router.py`**: Added `user_skills_dirs` field to `SkillsRequest`
- **Tests**: Added 7 new tests covering env var, extra_dirs, priority, and pass-through behavior

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?


@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6c50cce8-34bd-499c-85ed-15109c1c943f)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ae301f8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ae301f8-python \
  ghcr.io/openhands/agent-server:ae301f8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ae301f8-golang-amd64
ghcr.io/openhands/agent-server:ae301f8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ae301f8-golang-arm64
ghcr.io/openhands/agent-server:ae301f8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ae301f8-java-amd64
ghcr.io/openhands/agent-server:ae301f8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ae301f8-java-arm64
ghcr.io/openhands/agent-server:ae301f8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ae301f8-python-amd64
ghcr.io/openhands/agent-server:ae301f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ae301f8-python-arm64
ghcr.io/openhands/agent-server:ae301f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ae301f8-golang
ghcr.io/openhands/agent-server:ae301f8-java
ghcr.io/openhands/agent-server:ae301f8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ae301f8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ae301f8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->