### PR TITLE
feat(observability): add init_laminar_for_external helper for webhook integrations

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/__init__.py
+++ b/openhands-sdk/openhands/sdk/observability/__init__.py
@@ -1,4 +1,8 @@
-from openhands.sdk.observability.laminar import maybe_init_laminar, observe
+from openhands.sdk.observability.laminar import (
+    init_laminar_for_external,
+    maybe_init_laminar,
+    observe,
+)
 
 
-__all__ = ["maybe_init_laminar", "observe"]
+__all__ = ["init_laminar_for_external", "maybe_init_laminar", "observe"]

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -186,3 +186,39 @@ def end_active_span() -> None:
     except Exception:
         logger.debug("Error ending active span")
         pass
+
+
+def init_laminar_for_external():
+    """Initialize Laminar for external callers and return parent span context.
+
+    This is a convenience function for integrations (e.g., GitHub, Slack webhooks)
+    that need to:
+    1. Initialize Laminar if env vars are set (via maybe_init_laminar)
+    2. Capture the parent span context from the external trigger
+
+    Returns:
+        The parent span context if observability is enabled, None otherwise.
+
+    Example:
+        ```python
+        from openhands.sdk.observability import init_laminar_for_external
+        from lmnr import Laminar
+
+        # At the start of handling an external event (webhook, etc.)
+        laminar_span_context = init_laminar_for_external()
+
+        if laminar_span_context:
+            with Laminar.start_as_current_span(
+                name='my-integration',
+                parent_span_context=laminar_span_context,
+            ):
+                # Do work - traces will be children of the external trigger
+                await do_something()
+        else:
+            await do_something()
+        ```
+    """
+    maybe_init_laminar()
+    if should_enable_observability():
+        return Laminar.get_laminar_span_context()
+    return None


### PR DESCRIPTION
## Summary

Add `init_laminar_for_external()` helper function for external integrations (GitHub, Slack, etc.) that need to:
1. Initialize Laminar if env vars are set
2. Capture the parent span context from the webhook trigger

This enables proper trace hierarchy: **webhook → integration handler → agent**.

## Motivation

Currently, integrations like the GitHub resolver in OpenHands have to duplicate Laminar initialization and parent span context capture:

```python
# Current approach (verbose, duplicated)
LAMINAR_ENABLED = os.environ.get('LMNR_PROJECT_API_KEY', '') != ''
if LAMINAR_ENABLED:
    Laminar.initialize(project_api_key=...)
    laminar_span_context = Laminar.get_laminar_span_context()
```

This helper provides a simple one-liner that:
- Calls `maybe_init_laminar()` (handles all env var configuration)
- Registers `LaminarLiteLLMCallback` for automatic LLM tracing
- Returns the parent span context for proper trace hierarchy

## Usage

```python
from openhands.sdk.observability import init_laminar_for_external
from lmnr import Laminar

# At the start of handling an external event (webhook, etc.)
laminar_span_context = init_laminar_for_external()

if laminar_span_context:
    with Laminar.start_as_current_span(
        name='my-integration',
        parent_span_context=laminar_span_context,
    ):
        await do_something()
else:
    await do_something()
```

## Notes

This PR was co-authored by an AI agent on behalf of the user.


@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b51267fc-431a-4a59-8592-22907714f279)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9261201-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9261201-python \
  ghcr.io/openhands/agent-server:9261201-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9261201-golang-amd64
ghcr.io/openhands/agent-server:9261201-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9261201-golang-arm64
ghcr.io/openhands/agent-server:9261201-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9261201-java-amd64
ghcr.io/openhands/agent-server:9261201-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9261201-java-arm64
ghcr.io/openhands/agent-server:9261201-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9261201-python-amd64
ghcr.io/openhands/agent-server:9261201-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9261201-python-arm64
ghcr.io/openhands/agent-server:9261201-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9261201-golang
ghcr.io/openhands/agent-server:9261201-java
ghcr.io/openhands/agent-server:9261201-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9261201-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9261201-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->