### PR TITLE
fix: restore self-contained /agent-server with uv-managed Python

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -13,22 +13,29 @@ ARG PORT=8000
 # Builder (source mode)
 # We copy source + build a venv here for local dev and debugging.
 #
-# NOTE: We use the base image's system Python (--python-preference only-system)
-# instead of uv-managed python-build-standalone. The python-build-standalone
-# builds ship libpython with an executable stack (PT_GNU_STACK PF_X).
-# Docker containers running under seccomp restrictions (e.g. GitHub Actions
-# Docker-in-Docker) reject dlopen() on such libraries with:
-#   "cannot enable executable stack as shared object requires: Invalid argument"
-# Debian's CPython packages do not have this issue.
+# SELF-CONTAINED /agent-server CONTRACT:
+# uv installs python-build-standalone into /agent-server/uv-managed-python and
+# creates .venv against it. Both live under /agent-server, so downstream
+# consumers can COPY /agent-server onto any base image and the venv works.
+#
+# uv >= 0.11.5 pulls python-build-standalone >= 20260408, which ships
+# libpython without PT_GNU_STACK PF_X (executable stack). Earlier releases
+# had this flag set due to LLVM/BOLT bugs, causing glibc >= 2.41 and
+# DinD/sysbox/seccomp to reject dlopen() with "cannot enable executable
+# stack". No sanitizer or workaround is needed on fixed releases.
+# See OpenHands/software-agent-sdk#2761.
 ####################################################################################
 FROM python:3.13-bookworm AS builder
 ARG USERNAME UID GID
 ENV UV_PROJECT_ENVIRONMENT=/agent-server/.venv
+ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 
-COPY --from=ghcr.io/astral-sh/uv /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
 
 RUN groupadd -g ${GID} ${USERNAME} \
- && useradd -m -u ${UID} -g ${GID} -s /usr/sbin/nologin ${USERNAME}
+ && useradd -m -u ${UID} -g ${GID} -s /usr/sbin/nologin ${USERNAME} \
+ && mkdir -p /agent-server/uv-managed-python \
+ && chown -R ${USERNAME}:${USERNAME} /agent-server
 USER ${USERNAME}
 WORKDIR /agent-server
 # Cache-friendly: lockfiles first
@@ -38,7 +45,10 @@ COPY --chown=${USERNAME}:${USERNAME} openhands-tools ./openhands-tools
 COPY --chown=${USERNAME}:${USERNAME} openhands-workspace ./openhands-workspace
 COPY --chown=${USERNAME}:${USERNAME} openhands-agent-server ./openhands-agent-server
 RUN --mount=type=cache,target=/home/${USERNAME}/.cache,uid=${UID},gid=${GID} \
-    uv venv --python-preference only-system .venv && uv sync --frozen --no-editable --extra boto3
+    uv python install 3.13 && \
+    uv venv --python-preference only-managed --python 3.13 .venv && \
+    uv sync --frozen --no-editable --managed-python --extra boto3 && \
+    readlink -f .venv/bin/python | grep -q '^/agent-server/uv-managed-python/'
 
 ####################################################################################
 # Binary Builder (binary mode)
@@ -135,7 +145,7 @@ RUN mkdir -p /etc/claude-code && \
 
 # NOTE: we should NOT include UV_PROJECT_ENVIRONMENT here,
 # since the agent might use it to perform other work (e.g. tools that use Python)
-COPY --from=ghcr.io/astral-sh/uv /uv /uvx /bin/
+COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
 
 USER ${USERNAME}
 WORKDIR /

--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -30,6 +30,9 @@ ARG USERNAME UID GID
 ENV UV_PROJECT_ENVIRONMENT=/agent-server/.venv
 ENV UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python
 
+# uv 0.11.5+ embeds python-build-standalone 20260408 metadata, which is the
+# first release with the PT_GNU_STACK fix. Pin to 0.11.6 (latest at time of
+# writing) rather than :latest so builds are reproducible.
 COPY --from=ghcr.io/astral-sh/uv:0.11.6 /uv /uvx /bin/
 
 RUN groupadd -g ${GID} ${USERNAME} \


### PR DESCRIPTION
## Summary

Pin uv to 0.11.6 and switch from system Python (`--python-preference only-system`) back to uv-managed python-build-standalone installed into `/agent-server/uv-managed-python`. One file changed, no new scripts or tests needed.

This makes `/agent-server` fully self-contained again: downstream consumers can `COPY /agent-server` onto any base image without needing `/usr/local/bin/python3.13` or `libpython`.

## Why this works now

The executable-stack issue (`PT_GNU_STACK PF_X`) that originally forced the switch to system Python is **fixed upstream**:

- **Root cause**: Two LLVM bugs in python-build-standalone — BOLT optimizer stripping `PT_GNU_STACK` ([#956](https://github.com/astral-sh/python-build-standalone/issues/956)), and LLVM 22 assembler ignoring `--noexecstack` ([#1061](https://github.com/astral-sh/python-build-standalone/issues/1061))
- **Fix**: [python-build-standalone 20260408](https://github.com/astral-sh/python-build-standalone/releases/tag/20260408) ships `libpython` without `PF_X`
- **uv 0.11.5+** pulls that release for CPython 3.13.13

No ELF sanitizer, no `patchelf`, no workaround. Just pin the version that has the fix.

## What changed

One file: `openhands-agent-server/openhands/agent_server/docker/Dockerfile`

1. Pin `ghcr.io/astral-sh/uv:0.11.6` (both builder and base-image-minimal stages)
2. Set `UV_PYTHON_INSTALL_DIR=/agent-server/uv-managed-python`
3. `uv python install 3.13` before venv creation
4. `--python-preference only-managed` instead of `only-system`
5. Build-time assertion: `readlink -f .venv/bin/python | grep -q '^/agent-server/uv-managed-python/'`

## Comparison with #2762

This is a simplified alternative to #2762, which included a 217-line custom ELF sanitizer (`clear_execstack.py`) + 400 lines of tests. That approach was correct when the upstream fix didn't exist (PR was written before the 20260408 release). Now that the fix has shipped, the sanitizer is unnecessary.

| | #2762 | This PR |
|---|---|---|
| Files changed | 4 (+2 new) | 1 |
| Lines added | ~700 | 21 |
| Custom ELF code | 217-line `clear_execstack.py` | None |
| Tests added | 30 test cases | None needed |
| PyInstaller spec changes | Yes (post-Analysis hook) | None |
| Upstream dependency | None (self-sanitizes) | uv >= 0.11.5 (PBS 20260408) |

Closes #2761. Supersedes #2762, #2676, #2692.

## Eval evidence

All runs used `sdk_ref=fix/2761-uv-managed-python-simplified` (SHA `f8481216`) + `benchmarks_branch=fix/2761-drop-workaround-simplified` (SHA `90677ab`), `eval_limit=5`, `claude-sonnet-4-5-20250929`.

| Benchmark | Agent | Eval Job | Status | Errors |
|-----------|-------|----------|--------|--------|
| **gaia** | default | [eval-24195874502](https://github.com/OpenHands/evaluation/actions/runs/24195874502) | ✅ Success | 0/5 |
| **gaia** | acp-claude | [eval-24195881440](https://github.com/OpenHands/evaluation/actions/runs/24195881440) | ✅ Success | 0/5 |
| **commit0** | default | [eval-24197261838](https://github.com/OpenHands/evaluation/actions/runs/24197261838) | ✅ Success | 0/5 |
| **commit0** | acp-claude | [eval-24195875909](https://github.com/OpenHands/evaluation/actions/runs/24195875909) | ✅ Success | 0/5 |
| **swebench** | default | [eval-24197261249](https://github.com/OpenHands/evaluation/actions/runs/24197261249) | ✅ Success | 0/5 |
| **swebench** | acp-claude | [eval-24197266112](https://github.com/OpenHands/evaluation/actions/runs/24197266112) | ✅ Success | 0/5 |

**6/6 runs, 30/30 conversations, 0 errors.** No execstack failures, no PYI-37 errors.

## Test plan

- [x] CI Docker builds pass (builder, source, source-minimal, binary targets)
- [x] `readlink -f /agent-server/.venv/bin/python` resolves under `/agent-server/uv-managed-python/` (Dockerfile asserts this)
- [x] Feature-branch eval at `eval_limit=5` on gaia, commit0, swebench — 0 errors (default agent)
- [x] Feature-branch eval at `eval_limit=5` on gaia, commit0, swebench — 0 errors (acp-claude agent)
- [x] Downstream benchmarks PR: OpenHands/benchmarks#650

🤖 Generated with [Claude Code](https://claude.com/claude-code)