### PR TITLE
feat(terminal): standardize send_keys special key support across backends

### DIFF
--- a/openhands-tools/openhands/tools/terminal/definition.py
+++ b/openhands-tools/openhands/tools/terminal/definition.py
@@ -33,7 +33,17 @@ class TerminalAction(Action):
     """Schema for bash command execution."""
 
     command: str = Field(
-        description="The bash command to execute. Can be empty string to view additional logs when previous exit code is `-1`. Can be `C-c` (Ctrl+C) to interrupt the currently running process. Note: You can only execute one bash command at a time. If you need to run multiple commands sequentially, you can use `&&` or `;` to chain them together."  # noqa
+        description=(
+            "The bash command to execute. Can be empty string to view"
+            " additional logs when previous exit code is `-1`. Can be a"
+            " special key name when `is_input` is True: `C-c` (Ctrl+C),"
+            " `C-d` (Ctrl+D/EOF), `C-z` (Ctrl+Z), or any `C-<letter>`"
+            " for Ctrl sequences; navigation keys `UP`, `DOWN`, `LEFT`,"
+            " `RIGHT`, `HOME`, `END`, `PGUP`, `PGDN`; and `TAB`, `ESC`,"
+            " `BS` (Backspace), `ENTER`. Note: You can only execute one"
+            " bash command at a time. If you need to run multiple commands"
+            " sequentially, you can use `&&` or `;` to chain them together."
+        )
     )
     is_input: bool = Field(
         default=False,
@@ -217,6 +227,8 @@ TOOL_DESCRIPTION = """Execute a bash command in the terminal within a persistent
   - Send empty `command` to retrieve additional logs
   - Send text (set `command` to the text) to STDIN of the running process
   - Send control commands like `C-c` (Ctrl+C), `C-d` (Ctrl+D), or `C-z` (Ctrl+Z) to interrupt the process
+  - Send navigation keys like `UP`, `DOWN`, `LEFT`, `RIGHT`, `TAB`, `ESC`, `BS` (Backspace), `HOME`, `END`, `PGUP`, `PGDN`
+  - Any `C-<letter>` Ctrl sequence is supported (e.g. `C-a`, `C-e`, `C-l`)
   - If you do C-c, you can re-start the process with a longer "timeout" parameter to let it run to completion
 
 ### Best Practices

--- a/openhands-tools/openhands/tools/terminal/terminal/__init__.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/__init__.py
@@ -3,8 +3,10 @@ from typing import TYPE_CHECKING
 
 from openhands.tools.terminal.terminal.factory import create_terminal_session
 from openhands.tools.terminal.terminal.interface import (
+    SUPPORTED_SPECIAL_KEYS,
     TerminalInterface,
     TerminalSessionBase,
+    parse_ctrl_key,
 )
 from openhands.tools.terminal.terminal.terminal_session import (
     TerminalCommandStatus,
@@ -27,6 +29,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
+    "SUPPORTED_SPECIAL_KEYS",
     "TerminalInterface",
     "TerminalSessionBase",
     "TmuxTerminal",
@@ -34,4 +37,5 @@ __all__ = [
     "TerminalSession",
     "TerminalCommandStatus",
     "create_terminal_session",
+    "parse_ctrl_key",
 ]

--- a/openhands-tools/openhands/tools/terminal/terminal/interface.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/interface.py
@@ -12,6 +12,50 @@ from openhands.tools.terminal.definition import (
 )
 
 
+# Canonical set of named special keys that all TerminalInterface
+# implementations must support.  Each backend maps these to its own
+# representation (ANSI escape bytes for PTY, tmux key names for tmux).
+SUPPORTED_SPECIAL_KEYS: frozenset[str] = frozenset(
+    {
+        "ENTER",
+        "TAB",
+        "BS",
+        "ESC",
+        "UP",
+        "DOWN",
+        "LEFT",
+        "RIGHT",
+        "HOME",
+        "END",
+        "PGUP",
+        "PGDN",
+        "C-L",
+        "C-D",
+        "C-C",
+    }
+)
+
+
+def parse_ctrl_key(text: str) -> str | None:
+    """Parse a Ctrl-<letter> token and return the normalized form ``C-x``.
+
+    Accepts ``C-x``, ``CTRL-x``, and ``CTRL+x`` (case-insensitive)
+    where *x* is a single ASCII letter.  Returns ``None`` when *text*
+    is not a recognized Ctrl sequence.
+    """
+    upper = text.strip().upper()
+    key: str | None = None
+    if upper.startswith("C-"):
+        key = upper[2:]
+    elif upper.startswith("CTRL-"):
+        key = upper[5:]
+    elif upper.startswith("CTRL+"):
+        key = upper[5:]
+    if key and len(key) == 1 and "A" <= key <= "Z":
+        return f"C-{key.lower()}"
+    return None
+
+
 class TerminalInterface(ABC):
     """Abstract interface for terminal backends.
 
@@ -63,9 +107,17 @@ class TerminalInterface(ABC):
     def send_keys(self, text: str, enter: bool = True) -> None:
         """Send text/keys to the terminal.
 
+        All implementations must support:
+          - Plain text (sent verbatim)
+          - Named specials: ENTER, TAB, BS, ESC, UP, DOWN, LEFT, RIGHT,
+            HOME, END, PGUP, PGDN, C-L, C-D, C-C
+          - Generic Ctrl sequences: ``C-<letter>``, ``CTRL-<letter>``,
+            ``CTRL+<letter>`` (case-insensitive, a-z)
+
         Args:
             text: Text or key sequence to send to the terminal.
-            enter: Whether to send Enter key after the text. Defaults to True.
+            enter: Whether to send Enter key after the text.
+                   Defaults to True.  Ignored for special/ctrl keys.
         """
 
     @abstractmethod

--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -37,6 +37,25 @@ logger = get_logger(__name__)
 
 ENTER = b"\n"
 
+# Map normalized special key names to ANSI escape bytes for PTY.
+_SUBPROCESS_SPECIALS: dict[str, bytes] = {
+    "ENTER": ENTER,
+    "TAB": b"\t",
+    "BS": b"\x7f",  # Backspace (DEL)
+    "ESC": b"\x1b",
+    "UP": b"\x1b[A",
+    "DOWN": b"\x1b[B",
+    "RIGHT": b"\x1b[C",
+    "LEFT": b"\x1b[D",
+    "HOME": b"\x1b[H",
+    "END": b"\x1b[F",
+    "PGUP": b"\x1b[5~",
+    "PGDN": b"\x1b[6~",
+    "C-L": b"\x0c",  # Ctrl+L
+    "C-D": b"\x04",  # Ctrl+D (EOF)
+    "C-C": b"\x03",  # Ctrl+C (SIGINT)
+}
+
 
 def _normalize_eols(raw: bytes) -> bytes:
     # CRLF/LF/CR -> CR, so each logical line is terminated with \r for the TTY
@@ -351,36 +370,16 @@ class SubprocessTerminal(TerminalInterface):
         if not self._initialized:
             raise RuntimeError("PTY terminal is not initialized")
 
-        specials = {
-            "ENTER": ENTER,
-            "TAB": b"\t",
-            "BS": b"\x7f",  # Backspace (DEL)
-            "ESC": b"\x1b",
-            "UP": b"\x1b[A",
-            "DOWN": b"\x1b[B",
-            "RIGHT": b"\x1b[C",
-            "LEFT": b"\x1b[D",
-            "HOME": b"\x1b[H",
-            "END": b"\x1b[F",
-            "PGUP": b"\x1b[5~",
-            "PGDN": b"\x1b[6~",
-            "C-L": b"\x0c",  # Ctrl+L
-            "C-D": b"\x04",  # Ctrl+D (EOF)
-            "C-C": b"\x03",  # Ctrl+C (SIGINT)
-        }
-
         upper = text.upper().strip()
         payload: bytes | None = None
 
         # Named specials
-        if upper in specials:
-            payload = specials[upper]
+        if upper in _SUBPROCESS_SPECIALS:
+            payload = _SUBPROCESS_SPECIALS[upper]
             # Do NOT auto-append another EOL; special already includes it when needed.
             append_eol = False
         # Generic Ctrl-<letter>
-        elif parse_ctrl_key(text) is not None:
-            ctrl = parse_ctrl_key(text)
-            assert ctrl is not None
+        elif (ctrl := parse_ctrl_key(text)) is not None:
             # ctrl is "C-x" — extract the letter
             key_char = ctrl[-1].upper()
             payload = bytes([ord(key_char) & 0x1F])

--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -30,6 +30,7 @@ from openhands.tools.terminal.constants import (
 )
 from openhands.tools.terminal.metadata import CmdOutputMetadata
 from openhands.tools.terminal.terminal import TerminalInterface
+from openhands.tools.terminal.terminal.interface import parse_ctrl_key
 
 
 logger = get_logger(__name__)
@@ -341,7 +342,7 @@ class SubprocessTerminal(TerminalInterface):
           - Plain text
           - Ctrl sequences: 'C-a'..'C-z' (Ctrl+C sends ^C byte)
           - Special names: 'ENTER','TAB','BS','ESC','UP','DOWN','LEFT','RIGHT',
-                           'HOME','END','PGUP','PGDN','C-L','C-D'
+                           'HOME','END','PGUP','PGDN','C-L','C-D','C-C'
 
         For multi-line commands exceeding _MULTILINE_THRESHOLD lines, sends
         line-by-line with pacing to prevent overwhelming the shell's input
@@ -365,6 +366,7 @@ class SubprocessTerminal(TerminalInterface):
             "PGDN": b"\x1b[6~",
             "C-L": b"\x0c",  # Ctrl+L
             "C-D": b"\x04",  # Ctrl+D (EOF)
+            "C-C": b"\x03",  # Ctrl+C (SIGINT)
         }
 
         upper = text.upper().strip()
@@ -375,15 +377,13 @@ class SubprocessTerminal(TerminalInterface):
             payload = specials[upper]
             # Do NOT auto-append another EOL; special already includes it when needed.
             append_eol = False
-        # Generic Ctrl-<letter>, including C-C (preferred over sending SIGINT directly)
-        elif upper.startswith(("C-", "CTRL-", "CTRL+")):
-            # last char after dash/plus is the key
-            key = upper.split("-", 1)[-1].split("+", 1)[-1]
-            if len(key) == 1 and "A" <= key <= "Z":
-                payload = bytes([ord(key) & 0x1F])
-            else:
-                # Unknown form; fall back to raw text
-                payload = text.encode("utf-8", "ignore")
+        # Generic Ctrl-<letter>
+        elif parse_ctrl_key(text) is not None:
+            ctrl = parse_ctrl_key(text)
+            assert ctrl is not None
+            # ctrl is "C-x" — extract the letter
+            key_char = ctrl[-1].upper()
+            payload = bytes([ord(key_char) & 0x1F])
             append_eol = False  # ctrl combos are "instant"
         else:
             # Check if this is a long multi-line command that needs chunked sending

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -20,6 +20,25 @@ from openhands.tools.terminal.terminal.interface import parse_ctrl_key
 
 logger = get_logger(__name__)
 
+# Map normalized special key names to tmux key names.
+_TMUX_SPECIALS: dict[str, str] = {
+    "ENTER": "Enter",
+    "TAB": "Tab",
+    "BS": "BSpace",
+    "ESC": "Escape",
+    "UP": "Up",
+    "DOWN": "Down",
+    "LEFT": "Left",
+    "RIGHT": "Right",
+    "HOME": "Home",
+    "END": "End",
+    "PGUP": "PPage",
+    "PGDN": "NPage",
+    "C-L": "C-l",
+    "C-D": "C-d",
+    "C-C": "C-c",
+}
+
 
 class TmuxTerminal(TerminalInterface):
     """Tmux-based terminal backend.
@@ -130,24 +149,6 @@ class TmuxTerminal(TerminalInterface):
             raise RuntimeError("Tmux terminal is not initialized")
 
         # Map normalized names to tmux key names
-        _TMUX_SPECIALS = {
-            "ENTER": "Enter",
-            "TAB": "Tab",
-            "BS": "BSpace",
-            "ESC": "Escape",
-            "UP": "Up",
-            "DOWN": "Down",
-            "LEFT": "Left",
-            "RIGHT": "Right",
-            "HOME": "Home",
-            "END": "End",
-            "PGUP": "PPage",
-            "PGDN": "NPage",
-            "C-L": "C-l",
-            "C-D": "C-d",
-            "C-C": "C-c",
-        }
-
         upper = text.strip().upper()
 
         # 1) Named specials

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -15,6 +15,7 @@ from openhands.tools.terminal.constants import (
 )
 from openhands.tools.terminal.metadata import CmdOutputMetadata
 from openhands.tools.terminal.terminal import TerminalInterface
+from openhands.tools.terminal.terminal.interface import parse_ctrl_key
 
 
 logger = get_logger(__name__)
@@ -114,14 +115,57 @@ class TmuxTerminal(TerminalInterface):
     def send_keys(self, text: str, enter: bool = True) -> None:
         """Send text/keys to the tmux pane.
 
+        Supports:
+          - Plain text (uses literal paste; preserves spaces/newlines)
+          - Named specials: ENTER, TAB, BS, ESC, UP, DOWN, LEFT, RIGHT,
+            HOME, END, PGUP, PGDN, C-L, C-D, C-C
+          - Generic Ctrl sequences: C-a..C-z, CTRL-x, CTRL+x
+
         Args:
             text: Text or key sequence to send
-            enter: Whether to send Enter key after the text
+            enter: Whether to send Enter key after the text.
+                   Ignored for special/ctrl keys.
         """
         if not self._initialized or not isinstance(self.pane, libtmux.Pane):
             raise RuntimeError("Tmux terminal is not initialized")
 
-        self.pane.send_keys(text, enter=enter)
+        # Map normalized names to tmux key names
+        _TMUX_SPECIALS = {
+            "ENTER": "Enter",
+            "TAB": "Tab",
+            "BS": "BSpace",
+            "ESC": "Escape",
+            "UP": "Up",
+            "DOWN": "Down",
+            "LEFT": "Left",
+            "RIGHT": "Right",
+            "HOME": "Home",
+            "END": "End",
+            "PGUP": "PPage",
+            "PGDN": "NPage",
+            "C-L": "C-l",
+            "C-D": "C-d",
+            "C-C": "C-c",
+        }
+
+        upper = text.strip().upper()
+
+        # 1) Named specials
+        if upper in _TMUX_SPECIALS:
+            self.pane.send_keys(_TMUX_SPECIALS[upper], enter=False)
+            return
+
+        # 2) Generic Ctrl-<letter>
+        ctrl = parse_ctrl_key(text)
+        if ctrl is not None:
+            self.pane.send_keys(ctrl, enter=False)
+            return
+
+        # 3) Plain text — use literal=True so tmux doesn't split on
+        #    whitespace or interpret special tokens.
+        self.pane.send_keys(text, enter=False, literal=True)
+        if enter and not text.endswith("\n"):
+            self.pane.send_keys("Enter", enter=False)
 
     def read_screen(self) -> str:
         """Read the current tmux pane content.

--- a/tests/tools/terminal/test_send_keys.py
+++ b/tests/tools/terminal/test_send_keys.py
@@ -54,6 +54,23 @@ def test_supported_special_keys_contains_essentials() -> None:
         assert key in SUPPORTED_SPECIAL_KEYS
 
 
+def test_subprocess_specials_match_contract() -> None:
+    """Backend specials dicts must stay in sync with SUPPORTED_SPECIAL_KEYS."""
+    from openhands.tools.terminal.terminal.subprocess_terminal import (
+        _SUBPROCESS_SPECIALS,
+    )
+
+    assert set(_SUBPROCESS_SPECIALS.keys()) == SUPPORTED_SPECIAL_KEYS
+
+
+def test_tmux_specials_match_contract() -> None:
+    from openhands.tools.terminal.terminal.tmux_terminal import (
+        _TMUX_SPECIALS,
+    )
+
+    assert set(_TMUX_SPECIALS.keys()) == SUPPORTED_SPECIAL_KEYS
+
+
 # ── SubprocessTerminal.send_keys ────────────────────────────────────
 
 
@@ -88,6 +105,14 @@ def test_subprocess_send_keys_ctrl_variants(subprocess_terminal) -> None:
     """CTRL-x and CTRL+x forms should work."""
     subprocess_terminal.send_keys("CTRL-a")
     subprocess_terminal.send_keys("CTRL+e")
+
+
+def test_subprocess_send_keys_echo(subprocess_terminal) -> None:
+    """Verify data actually flows through the PTY dispatch path."""
+    subprocess_terminal.send_keys("echo hello_subprocess")
+    time.sleep(0.5)
+    screen = subprocess_terminal.read_screen()
+    assert "hello_subprocess" in screen
 
 
 # ── TmuxTerminal.send_keys ─────────────────────────────────────────

--- a/tests/tools/terminal/test_send_keys.py
+++ b/tests/tools/terminal/test_send_keys.py
@@ -1,0 +1,134 @@
+"""Tests for standardized send_keys special key handling."""
+
+import pytest
+
+from openhands.tools.terminal.terminal.interface import (
+    SUPPORTED_SPECIAL_KEYS,
+    parse_ctrl_key,
+)
+
+
+# ── parse_ctrl_key ──────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("C-a", "C-a"),
+        ("C-Z", "C-z"),
+        ("CTRL-c", "C-c"),
+        ("ctrl+d", "C-d"),
+        ("CTRL+L", "C-l"),
+        ("C-m", "C-m"),
+    ],
+)
+def test_parse_ctrl_key_valid(text: str, expected: str) -> None:
+    assert parse_ctrl_key(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "C-",  # no letter
+        "C-ab",  # two letters
+        "C-1",  # digit
+        "hello",  # plain text
+        "CTRL-",  # no letter
+        "CTRL+12",  # not single letter
+    ],
+)
+def test_parse_ctrl_key_invalid(text: str) -> None:
+    assert parse_ctrl_key(text) is None
+
+
+# ── SUPPORTED_SPECIAL_KEYS ──────────────────────────────────────────
+
+
+def test_supported_special_keys_contains_essentials() -> None:
+    for key in ("ENTER", "TAB", "ESC", "UP", "DOWN", "C-C", "C-D"):
+        assert key in SUPPORTED_SPECIAL_KEYS
+
+
+# ── SubprocessTerminal.send_keys ────────────────────────────────────
+
+
+@pytest.fixture
+def subprocess_terminal(tmp_path):
+    """Create a real SubprocessTerminal for send_keys testing."""
+    import platform
+
+    if platform.system() == "Windows":
+        pytest.skip("SubprocessTerminal not available on Windows")
+
+    from openhands.tools.terminal.terminal.subprocess_terminal import (
+        SubprocessTerminal,
+    )
+
+    term = SubprocessTerminal(work_dir=str(tmp_path))
+    term.initialize()
+    yield term
+    term.close()
+
+
+def test_subprocess_send_keys_ctrl_c(subprocess_terminal) -> None:
+    """C-c should be recognized as a special key (not sent as literal text)."""
+    # Should not raise; just verify it dispatches without error
+    subprocess_terminal.send_keys("C-c")
+
+
+def test_subprocess_send_keys_named_special(subprocess_terminal) -> None:
+    """Named specials like TAB should be dispatched without error."""
+    subprocess_terminal.send_keys("TAB")
+
+
+def test_subprocess_send_keys_ctrl_variants(subprocess_terminal) -> None:
+    """CTRL-x and CTRL+x forms should work."""
+    subprocess_terminal.send_keys("CTRL-a")
+    subprocess_terminal.send_keys("CTRL+e")
+
+
+# ── TmuxTerminal.send_keys ─────────────────────────────────────────
+
+
+@pytest.fixture
+def tmux_terminal(tmp_path):
+    """Create a real TmuxTerminal for send_keys testing."""
+    import platform
+    import shutil
+
+    if platform.system() == "Windows":
+        pytest.skip("TmuxTerminal not available on Windows")
+    if shutil.which("tmux") is None:
+        pytest.skip("tmux not installed")
+
+    from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
+
+    term = TmuxTerminal(work_dir=str(tmp_path))
+    term.initialize()
+    yield term
+    term.close()
+
+
+def test_tmux_send_keys_ctrl_c(tmux_terminal) -> None:
+    tmux_terminal.send_keys("C-c")
+
+
+def test_tmux_send_keys_named_special(tmux_terminal) -> None:
+    tmux_terminal.send_keys("TAB")
+    tmux_terminal.send_keys("UP")
+    tmux_terminal.send_keys("ESC")
+
+
+def test_tmux_send_keys_ctrl_variants(tmux_terminal) -> None:
+    tmux_terminal.send_keys("CTRL-a")
+    tmux_terminal.send_keys("CTRL+e")
+
+
+def test_tmux_send_keys_plain_text(tmux_terminal) -> None:
+    """Plain text should be sent literally (not interpreted as a key name)."""
+    import time
+
+    tmux_terminal.send_keys("echo hello_world")
+    time.sleep(0.3)
+    screen = tmux_terminal.read_screen()
+    assert "hello_world" in screen

--- a/tests/tools/terminal/test_send_keys.py
+++ b/tests/tools/terminal/test_send_keys.py
@@ -1,5 +1,10 @@
 """Tests for standardized send_keys special key handling."""
 
+import platform
+import shutil
+import tempfile
+import time
+
 import pytest
 
 from openhands.tools.terminal.terminal.interface import (
@@ -29,12 +34,12 @@ def test_parse_ctrl_key_valid(text: str, expected: str) -> None:
 @pytest.mark.parametrize(
     "text",
     [
-        "C-",  # no letter
-        "C-ab",  # two letters
-        "C-1",  # digit
-        "hello",  # plain text
-        "CTRL-",  # no letter
-        "CTRL+12",  # not single letter
+        "C-",
+        "C-ab",
+        "C-1",
+        "hello",
+        "CTRL-",
+        "CTRL+12",
     ],
 )
 def test_parse_ctrl_key_invalid(text: str) -> None:
@@ -53,10 +58,8 @@ def test_supported_special_keys_contains_essentials() -> None:
 
 
 @pytest.fixture
-def subprocess_terminal(tmp_path):
+def subprocess_terminal():
     """Create a real SubprocessTerminal for send_keys testing."""
-    import platform
-
     if platform.system() == "Windows":
         pytest.skip("SubprocessTerminal not available on Windows")
 
@@ -64,15 +67,15 @@ def subprocess_terminal(tmp_path):
         SubprocessTerminal,
     )
 
-    term = SubprocessTerminal(work_dir=str(tmp_path))
-    term.initialize()
-    yield term
-    term.close()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        term = SubprocessTerminal(work_dir=tmpdir)
+        term.initialize()
+        yield term
+        term.close()
 
 
 def test_subprocess_send_keys_ctrl_c(subprocess_terminal) -> None:
     """C-c should be recognized as a special key (not sent as literal text)."""
-    # Should not raise; just verify it dispatches without error
     subprocess_terminal.send_keys("C-c")
 
 
@@ -91,11 +94,8 @@ def test_subprocess_send_keys_ctrl_variants(subprocess_terminal) -> None:
 
 
 @pytest.fixture
-def tmux_terminal(tmp_path):
+def tmux_terminal():
     """Create a real TmuxTerminal for send_keys testing."""
-    import platform
-    import shutil
-
     if platform.system() == "Windows":
         pytest.skip("TmuxTerminal not available on Windows")
     if shutil.which("tmux") is None:
@@ -103,10 +103,11 @@ def tmux_terminal(tmp_path):
 
     from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
-    term = TmuxTerminal(work_dir=str(tmp_path))
-    term.initialize()
-    yield term
-    term.close()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        term = TmuxTerminal(work_dir=tmpdir)
+        term.initialize()
+        yield term
+        term.close()
 
 
 def test_tmux_send_keys_ctrl_c(tmux_terminal) -> None:
@@ -126,8 +127,6 @@ def test_tmux_send_keys_ctrl_variants(tmux_terminal) -> None:
 
 def test_tmux_send_keys_plain_text(tmux_terminal) -> None:
     """Plain text should be sent literally (not interpreted as a key name)."""
-    import time
-
     tmux_terminal.send_keys("echo hello_world")
     time.sleep(0.3)
     screen = tmux_terminal.read_screen()


### PR DESCRIPTION
<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->


>

- [x] A human has tested these changes.

------


## Why

The terminal's send_keys method handled special keys inconsistently across backends. SubprocessTerminal supported named specials (TAB, UP, ESC, etc.) and Ctrl sequences, but TmuxTerminal just passed everything
through to pane.send_keys(text, enter=enter) with no special key parsing. There was no shared contract defining which keys all backends must support, and the tool description only mentioned C-c, C-d, and C-z — the
LLM didn't know it could send arrow keys, Tab, etc.

## Summary

- Add SUPPORTED_SPECIAL_KEYS constant and shared parse_ctrl_key() helper to TerminalInterface, establishing a standard key vocabulary across all backends
- Rewrite TmuxTerminal.send_keys to dispatch named specials (mapped to tmux key names), generic Ctrl sequences, and plain text with literal=True to preserve whitespace
- Refactor SubprocessTerminal.send_keys to use the shared parse_ctrl_key() helper and add C-C to its named specials map
- Update TerminalAction.command description and TOOL_DESCRIPTION to document all supported special keys for the LLM

## Issue Number

Closes #112

## Testing


- unit tests passes

### Manual Testing

```python
OPENHANDS_SUPPRESS_BANNER=1 uv run python -c "
import time
from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal

t = TmuxTerminal(work_dir='/tmp')
t.initialize()
time.sleep(2)

# Test 1: C-c interrupts
t.send_keys('sleep 999')
time.sleep(1)
t.send_keys('C-c')
time.sleep(1)
screen = t.read_screen()
print('TEST 1 - C-c interrupt:', 'PASS' if '^C' in screen else 'FAIL')

# Test 2: TAB completion
t.send_keys('ech', enter=False)
time.sleep(0.3)
t.send_keys('TAB')
time.sleep(1)
screen = t.read_screen()
print('TEST 2 - TAB completion:', 'PASS' if 'echo' in screen else 'FAIL')

# Test 3: UP history recall
t.send_keys('C-c')
time.sleep(0.5)
t.send_keys('UP')
time.sleep(1)
screen = t.read_screen()
print('TEST 3 - UP history:', 'PASS' if 'sleep' in screen or 'echo' in screen else 'FAIL')

t.close()
print('All manual tests done.')
"
```


Output:

```
TEST 1 - C-c interrupt: PASS
TEST 2 - TAB completion: PASS
TEST 3 - UP history: PASS
All manual tests done.
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The literal=True change in TmuxTerminal.send_keys for plain text is important — without it, tmux splits text on whitespace and interprets tokens as key names, which could cause unexpected behavior for commands
containing spaces.
- LEFT/BS arrow key editing may not work on macOS with bash 3.2 (the ancient system bash) — this is a bash limitation, not a bug in the implementation. On Linux with bash 5.x (where OpenHands agents run), all keys
work correctly.