### PR TITLE
Skip PyPI publishing for GitHub pre-releases

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -10,6 +10,12 @@ on:
 
 jobs:
     publish:
+        # Skip PyPI publishing for pre-releases (e.g., release candidates).
+        # Pre-releases can still be created on GitHub for testing without
+        # pushing packages to PyPI.  Manual workflow_dispatch always runs.
+        if: >
+            github.event_name == 'workflow_dispatch' ||
+            !github.event.release.prerelease
         runs-on: ubuntu-24.04
         outputs:
             version: ${{ steps.extract_version.outputs.version }}


### PR DESCRIPTION
## Summary

When creating a GitHub release with the **"Set as a pre-release"** checkbox checked, the `pypi-release` workflow will now skip the publish job. This allows cutting release candidates or test releases on GitHub without pushing packages to PyPI.

## How it works

- Added an `if` condition to the `publish` job in `pypi-release.yml` that checks `github.event.release.prerelease`
- When a pre-release is published → PyPI publish is **skipped**
- When a regular release is published → PyPI publish runs as before
- Manual `workflow_dispatch` is **unaffected** and always publishes

## Downstream effects

The `version-bump-prs` workflow already guards on `workflow_run.conclusion == 'success'`, so it naturally won't create version-bump PRs when `pypi-release` is skipped due to a pre-release. No changes needed there.

## Usage

To create a pre-release that doesn't push to PyPI:
1. Go to **Releases → New release**
2. Create the tag and fill in release notes
3. Check **"Set as a pre-release"**
4. Publish

The release will be created on GitHub (visible to the team, with artifacts) but nothing will be published to PyPI.

---
_This PR was created by an AI assistant (OpenHands)._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:49f5c84-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-49f5c84-python \
  ghcr.io/openhands/agent-server:49f5c84-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:49f5c84-golang-amd64
ghcr.io/openhands/agent-server:49f5c84-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:49f5c84-golang-arm64
ghcr.io/openhands/agent-server:49f5c84-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:49f5c84-java-amd64
ghcr.io/openhands/agent-server:49f5c84-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:49f5c84-java-arm64
ghcr.io/openhands/agent-server:49f5c84-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:49f5c84-python-amd64
ghcr.io/openhands/agent-server:49f5c84-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:49f5c84-python-arm64
ghcr.io/openhands/agent-server:49f5c84-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:49f5c84-golang
ghcr.io/openhands/agent-server:49f5c84-java
ghcr.io/openhands/agent-server:49f5c84-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `49f5c84-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `49f5c84-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->