### PR TITLE
feat(agent-server): expose model switching (switch_profile) in agent-server REST API

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -290,7 +290,10 @@ async def set_conversation_security_analyzer(
 
 @conversation_router.post(
     "/{conversation_id}/switch_profile",
-    responses={404: {"description": "Conversation not found"}},
+    responses={
+        400: {"description": "Invalid or corrupted profile"},
+        404: {"description": "Conversation or profile not found"},
+    },
 )
 async def switch_conversation_profile(
     conversation_id: UUID,

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -288,6 +288,35 @@ async def set_conversation_security_analyzer(
     return Success()
 
 
+@conversation_router.post(
+    "/{conversation_id}/switch_profile",
+    responses={404: {"description": "Conversation not found"}},
+)
+async def switch_conversation_profile(
+    conversation_id: UUID,
+    profile_name: str = Body(..., embed=True),
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> Success:
+    """Switch the conversation's LLM profile to a named profile."""
+    event_service = await conversation_service.get_event_service(conversation_id)
+    if event_service is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    conversation = event_service.get_conversation()
+    try:
+        conversation.switch_profile(profile_name)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Profile '{profile_name}' not found",
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+    return Success()
+
+
 @conversation_router.patch(
     "/{conversation_id}", responses={404: {"description": "Item not found"}}
 )

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1703,3 +1703,29 @@ def test_switch_conversation_profile_nonexistent_profile(
         mock_conversation.switch_profile.assert_called_once_with("missing")
     finally:
         client.app.dependency_overrides.clear()
+
+
+def test_switch_conversation_profile_corrupted_profile(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """Test switch_conversation_profile when the profile is corrupted or invalid."""
+    mock_conversation = MagicMock()
+    mock_conversation.switch_profile.side_effect = ValueError("Invalid profile format")
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.get_conversation.return_value = mock_conversation
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_profile",
+            json={"profile_name": "corrupted"},
+        )
+
+        assert response.status_code == 400
+        assert "Invalid profile format" in response.json()["detail"]
+        mock_conversation.switch_profile.assert_called_once_with("corrupted")
+    finally:
+        client.app.dependency_overrides.clear()

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1,6 +1,6 @@
 """Tests for conversation_router.py endpoints."""
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 from uuid import uuid4
 
 import pytest
@@ -1616,5 +1616,90 @@ def test_update_secrets_with_mixed_formats(
         assert "STATIC_SECRET" in secrets_dict
         assert "LOOKUP_SECRET" in secrets_dict
 
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+# --- switch_profile endpoint tests ---
+
+
+def test_switch_conversation_profile_success(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """Test switch_conversation_profile endpoint with a valid profile."""
+    mock_conversation = MagicMock()
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.get_conversation.return_value = mock_conversation
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_profile",
+            json={"profile_name": "gpt"},
+        )
+
+        assert response.status_code == 200
+        assert response.json()["success"] is True
+
+        mock_conversation_service.get_event_service.assert_called_once_with(
+            sample_conversation_id
+        )
+        mock_event_service.get_conversation.assert_called_once()
+        mock_conversation.switch_profile.assert_called_once_with("gpt")
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_switch_conversation_profile_not_found(
+    client, mock_conversation_service, sample_conversation_id
+):
+    """Test switch_conversation_profile endpoint when conversation is not found."""
+    mock_conversation_service.get_event_service.return_value = None
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_profile",
+            json={"profile_name": "gpt"},
+        )
+
+        assert response.status_code == 404
+        mock_conversation_service.get_event_service.assert_called_once_with(
+            sample_conversation_id
+        )
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_switch_conversation_profile_nonexistent_profile(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """Test switch_conversation_profile when the profile does not exist on disk."""
+    mock_conversation = MagicMock()
+    mock_conversation.switch_profile.side_effect = FileNotFoundError(
+        "Profile 'missing' not found"
+    )
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.get_conversation.return_value = mock_conversation
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_profile",
+            json={"profile_name": "missing"},
+        )
+
+        assert response.status_code == 404
+        assert "missing" in response.json()["detail"]
+        mock_conversation.switch_profile.assert_called_once_with("missing")
     finally:
         client.app.dependency_overrides.clear()


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Summary

- Add POST /{conversation_id}/switch_profile endpoint to conversation_router.py, allowing API clients to switch a conversation's LLM mid-session using named profiles from LLMProfileStore                         
- Handle FileNotFoundError (unknown profile → 404) and ValueError (corrupted profile → 400) at the endpoint boundary
- Add 3 tests: success path, conversation not found, and nonexistent profile   

## Issue Number

Closes #2794 
Closes  #416

## How to Test
- test_switch_conversation_profile_success — valid profile switches correctly, returns 200                                                                                                                         
- test_switch_conversation_profile_not_found — missing conversation returns 404
- test_switch_conversation_profile_nonexistent_profile — missing profile returns 404 with detail message   

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:91ce99a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-91ce99a-python \
  ghcr.io/openhands/agent-server:91ce99a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:91ce99a-golang-amd64
ghcr.io/openhands/agent-server:91ce99a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:91ce99a-golang-arm64
ghcr.io/openhands/agent-server:91ce99a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:91ce99a-java-amd64
ghcr.io/openhands/agent-server:91ce99a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:91ce99a-java-arm64
ghcr.io/openhands/agent-server:91ce99a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:91ce99a-python-amd64
ghcr.io/openhands/agent-server:91ce99a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:91ce99a-python-arm64
ghcr.io/openhands/agent-server:91ce99a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:91ce99a-golang
ghcr.io/openhands/agent-server:91ce99a-java
ghcr.io/openhands/agent-server:91ce99a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `91ce99a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `91ce99a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->