### PR TITLE
fix(sdk): surface iteration budgets gracefully

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -111,6 +111,8 @@ When reviewing code, provide constructive feedback:
 - Workspace-wide uv resolver guardrails belong in the repository root `[tool.uv]` table. When `exclude-newer` is configured there, `uv lock` persists it into the root `uv.lock` `[options]` section as both an absolute cutoff and `exclude-newer-span`, and `uv sync --frozen` continues to use that locked workspace state.
 - `pr-review-by-openhands` delegates to `OpenHands/extensions/plugins/pr-review@main`. Repo-specific reviewer instructions live in `.agents/skills/custom-codereview-guide.md`, and because task-trigger matching is substring-based, that `/codereview` skill is also auto-injected for the workflow's `/codereview-roasted` prompt.
 - Auto-title generation should not re-read `ConversationState.events` from a background task triggered by a freshly received `MessageEvent`; extract message text synchronously from the incoming event and then reuse shared title helpers (`extract_message_text`, `generate_title_from_message`) to avoid persistence-order races.
+- In the separate `OpenHands/benchmarks` repo, eval instance end labels like `finish_tool`, `finished_no_finish_tool`, and `status=...` are computed in `benchmarks/utils/console_logging.py` from `conversation.state.execution_status` plus whether a `FinishAction` was emitted; they are not sourced from agent-server REST/WebSocket transport metadata.
+
 
 
 ## Package-specific guidance

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -400,6 +400,18 @@ class Agent(CriticMixin, AgentBase):
         """
         # Get secret infos from conversation's secret_registry
         secret_infos = state.secret_registry.get_secret_infos()
+        context_parts: list[str] = []
+
+        iteration_budget_context = (
+            "<iteration_budget>\n"
+            f"- This run is limited to at most {state.max_iterations} agent steps.\n"
+            "- Prioritize the most important work first and avoid long detours late "
+            "in the budget.\n"
+            "- If you are warned that you are on the final step, stop exploring and "
+            "provide your best possible answer immediately.\n"
+            "</iteration_budget>"
+        )
+        context_parts.append(iteration_budget_context)
 
         if not self.agent_context:
             # No agent_context but we might have secrets from registry
@@ -408,18 +420,25 @@ class Agent(CriticMixin, AgentBase):
 
                 # Create a minimal context just for secrets
                 temp_context = AgentContext()
-                return temp_context.get_system_message_suffix(
-                    llm_model=self.llm.model,
-                    llm_model_canonical=self.llm.model_canonical_name,
-                    additional_secret_infos=secret_infos,
+                context_parts.append(
+                    temp_context.get_system_message_suffix(
+                        llm_model=self.llm.model,
+                        llm_model_canonical=self.llm.model_canonical_name,
+                        additional_secret_infos=secret_infos,
+                    )
+                    or ""
                 )
-            return None
+            return "\n\n".join(part for part in context_parts if part)
 
-        return self.agent_context.get_system_message_suffix(
-            llm_model=self.llm.model,
-            llm_model_canonical=self.llm.model_canonical_name,
-            additional_secret_infos=secret_infos,
+        context_parts.append(
+            self.agent_context.get_system_message_suffix(
+                llm_model=self.llm.model,
+                llm_model_canonical=self.llm.model_canonical_name,
+                additional_secret_infos=secret_infos,
+            )
+            or ""
         )
+        return "\n\n".join(part for part in context_parts if part)
 
     def _execute_actions(
         self,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -29,6 +29,7 @@ from openhands.sdk.conversation.visualizer import (
 from openhands.sdk.event import (
     ActionEvent,
     CondensationRequest,
+    ConversationIterationLimitEvent,
     MessageEvent,
     ObservationEvent,
     PauseEvent,
@@ -547,6 +548,7 @@ class LocalConversation(BaseConversation):
         with self._state:
             if self._state.execution_status in (
                 ConversationExecutionStatus.FINISHED,
+                ConversationExecutionStatus.ITERATION_LIMIT,
                 ConversationExecutionStatus.STUCK,
             ):
                 self._state.execution_status = (
@@ -585,6 +587,39 @@ class LocalConversation(BaseConversation):
             )
             self._on_event(user_msg_event)
 
+    def _emit_iteration_budget_warning(self, iteration: int) -> None:
+        """Warn the LLM when the current run is about to exhaust its budget."""
+        remaining = self.max_iteration_per_run - iteration
+        if remaining not in (1, 2):
+            return
+
+        used = iteration
+        if remaining == 1:
+            warning_text = (
+                "[SYSTEM] You have used "
+                f"{used}/{self.max_iteration_per_run} steps. This is your FINAL "
+                "step. Do not start new investigations or delegate more work. "
+                "Provide your best possible answer now based on everything you "
+                "have already gathered."
+            )
+        else:
+            warning_text = (
+                "[SYSTEM] You have used "
+                f"{used}/{self.max_iteration_per_run} steps. Only {remaining} "
+                "steps remain in this run, including this one. Begin wrapping up "
+                "and prioritize a best-effort answer over more exploration."
+            )
+
+        self._on_event(
+            MessageEvent(
+                source="environment",
+                llm_message=Message(
+                    role="user",
+                    content=[TextContent(text=warning_text)],
+                ),
+            )
+        )
+
     @observe(name="conversation.run")
     def run(self) -> None:
         """Runs the conversation until the agent finishes.
@@ -606,6 +641,7 @@ class LocalConversation(BaseConversation):
                 ConversationExecutionStatus.IDLE,
                 ConversationExecutionStatus.PAUSED,
                 ConversationExecutionStatus.ERROR,
+                ConversationExecutionStatus.ITERATION_LIMIT,
                 ConversationExecutionStatus.STUCK,
             ]:
                 self._state.execution_status = ConversationExecutionStatus.RUNNING
@@ -672,6 +708,7 @@ class LocalConversation(BaseConversation):
                             ConversationExecutionStatus.RUNNING
                         )
 
+                    self._emit_iteration_budget_warning(iteration)
                     self.agent.step(
                         self, on_event=self._on_event, on_token=self._on_token
                     )
@@ -704,12 +741,15 @@ class LocalConversation(BaseConversation):
                             f"Agent reached maximum iterations limit "
                             f"({self.max_iteration_per_run})."
                         )
-                        logger.error(error_msg)
-                        self._state.execution_status = ConversationExecutionStatus.ERROR
+                        logger.warning(error_msg)
+                        self._state.execution_status = (
+                            ConversationExecutionStatus.ITERATION_LIMIT
+                        )
                         self._on_event(
-                            ConversationErrorEvent(
+                            ConversationIterationLimitEvent(
                                 source="environment",
-                                code="MaxIterationsReached",
+                                iteration=iteration,
+                                max_iterations=self.max_iteration_per_run,
                                 detail=error_msg,
                             )
                         )

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -53,6 +53,9 @@ class ConversationExecutionStatus(str, Enum):
     )
     FINISHED = "finished"  # Conversation has completed the current task
     ERROR = "error"  # Conversation encountered an error (optional for future use)
+    ITERATION_LIMIT = (
+        "iteration_limit"  # Conversation stopped after exhausting its run budget
+    )
     STUCK = "stuck"  # Conversation is stuck in a loop or unable to proceed
     DELETING = "deleting"  # Conversation is in the process of being deleted
 
@@ -60,7 +63,7 @@ class ConversationExecutionStatus(str, Enum):
         """Check if this status represents a terminal state.
 
         Terminal states indicate the run has completed and the agent is no longer
-        actively processing. These are: FINISHED, ERROR, STUCK.
+        actively processing. These are: FINISHED, ERROR, ITERATION_LIMIT, STUCK.
 
         Note: IDLE is NOT a terminal state - it's the initial state of a conversation
         before any run has started. Including IDLE would cause false positives when
@@ -72,6 +75,7 @@ class ConversationExecutionStatus(str, Enum):
         return self in (
             ConversationExecutionStatus.FINISHED,
             ConversationExecutionStatus.ERROR,
+            ConversationExecutionStatus.ITERATION_LIMIT,
             ConversationExecutionStatus.STUCK,
         )
 

--- a/openhands-sdk/openhands/sdk/event/__init__.py
+++ b/openhands-sdk/openhands/sdk/event/__init__.py
@@ -5,6 +5,9 @@ from openhands.sdk.event.condenser import (
     CondensationRequest,
     CondensationSummaryEvent,
 )
+from openhands.sdk.event.conversation_iteration_limit import (
+    ConversationIterationLimitEvent,
+)
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.hook_execution import HookExecutionEvent
 from openhands.sdk.event.llm_completion_log import LLMCompletionLogEvent
@@ -40,6 +43,7 @@ __all__ = [
     "Condensation",
     "CondensationRequest",
     "CondensationSummaryEvent",
+    "ConversationIterationLimitEvent",
     "ConversationStateUpdateEvent",
     "HookExecutionEvent",
     "LLMCompletionLogEvent",

--- a/openhands-sdk/openhands/sdk/event/conversation_iteration_limit.py
+++ b/openhands-sdk/openhands/sdk/event/conversation_iteration_limit.py
@@ -1,0 +1,23 @@
+from pydantic import Field
+from rich.text import Text
+
+from openhands.sdk.event.base import Event
+
+
+class ConversationIterationLimitEvent(Event):
+    """Conversation stopped because its per-run iteration budget was exhausted."""
+
+    iteration: int = Field(description="Iterations consumed in the just-finished run")
+    max_iterations: int = Field(description="Configured maximum iterations per run")
+    detail: str = Field(description="Human-readable description of the limit event")
+
+    @property
+    def visualize(self) -> Text:
+        """Return Rich Text representation of the iteration-limit event."""
+        content = Text()
+        content.append("Iteration Limit Reached\n", style="bold")
+        content.append("Iterations: ", style="bold")
+        content.append(f"{self.iteration}/{self.max_iterations}")
+        content.append("\n\nDetail:\n", style="bold")
+        content.append(self.detail)
+        return content

--- a/tests/sdk/agent/test_agent_init_state_invariants.py
+++ b/tests/sdk/agent/test_agent_init_state_invariants.py
@@ -20,13 +20,16 @@ def _make_agent() -> Agent:
     return Agent(llm=llm)
 
 
-def _make_state(agent: Agent, tmp_path) -> ConversationState:
+def _make_state(
+    agent: Agent, tmp_path, *, max_iterations: int = 500
+) -> ConversationState:
     from openhands.sdk.workspace.local import LocalWorkspace
 
     return ConversationState.create(
         id=uuid.uuid4(),
         agent=agent,
         workspace=LocalWorkspace(working_dir=str(tmp_path)),
+        max_iterations=max_iterations,
     )
 
 
@@ -44,6 +47,26 @@ def test_agent_init_state_adds_system_prompt_via_callback(tmp_path) -> None:
 
     assert len(emitted) == 1
     assert isinstance(emitted[0], SystemPromptEvent)
+
+
+def test_agent_init_state_includes_iteration_budget_context(tmp_path) -> None:
+    agent = _make_agent()
+    state = _make_state(agent, tmp_path, max_iterations=7)
+
+    emitted: list[SystemPromptEvent] = []
+
+    def on_event(e):
+        if isinstance(e, SystemPromptEvent):
+            emitted.append(e)
+
+    agent.init_state(state, on_event=on_event)
+
+    assert len(emitted) == 1
+    assert emitted[0].dynamic_context is not None
+    dynamic_context = emitted[0].dynamic_context.text
+    assert "<iteration_budget>" in dynamic_context
+    assert "at most 7 agent steps" in dynamic_context
+    assert "final step" in dynamic_context
 
 
 def test_agent_init_state_skips_when_system_prompt_already_present(tmp_path) -> None:

--- a/tests/sdk/conversation/local/test_agent_status_transition.py
+++ b/tests/sdk/conversation/local/test_agent_status_transition.py
@@ -17,15 +17,17 @@ State transition matrix tested:
 - FINISHED -> remain unchanged (run() exits immediately without new message)
 """
 
+import copy
 import threading
 from collections.abc import Sequence
-from typing import ClassVar
+from typing import Any, ClassVar
+
+from pydantic import PrivateAttr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.event import MessageEvent
-from openhands.sdk.event.conversation_error import ConversationErrorEvent
+from openhands.sdk.event import ConversationIterationLimitEvent, MessageEvent
 from openhands.sdk.llm import ImageContent, Message, MessageToolCall, TextContent
 from openhands.sdk.testing import TestLLM
 from openhands.sdk.tool import (
@@ -92,6 +94,26 @@ class StatusTransitionTestTool(
                 executor=executor,
             )
         ]
+
+
+class CapturingTestLLM(TestLLM):
+    """TestLLM variant that records the message history sent to the LLM."""
+
+    _captured_messages: list[list[Message]] = PrivateAttr(default_factory=list)
+
+    def __init__(
+        self, *, scripted_responses: list[Message | Exception], **kwargs: Any
+    ) -> None:
+        kwargs.setdefault("model", "test-model")
+        super().__init__(scripted_responses=scripted_responses, **kwargs)
+
+    @property
+    def captured_messages(self) -> list[list[Message]]:
+        return self._captured_messages
+
+    def completion(self, messages: list[Message], *args, **kwargs):
+        self._captured_messages.append(copy.deepcopy(messages))
+        return super().completion(messages, *args, **kwargs)
 
 
 def test_execution_status_transitions_to_running_from_idle():
@@ -416,8 +438,8 @@ def test_send_message_resets_stuck_to_idle():
     assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
 
 
-def test_execution_status_error_on_max_iterations():
-    """Test that status is set to ERROR with clear message when max iterations hit."""
+def test_execution_status_iteration_limit_on_max_iterations():
+    """Test that max iterations ends with a dedicated iteration-limit status."""
 
     status_during_execution: list[ConversationExecutionStatus] = []
     events_received: list = []
@@ -429,7 +451,6 @@ def test_execution_status_error_on_max_iterations():
 
     register_tool("test_tool", _make_tool)
 
-    # Create a tool call message that will be returned repeatedly
     tool_call_message = Message(
         role="assistant",
         content=[TextContent(text="")],
@@ -443,38 +464,85 @@ def test_execution_status_error_on_max_iterations():
         ],
     )
 
-    # Use TestLLM with enough responses to hit max iterations
-    # max_iteration_per_run=2 means we need at least 2 tool call responses
     llm = TestLLM.from_messages(
         [
             tool_call_message,
             tool_call_message,
-            tool_call_message,  # Extra in case needed
+            tool_call_message,
         ]
     )
     agent = Agent(llm=llm, tools=[Tool(name="test_tool")])
-    # Set max_iteration_per_run to 2 to quickly hit the limit
     conversation = Conversation(
         agent=agent,
         max_iteration_per_run=2,
         callbacks=[lambda e: events_received.append(e)],
     )
 
-    # Send message and run
     conversation.send_message(
         Message(role="user", content=[TextContent(text="Execute command")])
     )
     conversation.run()
 
-    # Status should be ERROR
-    assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+    assert (
+        conversation.state.execution_status
+        == ConversationExecutionStatus.ITERATION_LIMIT
+    )
 
-    # Should have emitted a ConversationErrorEvent with clear message
-    error_events = [e for e in events_received if isinstance(e, ConversationErrorEvent)]
-    assert len(error_events) == 1
-    assert error_events[0].code == "MaxIterationsReached"
-    assert "maximum iterations limit" in error_events[0].detail
-    assert "(2)" in error_events[0].detail  # max_iteration_per_run value
+    limit_events = [
+        e for e in events_received if isinstance(e, ConversationIterationLimitEvent)
+    ]
+    assert len(limit_events) == 1
+    assert limit_events[0].iteration == 2
+    assert limit_events[0].max_iterations == 2
+    assert "maximum iterations limit" in limit_events[0].detail
+    assert "(2)" in limit_events[0].detail
+
+
+def test_final_step_warning_is_visible_to_llm():
+    """The LLM should receive an explicit final-step wrap-up warning."""
+
+    def _make_tool(conv_state=None, **params) -> Sequence[ToolDefinition]:
+        return StatusTransitionTestTool.create(executor=StatusCheckingExecutor([]))
+
+    register_tool("test_tool", _make_tool)
+
+    tool_call_message = Message(
+        role="assistant",
+        content=[TextContent(text="")],
+        tool_calls=[
+            MessageToolCall(
+                id="call_1",
+                name="test_tool",
+                arguments='{"command": "test_command"}',
+                origin="completion",
+            )
+        ],
+    )
+    finish_message = Message(role="assistant", content=[TextContent(text="Done")])
+
+    llm = CapturingTestLLM(
+        scripted_responses=[tool_call_message, finish_message],
+        usage_id="capturing-test-llm",
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="test_tool")])
+    conversation = Conversation(agent=agent, max_iteration_per_run=2)
+
+    conversation.send_message(
+        Message(role="user", content=[TextContent(text="Execute command")])
+    )
+    conversation.run()
+
+    assert len(llm.captured_messages) == 2
+    second_call_messages = llm.captured_messages[1]
+    final_step_messages = [
+        content.text
+        for message in second_call_messages
+        if message.role == "user"
+        for content in message.content
+        if isinstance(content, TextContent) and "FINAL step" in content.text
+    ]
+    assert len(final_step_messages) == 1
+    assert "Provide your best possible answer now" in final_step_messages[0]
 
 
 def test_execution_status_finished_on_final_iteration():
@@ -537,9 +605,10 @@ def test_execution_status_finished_on_final_iteration():
         "Agent completing on the final iteration should not be treated as an error."
     )
 
-    # No MaxIterationsReached error event should have been emitted
-    error_events = [e for e in events_received if isinstance(e, ConversationErrorEvent)]
-    max_iter_errors = [e for e in error_events if e.code == "MaxIterationsReached"]
-    assert len(max_iter_errors) == 0, (
-        "Expected no MaxIterationsReached error when agent finishes on final iteration"
+    # No iteration-limit event should have been emitted when agent finishes in time
+    limit_events = [
+        e for e in events_received if isinstance(e, ConversationIterationLimitEvent)
+    ]
+    assert len(limit_events) == 0, (
+        "Expected no iteration-limit event when agent finishes on final iteration"
     )

--- a/tests/sdk/conversation/remote/test_remote_state.py
+++ b/tests/sdk/conversation/remote/test_remote_state.py
@@ -90,6 +90,7 @@ def test_remote_state_initialization(mock_client, conversation_id):
         ("running", ConversationExecutionStatus.RUNNING),
         ("paused", ConversationExecutionStatus.PAUSED),
         ("finished", ConversationExecutionStatus.FINISHED),
+        ("iteration_limit", ConversationExecutionStatus.ITERATION_LIMIT),
     ],
 )
 def test_remote_state_execution_status(

--- a/tests/sdk/conversation/test_conversation_execution_status_enum.py
+++ b/tests/sdk/conversation/test_conversation_execution_status_enum.py
@@ -41,6 +41,13 @@ def test_agent_execution_state_enum_basic():
     conversation._state.execution_status = ConversationExecutionStatus.ERROR
     assert conversation._state.execution_status == ConversationExecutionStatus.ERROR
 
+    # Test setting to ITERATION_LIMIT
+    conversation._state.execution_status = ConversationExecutionStatus.ITERATION_LIMIT
+    assert (
+        conversation._state.execution_status
+        == ConversationExecutionStatus.ITERATION_LIMIT
+    )
+
 
 def test_enum_values():
     """Test that all enum values are correct."""
@@ -53,6 +60,7 @@ def test_enum_values():
     )
     assert ConversationExecutionStatus.FINISHED == "finished"
     assert ConversationExecutionStatus.ERROR == "error"
+    assert ConversationExecutionStatus.ITERATION_LIMIT == "iteration_limit"
 
 
 def test_enum_serialization():
@@ -79,3 +87,12 @@ def test_enum_serialization():
     conversation._state.execution_status = ConversationExecutionStatus.ERROR
     serialized = conversation._state.model_dump_json()
     assert '"execution_status":"error"' in serialized
+
+    conversation._state.execution_status = ConversationExecutionStatus.ITERATION_LIMIT
+    serialized = conversation._state.model_dump_json()
+    assert '"execution_status":"iteration_limit"' in serialized
+
+
+def test_iteration_limit_is_terminal():
+    """Iteration-limit status should be treated as terminal."""
+    assert ConversationExecutionStatus.ITERATION_LIMIT.is_terminal() is True


### PR DESCRIPTION
## Summary

Fixes #2406 by making the per-run iteration budget visible to the LLM, warning the model when it is about to run out of steps, and ending max-iteration runs with a dedicated iteration-limit status/event instead of a generic error.

This PR:
- adds an `<iteration_budget>` block to the dynamic system prompt so the LLM sees the run budget up front
- injects late-stage wrap-up warnings when only 2 steps remain and when the final step begins
- emits `ConversationExecutionStatus.ITERATION_LIMIT` plus a dedicated `ConversationIterationLimitEvent` when the budget is exhausted
- adds focused SDK tests for the new prompt context, warning injection, and status parsing/serialization
- confirms the Commit0 `End Status` discussed on the issue comes from the benchmarks repo's `benchmarks/utils/console_logging.py`, which derives it from `conversation.state.execution_status` plus `FinishAction` usage rather than agent-server REST/WebSocket metadata

## Checklist

- [x] If the PR is changing/adding functionality, are there tests to reflect this?
- [x] If there is an example, have you run the example to make sure that it works? (N/A: no example changes)
- [x] If there are instructions on how to run the code, have you followed the instructions and made sure that it works? (Validated with targeted SDK pytest coverage.)
- [x] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name? (N/A: no public API or docs changes.)
- [ ] Is the github CI passing?

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/32e30298-d715-4d9a-b731-279c6e65b459)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a3fb7ff-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a3fb7ff-python \
  ghcr.io/openhands/agent-server:a3fb7ff-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a3fb7ff-golang-amd64
ghcr.io/openhands/agent-server:a3fb7ff-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a3fb7ff-golang-arm64
ghcr.io/openhands/agent-server:a3fb7ff-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a3fb7ff-java-amd64
ghcr.io/openhands/agent-server:a3fb7ff-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a3fb7ff-java-arm64
ghcr.io/openhands/agent-server:a3fb7ff-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a3fb7ff-python-amd64
ghcr.io/openhands/agent-server:a3fb7ff-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a3fb7ff-python-arm64
ghcr.io/openhands/agent-server:a3fb7ff-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a3fb7ff-golang
ghcr.io/openhands/agent-server:a3fb7ff-java
ghcr.io/openhands/agent-server:a3fb7ff-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a3fb7ff-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a3fb7ff-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->