### PR TITLE
fix: redact sensitive credentials from command logs

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/command.py
+++ b/openhands-sdk/openhands/sdk/utils/command.py
@@ -6,6 +6,7 @@ import threading
 from collections.abc import Mapping
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.redact import redact_text_secrets
 
 
 logger = get_logger(__name__)
@@ -61,11 +62,14 @@ def execute_command(
     if isinstance(cmd, str):
         cmd_to_run = cmd
         use_shell = True
-        logger.info("$ %s", cmd)
+        cmd_str = cmd
     else:
         cmd_to_run = cmd
         use_shell = False
-        logger.info("$ %s", " ".join(shlex.quote(c) for c in cmd))
+        cmd_str = " ".join(shlex.quote(c) for c in cmd)
+
+    # Log the command with sensitive values redacted
+    logger.info("$ %s", redact_text_secrets(cmd_str))
 
     proc = subprocess.Popen(
         cmd_to_run,

--- a/tests/sdk/utils/test_command.py
+++ b/tests/sdk/utils/test_command.py
@@ -1,8 +1,9 @@
 from collections import OrderedDict
+from unittest.mock import patch
 
 import pytest
 
-from openhands.sdk.utils.command import sanitized_env
+from openhands.sdk.utils.command import execute_command, sanitized_env
 
 
 def test_sanitized_env_returns_copy():
@@ -47,3 +48,81 @@ def test_sanitized_env_removes_ld_library_path_when_orig_empty():
     """When LD_LIBRARY_PATH_ORIG is empty, removes LD_LIBRARY_PATH."""
     env = {"LD_LIBRARY_PATH": "/pyinstaller", "LD_LIBRARY_PATH_ORIG": ""}
     assert "LD_LIBRARY_PATH" not in sanitized_env(env)
+
+
+# ---------------------------------------------------------------------------
+# execute_command logging redaction
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteCommandLoggingRedaction:
+    """Tests for sensitive value redaction in execute_command logging."""
+
+    def test_logs_command_without_errors(self, caplog):
+        """Command logging with redaction doesn't raise errors."""
+        with patch("subprocess.Popen") as mock_popen:
+            mock_process = mock_popen.return_value
+            mock_process.stdout = None
+            mock_process.stderr = None
+
+            cmd = ["docker", "run", "-e", "LMNR_PROJECT_API_KEY=secret123", "image"]
+
+            try:
+                execute_command(cmd)
+            except RuntimeError:
+                # Logging should happen even if subprocess fails
+                pass
+
+            # Command should be logged
+            assert "docker" in caplog.text
+            assert "run" in caplog.text
+            assert "image" in caplog.text
+
+    def test_redacts_api_key_from_string_command(self):
+        """API keys in string commands are properly redacted."""
+        from openhands.sdk.utils.redact import redact_text_secrets
+
+        # Test the redaction function directly
+        # Valid Anthropic key format: sk-ant-api[2 digits]-[20+ chars]
+        cmd_str = "curl -H 'Authorization: sk-ant-api00-abcd1234567890abcdefghijklmnop' https://api.anthropic.com"
+        redacted = redact_text_secrets(cmd_str)
+
+        # The secret should be redacted in the output of the function
+        assert "sk-ant-api00-abcd1234567890abcdefghijklmnop" not in redacted
+        assert "<redacted>" in redacted
+        # Command structure should be preserved
+        assert "curl" in redacted
+        assert "https://api.anthropic.com" in redacted
+
+    def test_redacts_key_value_env_format(self):
+        """KEY=VALUE environment variable format is redacted."""
+        from openhands.sdk.utils.redact import redact_text_secrets
+
+        cmd_str = "docker run -e api_key='secretvalue123456789' -e DEBUG=true image"
+        redacted = redact_text_secrets(cmd_str)
+
+        # api_key value should be redacted
+        assert "secretvalue123456789" not in redacted
+        # But non-sensitive DEBUG value should be present
+        assert "DEBUG" in redacted
+        # Command structure preserved
+        assert "docker" in redacted
+
+    def test_preserves_non_sensitive_args(self, caplog):
+        """Non-sensitive arguments are preserved in logs."""
+        with patch("subprocess.Popen") as mock_popen:
+            mock_process = mock_popen.return_value
+            mock_process.stdout = None
+            mock_process.stderr = None
+
+            cmd = ["docker", "run", "-e", "DEBUG=true", "image:latest"]
+
+            try:
+                execute_command(cmd)
+            except RuntimeError:
+                pass
+
+            # Non-sensitive values should be visible
+            assert "DEBUG=true" in caplog.text
+            assert "image:latest" in caplog.text
+            assert "docker" in caplog.text


### PR DESCRIPTION
## Summary

Redact sensitive environment variables and credentials from logged command output to prevent leaks to log aggregators (Datadog, CloudWatch, etc.).

## Problem

When credentials like `LMNR_PROJECT_API_KEY`, API keys, or tokens are passed via environment variables to subprocesses, they appear in the logged command output:

```
logger.info("$ docker run -e LMNR_PROJECT_API_KEY=sk-... -e RUNTIME_API_KEY=...")
```

These logs are captured by observability tools (Datadog, CloudWatch) and expose credentials.

## Solution

Use the existing `redact_text_secrets()` utility from `openhands.sdk.utils.redact` to redact sensitive values from all logged commands.

## Changes

- Import `redact_text_secrets` in execute_command
- Apply redaction to the formatted command string before logging
- Leverages existing comprehensive patterns for:
  - API keys from OpenAI, Anthropic, HuggingFace, Together, OpenRouter
  - Bearer tokens and session tokens
  - GitHub, GitLab, Slack tokens
  - Environment variables matching SECRET_KEY_PATTERNS
  - URL query parameters with sensitive values

## Test Plan

- [ ] Verify that commands with credentials are logged with redacted values
- [ ] Confirm that command structure is preserved (still shows KEY=<redacted>)
- [ ] Check that non-sensitive arguments remain unredacted
- [ ] Ensure no performance impact from redaction

## Example

```
# Before
"$ docker run -e LMNR_PROJECT_API_KEY=sk-proj-123abc... -e RUNTIME_API_KEY=secret123"

# After
"$ docker run -e LMNR_PROJECT_API_KEY=<redacted> -e RUNTIME_API_KEY=<redacted>"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:63db448-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-63db448-python \
  ghcr.io/openhands/agent-server:63db448-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:63db448-golang-amd64
ghcr.io/openhands/agent-server:63db448-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:63db448-golang-arm64
ghcr.io/openhands/agent-server:63db448-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:63db448-java-amd64
ghcr.io/openhands/agent-server:63db448-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:63db448-java-arm64
ghcr.io/openhands/agent-server:63db448-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:63db448-python-amd64
ghcr.io/openhands/agent-server:63db448-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:63db448-python-arm64
ghcr.io/openhands/agent-server:63db448-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:63db448-golang
ghcr.io/openhands/agent-server:63db448-java
ghcr.io/openhands/agent-server:63db448-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `63db448-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `63db448-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->