### PR TITLE
chore(ci): use GITHUB_TOKEN for label and stale workflows

### DIFF
--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -15,7 +15,7 @@ jobs:
             - name: Add needs-triage label
               uses: actions/github-script@v8
               with:
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
                       // Get the issue details
                       const issue = context.payload.issue;

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,12 +4,6 @@ name: Auto-label New Issues
 on:
     issues:
         types: [opened]
-    workflow_dispatch: # temporary — verifying write path
-        inputs:
-            issue_number:
-                description: 'Issue number to test labeling on'
-                required: true
-                type: number
 
 permissions:
     issues: write
@@ -23,19 +17,8 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
-                      // Get issue number from event payload or workflow_dispatch input
-                      const issueNumber = context.payload.issue?.number || Number('${{ inputs.issue_number }}');
-                      if (!issueNumber) {
-                        core.setFailed('No issue number available');
-                        return;
-                      }
-
-                      // Fetch issue details (needed for workflow_dispatch where payload.issue is null)
-                      const { data: issue } = await github.rest.issues.get({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: issueNumber,
-                      });
+                      // Get the issue details
+                      const issue = context.payload.issue;
                       const labels = issue.labels.map(label => label.name);
 
                       // Check if issue has already been triaged
@@ -47,7 +30,7 @@ jobs:
                         await github.rest.issues.addLabels({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          issue_number: issueNumber,
+                          issue_number: context.issue.number,
                           labels: ['needs-triage']
                         });
                       }

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,12 +4,6 @@ name: Auto-label New Issues
 on:
     issues:
         types: [opened]
-    workflow_dispatch: # temporary — remove after testing GITHUB_TOKEN
-        inputs:
-            issue_number:
-                description: 'Issue number to test labeling on'
-                required: true
-                type: number
 
 permissions:
     issues: write
@@ -23,19 +17,8 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
-                      // Get issue number from event payload or workflow_dispatch input
-                      const issueNumber = context.payload.issue?.number || Number('${{ inputs.issue_number }}');
-                      if (!issueNumber) {
-                        core.setFailed('No issue number available');
-                        return;
-                      }
-
-                      // Fetch issue details (needed for workflow_dispatch where payload.issue is null)
-                      const { data: issue } = await github.rest.issues.get({
-                        owner: context.repo.owner,
-                        repo: context.repo.repo,
-                        issue_number: issueNumber,
-                      });
+                      // Get the issue details
+                      const issue = context.payload.issue;
                       const labels = issue.labels.map(label => label.name);
 
                       // Check if issue has already been triaged
@@ -47,7 +30,7 @@ jobs:
                         await github.rest.issues.addLabels({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          issue_number: issueNumber,
+                          issue_number: context.issue.number,
                           labels: ['needs-triage']
                         });
                       }

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,6 +4,12 @@ name: Auto-label New Issues
 on:
     issues:
         types: [opened]
+    workflow_dispatch: # temporary — verifying write path
+        inputs:
+            issue_number:
+                description: 'Issue number to test labeling on'
+                required: true
+                type: number
 
 permissions:
     issues: write
@@ -17,8 +23,19 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
-                      // Get the issue details
-                      const issue = context.payload.issue;
+                      // Get issue number from event payload or workflow_dispatch input
+                      const issueNumber = context.payload.issue?.number || Number('${{ inputs.issue_number }}');
+                      if (!issueNumber) {
+                        core.setFailed('No issue number available');
+                        return;
+                      }
+
+                      // Fetch issue details (needed for workflow_dispatch where payload.issue is null)
+                      const { data: issue } = await github.rest.issues.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issueNumber,
+                      });
                       const labels = issue.labels.map(label => label.name);
 
                       // Check if issue has already been triaged
@@ -30,7 +47,7 @@ jobs:
                         await github.rest.issues.addLabels({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          issue_number: context.issue.number,
+                          issue_number: issueNumber,
                           labels: ['needs-triage']
                         });
                       }

--- a/.github/workflows/auto-label-issues.yml
+++ b/.github/workflows/auto-label-issues.yml
@@ -4,6 +4,12 @@ name: Auto-label New Issues
 on:
     issues:
         types: [opened]
+    workflow_dispatch: # temporary — remove after testing GITHUB_TOKEN
+        inputs:
+            issue_number:
+                description: 'Issue number to test labeling on'
+                required: true
+                type: number
 
 permissions:
     issues: write
@@ -17,8 +23,19 @@ jobs:
               with:
                   github-token: ${{ secrets.GITHUB_TOKEN }}
                   script: |
-                      // Get the issue details
-                      const issue = context.payload.issue;
+                      // Get issue number from event payload or workflow_dispatch input
+                      const issueNumber = context.payload.issue?.number || Number('${{ inputs.issue_number }}');
+                      if (!issueNumber) {
+                        core.setFailed('No issue number available');
+                        return;
+                      }
+
+                      // Fetch issue details (needed for workflow_dispatch where payload.issue is null)
+                      const { data: issue } = await github.rest.issues.get({
+                        owner: context.repo.owner,
+                        repo: context.repo.repo,
+                        issue_number: issueNumber,
+                      });
                       const labels = issue.labels.map(label => label.name);
 
                       // Check if issue has already been triaged
@@ -30,7 +47,7 @@ jobs:
                         await github.rest.issues.addLabels({
                           owner: context.repo.owner,
                           repo: context.repo.repo,
-                          issue_number: context.issue.number,
+                          issue_number: issueNumber,
                           labels: ['needs-triage']
                         });
                       }

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,11 @@ name: Close stale issues
 on:
     schedule:
         - cron: 30 1 * * *
+    workflow_dispatch: # temporary — remove after testing GITHUB_TOKEN
+
+permissions:
+    issues: write
+    pull-requests: write
 
 jobs:
     stale:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,6 @@ name: Close stale issues
 on:
     schedule:
         - cron: 30 1 * * *
-    workflow_dispatch: # temporary — remove after testing GITHUB_TOKEN
 
 permissions:
     issues: write

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,6 +6,7 @@ name: Close stale issues
 on:
     schedule:
         - cron: 30 1 * * *
+    workflow_dispatch: # temporary — write-path verification
 
 permissions:
     issues: write
@@ -24,11 +25,11 @@ jobs:
                       comment, otherwise it will be closed in 10 days.
                   stale-pr-message: This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment,
                       otherwise it will be closed in 10 days.
-                  days-before-stale: 40
+                  days-before-stale: 1
                   exempt-issue-labels: roadmap,backlog
                   close-issue-message: This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat 
                       manageable and focus on active issues.
                   close-pr-message: This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would 
                       like to continue the PR, please resubmit or let us know.
                   days-before-close: 10
-                  operations-per-run: 150
+                  operations-per-run: 4

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -20,15 +20,15 @@ jobs:
             - uses: actions/stale@v10
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a
+                  stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a 
                       comment, otherwise it will be closed in 10 days.
                   stale-pr-message: This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment,
                       otherwise it will be closed in 10 days.
                   days-before-stale: 40
                   exempt-issue-labels: roadmap,backlog
-                  close-issue-message: This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat
+                  close-issue-message: This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat 
                       manageable and focus on active issues.
-                  close-pr-message: This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would
+                  close-pr-message: This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would 
                       like to continue the PR, please resubmit or let us know.
                   days-before-close: 10
                   operations-per-run: 150

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -6,7 +6,6 @@ name: Close stale issues
 on:
     schedule:
         - cron: 30 1 * * *
-    workflow_dispatch: # temporary — write-path verification
 
 permissions:
     issues: write
@@ -21,15 +20,15 @@ jobs:
             - uses: actions/stale@v10
               with:
                   repo-token: ${{ secrets.GITHUB_TOKEN }}
-                  stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a 
+                  stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a
                       comment, otherwise it will be closed in 10 days.
                   stale-pr-message: This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment,
                       otherwise it will be closed in 10 days.
-                  days-before-stale: 1
+                  days-before-stale: 40
                   exempt-issue-labels: roadmap,backlog
-                  close-issue-message: This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat 
+                  close-issue-message: This issue was automatically closed due to 50 days of inactivity. We do this to help keep the issues somewhat
                       manageable and focus on active issues.
-                  close-pr-message: This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would 
+                  close-pr-message: This PR was closed because it had no activity for 50 days. If you feel this was closed in error, and you would
                       like to continue the PR, please resubmit or let us know.
                   days-before-close: 10
-                  operations-per-run: 4
+                  operations-per-run: 150

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -15,7 +15,7 @@ jobs:
         steps:
             - uses: actions/stale@v10
               with:
-                  repo-token: ${{ secrets.PAT_TOKEN }}
+                  repo-token: ${{ secrets.GITHUB_TOKEN }}
                   stale-issue-message: This issue is stale because it has been open for 40 days with no activity. Remove the stale label or leave a 
                       comment, otherwise it will be closed in 10 days.
                   stale-pr-message: This PR is stale because it has been open for 40 days with no activity. Remove the stale label or leave a comment,


### PR DESCRIPTION
## Summary

- Replace `secrets.PAT_TOKEN` with `secrets.GITHUB_TOKEN` in `auto-label-issues.yml` and `stale.yml`
- These workflows only perform same-repo operations (adding labels, marking stale) that don't require a PAT
- Reduces unnecessary exposure of the broader PAT_TOKEN, per OpenHands/evaluation#428

## Context

Both workflows currently use `PAT_TOKEN` but only need:
- **auto-label-issues.yml**: `issues:write` to add the `needs-triage` label — the workflow already declares `permissions: issues: write`, so the built-in `GITHUB_TOKEN` is sufficient
- **stale.yml**: `issues:write` + `pull-requests:write` to label/close stale items — `GITHUB_TOKEN` has these by default

A PAT would only be needed if the label/close events needed to trigger other workflows (since `GITHUB_TOKEN`-generated events don't). There are no downstream workflows that depend on these events.

## Test plan

- [ ] Wait for next scheduled stale run (01:30 UTC daily) or merge and monitor
- [ ] Open a test issue after merge and verify `needs-triage` label is applied
- [ ] Verify no downstream workflows depended on PAT-generated events from these two workflows

> **Note:** These workflows cannot be tested on a feature branch — see PR comment for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9231248-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9231248-python \
  ghcr.io/openhands/agent-server:9231248-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9231248-golang-amd64
ghcr.io/openhands/agent-server:9231248-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9231248-golang-arm64
ghcr.io/openhands/agent-server:9231248-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9231248-java-amd64
ghcr.io/openhands/agent-server:9231248-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9231248-java-arm64
ghcr.io/openhands/agent-server:9231248-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9231248-python-amd64
ghcr.io/openhands/agent-server:9231248-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9231248-python-arm64
ghcr.io/openhands/agent-server:9231248-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9231248-golang
ghcr.io/openhands/agent-server:9231248-java
ghcr.io/openhands/agent-server:9231248-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9231248-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9231248-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->