### PR TITLE
Add claude-opus-4-7 model support

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -112,6 +112,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "claude-4.7-opus": {
+        "id": "claude-4.7-opus",
+        "display_name": "Claude 4.7 Opus",
+        "llm_config": {
+            "model": "litellm_proxy/anthropic/claude-opus-4-7",
+            "temperature": 0.0,
+        },
+    },
     "claude-sonnet-4-6": {
         "id": "claude-sonnet-4-6",
         "display_name": "Claude Sonnet 4.6",

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -117,7 +117,6 @@ MODELS = {
         "display_name": "Claude 4.7 Opus",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-7",
-            "temperature": 0.0,
         },
     },
     "claude-sonnet-4-6": {

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -112,9 +112,9 @@ MODELS = {
             "temperature": 0.0,
         },
     },
-    "claude-4.7-opus": {
-        "id": "claude-4.7-opus",
-        "display_name": "Claude 4.7 Opus",
+    "claude-opus-4-7": {
+        "id": "claude-opus-4-7",
+        "display_name": "Claude Opus 4.7",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-7",
         },

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -110,6 +110,7 @@ PROMPT_CACHE_MODELS: list[str] = [
     "claude-sonnet-4-6",
     "claude-opus-4-5",
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-6",
 ]
 

--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -25,6 +25,7 @@ VERIFIED_ANTHROPIC_MODELS = [
     "claude-haiku-4-5-20251001",
     "claude-opus-4-5-20251101",
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-6",
     "claude-sonnet-4-20250514",
     "claude-opus-4-20250514",
@@ -66,6 +67,7 @@ VERIFIED_MINIMAX_MODELS = [
 
 VERIFIED_OPENHANDS_MODELS = [
     "claude-opus-4-6",
+    "claude-opus-4-7",
     "claude-sonnet-4-6",
     "gpt-5.4",
     "gpt-5.2",

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -614,10 +614,10 @@ def test_trinity_large_thinking_config():
     assert model["llm_config"]["top_p"] == 0.95
 
 
-def test_claude_4_7_opus_config():
-    """Test that claude-4.7-opus has correct configuration."""
-    model = MODELS["claude-4.7-opus"]
+def test_claude_opus_4_7_config():
+    """Test that claude-opus-4-7 has correct configuration."""
+    model = MODELS["claude-opus-4-7"]
 
-    assert model["id"] == "claude-4.7-opus"
-    assert model["display_name"] == "Claude 4.7 Opus"
+    assert model["id"] == "claude-opus-4-7"
+    assert model["display_name"] == "Claude Opus 4.7"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -612,3 +612,13 @@ def test_trinity_large_thinking_config():
     assert model["llm_config"]["model"] == "litellm_proxy/trinity-large-thinking"
     assert model["llm_config"]["temperature"] == 1.0
     assert model["llm_config"]["top_p"] == 0.95
+
+
+def test_claude_4_7_opus_config():
+    """Test that claude-4.7-opus has correct configuration."""
+    model = MODELS["claude-4.7-opus"]
+
+    assert model["id"] == "claude-4.7-opus"
+    assert model["display_name"] == "Claude 4.7 Opus"
+    assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
+    assert model["llm_config"]["temperature"] == 0.0

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -621,4 +621,3 @@ def test_claude_4_7_opus_config():
     assert model["id"] == "claude-4.7-opus"
     assert model["display_name"] == "Claude 4.7 Opus"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
-    assert model["llm_config"]["temperature"] == 0.0


### PR DESCRIPTION
## Why

Adding support for the new Claude Opus 4.7 model following the ADDINGMODEL.md guidelines.

## Summary

- Added `claude-4.7-opus` model configuration to `resolve_model_config.py`
- Added `claude-opus-4-7` to `VERIFIED_ANTHROPIC_MODELS` and `VERIFIED_OPENHANDS_MODELS`
- Added to `PROMPT_CACHE_MODELS` in `model_features.py` (supports prompt caching)
- Added test `test_claude_4_7_opus_config()` to verify configuration

## Issue Number

Fixes #2850

## How to Test

Run the unit tests:
```bash
pytest tests/cross/test_resolve_model_config.py::test_claude_4_7_opus_config -v
```

All 32 tests in the test file pass.

## Configuration

- Model ID: `claude-4.7-opus`
- Display Name: Claude 4.7 Opus
- Provider: Anthropic
- Model Path: `litellm_proxy/anthropic/claude-opus-4-7`
- Temperature: 0.0 (standard deterministic)

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This model follows the same pattern as existing Claude Opus 4.5 and 4.6 configurations.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7ffa6ed0-a7cc-4ac7-bf72-f3f41d936c7d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:47f024f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-47f024f-python \
  ghcr.io/openhands/agent-server:47f024f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:47f024f-golang-amd64
ghcr.io/openhands/agent-server:47f024f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:47f024f-golang-arm64
ghcr.io/openhands/agent-server:47f024f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:47f024f-java-amd64
ghcr.io/openhands/agent-server:47f024f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:47f024f-java-arm64
ghcr.io/openhands/agent-server:47f024f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:47f024f-python-amd64
ghcr.io/openhands/agent-server:47f024f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:47f024f-python-arm64
ghcr.io/openhands/agent-server:47f024f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:47f024f-golang
ghcr.io/openhands/agent-server:47f024f-java
ghcr.io/openhands/agent-server:47f024f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `47f024f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `47f024f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->