### PR TITLE
fix(docker): restore self-contained /agent-server via managed-Python + execstack sanitize

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -137,6 +137,62 @@ a = Analysis(
 _EXCLUDE_LIB_PREFIXES = ('libgcc_s.so', 'libtinfo.so', 'libncurses')
 a.binaries = [x for x in a.binaries if not x[0].startswith(_EXCLUDE_LIB_PREFIXES)]
 
+# ---------------------------------------------------------------------------
+# Fix executable stack flags on bundled shared libraries.
+#
+# python-build-standalone's libpython3.13.so.1.0 (used by uv-managed Python)
+# is built with PT_GNU_STACK PF_X.  glibc >= 2.41-12+deb13u2 (Debian Trixie,
+# used in the nikolaik runtime image) tightened NX-stack enforcement and the
+# dynamic linker now rejects such libraries with EINVAL.  sysbox-runc's
+# seccomp policy also blocks the mprotect(PROT_EXEC) fallback.
+#
+# We reuse the same clear_execstack helper the Dockerfile builder stage
+# applies to /agent-server/uv-managed-python, now as a post-Analysis hook
+# against PyInstaller's collected binaries — so the one-file archive ships
+# clean .so files that load under strict NX.
+#
+# We copy each affected .so into a temp directory (so we never mutate the
+# files on disk that Analysis pointed at) and rewrite the binaries list to
+# use the sanitized copy. PyInstaller's subsequent strip preserves program
+# headers, so the cleared flag survives into the final binary.
+# See OpenHands/software-agent-sdk#2761 (and #2574 for the original spec-only
+# version this supersedes).
+# ---------------------------------------------------------------------------
+import importlib.util as _clear_execstack_importer
+import shutil as _nxfix_shutil
+import tempfile as _nxfix_tempfile
+
+_clear_execstack_path = str(
+    project_root
+    / "openhands-agent-server"
+    / "openhands"
+    / "agent_server"
+    / "docker"
+    / "clear_execstack.py"
+)
+_spec = _clear_execstack_importer.spec_from_file_location(
+    "agent_server_clear_execstack", _clear_execstack_path
+)
+assert _spec is not None and _spec.loader is not None, (
+    f"clear_execstack helper not found at {_clear_execstack_path}"
+)
+_clear_execstack_mod = _clear_execstack_importer.module_from_spec(_spec)
+_spec.loader.exec_module(_clear_execstack_mod)
+
+_nxfix_tmpdir = _nxfix_tempfile.mkdtemp(prefix='pyinstaller_nxfix_')
+_fixed_binaries = []
+for _name, _path, _typecode in a.binaries:
+    if '.so' in _name:
+        _tmp_path = os.path.join(_nxfix_tmpdir, _name.replace(os.sep, '_'))
+        _nxfix_shutil.copy2(_path, _tmp_path)
+        if _clear_execstack_mod.clear_execstack(_tmp_path):
+            print(f'  [NX-fix] Cleared executable stack: {_name}')
+            _fixed_binaries.append((_name, _tmp_path, _typecode))
+            continue
+        os.unlink(_tmp_path)
+    _fixed_binaries.append((_name, _path, _typecode))
+a.binaries = _fixed_binaries
+
 pyz = PYZ(a.pure)
 
 exe = EXE(

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -13,22 +13,39 @@ ARG PORT=8000
 # Builder (source mode)
 # We copy source + build a venv here for local dev and debugging.
 #
-# NOTE: We use the base image's system Python (--python-preference only-system)
-# instead of uv-managed python-build-standalone. The python-build-standalone
-# builds ship libpython with an executable stack (PT_GNU_STACK PF_X).
-# Docker containers running under seccomp restrictions (e.g. GitHub Actions
-# Docker-in-Docker) reject dlopen() on such libraries with:
+# SELF-CONTAINED /agent-server CONTRACT:
+# We install a uv-managed (python-build-standalone) CPython into
+# /agent-server/uv-managed-python and use it as the interpreter for
+# /agent-server/.venv. Both live under /agent-server, so downstream
+# consumers can COPY /agent-server onto *any* base image (including ones
+# with no /usr/local/bin/python3) and the venv keeps working.
+#
+# The obstacle this used to trip on:
+# python-build-standalone ships libpython3.13.so.1.0 with
+# ``PT_GNU_STACK PF_X`` (executable stack).  Under Debian's glibc
+# 2.41-12+deb13u2 (Trixie) NX enforcement and under Docker-in-Docker with
+# seccomp restrictions (GitHub Actions, sysbox-runc), the dynamic linker
+# refuses to load such libraries with:
 #   "cannot enable executable stack as shared object requires: Invalid argument"
-# Debian's CPython packages do not have this issue.
+#
+# We address that at its actual layer (ELF program headers) by running the
+# clear_execstack helper across the uv-managed Python tree immediately
+# after install. The helper clears PF_X on every PT_GNU_STACK entry of
+# every bundled .so, making the Python tree DinD/sysbox/seccomp safe while
+# preserving the self-contained .venv property.
+# See OpenHands/software-agent-sdk#2761.
 ####################################################################################
 FROM python:3.13-bookworm AS builder
 ARG USERNAME UID GID
 ENV UV_PROJECT_ENVIRONMENT=/agent-server/.venv
+ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 
 COPY --from=ghcr.io/astral-sh/uv /uv /uvx /bin/
 
 RUN groupadd -g ${GID} ${USERNAME} \
- && useradd -m -u ${UID} -g ${GID} -s /usr/sbin/nologin ${USERNAME}
+ && useradd -m -u ${UID} -g ${GID} -s /usr/sbin/nologin ${USERNAME} \
+ && mkdir -p /agent-server/uv-managed-python \
+ && chown -R ${USERNAME}:${USERNAME} /agent-server
 USER ${USERNAME}
 WORKDIR /agent-server
 # Cache-friendly: lockfiles first
@@ -37,8 +54,20 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-sdk ./openhands-sdk
 COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
+# Install python-build-standalone into /agent-server/uv-managed-python, then
+# sanitize PT_GNU_STACK on every bundled .so before the venv is created so the
+# interpreter and its C extensions load under strict NX.
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv venv --python-preference only-system .venv && uv sync --frozen --no-editable --extra boto3
+    uv python install 3.13 && \
+    python3 openhands-agent-server/openhands/agent_server/docker/clear_execstack.py \
+        /agent-server/uv-managed-python && \
+    uv venv --python-preference only-managed --python 3.13 .venv && \
+    uv sync --frozen --no-editable --managed-python --extra boto3 && \
+    # Fail fast if the venv did not end up pointing at the bundled interpreter.
+    # If this assertion ever fires, downstream consumers are about to break on
+    # base images without a matching /usr/local/bin/python3 — bail in the
+    # builder instead.
+    readlink -f .venv/bin/python | grep -q '^/agent-server/uv-managed-python/'
 
 ####################################################################################
 # Binary Builder (binary mode)

--- a/openhands-agent-server/openhands/agent_server/docker/clear_execstack.py
+++ b/openhands-agent-server/openhands/agent_server/docker/clear_execstack.py
@@ -85,7 +85,7 @@ def clear_execstack(path: str | os.PathLike[str]) -> bool:
     """Clear ``PF_X`` from ``PT_GNU_STACK`` in the ELF at ``path``.
 
     Returns ``True`` if a byte was modified, ``False`` otherwise (not an ELF,
-    no ``PT_GNU_STACK`` entry, or ``PF_X`` already cleared).
+    symlink, no ``PT_GNU_STACK`` entry, or ``PF_X`` already cleared).
 
     Raises nothing for non-ELF files — they are silently skipped, so the
     caller can walk a tree indiscriminately.

--- a/openhands-agent-server/openhands/agent_server/docker/clear_execstack.py
+++ b/openhands-agent-server/openhands/agent_server/docker/clear_execstack.py
@@ -208,9 +208,7 @@ def _main(argv: list[str]) -> int:
         return 1
     for path in modified:
         print(f"  [execstack] cleared PF_X on {path}")
-    print(
-        f"clear_execstack: sanitized {len(modified)} shared object(s) under {target}"
-    )
+    print(f"clear_execstack: sanitized {len(modified)} shared object(s) under {target}")
     return 0
 
 

--- a/openhands-agent-server/openhands/agent_server/docker/clear_execstack.py
+++ b/openhands-agent-server/openhands/agent_server/docker/clear_execstack.py
@@ -1,0 +1,218 @@
+"""Clear the PF_X bit from PT_GNU_STACK on shared libraries.
+
+Some prebuilt ELF shared libraries ship with ``PT_GNU_STACK`` flagged as
+executable (``PF_X``) even though they do not actually need an executable
+stack. Notably, ``libpython3.13.so.1.0`` as distributed by
+``python-build-standalone`` (used by ``uv python install``) has this flag set.
+
+Under Debian's glibc ``2.41-12+deb13u2`` (Trixie) NX enforcement and under
+Docker-in-Docker with seccomp restrictions (GitHub Actions, sysbox-runc), the
+dynamic linker refuses to load such libraries with::
+
+    cannot enable executable stack as shared object requires: Invalid argument
+
+This module addresses the problem at its actual layer (ELF program headers)
+rather than dodging ``python-build-standalone``. It walks a directory tree,
+finds every ``.so*`` file, parses each ELF's program header table, and clears
+the ``PF_X`` bit on any ``PT_GNU_STACK`` entry that has it set.
+
+The helper is:
+
+* **Idempotent.** Re-running it on a directory that has already been sanitized
+  is a no-op.
+* **A no-op** on ELFs that do not have a ``PT_GNU_STACK`` program header, or on
+  ones where ``PT_GNU_STACK`` already has ``PF_X`` cleared.
+* **Architecture-agnostic.** Supports 32-bit and 64-bit ELF, little- and
+  big-endian, and respects the program-header layout differences between
+  ``Elf32_Phdr`` and ``Elf64_Phdr``.
+* **Strip-safe.** It only rewrites a single ``uint32`` inside an existing
+  program header; the segment table and section headers are untouched, so
+  running ``strip`` afterwards is fine.
+* **Dual-use.** Importable as ``from clear_execstack import clear_execstack``
+  or runnable as ``python clear_execstack.py <path>``.
+
+Usage::
+
+    # CLI — walk a directory tree
+    python clear_execstack.py /agent-server/uv-managed-python
+
+    # Library — single file or directory
+    from clear_execstack import clear_execstack, clear_execstack_in_tree
+    clear_execstack("/path/to/libpython3.13.so.1.0")
+    clear_execstack_in_tree("/agent-server/uv-managed-python")
+"""
+
+from __future__ import annotations
+
+import os
+import struct
+import sys
+from pathlib import Path
+
+
+# ELF constants — see <elf.h>.
+_ELF_MAGIC = b"\x7fELF"
+_ELFCLASS32 = 1
+_ELFCLASS64 = 2
+_ELFDATA2LSB = 1
+_ELFDATA2MSB = 2
+_PT_GNU_STACK = 0x6474E551
+_PF_X = 0x1
+
+
+def _is_shared_object(name: str) -> bool:
+    """Return True if ``name`` looks like a shared-object filename.
+
+    Matches ``foo.so``, ``foo.so.1``, ``foo.so.1.0``, etc. Deliberately ignores
+    ``.py``, ``.pyc``, and other non-ELF files so the caller can pass any
+    directory and have the helper pick only relevant payloads.
+    """
+    if ".so" not in name:
+        return False
+    # Must contain a ".so" path component followed by either end-of-string or
+    # a version suffix ("libfoo.so", "libfoo.so.1.2.3"). Reject things like
+    # "foo.sources" that happen to contain ".so".
+    parts = name.split(".")
+    for i, part in enumerate(parts):
+        if part == "so":
+            remainder = parts[i + 1 :]
+            if not remainder or all(p.isdigit() for p in remainder):
+                return True
+    return False
+
+
+def clear_execstack(path: str | os.PathLike[str]) -> bool:
+    """Clear ``PF_X`` from ``PT_GNU_STACK`` in the ELF at ``path``.
+
+    Returns ``True`` if a byte was modified, ``False`` otherwise (not an ELF,
+    no ``PT_GNU_STACK`` entry, or ``PF_X`` already cleared).
+
+    Raises nothing for non-ELF files — they are silently skipped, so the
+    caller can walk a tree indiscriminately.
+    """
+    path = os.fspath(path)
+    # Skip symlinks — we sanitize the real target once rather than chasing
+    # every alias and risking double-open issues.
+    if os.path.islink(path):
+        return False
+    try:
+        fd = os.open(path, os.O_RDWR)
+    except OSError:
+        return False
+    try:
+        with os.fdopen(fd, "r+b") as f:
+            ident = f.read(16)
+            if len(ident) < 16 or ident[:4] != _ELF_MAGIC:
+                return False
+            ei_class = ident[4]
+            ei_data = ident[5]
+            if ei_class not in (_ELFCLASS32, _ELFCLASS64):
+                return False
+            if ei_data == _ELFDATA2LSB:
+                endian = "<"
+            elif ei_data == _ELFDATA2MSB:
+                endian = ">"
+            else:
+                return False
+
+            if ei_class == _ELFCLASS64:
+                # Elf64_Ehdr: e_phoff @ 32 (u64), e_phentsize @ 54 (u16),
+                # e_phnum @ 56 (u16). Program header: p_type @ 0 (u32),
+                # p_flags @ 4 (u32).
+                f.seek(32)
+                (e_phoff,) = struct.unpack(endian + "Q", f.read(8))
+                f.seek(54)
+                e_phentsize, e_phnum = struct.unpack(endian + "HH", f.read(4))
+                phdr_flags_offset = 4
+                phdr_type_fmt = endian + "I"
+            else:
+                # Elf32_Ehdr: e_phoff @ 28 (u32), e_phentsize @ 42 (u16),
+                # e_phnum @ 44 (u16). Program header: p_type @ 0 (u32),
+                # p_flags @ 24 (u32).
+                f.seek(28)
+                (e_phoff,) = struct.unpack(endian + "I", f.read(4))
+                f.seek(42)
+                e_phentsize, e_phnum = struct.unpack(endian + "HH", f.read(4))
+                phdr_flags_offset = 24
+                phdr_type_fmt = endian + "I"
+
+            if e_phoff == 0 or e_phentsize == 0 or e_phnum == 0:
+                return False
+
+            for i in range(e_phnum):
+                entry_off = e_phoff + i * e_phentsize
+                f.seek(entry_off)
+                raw_type = f.read(4)
+                if len(raw_type) < 4:
+                    return False
+                (p_type,) = struct.unpack(phdr_type_fmt, raw_type)
+                if p_type != _PT_GNU_STACK:
+                    continue
+                flags_off = entry_off + phdr_flags_offset
+                f.seek(flags_off)
+                raw_flags = f.read(4)
+                if len(raw_flags) < 4:
+                    return False
+                (p_flags,) = struct.unpack(endian + "I", raw_flags)
+                if not (p_flags & _PF_X):
+                    return False
+                new_flags = p_flags & ~_PF_X
+                f.seek(flags_off)
+                f.write(struct.pack(endian + "I", new_flags))
+                return True
+    except OSError:
+        return False
+    return False
+
+
+def clear_execstack_in_tree(root: str | os.PathLike[str]) -> list[str]:
+    """Walk ``root`` and sanitize every shared object underneath it.
+
+    Returns the list of paths that were actually modified, in the order they
+    were visited. Directories that do not exist raise ``FileNotFoundError``
+    so CI catches a typo in the Dockerfile argument.
+    """
+    root_path = Path(root)
+    if not root_path.exists():
+        raise FileNotFoundError(f"clear_execstack: path does not exist: {root}")
+
+    modified: list[str] = []
+    if root_path.is_file():
+        if clear_execstack(root_path):
+            modified.append(str(root_path))
+        return modified
+
+    for dirpath, _, filenames in os.walk(root_path):
+        for name in filenames:
+            if not _is_shared_object(name):
+                continue
+            full = os.path.join(dirpath, name)
+            if clear_execstack(full):
+                modified.append(full)
+    return modified
+
+
+def _main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print(
+            "usage: python clear_execstack.py <path>\n"
+            "  <path> is a directory tree or a single .so file.",
+            file=sys.stderr,
+        )
+        return 2
+    target = argv[1]
+    try:
+        modified = clear_execstack_in_tree(target)
+    except FileNotFoundError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    for path in modified:
+        print(f"  [execstack] cleared PF_X on {path}")
+    print(
+        f"clear_execstack: sanitized {len(modified)} shared object(s) under {target}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_main(sys.argv))

--- a/tests/agent_server/test_clear_execstack.py
+++ b/tests/agent_server/test_clear_execstack.py
@@ -242,9 +242,7 @@ def test_clears_pf_x_on_pt_gnu_stack_rwx(tmp_path: Path, bits: int, endian: str)
 
 
 @pytest.mark.parametrize("bits,endian", _MATRIX)
-def test_noop_when_pt_gnu_stack_already_clean(
-    tmp_path: Path, bits: int, endian: str
-):
+def test_noop_when_pt_gnu_stack_already_clean(tmp_path: Path, bits: int, endian: str):
     elf = _build_elf(
         bits=bits,
         endian=endian,
@@ -295,9 +293,7 @@ def test_walks_tree_and_reports_modified_files(tmp_path: Path):
     dirty = _build_elf(
         bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W | _PF_X)]
     )
-    clean = _build_elf(
-        bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W)]
-    )
+    clean = _build_elf(bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W)])
 
     (tmp_path / "bin").mkdir()
     (tmp_path / "lib").mkdir()

--- a/tests/agent_server/test_clear_execstack.py
+++ b/tests/agent_server/test_clear_execstack.py
@@ -1,0 +1,411 @@
+"""Unit tests for ``clear_execstack``.
+
+We synthesize minimal but structurally valid ELF files in-memory so the tests
+do not depend on a target toolchain being installed. Each fixture exercises a
+different axis of the matrix called for by OpenHands/software-agent-sdk#2761:
+32/64-bit, little-/big-endian (which stands in for amd64/arm64 byte order
+shape + any future big-endian arch), and ``PT_GNU_STACK`` present / absent /
+already-clean. Idempotence and the no-match no-op guarantee are asserted
+explicitly.
+
+The sanitizer only edits a single ``uint32`` inside an existing program
+header, so our synthesized ELFs do not need real code or sections — just a
+coherent ELF header + program header table. If the helper touches anything
+outside the ``p_flags`` field, the post-call file comparisons will catch it.
+"""
+
+from __future__ import annotations
+
+import struct
+from pathlib import Path
+
+import pytest
+
+from openhands.agent_server.docker.clear_execstack import (
+    _is_shared_object,
+    clear_execstack,
+    clear_execstack_in_tree,
+)
+
+
+# ---------- ELF synthesis helpers ------------------------------------------------
+
+# From <elf.h>
+_PT_LOAD = 0x1
+_PT_GNU_STACK = 0x6474E551
+_PF_X = 0x1
+_PF_W = 0x2
+_PF_R = 0x4
+
+# Elf_Ehdr sizes
+_EHDR64_SIZE = 64
+_EHDR32_SIZE = 52
+# Phdr sizes
+_PHDR64_SIZE = 56
+_PHDR32_SIZE = 32
+
+
+def _build_elf(
+    *,
+    bits: int,
+    endian: str,
+    phdrs: list[tuple[int, int]],
+) -> bytes:
+    """Build a minimal ELF file containing the given program headers.
+
+    ``phdrs`` is a list of ``(p_type, p_flags)`` tuples. Remaining program
+    header fields (offsets, sizes, alignment) are filled with zeros — the
+    sanitizer only reads ``p_type`` and ``p_flags``.
+    """
+    assert bits in (32, 64)
+    assert endian in ("<", ">")
+
+    ei_class = 2 if bits == 64 else 1
+    ei_data = 1 if endian == "<" else 2
+
+    e_ident = bytearray(16)
+    e_ident[0:4] = b"\x7fELF"
+    e_ident[4] = ei_class
+    e_ident[5] = ei_data
+    e_ident[6] = 1  # EV_CURRENT
+    # remaining bytes stay zero — valid enough for our purposes
+
+    e_type = 3  # ET_DYN (shared object)
+    e_machine = 0x3E if bits == 64 else 0x28  # EM_X86_64 / EM_ARM
+    e_version = 1
+    e_entry = 0
+    e_flags = 0
+    e_shoff = 0
+    e_shentsize = 0
+    e_shnum = 0
+    e_shstrndx = 0
+
+    phdr_size = _PHDR64_SIZE if bits == 64 else _PHDR32_SIZE
+    ehdr_size = _EHDR64_SIZE if bits == 64 else _EHDR32_SIZE
+    e_phoff = ehdr_size
+    e_phentsize = phdr_size
+    e_phnum = len(phdrs)
+    e_ehsize = ehdr_size
+
+    if bits == 64:
+        # Elf64_Ehdr layout after e_ident:
+        #   Half e_type; Half e_machine; Word e_version; Addr e_entry;
+        #   Off e_phoff; Off e_shoff; Word e_flags; Half e_ehsize;
+        #   Half e_phentsize; Half e_phnum; Half e_shentsize; Half e_shnum;
+        #   Half e_shstrndx
+        ehdr_tail = struct.pack(
+            endian + "HHIQQQIHHHHHH",
+            e_type,
+            e_machine,
+            e_version,
+            e_entry,
+            e_phoff,
+            e_shoff,
+            e_flags,
+            e_ehsize,
+            e_phentsize,
+            e_phnum,
+            e_shentsize,
+            e_shnum,
+            e_shstrndx,
+        )
+    else:
+        ehdr_tail = struct.pack(
+            endian + "HHIIIIIHHHHHH",
+            e_type,
+            e_machine,
+            e_version,
+            e_entry,
+            e_phoff,
+            e_shoff,
+            e_flags,
+            e_ehsize,
+            e_phentsize,
+            e_phnum,
+            e_shentsize,
+            e_shnum,
+            e_shstrndx,
+        )
+
+    buf = bytearray(bytes(e_ident) + ehdr_tail)
+    assert len(buf) == ehdr_size, (len(buf), ehdr_size)
+
+    for p_type, p_flags in phdrs:
+        if bits == 64:
+            # Elf64_Phdr: Word p_type; Word p_flags; Off p_offset; Addr p_vaddr;
+            #            Addr p_paddr; Xword p_filesz; Xword p_memsz; Xword p_align
+            phdr = struct.pack(
+                endian + "IIQQQQQQ",
+                p_type,
+                p_flags,
+                0,  # p_offset
+                0,  # p_vaddr
+                0,  # p_paddr
+                0,  # p_filesz
+                0,  # p_memsz
+                0,  # p_align
+            )
+        else:
+            # Elf32_Phdr: Word p_type; Off p_offset; Addr p_vaddr; Addr p_paddr;
+            #            Word p_filesz; Word p_memsz; Word p_flags; Word p_align
+            phdr = struct.pack(
+                endian + "IIIIIIII",
+                p_type,
+                0,  # p_offset
+                0,  # p_vaddr
+                0,  # p_paddr
+                0,  # p_filesz
+                0,  # p_memsz
+                p_flags,
+                0,  # p_align
+            )
+        assert len(phdr) == phdr_size
+        buf.extend(phdr)
+
+    # A few bytes of tail padding so strip/readelf don't complain. Not required
+    # by the sanitizer but avoids empty-file edge cases.
+    buf.extend(b"\x00" * 16)
+    return bytes(buf)
+
+
+def _gnu_stack_flags(data: bytes) -> int | None:
+    """Read PT_GNU_STACK p_flags from a synthesized ELF, for assertions."""
+    ei_class = data[4]
+    ei_data = data[5]
+    endian = "<" if ei_data == 1 else ">"
+    if ei_class == 2:
+        e_phoff = struct.unpack(endian + "Q", data[32:40])[0]
+        e_phentsize, e_phnum = struct.unpack(endian + "HH", data[54:58])
+        flags_in_phdr = 4
+    else:
+        e_phoff = struct.unpack(endian + "I", data[28:32])[0]
+        e_phentsize, e_phnum = struct.unpack(endian + "HH", data[42:46])
+        flags_in_phdr = 24
+
+    for i in range(e_phnum):
+        off = e_phoff + i * e_phentsize
+        (p_type,) = struct.unpack(endian + "I", data[off : off + 4])
+        if p_type == _PT_GNU_STACK:
+            flags_off = off + flags_in_phdr
+            return struct.unpack(endian + "I", data[flags_off : flags_off + 4])[0]
+    return None
+
+
+# ---------- Parametrized matrix --------------------------------------------------
+
+_MATRIX = [
+    pytest.param(64, "<", id="elf64-le"),  # amd64
+    pytest.param(64, ">", id="elf64-be"),  # e.g. ppc64be — covers 64-bit BE
+    pytest.param(32, "<", id="elf32-le"),  # armhf
+    pytest.param(32, ">", id="elf32-be"),  # e.g. classic MIPS — covers 32-bit BE
+]
+
+
+@pytest.mark.parametrize("bits,endian", _MATRIX)
+def test_clears_pf_x_on_pt_gnu_stack_rwx(tmp_path: Path, bits: int, endian: str):
+    elf = _build_elf(
+        bits=bits,
+        endian=endian,
+        phdrs=[
+            (_PT_LOAD, _PF_R | _PF_X),  # code segment — must NOT be touched
+            (_PT_GNU_STACK, _PF_R | _PF_W | _PF_X),  # the offender
+        ],
+    )
+    path = tmp_path / "libtest.so.1.0"
+    path.write_bytes(elf)
+
+    changed = clear_execstack(path)
+    assert changed is True
+
+    new_bytes = path.read_bytes()
+    assert _gnu_stack_flags(new_bytes) == (_PF_R | _PF_W)
+
+    # Ensure the load segment kept its PF_X — we only target PT_GNU_STACK.
+    # Read the first program header's p_flags directly.
+    ei_class = new_bytes[4]
+    e_phoff_off = 32 if ei_class == 2 else 28
+    phdr_size = _PHDR64_SIZE if ei_class == 2 else _PHDR32_SIZE
+    flags_in_phdr = 4 if ei_class == 2 else 24
+    if ei_class == 2:
+        e_phoff = struct.unpack(endian + "Q", new_bytes[e_phoff_off : e_phoff_off + 8])[
+            0
+        ]
+    else:
+        e_phoff = struct.unpack(endian + "I", new_bytes[e_phoff_off : e_phoff_off + 4])[
+            0
+        ]
+    load_flags_off = e_phoff + 0 * phdr_size + flags_in_phdr
+    (load_flags,) = struct.unpack(
+        endian + "I", new_bytes[load_flags_off : load_flags_off + 4]
+    )
+    assert load_flags & _PF_X, "PT_LOAD PF_X must be preserved"
+
+
+@pytest.mark.parametrize("bits,endian", _MATRIX)
+def test_noop_when_pt_gnu_stack_already_clean(
+    tmp_path: Path, bits: int, endian: str
+):
+    elf = _build_elf(
+        bits=bits,
+        endian=endian,
+        phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W)],
+    )
+    path = tmp_path / "libclean.so"
+    path.write_bytes(elf)
+    before = path.read_bytes()
+
+    assert clear_execstack(path) is False
+    assert path.read_bytes() == before
+
+
+@pytest.mark.parametrize("bits,endian", _MATRIX)
+def test_noop_when_pt_gnu_stack_absent(tmp_path: Path, bits: int, endian: str):
+    # Only a PT_LOAD segment; no PT_GNU_STACK at all.
+    elf = _build_elf(
+        bits=bits,
+        endian=endian,
+        phdrs=[(_PT_LOAD, _PF_R | _PF_X)],
+    )
+    path = tmp_path / "libnostack.so"
+    path.write_bytes(elf)
+    before = path.read_bytes()
+
+    assert clear_execstack(path) is False
+    assert path.read_bytes() == before
+
+
+def test_idempotent(tmp_path: Path):
+    elf = _build_elf(
+        bits=64,
+        endian="<",
+        phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W | _PF_X)],
+    )
+    path = tmp_path / "libidem.so"
+    path.write_bytes(elf)
+
+    # First pass writes. Second pass must not change anything.
+    assert clear_execstack(path) is True
+    after_first = path.read_bytes()
+    assert clear_execstack(path) is False
+    assert path.read_bytes() == after_first
+    assert _gnu_stack_flags(after_first) == (_PF_R | _PF_W)
+
+
+def test_walks_tree_and_reports_modified_files(tmp_path: Path):
+    dirty = _build_elf(
+        bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W | _PF_X)]
+    )
+    clean = _build_elf(
+        bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W)]
+    )
+
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "lib").mkdir()
+    (tmp_path / "lib" / "nested").mkdir()
+
+    (tmp_path / "lib" / "libdirty.so.1.0").write_bytes(dirty)
+    (tmp_path / "lib" / "libclean.so").write_bytes(clean)
+    (tmp_path / "lib" / "nested" / "libdeep.so.3").write_bytes(dirty)
+    (tmp_path / "lib" / "README.md").write_text("not an elf")
+    (tmp_path / "lib" / "something.sources").write_text("not a shared object")
+    (tmp_path / "bin" / "binary").write_bytes(dirty)  # not .so — must be skipped
+
+    modified = clear_execstack_in_tree(tmp_path)
+    modified_names = sorted(Path(p).name for p in modified)
+    assert modified_names == ["libdeep.so.3", "libdirty.so.1.0"]
+
+
+def test_non_elf_file_is_skipped(tmp_path: Path):
+    path = tmp_path / "libjunk.so"
+    path.write_bytes(b"not an elf at all")
+    assert clear_execstack(path) is False
+    assert path.read_bytes() == b"not an elf at all"
+
+
+def test_truncated_elf_is_skipped(tmp_path: Path):
+    path = tmp_path / "libtrunc.so"
+    # Valid magic + class + data, but nothing else.
+    path.write_bytes(b"\x7fELF\x02\x01\x01\x00" + b"\x00" * 4)
+    assert clear_execstack(path) is False
+
+
+def test_symlink_is_skipped(tmp_path: Path):
+    elf = _build_elf(
+        bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W | _PF_X)]
+    )
+    real = tmp_path / "libreal.so.1.0"
+    real.write_bytes(elf)
+    link = tmp_path / "libreal.so"
+    link.symlink_to(real.name)
+
+    # Calling on the symlink must not modify anything…
+    assert clear_execstack(link) is False
+    # …and calling on the real file must still work.
+    assert clear_execstack(real) is True
+    assert _gnu_stack_flags(real.read_bytes()) == (_PF_R | _PF_W)
+
+
+def test_clear_execstack_in_tree_rejects_missing_path(tmp_path: Path):
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(FileNotFoundError):
+        clear_execstack_in_tree(missing)
+
+
+def test_clear_execstack_in_tree_accepts_single_file(tmp_path: Path):
+    elf = _build_elf(
+        bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W | _PF_X)]
+    )
+    path = tmp_path / "libsolo.so"
+    path.write_bytes(elf)
+    modified = clear_execstack_in_tree(path)
+    assert modified == [str(path)]
+
+
+@pytest.mark.parametrize(
+    "name,expected",
+    [
+        ("libfoo.so", True),
+        ("libfoo.so.1", True),
+        ("libfoo.so.1.2.3", True),
+        ("libpython3.13.so.1.0", True),
+        ("foo.sources", False),
+        ("notes.so.txt", False),
+        ("README.md", False),
+        ("pyconfig.h", False),
+    ],
+)
+def test_is_shared_object(name: str, expected: bool):
+    assert _is_shared_object(name) is expected
+
+
+def test_cli_entrypoint_reports_modifications(tmp_path: Path, capsys):
+    from openhands.agent_server.docker.clear_execstack import _main
+
+    elf = _build_elf(
+        bits=64, endian="<", phdrs=[(_PT_GNU_STACK, _PF_R | _PF_W | _PF_X)]
+    )
+    (tmp_path / "libcli.so").write_bytes(elf)
+
+    rc = _main(["clear_execstack.py", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "libcli.so" in out
+    assert "sanitized 1 shared object" in out
+
+
+def test_cli_entrypoint_usage_error(capsys):
+    from openhands.agent_server.docker.clear_execstack import _main
+
+    rc = _main(["clear_execstack.py"])
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "usage" in err.lower()
+
+
+def test_cli_entrypoint_missing_path(tmp_path: Path, capsys):
+    from openhands.agent_server.docker.clear_execstack import _main
+
+    rc = _main(["clear_execstack.py", str(tmp_path / "nope")])
+    assert rc == 1
+    err = capsys.readouterr().err
+    assert "does not exist" in err


### PR DESCRIPTION
## Summary
- Switch the `openhands-agent-server` builder stage from `uv venv --python-preference only-system` back to uv-managed python-build-standalone, installed into `/agent-server/uv-managed-python`. `.venv/bin/python` is a symlink inside `/agent-server` again, so `COPY /agent-server` works on any base image.
- Add `openhands-agent-server/openhands/agent_server/docker/clear_execstack.py`: walks a directory tree, parses ELF program headers, and clears `PF_X` on any `PT_GNU_STACK` entry that has it. ELF32/ELF64 + LE/BE, idempotent, strip-safe, importable or CLI.
- Wire the helper into two places: the builder stage runs it across `/agent-server/uv-managed-python` right after `uv python install 3.13`, and the PyInstaller spec applies it as a post-Analysis hook to every bundled `.so`. Both call sites share one implementation.
- Add a builder-side assertion that `.venv/bin/python` resolves into `/agent-server/uv-managed-python/` so any future regression on the self-contained contract fails at build time, not in downstream eval pods.

## Why this is better than the alternatives

| PR | Idea | Why it's not what we want |
|---|---|---|
| #2692 (closed) | Naive revert to `--managed-python` | Brings back `PYI-37` execstack crashes under DinD/sysbox — the exact problem `only-system` was added to work around. |
| #2676 | Bundle Debian Python into `/agent-server/.python` | Tactical: works on glibc bases but still breaks on musl/Alpine or mismatched glibc ABI. ~60 lines of shell to rewrite venv symlinks + `pyvenv.cfg`. Venvs are not generally portable when the interpreter is relocated. **To be closed in favor of this PR.** |
| #2574 (closed) | Inline execstack sanitizer in the PyInstaller spec | Only fixed the `binary` target, not `source`/`source-minimal`. This PR factors the sanitizer out and reuses it in both call sites. |

This PR addresses the execstack problem at its actual layer (ELF program headers) instead of dodging python-build-standalone, and restores managed-Python so `.venv` is self-contained by construction. It is simultaneously: self-contained `.venv`, DinD/sysbox-safe, PyInstaller-safe, no downstream Dockerfile coupling, no packaging prerequisites.

Closes #2761. Supersedes #2676 and #2692. Resurrects the approach validated end-to-end in #2574.

## Eval evidence

All runs used `sdk_ref=fix/2761-managed-python-execstack-sanitize` (SHA `6b9e0afc`) + `benchmarks_branch=fix/2761-drop-python-runtime-workaround`, `eval_limit=5`, default OpenHands agent, `claude-sonnet-4-5-20250929`.

| Benchmark | Eval Job | K8s Job | Status | Errors | Resolved | Duration |
|-----------|----------|---------|--------|--------|----------|----------|
| **gaia** | [eval-24161963891](https://github.com/OpenHands/evaluation/actions/runs/24161963891) | `eval-24161963891-claude-son` | ✅ Success | 0/5 | — | ~20m |
| **commit0** | [eval-24165870319](https://github.com/OpenHands/evaluation/actions/runs/24165870319) | `eval-24165870319-claude-son` | ✅ Success | 0/5 | 2/5 | ~30m |
| **swebench** | [eval-24167483095](https://github.com/OpenHands/evaluation/actions/runs/24167483095) | `eval-24167483095-claude-son` | ✅ Success | 0/5 | — | ~31m |
| **swtbench** | [eval-24185759897](https://github.com/OpenHands/evaluation/actions/runs/24185759897) | `eval-24185759897-claude-son` | 🔄 In progress | — | — | — |
| **swebenchmultimodal** | [eval-24185764625](https://github.com/OpenHands/evaluation/actions/runs/24185764625) | `eval-24185764625-claude-son` | 🔄 In progress | — | — | — |

All completed runs: **0 conversation errors, 0 PYI-37 failures, 0 execstack failures**.

## Test plan

- [x] Unit tests for `clear_execstack.py` — 30 cases covering the full matrix: ELF32/ELF64 × little/big-endian, `PT_GNU_STACK RWX`/`RW`/absent, tree walk, symlink skip, non-ELF skip, truncated ELF, idempotence, CLI entrypoint (all green locally).
- [x] Build `source-minimal` and confirm `readlink -f /agent-server/.venv/bin/python` resolves under `/agent-server/uv-managed-python/` (the Dockerfile asserts this, so any failure bails the build).
- [x] Feature-branch eval runs at `eval_limit=5`: GAIA, commit0, SWE-bench — all three completed with 0 errors and 0 execstack failures (see table above).
- [ ] `docker run --rm -it <image> /agent-server/.venv/bin/python -c "import sys; print(sys.executable)"` — expect a path inside `/agent-server/uv-managed-python/`, not `/usr/local/bin/python3`.
- [ ] `readelf -l $(find /agent-server/uv-managed-python -name 'libpython3.13.so*' | head -1) | grep GNU_STACK` — expect `RW ` (no `E`).
- [x] Downstream cleanup PR on `benchmarks` strips the COPY-Debian-Python workaround from `benchmarks/utils/Dockerfile.agent-layer{,-commit0}`: OpenHands/benchmarks#648.

## Follow-up

After merge and release:
1. Bump `vendor/software-agent-sdk` in `benchmarks` to the released SDK tag.
2. Land the benchmarks cleanup PR (OpenHands/benchmarks#648) that removes the COPY `/usr/local/bin/python3.13`, `libpython3.13.so*`, `LD_LIBRARY_PATH=/usr/local/lib`, and downstream `UV_PYTHON_INSTALL_DIR` shim from `Dockerfile.agent-layer` and `Dockerfile.agent-layer-commit0`.
3. Close #2676 as superseded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1121942-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1121942-python \
  ghcr.io/openhands/agent-server:1121942-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1121942-golang-amd64
ghcr.io/openhands/agent-server:1121942-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1121942-golang-arm64
ghcr.io/openhands/agent-server:1121942-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1121942-java-amd64
ghcr.io/openhands/agent-server:1121942-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1121942-java-arm64
ghcr.io/openhands/agent-server:1121942-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1121942-python-amd64
ghcr.io/openhands/agent-server:1121942-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1121942-python-arm64
ghcr.io/openhands/agent-server:1121942-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1121942-golang
ghcr.io/openhands/agent-server:1121942-java
ghcr.io/openhands/agent-server:1121942-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1121942-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1121942-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->