### PR TITLE
fix(hooks): allow prompt-based hooks in HookDefinition

### DIFF
--- a/openhands-sdk/openhands/sdk/hooks/config.py
+++ b/openhands-sdk/openhands/sdk/hooks/config.py
@@ -47,13 +47,22 @@ class HookDefinition(BaseModel):
     """A single hook definition."""
 
     type: HookType = HookType.COMMAND
-    command: str
+    command: str | None = None
+    prompt: str | None = None
     timeout: int = 60
     async_: bool = Field(default=False, alias="async")  # 'async' is a reserved keyword
 
     model_config = {
         "populate_by_name": True,  # Allow both 'async' and 'async_' in input
     }
+
+    @model_validator(mode="after")
+    def _check_required_fields(self) -> "HookDefinition":
+        if self.type == HookType.COMMAND and not self.command:
+            raise ValueError("'command' is required when type is 'command'")
+        if self.type == HookType.PROMPT and not self.prompt:
+            raise ValueError("'prompt' is required when type is 'prompt'")
+        return self
 
 
 class HookMatcher(BaseModel):

--- a/openhands-sdk/openhands/sdk/hooks/config.py
+++ b/openhands-sdk/openhands/sdk/hooks/config.py
@@ -47,7 +47,7 @@ class HookDefinition(BaseModel):
     """A single hook definition."""
 
     type: HookType = HookType.COMMAND
-    command: str | None = None
+    command: str
     prompt: str | None = None
     timeout: int = 60
     async_: bool = Field(default=False, alias="async")  # 'async' is a reserved keyword
@@ -55,6 +55,17 @@ class HookDefinition(BaseModel):
     model_config = {
         "populate_by_name": True,  # Allow both 'async' and 'async_' in input
     }
+
+    @model_validator(mode="before")
+    @classmethod
+    def _set_command_for_prompt_hooks(cls, data: Any) -> Any:
+        if (
+            isinstance(data, dict)
+            and data.get("type") == "prompt"
+            and "command" not in data
+        ):
+            data["command"] = ""
+        return data
 
     @model_validator(mode="after")
     def _check_required_fields(self) -> "HookDefinition":

--- a/tests/sdk/hooks/test_config.py
+++ b/tests/sdk/hooks/test_config.py
@@ -3,7 +3,10 @@
 import json
 import tempfile
 
-from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher
+import pytest
+from pydantic import ValidationError
+
+from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher, HookType
 from openhands.sdk.hooks.types import HookEventType
 
 
@@ -335,3 +338,21 @@ def test_issue_2749():
     hooks = config.get_hooks_for_event(HookEventType.STOP)
     assert len(hooks) == 1
     assert hooks[0].type.value == "prompt"
+    assert hooks[0].prompt == "Evaluate if we should stop."
+
+
+@pytest.mark.parametrize(
+    ("hook_type", "match"),
+    [
+        (HookType.COMMAND, "command"),
+        (HookType.PROMPT, "'prompt' is required"),
+    ],
+    ids=["command_requires_command", "prompt_requires_prompt"],
+)
+def test_issue_2749_validation(hook_type: HookType, match: str):
+    """Validator should enforce required fields based on hook type.
+
+    https://github.com/OpenHands/software-agent-sdk/issues/2749
+    """
+    with pytest.raises(ValidationError, match=match):
+        HookDefinition(type=hook_type)  # type: ignore[call-arg]

--- a/tests/sdk/hooks/test_config.py
+++ b/tests/sdk/hooks/test_config.py
@@ -309,3 +309,29 @@ class TestAsyncHooks:
         start_hooks = config.get_hooks_for_event(HookEventType.SESSION_START)
         assert len(start_hooks) == 1
         assert start_hooks[0].async_ is True
+
+
+def test_issue_2749():
+    """Prompt-based stop hooks should not cause a validation error.
+
+    https://github.com/OpenHands/software-agent-sdk/issues/2749
+    """
+    data = {
+        "hooks": {
+            "Stop": [
+                {
+                    "matcher": "*",
+                    "hooks": [
+                        {
+                            "type": "prompt",
+                            "prompt": "Evaluate if we should stop.",
+                        }
+                    ],
+                }
+            ]
+        }
+    }
+    config = HookConfig.from_dict(data)
+    hooks = config.get_hooks_for_event(HookEventType.STOP)
+    assert len(hooks) == 1
+    assert hooks[0].type.value == "prompt"


### PR DESCRIPTION
## Summary

- HookDefinition required the command field unconditionally, so prompt-type hooks (which provide prompt instead of command) caused a ValidationError at config load time. 
-  Made command and prompt both optional, and added a model_validator that enforces the correct field is present based on the hook type: command type requires command, prompt type requires prompt.                                    
-  Fully backward compatible — existing command-type hooks (including those relying on the default type) work exactly as before.

## Test plan                                                                                                                                                                                                                              
                                                                                                                                                                                                                                         
- Added test_issue_2749 regression test that loads a prompt-based stop hook config and verifies it parses without error       

Fixes #2749 

## Checklist

- [ ] If the PR is changing/adding functionality, are there tests to reflect this?
- [ ] If there is an example, have you run the example to make sure that it works?
- [ ] If there are instructions on how to run the code, have you followed the instructions and made sure that it works?
- [ ] If the feature is significant enough to require documentation, is there a PR open on the OpenHands/docs repository with the same branch name?
- [ ] Is the github CI passing?


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d34b563-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d34b563-python \
  ghcr.io/openhands/agent-server:d34b563-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d34b563-golang-amd64
ghcr.io/openhands/agent-server:d34b563-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d34b563-golang-arm64
ghcr.io/openhands/agent-server:d34b563-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d34b563-java-amd64
ghcr.io/openhands/agent-server:d34b563-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d34b563-java-arm64
ghcr.io/openhands/agent-server:d34b563-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d34b563-python-amd64
ghcr.io/openhands/agent-server:d34b563-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d34b563-python-arm64
ghcr.io/openhands/agent-server:d34b563-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d34b563-golang
ghcr.io/openhands/agent-server:d34b563-java
ghcr.io/openhands/agent-server:d34b563-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d34b563-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d34b563-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->