### PR TITLE
refactor: extract common extension patterns into openhands.sdk.extensions module

### DIFF
--- a/openhands-sdk/openhands/sdk/extensions/__init__.py
+++ b/openhands-sdk/openhands/sdk/extensions/__init__.py
@@ -1,0 +1,60 @@
+"""Extensions module for OpenHands SDK.
+
+This module provides shared infrastructure for installable extensions
+(plugins, skills, etc.), including:
+
+- Source specification types for describing where to fetch extensions
+- Catalog entry types for extension marketplaces
+- Generic installation management infrastructure
+- Fetching utilities for remote sources
+
+The types and utilities here are used by the plugin, skills, and marketplace
+modules to provide consistent behavior for extension management.
+
+Example:
+    >>> from openhands.sdk.extensions import ExtensionSource, InstalledExtensionManager
+    >>> source = ExtensionSource(source="github:owner/repo", ref="v1.0.0")
+"""
+
+from openhands.sdk.extensions.catalog import (
+    ExtensionAuthor,
+    ExtensionCatalogEntry,
+)
+from openhands.sdk.extensions.fetch import (
+    DEFAULT_CACHE_DIR,
+    ExtensionFetchError,
+    fetch_extension,
+    fetch_extension_with_resolution,
+    get_cache_path,
+    parse_extension_source,
+)
+from openhands.sdk.extensions.installed import (
+    InstalledExtensionInfo,
+    InstalledExtensionManager,
+    InstalledExtensionMetadata,
+)
+from openhands.sdk.extensions.source import (
+    ExtensionSource,
+    ResolvedExtensionSource,
+)
+
+
+__all__ = [
+    # Source types
+    "ExtensionSource",
+    "ResolvedExtensionSource",
+    # Catalog types
+    "ExtensionAuthor",
+    "ExtensionCatalogEntry",
+    # Installed extension management
+    "InstalledExtensionInfo",
+    "InstalledExtensionMetadata",
+    "InstalledExtensionManager",
+    # Fetching utilities
+    "ExtensionFetchError",
+    "fetch_extension",
+    "fetch_extension_with_resolution",
+    "parse_extension_source",
+    "get_cache_path",
+    "DEFAULT_CACHE_DIR",
+]

--- a/openhands-sdk/openhands/sdk/extensions/catalog.py
+++ b/openhands-sdk/openhands/sdk/extensions/catalog.py
@@ -1,0 +1,70 @@
+"""Extension catalog entry types.
+
+These types define entries in extension catalogs (marketplaces) that list
+available extensions with their metadata and source locations.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Self
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ExtensionAuthor(BaseModel):
+    """Author information for an extension."""
+
+    name: str = Field(description="Author's name")
+    email: str | None = Field(default=None, description="Author's email address")
+    url: str | None = Field(
+        default=None, description="Author's URL (e.g., GitHub profile)"
+    )
+
+    @classmethod
+    def from_string(cls, author_str: str) -> Self:
+        """Parse author from string format 'Name <email>'.
+
+        Examples:
+            >>> ExtensionAuthor.from_string("John Doe <john@example.com>")
+            ExtensionAuthor(name='John Doe', email='john@example.com', url=None)
+
+            >>> ExtensionAuthor.from_string("Jane Doe")
+            ExtensionAuthor(name='Jane Doe', email=None, url=None)
+        """
+        if "<" in author_str and ">" in author_str:
+            name = author_str.split("<")[0].strip()
+            email = author_str.split("<")[1].split(">")[0].strip()
+            return cls(name=name, email=email)
+        return cls(name=author_str.strip())
+
+
+class ExtensionCatalogEntry(BaseModel):
+    """Entry in an extension catalog (marketplace).
+
+    This is the base type for catalog entries that point to extensions
+    (plugins, skills, etc.) with their metadata and source locations.
+
+    Source is a string path that can be:
+    - Local path: "./path/to/extension", "/absolute/path"
+    - GitHub URL: "https://github.com/owner/repo/tree/branch/path"
+    """
+
+    name: str = Field(description="Identifier (kebab-case, no spaces)")
+    source: str = Field(description="Path to extension directory (local or GitHub URL)")
+    description: str | None = Field(default=None, description="Brief description")
+    version: str | None = Field(default=None, description="Version")
+    author: ExtensionAuthor | None = Field(default=None, description="Author info")
+    category: str | None = Field(default=None, description="Category for organization")
+    homepage: str | None = Field(
+        default=None, description="Homepage or documentation URL"
+    )
+
+    model_config = {"extra": "allow", "populate_by_name": True}
+
+    @field_validator("author", mode="before")
+    @classmethod
+    def _parse_author(cls, v: Any) -> Any:
+        """Parse author from string if needed."""
+        if isinstance(v, str):
+            return ExtensionAuthor.from_string(v)
+        return v

--- a/openhands-sdk/openhands/sdk/extensions/fetch.py
+++ b/openhands-sdk/openhands/sdk/extensions/fetch.py
@@ -1,0 +1,284 @@
+"""Extension fetching utilities for remote sources.
+
+This module provides the shared fetching infrastructure used by plugins,
+skills, and other installable extensions.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from openhands.sdk.git.cached_repo import GitHelper, try_cached_clone_or_update
+from openhands.sdk.git.utils import extract_repo_name, is_git_url, normalize_git_url
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+DEFAULT_CACHE_DIR = Path.home() / ".openhands" / "cache" / "extensions"
+
+
+class ExtensionFetchError(Exception):
+    """Raised when fetching an extension fails."""
+
+
+def parse_extension_source(source: str) -> tuple[str, str]:
+    """Parse extension source into (type, url).
+
+    Args:
+        source: Extension source string. Can be:
+            - "github:owner/repo" - GitHub repository shorthand
+            - "https://github.com/owner/repo.git" - Full git URL
+            - "git@github.com:owner/repo.git" - SSH git URL
+            - "/local/path" - Local path
+
+    Returns:
+        Tuple of (source_type, normalized_url) where source_type is one of:
+        - "github": GitHub repository
+        - "git": Any git URL
+        - "local": Local filesystem path
+
+    Raises:
+        ExtensionFetchError: If the source format is not recognized.
+
+    Examples:
+        >>> parse_extension_source("github:owner/repo")
+        ("github", "https://github.com/owner/repo.git")
+        >>> parse_extension_source("https://gitlab.com/org/repo.git")
+        ("git", "https://gitlab.com/org/repo.git")
+        >>> parse_extension_source("/local/path")
+        ("local", "/local/path")
+    """
+    source = source.strip()
+
+    # GitHub shorthand: github:owner/repo
+    if source.startswith("github:"):
+        repo_path = source[7:]  # Remove "github:" prefix
+        if "/" not in repo_path or repo_path.count("/") > 1:
+            raise ExtensionFetchError(
+                f"Invalid GitHub shorthand format: {source}. "
+                f"Expected format: github:owner/repo"
+            )
+        url = f"https://github.com/{repo_path}.git"
+        return ("github", url)
+
+    # Git URLs: detect by protocol/scheme rather than enumerating providers
+    if is_git_url(source):
+        url = normalize_git_url(source)
+        return ("git", url)
+
+    # Local path: starts with /, ~, . or contains / without a URL scheme
+    if source.startswith(("/", "~", ".")):
+        return ("local", source)
+
+    if "/" in source and "://" not in source:
+        # Relative path like "extensions/my-ext"
+        return ("local", source)
+
+    raise ExtensionFetchError(
+        f"Unable to parse extension source: {source}. "
+        f"Expected formats: 'github:owner/repo', git URL, or local path"
+    )
+
+
+def get_cache_path(source: str, cache_dir: Path | None = None) -> Path:
+    """Get the cache path for an extension source.
+
+    Creates a deterministic path based on a hash of the source URL.
+
+    Args:
+        source: The extension source (URL or path).
+        cache_dir: Base cache directory. Defaults to ~/.openhands/cache/extensions/
+
+    Returns:
+        Path where the extension should be cached.
+    """
+    if cache_dir is None:
+        cache_dir = DEFAULT_CACHE_DIR
+
+    source_hash = hashlib.sha256(source.encode()).hexdigest()[:16]
+    readable_name = extract_repo_name(source)
+    cache_name = f"{readable_name}-{source_hash}"
+    return cache_dir / cache_name
+
+
+def _resolve_local_source(url: str) -> Path:
+    """Resolve a local extension source to a path.
+
+    Args:
+        url: Local path string (may contain ~ for home directory).
+
+    Returns:
+        Resolved absolute path to the extension directory.
+
+    Raises:
+        ExtensionFetchError: If path doesn't exist.
+    """
+    local_path = Path(url).expanduser().resolve()
+    if not local_path.exists():
+        raise ExtensionFetchError(f"Local extension path does not exist: {local_path}")
+    return local_path
+
+
+def _apply_subpath(base_path: Path, subpath: str | None, context: str) -> Path:
+    """Apply a subpath to a base path, validating it exists.
+
+    Args:
+        base_path: The root path.
+        subpath: Optional subdirectory path (may have leading/trailing slashes).
+        context: Description for error messages (e.g., "extension repository").
+
+    Returns:
+        The final path (base_path if no subpath, otherwise base_path/subpath).
+
+    Raises:
+        ExtensionFetchError: If subpath doesn't exist.
+    """
+    if not subpath:
+        return base_path
+
+    final_path = base_path / subpath.strip("/")
+    if not final_path.exists():
+        raise ExtensionFetchError(f"Subdirectory '{subpath}' not found in {context}")
+    return final_path
+
+
+def _fetch_remote_source_with_resolution(
+    url: str,
+    cache_dir: Path,
+    ref: str | None,
+    update: bool,
+    subpath: str | None,
+    git_helper: GitHelper,
+    source: str,
+) -> tuple[Path, str]:
+    """Fetch a remote extension source and return path + resolved commit SHA.
+
+    Args:
+        url: Git URL to fetch.
+        cache_dir: Base directory for caching.
+        ref: Optional branch, tag, or commit to checkout.
+        update: Whether to update existing cache.
+        subpath: Optional subdirectory within the repository.
+        git_helper: GitHelper instance for git operations.
+        source: Original source string (for error messages).
+
+    Returns:
+        Tuple of (path, resolved_ref) where resolved_ref is the commit SHA.
+
+    Raises:
+        ExtensionFetchError: If fetching fails or subpath is invalid.
+    """
+    repo_cache_path = get_cache_path(url, cache_dir)
+    cache_dir.mkdir(parents=True, exist_ok=True)
+
+    result = try_cached_clone_or_update(
+        url=url,
+        repo_path=repo_cache_path,
+        ref=ref,
+        update=update,
+        git_helper=git_helper,
+    )
+
+    if result is None:
+        raise ExtensionFetchError(f"Failed to fetch extension from {source}")
+
+    # Get the actual commit SHA that was checked out
+    try:
+        resolved_ref = git_helper.get_head_commit(repo_cache_path)
+    except Exception as e:
+        logger.warning(f"Could not get commit SHA for {source}: {e}")
+        resolved_ref = ref or "HEAD"
+
+    final_path = _apply_subpath(repo_cache_path, subpath, "extension repository")
+    return final_path, resolved_ref
+
+
+def fetch_extension(
+    source: str,
+    cache_dir: Path | None = None,
+    ref: str | None = None,
+    update: bool = True,
+    repo_path: str | None = None,
+    git_helper: GitHelper | None = None,
+) -> Path:
+    """Fetch an extension from a source and return the local cached path.
+
+    Args:
+        source: Extension source - can be:
+            - Any git URL (GitHub, GitLab, Bitbucket, Codeberg, self-hosted, etc.)
+            - "github:owner/repo" - GitHub shorthand (convenience syntax)
+            - "/local/path" - Local path (returned as-is)
+        cache_dir: Directory for caching. Defaults to ~/.openhands/cache/extensions/
+        ref: Optional branch, tag, or commit to checkout.
+        update: If True and cache exists, update it. If False, use cached as-is.
+        repo_path: Subdirectory path within the git repository.
+        git_helper: GitHelper instance (for testing). Defaults to global instance.
+
+    Returns:
+        Path to the local extension directory.
+
+    Raises:
+        ExtensionFetchError: If fetching fails or repo_path doesn't exist.
+    """
+    path, _ = fetch_extension_with_resolution(
+        source=source,
+        cache_dir=cache_dir,
+        ref=ref,
+        update=update,
+        repo_path=repo_path,
+        git_helper=git_helper,
+    )
+    return path
+
+
+def fetch_extension_with_resolution(
+    source: str,
+    cache_dir: Path | None = None,
+    ref: str | None = None,
+    update: bool = True,
+    repo_path: str | None = None,
+    git_helper: GitHelper | None = None,
+) -> tuple[Path, str | None]:
+    """Fetch an extension and return both the path and resolved commit SHA.
+
+    This is similar to fetch_extension() but also returns the actual commit SHA
+    that was checked out. This is useful for persistence - storing the resolved
+    SHA ensures that conversation resume gets exactly the same version.
+
+    Args:
+        source: Extension source (see fetch_extension for formats).
+        cache_dir: Directory for caching. Defaults to ~/.openhands/cache/extensions/
+        ref: Optional branch, tag, or commit to checkout.
+        update: If True and cache exists, update it. If False, use cached as-is.
+        repo_path: Subdirectory path within the git repository.
+        git_helper: GitHelper instance (for testing). Defaults to global instance.
+
+    Returns:
+        Tuple of (path, resolved_ref) where:
+        - path: Path to the local extension directory
+        - resolved_ref: Commit SHA that was checked out (None for local sources)
+
+    Raises:
+        ExtensionFetchError: If fetching fails or repo_path doesn't exist.
+    """
+    source_type, url = parse_extension_source(source)
+
+    if source_type == "local":
+        if repo_path is not None:
+            raise ExtensionFetchError(
+                f"repo_path is not supported for local extension sources. "
+                f"Specify the full path directly instead of "
+                f"source='{source}' + repo_path='{repo_path}'"
+            )
+        return _resolve_local_source(url), None
+
+    if cache_dir is None:
+        cache_dir = DEFAULT_CACHE_DIR
+
+    git = git_helper if git_helper is not None else GitHelper()
+
+    return _fetch_remote_source_with_resolution(
+        url, cache_dir, ref, update, repo_path, git, source
+    )

--- a/openhands-sdk/openhands/sdk/extensions/installed.py
+++ b/openhands-sdk/openhands/sdk/extensions/installed.py
@@ -1,0 +1,537 @@
+"""Installed extension management.
+
+This module provides the generic infrastructure for managing installed extensions
+(plugins, skills, etc.) in a user's home directory.
+
+The installed extensions directory structure follows this pattern::
+
+    ~/.openhands/{type}/installed/
+    ├── extension-name-1/
+    │   └── ...
+    ├── extension-name-2/
+    │   └── ...
+    └── .installed.json  # Metadata about installed extensions
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from collections.abc import Callable
+from pathlib import Path
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk.extensions.fetch import fetch_extension_with_resolution
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+_METADATA_FILENAME = ".installed.json"
+
+
+class InstalledExtensionInfo(BaseModel):
+    """Common metadata for any installed extension.
+
+    This is the base class for tracking metadata about installed extensions.
+    Specific extension types (plugins, skills) can extend this with additional
+    fields while inheriting the common installation tracking fields.
+    """
+
+    name: str = Field(description="Extension name/identifier")
+    description: str = Field(default="", description="Extension description")
+    enabled: bool = Field(default=True, description="Whether the extension is enabled")
+    source: str = Field(description="Original source (e.g., 'github:owner/repo')")
+    resolved_ref: str | None = Field(
+        default=None,
+        description="Resolved git commit SHA (for version pinning)",
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description="Subdirectory path within the repository (for monorepos)",
+    )
+    installed_at: str = Field(description="ISO 8601 timestamp of installation")
+    install_path: str = Field(description="Path where the extension is installed")
+
+
+class InstalledExtensionMetadata[InfoT: InstalledExtensionInfo](BaseModel):
+    """Metadata file for tracking installed extensions.
+
+    This class manages the .installed.json file that tracks all installed
+    extensions in a directory.
+    """
+
+    items: dict[str, InfoT] = Field(
+        default_factory=dict,
+        description="Map of extension name to installation info",
+    )
+
+    @classmethod
+    def get_path(cls, installed_dir: Path) -> Path:
+        """Get the metadata file path for the given installed directory."""
+        return installed_dir / _METADATA_FILENAME
+
+    @classmethod
+    def load_from_dir(
+        cls,
+        installed_dir: Path,
+        info_type: type[InfoT],
+    ) -> InstalledExtensionMetadata[InfoT]:
+        """Load metadata from the installed directory.
+
+        Args:
+            installed_dir: Directory containing .installed.json
+            info_type: The Pydantic model class for individual info entries
+
+        Returns:
+            Loaded metadata instance, or empty metadata if file doesn't exist.
+        """
+        metadata_path = cls.get_path(installed_dir)
+        if not metadata_path.exists():
+            return cls()
+        try:
+            with open(metadata_path) as f:
+                data = json.load(f)
+            # Support both new format ("items") and legacy formats ("plugins", "skills")
+            items_data = data.get("items") or data.get("plugins") or data.get("skills")
+            if items_data is None:
+                items_data = {}
+            # Validate each item with the specific info type
+            items = {
+                name: info_type.model_validate(info_data)
+                for name, info_data in items_data.items()
+            }
+            return cls(items=items)
+        except Exception as e:
+            logger.warning(f"Failed to load installed extensions metadata: {e}")
+            return cls()
+
+    def save_to_dir(self, installed_dir: Path) -> None:
+        """Save metadata to the installed directory."""
+        metadata_path = self.get_path(installed_dir)
+        metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        # Serialize items using model_dump for each
+        data = {"items": {name: info.model_dump() for name, info in self.items.items()}}
+        with open(metadata_path, "w") as f:
+            json.dump(data, f, indent=2)
+
+
+class InstalledExtensionManager[ItemT, InfoT: InstalledExtensionInfo]:
+    """Generic manager for installed extensions.
+
+    This class provides all the common operations for managing installed
+    extensions: install, uninstall, list, load, enable, disable, update.
+
+    Type Parameters:
+        ItemT: The loaded extension type (e.g., Plugin, Skill)
+        InfoT: The installation info type (must extend InstalledExtensionInfo)
+
+    Example:
+        >>> manager = InstalledExtensionManager[Plugin, InstalledPluginInfo](
+        ...     default_dir=Path.home() / ".openhands" / "plugins" / "installed",
+        ...     validate_name=validate_plugin_name,
+        ...     load_item=Plugin.load,
+        ...     create_info=InstalledPluginInfo.from_plugin,
+        ...     info_type=InstalledPluginInfo,
+        ... )
+        >>> info = manager.install("github:owner/my-plugin")
+    """
+
+    def __init__(
+        self,
+        default_dir: Path,
+        validate_name: Callable[[str], None],
+        load_item: Callable[[Path], ItemT],
+        create_info: Callable[[ItemT, str, str | None, str | None, Path], InfoT],
+        info_type: type[InfoT],
+        get_item_name: Callable[[ItemT], str] | None = None,
+    ) -> None:
+        """Initialize the extension manager.
+
+        Args:
+            default_dir: Default directory for installed extensions.
+            validate_name: Function to validate extension names (raises on invalid).
+            load_item: Function to load an extension from a path.
+            create_info: Function to create InstalledInfo from a loaded item.
+                Signature: (item, source, resolved_ref, repo_path, path) -> InfoT
+            info_type: The Pydantic model class for installation info.
+            get_item_name: Optional function to get name from loaded item.
+                If None, assumes item has a .name attribute.
+        """
+        self._default_dir = default_dir
+        self._validate_name = validate_name
+        self._load_item = load_item
+        self._create_info = create_info
+        self._info_type = info_type
+        self._get_item_name = get_item_name or (lambda item: item.name)  # type: ignore[attr-defined]
+
+    def _resolve_dir(self, installed_dir: Path | None) -> Path:
+        """Return installed_dir or the default if None."""
+        return installed_dir if installed_dir is not None else self._default_dir
+
+    def _load_metadata(self, installed_dir: Path) -> InstalledExtensionMetadata[InfoT]:
+        """Load metadata from directory."""
+        return InstalledExtensionMetadata.load_from_dir(installed_dir, self._info_type)
+
+    def install(
+        self,
+        source: str,
+        ref: str | None = None,
+        repo_path: str | None = None,
+        installed_dir: Path | None = None,
+        force: bool = False,
+    ) -> InfoT:
+        """Install an extension from a source.
+
+        Fetches the extension from the source, copies it to the installed
+        directory, and records the installation metadata.
+
+        Args:
+            source: Extension source (GitHub shorthand, git URL, or local path).
+            ref: Optional branch, tag, or commit to install.
+            repo_path: Subdirectory path within the repository (for monorepos).
+            installed_dir: Directory for installed extensions. Uses default if None.
+            force: If True, overwrite existing installation.
+
+        Returns:
+            Installation info for the installed extension.
+
+        Raises:
+            ExtensionFetchError: If fetching the extension fails.
+            FileExistsError: If extension is already installed and force=False.
+            ValueError: If the extension name is invalid.
+        """
+        installed_dir = self._resolve_dir(installed_dir)
+
+        logger.info(f"Fetching extension from {source}")
+        fetched_path, resolved_ref = fetch_extension_with_resolution(
+            source=source,
+            ref=ref,
+            repo_path=repo_path,
+            update=True,
+        )
+
+        item = self._load_item(fetched_path)
+        item_name = self._get_item_name(item)
+        self._validate_name(item_name)
+
+        install_path = installed_dir / item_name
+        if install_path.exists() and not force:
+            raise FileExistsError(
+                f"Extension '{item_name}' is already installed at {install_path}. "
+                "Use force=True to overwrite."
+            )
+
+        if install_path.exists():
+            logger.info(f"Removing existing installation of '{item_name}'")
+            shutil.rmtree(install_path)
+
+        logger.info(f"Installing extension '{item_name}' to {install_path}")
+        installed_dir.mkdir(parents=True, exist_ok=True)
+        shutil.copytree(fetched_path, install_path)
+
+        info = self._create_info(item, source, resolved_ref, repo_path, install_path)
+
+        metadata = self._load_metadata(installed_dir)
+        existing_info = metadata.items.get(item_name)
+        if existing_info is not None:
+            # Preserve enabled state from previous installation
+            info.enabled = existing_info.enabled
+        metadata.items[item_name] = info
+        metadata.save_to_dir(installed_dir)
+
+        logger.info(f"Successfully installed extension '{item_name}'")
+        return info
+
+    def uninstall(
+        self,
+        name: str,
+        installed_dir: Path | None = None,
+    ) -> bool:
+        """Uninstall an extension by name.
+
+        Only extensions tracked in the metadata file can be uninstalled.
+
+        Args:
+            name: Name of the extension to uninstall.
+            installed_dir: Directory for installed extensions. Uses default if None.
+
+        Returns:
+            True if uninstalled successfully, False if not found.
+        """
+        self._validate_name(name)
+        installed_dir = self._resolve_dir(installed_dir)
+
+        metadata = self._load_metadata(installed_dir)
+        if name not in metadata.items:
+            logger.warning(f"Extension '{name}' is not tracked in metadata")
+            return False
+
+        extension_path = installed_dir / name
+        if extension_path.exists():
+            logger.info(f"Removing extension directory: {extension_path}")
+            shutil.rmtree(extension_path)
+
+        del metadata.items[name]
+        metadata.save_to_dir(installed_dir)
+
+        logger.info(f"Successfully uninstalled extension '{name}'")
+        return True
+
+    def list_installed(
+        self,
+        installed_dir: Path | None = None,
+    ) -> list[InfoT]:
+        """List all installed extensions.
+
+        This function is self-healing: it may update the metadata file to remove
+        entries whose directories were deleted, and to add entries for directories
+        that were manually copied into the installed dir.
+
+        Args:
+            installed_dir: Directory for installed extensions. Uses default if None.
+
+        Returns:
+            List of installation info for each installed extension.
+        """
+        installed_dir = self._resolve_dir(installed_dir)
+
+        if not installed_dir.exists():
+            return []
+
+        metadata = self._load_metadata(installed_dir)
+
+        valid_items, tracked_changed = self._validate_tracked(metadata, installed_dir)
+        discovered, discovered_changed = self._discover_untracked(
+            metadata, installed_dir
+        )
+
+        if tracked_changed or discovered_changed:
+            metadata.save_to_dir(installed_dir)
+
+        return valid_items + discovered
+
+    def load_installed(
+        self,
+        installed_dir: Path | None = None,
+    ) -> list[ItemT]:
+        """Load all installed and enabled extensions.
+
+        Args:
+            installed_dir: Directory for installed extensions. Uses default if None.
+
+        Returns:
+            List of loaded extension objects.
+        """
+        installed_dir = self._resolve_dir(installed_dir)
+
+        if not installed_dir.exists():
+            return []
+
+        installed_infos = self.list_installed(installed_dir)
+        items: list[ItemT] = []
+
+        for info in installed_infos:
+            if not info.enabled:
+                continue
+            item_path = installed_dir / info.name
+            if item_path.exists():
+                try:
+                    items.append(self._load_item(item_path))
+                except Exception as e:
+                    logger.warning(f"Failed to load extension '{info.name}': {e}")
+
+        return items
+
+    def get(
+        self,
+        name: str,
+        installed_dir: Path | None = None,
+    ) -> InfoT | None:
+        """Get information about a specific installed extension.
+
+        Args:
+            name: Name of the extension to look up.
+            installed_dir: Directory for installed extensions. Uses default if None.
+
+        Returns:
+            Installation info if the extension is installed, None otherwise.
+        """
+        self._validate_name(name)
+        installed_dir = self._resolve_dir(installed_dir)
+
+        metadata = self._load_metadata(installed_dir)
+        info = metadata.items.get(name)
+
+        if info is not None:
+            extension_path = installed_dir / name
+            if not extension_path.exists():
+                return None
+
+        return info
+
+    def enable(
+        self,
+        name: str,
+        installed_dir: Path | None = None,
+    ) -> bool:
+        """Enable an installed extension."""
+        return self._set_enabled(name, True, installed_dir)
+
+    def disable(
+        self,
+        name: str,
+        installed_dir: Path | None = None,
+    ) -> bool:
+        """Disable an installed extension."""
+        return self._set_enabled(name, False, installed_dir)
+
+    def _set_enabled(
+        self,
+        name: str,
+        enabled: bool,
+        installed_dir: Path | None,
+    ) -> bool:
+        """Set the enabled state of an extension."""
+        self._validate_name(name)
+        installed_dir = self._resolve_dir(installed_dir)
+
+        metadata = self._load_metadata(installed_dir)
+        if name not in metadata.items:
+            logger.warning(f"Extension '{name}' is not installed")
+            return False
+
+        metadata.items[name].enabled = enabled
+        metadata.save_to_dir(installed_dir)
+
+        state = "enabled" if enabled else "disabled"
+        logger.info(f"Extension '{name}' is now {state}")
+        return True
+
+    def update(
+        self,
+        name: str,
+        installed_dir: Path | None = None,
+    ) -> InfoT | None:
+        """Update an installed extension to the latest version.
+
+        Re-fetches the extension from its original source and reinstalls it.
+
+        Args:
+            name: Name of the extension to update.
+            installed_dir: Directory for installed extensions. Uses default if None.
+
+        Returns:
+            Updated installation info if successful, None if not installed.
+        """
+        self._validate_name(name)
+        installed_dir = self._resolve_dir(installed_dir)
+
+        current_info = self.get(name, installed_dir)
+        if current_info is None:
+            logger.warning(f"Extension '{name}' is not installed")
+            return None
+
+        logger.info(f"Updating extension '{name}' from {current_info.source}")
+        return self.install(
+            source=current_info.source,
+            ref=None,  # Get latest (don't use pinned ref)
+            repo_path=current_info.repo_path,
+            installed_dir=installed_dir,
+            force=True,
+        )
+
+    def _validate_tracked(
+        self,
+        metadata: InstalledExtensionMetadata[InfoT],
+        installed_dir: Path,
+    ) -> tuple[list[InfoT], bool]:
+        """Validate tracked extensions exist on disk.
+
+        Returns:
+            Tuple of (valid extensions list, whether metadata was modified).
+        """
+        valid_items: list[InfoT] = []
+        changed = False
+
+        for name in list(metadata.items.keys()):
+            try:
+                self._validate_name(name)
+            except ValueError as e:
+                logger.warning(
+                    f"Invalid tracked extension name {name!r}, removing: {e}"
+                )
+                del metadata.items[name]
+                changed = True
+                continue
+
+            extension_path = installed_dir / name
+            if extension_path.exists():
+                valid_items.append(metadata.items[name])
+            else:
+                logger.warning(
+                    f"Extension '{name}' directory missing, removing from metadata"
+                )
+                del metadata.items[name]
+                changed = True
+
+        return valid_items, changed
+
+    def _discover_untracked(
+        self,
+        metadata: InstalledExtensionMetadata[InfoT],
+        installed_dir: Path,
+    ) -> tuple[list[InfoT], bool]:
+        """Discover extension directories not tracked in metadata.
+
+        Returns:
+            Tuple of (discovered extensions list, whether metadata was modified).
+        """
+        discovered: list[InfoT] = []
+        changed = False
+
+        for item in installed_dir.iterdir():
+            if not item.is_dir() or item.name.startswith("."):
+                continue
+            if item.name in metadata.items:
+                continue
+
+            try:
+                self._validate_name(item.name)
+            except ValueError:
+                logger.debug(f"Skipping directory with invalid extension name: {item}")
+                continue
+
+            try:
+                loaded_item = self._load_item(item)
+            except Exception as e:
+                logger.debug(f"Skipping directory {item}: {e}")
+                continue
+
+            item_name = self._get_item_name(loaded_item)
+            if item_name != item.name:
+                logger.warning(
+                    "Skipping extension directory because name doesn't match: "
+                    f"dir={item.name!r}, extension={item_name!r}"
+                )
+                continue
+
+            info = self._create_info(
+                loaded_item,
+                "local",  # Unknown source, assume local
+                None,  # No resolved ref
+                None,  # No repo path
+                item,
+            )
+            discovered.append(info)
+            metadata.items[item.name] = info
+            changed = True
+            logger.info(f"Discovered untracked extension: {item_name}")
+
+        return discovered, changed
+
+    @property
+    def default_dir(self) -> Path:
+        """Get the default installation directory."""
+        return self._default_dir

--- a/openhands-sdk/openhands/sdk/extensions/source.py
+++ b/openhands-sdk/openhands/sdk/extensions/source.py
@@ -1,0 +1,156 @@
+"""Extension source specification types.
+
+These types define where to fetch an extension (plugin, skill, etc.) from,
+supporting GitHub shorthand, git URLs, and local paths.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Self
+
+from pydantic import BaseModel, Field, field_validator
+
+
+class ExtensionSource(BaseModel):
+    """Specification for where to fetch an extension.
+
+    Supports multiple source formats:
+    - GitHub shorthand: "github:owner/repo"
+    - Git URLs: "https://github.com/owner/repo.git", "git@github.com:owner/repo.git"
+    - Local paths: "/path/to/extension", "./relative/path"
+
+    Examples:
+        >>> ExtensionSource(source="github:owner/repo", ref="v1.0.0")
+        >>> ExtensionSource(
+        ...     source="github:owner/monorepo",
+        ...     repo_path="extensions/my-ext",
+        ... )
+        >>> ExtensionSource(source="/path/to/extension")
+    """
+
+    source: str = Field(
+        description="Extension source: 'github:owner/repo', any git URL, or local path"
+    )
+    ref: str | None = Field(
+        default=None,
+        description="Optional branch, tag, or commit (only for git sources)",
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description=(
+            "Subdirectory path within the git repository "
+            "(e.g., 'extensions/my-ext' for monorepos). "
+            "Only relevant for git sources, not local paths."
+        ),
+    )
+
+    @field_validator("repo_path")
+    @classmethod
+    def validate_repo_path(cls, v: str | None) -> str | None:
+        """Validate repo_path is a safe relative path within the repository."""
+        if v is None:
+            return v
+        if v.startswith("/"):
+            raise ValueError("repo_path must be relative, not absolute")
+        if ".." in Path(v).parts:
+            raise ValueError(
+                "repo_path cannot contain '..' (parent directory traversal)"
+            )
+        return v
+
+    @property
+    def source_url(self) -> str | None:
+        """Convert the extension source to a canonical URL.
+
+        Converts the 'github:' convenience prefix to a full URL.
+        For sources that are already URLs, returns them directly.
+        Local paths return None (not portable).
+
+        Returns:
+            URL string, or None for local paths.
+
+        Examples:
+            >>> ExtensionSource(source="github:owner/repo").source_url
+            'https://github.com/owner/repo'
+
+            >>> ExtensionSource(source="github:owner/repo", ref="v1.0").source_url
+            'https://github.com/owner/repo/tree/v1.0'
+
+            >>> ExtensionSource(source="https://github.com/owner/repo").source_url
+            'https://github.com/owner/repo'
+
+            >>> ExtensionSource(source="/local/path").source_url
+            None
+        """
+        if self.source.startswith("github:"):
+            repo_part = self.source[7:]  # Remove 'github:' prefix
+            base_url = f"https://github.com/{repo_part}"
+            if self.ref or self.repo_path:
+                ref = self.ref or "main"
+                if self.repo_path:
+                    return f"{base_url}/tree/{ref}/{self.repo_path}"
+                return f"{base_url}/tree/{ref}"
+            return base_url
+
+        if self.source.startswith(("https://", "http://", "git@", "git://")):
+            return self.source
+
+        return None
+
+
+class ResolvedExtensionSource(BaseModel):
+    """An extension source with resolved ref (pinned to commit SHA).
+
+    Used for persistence to ensure deterministic behavior across pause/resume.
+    When a conversation is resumed, the resolved ref ensures we get exactly
+    the same extension version that was used when the conversation started.
+
+    The resolved_ref is the actual commit SHA that was fetched, even if the
+    original ref was a branch name like 'main'. This prevents drift when
+    branches are updated between pause and resume.
+    """
+
+    source: str = Field(
+        description="Extension source: 'github:owner/repo', any git URL, or local path"
+    )
+    resolved_ref: str | None = Field(
+        default=None,
+        description=(
+            "Resolved commit SHA (for git sources). None for local paths. "
+            "This is the actual commit that was checked out, even if the "
+            "original ref was a branch name."
+        ),
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description="Subdirectory path within the git repository",
+    )
+    original_ref: str | None = Field(
+        default=None,
+        description="Original ref from ExtensionSource (for debugging/display)",
+    )
+
+    @classmethod
+    def from_source(
+        cls, extension_source: ExtensionSource, resolved_ref: str | None
+    ) -> Self:
+        """Create a ResolvedExtensionSource from an ExtensionSource and resolved ref."""
+        return cls(
+            source=extension_source.source,
+            resolved_ref=resolved_ref,
+            repo_path=extension_source.repo_path,
+            original_ref=extension_source.ref,
+        )
+
+    def to_source(self) -> ExtensionSource:
+        """Convert back to ExtensionSource using the resolved ref.
+
+        When loading from persistence, use the resolved_ref to ensure we get
+        the exact same version that was originally fetched.
+        """
+        return ExtensionSource(
+            source=self.source,
+            ref=self.resolved_ref,  # Use resolved SHA, not original ref
+            repo_path=self.repo_path,
+        )

--- a/openhands-sdk/openhands/sdk/plugin/installed.py
+++ b/openhands-sdk/openhands/sdk/plugin/installed.py
@@ -18,35 +18,24 @@ The installed plugins directory structure follows the Claude Code pattern::
 
 from __future__ import annotations
 
-import json
 import re
-import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
-from openhands.sdk.logger import get_logger
-from openhands.sdk.plugin.fetch import (
-    fetch_plugin_with_resolution,
+from openhands.sdk.extensions import (
+    InstalledExtensionInfo,
+    InstalledExtensionManager,
+    InstalledExtensionMetadata,
 )
 from openhands.sdk.plugin.plugin import Plugin
 
 
-logger = get_logger(__name__)
-
 # Default directory for installed plugins
 DEFAULT_INSTALLED_PLUGINS_DIR = Path.home() / ".openhands" / "plugins" / "installed"
 
-# Metadata file for tracking installed plugins
-_METADATA_FILENAME = ".installed.json"
-
 _PLUGIN_NAME_PATTERN = re.compile(r"^[a-z0-9]+(?:-[a-z0-9]+)*$")
-
-
-def _resolve_installed_dir(installed_dir: Path | None) -> Path:
-    """Return installed_dir or the default if None."""
-    return installed_dir if installed_dir is not None else DEFAULT_INSTALLED_PLUGINS_DIR
 
 
 def get_installed_plugins_dir() -> Path:
@@ -69,32 +58,16 @@ def _validate_plugin_name(name: str) -> None:
         )
 
 
-class InstalledPluginInfo(BaseModel):
+class InstalledPluginInfo(InstalledExtensionInfo):
     """Information about an installed plugin.
 
     This model tracks metadata about a plugin installation, including
     where it was installed from and when.
+
+    Extends InstalledExtensionInfo with plugin-specific fields.
     """
 
-    name: str = Field(description="Plugin name (from manifest)")
     version: str = Field(default="1.0.0", description="Plugin version")
-    description: str = Field(default="", description="Plugin description")
-    enabled: bool = Field(default=True, description="Whether the plugin is enabled")
-    source: str = Field(description="Original source (e.g., 'github:owner/repo')")
-    resolved_ref: str | None = Field(
-        default=None,
-        description="Resolved git commit SHA (for version pinning)",
-    )
-    repo_path: str | None = Field(
-        default=None,
-        description="Subdirectory path within the repository (for monorepos)",
-    )
-    installed_at: str = Field(
-        description="ISO 8601 timestamp of installation",
-    )
-    install_path: str = Field(
-        description="Path where the plugin is installed",
-    )
 
     @classmethod
     def from_plugin(
@@ -118,39 +91,84 @@ class InstalledPluginInfo(BaseModel):
         )
 
 
-class InstalledPluginsMetadata(BaseModel):
-    """Metadata file for tracking all installed plugins."""
+# For backward compatibility, provide InstalledPluginsMetadata as a wrapper
+# around InstalledExtensionMetadata.
+class InstalledPluginsMetadata(InstalledExtensionMetadata[InstalledPluginInfo]):
+    """Metadata file for tracking all installed plugins.
 
-    plugins: dict[str, InstalledPluginInfo] = Field(
-        default_factory=dict,
-        description="Map of plugin name to installation info",
-    )
+    This class wraps InstalledExtensionMetadata for backward compatibility.
+    New code should use the InstalledExtensionManager instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        items: dict[str, InstalledPluginInfo] | None = None,
+        plugins: dict[str, InstalledPluginInfo] | None = None,
+    ) -> None:
+        """Initialize with either items or plugins keyword argument."""
+        # Support both 'items' (new) and 'plugins' (legacy) kwarg
+        data = items if items is not None else (plugins or {})
+        super().__init__(items=data)
+
+    # Alias 'items' as 'plugins' for backward compatibility
+    @property
+    def plugins(self) -> dict[str, InstalledPluginInfo]:
+        """Get installed plugins (alias for items)."""
+        return self.items
+
+    @plugins.setter
+    def plugins(self, value: dict[str, InstalledPluginInfo]) -> None:
+        """Set installed plugins (alias for items)."""
+        self.items = value
 
     @classmethod
-    def get_path(cls, installed_dir: Path) -> Path:
-        """Get the metadata file path for the given installed plugins directory."""
-        return installed_dir / _METADATA_FILENAME
-
-    @classmethod
-    def load_from_dir(cls, installed_dir: Path) -> InstalledPluginsMetadata:
+    def load_from_dir(  # type: ignore[override]
+        cls, installed_dir: Path
+    ) -> InstalledPluginsMetadata:
         """Load metadata from the installed plugins directory."""
-        metadata_path = cls.get_path(installed_dir)
-        if not metadata_path.exists():
-            return cls()
-        try:
-            with open(metadata_path) as f:
-                data = json.load(f)
-            return cls.model_validate(data)
-        except Exception as e:
-            logger.warning(f"Failed to load installed plugins metadata: {e}")
-            return cls()
+        base = InstalledExtensionMetadata.load_from_dir(
+            installed_dir, InstalledPluginInfo
+        )
+        return cls(items=base.items)
 
     def save_to_dir(self, installed_dir: Path) -> None:
-        """Save metadata to the installed plugins directory."""
+        """Save metadata to the installed plugins directory (legacy format)."""
+        import json
+
         metadata_path = self.get_path(installed_dir)
         metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        # Use "plugins" key for backward compatibility
+        data = {
+            "plugins": {name: info.model_dump() for name, info in self.items.items()}
+        }
         with open(metadata_path, "w") as f:
-            json.dump(self.model_dump(), f, indent=2)
+            json.dump(data, f, indent=2)
+
+
+def _create_plugin_info(
+    plugin: Plugin,
+    source: str,
+    resolved_ref: str | None,
+    repo_path: str | None,
+    install_path: Path,
+) -> InstalledPluginInfo:
+    """Create InstalledPluginInfo from a loaded Plugin (for manager callback)."""
+    return InstalledPluginInfo.from_plugin(
+        plugin, source, resolved_ref, repo_path, install_path
+    )
+
+
+# Create the plugin manager instance
+_plugin_manager: InstalledExtensionManager[Plugin, InstalledPluginInfo] = (
+    InstalledExtensionManager(
+        default_dir=DEFAULT_INSTALLED_PLUGINS_DIR,
+        validate_name=_validate_plugin_name,
+        load_item=Plugin.load,
+        create_info=_create_plugin_info,
+        info_type=InstalledPluginInfo,
+    )
+)
 
 
 def install_plugin(
@@ -189,59 +207,13 @@ def install_plugin(
         >>> info = install_plugin("github:owner/my-plugin", ref="v1.0.0")
         >>> print(f"Installed {info.name} from {info.source}")
     """
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    # Fetch the plugin (downloads to cache if remote)
-    logger.info(f"Fetching plugin from {source}")
-    fetched_path, resolved_ref = fetch_plugin_with_resolution(
+    return _plugin_manager.install(
         source=source,
         ref=ref,
         repo_path=repo_path,
-        update=True,
+        installed_dir=installed_dir,
+        force=force,
     )
-
-    # Load the plugin to get its metadata
-    plugin = Plugin.load(fetched_path)
-    plugin_name = plugin.name
-    _validate_plugin_name(plugin_name)
-
-    # Check if already installed
-    install_path = installed_dir / plugin_name
-    if install_path.exists() and not force:
-        raise FileExistsError(
-            f"Plugin '{plugin_name}' is already installed at {install_path}. "
-            f"Use force=True to overwrite."
-        )
-
-    # Remove existing installation if force=True
-    if install_path.exists():
-        logger.info(f"Removing existing installation of '{plugin_name}'")
-        shutil.rmtree(install_path)
-
-    # Copy plugin to installed directory
-    logger.info(f"Installing plugin '{plugin_name}' to {install_path}")
-    installed_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(fetched_path, install_path)
-
-    # Create installation info
-    info = InstalledPluginInfo.from_plugin(
-        plugin=plugin,
-        source=source,
-        resolved_ref=resolved_ref,
-        repo_path=repo_path,
-        install_path=install_path,
-    )
-
-    # Update metadata
-    metadata = InstalledPluginsMetadata.load_from_dir(installed_dir)
-    existing_info = metadata.plugins.get(plugin_name)
-    if existing_info is not None:
-        info.enabled = existing_info.enabled
-    metadata.plugins[plugin_name] = info
-    metadata.save_to_dir(installed_dir)
-
-    logger.info(f"Successfully installed plugin '{plugin_name}' v{plugin.version}")
-    return info
 
 
 def uninstall_plugin(
@@ -267,65 +239,7 @@ def uninstall_plugin(
         ... else:
         ...     print("Plugin was not installed")
     """
-    _validate_plugin_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    metadata = InstalledPluginsMetadata.load_from_dir(installed_dir)
-    if name not in metadata.plugins:
-        logger.warning(f"Plugin '{name}' is not installed")
-        return False
-
-    plugin_path = installed_dir / name
-    if plugin_path.exists():
-        logger.info(f"Uninstalling plugin '{name}' from {plugin_path}")
-        shutil.rmtree(plugin_path)
-    else:
-        logger.warning(
-            f"Plugin '{name}' was tracked but its directory is missing: {plugin_path}"
-        )
-
-    del metadata.plugins[name]
-    metadata.save_to_dir(installed_dir)
-
-    logger.info(f"Successfully uninstalled plugin '{name}'")
-    return True
-
-
-def _set_plugin_enabled(
-    name: str,
-    enabled: bool,
-    installed_dir: Path | None = None,
-) -> bool:
-    _validate_plugin_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    if not installed_dir.exists():
-        logger.warning(f"Installed plugins directory does not exist: {installed_dir}")
-        return False
-
-    metadata, _ = _sync_installed_plugins_metadata(installed_dir)
-    info = metadata.plugins.get(name)
-    if info is None:
-        logger.warning(f"Plugin '{name}' is not installed")
-        return False
-
-    plugin_path = installed_dir / name
-    if not plugin_path.exists():
-        logger.warning(
-            f"Plugin '{name}' was tracked but its directory is missing: {plugin_path}"
-        )
-        return False
-
-    if info.enabled == enabled:
-        return True
-
-    info.enabled = enabled
-    metadata.plugins[name] = info
-    metadata.save_to_dir(installed_dir)
-
-    state = "enabled" if enabled else "disabled"
-    logger.info(f"Successfully {state} plugin '{name}'")
-    return True
+    return _plugin_manager.uninstall(name=name, installed_dir=installed_dir)
 
 
 def enable_plugin(
@@ -333,7 +247,7 @@ def enable_plugin(
     installed_dir: Path | None = None,
 ) -> bool:
     """Enable an installed plugin by name."""
-    return _set_plugin_enabled(name, True, installed_dir)
+    return _plugin_manager.enable(name=name, installed_dir=installed_dir)
 
 
 def disable_plugin(
@@ -341,106 +255,7 @@ def disable_plugin(
     installed_dir: Path | None = None,
 ) -> bool:
     """Disable an installed plugin by name."""
-    return _set_plugin_enabled(name, False, installed_dir)
-
-
-def _validate_tracked_plugins(
-    metadata: InstalledPluginsMetadata, installed_dir: Path
-) -> tuple[list[InstalledPluginInfo], bool]:
-    """Validate tracked plugins exist on disk.
-
-    Returns:
-        Tuple of (valid plugins list, whether metadata was modified).
-    """
-    valid_plugins: list[InstalledPluginInfo] = []
-    changed = False
-
-    for name, info in list(metadata.plugins.items()):
-        try:
-            _validate_plugin_name(name)
-        except ValueError as e:
-            logger.warning(f"Invalid tracked plugin name {name!r}, removing: {e}")
-            del metadata.plugins[name]
-            changed = True
-            continue
-
-        plugin_path = installed_dir / name
-        if plugin_path.exists():
-            valid_plugins.append(info)
-        else:
-            logger.warning(f"Plugin '{name}' directory missing, removing from metadata")
-            del metadata.plugins[name]
-            changed = True
-
-    return valid_plugins, changed
-
-
-def _discover_untracked_plugins(
-    metadata: InstalledPluginsMetadata, installed_dir: Path
-) -> tuple[list[InstalledPluginInfo], bool]:
-    """Discover plugin directories not tracked in metadata.
-
-    Returns:
-        Tuple of (discovered plugins list, whether metadata was modified).
-    """
-    discovered: list[InstalledPluginInfo] = []
-    changed = False
-
-    for item in installed_dir.iterdir():
-        if not item.is_dir() or item.name.startswith("."):
-            continue
-        if item.name in metadata.plugins:
-            continue
-
-        try:
-            _validate_plugin_name(item.name)
-        except ValueError:
-            logger.debug(f"Skipping directory with invalid plugin name: {item}")
-            continue
-
-        try:
-            plugin = Plugin.load(item)
-        except Exception as e:
-            logger.debug(f"Skipping directory {item}: {e}")
-            continue
-
-        if plugin.name != item.name:
-            logger.warning(
-                "Skipping plugin directory because manifest name doesn't match "
-                f"directory name: dir={item.name!r}, manifest={plugin.name!r}"
-            )
-            continue
-
-        info = InstalledPluginInfo(
-            name=plugin.name,
-            version=plugin.version,
-            description=plugin.description,
-            source="local",
-            installed_at=datetime.now(UTC).isoformat(),
-            install_path=str(item),
-        )
-        discovered.append(info)
-        metadata.plugins[item.name] = info
-        changed = True
-        logger.info(f"Discovered untracked plugin: {plugin.name}")
-
-    return discovered, changed
-
-
-def _sync_installed_plugins_metadata(
-    installed_dir: Path,
-) -> tuple[InstalledPluginsMetadata, list[InstalledPluginInfo]]:
-    """Sync installed plugins metadata with on-disk plugin directories."""
-    metadata = InstalledPluginsMetadata.load_from_dir(installed_dir)
-    valid_plugins, tracked_changed = _validate_tracked_plugins(metadata, installed_dir)
-    discovered, discovered_changed = _discover_untracked_plugins(
-        metadata, installed_dir
-    )
-
-    if tracked_changed or discovered_changed:
-        metadata.save_to_dir(installed_dir)
-
-    return metadata, valid_plugins + discovered
+    return _plugin_manager.disable(name=name, installed_dir=installed_dir)
 
 
 def list_installed_plugins(
@@ -463,13 +278,7 @@ def list_installed_plugins(
         >>> for info in list_installed_plugins():
         ...     print(f"{info.name} v{info.version} - {info.description}")
     """
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    if not installed_dir.exists():
-        return []
-
-    _, plugins = _sync_installed_plugins_metadata(installed_dir)
-    return plugins
+    return _plugin_manager.list_installed(installed_dir=installed_dir)
 
 
 def load_installed_plugins(
@@ -492,20 +301,7 @@ def load_installed_plugins(
         >>> for plugin in plugins:
         ...     print(f"Loaded {plugin.name} with {len(plugin.skills)} skills")
     """
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    if not installed_dir.exists():
-        return []
-
-    installed_infos = list_installed_plugins(installed_dir)
-    plugins: list[Plugin] = []
-    for info in installed_infos:
-        if not info.enabled:
-            continue
-        plugin_path = installed_dir / info.name
-        if plugin_path.exists():
-            plugins.append(Plugin.load(plugin_path))
-    return plugins
+    return _plugin_manager.load_installed(installed_dir=installed_dir)
 
 
 def get_installed_plugin(
@@ -527,19 +323,7 @@ def get_installed_plugin(
         >>> if info:
         ...     print(f"Installed from {info.source} at {info.installed_at}")
     """
-    _validate_plugin_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    metadata = InstalledPluginsMetadata.load_from_dir(installed_dir)
-    info = metadata.plugins.get(name)
-
-    # Verify the plugin directory still exists
-    if info is not None:
-        plugin_path = installed_dir / name
-        if not plugin_path.exists():
-            return None
-
-    return info
+    return _plugin_manager.get(name=name, installed_dir=installed_dir)
 
 
 def update_plugin(
@@ -569,21 +353,4 @@ def update_plugin(
         >>> if info:
         ...     print(f"Updated to v{info.version}")
     """
-    _validate_plugin_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    # Get current installation info
-    current_info = get_installed_plugin(name, installed_dir)
-    if current_info is None:
-        logger.warning(f"Plugin '{name}' is not installed")
-        return None
-
-    # Re-install from the original source
-    logger.info(f"Updating plugin '{name}' from {current_info.source}")
-    return install_plugin(
-        source=current_info.source,
-        ref=None,  # Get latest (don't use pinned ref)
-        repo_path=current_info.repo_path,
-        installed_dir=installed_dir,
-        force=True,
-    )
+    return _plugin_manager.update(name=name, installed_dir=installed_dir)

--- a/openhands-sdk/openhands/sdk/plugin/types.py
+++ b/openhands-sdk/openhands/sdk/plugin/types.py
@@ -3,13 +3,17 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Self
 
 import frontmatter
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field
+
+from openhands.sdk.extensions import ExtensionAuthor, ExtensionSource
 
 
-class PluginSource(BaseModel):
+# PluginSource is an alias for ExtensionSource for backward compatibility
+# and semantic clarity when working with plugins specifically.
+class PluginSource(ExtensionSource):
     """Specification for a plugin to load.
 
     This model describes where to find a plugin and is used by load_plugins()
@@ -28,80 +32,6 @@ class PluginSource(BaseModel):
         >>> # Local path
         >>> PluginSource(source="/path/to/plugin")
     """
-
-    source: str = Field(
-        description="Plugin source: 'github:owner/repo', any git URL, or local path"
-    )
-    ref: str | None = Field(
-        default=None,
-        description="Optional branch, tag, or commit (only for git sources)",
-    )
-    repo_path: str | None = Field(
-        default=None,
-        description=(
-            "Subdirectory path within the git repository "
-            "(e.g., 'plugins/my-plugin' for monorepos). "
-            "Only relevant for git sources, not local paths."
-        ),
-    )
-
-    @field_validator("repo_path")
-    @classmethod
-    def validate_repo_path(cls, v: str | None) -> str | None:
-        """Validate repo_path is a safe relative path within the repository."""
-        if v is None:
-            return v
-        # Must be relative (no absolute paths)
-        if v.startswith("/"):
-            raise ValueError("repo_path must be relative, not absolute")
-        # No parent directory traversal
-        if ".." in Path(v).parts:
-            raise ValueError(
-                "repo_path cannot contain '..' (parent directory traversal)"
-            )
-        return v
-
-    @property
-    def source_url(self) -> str | None:
-        """Convert the plugin source to a canonical URL.
-
-        Converts the 'github:' convenience prefix to a full URL.
-        For sources that are already URLs, returns them directly.
-        Local paths return None (not portable).
-
-        Returns:
-            URL string, or None for local paths.
-
-        Examples:
-            >>> PluginSource(source="github:owner/repo").source_url
-            'https://github.com/owner/repo'
-
-            >>> PluginSource(source="github:owner/repo", ref="v1.0").source_url
-            'https://github.com/owner/repo/tree/v1.0'
-
-            >>> PluginSource(source="https://github.com/owner/repo").source_url
-            'https://github.com/owner/repo'
-
-            >>> PluginSource(source="/local/path").source_url
-            None
-        """
-        # Handle github: shorthand - the only convenience prefix we support
-        if self.source.startswith("github:"):
-            repo_part = self.source[7:]  # Remove 'github:' prefix
-            base_url = f"https://github.com/{repo_part}"
-            if self.ref or self.repo_path:
-                ref = self.ref or "main"
-                if self.repo_path:
-                    return f"{base_url}/tree/{ref}/{self.repo_path}"
-                return f"{base_url}/tree/{ref}"
-            return base_url
-
-        # Already a URL - return as-is
-        if self.source.startswith(("https://", "http://", "git@", "git://")):
-            return self.source
-
-        # Local paths - not portable, return None
-        return None
 
 
 class ResolvedPluginSource(BaseModel):
@@ -139,7 +69,7 @@ class ResolvedPluginSource(BaseModel):
     @classmethod
     def from_plugin_source(
         cls, plugin_source: PluginSource, resolved_ref: str | None
-    ) -> ResolvedPluginSource:
+    ) -> Self:
         """Create a ResolvedPluginSource from a PluginSource and resolved ref."""
         return cls(
             source=plugin_source.source,
@@ -185,23 +115,9 @@ if TYPE_CHECKING:
     from openhands.sdk.skills.skill import Skill
 
 
-class PluginAuthor(BaseModel):
+# PluginAuthor is an alias for ExtensionAuthor for backward compatibility
+class PluginAuthor(ExtensionAuthor):
     """Author information for a plugin."""
-
-    name: str = Field(description="Author's name")
-    email: str | None = Field(default=None, description="Author's email address")
-    url: str | None = Field(
-        default=None, description="Author's URL (e.g., GitHub profile)"
-    )
-
-    @classmethod
-    def from_string(cls, author_str: str) -> PluginAuthor:
-        """Parse author from string format 'Name <email>'."""
-        if "<" in author_str and ">" in author_str:
-            name = author_str.split("<")[0].strip()
-            email = author_str.split("<")[1].split(">")[0].strip()
-            return cls(name=name, email=email)
-        return cls(name=author_str.strip())
 
 
 class PluginManifest(BaseModel):

--- a/openhands-sdk/openhands/sdk/skills/installed.py
+++ b/openhands-sdk/openhands/sdk/skills/installed.py
@@ -6,16 +6,18 @@ home directory (~/.openhands/skills/installed/).
 
 from __future__ import annotations
 
-import json
-import shutil
 from datetime import UTC, datetime
 from pathlib import Path
 
-from pydantic import BaseModel, Field
+from pydantic import Field
 
+from openhands.sdk.extensions import (
+    InstalledExtensionInfo,
+    InstalledExtensionManager,
+    InstalledExtensionMetadata,
+)
 from openhands.sdk.logger import get_logger
-from openhands.sdk.skills.exceptions import SkillError, SkillValidationError
-from openhands.sdk.skills.fetch import fetch_skill_with_resolution
+from openhands.sdk.skills.exceptions import SkillValidationError
 from openhands.sdk.skills.skill import Skill, load_skills_from_dir
 from openhands.sdk.skills.utils import find_skill_md, validate_skill_name
 
@@ -23,12 +25,6 @@ from openhands.sdk.skills.utils import find_skill_md, validate_skill_name
 logger = get_logger(__name__)
 
 DEFAULT_INSTALLED_SKILLS_DIR = Path.home() / ".openhands" / "skills" / "installed"
-_METADATA_FILENAME = ".installed.json"
-
-
-def _resolve_installed_dir(installed_dir: Path | None) -> Path:
-    """Return installed_dir or the default if None."""
-    return installed_dir if installed_dir is not None else DEFAULT_INSTALLED_SKILLS_DIR
 
 
 def get_installed_skills_dir() -> Path:
@@ -55,11 +51,12 @@ def _load_skill_from_dir(skill_root: Path) -> Skill:
     return Skill.load(skill_md, strict=True)
 
 
-class InstalledSkillInfo(BaseModel):
-    """Information about an installed skill."""
+class InstalledSkillInfo(InstalledExtensionInfo):
+    """Information about an installed skill.
 
-    name: str = Field(description="Skill name")
-    description: str = Field(default="", description="Skill description")
+    Extends InstalledExtensionInfo with AgentSkills-specific fields.
+    """
+
     license: str | None = Field(default=None, description="Skill license")
     compatibility: str | None = Field(
         default=None, description="Compatibility notes for the skill"
@@ -70,18 +67,6 @@ class InstalledSkillInfo(BaseModel):
     allowed_tools: list[str] | None = Field(
         default=None, description="Allowed tools list for the skill"
     )
-    enabled: bool = Field(default=True, description="Whether the skill is enabled")
-    source: str = Field(description="Original source (e.g., 'github:owner/repo')")
-    resolved_ref: str | None = Field(
-        default=None,
-        description="Resolved git commit SHA (for version pinning)",
-    )
-    repo_path: str | None = Field(
-        default=None,
-        description="Subdirectory path within the repository (for monorepos)",
-    )
-    installed_at: str = Field(description="ISO 8601 timestamp of installation")
-    install_path: str = Field(description="Path where the skill is installed")
 
     @classmethod
     def from_skill(
@@ -108,39 +93,84 @@ class InstalledSkillInfo(BaseModel):
         )
 
 
-class InstalledSkillsMetadata(BaseModel):
-    """Metadata file for tracking installed skills."""
+# For backward compatibility, provide InstalledSkillsMetadata as a wrapper
+# around InstalledExtensionMetadata.
+class InstalledSkillsMetadata(InstalledExtensionMetadata[InstalledSkillInfo]):
+    """Metadata file for tracking all installed skills.
 
-    skills: dict[str, InstalledSkillInfo] = Field(
-        default_factory=dict,
-        description="Map of skill name to installation info",
-    )
+    This class wraps InstalledExtensionMetadata for backward compatibility.
+    New code should use the InstalledExtensionManager instead.
+    """
+
+    def __init__(
+        self,
+        *,
+        items: dict[str, InstalledSkillInfo] | None = None,
+        skills: dict[str, InstalledSkillInfo] | None = None,
+    ) -> None:
+        """Initialize with either items or skills keyword argument."""
+        # Support both 'items' (new) and 'skills' (legacy) kwarg
+        data = items if items is not None else (skills or {})
+        super().__init__(items=data)
+
+    # Alias 'items' as 'skills' for backward compatibility
+    @property
+    def skills(self) -> dict[str, InstalledSkillInfo]:
+        """Get installed skills (alias for items)."""
+        return self.items
+
+    @skills.setter
+    def skills(self, value: dict[str, InstalledSkillInfo]) -> None:
+        """Set installed skills (alias for items)."""
+        self.items = value
 
     @classmethod
-    def get_path(cls, installed_dir: Path) -> Path:
-        """Get the metadata file path for the given installed skills directory."""
-        return installed_dir / _METADATA_FILENAME
-
-    @classmethod
-    def load_from_dir(cls, installed_dir: Path) -> InstalledSkillsMetadata:
+    def load_from_dir(  # type: ignore[override]
+        cls, installed_dir: Path
+    ) -> InstalledSkillsMetadata:
         """Load metadata from the installed skills directory."""
-        metadata_path = cls.get_path(installed_dir)
-        if not metadata_path.exists():
-            return cls()
-        try:
-            with open(metadata_path) as f:
-                data = json.load(f)
-            return cls.model_validate(data)
-        except Exception as e:
-            logger.warning(f"Failed to load installed skills metadata: {e}")
-            return cls()
+        base = InstalledExtensionMetadata.load_from_dir(
+            installed_dir, InstalledSkillInfo
+        )
+        return cls(items=base.items)
 
     def save_to_dir(self, installed_dir: Path) -> None:
-        """Save metadata to the installed skills directory."""
+        """Save metadata to the installed skills directory (legacy format)."""
+        import json
+
         metadata_path = self.get_path(installed_dir)
         metadata_path.parent.mkdir(parents=True, exist_ok=True)
+        # Use "skills" key for backward compatibility
+        data = {
+            "skills": {name: info.model_dump() for name, info in self.items.items()}
+        }
         with open(metadata_path, "w") as f:
-            json.dump(self.model_dump(), f, indent=2)
+            json.dump(data, f, indent=2)
+
+
+def _create_skill_info(
+    skill: Skill,
+    source: str,
+    resolved_ref: str | None,
+    repo_path: str | None,
+    install_path: Path,
+) -> InstalledSkillInfo:
+    """Create InstalledSkillInfo from a loaded Skill (for manager callback)."""
+    return InstalledSkillInfo.from_skill(
+        skill, source, resolved_ref, repo_path, install_path
+    )
+
+
+# Create the skill manager instance
+_skill_manager: InstalledExtensionManager[Skill, InstalledSkillInfo] = (
+    InstalledExtensionManager(
+        default_dir=DEFAULT_INSTALLED_SKILLS_DIR,
+        validate_name=_validate_skill_name,
+        load_item=_load_skill_from_dir,
+        create_info=_create_skill_info,
+        info_type=InstalledSkillInfo,
+    )
+)
 
 
 def install_skill(
@@ -169,52 +199,13 @@ def install_skill(
         FileExistsError: If skill is already installed and force=False.
         SkillValidationError: If the skill metadata is invalid.
     """
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    logger.info(f"Fetching skill from {source}")
-    fetched_path, resolved_ref = fetch_skill_with_resolution(
+    return _skill_manager.install(
         source=source,
         ref=ref,
         repo_path=repo_path,
-        update=True,
+        installed_dir=installed_dir,
+        force=force,
     )
-
-    skill = _load_skill_from_dir(fetched_path)
-    skill_name = skill.name
-    _validate_skill_name(skill_name)
-
-    install_path = installed_dir / skill_name
-    if install_path.exists() and not force:
-        raise FileExistsError(
-            f"Skill '{skill_name}' is already installed at {install_path}. "
-            "Use force=True to overwrite."
-        )
-
-    if install_path.exists():
-        logger.info(f"Removing existing installation of '{skill_name}'")
-        shutil.rmtree(install_path)
-
-    logger.info(f"Installing skill '{skill_name}' to {install_path}")
-    installed_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copytree(fetched_path, install_path)
-
-    info = InstalledSkillInfo.from_skill(
-        skill=skill,
-        source=source,
-        resolved_ref=resolved_ref,
-        repo_path=repo_path,
-        install_path=install_path,
-    )
-
-    metadata = InstalledSkillsMetadata.load_from_dir(installed_dir)
-    existing_info = metadata.skills.get(skill_name)
-    if existing_info is not None:
-        info.enabled = existing_info.enabled
-    metadata.skills[skill_name] = info
-    metadata.save_to_dir(installed_dir)
-
-    logger.info(f"Successfully installed skill '{skill_name}'")
-    return info
 
 
 def uninstall_skill(
@@ -231,68 +222,9 @@ def uninstall_skill(
             Defaults to ~/.openhands/skills/installed/
 
     Returns:
-        True if the skill was uninstalled, False if it wasn't installed.
+        True if uninstalled successfully, False if not found.
     """
-    _validate_skill_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    metadata = InstalledSkillsMetadata.load_from_dir(installed_dir)
-    if name not in metadata.skills:
-        logger.warning(f"Skill '{name}' is not installed")
-        return False
-
-    skill_path = installed_dir / name
-    if skill_path.exists():
-        logger.info(f"Uninstalling skill '{name}' from {skill_path}")
-        shutil.rmtree(skill_path)
-    else:
-        logger.warning(
-            f"Skill '{name}' was tracked but its directory is missing: {skill_path}"
-        )
-
-    del metadata.skills[name]
-    metadata.save_to_dir(installed_dir)
-
-    logger.info(f"Successfully uninstalled skill '{name}'")
-    return True
-
-
-def _set_skill_enabled(
-    name: str,
-    enabled: bool,
-    installed_dir: Path | None = None,
-) -> bool:
-    _validate_skill_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    if not installed_dir.exists():
-        logger.warning(f"Installed skills directory does not exist: {installed_dir}")
-        return False
-
-    list_installed_skills(installed_dir)
-    metadata = InstalledSkillsMetadata.load_from_dir(installed_dir)
-    info = metadata.skills.get(name)
-    if info is None:
-        logger.warning(f"Skill '{name}' is not installed")
-        return False
-
-    skill_path = installed_dir / name
-    if not skill_path.exists():
-        logger.warning(
-            f"Skill '{name}' was tracked but its directory is missing: {skill_path}"
-        )
-        return False
-
-    if info.enabled == enabled:
-        return True
-
-    info.enabled = enabled
-    metadata.skills[name] = info
-    metadata.save_to_dir(installed_dir)
-
-    state = "enabled" if enabled else "disabled"
-    logger.info(f"Successfully {state} skill '{name}'")
-    return True
+    return _skill_manager.uninstall(name=name, installed_dir=installed_dir)
 
 
 def enable_skill(
@@ -300,7 +232,7 @@ def enable_skill(
     installed_dir: Path | None = None,
 ) -> bool:
     """Enable an installed skill by name."""
-    return _set_skill_enabled(name, True, installed_dir)
+    return _skill_manager.enable(name=name, installed_dir=installed_dir)
 
 
 def disable_skill(
@@ -308,85 +240,7 @@ def disable_skill(
     installed_dir: Path | None = None,
 ) -> bool:
     """Disable an installed skill by name."""
-    return _set_skill_enabled(name, False, installed_dir)
-
-
-def _validate_tracked_skills(
-    metadata: InstalledSkillsMetadata, installed_dir: Path
-) -> tuple[list[InstalledSkillInfo], bool]:
-    """Validate tracked skills exist on disk."""
-    valid_skills: list[InstalledSkillInfo] = []
-    changed = False
-
-    for name, info in list(metadata.skills.items()):
-        try:
-            _validate_skill_name(name)
-        except ValueError as e:
-            logger.warning(f"Invalid tracked skill name {name!r}, removing: {e}")
-            del metadata.skills[name]
-            changed = True
-            continue
-
-        skill_path = installed_dir / name
-        if skill_path.exists():
-            valid_skills.append(info)
-        else:
-            logger.warning(f"Skill '{name}' directory missing, removing from metadata")
-            del metadata.skills[name]
-            changed = True
-
-    return valid_skills, changed
-
-
-def _discover_untracked_skills(
-    metadata: InstalledSkillsMetadata, installed_dir: Path
-) -> tuple[list[InstalledSkillInfo], bool]:
-    """Discover skill directories not tracked in metadata."""
-    discovered: list[InstalledSkillInfo] = []
-    changed = False
-
-    for item in installed_dir.iterdir():
-        if not item.is_dir() or item.name.startswith("."):
-            continue
-        if item.name in metadata.skills:
-            continue
-
-        try:
-            _validate_skill_name(item.name)
-        except ValueError:
-            logger.debug(f"Skipping directory with invalid skill name: {item}")
-            continue
-
-        try:
-            skill = _load_skill_from_dir(item)
-        except (SkillError, OSError) as e:
-            logger.debug(f"Skipping directory {item}: {e}")
-            continue
-
-        if skill.name != item.name:
-            logger.warning(
-                "Skipping skill directory because name doesn't match directory: "
-                f"dir={item.name!r}, skill={skill.name!r}"
-            )
-            continue
-
-        info = InstalledSkillInfo(
-            name=skill.name,
-            description=skill.description or "",
-            license=skill.license,
-            compatibility=skill.compatibility,
-            metadata=skill.metadata,
-            allowed_tools=skill.allowed_tools,
-            source="local",
-            installed_at=datetime.now(UTC).isoformat(),
-            install_path=str(item),
-        )
-        discovered.append(info)
-        metadata.skills[item.name] = info
-        changed = True
-        logger.info(f"Discovered untracked skill: {skill.name}")
-
-    return discovered, changed
+    return _skill_manager.disable(name=name, installed_dir=installed_dir)
 
 
 def list_installed_skills(
@@ -405,20 +259,7 @@ def list_installed_skills(
     Returns:
         List of InstalledSkillInfo for each installed skill.
     """
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    if not installed_dir.exists():
-        return []
-
-    metadata = InstalledSkillsMetadata.load_from_dir(installed_dir)
-
-    valid_skills, tracked_changed = _validate_tracked_skills(metadata, installed_dir)
-    discovered, discovered_changed = _discover_untracked_skills(metadata, installed_dir)
-
-    if tracked_changed or discovered_changed:
-        metadata.save_to_dir(installed_dir)
-
-    return valid_skills + discovered
+    return _skill_manager.list_installed(installed_dir=installed_dir)
 
 
 def load_installed_skills(
@@ -433,16 +274,19 @@ def load_installed_skills(
     Returns:
         List of loaded Skill objects.
     """
-    installed_dir = _resolve_installed_dir(installed_dir)
+    resolved_dir = installed_dir or DEFAULT_INSTALLED_SKILLS_DIR
 
-    if not installed_dir.exists():
+    if not resolved_dir.exists():
         return []
 
-    installed_infos = list_installed_skills(installed_dir)
+    # Get enabled skill names
+    installed_infos = list_installed_skills(resolved_dir)
     enabled_names = {info.name for info in installed_infos if info.enabled}
 
-    repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(installed_dir)
+    # Load all skills from directory using existing loader
+    repo_skills, knowledge_skills, agent_skills = load_skills_from_dir(resolved_dir)
     all_skills = {**repo_skills, **knowledge_skills, **agent_skills}
+
     return [skill for name, skill in all_skills.items() if name in enabled_names]
 
 
@@ -451,18 +295,7 @@ def get_installed_skill(
     installed_dir: Path | None = None,
 ) -> InstalledSkillInfo | None:
     """Get information about a specific installed skill."""
-    _validate_skill_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    metadata = InstalledSkillsMetadata.load_from_dir(installed_dir)
-    info = metadata.skills.get(name)
-
-    if info is not None:
-        skill_path = installed_dir / name
-        if not skill_path.exists():
-            return None
-
-    return info
+    return _skill_manager.get(name=name, installed_dir=installed_dir)
 
 
 def update_skill(
@@ -470,22 +303,7 @@ def update_skill(
     installed_dir: Path | None = None,
 ) -> InstalledSkillInfo | None:
     """Update an installed skill to the latest version."""
-    _validate_skill_name(name)
-    installed_dir = _resolve_installed_dir(installed_dir)
-
-    current_info = get_installed_skill(name, installed_dir)
-    if current_info is None:
-        logger.warning(f"Skill '{name}' is not installed")
-        return None
-
-    logger.info(f"Updating skill '{name}' from {current_info.source}")
-    return install_skill(
-        source=current_info.source,
-        ref=None,
-        repo_path=current_info.repo_path,
-        installed_dir=installed_dir,
-        force=True,
-    )
+    return _skill_manager.update(name=name, installed_dir=installed_dir)
 
 
 def install_skills_from_marketplace(
@@ -522,7 +340,7 @@ def install_skills_from_marketplace(
     from openhands.sdk.plugin import resolve_source_path
 
     marketplace_path = Path(marketplace_path)
-    installed_dir = _resolve_installed_dir(installed_dir)
+    resolved_dir = installed_dir or DEFAULT_INSTALLED_SKILLS_DIR
 
     # Load the marketplace
     marketplace = Marketplace.load(marketplace_path)
@@ -574,7 +392,7 @@ def install_skills_from_marketplace(
     # Install all collected skills
     for name, path in skill_dirs:
         try:
-            info = install_skill(str(path), installed_dir=installed_dir, force=force)
+            info = install_skill(str(path), installed_dir=resolved_dir, force=force)
             installed.append(info)
             logger.info(f"Installed skill '{info.name}'")
         except FileExistsError:

--- a/tests/sdk/plugin/test_installed_plugins.py
+++ b/tests/sdk/plugin/test_installed_plugins.py
@@ -217,7 +217,7 @@ def test_install_with_force_overwrites(
     assert not marker_file.exists()
 
 
-@patch("openhands.sdk.plugin.installed.fetch_plugin_with_resolution")
+@patch("openhands.sdk.extensions.installed.fetch_extension_with_resolution")
 def test_install_from_github_mocked(
     mock_fetch, sample_plugin_dir: Path, installed_dir: Path
 ) -> None:
@@ -481,7 +481,7 @@ def test_update_existing_plugin_mocked(
 
     # Now mock for the update call only
     with patch(
-        "openhands.sdk.plugin.installed.fetch_plugin_with_resolution"
+        "openhands.sdk.extensions.installed.fetch_extension_with_resolution"
     ) as mock_fetch:
         mock_fetch.return_value = (sample_plugin_dir, "newcommit123")
 


### PR DESCRIPTION
<!-- AI Agent Generated PR -->

- [ ] A human has tested these changes.

---

## Why

The `plugin`, `marketplace`, and `skills` modules had significant code duplication:
- `InstalledPluginInfo` and `InstalledSkillInfo` shared 90% of their fields
- `PluginSource` and skill source handling had identical logic
- `InstalledPluginsMetadata` and `InstalledSkillsMetadata` had identical persistence code
- Install/uninstall/enable/disable/list/load/get/update operations were copy-pasted between modules

## Summary

- Create a new `openhands.sdk.extensions` module with shared base classes
- Extract `ExtensionSource`, `ResolvedExtensionSource`, `ExtensionAuthor` into `source.py`
- Extract `ExtensionCatalogEntry`, `ExtensionCatalog` into `catalog.py`
- Extract `fetch_extension_with_resolution` into `fetch.py`
- Extract `InstalledExtensionInfo`, `InstalledExtensionMetadata[T]`, `InstalledExtensionManager[ItemT, InfoT]` into `installed.py`
- Refactor `plugin/installed.py` (~500 → ~150 lines) and `skills/installed.py` (~580 → ~200 lines) to use the new generic manager
- Maintain full backward compatibility with legacy API and metadata formats

## Issue Number

N/A - Internal refactoring task

## How to Test

Run the tests for installed plugins and skills:

```bash
uv run pytest tests/sdk/plugin/test_installed_plugins.py tests/sdk/skills/test_installed_skills.py -v
```

All 53 tests pass.

Backward compatibility verified:
- `InstalledPluginsMetadata(plugins={...})` still works (legacy kwarg)
- Loading metadata files with `{"plugins": ...}` or `{"skills": ...}` keys still works
- `PluginSource`, `PluginAuthor`, `InstalledPluginInfo` all still work as before

## Video/Screenshots

N/A - This is a refactoring PR with no UI changes.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Uses Python 3.12+ generic syntax: `class Foo[T: Bound]`
- The new `InstalledExtensionManager` is generic over both the item type (e.g., `Plugin`, `Skill`) and the info type (e.g., `InstalledPluginInfo`, `InstalledSkillInfo`)
- The marketplace module could also be updated to use these patterns in a follow-up PR

---

*This PR was created by an AI assistant (OpenHands) on behalf of the user.*
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:776ea8c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-776ea8c-python \
  ghcr.io/openhands/agent-server:776ea8c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:776ea8c-golang-amd64
ghcr.io/openhands/agent-server:776ea8c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:776ea8c-golang-arm64
ghcr.io/openhands/agent-server:776ea8c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:776ea8c-java-amd64
ghcr.io/openhands/agent-server:776ea8c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:776ea8c-java-arm64
ghcr.io/openhands/agent-server:776ea8c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:776ea8c-python-amd64
ghcr.io/openhands/agent-server:776ea8c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:776ea8c-python-arm64
ghcr.io/openhands/agent-server:776ea8c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:776ea8c-golang
ghcr.io/openhands/agent-server:776ea8c-java
ghcr.io/openhands/agent-server:776ea8c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `776ea8c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `776ea8c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->