### PR TITLE
chore(deps): add Dependabot uv ecosystem for Python dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,9 +1,6 @@
 ---
 # Dependabot configuration for automated dependency updates
 # See: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
-#
-# Note: Python (pip) ecosystem is not configured here because Dependabot does not
-# fully support uv workspaces yet. See issue #2510 for tracking.
 
 version: 2
 
@@ -13,5 +10,27 @@ updates:
       directory: /
       schedule:
           interval: weekly
+      groups:
+          github-actions:
+              patterns:
+                  - '*'
+      commit-message:
+          prefix: chore(deps)
+
+  # Python (uv) — workspace root covers all member packages
+    - package-ecosystem: uv
+      directory: /
+      schedule:
+          interval: weekly
+      groups:
+          production:
+              dependency-type: production
+          development:
+              dependency-type: development
+      ignore:
+          - dependency-name: openhands-sdk
+          - dependency-name: openhands-tools
+          - dependency-name: openhands-workspace
+          - dependency-name: openhands-agent-server
       commit-message:
           prefix: chore(deps)


### PR DESCRIPTION
## Summary

Enables Dependabot's native `uv` ecosystem to manage Python dependency updates in this uv workspace monorepo.

Closes #2510

## Background

When Dependabot was first configured in #2501, Python dependencies were deliberately excluded because Dependabot didn't fully support uv workspaces. Since then, uv support has matured:

- **March 2025**: Dependabot [version updates for uv reached GA](https://github.blog/changelog/2025-03-13-dependabot-version-updates-now-support-uv-in-general-availability/)
- **December 2025**: Dependabot [security updates for uv shipped](https://github.blog/changelog/2025-12-16-dependabot-security-updates-now-support-uv/)
- **Workspace support** was added and [dependabot/dependabot-core#12072](https://github.com/dependabot/dependabot-core/issues/12072) was closed

Per @VascoSch92's [recommendation in #2510](https://github.com/OpenHands/software-agent-sdk/issues/2510#issuecomment-4197738449), this PR adds the `uv` ecosystem config.

## Changes

- **`package-ecosystem: uv`** at `/` — the workspace root, so Dependabot picks up the root `pyproject.toml`, understands the workspace members, and updates `uv.lock`
- **Grouped dependencies** — `production` and `development` groups keep PR volume manageable
- **Ignore workspace-internal packages** — `openhands-sdk`, `openhands-tools`, `openhands-workspace`, `openhands-agent-server` are ignored to work around [dependabot-core#14004](https://github.com/dependabot/dependabot-core/issues/14004) (Dependabot sometimes tries to update workspace members as external deps)
- **Grouped github-actions** — added a wildcard group for the existing github-actions ecosystem to batch those updates too
- Removed the old comment about uv not being supported

## Known caveats

There are still some edge-case bugs in Dependabot's uv workspace support:
- [dependabot-core#14004](https://github.com/dependabot/dependabot-core/issues/14004) — Tries to update workspace members as external deps (mitigated by `ignore` rules above)
- [dependabot-core#12788](https://github.com/dependabot/dependabot-core/issues/12788) — May update `uv.lock` but not `pyproject.toml` in some cases
- [dependabot-core#12162](https://github.com/dependabot/dependabot-core/issues/12162) — No `versioning-strategy` support for the uv ecosystem

If this causes noisy or broken PRs, we can adjust ignore rules or fall back to a custom GitHub Action (`uv lock --upgrade` on a cron).

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9c2518e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9c2518e-python \
  ghcr.io/openhands/agent-server:9c2518e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9c2518e-golang-amd64
ghcr.io/openhands/agent-server:9c2518e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9c2518e-golang-arm64
ghcr.io/openhands/agent-server:9c2518e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9c2518e-java-amd64
ghcr.io/openhands/agent-server:9c2518e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9c2518e-java-arm64
ghcr.io/openhands/agent-server:9c2518e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9c2518e-python-amd64
ghcr.io/openhands/agent-server:9c2518e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9c2518e-python-arm64
ghcr.io/openhands/agent-server:9c2518e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9c2518e-golang
ghcr.io/openhands/agent-server:9c2518e-java
ghcr.io/openhands/agent-server:9c2518e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9c2518e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9c2518e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->