### PR TITLE
fix(ci): use AGENT_SERVER_SHA to avoid conflict with GitHub's default GITHUB_SHA

### DIFF
--- a/.github/workflows/run-examples.yml
+++ b/.github/workflows/run-examples.yml
@@ -76,7 +76,9 @@ jobs:
                   PR_NUMBER: ${{ github.event.pull_request.number }}
                   REPO_OWNER: ${{ github.repository_owner }}
                   REPO_NAME: ${{ github.event.repository.name }}
-                  GITHUB_SHA: ${{ github.event.pull_request.head.sha }}
+                  # Use custom var name to avoid conflict with GitHub's default GITHUB_SHA
+                  # which points to the merge commit, not the PR head commit
+                  AGENT_SERVER_SHA: ${{ github.event.pull_request.head.sha }}
                   OPENHANDS_CLOUD_API_KEY: ${{ secrets.ALLHANDS_BOT_OPENHANDS_SAAS_API_KEY }}
                   # ACP agents (Claude Code, Codex) route through LiteLLM proxy
                   ANTHROPIC_BASE_URL: https://llm-proxy.app.all-hands.dev

--- a/examples/02_remote_agent_server/02_convo_with_docker_sandboxed_server.py
+++ b/examples/02_remote_agent_server/02_convo_with_docker_sandboxed_server.py
@@ -40,11 +40,11 @@ def get_server_image():
     """Get the server image tag, using PR-specific image in CI."""
     platform_str = detect_platform()
     arch = "arm64" if "arm64" in platform_str else "amd64"
-    # If GITHUB_SHA is set (e.g. running in CI of a PR), use that to ensure consistency
-    # Otherwise, use the latest image from main
-    github_sha = os.getenv("GITHUB_SHA")
-    if github_sha:
-        return f"ghcr.io/openhands/agent-server:{github_sha[:7]}-python-{arch}"
+    # AGENT_SERVER_SHA is set by CI to the PR head commit SHA
+    # This avoids conflict with GitHub's default GITHUB_SHA (merge commit)
+    server_sha = os.getenv("AGENT_SERVER_SHA")
+    if server_sha:
+        return f"ghcr.io/openhands/agent-server:{server_sha[:7]}-python-{arch}"
     return "ghcr.io/openhands/agent-server:latest-python"
 
 

--- a/examples/02_remote_agent_server/03_browser_use_with_docker_sandboxed_server.py
+++ b/examples/02_remote_agent_server/03_browser_use_with_docker_sandboxed_server.py
@@ -35,11 +35,11 @@ def get_server_image():
     """Get the server image tag, using PR-specific image in CI."""
     platform_str = detect_platform()
     arch = "arm64" if "arm64" in platform_str else "amd64"
-    # If GITHUB_SHA is set (e.g. running in CI of a PR), use that to ensure consistency
-    # Otherwise, use the latest image from main
-    github_sha = os.getenv("GITHUB_SHA")
-    if github_sha:
-        return f"ghcr.io/openhands/agent-server:{github_sha[:7]}-python-{arch}"
+    # AGENT_SERVER_SHA is set by CI to the PR head commit SHA
+    # This avoids conflict with GitHub's default GITHUB_SHA (merge commit)
+    server_sha = os.getenv("AGENT_SERVER_SHA")
+    if server_sha:
+        return f"ghcr.io/openhands/agent-server:{server_sha[:7]}-python-{arch}"
     return "ghcr.io/openhands/agent-server:latest-python"
 
 

--- a/examples/02_remote_agent_server/04_convo_with_api_sandboxed_server.py
+++ b/examples/02_remote_agent_server/04_convo_with_api_sandboxed_server.py
@@ -45,9 +45,9 @@ if not runtime_api_key:
     exit(1)
 
 
-# If GITHUB_SHA is set (e.g. running in CI of a PR), use that to ensure consistency
-# Otherwise, use the latest image from main
-server_image_sha = os.getenv("GITHUB_SHA") or "main"
+# AGENT_SERVER_SHA is set by CI to the PR head commit SHA
+# This avoids conflict with GitHub's default GITHUB_SHA (merge commit)
+server_image_sha = os.getenv("AGENT_SERVER_SHA") or "main"
 server_image = f"ghcr.io/openhands/agent-server:{server_image_sha[:7]}-python-amd64"
 logger.info(f"Using server image: {server_image}")
 

--- a/examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py
+++ b/examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py
@@ -37,11 +37,11 @@ def get_server_image():
     """Get the server image tag, using PR-specific image in CI."""
     platform_str = detect_platform()
     arch = "arm64" if "arm64" in platform_str else "amd64"
-    # If GITHUB_SHA is set (e.g. running in CI of a PR), use that to ensure consistency
-    # Otherwise, use the latest image from main
-    github_sha = os.getenv("GITHUB_SHA")
-    if github_sha:
-        return f"ghcr.io/openhands/agent-server:{github_sha[:7]}-python-{arch}"
+    # AGENT_SERVER_SHA is set by CI to the PR head commit SHA
+    # This avoids conflict with GitHub's default GITHUB_SHA (merge commit)
+    server_sha = os.getenv("AGENT_SERVER_SHA")
+    if server_sha:
+        return f"ghcr.io/openhands/agent-server:{server_sha[:7]}-python-{arch}"
     return "ghcr.io/openhands/agent-server:latest-python"
 
 

--- a/examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py
+++ b/examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py
@@ -40,11 +40,11 @@ def get_server_image():
     """Get the server image tag, using PR-specific image in CI."""
     platform_str = detect_platform()
     arch = "arm64" if "arm64" in platform_str else "amd64"
-    # If GITHUB_SHA is set (e.g. running in CI of a PR), use that to ensure consistency
-    # Otherwise, use the latest image from main
-    github_sha = os.getenv("GITHUB_SHA")
-    if github_sha:
-        return f"ghcr.io/openhands/agent-server:{github_sha[:7]}-python-{arch}"
+    # AGENT_SERVER_SHA is set by CI to the PR head commit SHA
+    # This avoids conflict with GitHub's default GITHUB_SHA (merge commit)
+    server_sha = os.getenv("AGENT_SERVER_SHA")
+    if server_sha:
+        return f"ghcr.io/openhands/agent-server:{server_sha[:7]}-python-{arch}"
     return "ghcr.io/openhands/agent-server:latest-python"
 
 

--- a/examples/02_remote_agent_server/09_acp_agent_with_remote_runtime.py
+++ b/examples/02_remote_agent_server/09_acp_agent_with_remote_runtime.py
@@ -41,9 +41,9 @@ os.environ["ANTHROPIC_API_KEY"] = llm_api_key
 runtime_api_key = os.getenv("RUNTIME_API_KEY")
 assert runtime_api_key, "RUNTIME_API_KEY required"
 
-# If GITHUB_SHA is set (e.g. running in CI of a PR), use that to ensure consistency
-# Otherwise, use the latest image from main
-server_image_sha = os.getenv("GITHUB_SHA") or "main"
+# AGENT_SERVER_SHA is set by CI to the PR head commit SHA
+# This avoids conflict with GitHub's default GITHUB_SHA (merge commit)
+server_image_sha = os.getenv("AGENT_SERVER_SHA") or "main"
 server_image = f"ghcr.io/openhands/agent-server:{server_image_sha[:7]}-python-amd64"
 logger.info(f"Using server image: {server_image}")
 


### PR DESCRIPTION
## Summary

Fixes the 5 docker/apptainer/remote-runtime example failures seen in the v1.17.0 release PR (#2812).

## Problem

`GITHUB_SHA` is a GitHub Actions built-in env var that defaults to the **merge commit SHA** for `pull_request` events. The `run-examples.yml` workflow attempted to override it at step level with the PR head SHA, but this stopped working reliably with runner image `ubuntu24/20260406.80` (it worked on `ubuntu24/20260323.65` used by v1.16.0).

The result: example scripts resolved `os.getenv("GITHUB_SHA")` to the merge commit SHA (`a76b56b`), but agent-server images were tagged with the head SHA (`9e90afa`). The images existed — the examples just looked for the wrong tag.

## Fix

Use a custom variable name `AGENT_SERVER_SHA` that doesn't conflict with GitHub's built-in. This is the same approach `server.yml` already uses with `SDK_SHA`.

### Files changed
- `.github/workflows/run-examples.yml` — `GITHUB_SHA` → `AGENT_SERVER_SHA`
- `examples/02_remote_agent_server/02_convo_with_docker_sandboxed_server.py`
- `examples/02_remote_agent_server/03_browser_use_with_docker_sandboxed_server.py`
- `examples/02_remote_agent_server/04_convo_with_api_sandboxed_server.py`
- `examples/02_remote_agent_server/05_vscode_with_docker_sandboxed_server.py`
- `examples/02_remote_agent_server/08_convo_with_apptainer_sandboxed_server.py`
- `examples/02_remote_agent_server/09_acp_agent_with_remote_runtime.py`

## Context

Full diagnosis in [PR #2812 comments](https://github.com/OpenHands/software-agent-sdk/pull/2812).

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f5440c3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f5440c3-python \
  ghcr.io/openhands/agent-server:f5440c3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f5440c3-golang-amd64
ghcr.io/openhands/agent-server:f5440c3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f5440c3-golang-arm64
ghcr.io/openhands/agent-server:f5440c3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f5440c3-java-amd64
ghcr.io/openhands/agent-server:f5440c3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f5440c3-java-arm64
ghcr.io/openhands/agent-server:f5440c3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f5440c3-python-amd64
ghcr.io/openhands/agent-server:f5440c3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f5440c3-python-arm64
ghcr.io/openhands/agent-server:f5440c3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f5440c3-golang
ghcr.io/openhands/agent-server:f5440c3-java
ghcr.io/openhands/agent-server:f5440c3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f5440c3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f5440c3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->