### PR TITLE
fix: override exclude-newer in version-bump-prs workflow

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -138,7 +138,10 @@ jobs:
                   fi
 
                   # OpenHands-CLI currently requires Python 3.12, so resolve with that interpreter.
-                  uv add --python 3.12 --refresh \
+                  # Override exclude-newer so uv can find the just-published packages
+                  # (the target repo's lockfile may have an older cutoff date).
+                  UV_EXCLUDE_NEWER="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+                    uv add --python 3.12 --refresh \
                     "openhands-sdk==$VERSION" \
                     "openhands-tools==$VERSION"
 


### PR DESCRIPTION
## Problem

The `version-bump-prs.yml` workflow fails when the target repo (`openhands-cli`) has an `exclude-newer` constraint in its `uv.lock` that predates the just-published SDK release. `uv add` then cannot resolve the new package version:

```
Resolving despite existing lockfile due to addition of global exclude newer 2026-04-06T19:05:07Z
× No solution found when resolving dependencies:
╰─▶ Because there is no version of openhands-sdk==1.17.0 ...
```

This blocked v1.17.0 downstream version bump PRs from being created ([failed run](https://github.com/OpenHands/software-agent-sdk/actions/runs/24361579943)).

## Fix

Set `UV_EXCLUDE_NEWER` to the current UTC timestamp when running `uv add`, so the resolver can see freshly published packages regardless of any `exclude-newer` constraint in the target repo's lockfile.

---
_This PR was created by an AI assistant (OpenHands)._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd7fbcf9-e514-4824-aaa4-c3233b40d363)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:571d06f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-571d06f-python \
  ghcr.io/openhands/agent-server:571d06f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:571d06f-golang-amd64
ghcr.io/openhands/agent-server:571d06f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:571d06f-golang-arm64
ghcr.io/openhands/agent-server:571d06f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:571d06f-java-amd64
ghcr.io/openhands/agent-server:571d06f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:571d06f-java-arm64
ghcr.io/openhands/agent-server:571d06f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:571d06f-python-amd64
ghcr.io/openhands/agent-server:571d06f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:571d06f-python-arm64
ghcr.io/openhands/agent-server:571d06f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:571d06f-golang
ghcr.io/openhands/agent-server:571d06f-java
ghcr.io/openhands/agent-server:571d06f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `571d06f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `571d06f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->