### PR TITLE
fix: use GITHUB_SHA env var for image tag in server workflow

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -210,8 +210,9 @@ jobs:
             ARCH: ${{ matrix.arch }}
             TARGET: binary
             PLATFORM: ${{ matrix.platform }}
-            # Use PR head SHA for pull requests to match the image tag expected by run-examples.yml
-            GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+            # Use SDK_SHA for PR head SHA - GITHUB_SHA is a built-in that gets overwritten by checkout
+            # build.py checks SDK_SHA before GITHUB_SHA (see _git_info priority order)
+            SDK_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
             GITHUB_REF: ${{ github.ref }}
             CI: 'true'
 
@@ -240,8 +241,8 @@ jobs:
               run: |
                   uv sync --frozen
 
-                  # Debug: Print GITHUB_SHA to verify it's available
-                  echo "DEBUG: GITHUB_SHA env = $GITHUB_SHA"
+                  # Debug: Print SDK_SHA to verify it's available
+                  echo "DEBUG: SDK_SHA env = $SDK_SHA"
                   echo "DEBUG: git rev-parse HEAD = $(git rev-parse HEAD)"
 
                   # Generate build context and tags with arch suffix
@@ -258,8 +259,8 @@ jobs:
                   echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
                   # Extract short SHA for consolidation
-                  # Use GITHUB_SHA env var (set above to PR head SHA for PRs)
-                  SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
+                  # Use SDK_SHA env var (set above to PR head SHA for PRs)
+                  SHORT_SHA=$(echo $SDK_SHA | cut -c1-7)
                   echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
 
                   # Extract versioned tags CSV for consolidation

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -254,7 +254,8 @@ jobs:
                   echo "tags=$TAGS" >> $GITHUB_OUTPUT
 
                   # Extract short SHA for consolidation
-                  SHORT_SHA=$(echo ${{ github.sha }} | cut -c1-7)
+                  # Use GITHUB_SHA env var (set above to PR head SHA for PRs)
+                  SHORT_SHA=$(echo $GITHUB_SHA | cut -c1-7)
                   echo "short_sha=$SHORT_SHA" >> $GITHUB_OUTPUT
 
                   # Extract versioned tags CSV for consolidation

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -241,10 +241,6 @@ jobs:
               run: |
                   uv sync --frozen
 
-                  # Debug: Print SDK_SHA to verify it's available
-                  echo "DEBUG: SDK_SHA env = $SDK_SHA"
-                  echo "DEBUG: git rev-parse HEAD = $(git rev-parse HEAD)"
-
                   # Generate build context and tags with arch suffix
                   # build.py now handles architecture tagging internally via --arch flag
                   # Add --versioned-tag when triggered by a git tag (e.g., v1.0.0)

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -240,6 +240,10 @@ jobs:
               run: |
                   uv sync --frozen
 
+                  # Debug: Print GITHUB_SHA to verify it's available
+                  echo "DEBUG: GITHUB_SHA env = $GITHUB_SHA"
+                  echo "DEBUG: git rev-parse HEAD = $(git rev-parse HEAD)"
+
                   # Generate build context and tags with arch suffix
                   # build.py now handles architecture tagging internally via --arch flag
                   # Add --versioned-tag when triggered by a git tag (e.g., v1.0.0)

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -298,7 +298,10 @@ def _git_info() -> tuple[str, str]:
     3. git symbolic-ref HEAD - Local development
     """
     sdk_root = _default_sdk_project_root()
-    git_sha = os.environ.get("SDK_SHA") or os.environ.get("GITHUB_SHA")
+    sdk_sha_env = os.environ.get("SDK_SHA")
+    github_sha_env = os.environ.get("GITHUB_SHA")
+    logger.info(f"[_git_info] SDK_SHA={sdk_sha_env!r}, GITHUB_SHA={github_sha_env!r}")
+    git_sha = sdk_sha_env or github_sha_env
     if not git_sha:
         try:
             git_sha = _run(
@@ -317,6 +320,7 @@ def _git_info() -> tuple[str, str]:
             ).stdout.strip()
         except subprocess.CalledProcessError:
             git_ref = "unknown"
+    logger.info(f"[_git_info] Resolved: git_ref={git_ref!r}, git_sha={git_sha!r}")
     return git_ref, git_sha
 
 

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -298,10 +298,7 @@ def _git_info() -> tuple[str, str]:
     3. git symbolic-ref HEAD - Local development
     """
     sdk_root = _default_sdk_project_root()
-    sdk_sha_env = os.environ.get("SDK_SHA")
-    github_sha_env = os.environ.get("GITHUB_SHA")
-    logger.info(f"[_git_info] SDK_SHA={sdk_sha_env!r}, GITHUB_SHA={github_sha_env!r}")
-    git_sha = sdk_sha_env or github_sha_env
+    git_sha = os.environ.get("SDK_SHA") or os.environ.get("GITHUB_SHA")
     if not git_sha:
         try:
             git_sha = _run(
@@ -320,7 +317,6 @@ def _git_info() -> tuple[str, str]:
             ).stdout.strip()
         except subprocess.CalledProcessError:
             git_ref = "unknown"
-    logger.info(f"[_git_info] Resolved: git_ref={git_ref!r}, git_sha={git_sha!r}")
     return git_ref, git_sha
 
 


### PR DESCRIPTION
## Summary

Fix a bug in the Agent Server build workflow where PR Docker images are tagged with the merge commit SHA instead of the PR head commit SHA.

## Problem

The `server.yml` workflow was setting:

```yaml
GITHUB_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
```

However, `GITHUB_SHA` is a **built-in GitHub Actions environment variable** that gets **overwritten by the checkout action** to be the merge commit SHA.

### Evidence from CI logs

```
# Workflow shows the correct PR head SHA
GITHUB_SHA: c8095d2885519de73f0eff9dd41edb2045b2815b

# But inside the shell script, GITHUB_SHA has been overwritten by checkout
DEBUG: GITHUB_SHA env = 6e83a950e8d850189e35804c6d8ac921b27de653
```

This caused images to be built with the merge commit SHA while `run-examples.yml` expected the PR head commit SHA.

## Fix

Use `SDK_SHA` instead of `GITHUB_SHA`. The `build.py` script already checks `SDK_SHA` first in its priority order (see `_git_info()`):

```python
git_sha = os.environ.get("SDK_SHA") or os.environ.get("GITHUB_SHA")
```

So by setting `SDK_SHA` to the PR head SHA, `build.py` will use it correctly without being affected by the checkout action overwriting `GITHUB_SHA`.

## Impact

This fixes the Docker-related example test failures that were seen in PR #2765 and likely other PRs.

## Test plan

- [x] CI passes
- [ ] Verify debug logs show `SDK_SHA` is used correctly
- [ ] Re-run `test-examples` workflow to verify the fix

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6f96e03-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6f96e03-python \
  ghcr.io/openhands/agent-server:6f96e03-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6f96e03-golang-amd64
ghcr.io/openhands/agent-server:6f96e03-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6f96e03-golang-arm64
ghcr.io/openhands/agent-server:6f96e03-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6f96e03-java-amd64
ghcr.io/openhands/agent-server:6f96e03-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6f96e03-java-arm64
ghcr.io/openhands/agent-server:6f96e03-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6f96e03-python-amd64
ghcr.io/openhands/agent-server:6f96e03-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6f96e03-python-arm64
ghcr.io/openhands/agent-server:6f96e03-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6f96e03-golang
ghcr.io/openhands/agent-server:6f96e03-java
ghcr.io/openhands/agent-server:6f96e03-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6f96e03-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6f96e03-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->