### PR TITLE
chore(test): update docstring link to correct PR (#2264)

### DIFF
--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1081,7 +1081,7 @@ def test_max_output_tokens_capped_when_using_max_tokens_fallback(mock_get_model_
     rather than the output limit. Without capping, this could request output
     that exceeds the context window.
 
-    See: https://github.com/OpenHands/software-agent-sdk/issues/XXX
+    See: https://github.com/OpenHands/software-agent-sdk/pull/2264
     """
     from openhands.sdk.llm.llm import DEFAULT_MAX_OUTPUT_TOKENS_CAP
 


### PR DESCRIPTION
## Summary

Replaces an invalid placeholder issue link (`issues/XXX`) in the test docstring with the correct PR reference (#2264).

## Changes

- Updated docstring link in `test_max_output_tokens_capped_when_using_max_tokens_fallback`
- No functional changes; test-only cleanup

## Notes

- Improves traceability by linking to the actual implementation PR
- No impact on runtime behavior

## Checklist

- [x] No functional changes
- [x] Verified locally
- [x] CI passing (pending)