### PR TITLE
feat(tool): structured output via response_schema on any tool

### DIFF
--- a/examples/01_standalone_sdk/48_structured_output.py
+++ b/examples/01_standalone_sdk/48_structured_output.py
@@ -37,7 +37,9 @@ class CommandRationale(BaseModel):
 
 
 class ProjectFacts(BaseModel):
-    summary: str = Field(description="One-paragraph summary of the project.")
+    # NOTE: avoid the field name ``summary`` — the SDK already injects a
+    # meta ``summary`` field on every action schema for explainability.
+    description: str = Field(description="One-paragraph description of the project.")
     facts: list[str] = Field(description="Three concise, distinct facts.")
 
 
@@ -100,7 +102,7 @@ for event in events:
 facts = cast(ProjectFacts | None, finish_tool.parse_last_response(events))
 if facts:
     print("\n[Finish]")
-    print(f"  summary: {facts.summary}")
+    print(f"  description: {facts.description}")
     for fact in facts.facts:
         print(f"  - {fact}")
 

--- a/examples/01_standalone_sdk/48_structured_output.py
+++ b/examples/01_standalone_sdk/48_structured_output.py
@@ -1,0 +1,108 @@
+"""Structured output via ``response_schema``.
+
+Attach a Pydantic model to *any* tool spec and the agent must populate those
+fields when calling that tool. The schema is sent to the LLM as the tool's
+JSON-schema parameters and validated on receipt.
+
+Demonstrated here on two tools:
+  - ``TerminalTool`` (existing SDK tool) — every command must come with a
+    ``purpose`` and ``expected_outcome``, on top of the tool's own ``command``
+    field. No subclassing required: the schema is merged in via the spec.
+  - ``FinishTool`` (built-in) — the final answer comes back as a typed object.
+"""
+
+import os
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.tool import Tool, register_tool
+from openhands.sdk.tool.builtins.finish import FinishTool
+from openhands.tools.file_editor import FileEditorTool
+from openhands.tools.terminal import TerminalTool
+
+
+# --- Structured-output schemas ------------------------------------------------
+
+
+class CommandRationale(BaseModel):
+    """Forced-annotation schema attached to TerminalTool."""
+
+    purpose: str = Field(description="Why this command is being run, in one line.")
+    expected_outcome: str = Field(
+        description="What the assistant expects to observe from running it."
+    )
+
+
+class ProjectFacts(BaseModel):
+    summary: str = Field(description="One-paragraph summary of the project.")
+    facts: list[str] = Field(description="Three concise, distinct facts.")
+
+
+# Register FinishTool so we can attach a response_schema via Tool spec.
+register_tool("FinishTool", FinishTool)
+
+
+# --- Agent setup --------------------------------------------------------------
+
+
+llm = LLM(
+    model=os.getenv("LLM_MODEL", "anthropic/claude-sonnet-4-5-20250929"),
+    api_key=os.getenv("LLM_API_KEY"),
+    base_url=os.getenv("LLM_BASE_URL", None),
+)
+
+agent = Agent(
+    llm=llm,
+    tools=[
+        # Existing tool, augmented with a forced-annotation schema:
+        Tool(name=TerminalTool.name, params={"response_schema": CommandRationale}),
+        Tool(name=FileEditorTool.name),
+        Tool(name="FinishTool", params={"response_schema": ProjectFacts}),
+    ],
+    # Skip the auto-injected default FinishTool so our schema-bound one is used.
+    include_default_tools=["ThinkTool"],
+)
+
+conversation = Conversation(agent=agent, workspace=os.getcwd())
+conversation.send_message(
+    "Inspect the repo using terminal commands, then finish with three facts "
+    "about the project."
+)
+conversation.run()
+
+
+# --- Recover typed outputs from any tool with a response_schema ---------------
+
+events = conversation.state.events
+terminal_tool = agent.tools_map[TerminalTool.name]
+finish_tool = agent.tools_map["finish"]
+
+# Every TerminalTool call now carries our annotation fields. Walk all events to
+# show that the LLM populated them on every invocation.
+print("\n[Terminal commands with rationale]")
+
+for event in events:
+    if (
+        isinstance(event, ActionEvent)
+        and event.tool_name == TerminalTool.name
+        and event.action is not None
+    ):
+        rationale = terminal_tool.parse_response(event.action)
+        # action.command is the tool's own field; rationale.* came from the schema.
+        print(f"  $ {getattr(event.action, 'command', '?')}")
+        print(f"    purpose:          {rationale.purpose}")  # type: ignore[attr-defined]
+        print(f"    expected_outcome: {rationale.expected_outcome}")  # type: ignore[attr-defined]
+
+# And the typed final answer:
+facts = finish_tool.parse_last_response(events)
+if facts:
+    print("\n[Finish]")
+    print(f"  summary: {facts.summary}")  # type: ignore[attr-defined]
+    for fact in facts.facts:  # type: ignore[attr-defined]
+        print(f"  - {fact}")
+
+# Report cost
+cost = conversation.conversation_stats.get_combined_metrics().accumulated_cost
+print(f"\nEXAMPLE_COST: {cost}")

--- a/examples/01_standalone_sdk/48_structured_output.py
+++ b/examples/01_standalone_sdk/48_structured_output.py
@@ -12,6 +12,7 @@ Demonstrated here on two tools:
 """
 
 import os
+from typing import cast
 
 from pydantic import BaseModel, Field
 
@@ -89,18 +90,18 @@ for event in events:
         and event.tool_name == TerminalTool.name
         and event.action is not None
     ):
-        rationale = terminal_tool.parse_response(event.action)
+        rationale = cast(CommandRationale, terminal_tool.parse_response(event.action))
         # action.command is the tool's own field; rationale.* came from the schema.
         print(f"  $ {getattr(event.action, 'command', '?')}")
-        print(f"    purpose:          {rationale.purpose}")  # type: ignore[attr-defined]
-        print(f"    expected_outcome: {rationale.expected_outcome}")  # type: ignore[attr-defined]
+        print(f"    purpose:          {rationale.purpose}")
+        print(f"    expected_outcome: {rationale.expected_outcome}")
 
 # And the typed final answer:
-facts = finish_tool.parse_last_response(events)
+facts = cast(ProjectFacts | None, finish_tool.parse_last_response(events))
 if facts:
     print("\n[Finish]")
-    print(f"  summary: {facts.summary}")  # type: ignore[attr-defined]
-    for fact in facts.facts:  # type: ignore[attr-defined]
+    print(f"  summary: {facts.summary}")
+    for fact in facts.facts:
         print(f"  - {fact}")
 
 # Report cost

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -165,7 +165,17 @@ def resolve_tool(
     if resolver is None:
         raise KeyError(f"ToolDefinition '{tool_spec.name}' is not registered")
 
-    return resolver(tool_spec.params, conv_state)
+    # `response_schema` is a generic, tool-agnostic mechanism for structured
+    # output, so it must NOT be forwarded into the tool's own ``.create()``.
+    # Pop it *before* calling the resolver — otherwise factories with a fixed
+    # kwarg list (e.g. ``FinishTool.create`` which rejects extra params, or
+    # any ``def create(cls, conv_state, working_dir=None)``) will raise.
+    params = dict(tool_spec.params)
+    response_schema = params.pop("response_schema", None)
+    tools = resolver(params, conv_state)
+    if response_schema is not None:
+        tools = [t.set_response_schema(response_schema) for t in tools]
+    return tools
 
 
 def list_registered_tools() -> list[str]:

--- a/openhands-sdk/openhands/sdk/tool/spec.py
+++ b/openhands-sdk/openhands/sdk/tool/spec.py
@@ -1,6 +1,6 @@
 from typing import Any
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 
 class Tool(BaseModel):
@@ -37,3 +37,11 @@ class Tool(BaseModel):
     def validate_params(cls, v: dict[str, Any] | None) -> dict[str, Any]:
         """Convert None params to empty dict."""
         return v if v is not None else {}
+
+    @field_serializer("params")
+    def _ser_params(self, params: dict[str, Any]) -> dict[str, Any]:
+        """Drop non-JSON-serialisable class values (e.g. ``response_schema``
+        Pydantic classes) so the spec can be persisted as part of conversation
+        state. These runtime values are reapplied by the registry on resolve.
+        """
+        return {k: v for k, v in params.items() if not isinstance(v, type)}

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -363,6 +363,11 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
     def parse_response(self, action: Action) -> BaseModel:
         """Validate ``action`` against ``response_schema`` and return the model.
 
+        The return type is declared as ``BaseModel`` because ``ToolDefinition``
+        is not generic over the schema; cast at the call site for type safety::
+
+            result = cast(MySchema, tool.parse_response(action))
+
         Raises ``ValueError`` if no ``response_schema`` is configured.
         """
         if self.response_schema is None:

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -10,6 +10,7 @@ from typing import (
     Protocol,
     Self,
     TypeVar,
+    cast,
 )
 
 from litellm import (
@@ -44,6 +45,7 @@ ActionT = TypeVar("ActionT", bound=Action)
 ObservationT = TypeVar("ObservationT", bound=Observation)
 _action_types_with_risk: dict[type, type] = {}
 _action_types_with_summary: dict[type, type] = {}
+_action_types_with_schema: dict[tuple[type, type], type] = {}
 _action_type_lock = threading.Lock()
 
 
@@ -239,6 +241,14 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         default=None, repr=False, exclude=True
     )
 
+    # Optional Pydantic model describing the structured payload the LLM must
+    # return when invoking this tool. When set, the model's fields are merged
+    # into the action schema sent to the LLM, and ``action_from_arguments``
+    # validates the call against that augmented schema. Runtime-only.
+    response_schema: SkipJsonSchema[type[BaseModel] | None] = Field(
+        default=None, repr=False, exclude=True
+    )
+
     @classmethod
     @abstractmethod
     def create(cls, *args, **kwargs) -> Sequence[Self]:
@@ -300,6 +310,10 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         """Create a new Tool instance with the given executor."""
         return self.model_copy(update={"executor": executor})
 
+    def set_response_schema(self, response_schema: type[BaseModel] | None) -> Self:
+        """Return a copy of this tool with the structured ``response_schema`` set."""
+        return self.model_copy(update={"response_schema": response_schema})
+
     def as_executable(self) -> ExecutableTool:
         """Return this tool as an ExecutableTool, ensuring it has an executor.
 
@@ -338,7 +352,41 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         Returns:
             The action instance created from the arguments.
         """
-        return self.action_type.model_validate(arguments)
+        action_type: type[Action] = self.action_type
+        if self.response_schema is not None:
+            action_type = cast(
+                type[Action],
+                _create_action_type_with_schema(action_type, self.response_schema),
+            )
+        return action_type.model_validate(arguments)
+
+    def parse_response(self, action: Action) -> BaseModel:
+        """Validate ``action`` against ``response_schema`` and return the model.
+
+        Raises ``ValueError`` if no ``response_schema`` is configured.
+        """
+        if self.response_schema is None:
+            raise ValueError(f"Tool '{self.name}' has no response_schema configured.")
+        # Pick only the schema's own fields so meta-fields (kind, summary, ...)
+        # don't leak in and we don't have to chase them.
+        data = {k: getattr(action, k) for k in self.response_schema.model_fields}
+        return self.response_schema.model_validate(data)
+
+    def parse_last_response(self, events: "Sequence[Any]") -> BaseModel | None:
+        """Find the most recent ``ActionEvent`` for this tool and parse it.
+
+        Returns ``None`` if the tool has not been called yet.
+        """
+        from openhands.sdk.event import ActionEvent  # avoid circular import
+
+        for event in reversed(events):
+            if (
+                isinstance(event, ActionEvent)
+                and event.tool_name == self.name
+                and event.action is not None
+            ):
+                return self.parse_response(event.action)
+        return None
 
     def __call__(
         self, action: ActionT, conversation: "LocalConversation | None" = None
@@ -411,6 +459,12 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         action_type: type[Schema] | None = None,
     ) -> dict[str, Any]:
         action_type = action_type or self.action_type
+
+        # Merge the structured response schema (if any) into the action schema
+        if self.response_schema is not None:
+            action_type = _create_action_type_with_schema(
+                action_type, self.response_schema
+            )
 
         # Apply security risk enhancement if enabled
         add_security_risk_prediction = add_security_risk_prediction and (
@@ -550,6 +604,48 @@ def create_action_type_with_risk(action_type: type[Schema]) -> type[Schema]:
         )
         _action_types_with_risk[action_type] = action_type_with_risk
         return action_type_with_risk
+
+
+def _create_action_type_with_schema(
+    action_type: type[Schema], response_schema: type[BaseModel]
+) -> type[Schema]:
+    """Return an action type extended with the fields of ``response_schema``.
+
+    Every field declared on the Pydantic ``response_schema`` becomes an extra
+    field on the returned action class. This is what enables an LLM to reply
+    with structured output: the JSON schema sent to the model includes both
+    the tool's own parameters and the user-defined response fields.
+
+    A field name collision between the action and the response schema is a
+    programming error and raises ``ValueError``.
+    """
+    cache_key = (action_type, response_schema)
+    with _action_type_lock:
+        cached = _action_types_with_schema.get(cache_key)
+        if cached is not None:
+            return cached
+
+        overlap = set(action_type.model_fields) & set(response_schema.model_fields)
+        if overlap:
+            raise ValueError(
+                f"response_schema fields {sorted(overlap)} collide with "
+                f"existing fields on {action_type.__name__}."
+            )
+
+        attrs: dict[str, Any] = {}
+        annotations: dict[str, Any] = {}
+        for field_name, field_info in response_schema.model_fields.items():
+            attrs[field_name] = field_info
+            annotations[field_name] = field_info.annotation
+        attrs["__annotations__"] = annotations
+
+        new_type = type(
+            f"{action_type.__name__}With{response_schema.__name__}",
+            (action_type,),
+            attrs,
+        )
+        _action_types_with_schema[cache_key] = new_type
+        return new_type
 
 
 def _create_action_type_with_summary(action_type: type[Schema]) -> type[Schema]:

--- a/tests/sdk/tool/test_response_schema.py
+++ b/tests/sdk/tool/test_response_schema.py
@@ -1,0 +1,235 @@
+"""Tests for the ``response_schema`` structured-output mechanism on tools."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel, Field, ValidationError
+
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.llm import MessageToolCall
+from openhands.sdk.tool.builtins.finish import (
+    FinishAction,
+    FinishObservation,
+    FinishTool,
+)
+from openhands.sdk.tool.registry import register_tool, resolve_tool
+from openhands.sdk.tool.spec import Tool
+from openhands.sdk.tool.tool import ToolDefinition, _create_action_type_with_schema
+
+
+class TaskResult(BaseModel):
+    success: bool = Field(description="Whether the task succeeded.")
+    summary_text: str = Field(description="One-line summary of what was done.")
+    files_changed: list[str] = Field(default_factory=list)
+
+
+def _finish_with_schema(schema: type[BaseModel]) -> ToolDefinition:
+    """Resolve a FinishTool instance via the registry with response_schema set."""
+    register_tool("FinishTool", FinishTool)
+    [tool] = resolve_tool(
+        Tool(name="FinishTool", params={"response_schema": schema}),
+        conv_state=MagicMock(),
+    )
+    return tool
+
+
+def _make_finish_event(tool: ToolDefinition, tool_name: str, **fields) -> ActionEvent:
+    defaults = {
+        "message": "m",
+        "success": True,
+        "summary_text": "s",
+        "files_changed": [],
+    }
+    defaults.update(fields)
+    action = tool.action_from_arguments(defaults)
+    return ActionEvent(
+        tool_name=tool_name,
+        tool_call_id="tc",
+        tool_call=MessageToolCall(
+            id="tc", name=tool_name, arguments="{}", origin="completion"
+        ),
+        llm_response_id="r",
+        action=action,
+        thought=[],
+        reasoning_content="",
+    )
+
+
+def test_finish_tool_without_schema_is_unchanged():
+    [tool] = FinishTool.create()
+    assert tool.response_schema is None
+    schema = tool._get_tool_schema()
+    assert set(schema["properties"]) == {"message", "summary"}
+
+
+def test_response_schema_extends_action_schema():
+    tool = _finish_with_schema(TaskResult)
+    assert tool.response_schema is TaskResult
+    props = tool._get_tool_schema()["properties"]
+    assert {"message", "success", "summary_text", "files_changed"} <= set(props)
+    # original Pydantic descriptions are preserved for the LLM
+    assert props["success"]["description"] == "Whether the task succeeded."
+
+
+def test_action_from_arguments_validates_extended_payload():
+    tool = _finish_with_schema(TaskResult)
+    action = tool.action_from_arguments(
+        {
+            "message": "done",
+            "success": True,
+            "summary_text": "fixed bug",
+            "files_changed": ["a.py", "b.py"],
+        }
+    )
+    assert isinstance(action, FinishAction)
+    assert action.message == "done"
+    typed = tool.parse_response(action)
+    assert isinstance(typed, TaskResult)
+    assert typed.success is True
+    assert typed.files_changed == ["a.py", "b.py"]
+
+
+@pytest.mark.parametrize(
+    "bad_payload",
+    [
+        pytest.param({"message": "done"}, id="missing-all-schema-fields"),
+        pytest.param(
+            {"message": "done", "success": True, "files_changed": []},
+            id="missing-summary_text",
+        ),
+        pytest.param(
+            {
+                "message": "done",
+                "success": {"not": "a bool"},
+                "summary_text": "s",
+                "files_changed": [],
+            },
+            id="wrong-type-for-bool",
+        ),
+        pytest.param(
+            {
+                "message": "done",
+                "success": True,
+                "summary_text": "s",
+                "files_changed": "not-a-list",
+            },
+            id="wrong-type-for-list",
+        ),
+    ],
+)
+def test_action_from_arguments_rejects_invalid_payload(bad_payload):
+    tool = _finish_with_schema(TaskResult)
+    with pytest.raises(ValidationError):
+        tool.action_from_arguments(bad_payload)
+
+
+def test_nested_pydantic_schema_roundtrips():
+    """Nested Pydantic models: descriptions flow to the LLM schema, and
+    ``parse_response`` reconstructs the full tree typed."""
+
+    class Change(BaseModel):
+        path: str = Field(description="File that changed.")
+        lines: int = Field(description="Lines changed.")
+
+    class NestedResult(BaseModel):
+        headline: str
+        changes: list[Change]
+
+    tool = _finish_with_schema(NestedResult)
+    props = tool._get_tool_schema()["properties"]
+    change_props = props["changes"]["items"]["properties"]
+    assert change_props["path"]["description"] == "File that changed."
+
+    action = tool.action_from_arguments(
+        {
+            "message": "ok",
+            "headline": "big refactor",
+            "changes": [
+                {"path": "a.py", "lines": 3},
+                {"path": "b.py", "lines": 7},
+            ],
+        }
+    )
+    typed = tool.parse_response(action)
+    assert isinstance(typed, NestedResult)
+    assert typed.changes[1].path == "b.py"
+    assert isinstance(typed.changes[0], Change)
+
+
+def test_parse_response_requires_schema():
+    [tool] = FinishTool.create()
+    with pytest.raises(ValueError):
+        tool.parse_response(FinishAction(message="hi"))
+
+
+def test_executor_still_works_with_schema():
+    tool = _finish_with_schema(TaskResult)
+    action = tool.action_from_arguments(
+        {"message": "ok", "success": True, "summary_text": "ok", "files_changed": []}
+    )
+    obs = tool(action)
+    assert isinstance(obs, FinishObservation)
+
+
+@pytest.mark.parametrize(
+    "params, expected_serialised",
+    [
+        pytest.param({"response_schema": TaskResult}, {}, id="schema-only-dropped"),
+        pytest.param(
+            {"response_schema": TaskResult, "keep_me": 7, "opts": {"a": 1}},
+            {"keep_me": 7, "opts": {"a": 1}},
+            id="schema-dropped-others-kept",
+        ),
+        pytest.param({"keep_me": 7}, {"keep_me": 7}, id="no-schema"),
+    ],
+)
+def test_tool_spec_strips_class_valued_params_on_dump(params, expected_serialised):
+    """Regression: a class-valued param must not break ``model_dump_json`` —
+    otherwise persisting conversation state crashes at ``_save_base_state``.
+    The class is runtime-only and is dropped on dump; the registry re-applies
+    it from the in-memory spec on resolve.
+    """
+    spec = Tool(name="FinishTool", params=params)
+    assert json.loads(spec.model_dump_json())["params"] == expected_serialised
+
+
+def test_create_action_type_with_schema_is_cached():
+    """Schema augmentation is called on every LLM serialization; it must be
+    cached, not rebuild a class every time."""
+    a = _create_action_type_with_schema(FinishAction, TaskResult)
+    b = _create_action_type_with_schema(FinishAction, TaskResult)
+    assert a is b
+
+
+def test_parse_last_response_ignores_other_tools():
+    """Must match on ``tool_name`` — an event from a different tool doesn't
+    count."""
+    tool = _finish_with_schema(TaskResult)
+    events = [
+        _make_finish_event(tool, tool_name="finish"),
+        _make_finish_event(tool, tool_name="something_else"),
+    ]
+    result = tool.parse_last_response(events)
+    assert isinstance(result, TaskResult)
+
+
+def test_parse_last_response_picks_most_recent():
+    tool = _finish_with_schema(TaskResult)
+    events = [
+        _make_finish_event(tool, tool_name="finish", success=False),
+        _make_finish_event(tool, tool_name="finish", success=True),
+    ]
+    result = tool.parse_last_response(events)
+    assert isinstance(result, TaskResult)
+    assert result.success is True
+    assert tool.parse_last_response([]) is None
+
+
+def test_field_collision_raises():
+    class Bad(BaseModel):
+        message: str  # collides with FinishAction.message
+
+    tool = _finish_with_schema(Bad)
+    with pytest.raises(ValueError, match="collide"):
+        tool._get_tool_schema()


### PR DESCRIPTION
- [x] A human has tested these changes.


## Why

Feature requested in issue #2566 

## Summary

Adds first-class support for structured output (issue #2566). Any registered tool can opt in by attaching a Pydantic model to its Tool spec; the agent is then required to populate those fields when calling the tool, and the result
  is recoverable as a typed model.

  Mirrors pydantic-AI's default "Tool Output" mode: the schema rides on the existing tool-calling channel rather than provider-specific response_format, so it works across every provider that supports tool calls and composes with
  existing tools untouched.

```python
  from pydantic import BaseModel

  class ProjectFacts(BaseModel):
      summary: str
      facts: list[str]

  agent = Agent(
      llm=llm,
      tools=[
          Tool(name="TerminalTool", params={"response_schema": CommandRationale}),
          Tool(name="FinishTool",   params={"response_schema": ProjectFacts}),
      ],
  )

  facts: ProjectFacts = agent.tools_map["finish"].parse_last_response(events)
```

  How it works

  1. Spec — Tool(name=..., params={"response_schema": SomeModel}). The key is an SDK-wide convention.
  2. Registry — resolve_tool pops response_schema out of params before calling the tool's .create(**params) (so factories don't see it), then applies it to every returned tool via set_response_schema.
  3. LLM schema — in _get_tool_schema, the tool's action_type is dynamically extended with the schema's fields (cached), and the merged JSON schema is what the LLM sees as the function's parameters.
  4. Validation — action_from_arguments validates against the merged class; malformed LLM output raises ValidationError, same hard gate as any other tool argument.
  5. Retrieval — tool.parse_response(action) / tool.parse_last_response(events) return the typed response_schema instance.

## Issue Number
Closes issue #2566 


## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9d89f4c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9d89f4c-python \
  ghcr.io/openhands/agent-server:9d89f4c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9d89f4c-golang-amd64
ghcr.io/openhands/agent-server:9d89f4c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9d89f4c-golang-arm64
ghcr.io/openhands/agent-server:9d89f4c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9d89f4c-java-amd64
ghcr.io/openhands/agent-server:9d89f4c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9d89f4c-java-arm64
ghcr.io/openhands/agent-server:9d89f4c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9d89f4c-python-amd64
ghcr.io/openhands/agent-server:9d89f4c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9d89f4c-python-arm64
ghcr.io/openhands/agent-server:9d89f4c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9d89f4c-golang
ghcr.io/openhands/agent-server:9d89f4c-java
ghcr.io/openhands/agent-server:9d89f4c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9d89f4c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9d89f4c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->