### PR TITLE
test(agent-server): add regression test for tags forwarding on conversation create

### DIFF
--- a/tests/agent_server/test_conversation_tags.py
+++ b/tests/agent_server/test_conversation_tags.py
@@ -1,6 +1,7 @@
 """Tests for conversation tags in the API layer."""
 
-from unittest.mock import AsyncMock
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -14,11 +15,13 @@ from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import (
     ConversationInfo,
+    StoredConversation,
     UpdateConversationRequest,
 )
 from openhands.agent_server.utils import utc_now
 from openhands.sdk import LLM, Agent, Tool
 from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.security.confirmation_policy import NeverConfirm
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -220,3 +223,50 @@ def test_get_conversation_includes_tags(
         assert data["tags"] == {"env": "test", "team": "backend"}
     finally:
         client.app.dependency_overrides.clear()
+
+
+@pytest.mark.asyncio
+async def test_event_service_start_forwards_tags_to_local_conversation(tmp_path):
+    """EventService.start() must pass stored tags to LocalConversation.
+
+    Regression test for https://github.com/OpenHands/software-agent-sdk/issues/2821:
+    tags sent via POST /api/conversations were persisted in StoredConversation but
+    not forwarded to the LocalConversation constructor, so state.tags was always {}.
+    """
+    tags = {"source": "pipeline", "symbol": "gold"}
+    stored = StoredConversation(
+        id=uuid4(),
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(tmp_path)),
+        confirmation_policy=NeverConfirm(),
+        tags=tags,
+        created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        updated_at=datetime(2025, 1, 1, 12, 30, 0, tzinfo=UTC),
+    )
+
+    event_service = EventService(
+        stored=stored,
+        conversations_dir=tmp_path / "conversations",
+    )
+
+    with patch(
+        "openhands.agent_server.event_service.LocalConversation"
+    ) as MockConversation:
+        mock_conv = MagicMock()
+        mock_state = MagicMock()
+        mock_state.execution_status = ConversationExecutionStatus.IDLE
+        mock_state.events = []
+        mock_agent = MagicMock()
+        mock_agent.get_all_llms.return_value = []
+        mock_conv._state = mock_state
+        mock_conv.state = mock_state
+        mock_conv.agent = mock_agent
+        mock_conv._on_event = MagicMock()
+        MockConversation.return_value = mock_conv
+
+        await event_service.start()
+
+        # Verify LocalConversation was called with the correct tags
+        MockConversation.assert_called_once()
+        call_kwargs = MockConversation.call_args.kwargs
+        assert call_kwargs["tags"] == tags


### PR DESCRIPTION
## Summary

Closes #2821

The one-line fix (`tags=self.stored.tags` in `EventService.start()`) was already applied in #2632. This PR adds a **regression test** that verifies `EventService.start()` forwards tags from `StoredConversation` to `LocalConversation`, preventing the bug described in #2821 from recurring.

## What was the bug?

When creating a conversation via `POST /api/conversations` with `tags`, the tags were persisted into `StoredConversation` but not forwarded to `LocalConversation` in `EventService.start()`. This meant `state.tags` was always `{}` even though the client sent valid tags. The `PATCH` endpoint worked correctly because it explicitly mutated both `stored.tags` and `state.tags`.

## What does this PR add?

A new test `test_event_service_start_forwards_tags_to_local_conversation` that:
1. Creates a `StoredConversation` with tags
2. Creates an `EventService` with that stored conversation
3. Calls `start()` and verifies the `LocalConversation` constructor receives `tags` matching the stored tags

This test would have caught the original bug (missing `tags=self.stored.tags` argument) and guards against future regressions.

---
*This PR was created by an AI assistant (OpenHands) on behalf of the user.*

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8aaa94b5-4b03-402a-8e9b-d934b7c4c575)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:35e0379-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-35e0379-python \
  ghcr.io/openhands/agent-server:35e0379-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:35e0379-golang-amd64
ghcr.io/openhands/agent-server:35e0379-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:35e0379-golang-arm64
ghcr.io/openhands/agent-server:35e0379-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:35e0379-java-amd64
ghcr.io/openhands/agent-server:35e0379-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:35e0379-java-arm64
ghcr.io/openhands/agent-server:35e0379-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:35e0379-python-amd64
ghcr.io/openhands/agent-server:35e0379-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:35e0379-python-arm64
ghcr.io/openhands/agent-server:35e0379-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:35e0379-golang
ghcr.io/openhands/agent-server:35e0379-java
ghcr.io/openhands/agent-server:35e0379-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `35e0379-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `35e0379-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->