### PR TITLE
feat: ExtensionConfig — models, Conversation wiring, and server integration

### DIFF
--- a/examples/01_standalone_sdk/03_activate_skill.py
+++ b/examples/01_standalone_sdk/03_activate_skill.py
@@ -8,6 +8,7 @@ from openhands.sdk import (
     AgentContext,
     Conversation,
     Event,
+    ExtensionConfig,
     LLMConvertibleEvent,
     get_logger,
 )
@@ -87,9 +88,6 @@ agent_context = AgentContext(
     system_message_suffix="Always finish your response with the word 'yay!'",
     # user_message_suffix is appended to each user message
     user_message_suffix="The first character of your response should be 'I'",
-    # You can also enable automatic load skills from
-    # public registry at https://github.com/OpenHands/extensions
-    load_public_skills=True,
 )
 
 # Agent
@@ -103,8 +101,13 @@ def conversation_callback(event: Event):
         llm_messages.append(event.to_llm_message())
 
 
+# ExtensionConfig controls loading of extensions (skills, plugins, hooks)
+# from well-known locations at the conversation level.
 conversation = Conversation(
-    agent=agent, callbacks=[conversation_callback], workspace=cwd
+    agent=agent,
+    callbacks=[conversation_callback],
+    workspace=cwd,
+    extension_config=ExtensionConfig(load_public_extensions=True),
 )
 
 print("=" * 100)

--- a/examples/05_skills_and_plugins/01_loading_agentskills/main.py
+++ b/examples/05_skills_and_plugins/01_loading_agentskills/main.py
@@ -110,8 +110,6 @@ llm = LLM(
 # Create agent context with loaded skills
 agent_context = AgentContext(
     skills=list(agent_skills.values()),
-    # Disable public skills for this demo to keep output focused
-    load_public_skills=False,
 )
 
 # Create agent with tools so it can read skill resources

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -472,10 +472,8 @@ class EventService:
             self.stored.agent.model_dump(context={"expose_secrets": True}),
         )
 
-        # Create LocalConversation with plugins and hook_config.
-        # Plugins are loaded lazily on first run()/send_message() call.
-        # Hook execution semantics: OpenHands runs hooks sequentially with early-exit
-        # on block (PreToolUse), unlike Claude Code's parallel execution model.
+        # Extensions (plugins, hooks, skills) are loaded lazily on first
+        # run()/send_message() call via ExtensionConfig.resolve().
 
         # Create and store callback wrapper to allow flushing pending events
         self._callback_wrapper = AsyncCallbackWrapper(
@@ -485,6 +483,7 @@ class EventService:
         conversation = LocalConversation(
             agent=agent,
             workspace=workspace,
+            extension_config=self.stored.extension_config,
             plugins=self.stored.plugins,
             persistence_dir=str(self.conversations_dir),
             conversation_id=self.stored.id,

--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -20,6 +20,7 @@ from openhands.sdk.conversation import (
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.event import Event, HookExecutionEvent, LLMConvertibleEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.io import FileStore, LocalFileStore
 from openhands.sdk.llm import (
     LLM,
@@ -134,6 +135,7 @@ __all__ = [
     "ConversationExecutionStatus",
     "ConversationCallbackType",
     "Event",
+    "ExtensionConfig",
     "LLMConvertibleEvent",
     "AgentContext",
     "LLMSummarizingCondenser",

--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -18,6 +18,7 @@ from openhands.sdk.skills import (
     to_prompt,
 )
 from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
+from openhands.sdk.utils.deprecation import warn_deprecated
 
 
 logger = get_logger(__name__)
@@ -59,6 +60,10 @@ class AgentContext(BaseModel):
     )
     load_user_skills: bool = Field(
         default=False,
+        deprecated=(
+            "Deprecated since v1.18.0; will be removed in v1.23.0. "
+            "Use ExtensionConfig(load_user_extensions=True) on Conversation."
+        ),
         description=(
             "Whether to automatically load user skills from ~/.openhands/skills/ "
             "and ~/.openhands/microagents/ (for backward compatibility). "
@@ -66,6 +71,10 @@ class AgentContext(BaseModel):
     )
     load_public_skills: bool = Field(
         default=False,
+        deprecated=(
+            "Deprecated since v1.18.0; will be removed in v1.23.0. "
+            "Use ExtensionConfig(load_public_extensions=True) on Conversation."
+        ),
         description=(
             "Whether to automatically load skills from the public OpenHands "
             "skills repository at https://github.com/OpenHands/extensions. "
@@ -74,6 +83,10 @@ class AgentContext(BaseModel):
     )
     marketplace_path: str | None = Field(
         default=DEFAULT_MARKETPLACE_PATH,
+        deprecated=(
+            "Deprecated since v1.18.0; will be removed in v1.23.0. "
+            "Use ExtensionConfig(marketplace_path=...) on Conversation."
+        ),
         description=(
             "Relative marketplace JSON path within the public skills repository. "
             "Set to None to load all public skills without marketplace filtering."
@@ -114,9 +127,36 @@ class AgentContext(BaseModel):
 
     @model_validator(mode="after")
     def _load_auto_skills(self):
-        """Load user and/or public skills if enabled."""
+        """Load user and/or public skills if enabled.
+
+        .. deprecated:: 1.18.0
+            Use ``ExtensionConfig(load_user_extensions=...,
+            load_public_extensions=...)`` on ``Conversation`` instead.
+            Will be removed in v1.23.0.
+        """
         if not self.load_user_skills and not self.load_public_skills:
             return self
+
+        _details = (
+            "Use ExtensionConfig(load_user_extensions=..., "
+            "load_public_extensions=...) on Conversation instead."
+        )
+        if self.load_user_skills:
+            warn_deprecated(
+                "AgentContext.load_user_skills",
+                deprecated_in="1.18.0",
+                removed_in="1.23.0",
+                details=_details,
+                stacklevel=3,
+            )
+        if self.load_public_skills:
+            warn_deprecated(
+                "AgentContext.load_public_skills",
+                deprecated_in="1.18.0",
+                removed_in="1.23.0",
+                details=_details,
+                stacklevel=3,
+            )
 
         auto_skills = load_available_skills(
             work_dir=None,

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -14,6 +14,7 @@ from openhands.sdk.conversation.visualizer import (
     ConversationVisualizerBase,
     DefaultConversationVisualizer,
 )
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.logger import get_logger
 from openhands.sdk.plugin import PluginSource
@@ -63,6 +64,7 @@ class Conversation:
         agent: AgentBase,
         *,
         workspace: str | Path | LocalWorkspace = "workspace/project",
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         persistence_dir: str | Path | None = None,
         conversation_id: ConversationID | None = None,
@@ -88,6 +90,7 @@ class Conversation:
         agent: AgentBase,
         *,
         workspace: RemoteWorkspace,
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
@@ -111,6 +114,7 @@ class Conversation:
         agent: AgentBase,
         *,
         workspace: str | Path | LocalWorkspace | RemoteWorkspace = "workspace/project",
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         persistence_dir: str | Path | None = None,
         conversation_id: ConversationID | None = None,
@@ -168,6 +172,7 @@ class Conversation:
 
             return RemoteConversation(
                 agent=agent,
+                extension_config=extension_config,
                 plugins=plugins,
                 conversation_id=conversation_id,
                 callbacks=callbacks,
@@ -185,6 +190,7 @@ class Conversation:
 
         return LocalConversation(
             agent=agent,
+            extension_config=extension_config,
             plugins=plugins,
             conversation_id=conversation_id,
             callbacks=callbacks,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.event_store import EventLog
@@ -35,26 +36,23 @@ from openhands.sdk.event import (
     UserRejectObservation,
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.hooks import HookConfig, HookEventProcessor, create_hook_callback
 from openhands.sdk.io import LocalFileStore
 from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
-from openhands.sdk.mcp.utils import merge_mcp_configs
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.plugin import (
-    Plugin,
     PluginSource,
     ResolvedPluginSource,
-    fetch_plugin_with_resolution,
 )
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
 from openhands.sdk.subagent import (
-    AgentDefinition,
     register_file_agents,
     register_plugin_agents,
 )
@@ -79,16 +77,16 @@ class LocalConversation(BaseConversation):
     _cleanup_initiated: bool
     _hook_processor: HookEventProcessor | None
     delete_on_close: bool = True
-    # Plugin lazy loading state
-    _plugin_specs: list[PluginSource] | None
+    # Extension config (replaces per-field plugin/hook tracking)
+    _extension_config: ExtensionConfig
     _resolved_plugins: list[ResolvedPluginSource] | None
-    _plugins_loaded: bool
-    _pending_hook_config: HookConfig | None  # Hook config to combine with plugin hooks
+    _extensions_loaded: bool
 
     def __init__(
         self,
         agent: AgentBase,
         workspace: str | Path | LocalWorkspace,
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         persistence_dir: str | Path | None = None,
         conversation_id: ConversationID | None = None,
@@ -115,12 +113,14 @@ class LocalConversation(BaseConversation):
             agent: The agent to use for the conversation.
             workspace: Working directory for agent operations and tool execution.
                 Can be a string path, Path object, or LocalWorkspace instance.
-            plugins: Optional list of plugins to load. Each plugin is specified
-                with a source (github:owner/repo, git URL, or local path),
-                optional ref (branch/tag/commit), and optional repo_path for
-                monorepos. Plugins are loaded in order with these merge
-                semantics: skills override by name (last wins), MCP config
-                override by key (last wins), hooks concatenate (all run).
+            extension_config: Declarative specification of all extensions to
+                load (skills, plugins, hooks). When provided, ``plugins`` and
+                ``hook_config`` are ignored — use the config object instead.
+                When ``None`` (the default), an ``ExtensionConfig`` is built
+                from the ``plugins`` and ``hook_config`` parameters for
+                backward compatibility.
+            plugins: Optional list of plugins to load. Ignored when
+                ``extension_config`` is provided.
             persistence_dir: Directory for persisting conversation state and events.
                 Can be a string path or Path object.
             conversation_id: Optional ID for the conversation. If provided, will
@@ -129,7 +129,7 @@ class LocalConversation(BaseConversation):
             callbacks: Optional list of callback functions to handle events
             token_callbacks: Optional list of callbacks invoked for streaming deltas
             hook_config: Optional hook configuration to auto-wire session hooks.
-                If plugins are loaded, their hooks are combined with this config.
+                Ignored when ``extension_config`` is provided.
             max_iteration_per_run: Maximum number of iterations per run
             visualizer: Visualization configuration. Can be:
                        - ConversationVisualizerBase subclass: Class to instantiate
@@ -154,13 +154,17 @@ class LocalConversation(BaseConversation):
         # initialized instances during interpreter shutdown.
         self._cleanup_initiated = False
 
-        # Store plugin specs for lazy loading (no IO in constructor)
-        # Plugins will be loaded on first run() or send_message() call
-        self._plugin_specs = plugins
+        # Build ExtensionConfig: prefer explicit config, fall back to legacy params
+        if extension_config is not None:
+            self._extension_config = extension_config
+        else:
+            self._extension_config = ExtensionConfig(
+                plugins=plugins or [],
+                hook_config=hook_config,
+            )
         self._resolved_plugins = None
-        self._plugins_loaded = False
-        self._pending_hook_config = hook_config  # Will be combined with plugin hooks
-        self._agent_ready = False  # Agent initialized lazily after plugins loaded
+        self._extensions_loaded = False
+        self._agent_ready = False  # Agent initialized lazily after extensions
 
         self.agent = agent
         if isinstance(workspace, (str, Path)):
@@ -227,9 +231,9 @@ class LocalConversation(BaseConversation):
 
         # Compose the base callback chain (visualizer -> user callbacks -> default)
         base_callback = BaseConversation.compose_callbacks(composed_list)
-        self._base_callback = base_callback  # Store for _ensure_plugins_loaded
+        self._base_callback = base_callback  # Store for _ensure_extensions_loaded
 
-        # Defer all hook setup to _ensure_plugins_loaded() for consistency
+        # Defer all hook setup to _ensure_extensions_loaded() for consistency
         # This runs on first run()/send_message() call and handles both
         # explicit hooks and plugin hooks in one place
         self._hook_processor = None
@@ -308,108 +312,78 @@ class LocalConversation(BaseConversation):
         """
         return self._resolved_plugins
 
-    def _ensure_plugins_loaded(self) -> None:
-        """Lazy load plugins and set up hooks on first use.
+    def _ensure_extensions_loaded(self) -> None:
+        """Lazy-load all extensions and set up hooks on first use.
 
-        This method is called automatically before run() and send_message().
-        It handles both plugin loading and hook initialization in one place
-        for consistency.
+        This method is called automatically before ``run()`` and
+        ``send_message()``.  It delegates to ``ExtensionConfig.resolve()``
+        for the actual I/O (plugin fetching, skill loading, MCP merging)
+        and then applies the ``ResolvedExtensions`` to the agent and
+        conversation state.
 
         The method:
-        1. Fetches plugins from their sources (network IO for remote sources)
-        2. Resolves refs to commit SHAs for deterministic resume
-        3. Loads plugin contents (skills, MCP config, hooks)
-        4. Merges plugin contents into the agent
-        5. Sets up hook processor with combined hooks (explicit + plugin)
-        6. Runs session_start hooks
+        1. Calls ``ExtensionConfig.resolve()`` with the workspace and
+           agent's existing skills/MCP config.
+        2. Updates the agent with merged skills and MCP config.
+        3. Registers plugin-provided agent definitions.
+        4. Sets up hook processor with combined hooks (explicit + plugin).
+        5. Runs ``session_start`` hooks.
         """
-        if self._plugins_loaded:
+        if self._extensions_loaded:
             return
 
-        all_plugin_hooks: list[HookConfig] = []
-        all_plugin_agents: list[AgentDefinition] = []
+        # Only pass work_dir when the config requests extension loading;
+        # otherwise project skills are loaded by AgentContext during the
+        # deprecation period and we avoid unintentional side effects.
+        wants_loading = (
+            self._extension_config.plugins
+            or self._extension_config.load_user_extensions
+            or self._extension_config.load_public_extensions
+        )
+        resolved = self._extension_config.resolve(
+            work_dir=self.workspace.working_dir if wants_loading else None,
+            existing_skills=(
+                list(self.agent.agent_context.skills)
+                if self.agent.agent_context
+                else None
+            ),
+            existing_mcp_config=(
+                dict(self.agent.mcp_config) if self.agent.mcp_config else None
+            ),
+        )
 
-        # Load plugins if specified
-        if self._plugin_specs:
-            logger.info(f"Loading {len(self._plugin_specs)} plugin(s)...")
-            self._resolved_plugins = []
+        # Store resolved plugins for persistence / deterministic resume
+        self._resolved_plugins = resolved.resolved_plugins or None
 
-            # Start with agent's existing context and MCP config
-            merged_context = self.agent.agent_context
-            merged_mcp = dict(self.agent.mcp_config) if self.agent.mcp_config else {}
-
-            for spec in self._plugin_specs:
-                # Fetch plugin and get resolved commit SHA
-                path, resolved_ref = fetch_plugin_with_resolution(
-                    source=spec.source,
-                    ref=spec.ref,
-                    repo_path=spec.repo_path,
+        # Update agent with merged skills and MCP config
+        has_new_skills = bool(resolved.skills)
+        has_new_mcp = bool(resolved.mcp_config)
+        if has_new_skills or has_new_mcp:
+            update: dict = {}
+            if has_new_skills:
+                ctx = self.agent.agent_context or AgentContext()
+                update["agent_context"] = ctx.model_copy(
+                    update={"skills": resolved.skills}
                 )
+            if has_new_mcp:
+                update["mcp_config"] = resolved.mcp_config
+            self.agent = self.agent.model_copy(update=update)
 
-                # Store resolved ref for persistence
-                resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
-                self._resolved_plugins.append(resolved)
-
-                # Load the plugin
-                plugin = Plugin.load(path)
-                logger.debug(
-                    f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
-                    + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
-                )
-
-                # Merge plugin contents
-                merged_context = plugin.add_skills_to(merged_context)
-                merged_mcp = merge_mcp_configs(merged_mcp, plugin.mcp_config)
-
-                # Collect hooks
-                if plugin.hooks and not plugin.hooks.is_empty():
-                    all_plugin_hooks.append(plugin.hooks)
-
-                # Collect agent definitions
-                if plugin.agents:
-                    all_plugin_agents.extend(plugin.agents)
-
-            # Update agent with merged content
-            self.agent = self.agent.model_copy(
-                update={
-                    "agent_context": merged_context,
-                    "mcp_config": merged_mcp,
-                }
-            )
-
-            # Also update the agent in _state so API responses reflect loaded plugins
             with self._state:
                 self._state.agent = self.agent
 
-            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
-
-        # Register file-based agents defined in plugins
-        if all_plugin_agents:
+        # Register plugin-provided agent definitions
+        if resolved.agents:
             register_plugin_agents(
-                agents=all_plugin_agents,
+                agents=resolved.agents,
                 work_dir=self.workspace.working_dir,
             )
 
-        # Combine explicit hook_config with plugin hooks
-        # Explicit hooks run first (before plugin hooks)
-        final_hook_config = self._pending_hook_config
-        if all_plugin_hooks:
-            plugin_hooks = HookConfig.merge(all_plugin_hooks)
-            if plugin_hooks is not None:
-                if final_hook_config is not None:
-                    final_hook_config = HookConfig.merge(
-                        [final_hook_config, plugin_hooks]
-                    )
-                else:
-                    final_hook_config = plugin_hooks
-
-        # Set up hook processor with the combined config
-        if final_hook_config is not None:
-            # Store final hook_config in state for observability
-            self._state.hook_config = final_hook_config
-
+        # Set up hook processor
+        if resolved.hooks is not None:
+            self._state.hook_config = resolved.hooks
             self._hook_processor, self._on_event = create_hook_callback(
-                hook_config=final_hook_config,
+                hook_config=resolved.hooks,
                 working_dir=str(self.workspace.working_dir),
                 session_id=str(self._state.id),
                 original_callback=self._base_callback,
@@ -417,7 +391,7 @@ class LocalConversation(BaseConversation):
             self._hook_processor.set_conversation_state(self._state)
             self._hook_processor.run_session_start()
 
-        self._plugins_loaded = True
+        self._extensions_loaded = True
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.
@@ -428,8 +402,8 @@ class LocalConversation(BaseConversation):
 
         Registration order (highest to lowest priority):
           1. Programmatic `register_agent()` calls (already in the registry)
-          2. Plugin agents (registered during plugin loading, i.e.,
-                in _ensure_plugins_loaded())
+          2. Plugin agents (registered during extension loading, i.e.,
+                in _ensure_extensions_loaded())
           3. Project-level file agents (`{project}/.agents/agents/*.md`,
                 then `{project}/.openhands/agents/*.md`)
           4. User-level file agents (`~/.agents/agents/*.md`,
@@ -439,14 +413,14 @@ class LocalConversation(BaseConversation):
         register_file_agents(self.workspace.working_dir)
 
     def _ensure_agent_ready(self) -> None:
-        """Ensure the agent is fully initialized with plugins and agents loaded.
+        """Ensure the agent is fully initialized with extensions and agents loaded.
 
         Performs one-time lazy initialization on the first `send_message()`
         or `run()` call.  The steps executed (in order) are:
 
-        1. Load plugins (merges skills, MCP config, and hooks).
+        1. Load extensions (merges skills, MCP config, and hooks).
         2. Register file-based agents into the agent registry.
-        3. Initialize the agent with complete plugin config and hooks.
+        3. Initialize the agent with complete extension config and hooks.
         4. Register LLMs in the LLM registry.
 
         This preserves the design principle that constructors should not perform
@@ -468,8 +442,8 @@ class LocalConversation(BaseConversation):
             if self._agent_ready:
                 return
 
-            # Load plugins first (merges skills, MCP config, hooks)
-            self._ensure_plugins_loaded()
+            # Load extensions first (merges skills, MCP config, hooks)
+            self._ensure_extensions_loaded()
 
             # register file-based agents
             self._register_file_based_agents()

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -18,6 +18,7 @@ from openhands.sdk.conversation.base import BaseConversation, ConversationStateP
 
 
 if TYPE_CHECKING:
+    from openhands.sdk.extensions.config import ExtensionConfig
     from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.conversation.events_list_base import EventsListBase
@@ -614,6 +615,7 @@ class RemoteConversation(BaseConversation):
         self,
         agent: AgentBase,
         workspace: RemoteWorkspace,
+        extension_config: "ExtensionConfig | None" = None,
         plugins: list | None = None,
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
@@ -636,8 +638,12 @@ class RemoteConversation(BaseConversation):
         Args:
             agent: Agent configuration (will be sent to the server)
             workspace: The working directory for agent operations and tool execution.
-            plugins: Optional list of plugins to load on the server. Each plugin
-                    is a PluginSource specifying source, ref, and repo_path.
+            extension_config: Declarative specification of all extensions to
+                load (skills, plugins, hooks). When provided, ``plugins`` and
+                ``hook_config`` are ignored — use the config object instead.
+                Serialized and sent to the server in the creation payload.
+            plugins: Optional list of plugins to load on the server. Ignored
+                when ``extension_config`` is provided.
             conversation_id: Optional existing conversation id to attach to
             callbacks: Optional callbacks to receive events (not yet streamed)
             max_iteration_per_run: Max iterations configured on server
@@ -648,7 +654,7 @@ class RemoteConversation(BaseConversation):
                       'monologue', 'alternating_pattern'. Values are integers
                       representing the number of repetitions before triggering.
             hook_config: Optional hook configuration sent to the server.
-                      All hooks are executed server-side.
+                Ignored when ``extension_config`` is provided.
             visualizer: Visualization configuration. Can be:
                        - ConversationVisualizerBase subclass: Class to instantiate
                          (default: ConversationVisualizer)
@@ -712,6 +718,16 @@ class RemoteConversation(BaseConversation):
             serialized_defs = [d.model_dump(mode="json") for d in agent_defs]
             logger.debug(f"Sending {len(serialized_defs)} agent_definitions to server")
 
+            # Derive effective plugins/hook_config from extension_config
+            # when provided; otherwise use the legacy parameters directly.
+            effective_plugins = plugins
+            effective_hook_config = hook_config
+            serialized_ext_config = None
+            if extension_config is not None:
+                effective_plugins = extension_config.plugins or None
+                effective_hook_config = extension_config.hook_config
+                serialized_ext_config = extension_config.model_dump()
+
             payload = {
                 "agent": agent.model_dump(
                     mode="json", context={"expose_secrets": True}
@@ -727,10 +743,20 @@ class RemoteConversation(BaseConversation):
                 "tool_module_qualnames": tool_qualnames,
                 # Include agent definitions for subagent registration on server
                 "agent_definitions": serialized_defs,
-                # Include plugins to load on server
-                "plugins": [p.model_dump() for p in plugins] if plugins else None,
-                # Include hook_config for server-side hooks
-                "hook_config": hook_config.model_dump() if hook_config else None,
+                # Include extension_config for server-side resolution
+                "extension_config": serialized_ext_config,
+                # Include plugins to load on server (legacy)
+                "plugins": (
+                    [p.model_dump() for p in effective_plugins]
+                    if effective_plugins
+                    else None
+                ),
+                # Include hook_config for server-side hooks (legacy)
+                "hook_config": (
+                    effective_hook_config.model_dump()
+                    if effective_hook_config
+                    else None
+                ),
                 # Include tags if provided
                 "tags": tags or {},
             }

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -16,6 +16,7 @@ from pydantic import BaseModel, Discriminator, Field, Tag
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.agent import Agent
 from openhands.sdk.conversation.types import ConversationTags
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm.message import ImageContent, Message, TextContent
 from openhands.sdk.plugin import PluginSource
@@ -117,12 +118,21 @@ class _StartConversationRequestBase(BaseModel):
             "can see user-registered subagents."
         ),
     )
+    extension_config: ExtensionConfig | None = Field(
+        default=None,
+        description=(
+            "Declarative specification of all extensions to load (skills, "
+            "plugins, hooks). When provided, ``plugins`` and ``hook_config`` "
+            "are ignored — use the config object instead."
+        ),
+    )
     plugins: list[PluginSource] | None = Field(
         default=None,
         description=(
             "List of plugins to load for this conversation. Plugins are loaded "
             "and their skills/MCP config are merged into the agent. "
-            "Hooks are extracted and stored for runtime execution."
+            "Hooks are extracted and stored for runtime execution. "
+            "Ignored when ``extension_config`` is provided."
         ),
     )
     hook_config: HookConfig | None = Field(
@@ -132,7 +142,7 @@ class _StartConversationRequestBase(BaseModel):
             "scripts that run at key lifecycle events (PreToolUse, PostToolUse, "
             "UserPromptSubmit, Stop, etc.). If both hook_config and plugins are "
             "provided, they are merged with explicit hooks running before plugin "
-            "hooks."
+            "hooks. Ignored when ``extension_config`` is provided."
         ),
     )
     tags: ConversationTags = Field(

--- a/openhands-sdk/openhands/sdk/extensions/config.py
+++ b/openhands-sdk/openhands/sdk/extensions/config.py
@@ -23,6 +23,7 @@ from pydantic import BaseModel, Field
 
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp.utils import merge_mcp_configs
 from openhands.sdk.plugin import (
     Plugin,
     PluginSource,
@@ -103,13 +104,13 @@ class ExtensionConfig(BaseModel):
 
     # -- Auto-loading flags -----------------------------------------------
 
-    load_user_skills: bool = Field(
+    load_user_extensions: bool = Field(
         default=False,
-        description="Load skills from ~/.openhands/skills/.",
+        description="Load extensions from ~/.openhands/skills/.",
     )
-    load_public_skills: bool = Field(
+    load_public_extensions: bool = Field(
         default=False,
-        description="Load skills from the public OpenHands extensions repo.",
+        description="Load extensions from the public OpenHands extensions repo.",
     )
     marketplace_path: str | None = Field(
         default=DEFAULT_MARKETPLACE_PATH,
@@ -161,12 +162,12 @@ class ExtensionConfig(BaseModel):
                 skills_by_name[s.name] = s
 
         # -- 2-4. Auto-load from well-known locations ---------------------
-        if self.load_public_skills or self.load_user_skills or work_dir:
+        if self.load_public_extensions or self.load_user_extensions or work_dir:
             auto = load_available_skills(
                 work_dir=work_dir,
-                include_user=self.load_user_skills,
+                include_user=self.load_user_extensions,
                 include_project=work_dir is not None,
-                include_public=self.load_public_skills,
+                include_public=self.load_public_extensions,
                 marketplace_path=self.marketplace_path,
             )
             for name, skill in auto.items():
@@ -217,7 +218,7 @@ class ExtensionConfig(BaseModel):
                 skills_by_name[skill.name] = skill
 
             # MCP: server-name-based last-wins
-            mcp_config = plugin.add_mcp_config_to(mcp_config)
+            mcp_config = merge_mcp_configs(mcp_config, plugin.mcp_config)
 
             # Hooks: concatenate
             if plugin.hooks and not plugin.hooks.is_empty():

--- a/openhands-sdk/openhands/sdk/extensions/config.py
+++ b/openhands-sdk/openhands/sdk/extensions/config.py
@@ -1,0 +1,245 @@
+"""Extension configuration and resolution.
+
+This module defines the declarative specification for what extensions a
+conversation should load (``ExtensionConfig``) and the materialized result
+after loading and merging (``ResolvedExtensions``).
+
+Import note:
+    This module imports from ``skills``, ``plugin``, and ``hooks``.  Because
+    those packages import from ``extensions.fetch`` at package-init time, this
+    module must **not** be re-exported from ``extensions/__init__.py`` until the
+    loader functions are migrated into ``extensions/`` (removing the reverse
+    dependency).  Consumers import directly::
+
+        from openhands.sdk.extensions.config import ExtensionConfig
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+from openhands.sdk.hooks import HookConfig
+from openhands.sdk.logger import get_logger
+from openhands.sdk.plugin import (
+    Plugin,
+    PluginSource,
+    ResolvedPluginSource,
+    fetch_plugin_with_resolution,
+)
+from openhands.sdk.skills import Skill, load_available_skills
+from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
+from openhands.sdk.subagent.schema import AgentDefinition
+
+
+logger = get_logger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Resolved result
+# ---------------------------------------------------------------------------
+
+
+class ResolvedExtensions(BaseModel):
+    """Materialized extensions after loading and merging.
+
+    This is the output of ``ExtensionConfig.resolve()``.  The conversation
+    destructures it and applies each part to the appropriate target:
+
+    - ``skills`` → ``agent.agent_context.skills`` (prompt injection)
+    - ``mcp_config`` → ``agent.mcp_config`` (MCP tool creation)
+    - ``hooks`` → ``HookEventProcessor`` (event-level callbacks)
+    - ``agents`` → subagent registry
+    - ``resolved_plugins`` → persisted for deterministic resume
+    """
+
+    skills: list[Skill] = Field(default_factory=list)
+    mcp_config: dict[str, Any] = Field(default_factory=dict)
+    hooks: HookConfig | None = None
+    agents: list[AgentDefinition] = Field(default_factory=list)
+    resolved_plugins: list[ResolvedPluginSource] = Field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# Declarative config
+# ---------------------------------------------------------------------------
+
+
+class ExtensionConfig(BaseModel):
+    """Declarative specification of what extensions to load.
+
+    Holds both explicit extension objects (skills, hooks) and flags that
+    trigger loading from well-known locations (user dir, public repo,
+    project workspace).  Nothing is fetched or loaded at construction
+    time — all I/O is deferred to ``resolve()``.
+
+    Merge precedence (later overrides earlier for name collisions):
+
+        auto-loaded skills (public < user < project)
+          → explicit skills
+            → plugin skills (in plugin-list order)
+
+    Hooks use concatenation semantics (all hooks run); explicit hooks
+    execute before plugin hooks.  MCP configs merge by server name
+    (last wins).
+    """
+
+    # -- Explicit extensions (already materialized) -----------------------
+
+    skills: list[Skill] = Field(
+        default_factory=list,
+        description="Pre-built Skill objects. Override auto-loaded skills by name.",
+    )
+    plugins: list[PluginSource] = Field(
+        default_factory=list,
+        description="Plugin sources to fetch and load.",
+    )
+    hook_config: HookConfig | None = Field(
+        default=None,
+        description="Explicit hook configuration. Runs before plugin hooks.",
+    )
+
+    # -- Auto-loading flags -----------------------------------------------
+
+    load_user_skills: bool = Field(
+        default=False,
+        description="Load skills from ~/.openhands/skills/.",
+    )
+    load_public_skills: bool = Field(
+        default=False,
+        description="Load skills from the public OpenHands extensions repo.",
+    )
+    marketplace_path: str | None = Field(
+        default=DEFAULT_MARKETPLACE_PATH,
+        description=(
+            "Marketplace JSON path within the public skills repo. "
+            "None = load all public skills without filtering."
+        ),
+    )
+
+    # -- Resolution -------------------------------------------------------
+
+    def resolve(
+        self,
+        work_dir: str | Path | None = None,
+        *,
+        existing_skills: list[Skill] | None = None,
+        existing_mcp_config: dict[str, Any] | None = None,
+    ) -> ResolvedExtensions:
+        """Load, merge, and return resolved extensions.
+
+        This is the single authoritative merge path.  It performs all
+        network I/O (git clone/pull for public skills and remote plugins)
+        and returns a fully materialized ``ResolvedExtensions``.
+
+        Args:
+            work_dir: Project workspace directory.  Used for loading
+                project-level skills.  ``None`` skips project skills.
+            existing_skills: Skills already on the agent (e.g. from
+                ``AgentContext.skills`` during the deprecation period).
+                Treated as the lowest-precedence layer.
+            existing_mcp_config: MCP config already on the agent.
+                Used as the base for MCP merging.
+
+        Returns:
+            A ``ResolvedExtensions`` with everything merged.
+
+        Precedence for skills (later overrides earlier by name):
+            1. existing_skills          (backward-compat, lowest)
+            2. auto-loaded public
+            3. auto-loaded user
+            4. auto-loaded project
+            5. self.skills              (explicit on config)
+            6. plugin skills            (in plugin-list order)
+        """
+        # -- 1. Start with existing agent skills (backward-compat layer) --
+        skills_by_name: dict[str, Skill] = {}
+        if existing_skills:
+            for s in existing_skills:
+                skills_by_name[s.name] = s
+
+        # -- 2-4. Auto-load from well-known locations ---------------------
+        if self.load_public_skills or self.load_user_skills or work_dir:
+            auto = load_available_skills(
+                work_dir=work_dir,
+                include_user=self.load_user_skills,
+                include_project=work_dir is not None,
+                include_public=self.load_public_skills,
+                marketplace_path=self.marketplace_path,
+            )
+            for name, skill in auto.items():
+                skills_by_name[name] = skill
+
+        # -- 5. Explicit skills on config (override auto-loaded) ----------
+        for skill in self.skills:
+            if skill.name in skills_by_name:
+                logger.debug(
+                    "Explicit skill '%s' overrides auto-loaded skill",
+                    skill.name,
+                )
+            skills_by_name[skill.name] = skill
+
+        # -- 6. Plugins (fetch → load → merge) ---------------------------
+        mcp_config: dict[str, Any] = (
+            dict(existing_mcp_config) if existing_mcp_config else {}
+        )
+        all_hooks: list[HookConfig] = []
+        all_agents: list[AgentDefinition] = []
+        resolved_plugins: list[ResolvedPluginSource] = []
+
+        for spec in self.plugins:
+            path, resolved_ref = fetch_plugin_with_resolution(
+                source=spec.source,
+                ref=spec.ref,
+                repo_path=spec.repo_path,
+            )
+            resolved_plugins.append(
+                ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
+            )
+
+            plugin = Plugin.load(path)
+            logger.debug(
+                "Loaded plugin '%s' from %s%s",
+                plugin.manifest.name,
+                spec.source,
+                f" @ {resolved_ref[:8]}" if resolved_ref else "",
+            )
+
+            # Skills: name-based last-wins
+            for skill in plugin.get_all_skills():
+                if skill.name in skills_by_name:
+                    logger.debug(
+                        "Plugin skill '%s' overrides existing skill",
+                        skill.name,
+                    )
+                skills_by_name[skill.name] = skill
+
+            # MCP: server-name-based last-wins
+            mcp_config = plugin.add_mcp_config_to(mcp_config)
+
+            # Hooks: concatenate
+            if plugin.hooks and not plugin.hooks.is_empty():
+                all_hooks.append(plugin.hooks)
+
+            # Agents: collect
+            if plugin.agents:
+                all_agents.extend(plugin.agents)
+
+        # -- Combine hooks (explicit first, then plugins) -----------------
+        final_hooks: HookConfig | None = None
+        hook_parts: list[HookConfig] = []
+        if self.hook_config is not None:
+            hook_parts.append(self.hook_config)
+        hook_parts.extend(all_hooks)
+        if hook_parts:
+            final_hooks = HookConfig.merge(hook_parts)
+
+        return ResolvedExtensions(
+            skills=list(skills_by_name.values()),
+            mcp_config=mcp_config,
+            hooks=final_hooks,
+            agents=all_agents,
+            resolved_plugins=resolved_plugins,
+        )

--- a/openhands-sdk/openhands/sdk/subagent/AGENTS.md
+++ b/openhands-sdk/openhands/sdk/subagent/AGENTS.md
@@ -81,7 +81,7 @@ When a `LocalConversation` becomes ready, it establishes the following priority:
 
 This is the order implemented by:
 
-- `LocalConversation._ensure_plugins_loaded()` → registers plugin agents
+- `LocalConversation._ensure_extensions_loaded()` → registers plugin agents
 - `LocalConversation._register_file_based_agents()` → registers project/user file agents, then built-ins
 
 ### Deduplication rules inside file-based loading

--- a/tests/agent_server/test_conversation_service_plugin.py
+++ b/tests/agent_server/test_conversation_service_plugin.py
@@ -455,7 +455,7 @@ async def test_start_conversation_stores_both_hooks_and_plugins_for_lazy_merge(
             await conversation_service.start_conversation(request)
 
             # Verify both explicit hooks AND plugins are stored
-            # (merging happens lazily in LocalConversation._ensure_plugins_loaded)
+            # (merging happens lazily in LocalConversation._ensure_extensions_loaded)
             stored = mock_event_service_class.call_args.kwargs["stored"]
 
             # Explicit hook_config is stored as-is (not merged yet)

--- a/tests/agent_server/test_conversation_service_plugin.py
+++ b/tests/agent_server/test_conversation_service_plugin.py
@@ -1,13 +1,16 @@
-"""Tests for plugin handling in ConversationService.
+"""Tests for plugin and extension_config handling in ConversationService.
 
 This module tests plugin handling via the `plugins` list parameter
-on StartConversationRequest.
+and extension_config via the `extension_config` parameter on
+StartConversationRequest.
 
 These tests verify that:
 1. Plugin specs are passed through to StoredConversation (for lazy loading)
 2. Explicit hook_config is preserved (merging happens lazily in LocalConversation)
 3. Plugins ARE persisted (unlike the old eager loading model) since
    LocalConversation loads them lazily on first run()/send_message()
+4. ExtensionConfig is passed through to StoredConversation and
+   forwarded to LocalConversation for centralized extension loading.
 """
 
 import tempfile
@@ -30,6 +33,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.hooks import HookConfig, HookDefinition, HookMatcher, HookType
 from openhands.sdk.plugin import PluginSource
 from openhands.sdk.workspace import LocalWorkspace
@@ -468,3 +472,116 @@ async def test_start_conversation_stores_both_hooks_and_plugins_for_lazy_merge(
             # Plugins are stored for lazy loading
             assert stored.plugins is not None
             assert len(stored.plugins) == 1
+
+
+# Tests for extension_config
+
+
+def test_start_conversation_request_has_extension_config_field():
+    """Verify StartConversationRequest has extension_config field."""
+    fields = StartConversationRequest.model_fields
+    assert "extension_config" in fields
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_with_extension_config(conversation_service, tmp_path):
+    """Test that extension_config is passed through to StoredConversation."""
+    plugin_dir = create_test_plugin_dir(
+        tmp_path,
+        skills=[{"name": "ext-skill", "content": "From ExtensionConfig"}],
+    )
+
+    hook_config = HookConfig(
+        pre_tool_use=[
+            HookMatcher(
+                matcher="*",
+                hooks=[HookDefinition(type=HookType.COMMAND, command="echo ext")],
+            )
+        ]
+    )
+
+    ext_config = ExtensionConfig(
+        plugins=[PluginSource(source=str(plugin_dir))],
+        hook_config=hook_config,
+        load_public_extensions=True,
+    )
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        request = StartConversationRequest(
+            agent=Agent(
+                llm=LLM(model="gpt-4o", usage_id="test-llm"),
+                tools=[],
+            ),
+            workspace=LocalWorkspace(working_dir=temp_dir),
+            extension_config=ext_config,
+        )
+
+        with patch(
+            "openhands.agent_server.conversation_service.EventService"
+        ) as mock_event_service_class:
+            mock_event_service = AsyncMock(spec=EventService)
+            mock_event_service_class.return_value = mock_event_service
+
+            mock_state = ConversationState(
+                id=uuid4(),
+                agent=request.agent,
+                workspace=request.workspace,
+                execution_status=ConversationExecutionStatus.IDLE,
+                confirmation_policy=request.confirmation_policy,
+            )
+            mock_event_service.get_state.return_value = mock_state
+            mock_event_service.stored = StoredConversation(
+                id=mock_state.id,
+                **request.model_dump(),
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+
+            await conversation_service.start_conversation(request)
+
+            stored = mock_event_service_class.call_args.kwargs["stored"]
+            assert stored.extension_config is not None
+            assert len(stored.extension_config.plugins) == 1
+            assert stored.extension_config.hook_config is not None
+            assert stored.extension_config.load_public_extensions is True
+
+
+@pytest.mark.asyncio
+async def test_start_conversation_without_extension_config(
+    conversation_service,
+):
+    """extension_config defaults to None when not provided."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        request = StartConversationRequest(
+            agent=Agent(
+                llm=LLM(model="gpt-4o", usage_id="test-llm"),
+                tools=[],
+            ),
+            workspace=LocalWorkspace(working_dir=temp_dir),
+        )
+
+        with patch(
+            "openhands.agent_server.conversation_service.EventService"
+        ) as mock_event_service_class:
+            mock_event_service = AsyncMock(spec=EventService)
+            mock_event_service_class.return_value = mock_event_service
+
+            mock_state = ConversationState(
+                id=uuid4(),
+                agent=request.agent,
+                workspace=request.workspace,
+                execution_status=ConversationExecutionStatus.IDLE,
+                confirmation_policy=request.confirmation_policy,
+            )
+            mock_event_service.get_state.return_value = mock_state
+            mock_event_service.stored = StoredConversation(
+                id=mock_state.id,
+                **request.model_dump(),
+                created_at=datetime.now(UTC),
+                updated_at=datetime.now(UTC),
+            )
+
+            await conversation_service.start_conversation(request)
+
+            stored = mock_event_service_class.call_args.kwargs["stored"]
+            assert stored.extension_config is None

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -71,7 +71,7 @@ class TestLocalConversationPlugins:
     """Tests for plugin loading in LocalConversation.
 
     Note: Plugins are lazy-loaded on first run()/send_message() call.
-    Tests trigger _ensure_plugins_loaded() to verify loading behavior.
+    Tests trigger _ensure_extensions_loaded() to verify loading behavior.
     """
 
     def test_create_conversation_with_plugins(self, tmp_path: Path, basic_agent):
@@ -92,7 +92,7 @@ class TestLocalConversationPlugins:
         )
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         # Agent should have been updated with plugin skills
         assert conversation.agent.agent_context is not None
@@ -132,7 +132,7 @@ class TestLocalConversationPlugins:
         )
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         assert conversation.agent.agent_context is not None
         skill_names = [s.name for s in conversation.agent.agent_context.skills]
@@ -180,7 +180,7 @@ class TestLocalConversationPlugins:
         )
 
         # Hooks are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         # Both hook sources should be combined
         assert conversation._hook_processor is not None
@@ -206,14 +206,14 @@ class TestLocalConversationPlugins:
         )
 
         # Before loading, plugins should not be applied
-        assert conversation._plugins_loaded is False
+        assert conversation._extensions_loaded is False
         assert conversation.resolved_plugins is None
         assert conversation.agent.agent_context is None
 
         # After triggering load
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
-        assert conversation._plugins_loaded is True
+        assert conversation._extensions_loaded is True
         assert conversation.resolved_plugins is not None
         assert conversation.agent.agent_context is not None
 
@@ -305,7 +305,7 @@ class TestConversationFactoryPlugins:
         assert isinstance(conversation, LocalConversation)
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         assert conversation.agent.agent_context is not None
         skill_names = [s.name for s in conversation.agent.agent_context.skills]
@@ -332,7 +332,7 @@ class TestConversationFactoryPlugins:
         )
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         assert conversation.agent.agent_context is not None
         assert len(conversation.agent.agent_context.skills) == 1
@@ -351,4 +351,155 @@ class TestConversationFactoryPlugins:
 
         # Should work without errors
         assert conversation is not None
+        conversation.close()
+
+
+class TestExtensionConfigWiring:
+    """Tests for ExtensionConfig integration with LocalConversation."""
+
+    def test_extension_config_with_plugins(self, tmp_path: Path, basic_agent):
+        """ExtensionConfig with plugins loads them during resolution."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        plugin_dir = create_test_plugin(
+            tmp_path / "plugin",
+            name="ext-plugin",
+            skills=[{"name": "ext-skill", "content": "From extension config"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        ext_config = ExtensionConfig(
+            plugins=[PluginSource(source=str(plugin_dir))],
+        )
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "ext-skill" in skill_names
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+        conversation.close()
+
+    def test_extension_config_overrides_legacy_params(
+        self, tmp_path: Path, basic_agent
+    ):
+        """When extension_config is provided, legacy plugins/hook_config are ignored."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        plugin_dir = create_test_plugin(
+            tmp_path / "ext-plugin",
+            name="ext-plugin",
+            skills=[{"name": "ext-skill", "content": "From config"}],
+        )
+        legacy_dir = create_test_plugin(
+            tmp_path / "legacy-plugin",
+            name="legacy-plugin",
+            skills=[{"name": "legacy-skill", "content": "From legacy"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        ext_config = ExtensionConfig(
+            plugins=[PluginSource(source=str(plugin_dir))],
+        )
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            plugins=[PluginSource(source=str(legacy_dir))],  # should be ignored
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "ext-skill" in skill_names
+        assert "legacy-skill" not in skill_names
+        conversation.close()
+
+    def test_extension_config_with_hook_config(self, tmp_path: Path, basic_agent):
+        """ExtensionConfig hook_config is applied to conversation state."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        hook_config = HookConfig(
+            session_start=[
+                HookMatcher(
+                    matcher="*",
+                    hooks=[HookDefinition(command="echo hello")],
+                )
+            ]
+        )
+        ext_config = ExtensionConfig(hook_config=hook_config)
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.state.hook_config is not None
+        assert len(conversation.state.hook_config.session_start) == 1
+        conversation.close()
+
+    def test_factory_accepts_extension_config(self, tmp_path: Path, basic_agent):
+        """Conversation factory forwards extension_config to LocalConversation."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        plugin_dir = create_test_plugin(
+            tmp_path / "plugin",
+            name="factory-plugin",
+            skills=[{"name": "factory-skill", "content": "From factory"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        ext_config = ExtensionConfig(
+            plugins=[PluginSource(source=str(plugin_dir))],
+        )
+        conversation = Conversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "factory-skill" in skill_names
+        conversation.close()
+
+    def test_empty_extension_config_no_side_effects(self, tmp_path: Path, basic_agent):
+        """Empty ExtensionConfig doesn't modify the agent."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        original_agent = basic_agent
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ExtensionConfig(),
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        # Agent should be the same object (no model_copy)
+        assert conversation.agent is original_agent
         conversation.close()

--- a/tests/sdk/extensions/test_config.py
+++ b/tests/sdk/extensions/test_config.py
@@ -1,0 +1,380 @@
+"""Tests for ExtensionConfig and ResolvedExtensions.
+
+Phase 1 of the extensions-config migration: tests written first (TDD),
+implementation follows in Phase 2.
+"""
+
+import json
+from pathlib import Path
+
+from openhands.sdk.extensions.config import ExtensionConfig, ResolvedExtensions
+from openhands.sdk.hooks import HookConfig
+from openhands.sdk.hooks.config import HookDefinition, HookMatcher
+from openhands.sdk.plugin import PluginSource
+from openhands.sdk.skills.skill import Skill
+
+
+def _make_hook_config() -> HookConfig:
+    """Create a minimal HookConfig for testing."""
+    return HookConfig(
+        session_start=[
+            HookMatcher(
+                matcher="*",
+                hooks=[HookDefinition(command="echo hello")],
+            )
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_skill(name: str, description: str = "") -> Skill:
+    """Create a minimal Skill for testing."""
+    return Skill(
+        name=name,
+        content=description or f"Skill {name}",
+        description=description or f"Skill {name}",
+    )
+
+
+def _create_plugin_dir(
+    base: Path,
+    name: str,
+    *,
+    skills: list[dict[str, str]] | None = None,
+    mcp_config: dict | None = None,
+    hooks: dict | None = None,
+    agents: list[dict] | None = None,
+) -> Path:
+    """Create a real plugin directory on disk for testing."""
+    plugin_dir = base / name
+    manifest_dir = plugin_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = {
+        "name": name,
+        "version": "1.0.0",
+        "description": f"Test plugin {name}",
+    }
+    (manifest_dir / "plugin.json").write_text(json.dumps(manifest))
+
+    if skills:
+        skills_dir = plugin_dir / "skills"
+        skills_dir.mkdir(exist_ok=True)
+        for s in skills:
+            skill_file = skills_dir / f"{s['name']}.md"
+            skill_file.write_text(
+                f"---\nname: {s['name']}\n---\n{s.get('content', '')}"
+            )
+
+    if mcp_config:
+        (plugin_dir / ".mcp.json").write_text(json.dumps(mcp_config))
+
+    if hooks:
+        hooks_dir = plugin_dir / "hooks"
+        hooks_dir.mkdir(exist_ok=True)
+        # HookConfig expects event-type keys (session_start, pre_tool_use, etc.)
+        # with lists of HookMatcher objects
+        (hooks_dir / "hooks.json").write_text(json.dumps(hooks))
+
+    if agents:
+        agents_dir = plugin_dir / "agents"
+        agents_dir.mkdir(exist_ok=True)
+        for agent_def in agents:
+            agent_name = agent_def["name"]
+            agent_file = agents_dir / f"{agent_name}.md"
+            agent_file.write_text(
+                f"---\nname: {agent_name}\n"
+                f"model: test/model\n"
+                f"---\n{agent_def.get('content', '')}"
+            )
+
+    return plugin_dir
+
+
+# ---------------------------------------------------------------------------
+# Model construction
+# ---------------------------------------------------------------------------
+
+
+def test_default_config():
+    """Empty config has sensible defaults."""
+    cfg = ExtensionConfig()
+    assert cfg.skills == []
+    assert cfg.plugins == []
+    assert cfg.hook_config is None
+    assert cfg.load_user_extensions is False
+    assert cfg.load_public_extensions is False
+
+
+def test_config_with_renamed_flags():
+    """The renamed flags are accepted and stored."""
+    cfg = ExtensionConfig(
+        load_user_extensions=True,
+        load_public_extensions=True,
+    )
+    assert cfg.load_user_extensions is True
+    assert cfg.load_public_extensions is True
+
+
+def test_config_with_explicit_skills():
+    """Explicit skills are stored on the config."""
+    s = _make_skill("my-skill")
+    cfg = ExtensionConfig(skills=[s])
+    assert len(cfg.skills) == 1
+    assert cfg.skills[0].name == "my-skill"
+
+
+def test_config_with_plugins():
+    """PluginSource specs are stored on the config."""
+    cfg = ExtensionConfig(plugins=[PluginSource(source="/tmp/fake-plugin")])
+    assert len(cfg.plugins) == 1
+
+
+def test_config_with_hook_config():
+    """Explicit hook config is stored."""
+    cfg = ExtensionConfig(hook_config=_make_hook_config())
+    assert cfg.hook_config is not None
+
+
+# ---------------------------------------------------------------------------
+# ResolvedExtensions model
+# ---------------------------------------------------------------------------
+
+
+def test_resolved_extensions_defaults():
+    """ResolvedExtensions has empty defaults."""
+    r = ResolvedExtensions()
+    assert r.skills == []
+    assert r.mcp_config == {}
+    assert r.hooks is None
+    assert r.agents == []
+    assert r.resolved_plugins == []
+
+
+# ---------------------------------------------------------------------------
+# resolve() — no I/O paths (no plugins, no auto-loading)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_empty_config():
+    """Empty config resolves to empty extensions."""
+    resolved = ExtensionConfig().resolve()
+    assert resolved.skills == []
+    assert resolved.mcp_config == {}
+    assert resolved.hooks is None
+    assert resolved.agents == []
+    assert resolved.resolved_plugins == []
+
+
+def test_resolve_explicit_skills_only():
+    """Explicit skills pass through to resolved output."""
+    s1 = _make_skill("alpha")
+    s2 = _make_skill("beta")
+    resolved = ExtensionConfig(skills=[s1, s2]).resolve()
+
+    names = {s.name for s in resolved.skills}
+    assert names == {"alpha", "beta"}
+
+
+def test_resolve_existing_skills_as_lowest_precedence():
+    """existing_skills are overridden by explicit config skills."""
+    existing = _make_skill("shared", description="old")
+    explicit = _make_skill("shared", description="new")
+
+    resolved = ExtensionConfig(skills=[explicit]).resolve(existing_skills=[existing])
+    matched = [s for s in resolved.skills if s.name == "shared"]
+    assert len(matched) == 1
+    assert matched[0].description == "new"
+
+
+def test_resolve_existing_skills_preserved_when_no_override():
+    """existing_skills that aren't overridden appear in the output."""
+    existing = _make_skill("only-existing")
+    resolved = ExtensionConfig().resolve(existing_skills=[existing])
+    assert any(s.name == "only-existing" for s in resolved.skills)
+
+
+def test_resolve_explicit_hook_config():
+    """Explicit hook_config passes through when no plugins."""
+    resolved = ExtensionConfig(hook_config=_make_hook_config()).resolve()
+    assert resolved.hooks is not None
+
+
+def test_resolve_existing_mcp_config_passthrough():
+    """existing_mcp_config is the base when no plugins add MCP."""
+    base_mcp = {"mcpServers": {"base-server": {"command": "test"}}}
+    resolved = ExtensionConfig().resolve(existing_mcp_config=base_mcp)
+    assert "base-server" in resolved.mcp_config.get("mcpServers", {})
+
+
+# ---------------------------------------------------------------------------
+# resolve() — with local plugins (real dirs, no git)
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_plugin_skills_override_explicit(tmp_path):
+    """Plugin skills override explicit skills with the same name (last-wins)."""
+    plugin_dir = _create_plugin_dir(
+        tmp_path,
+        "overrider",
+        skills=[{"name": "shared", "content": "from plugin"}],
+    )
+    explicit = _make_skill("shared", description="from config")
+
+    resolved = ExtensionConfig(
+        skills=[explicit],
+        plugins=[PluginSource(source=str(plugin_dir))],
+    ).resolve()
+
+    matched = [s for s in resolved.skills if s.name == "shared"]
+    assert len(matched) == 1
+    # Plugin skill wins over explicit (plugins are highest precedence)
+    assert "from plugin" in (matched[0].description or matched[0].content or "")
+
+
+def test_resolve_plugin_mcp_merges(tmp_path):
+    """Plugin MCP config merges with existing, last-wins by server name."""
+    plugin_dir = _create_plugin_dir(
+        tmp_path,
+        "mcp-plugin",
+        mcp_config={
+            "mcpServers": {
+                "new-server": {"command": "new-cmd"},
+                "shared": {"command": "plugin-cmd"},
+            }
+        },
+    )
+    existing_mcp = {"mcpServers": {"shared": {"command": "old-cmd"}}}
+
+    resolved = ExtensionConfig(
+        plugins=[PluginSource(source=str(plugin_dir))],
+    ).resolve(existing_mcp_config=existing_mcp)
+
+    servers = resolved.mcp_config.get("mcpServers", {})
+    assert "new-server" in servers
+    assert servers["shared"]["command"] == "plugin-cmd"
+
+
+def test_resolve_plugin_hooks_concatenate(tmp_path):
+    """Plugin hooks concatenate with explicit hooks (explicit first)."""
+    plugin_dir = _create_plugin_dir(
+        tmp_path,
+        "hook-plugin",
+        hooks={
+            "session_start": [
+                {
+                    "matcher": "*",
+                    "hooks": [{"command": "echo from-plugin"}],
+                }
+            ]
+        },
+    )
+    explicit_hooks = HookConfig(
+        session_start=[
+            HookMatcher(
+                matcher="*",
+                hooks=[HookDefinition(command="echo from-config")],
+            )
+        ]
+    )
+
+    resolved = ExtensionConfig(
+        hook_config=explicit_hooks,
+        plugins=[PluginSource(source=str(plugin_dir))],
+    ).resolve()
+
+    assert resolved.hooks is not None
+    # Both session_start matchers should be present (concatenation)
+    assert len(resolved.hooks.session_start) >= 2
+
+
+def test_resolve_plugin_agents_collected(tmp_path):
+    """Agent definitions from plugins are collected."""
+    plugin_dir = _create_plugin_dir(
+        tmp_path,
+        "agent-plugin",
+        agents=[{"name": "helper-agent", "content": "A helper agent."}],
+    )
+
+    resolved = ExtensionConfig(
+        plugins=[PluginSource(source=str(plugin_dir))],
+    ).resolve()
+
+    assert len(resolved.agents) >= 1
+    assert any(a.name == "helper-agent" for a in resolved.agents)
+
+
+def test_resolve_multiple_plugins_merge_order(tmp_path):
+    """Multiple plugins merge in list order (later overrides earlier)."""
+    p1 = _create_plugin_dir(
+        tmp_path,
+        "first-plugin",
+        skills=[{"name": "shared-skill", "content": "from first"}],
+        mcp_config={"mcpServers": {"srv": {"command": "first"}}},
+    )
+    p2 = _create_plugin_dir(
+        tmp_path,
+        "second-plugin",
+        skills=[{"name": "shared-skill", "content": "from second"}],
+        mcp_config={"mcpServers": {"srv": {"command": "second"}}},
+    )
+
+    resolved = ExtensionConfig(
+        plugins=[
+            PluginSource(source=str(p1)),
+            PluginSource(source=str(p2)),
+        ],
+    ).resolve()
+
+    # Second plugin wins for same-named skill
+    matched = [s for s in resolved.skills if s.name == "shared-skill"]
+    assert len(matched) == 1
+    assert "from second" in (matched[0].description or matched[0].content or "")
+
+    # Second plugin wins for same-named MCP server
+    assert resolved.mcp_config["mcpServers"]["srv"]["command"] == "second"
+
+
+def test_resolve_resolved_plugins_populated(tmp_path):
+    """resolved_plugins list is populated for each plugin spec."""
+    p1 = _create_plugin_dir(tmp_path, "plugin-a")
+    p2 = _create_plugin_dir(tmp_path, "plugin-b")
+
+    resolved = ExtensionConfig(
+        plugins=[
+            PluginSource(source=str(p1)),
+            PluginSource(source=str(p2)),
+        ],
+    ).resolve()
+
+    assert len(resolved.resolved_plugins) == 2
+
+
+# ---------------------------------------------------------------------------
+# Full merge precedence
+# ---------------------------------------------------------------------------
+
+
+def test_full_merge_precedence(tmp_path):
+    """Verify: existing < explicit < plugin for skills."""
+    existing = _make_skill("s1", description="existing")
+    explicit = _make_skill("s1", description="explicit")
+    plugin_dir = _create_plugin_dir(
+        tmp_path,
+        "precedence-plugin",
+        skills=[{"name": "s1", "content": "plugin wins"}],
+    )
+
+    resolved = ExtensionConfig(
+        skills=[explicit],
+        plugins=[PluginSource(source=str(plugin_dir))],
+    ).resolve(existing_skills=[existing])
+
+    matched = [s for s in resolved.skills if s.name == "s1"]
+    assert len(matched) == 1
+    # Plugin (highest) should win
+    assert "plugin wins" in (matched[0].description or matched[0].content or "")

--- a/tests/tools/delegate/test_delegation.py
+++ b/tests/tools/delegate/test_delegation.py
@@ -485,9 +485,9 @@ def test_spawn_passes_hook_config_to_sub_conversation():
     assert "Successfully spawned" in observation.text
     sub_conv = executor._sub_agents["h1"]
     # The sub-conversation should have the hook_config set
-    assert sub_conv._pending_hook_config is not None
-    assert len(sub_conv._pending_hook_config.pre_tool_use) == 1
-    assert sub_conv._pending_hook_config.pre_tool_use[0].matcher == "terminal"
+    assert sub_conv._extension_config.hook_config is not None
+    assert len(sub_conv._extension_config.hook_config.pre_tool_use) == 1
+    assert sub_conv._extension_config.hook_config.pre_tool_use[0].matcher == "terminal"
 
     _reset_registry_for_tests()
 

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -743,9 +743,11 @@ class TestTaskManagerHooks:
 
         sub_conv = task.conversation
         assert sub_conv is not None
-        assert sub_conv._pending_hook_config is not None
-        assert len(sub_conv._pending_hook_config.pre_tool_use) == 1
-        assert sub_conv._pending_hook_config.pre_tool_use[0].matcher == "terminal"
+        assert sub_conv._extension_config.hook_config is not None
+        assert len(sub_conv._extension_config.hook_config.pre_tool_use) == 1
+        assert (
+            sub_conv._extension_config.hook_config.pre_tool_use[0].matcher == "terminal"
+        )
 
     def test_create_task_no_hooks_passes_none(self, tmp_path):
         """When the agent definition has no hooks, hook_config should be None."""
@@ -759,7 +761,7 @@ class TestTaskManagerHooks:
 
         sub_conv = task.conversation
         assert sub_conv is not None
-        assert sub_conv._pending_hook_config is None
+        assert sub_conv._extension_config.hook_config is None
 
     def test_resume_task_passes_hook_config(self, tmp_path):
         """_resume_task should pass hooks from the agent definition."""
@@ -789,9 +791,9 @@ class TestTaskManagerHooks:
         )
         sub_conv = resumed.conversation
         assert sub_conv is not None
-        assert sub_conv._pending_hook_config is not None
-        assert len(sub_conv._pending_hook_config.post_tool_use) == 1
-        assert sub_conv._pending_hook_config.post_tool_use[0].matcher == "*"
+        assert sub_conv._extension_config.hook_config is not None
+        assert len(sub_conv._extension_config.hook_config.post_tool_use) == 1
+        assert sub_conv._extension_config.hook_config.post_tool_use[0].matcher == "*"
 
     def test_get_conversation_passes_hook_config(self, tmp_path):
         """_get_conversation should forward hook_config to LocalConversation."""
@@ -819,9 +821,11 @@ class TestTaskManagerHooks:
             hook_config=hook_config,
         )
 
-        assert conv._pending_hook_config is not None
-        assert len(conv._pending_hook_config.pre_tool_use) == 1
-        assert conv._pending_hook_config.pre_tool_use[0].matcher == "file_editor"
+        assert conv._extension_config.hook_config is not None
+        assert len(conv._extension_config.hook_config.pre_tool_use) == 1
+        assert (
+            conv._extension_config.hook_config.pre_tool_use[0].matcher == "file_editor"
+        )
 
     def test_get_conversation_without_hook_config(self, tmp_path):
         """_get_conversation without hook_config should leave it as None."""
@@ -839,7 +843,7 @@ class TestTaskManagerHooks:
             worker_agent=agent,
         )
 
-        assert conv._pending_hook_config is None
+        assert conv._extension_config.hook_config is None
 
 
 class TestTaskManagerPersistence:


### PR DESCRIPTION
## Summary

Consolidated PR (previously #2858, #2859, #2860) introducing `ExtensionConfig` for centralized extension loading across the SDK and server.

### 1. ExtensionConfig and ResolvedExtensions models
`ExtensionConfig` holds the specification (skills, plugins, hooks, auto-loading flags); `resolve()` loads, merges, and returns a `ResolvedExtensions` with the materialized result.

### 2. Wire ExtensionConfig into Conversation

**LocalConversation:**
- New `_extension_config` field replaces `_plugin_specs`/`_pending_hook_config`
- `_ensure_plugins_loaded()` renamed to `_ensure_extensions_loaded()`
- Delegates to `ExtensionConfig.resolve(work_dir)` then merges skills/mcp/hooks
- Backward-compatible: builds `ExtensionConfig` from legacy params when not provided

**Conversation factory & RemoteConversation:**
- All overloads accept `extension_config` kwarg
- `ExtensionConfig` exported from `openhands.sdk`

### 3. Server-side integration and deprecations

**Server request model:**
- Add `extension_config` field to `_StartConversationRequestBase`
- Flows through `StoredConversation` automatically via inheritance

**Event service:**
- Forward `extension_config` from `StoredConversation` to `LocalConversation`

**AgentContext deprecation:**
- `load_user_skills`, `load_public_skills`, `marketplace_path` deprecated (1.18.0 → 1.23.0)

**Examples:**
- `03_activate_skill`: move `load_public_skills` to `ExtensionConfig`
- `01_loading_agentskills`: remove redundant `load_public_skills=False`

### Changes
- `extensions/config.py`: `ExtensionConfig` model with `resolve(work_dir)` method and `ResolvedExtensions` dataclass
- Comprehensive tests in `tests/sdk/extensions/test_config.py`
- Conversation wiring (local, remote, factory)
- Server request model and event service integration
- AgentContext field deprecations
- Example updates

### Stack
Part of a `gh stack` — review bottom-up:
1. ⬇️ #2811 `feat/installed-extensions` → `main`
2. ⬇️ #2848 `refactor/mcp-merge-to-mcp-module` → `feat/installed-extensions`
3. **→ This PR** (#2858) — consolidated from #2858, #2859, #2860

---
_This PR was updated by an AI assistant (OpenHands) on behalf of the user._