### PR TITLE
Fix NoCondensationAvailableException causing 100% failure rate

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/base.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/base.py
@@ -171,10 +171,23 @@ class RollingCondenser(PipelinableCondenserBase, ABC):
                         if hard_reset_condensation is not None:
                             return hard_reset_condensation
 
-                    # And if something goes wrong with the hard reset make sure we keep
-                    # both errors in the stack
                     except Exception as hard_reset_exception:
-                        raise hard_reset_exception from e
+                        # Log the hard reset failure but don't crash - fall through
+                        # to return the uncondensed view below
+                        logger.warning(
+                            f"Hard context reset also failed: {hard_reset_exception}. "
+                            f"Falling back to uncondensed view."
+                        )
+
+                    # If we reach here, both condensation and hard reset failed.
+                    # Return the uncondensed view instead of crashing the conversation.
+                    # The condensation request will remain unhandled and may be
+                    # retried on the next agent step.
+                    logger.warning(
+                        f"Condensation unavailable for HARD requirement: {e}. "
+                        "Returning uncondensed view."
+                    )
+                    return view
 
                 # In all other situations re-raise the exception.
                 raise e

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -662,19 +662,19 @@ def test_condensation_requirement_returns_hard(
 def test_condense_with_hard_requirement_and_no_condensation_available(
     mock_llm: LLM,
 ) -> None:
-    """Test that condense raises error with hard requirement but no condensation.
+    """Test that condense falls back to view with hard requirement but no condensation.
 
-    When there's a hard requirement but no valid condensation range available
-    (e.g., entire view is a single atomic unit), should raise an exception.
+    When there's a hard requirement but no valid condensation range available,
+    and hard_context_reset also fails, should fall back to returning the
+    uncondensed view instead of raising an exception. This prevents conversations
+    from crashing when condensation cannot be performed.
     """
-    from openhands.sdk.context.condenser.base import NoCondensationAvailableException
-
     condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=100, keep_first=2)
     events: list[Event] = [message_event(f"Event {i}") for i in range(10)]
     view = View.from_events(events)
 
     # Mock to return HARD requirement but no events to condense
-    # Also mock hard_context_reset to return None so the exception gets re-raised
+    # Also mock hard_context_reset to return None so it falls back to view
     with (
         patch.object(
             LLMSummarizingCondenser,
@@ -684,8 +684,10 @@ def test_condense_with_hard_requirement_and_no_condensation_available(
         patch.object(condenser, "_get_forgotten_events", return_value=([], 0)),
         patch.object(LLMSummarizingCondenser, "hard_context_reset", return_value=None),
     ):
-        with pytest.raises(NoCondensationAvailableException):
-            condenser.condense(view)
+        result = condenser.condense(view)
+        # Should return the view instead of raising an exception
+        assert isinstance(result, View)
+        assert result == view
 
 
 def test_condense_with_soft_requirement_and_no_condensation_available(

--- a/tests/sdk/context/condenser/test_rolling_condenser.py
+++ b/tests/sdk/context/condenser/test_rolling_condenser.py
@@ -157,12 +157,13 @@ def test_no_condensation_available_exception_message() -> None:
         raise NoCondensationAvailableException(exception_message)
 
 
-def test_default_hard_context_reset_raises_error() -> None:
-    """Test that default hard_context_reset raises NoCondensationAvailableException.
+def test_default_hard_context_reset_falls_back_to_view() -> None:
+    """Test that default hard_context_reset falls back to returning uncondensed view.
 
     When there's a hard requirement but no condensation available, and the default
-    hard_context_reset implementation is used (returns None), the
-    NoCondensationAvailableException should be raised.
+    hard_context_reset implementation is used (returns None), the condenser should
+    fall back to returning the uncondensed view instead of raising an exception.
+    This prevents conversations from crashing when condensation cannot be performed.
     """
     condenser = MockRollingCondenser(
         condensation_requirement_value=CondensationRequirement.HARD,
@@ -176,9 +177,11 @@ def test_default_hard_context_reset_raises_error() -> None:
     ]
     view = View.from_events(events)
 
-    # The default hard_context_reset returns None, so the exception should be raised
-    with pytest.raises(NoCondensationAvailableException):
-        condenser.condense(view)
+    # The default hard_context_reset returns None, so the view should be returned
+    # instead of raising an exception (prevents conversation crashes)
+    result = condenser.condense(view)
+    assert isinstance(result, View)
+    assert result == view
 
 
 class MockRollingCondenserWithHardReset(RollingCondenser):


### PR DESCRIPTION
## Summary

Fix issue #2703 where the Converse Nemotron model was experiencing 100% failure rate with `NoCondensationAvailableException: Unable to compute forgotten events` during SWE-bench evaluations.

### Problem
When condensation was triggered (even prematurely with only 7 events), the condenser would fail to produce a valid condensation. This resulted in a `NoCondensationAvailableException` being raised and propagated up, crashing the entire conversation.

### Solution
Modified `RollingCondenser.condense()` in `openhands-sdk/openhands/sdk/context/condenser/base.py` to gracefully handle condensation failures for HARD requirements:

1. When condensation fails for a HARD requirement, the exception is now caught and logged as a warning
2. The uncondensed view is returned instead of re-raising the exception
3. This allows the conversation to continue instead of crashing

This is the same fallback behavior that was already in place for SOFT requirements. The key insight is that when condensation cannot be performed, it's better to let the conversation continue (and potentially retry condensation later) than to crash entirely.

### Changes
- `openhands-sdk/openhands/sdk/context/condenser/base.py`: Modified `condense()` to fall back to returning the uncondensed view when condensation fails for HARD requirements
- `tests/sdk/context/condenser/test_rolling_condenser.py`: Updated test to reflect new fallback behavior
- `tests/sdk/context/condenser/test_llm_summarizing_condenser.py`: Updated test to reflect new fallback behavior

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works?
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

## Related Issue
Fixes #2703

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/261ff788-cb54-405b-a135-20e20fcceb88)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e7a919b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e7a919b-python \
  ghcr.io/openhands/agent-server:e7a919b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e7a919b-golang-amd64
ghcr.io/openhands/agent-server:e7a919b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e7a919b-golang-arm64
ghcr.io/openhands/agent-server:e7a919b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e7a919b-java-amd64
ghcr.io/openhands/agent-server:e7a919b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e7a919b-java-arm64
ghcr.io/openhands/agent-server:e7a919b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e7a919b-python-amd64
ghcr.io/openhands/agent-server:e7a919b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e7a919b-python-arm64
ghcr.io/openhands/agent-server:e7a919b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e7a919b-golang
ghcr.io/openhands/agent-server:e7a919b-java
ghcr.io/openhands/agent-server:e7a919b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e7a919b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e7a919b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->