### PR TITLE
refactor: Centralize MCP utils in `openhands.sdk.mcp`

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -42,6 +42,7 @@ from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.config import expand_mcp_variables
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.plugin import (
     Plugin,
@@ -53,7 +54,6 @@ from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
-from openhands.sdk.skills.utils import expand_mcp_variables
 from openhands.sdk.subagent import (
     AgentDefinition,
     register_file_agents,

--- a/openhands-sdk/openhands/sdk/extensions/source.py
+++ b/openhands-sdk/openhands/sdk/extensions/source.py
@@ -1,0 +1,107 @@
+"""Source path handling for extensions (plugins and skills).
+
+Supports local paths (./path, /path, ~/path, file:///path) and
+GitHub URLs (https://github.com/{owner}/{repo}/blob/{branch}/{path}).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import NamedTuple
+
+from openhands.sdk.git.cached_repo import try_cached_clone_or_update
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+GITHUB_URL_PATTERN = re.compile(
+    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/"
+    r"(?:blob|tree)/(?P<branch>[^/]+)/(?P<path>.+)$"
+)
+DEFAULT_CACHE_DIR = Path.home() / ".openhands" / "cache" / "git"
+
+LOCAL_PREFIXES = ("./", "../", "/", "~", "file://")
+
+
+class GitHubURLComponents(NamedTuple):
+    """Parsed components of a GitHub blob/tree URL."""
+
+    owner: str
+    repo: str
+    branch: str
+    path: str
+
+
+def parse_github_url(url: str) -> GitHubURLComponents | None:
+    """Parse GitHub URL into components, or None if not a valid GitHub URL."""
+    if match := GITHUB_URL_PATTERN.match(url):
+        return GitHubURLComponents(
+            match.group("owner"),
+            match.group("repo"),
+            match.group("branch"),
+            match.group("path"),
+        )
+    return None
+
+
+def is_local_path(source: str) -> bool:
+    """Check if source is a local path (./, ../, /, ~, file://)."""
+    return source.startswith(LOCAL_PREFIXES)
+
+
+def validate_source_path(source: str) -> str:
+    """Validate source path format. Raises ValueError if invalid."""
+    if is_local_path(source) or parse_github_url(source):
+        return source
+    raise ValueError(
+        f"Invalid source path: {source!r}. Must be local path or GitHub URL."
+    )
+
+
+def resolve_source_path(
+    source: str,
+    base_path: Path | None = None,
+    cache_dir: Path | None = None,
+    update: bool = True,
+) -> Path | None:
+    """Resolve source path to absolute local path.
+
+    Args:
+        source: Source path string (local path, file:// URL, or GitHub URL).
+        base_path: Base directory for resolving relative paths.
+        cache_dir: Directory for caching cloned GitHub repos.
+        update: Whether to update cached repos (git pull).
+
+    Returns:
+        Resolved absolute Path, or None if GitHub clone/update fails.
+        Callers should handle None gracefully (e.g., skip with warning).
+
+    Supported source formats:
+        - Local paths: ./path, ../path, /absolute, ~/home
+        - file:// URLs: file:///absolute/path
+        - GitHub URLs: https://github.com/{owner}/{repo}/blob/{branch}/{path}
+    """
+    # Handle file:// URLs
+    if source.startswith("file://"):
+        return Path(source[7:])
+
+    # Handle GitHub URLs
+    if gh := parse_github_url(source):
+        cache = cache_dir or DEFAULT_CACHE_DIR
+        repo_path = cache / "github.com" / gh.owner.lower() / gh.repo.lower()
+        clone_url = f"https://github.com/{gh.owner}/{gh.repo}.git"
+
+        if try_cached_clone_or_update(clone_url, repo_path, gh.branch, update):
+            return repo_path / gh.path
+        logger.warning(f"Failed to clone/update: {source}")
+        return None
+
+    # Handle local paths
+    path = Path(source).expanduser()
+    if path.is_absolute():
+        return path
+    if base_path:
+        return (base_path / path).resolve()
+    return path.resolve()

--- a/openhands-sdk/openhands/sdk/mcp/__init__.py
+++ b/openhands-sdk/openhands/sdk/mcp/__init__.py
@@ -1,5 +1,7 @@
 """MCP (Model Context Protocol) integration for agent-sdk."""
 
+from typing import Any
+
 from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.definition import MCPToolAction, MCPToolObservation
 from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
@@ -12,6 +14,25 @@ from openhands.sdk.mcp.utils import (
 )
 
 
+# Config utilities are lazily exported to avoid circular imports:
+# skills/skill.py → mcp/__init__ → mcp/definition → tool → skills
+_CONFIG_NAMES = {
+    "SecretLookup",
+    "find_mcp_config",
+    "expand_mcp_variables",
+    "load_mcp_config",
+    "merge_mcp_configs",
+}
+
+
+def __getattr__(name: str) -> Any:
+    if name in _CONFIG_NAMES:
+        from openhands.sdk.mcp import config as _cfg
+
+        return getattr(_cfg, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "MCPClient",
     "MCPToolDefinition",
@@ -21,4 +42,10 @@ __all__ = [
     "create_mcp_tools",
     "MCPError",
     "MCPTimeoutError",
+    # Config utilities (lazy)
+    "SecretLookup",
+    "find_mcp_config",
+    "expand_mcp_variables",
+    "load_mcp_config",
+    "merge_mcp_configs",
 ]

--- a/openhands-sdk/openhands/sdk/mcp/config.py
+++ b/openhands-sdk/openhands/sdk/mcp/config.py
@@ -1,0 +1,219 @@
+"""MCP configuration file loading, variable expansion, and merging.
+
+Handles ``.mcp.json`` discovery, ``${VAR}`` / ``${VAR:-default}`` expansion,
+validation via :class:`fastmcp.mcp_config.MCPConfig`, and config merging.
+"""
+
+import json
+import os
+import re
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+from fastmcp.mcp_config import MCPConfig
+
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+# Type alias for secret lookup functions
+SecretLookup = Callable[[str], str | None]
+
+
+def find_mcp_config(directory: Path) -> Path | None:
+    """Find ``.mcp.json`` in *directory*.
+
+    Returns:
+        Path to the file if it exists, ``None`` otherwise.
+    """
+    if not directory.is_dir():
+        return None
+    mcp_json = directory / ".mcp.json"
+    if mcp_json.exists() and mcp_json.is_file():
+        return mcp_json
+    return None
+
+
+def _serialize_for_json(obj: object) -> object:
+    """Recursively convert Pydantic models to dicts for JSON serialization.
+
+    This handles the case where MCP config contains Pydantic model objects
+    (RemoteMCPServer, StdioMCPServer) instead of plain dicts.
+    """
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    elif isinstance(obj, dict):
+        return {k: _serialize_for_json(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_serialize_for_json(item) for item in obj]
+    return obj
+
+
+def expand_mcp_variables(
+    config: dict[str, Any],
+    variables: dict[str, str],
+    get_secret: SecretLookup | None = None,
+    *,
+    expand_defaults: bool = True,
+) -> dict[str, Any]:
+    """Expand variables in MCP configuration.
+
+    Supports variable expansion similar to Claude Code:
+    - ${VAR} - Environment variables, provided variables, or secrets
+    - ${VAR:-default} - With default value
+
+    Resolution order:
+    1. Provided variables (e.g., SKILL_ROOT)
+    2. Secrets (via get_secret callback, if provided)
+    3. Environment variables
+    4. Default value (if specified and expand_defaults=True)
+
+    Args:
+        config: MCP configuration dictionary. May contain Pydantic model
+            objects (e.g., RemoteMCPServer, StdioMCPServer) which will be
+            converted to dicts before JSON serialization.
+        variables: Dictionary of variable names to values (e.g., SKILL_ROOT).
+        get_secret: Callback to look up a secret by name. We use a callback
+            rather than a dict to avoid extracting all secrets into plain text.
+            Pass ``secret_registry.get_secret_value`` or ``{"K": "V"}.get``
+            for tests.
+        expand_defaults: If True, apply default values for unresolved
+            variables. If False, preserve ${VAR:-default} as-is for later
+            expansion. This allows deferred expansion when secrets are not
+            yet available.
+
+    Returns:
+        Configuration with variables expanded.
+    """
+    serializable_config = _serialize_for_json(config)
+    config_str = json.dumps(serializable_config)
+
+    var_pattern = re.compile(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}")
+
+    def replace_var(match: re.Match[str]) -> str:
+        var_name = match.group(1)
+        default_value = match.group(2)
+
+        if var_name in variables:
+            return variables[var_name]
+        if get_secret is not None:
+            secret_value = get_secret(var_name)
+            if secret_value is not None:
+                return secret_value
+        if var_name in os.environ:
+            return os.environ[var_name]
+        if expand_defaults and default_value is not None:
+            return default_value
+        return match.group(0)
+
+    config_str = var_pattern.sub(replace_var, config_str)
+    return json.loads(config_str)
+
+
+def load_mcp_config(
+    mcp_json_path: Path,
+    root_dir: Path | None = None,
+    get_secret: SecretLookup | None = None,
+    *,
+    expand_defaults: bool = True,
+) -> dict[str, Any]:
+    """Load and validate a ``.mcp.json`` file.
+
+    Args:
+        mcp_json_path: Path to the ``.mcp.json`` file.
+        root_dir: Root directory of the extension (exposed as
+            ``${SKILL_ROOT}`` during variable expansion).
+        get_secret: Optional callback to look up per-conversation secrets.
+            See :func:`expand_mcp_variables` for details.
+        expand_defaults: If True, apply default values for unresolved
+            variables. If False, preserve ``${VAR:-default}`` as-is for
+            later expansion. Use False during plugin loading to defer
+            until secrets are available.
+
+    Returns:
+        Parsed and validated MCP configuration dictionary.
+
+    Raises:
+        ValueError: If the file cannot be read, parsed, or fails
+            :class:`MCPConfig` validation.
+    """
+    try:
+        with open(mcp_json_path) as f:
+            config = json.load(f)
+    except json.JSONDecodeError as e:
+        raise ValueError(f"Invalid JSON in {mcp_json_path}: {e}") from e
+    except OSError as e:
+        raise ValueError(f"Cannot read {mcp_json_path}: {e}") from e
+
+    if not isinstance(config, dict):
+        raise ValueError(
+            f"Invalid .mcp.json format: expected object, got {type(config).__name__}"
+        )
+
+    variables: dict[str, str] = {}
+    if root_dir:
+        variables["SKILL_ROOT"] = str(root_dir)
+
+    config = expand_mcp_variables(
+        config,
+        variables,
+        get_secret=get_secret,
+        expand_defaults=expand_defaults,
+    )
+
+    try:
+        MCPConfig.model_validate(config)
+    except Exception as e:
+        raise ValueError(f"Invalid MCP configuration: {e}") from e
+
+    return config
+
+
+def merge_mcp_configs(
+    base: dict[str, Any] | None,
+    override: dict[str, Any] | None,
+) -> dict[str, Any]:
+    """Merge two MCP configuration dicts with last-wins semantics.
+
+    Merge rules (Claude Code compatible):
+    - ``mcpServers``: deep-merge by server name (override wins per server)
+    - Other top-level keys: shallow override (override wins)
+
+    Neither input dict is mutated.
+
+    Args:
+        base: Existing MCP config (may be ``None`` or empty).
+        override: MCP config to layer on top (may be ``None`` or empty).
+
+    Returns:
+        A new merged dict. Empty dict if both inputs are ``None``.
+    """
+    if base is None and override is None:
+        return {}
+    if base is None:
+        return dict(override) if override else {}
+    if override is None:
+        return dict(base)
+
+    result = dict(base)
+
+    if "mcpServers" in override:
+        existing_servers = result.get("mcpServers", {})
+        for server_name in override["mcpServers"]:
+            if server_name in existing_servers:
+                logger.warning("MCP server '%s' overridden during merge", server_name)
+        result["mcpServers"] = {
+            **existing_servers,
+            **override["mcpServers"],
+        }
+
+    for key, value in override.items():
+        if key != "mcpServers":
+            if key in result:
+                logger.warning("MCP config key '%s' overridden during merge", key)
+            result[key] = value
+
+    return result

--- a/openhands-sdk/openhands/sdk/plugin/__init__.py
+++ b/openhands-sdk/openhands/sdk/plugin/__init__.py
@@ -16,6 +16,14 @@ importing them from here will emit a deprecation warning.
 
 from typing import Any
 
+from openhands.sdk.extensions.source import (
+    GitHubURLComponents,
+    is_local_path,
+    parse_github_url,
+    resolve_source_path,
+    validate_source_path,
+)
+
 # Import marketplace classes from new location for internal use
 # (no deprecation warning since we're importing from the canonical location)
 from openhands.sdk.marketplace import (
@@ -44,13 +52,6 @@ from openhands.sdk.plugin.installed import (
 )
 from openhands.sdk.plugin.loader import load_plugins
 from openhands.sdk.plugin.plugin import Plugin
-from openhands.sdk.plugin.source import (
-    GitHubURLComponents,
-    is_local_path,
-    parse_github_url,
-    resolve_source_path,
-    validate_source_path,
-)
 from openhands.sdk.plugin.types import (
     CommandDefinition,
     PluginAuthor,

--- a/openhands-sdk/openhands/sdk/plugin/loader.py
+++ b/openhands-sdk/openhands/sdk/plugin/loader.py
@@ -12,9 +12,9 @@ from typing import TYPE_CHECKING, Any
 
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.config import SecretLookup, expand_mcp_variables
 from openhands.sdk.plugin.plugin import Plugin
 from openhands.sdk.plugin.types import PluginSource
-from openhands.sdk.skills.utils import SecretLookup, expand_mcp_variables
 
 
 if TYPE_CHECKING:

--- a/openhands-sdk/openhands/sdk/plugin/plugin.py
+++ b/openhands-sdk/openhands/sdk/plugin/plugin.py
@@ -10,6 +10,7 @@ from pydantic import BaseModel, Field
 
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.config import load_mcp_config
 from openhands.sdk.plugin.fetch import fetch_plugin
 from openhands.sdk.plugin.types import (
     CommandDefinition,
@@ -20,7 +21,6 @@ from openhands.sdk.skills.skill import Skill
 from openhands.sdk.skills.utils import (
     discover_skill_resources,
     find_skill_md,
-    load_mcp_config,
 )
 from openhands.sdk.subagent.schema import AgentDefinition
 
@@ -474,7 +474,7 @@ def _load_mcp_config(plugin_dir: Path) -> dict[str, Any] | None:
     try:
         # expand_defaults=False: preserve ${VAR:-default} placeholders for later
         # expansion with per-conversation secrets. Only SKILL_ROOT is expanded now.
-        config = load_mcp_config(mcp_json, skill_root=plugin_dir, expand_defaults=False)
+        config = load_mcp_config(mcp_json, root_dir=plugin_dir, expand_defaults=False)
         if config and "mcpServers" in config:
             server_names = list(config["mcpServers"].keys())
             logger.info(

--- a/openhands-sdk/openhands/sdk/plugin/source.py
+++ b/openhands-sdk/openhands/sdk/plugin/source.py
@@ -1,105 +1,30 @@
-"""Source path handling for marketplace plugins and skills.
+"""Source path handling — **deprecated re-exports**.
 
-Supports local paths (./path, /path, ~/path, file:///path) and
-GitHub URLs (https://github.com/{owner}/{repo}/blob/{branch}/{path}).
+.. deprecated:: 1.17.0
+    All symbols have moved to :mod:`openhands.sdk.extensions.source`.
+    This module re-exports them for backward compatibility and will be
+    removed in 1.22.0.
 """
 
-from __future__ import annotations
-
-import re
-from pathlib import Path
-from typing import NamedTuple
-
-from openhands.sdk.git.cached_repo import try_cached_clone_or_update
-from openhands.sdk.logger import get_logger
-
-
-logger = get_logger(__name__)
-
-GITHUB_URL_PATTERN = re.compile(
-    r"^https://github\.com/(?P<owner>[^/]+)/(?P<repo>[^/]+)/"
-    r"(?:blob|tree)/(?P<branch>[^/]+)/(?P<path>.+)$"
+from openhands.sdk.extensions.source import (
+    DEFAULT_CACHE_DIR,
+    GITHUB_URL_PATTERN,
+    LOCAL_PREFIXES,
+    GitHubURLComponents,
+    is_local_path,
+    parse_github_url,
+    resolve_source_path,
+    validate_source_path,
 )
-DEFAULT_CACHE_DIR = Path.home() / ".openhands" / "cache" / "git"
 
 
-class GitHubURLComponents(NamedTuple):
-    """Parsed components of a GitHub blob/tree URL."""
-
-    owner: str
-    repo: str
-    branch: str
-    path: str
-
-
-def parse_github_url(url: str) -> GitHubURLComponents | None:
-    """Parse GitHub URL into components, or None if not a valid GitHub URL."""
-    if match := GITHUB_URL_PATTERN.match(url):
-        return GitHubURLComponents(
-            match.group("owner"),
-            match.group("repo"),
-            match.group("branch"),
-            match.group("path"),
-        )
-    return None
-
-
-def is_local_path(source: str) -> bool:
-    """Check if source is a local path (./, ../, /, ~, file://)."""
-    return any(source.startswith(p) for p in ("./", "../", "/", "~", "file://"))
-
-
-def validate_source_path(source: str) -> str:
-    """Validate source path format. Raises ValueError if invalid."""
-    if is_local_path(source) or parse_github_url(source):
-        return source
-    raise ValueError(
-        f"Invalid source path: {source!r}. Must be local path or GitHub URL."
-    )
-
-
-def resolve_source_path(
-    source: str,
-    base_path: Path | None = None,
-    cache_dir: Path | None = None,
-    update: bool = True,
-) -> Path | None:
-    """Resolve source path to absolute local path.
-
-    Args:
-        source: Source path string (local path, file:// URL, or GitHub URL).
-        base_path: Base directory for resolving relative paths.
-        cache_dir: Directory for caching cloned GitHub repos.
-        update: Whether to update cached repos (git pull).
-
-    Returns:
-        Resolved absolute Path, or None if GitHub clone/update fails.
-        Callers should handle None gracefully (e.g., skip with warning).
-
-    Supported source formats:
-        - Local paths: ./path, ../path, /absolute, ~/home
-        - file:// URLs: file:///absolute/path
-        - GitHub URLs: https://github.com/{owner}/{repo}/blob/{branch}/{path}
-    """
-    # Handle file:// URLs
-    if source.startswith("file://"):
-        return Path(source[7:])
-
-    # Handle GitHub URLs
-    if gh := parse_github_url(source):
-        cache = cache_dir or DEFAULT_CACHE_DIR
-        repo_path = cache / "github.com" / gh.owner.lower() / gh.repo.lower()
-        clone_url = f"https://github.com/{gh.owner}/{gh.repo}.git"
-
-        if try_cached_clone_or_update(clone_url, repo_path, gh.branch, update):
-            return repo_path / gh.path
-        logger.warning(f"Failed to clone/update: {source}")
-        return None
-
-    # Handle local paths
-    path = Path(source).expanduser()
-    if path.is_absolute():
-        return path
-    if base_path:
-        return (base_path / path).resolve()
-    return path.resolve()
+__all__ = [
+    "DEFAULT_CACHE_DIR",
+    "GITHUB_URL_PATTERN",
+    "LOCAL_PREFIXES",
+    "GitHubURLComponents",
+    "is_local_path",
+    "parse_github_url",
+    "resolve_source_path",
+    "validate_source_path",
+]

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -21,13 +21,11 @@ from openhands.sdk.skills.trigger import (
 from openhands.sdk.skills.types import InputMetadata
 from openhands.sdk.skills.utils import (
     discover_skill_resources,
-    find_mcp_config,
     find_regular_md_files,
     find_skill_md_directories,
     find_third_party_files,
     get_skills_cache_dir,
     load_and_categorize,
-    load_mcp_config,
     update_skills_repository,
     validate_skill_name,
 )
@@ -327,10 +325,16 @@ class Skill(BaseModel):
                 )
 
         # Load MCP configuration from .mcp.json (agent_skills ONLY use .mcp.json)
+        # Inline import avoids circular: skills → mcp → tool → skills
+        from openhands.sdk.mcp.config import find_mcp_config, load_mcp_config
+
         mcp_tools: dict | None = None
         mcp_json_path = find_mcp_config(skill_root)
         if mcp_json_path:
-            mcp_tools = load_mcp_config(mcp_json_path, skill_root)
+            try:
+                mcp_tools = load_mcp_config(mcp_json_path, root_dir=skill_root)
+            except ValueError as e:
+                raise SkillValidationError(str(e)) from e
 
         # Discover resource directories
         resources: SkillResources | None = None

--- a/openhands-sdk/openhands/sdk/skills/utils.py
+++ b/openhands-sdk/openhands/sdk/skills/utils.py
@@ -2,14 +2,10 @@
 
 from __future__ import annotations
 
-import json
-import os
 import re
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING
-
-from fastmcp.mcp_config import MCPConfig
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk.git.cached_repo import try_cached_clone_or_update
 from openhands.sdk.logger import get_logger
@@ -19,8 +15,9 @@ from openhands.sdk.skills.exceptions import SkillValidationError
 if TYPE_CHECKING:
     from openhands.sdk.skills.skill import Skill, SkillResources
 
-# Type alias for secret lookup functions
+# Type alias for secret lookup functions (same definition as mcp.config.SecretLookup)
 SecretLookup = Callable[[str], str | None]
+
 
 logger = get_logger(__name__)
 
@@ -52,159 +49,68 @@ def find_skill_md(skill_dir: Path) -> Path | None:
     return None
 
 
-def find_mcp_config(skill_dir: Path) -> Path | None:
-    """Find .mcp.json file in a skill directory.
+def find_mcp_config(directory: Path) -> Path | None:
+    """Find ``.mcp.json`` in *directory*.
 
-    Args:
-        skill_dir: Path to the skill directory to search.
-
-    Returns:
-        Path to .mcp.json if found, None otherwise.
+    .. deprecated:: 1.17.0
+        Import from :mod:`openhands.sdk.mcp.config` instead.
+        Will be removed in 1.22.0.
     """
-    if not skill_dir.is_dir():
-        return None
-    mcp_json = skill_dir / ".mcp.json"
-    if mcp_json.exists() and mcp_json.is_file():
-        return mcp_json
-    return None
+    from openhands.sdk.mcp.config import find_mcp_config as _canonical
 
-
-def _serialize_for_json(obj: object) -> object:
-    """Recursively convert Pydantic models to dicts for JSON serialization.
-
-    This handles the case where MCP config contains Pydantic model objects
-    (RemoteMCPServer, StdioMCPServer) instead of plain dicts.
-    """
-    # Check for Pydantic v2 model_dump method
-    model_dump = getattr(obj, "model_dump", None)
-    if callable(model_dump):
-        return model_dump()
-    elif isinstance(obj, dict):
-        return {k: _serialize_for_json(v) for k, v in obj.items()}
-    elif isinstance(obj, list):
-        return [_serialize_for_json(item) for item in obj]
-    return obj
+    return _canonical(directory)
 
 
 def expand_mcp_variables(
-    config: dict,
+    config: dict[str, Any],
     variables: dict[str, str],
     get_secret: SecretLookup | None = None,
-    *,  # keyword-only after this (PEP 3102)
+    *,
     expand_defaults: bool = True,
-) -> dict:
-    """Expand variables in MCP configuration.
+) -> dict[str, Any]:
+    """Expand ``${VAR}`` placeholders in MCP config.
 
-    Supports variable expansion similar to Claude Code:
-    - ${VAR} - Environment variables, provided variables, or secrets
-    - ${VAR:-default} - With default value
-
-    Resolution order:
-    1. Provided variables (e.g., SKILL_ROOT)
-    2. Secrets (via get_secret callback, if provided)
-    3. Environment variables
-    4. Default value (if specified and expand_defaults=True)
-
-    Args:
-        config: MCP configuration dictionary. May contain Pydantic model objects
-            (e.g., RemoteMCPServer, StdioMCPServer) which will be converted to
-            dicts before JSON serialization.
-        variables: Dictionary of variable names to values (e.g., SKILL_ROOT).
-        get_secret: Callback to look up a secret by name. We use a callback
-            rather than a dict to avoid extracting all secrets into plain text.
-            Pass `secret_registry.get_secret_value` or `{"K": "V"}.get` for tests.
-        expand_defaults: If True, apply default values for unresolved variables.
-            If False, preserve ${VAR:-default} as-is for later expansion.
-            This allows deferred expansion when secrets are not yet available.
-
-    Returns:
-        Configuration with variables expanded.
+    .. deprecated:: 1.17.0
+        Import from :mod:`openhands.sdk.mcp.config` instead.
+        Will be removed in 1.22.0.
     """
-    # Convert Pydantic models to dicts before JSON serialization
-    serializable_config = _serialize_for_json(config)
-    # Convert to JSON string for easy replacement
-    config_str = json.dumps(serializable_config)
+    from openhands.sdk.mcp.config import expand_mcp_variables as _canonical
 
-    # Pattern for ${VAR} or ${VAR:-default}
-    var_pattern = re.compile(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}")
-
-    def replace_var(match: re.Match) -> str:
-        var_name = match.group(1)
-        default_value = match.group(2)
-
-        # Check provided variables first, then secrets, then environment
-        if var_name in variables:
-            return variables[var_name]
-        if get_secret is not None:
-            secret_value = get_secret(var_name)
-            if secret_value is not None:
-                return secret_value
-        if var_name in os.environ:
-            return os.environ[var_name]
-        # Apply default only if expand_defaults is True
-        if expand_defaults and default_value is not None:
-            return default_value
-        # Return original if not found (preserves placeholder for later expansion)
-        return match.group(0)
-
-    config_str = var_pattern.sub(replace_var, config_str)
-    return json.loads(config_str)
+    return _canonical(
+        config,
+        variables,
+        get_secret=get_secret,
+        expand_defaults=expand_defaults,
+    )
 
 
 def load_mcp_config(
     mcp_json_path: Path,
     skill_root: Path | None = None,
     get_secret: SecretLookup | None = None,
-    *,  # keyword-only after this (PEP 3102)
+    *,
     expand_defaults: bool = True,
-) -> dict:
+) -> dict[str, Any]:
     """Load and parse .mcp.json with variable expansion.
 
-    Args:
-        mcp_json_path: Path to the .mcp.json file.
-        skill_root: Root directory of the skill (for ${SKILL_ROOT} expansion).
-        get_secret: Optional callback to look up per-conversation secrets.
-            See expand_mcp_variables() for details on why this is a callback.
-        expand_defaults: If True, apply default values for unresolved variables.
-            If False, preserve ${VAR:-default} as-is for later expansion.
-            Use False during plugin loading to defer until secrets are available.
+    .. deprecated:: 1.17.0
+        Import from :mod:`openhands.sdk.mcp.config` instead.
+        Will be removed in 1.22.0.
 
-    Returns:
-        Parsed MCP configuration dictionary.
-
-    Raises:
-        SkillValidationError: If the file cannot be parsed or is invalid.
+    Wraps :class:`ValueError` from the canonical implementation as
+    :class:`SkillValidationError` for backward compatibility.
     """
-    try:
-        with open(mcp_json_path) as f:
-            config = json.load(f)
-    except json.JSONDecodeError as e:
-        raise SkillValidationError(f"Invalid JSON in {mcp_json_path}: {e}") from e
-    except OSError as e:
-        raise SkillValidationError(f"Cannot read {mcp_json_path}: {e}") from e
+    from openhands.sdk.mcp.config import load_mcp_config as _canonical
 
-    if not isinstance(config, dict):
-        raise SkillValidationError(
-            f"Invalid .mcp.json format: expected object, got {type(config).__name__}"
+    try:
+        return _canonical(
+            mcp_json_path,
+            root_dir=skill_root,
+            get_secret=get_secret,
+            expand_defaults=expand_defaults,
         )
-
-    # Prepare variables for expansion
-    variables: dict[str, str] = {}
-    if skill_root:
-        variables["SKILL_ROOT"] = str(skill_root)
-
-    # Expand variables (includes secrets if provided)
-    config = expand_mcp_variables(
-        config, variables, get_secret=get_secret, expand_defaults=expand_defaults
-    )
-
-    # Validate using MCPConfig
-    try:
-        MCPConfig.model_validate(config)
-    except Exception as e:
-        raise SkillValidationError(f"Invalid MCP configuration: {e}") from e
-
-    return config
+    except ValueError as e:
+        raise SkillValidationError(str(e)) from e
 
 
 def validate_skill_name(name: str, directory_name: str | None = None) -> list[str]:

--- a/tests/sdk/extensions/test_source.py
+++ b/tests/sdk/extensions/test_source.py
@@ -1,0 +1,108 @@
+"""Tests for extension source path handling."""
+
+from pathlib import Path
+
+import pytest
+
+from openhands.sdk.extensions.source import (
+    is_local_path,
+    parse_github_url,
+    resolve_source_path,
+    validate_source_path,
+)
+
+
+# -- parse_github_url ---------------------------------------------------------
+
+
+def test_parse_github_blob_url():
+    result = parse_github_url(
+        "https://github.com/OpenHands/extensions/blob/main/skills/github"
+    )
+    assert result is not None
+    assert result.owner == "OpenHands"
+    assert result.repo == "extensions"
+    assert result.branch == "main"
+    assert result.path == "skills/github"
+
+
+def test_parse_github_tree_url():
+    result = parse_github_url(
+        "https://github.com/OpenHands/extensions/tree/main/skills/github"
+    )
+    assert result is not None
+    assert result.path == "skills/github"
+
+
+@pytest.mark.parametrize(
+    "url",
+    ["./skills/my-skill", "https://gitlab.com/o/r/blob/main/p"],
+)
+def test_parse_github_url_returns_none_for_non_github(url: str):
+    assert parse_github_url(url) is None
+
+
+# -- is_local_path ------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "./skills/my-skill",
+        "../parent/skill",
+        "/absolute/path",
+        "~/home/path",
+        "file:///path/to/file",
+    ],
+)
+def test_is_local_path_true(source: str):
+    assert is_local_path(source)
+
+
+@pytest.mark.parametrize(
+    "source",
+    ["https://github.com/o/r/blob/main/p", "just-a-name"],
+)
+def test_is_local_path_false(source: str):
+    assert not is_local_path(source)
+
+
+# -- validate_source_path -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "source",
+    [
+        "./skills/my-skill",
+        "/absolute/path",
+        "https://github.com/owner/repo/blob/main/path",
+    ],
+)
+def test_validate_source_path_accepts_valid(source: str):
+    assert validate_source_path(source) == source
+
+
+def test_validate_source_path_rejects_invalid():
+    with pytest.raises(ValueError, match="Invalid source path"):
+        validate_source_path("just-a-name")
+
+
+# -- resolve_source_path ------------------------------------------------------
+
+
+def test_resolve_source_path_file_url():
+    assert resolve_source_path("file:///tmp/skill") == Path("/tmp/skill")
+
+
+def test_resolve_source_path_absolute():
+    assert resolve_source_path("/absolute/path") == Path("/absolute/path")
+
+
+def test_resolve_source_path_relative_with_base():
+    result = resolve_source_path("./skill", base_path=Path("/project"))
+    assert result == Path("/project/skill")
+
+
+def test_resolve_source_path_home():
+    result = resolve_source_path("~/documents/skill")
+    assert result == Path.home() / "documents" / "skill"

--- a/tests/sdk/mcp/test_mcp_config.py
+++ b/tests/sdk/mcp/test_mcp_config.py
@@ -1,0 +1,189 @@
+"""Tests for openhands.sdk.mcp.config."""
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from openhands.sdk.mcp.config import (
+    expand_mcp_variables,
+    find_mcp_config,
+    load_mcp_config,
+    merge_mcp_configs,
+)
+
+
+# -- find_mcp_config ----------------------------------------------------------
+
+
+def test_find_mcp_config_present(tmp_path: Path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text("{}")
+    assert find_mcp_config(tmp_path) == mcp_file
+
+
+def test_find_mcp_config_absent(tmp_path: Path):
+    assert find_mcp_config(tmp_path) is None
+
+
+def test_find_mcp_config_not_a_dir(tmp_path: Path):
+    f = tmp_path / "file.txt"
+    f.write_text("")
+    assert find_mcp_config(f) is None
+
+
+# -- expand_mcp_variables -----------------------------------------------------
+
+
+def test_expand_provided_variable():
+    config: dict[str, Any] = {"mcpServers": {"s": {"env": {"ROOT": "${SKILL_ROOT}"}}}}
+    result = expand_mcp_variables(config, {"SKILL_ROOT": "/skills/test"})
+    assert result["mcpServers"]["s"]["env"]["ROOT"] == "/skills/test"
+
+
+def test_expand_default_value():
+    config: dict[str, Any] = {"mcpServers": {"s": {"env": {"PORT": "${PORT:-8080}"}}}}
+    result = expand_mcp_variables(config, {})
+    assert result["mcpServers"]["s"]["env"]["PORT"] == "8080"
+
+
+def test_expand_defaults_false_preserves_placeholder():
+    config: dict[str, Any] = {"mcpServers": {"s": {"env": {"PORT": "${PORT:-8080}"}}}}
+    result = expand_mcp_variables(config, {}, expand_defaults=False)
+    assert result["mcpServers"]["s"]["env"]["PORT"] == "${PORT:-8080}"
+
+
+def test_expand_env_variable(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("MY_TEST_VAR", "env-value")
+    config: dict[str, Any] = {"mcpServers": {"s": {"env": {"V": "${MY_TEST_VAR}"}}}}
+    result = expand_mcp_variables(config, {})
+    assert result["mcpServers"]["s"]["env"]["V"] == "env-value"
+
+
+def test_expand_secret_callback():
+    secrets = {"MY_SECRET": "secret-val"}
+    config: dict[str, Any] = {"mcpServers": {"s": {"env": {"K": "${MY_SECRET}"}}}}
+    result = expand_mcp_variables(config, {}, get_secret=secrets.get)
+    assert result["mcpServers"]["s"]["env"]["K"] == "secret-val"
+
+
+def test_expand_resolution_order(monkeypatch: pytest.MonkeyPatch):
+    """Provided variables win over secrets and env."""
+    monkeypatch.setenv("VAR", "from-env")
+    secrets = {"VAR": "from-secret"}
+    config: dict[str, Any] = {"mcpServers": {"s": {"v": "${VAR}"}}}
+    result = expand_mcp_variables(config, {"VAR": "from-vars"}, get_secret=secrets.get)
+    assert result["mcpServers"]["s"]["v"] == "from-vars"
+
+
+def test_expand_pydantic_model_objects():
+    """Pydantic model objects are serialized before expansion."""
+    from pydantic import BaseModel
+
+    class FakeServer(BaseModel):
+        command: str
+        env: dict[str, str]
+
+    config = {"mcpServers": {"s": FakeServer(command="node", env={"K": "${V}"})}}
+    result = expand_mcp_variables(config, {"V": "val"})
+    assert result["mcpServers"]["s"]["command"] == "node"
+    assert result["mcpServers"]["s"]["env"]["K"] == "val"
+
+
+# -- load_mcp_config ----------------------------------------------------------
+
+
+def test_load_mcp_config(tmp_path: Path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "test": {
+                        "command": "python",
+                        "env": {"ROOT": "${SKILL_ROOT}"},
+                    }
+                }
+            }
+        )
+    )
+    result = load_mcp_config(mcp_file, root_dir=tmp_path)
+    assert result["mcpServers"]["test"]["env"]["ROOT"] == str(tmp_path)
+
+
+def test_load_mcp_config_invalid_json(tmp_path: Path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text("not json")
+    with pytest.raises(ValueError, match="Invalid JSON"):
+        load_mcp_config(mcp_file)
+
+
+def test_load_mcp_config_not_dict(tmp_path: Path):
+    mcp_file = tmp_path / ".mcp.json"
+    mcp_file.write_text("[]")
+    with pytest.raises(ValueError, match="expected object"):
+        load_mcp_config(mcp_file)
+
+
+# -- merge_mcp_configs --------------------------------------------------------
+
+
+def test_merge_both_none():
+    assert merge_mcp_configs(None, None) == {}
+
+
+def test_merge_base_none():
+    override = {"mcpServers": {"s1": {"command": "node"}}}
+    result = merge_mcp_configs(None, override)
+    assert result == override
+    assert result is not override
+
+
+def test_merge_override_none():
+    base = {"mcpServers": {"s1": {"command": "node"}}}
+    result = merge_mcp_configs(base, None)
+    assert result == base
+    assert result is not base
+
+
+def test_merge_disjoint_servers():
+    base: dict[str, Any] = {"mcpServers": {"s1": {"command": "base"}}}
+    override: dict[str, Any] = {"mcpServers": {"s2": {"command": "override"}}}
+    result = merge_mcp_configs(base, override)
+    assert result["mcpServers"] == {
+        "s1": {"command": "base"},
+        "s2": {"command": "override"},
+    }
+
+
+def test_merge_override_wins_same_server():
+    base: dict[str, Any] = {
+        "mcpServers": {"s1": {"command": "base", "args": ["-m", "old"]}}
+    }
+    override: dict[str, Any] = {
+        "mcpServers": {"s1": {"command": "override", "args": ["-m", "new"]}}
+    }
+    result = merge_mcp_configs(base, override)
+    assert result["mcpServers"]["s1"]["command"] == "override"
+
+
+def test_merge_non_server_keys_override():
+    base: dict[str, Any] = {
+        "mcpServers": {"s1": {"command": "base"}},
+        "timeout": 10,
+    }
+    override: dict[str, Any] = {"timeout": 30}
+    result = merge_mcp_configs(base, override)
+    assert result["timeout"] == 30
+    assert result["mcpServers"] == {"s1": {"command": "base"}}
+
+
+def test_merge_inputs_not_mutated():
+    base: dict[str, Any] = {"mcpServers": {"s1": {"command": "base"}}}
+    override: dict[str, Any] = {"mcpServers": {"s2": {"command": "new"}}}
+    base_copy = {"mcpServers": {"s1": {"command": "base"}}}
+    override_copy = {"mcpServers": {"s2": {"command": "new"}}}
+    merge_mcp_configs(base, override)
+    assert base == base_copy
+    assert override == override_copy


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

MCP functionality is partially spread out between plugins, skills, and MCP modules. The result is some links between modules that probably aren't necessary.

This PR adds no new functionality. Instead, it just reorganizes existing functions as much as possible to break unnecessary dependencies.

## Summary

* Source path utilities (`parse_github_url`, `is_local_path`, `resolve_source_path`, etc.) moved from `openhands.sdk.plugin.source` to `openhands.sdk.extensions.source` — they serve both plugins and skills, so `extensions` is a more general location.
* MCP config utilities (`find_mcp_config`, `expand_mcp_variables`, `load_mcp_config`, `merge_mcp_configs`, `SecretLookup`) centralized in `openhands.sdk.mcp.config`.
* All existing callers updated to import from new canonical locations.
* Backward-compatible re-exports in old locations (`plugin/source.py`, `skills/utils.py`).

**Rebased onto main** incorporating PRs #2811 (extension installation module), #2873 (secrets support for MCP config expansion), and #2962 (Pydantic model serialization fix).

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `mcp/__init__.py` uses lazy `__getattr__` exports for config utilities to avoid a circular import chain (skills → mcp → tool → skills).
- `skills/skill.py` uses inline import for `mcp.config` for the same reason.
- `subagent/schema.py` is no longer modified — deferred MCP expansion at conversation time (from PR #2873) is preserved as-is.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:73a9f3b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-73a9f3b-python \
  ghcr.io/openhands/agent-server:73a9f3b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:73a9f3b-golang-amd64
ghcr.io/openhands/agent-server:73a9f3b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:73a9f3b-golang-arm64
ghcr.io/openhands/agent-server:73a9f3b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:73a9f3b-java-amd64
ghcr.io/openhands/agent-server:73a9f3b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:73a9f3b-java-arm64
ghcr.io/openhands/agent-server:73a9f3b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:73a9f3b-python-amd64
ghcr.io/openhands/agent-server:73a9f3b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:73a9f3b-python-arm64
ghcr.io/openhands/agent-server:73a9f3b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:73a9f3b-golang
ghcr.io/openhands/agent-server:73a9f3b-java
ghcr.io/openhands/agent-server:73a9f3b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `73a9f3b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `73a9f3b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->