### PR TITLE
chore(ci): rename secrets.PAT_TOKEN to secrets.ALLHANDS_BOT_GITHUB_PAT

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -190,7 +190,7 @@ jobs:
             - name: Run task
               env:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   PYTHONPATH: ''
               run: |
                   echo "Running agent script: $AGENT_SCRIPT_URL"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Trigger docs repo sync
               uses: peter-evans/repository-dispatch@v4
               with:
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   repository: OpenHands/docs
                   event-type: update
                   client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
               if: steps.check-fork.outputs.is_fork == 'false'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
 
             - name: Remove .pr/ directory
               id: remove

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -50,5 +50,5 @@ jobs:
                   # Enable experimental sub-agent delegation for file-level reviews
                   use-sub-agents: 'true'
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -69,7 +69,7 @@ jobs:
 
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+                  GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
               run: |
                   cat > pr_body.txt << 'EOF'
                   ## Release v${{ inputs.version }}

--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -50,5 +50,5 @@ jobs:
                   # EXPERIMENTAL: use the feature branch of extensions
                   extensions-version: feat/qa-changes-plugin
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -255,7 +255,7 @@ jobs:
               env:
                   DEFAULT_MODEL: ${{ steps.load-models.outputs.default_model }}
                   ALLOWED_MODEL_IDS_JSON: ${{ steps.load-models.outputs.allowed_model_ids }}
-                  PAT_TOKEN_DEFAULT: ${{ secrets.PAT_TOKEN }}
+                  PAT_TOKEN_DEFAULT: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
               run: |
                   set -euo pipefail
 

--- a/.github/workflows/todo-management.yml
+++ b/.github/workflows/todo-management.yml
@@ -130,7 +130,7 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
 
             - name: Switch to feature branch with TODO management files
               run: |
@@ -170,7 +170,7 @@ jobs:
                   LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929
                   LLM_BASE_URL: https://llm-proxy.app.all-hands.dev
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
                   TODO_FILE: ${{ matrix.todo.file }}
                   TODO_LINE: ${{ matrix.todo.line }}

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -24,7 +24,7 @@ jobs:
             (github.event.workflow_run.conclusion == 'success' &&
              github.event.workflow_run.event == 'release')
         env:
-            GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+            GH_TOKEN: ${{ secrets.ALLHANDS_BOT_GITHUB_PAT }}
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Rename `secrets.PAT_TOKEN` → `secrets.ALLHANDS_BOT_GITHUB_PAT` across 9 workflow files (11 references)
- Standardizes on `ALLHANDS_BOT_GITHUB_PAT` as the org-wide secret name for the bot's GitHub PAT
- Internal env var names passed to scripts are unchanged — only the GitHub Actions secret reference is renamed
- Part of OpenHands/evaluation#428

## Affected workflows
`assign-reviews.yml`, `deploy-docs.yml`, `pr-artifacts.yml`, `pr-review-by-openhands.yml`, `prepare-release.yml`, `qa-changes-by-openhands.yml`, `run-eval.yml`, `todo-management.yml`, `version-bump-prs.yml`

## Prerequisite
`ALLHANDS_BOT_GITHUB_PAT` must be configured as an org/repo secret visible to this repo before merging.

## Test plan
- [ ] Verify `ALLHANDS_BOT_GITHUB_PAT` secret is available to this repo
- [ ] After merge, trigger one workflow from each category and verify it succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)