### PR TITLE
Rename levelname so data dog can correctly categorize errors

### DIFF
--- a/openhands-agent-server/openhands/agent_server/logging_config.py
+++ b/openhands-agent-server/openhands/agent_server/logging_config.py
@@ -5,7 +5,7 @@ from typing import Any
 
 from pythonjsonlogger.json import JsonFormatter
 
-from openhands.sdk.logger import ENV_JSON, ENV_LOG_LEVEL, IN_CI
+from openhands.sdk.logger import ENV_JSON, ENV_JSON_LEVEL_KEY, ENV_LOG_LEVEL, IN_CI
 
 
 class UvicornAccessJsonFormatter(JsonFormatter):
@@ -85,6 +85,7 @@ def get_uvicorn_logging_config() -> dict[str, Any]:
         config["formatters"]["access_json"] = {
             "()": UvicornAccessJsonFormatter,
             "fmt": "%(asctime)s %(levelname)s %(name)s %(message)s",
+            "rename_fields": {"levelname": ENV_JSON_LEVEL_KEY},
         }
 
         # Define handler for access logs

--- a/openhands-sdk/openhands/sdk/logger/__init__.py
+++ b/openhands-sdk/openhands/sdk/logger/__init__.py
@@ -1,6 +1,7 @@
 from .logger import (
     DEBUG,
     ENV_JSON,
+    ENV_JSON_LEVEL_KEY,
     ENV_LOG_DIR,
     ENV_LOG_LEVEL,
     IN_CI,
@@ -15,6 +16,7 @@ __all__ = [
     "setup_logging",
     "DEBUG",
     "ENV_JSON",
+    "ENV_JSON_LEVEL_KEY",
     "ENV_LOG_LEVEL",
     "ENV_LOG_DIR",
     "IN_CI",

--- a/openhands-sdk/openhands/sdk/logger/logger.py
+++ b/openhands-sdk/openhands/sdk/logger/logger.py
@@ -39,6 +39,8 @@ ENV_BACKUP_COUNT = int(os.getenv("LOG_BACKUP_COUNT", "7"))
 
 # Rich vs JSON
 ENV_JSON = os.getenv("LOG_JSON", "false").lower() in {"1", "true", "yes"}
+# JSON log level field name (defaults to 'status' for Datadog compatibility)
+ENV_JSON_LEVEL_KEY = os.getenv("LOG_JSON_LEVEL_KEY", "status")
 IN_CI = os.getenv("CI", "false").lower() in {"1", "true", "yes"} or bool(
     os.environ.get("GITHUB_ACTIONS")
 )
@@ -125,7 +127,8 @@ def setup_logging(
             ch.setFormatter(
                 JsonFormatter(
                     fmt="%(asctime)s %(levelname)s %(name)s "
-                    "%(filename)s %(lineno)d %(message)s"
+                    "%(filename)s %(lineno)d %(message)s",
+                    rename_fields={"levelname": ENV_JSON_LEVEL_KEY},
                 )
             )
             root.addHandler(ch)
@@ -153,7 +156,8 @@ def setup_logging(
             fh.setFormatter(
                 JsonFormatter(
                     fmt="%(asctime)s %(levelname)s %(name)s "
-                    "%(filename)s %(lineno)d %(message)s"
+                    "%(filename)s %(lineno)d %(message)s",
+                    rename_fields={"levelname": ENV_JSON_LEVEL_KEY},
                 )
             )
         else:


### PR DESCRIPTION
## Summary

- Added rename_fields={"levelname": ENV_JSON_LEVEL_KEY} to both JsonFormatters. 
- Added "rename_fields": {"levelname": ENV_JSON_LEVEL_KEY} to uvicorn access formatter 
- Defaults to `status` 

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?
- [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] - [ ] 
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a98331f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a98331f-python \
  ghcr.io/openhands/agent-server:a98331f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a98331f-golang-amd64
ghcr.io/openhands/agent-server:a98331f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a98331f-golang-arm64
ghcr.io/openhands/agent-server:a98331f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a98331f-java-amd64
ghcr.io/openhands/agent-server:a98331f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a98331f-java-arm64
ghcr.io/openhands/agent-server:a98331f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a98331f-python-amd64
ghcr.io/openhands/agent-server:a98331f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a98331f-python-arm64
ghcr.io/openhands/agent-server:a98331f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a98331f-golang
ghcr.io/openhands/agent-server:a98331f-java
ghcr.io/openhands/agent-server:a98331f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a98331f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a98331f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->