### PR TITLE
fix(agent-server): await conversation teardown in EventService.close()    

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -655,7 +655,8 @@ class EventService:
         await self._pub_sub.close()
         if self._conversation:
             loop = asyncio.get_running_loop()
-            loop.run_in_executor(None, self._conversation.close)
+            await loop.run_in_executor(None, self._conversation.close)
+            self._conversation = None
 
     async def generate_title(
         self, llm: "LLM | None" = None, max_length: int = 50

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1725,3 +1725,49 @@ class TestSearchEventsBlockedByRunLoop:
             f"for {hold_seconds}s.  The read path is blocked by the write lock "
             f"(see HANG_REPRO.md)."
         )
+
+
+class TestEventServiceClose:
+    """Tests for EventService.close() awaiting conversation teardown."""
+
+    @pytest.mark.asyncio
+    async def test_close_awaits_conversation_close(self, event_service):
+        """close() must await conversation.close(), not fire-and-forget."""
+        conversation = MagicMock(spec=Conversation)
+        event_service._conversation = conversation
+
+        closed = asyncio.Event()
+
+        def slow_close():
+            # Simulate non-trivial teardown work
+            time.sleep(0.05)
+            closed.set()
+
+        conversation.close = slow_close
+
+        await event_service.close()
+
+        assert closed.is_set(), (
+            "EventService.close() returned before conversation.close() finished"
+        )
+
+    @pytest.mark.asyncio
+    async def test_close_clears_conversation_reference(self, event_service):
+        """close() must set _conversation to None after closing."""
+        conversation = MagicMock()
+        event_service._conversation = conversation
+
+        await event_service.close()
+
+        assert event_service._conversation is None
+
+    @pytest.mark.asyncio
+    async def test_close_is_idempotent(self, event_service):
+        """Calling close() twice must not raise."""
+        conversation = MagicMock()
+        event_service._conversation = conversation
+
+        await event_service.close()
+        await event_service.close()  # second call — _conversation is already None
+
+        conversation.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Await run_in_executor in EventService.close(): the conversation close was fire-and-forget, meaning callers (conversation deletion, server shutdown) could proceed before MCP clients and other resources were actually torn down. Now close() properly waits for conversation.close() to finish.                                                                
- Clear self._conversation after close — prevents double-close and makes is_open() return False after teardown.                                                                    
- Add tests for close lifecycle — verify that close awaits teardown, clears the reference, and is idempotent.                                                                      
                                                                                                                                                                                     
Partial fix for #2603 (point 1 of the short-term fixes).                                                                                                                           
                                                                                                                                                                                     
## Test plan                                                                                                                                                                          
 - TestEventServiceClose::test_close_awaits_conversation_close — proves close blocks until conversation teardown finishes                                                           
  - TestEventServiceClose::test_close_clears_conversation_reference — verifies _conversation is None after close                                                                     
  - TestEventServiceClose::test_close_is_idempotent — calling close twice doesn't raise or double-close      

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f36e022-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f36e022-python \
  ghcr.io/openhands/agent-server:f36e022-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f36e022-golang-amd64
ghcr.io/openhands/agent-server:f36e022-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f36e022-golang-arm64
ghcr.io/openhands/agent-server:f36e022-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f36e022-java-amd64
ghcr.io/openhands/agent-server:f36e022-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f36e022-java-arm64
ghcr.io/openhands/agent-server:f36e022-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f36e022-python-amd64
ghcr.io/openhands/agent-server:f36e022-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f36e022-python-arm64
ghcr.io/openhands/agent-server:f36e022-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f36e022-golang
ghcr.io/openhands/agent-server:f36e022-java
ghcr.io/openhands/agent-server:f36e022-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f36e022-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f36e022-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->