### PR TITLE
fix(sdk): metrics desync between LLM and Telemetry after restore

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -657,6 +657,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def restore_metrics(self, metrics: Metrics) -> None:
         # Only used by ConversationStats to seed metrics
         self._metrics = metrics
+        # Keep telemetry in sync so post-resume LLM calls record into
+        # the restored metrics object, not the stale one from __init__.
+        if self._telemetry is not None:
+            self._telemetry.metrics = metrics
 
     def reset_metrics(self) -> None:
         """Reset metrics and telemetry to fresh instances.

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1070,6 +1070,31 @@ def test_llm_reset_metrics():
     assert llm.metrics.accumulated_cost == 0.0
 
 
+def test_issue_2459_restore_metrics_syncs_telemetry():
+    """Restore metrics must update telemetry's reference to avoid desync.
+
+    After restore_metrics(), llm.telemetry.metrics must point to the same
+    object as llm.metrics. Otherwise post-resume LLM calls record
+    tokens/cost into a stale metrics object and accounting data is lost.
+
+    See: https://github.com/OpenHands/software-agent-sdk/issues/2459
+    """
+    llm = LLM(
+        model="gpt-4o-mini",
+        api_key=SecretStr("test-key"),
+    )
+
+    # Force telemetry creation (simulates normal init before resume)
+    _ = llm.telemetry
+
+    restored = Metrics(model_name=llm.model)
+    llm.restore_metrics(restored)
+
+    assert llm.metrics is restored
+    assert llm.telemetry.metrics is restored
+    assert llm.telemetry.metrics is llm.metrics
+
+
 # max_output_tokens Capping Tests
 
 


### PR DESCRIPTION
## Summary

- Fixes `restore_metrics()` to also update `self._telemetry.metrics`, preventing `llm.metrics` and `llm.telemetry.metrics` from diverging after a conversation resume
- Without this fix, post-resume LLM calls record tokens/cost into a stale metrics object, silently losing accounting data

Fixes #2459

## Test plan

- [x] Reproduced with the issue's code sample — all three identity checks now pass
- [x] All 637 existing LLM tests pass (`pytest tests/sdk/llm/`)
- [ ] Verify with a real conversation pause/resume cycle

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ca8e1a9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ca8e1a9-python \
  ghcr.io/openhands/agent-server:ca8e1a9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ca8e1a9-golang-amd64
ghcr.io/openhands/agent-server:ca8e1a9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ca8e1a9-golang-arm64
ghcr.io/openhands/agent-server:ca8e1a9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ca8e1a9-java-amd64
ghcr.io/openhands/agent-server:ca8e1a9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ca8e1a9-java-arm64
ghcr.io/openhands/agent-server:ca8e1a9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ca8e1a9-python-amd64
ghcr.io/openhands/agent-server:ca8e1a9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ca8e1a9-python-arm64
ghcr.io/openhands/agent-server:ca8e1a9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ca8e1a9-golang
ghcr.io/openhands/agent-server:ca8e1a9-java
ghcr.io/openhands/agent-server:ca8e1a9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ca8e1a9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ca8e1a9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->