### PR TITLE
feat(pr-review): enable sub-agent delegation for file-level reviews

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -40,6 +40,7 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Run PR Review
+              # TODO: Revert to @main after OpenHands/extensions#164 is merged
               uses: OpenHands/extensions/plugins/pr-review@feat/pr-review-sub-agent-delegation
               with:
                   llm-model: litellm_proxy/claude-sonnet-4-5-20250929

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -40,12 +40,14 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Run PR Review
-              uses: OpenHands/extensions/plugins/pr-review@main
+              uses: OpenHands/extensions/plugins/pr-review@feat/pr-review-sub-agent-delegation
               with:
                   llm-model: litellm_proxy/claude-sonnet-4-5-20250929
                   llm-base-url: https://llm-proxy.app.all-hands.dev
                   # Review style: roasted (other option: standard)
                   review-style: roasted
+                  # Enable experimental sub-agent delegation for file-level reviews
+                  use-sub-agents: 'true'
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Why

This is the companion PR to [OpenHands/extensions#164](https://github.com/OpenHands/extensions/pull/164), which adds experimental sub-agent delegation support to the pr-review plugin.

Per-PR code reviews can get too large for a single agent to handle well. By delegating file-level reviews to sub-agents, we can:
1. Give each sub-agent focused context on a single file (or small group of related files)
2. Let the coordinator merge findings and post a cohesive review
3. Leverage the SDK `DelegateTool` / `TaskToolSet` for parallel file-level analysis

## Summary

- Update `pr-review-by-openhands.yml` to point at the extensions feature branch (`feat/pr-review-sub-agent-delegation`) instead of `main`
- Enable `use-sub-agents: 'true'` to activate the experimental sub-agent delegation mode
- When enabled, the main review agent acts as a **review coordinator** that spawns `file_reviewer` sub-agents via `TaskToolSet`, delegates per-file review work, and consolidates findings into a single PR review

## How to Test

Once both PRs are merged, the sub-agent review mode will be active on this repo's PR reviews. In the meantime, testing requires:
1. A PR opened on this repo (to trigger the workflow)
2. The extensions feature branch must be available at `OpenHands/extensions@feat/pr-review-sub-agent-delegation`

## ⚠️ Important

- This workflow currently pins to the **feature branch** of extensions — it should be updated to point back to `@main` once [OpenHands/extensions#164](https://github.com/OpenHands/extensions/pull/164) is merged
- The sub-agent delegation is **experimental** and can be disabled by setting `use-sub-agents: 'false'`

_This PR was created by an AI assistant (OpenHands) on behalf of a user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d1f6a8fe-bd3c-4eb8-9085-a557333b7c23)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:85ddc2b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-85ddc2b-python \
  ghcr.io/openhands/agent-server:85ddc2b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:85ddc2b-golang-amd64
ghcr.io/openhands/agent-server:85ddc2b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:85ddc2b-golang-arm64
ghcr.io/openhands/agent-server:85ddc2b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:85ddc2b-java-amd64
ghcr.io/openhands/agent-server:85ddc2b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:85ddc2b-java-arm64
ghcr.io/openhands/agent-server:85ddc2b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:85ddc2b-python-amd64
ghcr.io/openhands/agent-server:85ddc2b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:85ddc2b-python-arm64
ghcr.io/openhands/agent-server:85ddc2b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:85ddc2b-golang
ghcr.io/openhands/agent-server:85ddc2b-java
ghcr.io/openhands/agent-server:85ddc2b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `85ddc2b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `85ddc2b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->