### PR TITLE
Fix remaining tmux session leaks in agent-server startup and task cleanup

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -44,34 +44,30 @@ from openhands.agent_server.vscode_router import vscode_router
 from openhands.agent_server.vscode_service import get_vscode_service
 from openhands.sdk.logger import DEBUG, get_logger
 from openhands.sdk.utils.redact import sanitize_dict
+from openhands.tools.terminal.constants import TMUX_SOCKET_NAME
 
 
 logger = get_logger(__name__)
 
 
-async def cleanup_stale_tmux_sessions() -> None:
+def cleanup_stale_tmux_sessions() -> None:
     """Clean up any stale tmux sessions on server startup.
 
     Tmux sessions live in a separate process that survives agent-server restarts.
-    This function kills all existing sessions on the openhands socket to prevent
-    accumulation of orphaned sessions. Reconnecting conversations will create
-    fresh sessions as needed.
+    This function kills all existing sessions on the shared OpenHands tmux socket
+    to prevent accumulation of orphaned sessions.
     """
     try:
         import libtmux
 
-        # Connect to the dedicated OpenHands tmux server
-        server = libtmux.Server(socket_name="openhands")
-
-        # Get all sessions on this server
+        server = libtmux.Server(socket_name=TMUX_SOCKET_NAME)
         sessions = server.sessions
         if not sessions:
-            logger.debug("No tmux sessions found on openhands socket")
+            logger.debug("No tmux sessions found on %s socket", TMUX_SOCKET_NAME)
             return
 
         logger.info("Cleaning up %d stale tmux session(s) on startup", len(sessions))
 
-        # Kill all sessions - they're all stale since we're starting up
         for session in sessions:
             try:
                 logger.debug("Killing tmux session: %s", session.name)
@@ -91,7 +87,7 @@ async def cleanup_stale_tmux_sessions() -> None:
 @asynccontextmanager
 async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
     # Clean up stale tmux sessions from previous server runs
-    await cleanup_stale_tmux_sessions()
+    cleanup_stale_tmux_sessions()
 
     service = get_default_conversation_service()
     vscode_service = get_vscode_service()

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -5,6 +5,7 @@ from contextlib import asynccontextmanager
 from typing import Any
 from urllib.parse import urlparse
 
+import libtmux
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -50,7 +51,7 @@ from openhands.tools.terminal.constants import TMUX_SOCKET_NAME
 logger = get_logger(__name__)
 
 
-def cleanup_stale_tmux_sessions() -> None:
+def _cleanup_stale_tmux_sessions() -> None:
     """Clean up any stale tmux sessions on server startup.
 
     Tmux sessions live in a separate process that survives agent-server restarts.
@@ -58,8 +59,6 @@ def cleanup_stale_tmux_sessions() -> None:
     to prevent accumulation of orphaned sessions.
     """
     try:
-        import libtmux
-
         server = libtmux.Server(socket_name=TMUX_SOCKET_NAME)
         sessions = server.sessions
         if not sessions:
@@ -77,8 +76,6 @@ def cleanup_stale_tmux_sessions() -> None:
 
         logger.info("Tmux cleanup completed")
 
-    except ImportError:
-        logger.debug("libtmux not available, skipping tmux cleanup")
     except Exception as e:
         # Don't let tmux cleanup failures prevent server startup
         logger.warning("Failed to cleanup tmux sessions: %s", e)
@@ -87,7 +84,7 @@ def cleanup_stale_tmux_sessions() -> None:
 @asynccontextmanager
 async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
     # Clean up stale tmux sessions from previous server runs
-    cleanup_stale_tmux_sessions()
+    _cleanup_stale_tmux_sessions()
 
     service = get_default_conversation_service()
     vscode_service = get_vscode_service()

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -49,8 +49,50 @@ from openhands.sdk.utils.redact import sanitize_dict
 logger = get_logger(__name__)
 
 
+async def cleanup_stale_tmux_sessions() -> None:
+    """Clean up any stale tmux sessions on server startup.
+
+    Tmux sessions live in a separate process that survives agent-server restarts.
+    This function kills all existing sessions on the openhands socket to prevent
+    accumulation of orphaned sessions. Reconnecting conversations will create
+    fresh sessions as needed.
+    """
+    try:
+        import libtmux
+
+        # Connect to the dedicated OpenHands tmux server
+        server = libtmux.Server(socket_name="openhands")
+
+        # Get all sessions on this server
+        sessions = server.sessions
+        if not sessions:
+            logger.debug("No tmux sessions found on openhands socket")
+            return
+
+        logger.info("Cleaning up %d stale tmux session(s) on startup", len(sessions))
+
+        # Kill all sessions - they're all stale since we're starting up
+        for session in sessions:
+            try:
+                logger.debug("Killing tmux session: %s", session.name)
+                session.kill()
+            except Exception as e:
+                logger.warning("Failed to kill tmux session %s: %s", session.name, e)
+
+        logger.info("Tmux cleanup completed")
+
+    except ImportError:
+        logger.debug("libtmux not available, skipping tmux cleanup")
+    except Exception as e:
+        # Don't let tmux cleanup failures prevent server startup
+        logger.warning("Failed to cleanup tmux sessions: %s", e)
+
+
 @asynccontextmanager
 async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
+    # Clean up stale tmux sessions from previous server runs
+    await cleanup_stale_tmux_sessions()
+
     service = get_default_conversation_service()
     vscode_service = get_vscode_service()
     desktop_service = get_desktop_service()

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -198,7 +198,7 @@ class TaskManager:
                 persistence_dir=self._persistence_dir,
                 conversation_id=conversation_id,
                 hook_config=factory.definition.hooks,
-                delete_on_close=False,
+                delete_on_close=True,
             )
 
             self._set_confirmation_policy(
@@ -285,7 +285,7 @@ class TaskManager:
             conversation_id=conversation_id,
             max_iteration_per_run=max_iteration_per_run,
             hook_config=hook_config,
-            delete_on_close=False,
+            delete_on_close=True,
         )
 
     def _get_sub_agent(self, subagent_type: str) -> Agent:

--- a/openhands-tools/openhands/tools/terminal/constants.py
+++ b/openhands-tools/openhands/tools/terminal/constants.py
@@ -34,6 +34,8 @@ NO_CHANGE_TIMEOUT_SECONDS: Final[int] = 30
 POLL_INTERVAL: Final[float] = 0.5
 HISTORY_LIMIT: Final[int] = 10_000
 
+TMUX_SOCKET_NAME: Final[str] = "openhands"
+
 # Tmux session dimensions (columns x rows).
 # Large values ensure output is not wrapped or truncated by the virtual terminal.
 TMUX_SESSION_WIDTH: Final[int] = 1000

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
@@ -23,6 +23,7 @@ from openhands.tools.terminal.constants import (
     HISTORY_LIMIT,
     TMUX_SESSION_HEIGHT,
     TMUX_SESSION_WIDTH,
+    TMUX_SOCKET_NAME,
 )
 from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
@@ -112,7 +113,7 @@ class TmuxPanePool:
             return
 
         env = sanitized_env()
-        self._server = libtmux.Server(socket_name="openhands", environment=env)
+        self._server = libtmux.Server(socket_name=TMUX_SOCKET_NAME, environment=env)
         session_name = f"openhands-pool-{self.username}-{uuid.uuid4()}"
         self._session = self._server.new_session(
             session_name=session_name,

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -11,6 +11,7 @@ from openhands.tools.terminal.constants import (
     HISTORY_LIMIT,
     TMUX_SESSION_HEIGHT,
     TMUX_SESSION_WIDTH,
+    TMUX_SOCKET_NAME,
 )
 from openhands.tools.terminal.metadata import CmdOutputMetadata
 from openhands.tools.terminal.terminal import TerminalInterface
@@ -47,7 +48,7 @@ class TmuxTerminal(TerminalInterface):
 
         env = sanitized_env()
         # Use a dedicated socket to isolate OpenHands sessions from the user's tmux
-        self.server = libtmux.Server(socket_name="openhands", environment=env)
+        self.server = libtmux.Server(socket_name=TMUX_SOCKET_NAME, environment=env)
         _shell_command = "/bin/bash"
         if self.username in ["root", "openhands"]:
             # This starts a non-login (new) shell for the given user


### PR DESCRIPTION
## Problem
This PR fixes the remaining two critical bugs that caused unbounded accumulation of orphaned tmux sessions and bash processes. The original EventService.close() await bug is already fixed in the current codebase and is not part of this diff.

1. **No tmux session cleanup on startup (MEDIUM)**: Orphaned sessions from previous server runs accumulated indefinitely
2. **Task manager sub-conversations use delete_on_close=False (MEDIUM)**: Sub-task terminal sessions were never terminated

## Solution

### EventService.close() await fix
- **Status**: Already fixed in the current codebase
- **Location**: `openhands-agent-server/openhands/agent_server/event_service.py:659`
- **Verification**: `EventService.close()` still awaits `loop.run_in_executor(None, self._conversation.close)` on current HEAD

### Tmux cleanup on startup
- **Location**: `openhands-agent-server/openhands/agent_server/api.py`
- **Fix**:
  - Run startup tmux cleanup through a synchronous helper
  - Reuse a shared `TMUX_SOCKET_NAME` constant instead of a hardcoded socket name
  - Keep startup cleanup best-effort so failures never block server initialization

### Task manager delete_on_close fix
- **Locations**:
  - `openhands-tools/openhands/tools/task/manager.py:201`
  - `openhands-tools/openhands/tools/task/manager.py:288`
- **Fix**: Changed `delete_on_close=False` to `delete_on_close=True`
- **Impact**: Ensures tool cleanup loop runs and terminates tmux sessions

### Shared tmux socket constant
- **Locations**:
  - `openhands-tools/openhands/tools/terminal/constants.py`
  - `openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py`
  - `openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py`
  - `openhands-agent-server/openhands/agent_server/api.py`
- **Fix**: Added `TMUX_SOCKET_NAME` and reused it across tmux session creation and cleanup paths

## Files Changed
- `openhands-agent-server/openhands/agent_server/api.py`
- `openhands-tools/openhands/tools/task/manager.py`
- `openhands-tools/openhands/tools/terminal/constants.py`
- `openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py`
- `openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py`

## Testing
- [x] `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/api.py openhands-tools/openhands/tools/terminal/constants.py openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py`
- [x] Import validation for `cleanup_stale_tmux_sessions` and `TMUX_SOCKET_NAME`
- [x] Branch remains focused on tmux/session leak cleanup

## Impact
These fixes prevent resource exhaustion from unbounded session accumulation that could crash the agent-server over time.

Closes: Fixes critical memory/process leaks in agent-server

_This PR title/description was updated by an AI assistant (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9ddf3ed-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9ddf3ed-python \
  ghcr.io/openhands/agent-server:9ddf3ed-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9ddf3ed-golang-amd64
ghcr.io/openhands/agent-server:9ddf3ed-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9ddf3ed-golang-arm64
ghcr.io/openhands/agent-server:9ddf3ed-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9ddf3ed-java-amd64
ghcr.io/openhands/agent-server:9ddf3ed-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9ddf3ed-java-arm64
ghcr.io/openhands/agent-server:9ddf3ed-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9ddf3ed-python-amd64
ghcr.io/openhands/agent-server:9ddf3ed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9ddf3ed-python-arm64
ghcr.io/openhands/agent-server:9ddf3ed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9ddf3ed-golang
ghcr.io/openhands/agent-server:9ddf3ed-java
ghcr.io/openhands/agent-server:9ddf3ed-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9ddf3ed-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9ddf3ed-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
