### PR TITLE
fix(hooks): inject conversation secrets into hook subprocesses

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -93,6 +93,31 @@ class SecretRegistry(OpenHandsModel):
         logger.debug(f"Prepared {len(env_vars)} secrets as environment variables")
         return env_vars
 
+    def get_all_secrets_as_env_vars(self) -> dict[str, str]:
+        """Resolve all secrets and return them as environment variables.
+
+        Unlike :meth:`get_secrets_as_env_vars`, this does not filter by
+        command text — every registered secret is resolved.  This is used
+        for hook subprocesses which need the same secrets available to
+        agent bash commands but whose *command strings* do not reference
+        them directly.
+
+        Returns:
+            Dictionary of environment variables (key → value) for all
+            successfully resolved secrets.
+        """
+        env_vars: dict[str, str] = {}
+        for key, source in self.secret_sources.items():
+            try:
+                value = source.get_value()
+                if value:
+                    env_vars[key] = value
+                    self._exported_values[key] = value
+            except Exception as e:
+                logger.error(f"Failed to retrieve secret for key '{key}': {e}")
+                continue
+        return env_vars
+
     def mask_secrets_in_output(self, text: str) -> str:
         """Mask secret values in the given text.
 

--- a/openhands-sdk/openhands/sdk/hooks/conversation_hooks.py
+++ b/openhands-sdk/openhands/sdk/hooks/conversation_hooks.py
@@ -67,6 +67,23 @@ class HookEventProcessor:
         """Set conversation state for blocking support."""
         self._conversation_state = state
 
+    def _get_secret_env(self) -> dict[str, str] | None:
+        """Resolve all conversation secrets as env vars for hook subprocesses.
+
+        The agent-server process may not have secrets (e.g. ``GITHUB_TOKEN``)
+        in its own ``os.environ``; they are injected per-command for agent
+        bash actions via :class:`SecretRegistry`.  Hook subprocesses bypass
+        that injection, so we explicitly resolve secrets here and pass them
+        through the ``env`` parameter of the executor.
+        """
+        if self._conversation_state is None:
+            return None
+        registry = self._conversation_state.secret_registry
+        if not registry.secret_sources:
+            return None
+        env = registry.get_all_secrets_as_env_vars()
+        return env or None
+
     def _emit_hook_execution_event(
         self,
         hook_event_type: HookEventType,
@@ -143,6 +160,7 @@ class HookEventProcessor:
         should_continue, results = self.hook_manager.run_pre_tool_use(
             tool_name=tool_name,
             tool_input=tool_input,
+            env=self._get_secret_env(),
         )
 
         # Emit HookExecutionEvents for each hook
@@ -218,6 +236,7 @@ class HookEventProcessor:
             tool_name=tool_name,
             tool_input=tool_input,
             tool_response=tool_response,
+            env=self._get_secret_env(),
         )
 
         # Emit HookExecutionEvents for each hook and log errors
@@ -259,7 +278,9 @@ class HookEventProcessor:
         )
 
         should_continue, additional_context, results = (
-            self.hook_manager.run_user_prompt_submit(message=message)
+            self.hook_manager.run_user_prompt_submit(
+                message=message, env=self._get_secret_env()
+            )
         )
 
         # Emit HookExecutionEvents for each hook
@@ -323,7 +344,7 @@ class HookEventProcessor:
         hooks = self.hook_manager.config.get_hooks_for_event(
             HookEventType.SESSION_START
         )
-        results = self.hook_manager.run_session_start()
+        results = self.hook_manager.run_session_start(env=self._get_secret_env())
 
         for hook, result in zip(hooks, results, strict=False):
             self._emit_hook_execution_event(
@@ -337,7 +358,7 @@ class HookEventProcessor:
     def run_session_end(self) -> None:
         """Run SessionEnd hooks. Call before conversation is closed."""
         hooks = self.hook_manager.config.get_hooks_for_event(HookEventType.SESSION_END)
-        results = self.hook_manager.run_session_end()
+        results = self.hook_manager.run_session_end(env=self._get_secret_env())
 
         for hook, result in zip(hooks, results, strict=False):
             self._emit_hook_execution_event(
@@ -354,7 +375,9 @@ class HookEventProcessor:
             return True, None
 
         hooks = self.hook_manager.config.get_hooks_for_event(HookEventType.STOP)
-        should_stop, results = self.hook_manager.run_stop(reason=reason)
+        should_stop, results = self.hook_manager.run_stop(
+            reason=reason, env=self._get_secret_env()
+        )
 
         # Emit events and log errors
         for hook, result in zip(hooks, results, strict=False):

--- a/openhands-sdk/openhands/sdk/hooks/manager.py
+++ b/openhands-sdk/openhands/sdk/hooks/manager.py
@@ -50,6 +50,7 @@ class HookManager:
         self,
         tool_name: str,
         tool_input: dict[str, Any],
+        env: dict[str, str] | None = None,
     ) -> tuple[bool, list[HookResult]]:
         """Run PreToolUse hooks. Returns (should_continue, results)."""
         hooks = self.config.get_hooks_for_event(HookEventType.PRE_TOOL_USE, tool_name)
@@ -70,7 +71,7 @@ class HookManager:
             tool_input=tool_input,
         )
 
-        results = self.executor.execute_all(hooks, event, stop_on_block=True)
+        results = self.executor.execute_all(hooks, event, env=env, stop_on_block=True)
 
         # Check if any hook blocked the operation
         should_continue = all(r.should_continue for r in results)
@@ -82,6 +83,7 @@ class HookManager:
         tool_name: str,
         tool_input: dict[str, Any],
         tool_response: dict[str, Any],
+        env: dict[str, str] | None = None,
     ) -> list[HookResult]:
         """Run PostToolUse hooks after a tool completes."""
         hooks = self.config.get_hooks_for_event(HookEventType.POST_TOOL_USE, tool_name)
@@ -96,11 +98,12 @@ class HookManager:
         )
 
         # PostToolUse hooks don't block - they just run
-        return self.executor.execute_all(hooks, event, stop_on_block=False)
+        return self.executor.execute_all(hooks, event, env=env, stop_on_block=False)
 
     def run_user_prompt_submit(
         self,
         message: str,
+        env: dict[str, str] | None = None,
     ) -> tuple[bool, str | None, list[HookResult]]:
         """Run UserPromptSubmit hooks."""
         hooks = self.config.get_hooks_for_event(HookEventType.USER_PROMPT_SUBMIT)
@@ -112,7 +115,7 @@ class HookManager:
             message=message,
         )
 
-        results = self.executor.execute_all(hooks, event, stop_on_block=True)
+        results = self.executor.execute_all(hooks, event, env=env, stop_on_block=True)
 
         # Check if any hook blocked
         should_continue = all(r.should_continue for r in results)
@@ -127,22 +130,30 @@ class HookManager:
 
         return should_continue, additional_context, results
 
-    def run_session_start(self) -> list[HookResult]:
+    def run_session_start(
+        self,
+        env: dict[str, str] | None = None,
+    ) -> list[HookResult]:
         """Run SessionStart hooks when a conversation begins."""
         hooks = self.config.get_hooks_for_event(HookEventType.SESSION_START)
         if not hooks:
             return []
 
         event = self._create_event(HookEventType.SESSION_START)
-        return self.executor.execute_all(hooks, event, stop_on_block=False)
+        return self.executor.execute_all(hooks, event, env=env, stop_on_block=False)
 
-    def run_session_end(self) -> list[HookResult]:
+    def run_session_end(
+        self,
+        env: dict[str, str] | None = None,
+    ) -> list[HookResult]:
         """Run SessionEnd hooks when a conversation ends."""
         hooks = self.config.get_hooks_for_event(HookEventType.SESSION_END)
         results: list[HookResult] = []
         if hooks:
             event = self._create_event(HookEventType.SESSION_END)
-            results = self.executor.execute_all(hooks, event, stop_on_block=False)
+            results = self.executor.execute_all(
+                hooks, event, env=env, stop_on_block=False
+            )
 
         # Cleanup any background async processes
         self.cleanup_async_processes()
@@ -156,6 +167,7 @@ class HookManager:
     def run_stop(
         self,
         reason: str | None = None,
+        env: dict[str, str] | None = None,
     ) -> tuple[bool, list[HookResult]]:
         """Run Stop hooks. Returns (should_stop, results)."""
         hooks = self.config.get_hooks_for_event(HookEventType.STOP)
@@ -167,7 +179,7 @@ class HookManager:
             metadata={"reason": reason} if reason else {},
         )
 
-        results = self.executor.execute_all(hooks, event, stop_on_block=True)
+        results = self.executor.execute_all(hooks, event, env=env, stop_on_block=True)
 
         # If a hook blocks, the agent should NOT stop (continue running)
         should_stop = all(r.should_continue for r in results)

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -152,3 +152,47 @@ def test_get_secrets_as_env_vars_handles_callable_exceptions():
 
     # Only working secret should be returned
     assert env_vars == {"WORKING_SECRET": "working-value"}
+
+
+def test_get_all_secrets_as_env_vars():
+    """Test that get_all_secrets_as_env_vars resolves all secrets."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets(
+        {
+            "API_KEY": "test-api-key",
+            "DATABASE_URL": "postgresql://localhost/test",
+            "GITHUB_TOKEN": "ghp_abc123",
+        }
+    )
+
+    env_vars = secret_registry.get_all_secrets_as_env_vars()
+    assert env_vars == {
+        "API_KEY": "test-api-key",
+        "DATABASE_URL": "postgresql://localhost/test",
+        "GITHUB_TOKEN": "ghp_abc123",
+    }
+
+
+def test_get_all_secrets_as_env_vars_empty_registry():
+    """get_all_secrets_as_env_vars returns empty dict when no secrets."""
+    secret_registry = SecretRegistry()
+    assert secret_registry.get_all_secrets_as_env_vars() == {}
+
+
+def test_get_all_secrets_as_env_vars_skips_failures():
+    """get_all_secrets_as_env_vars skips secrets that fail to resolve."""
+    secret_registry = SecretRegistry()
+
+    class FailingSource(SecretSource):
+        def get_value(self):
+            raise ValueError("boom")
+
+    secret_registry.update_secrets(
+        {
+            "GOOD": "good-value",
+            "BAD": FailingSource(),
+        }
+    )
+
+    env_vars = secret_registry.get_all_secrets_as_env_vars()
+    assert env_vars == {"GOOD": "good-value"}

--- a/tests/sdk/hooks/test_integration.py
+++ b/tests/sdk/hooks/test_integration.py
@@ -1199,3 +1199,106 @@ class TestHookExecutionEventEmission:
         assert hook_event.hook_event_type == "Stop"
         assert hook_event.success is True
         assert hook_event.hook_input == {"reason": "finish"}
+
+
+class TestHookSecretInjection:
+    """Tests that conversation secrets are injected into hook subprocesses."""
+
+    @pytest.fixture
+    def conversation_state(self, tmp_path):
+        import uuid
+
+        from pydantic import SecretStr
+
+        from openhands.sdk.agent import Agent
+        from openhands.sdk.llm import LLM
+        from openhands.sdk.workspace import LocalWorkspace
+
+        llm = LLM(model="test-model", api_key=SecretStr("k"))
+        agent = Agent(llm=llm, tools=[])
+        workspace = LocalWorkspace(working_dir=str(tmp_path))
+        return ConversationState(
+            id=uuid.uuid4(),
+            agent=agent,
+            workspace=workspace,
+            persistence_dir=None,
+        )
+
+    def test_stop_hook_subprocess_sees_secret_env_var(
+        self, tmp_path, conversation_state
+    ):
+        """End-to-end: hook subprocess can read a secret env var.
+
+        Regression test: the agent-server process may not have secrets
+        like GITHUB_TOKEN in os.environ — they live only in the
+        conversation's SecretRegistry. Without explicit injection, hook
+        subprocesses would not see them.
+        """  # noqa: E501
+        script = tmp_path / "echo_secret.sh"
+        script.write_text(
+            "#!/bin/bash\n"
+            'if [ "$MY_TOKEN" = "token-123" ]; then\n'
+            '  echo \'{"decision":"allow"}\'\n'
+            "else\n"
+            '  echo \'{"decision":"deny","reason":"token missing"}\'\n'
+            "  exit 2\n"
+            "fi\n"
+        )
+        script.chmod(0o755)
+
+        config = HookConfig.model_validate({"stop": [{"command": f"bash {script}"}]})
+        conversation_state.secret_registry.update_secrets({"MY_TOKEN": "token-123"})
+
+        manager = HookManager(config=config, working_dir=str(tmp_path))
+        processor = HookEventProcessor(hook_manager=manager)
+        processor.set_conversation_state(conversation_state)
+
+        should_stop, feedback = processor.run_stop()
+
+        # Hook should succeed because it received the secret
+        assert should_stop is True
+        assert feedback is None
+
+    def test_stop_hook_without_secrets_does_not_crash(
+        self, tmp_path, conversation_state
+    ):
+        """Hooks still work when no secrets are registered."""
+        config = HookConfig.model_validate({"stop": [{"command": "echo '{}'"}]})
+
+        manager = HookManager(config=config, working_dir=str(tmp_path))
+        processor = HookEventProcessor(hook_manager=manager)
+        processor.set_conversation_state(conversation_state)
+
+        should_stop, _ = processor.run_stop()
+        assert should_stop is True
+
+    def test_get_secret_env_returns_none_without_state(self, tmp_path):
+        """_get_secret_env returns None when no state is set."""
+        manager = HookManager(config=HookConfig(), working_dir=str(tmp_path))
+        processor = HookEventProcessor(hook_manager=manager)
+
+        assert processor._get_secret_env() is None
+
+    def test_session_start_hook_receives_secrets(self, tmp_path, conversation_state):
+        """SessionStart hooks also receive secrets."""
+        script = tmp_path / "start_check.sh"
+        script.write_text(
+            '#!/bin/bash\nif [ -n "$GH_TOKEN" ]; then exit 0; else exit 1; fi\n'
+        )
+        script.chmod(0o755)
+
+        config = HookConfig.model_validate(
+            {"session_start": [{"command": f"bash {script}"}]}
+        )
+        conversation_state.secret_registry.update_secrets({"GH_TOKEN": "ghp_abc123"})
+
+        manager = HookManager(config=config, working_dir=str(tmp_path))
+        processor = HookEventProcessor(hook_manager=manager)
+        processor.set_conversation_state(conversation_state)
+
+        processor.run_session_start()
+
+        # Verify the _get_secret_env includes the token
+        env = processor._get_secret_env()
+        assert env is not None
+        assert "GH_TOKEN" in env


### PR DESCRIPTION
## Problem

Closes #2417 (partial — hook secret injection aspect)

Hook subprocesses (e.g., `on_stop.sh` that needs `GITHUB_TOKEN`) cannot access conversation secrets. The agent-server process does not have secrets like `GITHUB_TOKEN` in `os.environ` — they are stored in the conversation's `SecretRegistry` and injected per-command for agent bash actions. Hook subprocesses were bypassing this injection entirely.

## Root Cause

`HookExecutor.execute()` builds its subprocess environment from `sanitized_env()` which copies `os.environ`. The agent-server process (PID 1/37 in containers) does NOT have secrets in its environment — confirmed via `/proc/37/environ`. Secrets are injected per-command by the `SecretRegistry` for agent bash actions, but hooks call `subprocess.run()` directly without this injection.

## Changes

- **`SecretRegistry.get_all_secrets_as_env_vars()`** — new method that resolves ALL registered secrets without command-text filtering (unlike `get_secrets_as_env_vars(command)` which scans command text for references)
- **`HookEventProcessor._get_secret_env()`** — resolves conversation secrets from `ConversationState.secret_registry` for hook subprocess injection
- **Thread `env` parameter** through `HookManager.run_*()` → `HookExecutor.execute_all()` → `subprocess.run()` for all 6 hook types (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, SessionEnd, Stop)

## Testing

- 3 unit tests for `get_all_secrets_as_env_vars()` in `test_secrets_manager.py`
- 4 integration tests in `test_integration.py::TestHookSecretInjection`:
  - End-to-end: hook subprocess reads secret env var successfully
  - Hooks work without secrets (no crash)
  - `_get_secret_env()` returns None without state
  - SessionStart hooks also receive secrets
- All 84 existing hook tests still pass

---
_This PR was created by an AI assistant (OpenHands) on behalf of @xingyaoww._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6c50cce8-34bd-499c-85ed-15109c1c943f)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7ccb2c7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7ccb2c7-python \
  ghcr.io/openhands/agent-server:7ccb2c7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7ccb2c7-golang-amd64
ghcr.io/openhands/agent-server:7ccb2c7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7ccb2c7-golang-arm64
ghcr.io/openhands/agent-server:7ccb2c7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7ccb2c7-java-amd64
ghcr.io/openhands/agent-server:7ccb2c7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7ccb2c7-java-arm64
ghcr.io/openhands/agent-server:7ccb2c7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7ccb2c7-python-amd64
ghcr.io/openhands/agent-server:7ccb2c7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7ccb2c7-python-arm64
ghcr.io/openhands/agent-server:7ccb2c7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7ccb2c7-golang
ghcr.io/openhands/agent-server:7ccb2c7-java
ghcr.io/openhands/agent-server:7ccb2c7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7ccb2c7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7ccb2c7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->