### PR TITLE
Add openrouter/z-ai/glm-5.1 to resolve_model_config (fixes #2768)

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -242,6 +242,16 @@ MODELS = {
             "disable_vision": True,
         },
     },
+    "glm-5.1": {
+        "id": "glm-5.1",
+        "display_name": "GLM-5.1",
+        "llm_config": {
+            "model": "litellm_proxy/openrouter/z-ai/glm-5.1",
+            "temperature": 0.0,
+            # OpenRouter glm-5.1 is text-only despite LiteLLM reporting vision support
+            "disable_vision": True,
+        },
+    },
     "qwen3-coder-next": {
         "id": "qwen3-coder-next",
         "display_name": "Qwen3 Coder Next",

--- a/tests/github_workflows/test_resolve_model_config.py
+++ b/tests/github_workflows/test_resolve_model_config.py
@@ -268,6 +268,16 @@ def test_glm_5_config():
     assert model["llm_config"]["disable_vision"] is True
 
 
+def test_glm_5_1_config():
+    """Test that glm-5.1 has correct configuration."""
+    model = MODELS["glm-5.1"]
+
+    assert model["id"] == "glm-5.1"
+    assert model["display_name"] == "GLM-5.1"
+    assert model["llm_config"]["model"] == "litellm_proxy/openrouter/z-ai/glm-5.1"
+    assert model["llm_config"]["disable_vision"] is True
+
+
 # Tests for preflight check functionality
 
 


### PR DESCRIPTION
## Summary

Added `glm-5.1` model to the `resolve_model_config.py` file following the same pattern as `glm-5`.

## Changes

- Added new model entry for `glm-5.1` with:
  - Model ID: `glm-5.1`
  - Display name: `GLM-5.1`
  - LLM config model: `litellm_proxy/openrouter/z-ai/glm-5.1`
  - Temperature: `0.0`
  - `disable_vision: True` (since the OpenRouter endpoint is text-only, matching glm-5's pattern)

## Testing

- Added test `test_glm_5_1_config` to verify the new model configuration
- All relevant tests pass:
  - `test_glm_5_1_config`
  - `test_all_models_valid_with_pydantic`
  - `test_find_all_models`

## Fixes

Fixes #2768

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0219891f-7a84-4d33-b8a7-39915469432b)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9ec6077-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9ec6077-python \
  ghcr.io/openhands/agent-server:9ec6077-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9ec6077-golang-amd64
ghcr.io/openhands/agent-server:9ec6077-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9ec6077-golang-arm64
ghcr.io/openhands/agent-server:9ec6077-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9ec6077-java-amd64
ghcr.io/openhands/agent-server:9ec6077-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9ec6077-java-arm64
ghcr.io/openhands/agent-server:9ec6077-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9ec6077-python-amd64
ghcr.io/openhands/agent-server:9ec6077-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9ec6077-python-arm64
ghcr.io/openhands/agent-server:9ec6077-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9ec6077-golang
ghcr.io/openhands/agent-server:9ec6077-java
ghcr.io/openhands/agent-server:9ec6077-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9ec6077-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9ec6077-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->