### PR TITLE
Add claude-opus-4-7 model

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -40,7 +40,7 @@ signal.signal(signal.SIGALRM, _sigterm_handler)
 # SDK-specific parameters that should not be passed to litellm.
 # These parameters are used by the SDK's LLM wrapper but are not part of litellm's API.
 # Keep this list in sync with SDK LLM config parameters that are SDK-internal.
-SDK_ONLY_PARAMS = {"disable_vision"}
+SDK_ONLY_PARAMS = {"disable_vision", "enable_vision"}
 
 
 # Model configurations dictionary
@@ -117,6 +117,9 @@ MODELS = {
         "display_name": "Claude 4.7 Opus",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-7",
+            # LiteLLM doesn't have claude-opus-4-7 in its model database yet,
+            # so we explicitly enable vision until LiteLLM is updated
+            "enable_vision": True,
         },
     },
     "claude-sonnet-4-6": {

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -112,6 +112,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "claude-4.7-opus": {
+        "id": "claude-4.7-opus",
+        "display_name": "Claude 4.7 Opus",
+        "llm_config": {
+            "model": "litellm_proxy/anthropic/claude-opus-4-7",
+            "temperature": 0.0,
+        },
+    },
     "claude-sonnet-4-6": {
         "id": "claude-sonnet-4-6",
         "display_name": "Claude Sonnet 4.6",

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -112,8 +112,8 @@ MODELS = {
             "temperature": 0.0,
         },
     },
-    "claude-4.7-opus": {
-        "id": "claude-4.7-opus",
+    "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
         "display_name": "Claude 4.7 Opus",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-7",

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -117,7 +117,6 @@ MODELS = {
         "display_name": "Claude 4.7 Opus",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-7",
-            "temperature": 0.0,
         },
     },
     "claude-sonnet-4-6": {

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -319,6 +319,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         description="If model is vision capable, this option allows to disable image "
         "processing (useful for cost reduction).",
     )
+    enable_vision: bool | None = Field(
+        default=None,
+        description="Explicitly enable vision for models where LiteLLM detection "
+        "is incorrect (e.g., new models not yet in LiteLLM database).",
+    )
     disable_stop_word: bool | None = Field(
         default=False,
         description="Disable using of stop word.",
@@ -1291,6 +1296,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def vision_is_active(self) -> bool:
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
+            # Explicit enable_vision takes precedence over automatic detection
+            if self.enable_vision is True:
+                return True
+            if self.enable_vision is False:
+                return False
             return not self.disable_vision and self._supports_vision()
 
     def _supports_vision(self) -> bool:

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -110,6 +110,7 @@ PROMPT_CACHE_MODELS: list[str] = [
     "claude-sonnet-4-6",
     "claude-opus-4-5",
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-6",
 ]
 

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -614,7 +614,7 @@ def test_trinity_large_thinking_config():
     assert model["llm_config"]["top_p"] == 0.95
 
 
-def test_claude_4_7_opus_config():
+def test_claude_opus_4_7_config():
     """Test that claude-opus-4-7 has correct configuration."""
     model = MODELS["claude-opus-4-7
 

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -612,3 +612,13 @@ def test_trinity_large_thinking_config():
     assert model["llm_config"]["model"] == "litellm_proxy/trinity-large-thinking"
     assert model["llm_config"]["temperature"] == 1.0
     assert model["llm_config"]["top_p"] == 0.95
+
+
+def test_claude_4_7_opus_config():
+    """Test that claude-4.7-opus has correct configuration."""
+    model = MODELS["claude-4.7-opus"]
+
+    assert model["id"] == "claude-4.7-opus"
+    assert model["display_name"] == "Claude 4.7 Opus"
+    assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
+    assert model["llm_config"]["temperature"] == 0.0

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -621,4 +621,6 @@ def test_claude_opus_4_7_config():
     assert model["id"] == "claude-opus-4-7"
     assert model["display_name"] == "Claude 4.7 Opus"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
-    # Note: temperature is not set for claude-opus-4-7 as it's deprecated for this model
+    # LiteLLM doesn't have claude-opus-4-7 in its model database yet,
+    # so we explicitly enable vision
+    assert model["llm_config"]["enable_vision"] is True

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -616,9 +616,9 @@ def test_trinity_large_thinking_config():
 
 def test_claude_opus_4_7_config():
     """Test that claude-opus-4-7 has correct configuration."""
-    model = MODELS["claude-opus-4-7
+    model = MODELS["claude-opus-4-7"]
 
     assert model["id"] == "claude-opus-4-7"
-    assert model["display_name"] == "Claude Opus 4.7"
+    assert model["display_name"] == "Claude 4.7 Opus"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
-    assert model["llm_config"]["temperature"] == 0.0
+    # Note: temperature is not set for claude-opus-4-7 as it's deprecated for this model

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -615,10 +615,10 @@ def test_trinity_large_thinking_config():
 
 
 def test_claude_4_7_opus_config():
-    """Test that claude-4.7-opus has correct configuration."""
-    model = MODELS["claude-4.7-opus"]
+    """Test that claude-opus-4-7 has correct configuration."""
+    model = MODELS["claude-opus-4-7
 
-    assert model["id"] == "claude-4.7-opus"
-    assert model["display_name"] == "Claude 4.7 Opus"
+    assert model["id"] == "claude-opus-4-7"
+    assert model["display_name"] == "Claude Opus 4.7"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
     assert model["llm_config"]["temperature"] == 0.0


### PR DESCRIPTION
## Summary
Adds the `claude-opus-4-7` model to resolve_model_config.py.

## Changes
- Added claude-opus-4-7 model configuration to resolve_model_config.py
- Added claude-opus-4-7 to PROMPT_CACHE_MODELS in model_features.py
- Added test_claude_opus_4_7_config test function

## Configuration
- Model ID: claude-opus-4-7
- Provider: Anthropic
- Temperature: Not set (using model default - LiteLLM doesn't have claude-opus-4-7 in its model database yet)
- Special Parameters: enable_vision=True (explicitly enables vision since LiteLLM doesn't have this model in its database yet)

## Test Results
✅ Unit tests pass

Fixes #2850

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7462a398-bf36-4908-818a-c52fde8deb4f)