### PR TITLE
feat: wire ExtensionConfig into Conversation for centralized extension loading

### DIFF
--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -20,6 +20,7 @@ from openhands.sdk.conversation import (
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.event import Event, HookExecutionEvent, LLMConvertibleEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.io import FileStore, LocalFileStore
 from openhands.sdk.llm import (
     LLM,
@@ -134,6 +135,7 @@ __all__ = [
     "ConversationExecutionStatus",
     "ConversationCallbackType",
     "Event",
+    "ExtensionConfig",
     "LLMConvertibleEvent",
     "AgentContext",
     "LLMSummarizingCondenser",

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -14,6 +14,7 @@ from openhands.sdk.conversation.visualizer import (
     ConversationVisualizerBase,
     DefaultConversationVisualizer,
 )
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.logger import get_logger
 from openhands.sdk.plugin import PluginSource
@@ -63,6 +64,7 @@ class Conversation:
         agent: AgentBase,
         *,
         workspace: str | Path | LocalWorkspace = "workspace/project",
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         persistence_dir: str | Path | None = None,
         conversation_id: ConversationID | None = None,
@@ -88,6 +90,7 @@ class Conversation:
         agent: AgentBase,
         *,
         workspace: RemoteWorkspace,
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
@@ -111,6 +114,7 @@ class Conversation:
         agent: AgentBase,
         *,
         workspace: str | Path | LocalWorkspace | RemoteWorkspace = "workspace/project",
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         persistence_dir: str | Path | None = None,
         conversation_id: ConversationID | None = None,
@@ -168,6 +172,7 @@ class Conversation:
 
             return RemoteConversation(
                 agent=agent,
+                extension_config=extension_config,
                 plugins=plugins,
                 conversation_id=conversation_id,
                 callbacks=callbacks,
@@ -185,6 +190,7 @@ class Conversation:
 
         return LocalConversation(
             agent=agent,
+            extension_config=extension_config,
             plugins=plugins,
             conversation_id=conversation_id,
             callbacks=callbacks,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
+from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.event_store import EventLog
@@ -35,26 +36,23 @@ from openhands.sdk.event import (
     UserRejectObservation,
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
+from openhands.sdk.extensions.config import ExtensionConfig
 from openhands.sdk.hooks import HookConfig, HookEventProcessor, create_hook_callback
 from openhands.sdk.io import LocalFileStore
 from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
-from openhands.sdk.mcp.utils import merge_mcp_configs
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.plugin import (
-    Plugin,
     PluginSource,
     ResolvedPluginSource,
-    fetch_plugin_with_resolution,
 )
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
 from openhands.sdk.subagent import (
-    AgentDefinition,
     register_file_agents,
     register_plugin_agents,
 )
@@ -79,16 +77,16 @@ class LocalConversation(BaseConversation):
     _cleanup_initiated: bool
     _hook_processor: HookEventProcessor | None
     delete_on_close: bool = True
-    # Plugin lazy loading state
-    _plugin_specs: list[PluginSource] | None
+    # Extension config (replaces per-field plugin/hook tracking)
+    _extension_config: ExtensionConfig
     _resolved_plugins: list[ResolvedPluginSource] | None
-    _plugins_loaded: bool
-    _pending_hook_config: HookConfig | None  # Hook config to combine with plugin hooks
+    _extensions_loaded: bool
 
     def __init__(
         self,
         agent: AgentBase,
         workspace: str | Path | LocalWorkspace,
+        extension_config: ExtensionConfig | None = None,
         plugins: list[PluginSource] | None = None,
         persistence_dir: str | Path | None = None,
         conversation_id: ConversationID | None = None,
@@ -115,12 +113,14 @@ class LocalConversation(BaseConversation):
             agent: The agent to use for the conversation.
             workspace: Working directory for agent operations and tool execution.
                 Can be a string path, Path object, or LocalWorkspace instance.
-            plugins: Optional list of plugins to load. Each plugin is specified
-                with a source (github:owner/repo, git URL, or local path),
-                optional ref (branch/tag/commit), and optional repo_path for
-                monorepos. Plugins are loaded in order with these merge
-                semantics: skills override by name (last wins), MCP config
-                override by key (last wins), hooks concatenate (all run).
+            extension_config: Declarative specification of all extensions to
+                load (skills, plugins, hooks). When provided, ``plugins`` and
+                ``hook_config`` are ignored — use the config object instead.
+                When ``None`` (the default), an ``ExtensionConfig`` is built
+                from the ``plugins`` and ``hook_config`` parameters for
+                backward compatibility.
+            plugins: Optional list of plugins to load. Ignored when
+                ``extension_config`` is provided.
             persistence_dir: Directory for persisting conversation state and events.
                 Can be a string path or Path object.
             conversation_id: Optional ID for the conversation. If provided, will
@@ -129,7 +129,7 @@ class LocalConversation(BaseConversation):
             callbacks: Optional list of callback functions to handle events
             token_callbacks: Optional list of callbacks invoked for streaming deltas
             hook_config: Optional hook configuration to auto-wire session hooks.
-                If plugins are loaded, their hooks are combined with this config.
+                Ignored when ``extension_config`` is provided.
             max_iteration_per_run: Maximum number of iterations per run
             visualizer: Visualization configuration. Can be:
                        - ConversationVisualizerBase subclass: Class to instantiate
@@ -154,13 +154,17 @@ class LocalConversation(BaseConversation):
         # initialized instances during interpreter shutdown.
         self._cleanup_initiated = False
 
-        # Store plugin specs for lazy loading (no IO in constructor)
-        # Plugins will be loaded on first run() or send_message() call
-        self._plugin_specs = plugins
+        # Build ExtensionConfig: prefer explicit config, fall back to legacy params
+        if extension_config is not None:
+            self._extension_config = extension_config
+        else:
+            self._extension_config = ExtensionConfig(
+                plugins=plugins or [],
+                hook_config=hook_config,
+            )
         self._resolved_plugins = None
-        self._plugins_loaded = False
-        self._pending_hook_config = hook_config  # Will be combined with plugin hooks
-        self._agent_ready = False  # Agent initialized lazily after plugins loaded
+        self._extensions_loaded = False
+        self._agent_ready = False  # Agent initialized lazily after extensions
 
         self.agent = agent
         if isinstance(workspace, (str, Path)):
@@ -227,9 +231,9 @@ class LocalConversation(BaseConversation):
 
         # Compose the base callback chain (visualizer -> user callbacks -> default)
         base_callback = BaseConversation.compose_callbacks(composed_list)
-        self._base_callback = base_callback  # Store for _ensure_plugins_loaded
+        self._base_callback = base_callback  # Store for _ensure_extensions_loaded
 
-        # Defer all hook setup to _ensure_plugins_loaded() for consistency
+        # Defer all hook setup to _ensure_extensions_loaded() for consistency
         # This runs on first run()/send_message() call and handles both
         # explicit hooks and plugin hooks in one place
         self._hook_processor = None
@@ -308,108 +312,78 @@ class LocalConversation(BaseConversation):
         """
         return self._resolved_plugins
 
-    def _ensure_plugins_loaded(self) -> None:
-        """Lazy load plugins and set up hooks on first use.
+    def _ensure_extensions_loaded(self) -> None:
+        """Lazy-load all extensions and set up hooks on first use.
 
-        This method is called automatically before run() and send_message().
-        It handles both plugin loading and hook initialization in one place
-        for consistency.
+        This method is called automatically before ``run()`` and
+        ``send_message()``.  It delegates to ``ExtensionConfig.resolve()``
+        for the actual I/O (plugin fetching, skill loading, MCP merging)
+        and then applies the ``ResolvedExtensions`` to the agent and
+        conversation state.
 
         The method:
-        1. Fetches plugins from their sources (network IO for remote sources)
-        2. Resolves refs to commit SHAs for deterministic resume
-        3. Loads plugin contents (skills, MCP config, hooks)
-        4. Merges plugin contents into the agent
-        5. Sets up hook processor with combined hooks (explicit + plugin)
-        6. Runs session_start hooks
+        1. Calls ``ExtensionConfig.resolve()`` with the workspace and
+           agent's existing skills/MCP config.
+        2. Updates the agent with merged skills and MCP config.
+        3. Registers plugin-provided agent definitions.
+        4. Sets up hook processor with combined hooks (explicit + plugin).
+        5. Runs ``session_start`` hooks.
         """
-        if self._plugins_loaded:
+        if self._extensions_loaded:
             return
 
-        all_plugin_hooks: list[HookConfig] = []
-        all_plugin_agents: list[AgentDefinition] = []
+        # Only pass work_dir when the config requests extension loading;
+        # otherwise project skills are loaded by AgentContext during the
+        # deprecation period and we avoid unintentional side effects.
+        wants_loading = (
+            self._extension_config.plugins
+            or self._extension_config.load_user_extensions
+            or self._extension_config.load_public_extensions
+        )
+        resolved = self._extension_config.resolve(
+            work_dir=self.workspace.working_dir if wants_loading else None,
+            existing_skills=(
+                list(self.agent.agent_context.skills)
+                if self.agent.agent_context
+                else None
+            ),
+            existing_mcp_config=(
+                dict(self.agent.mcp_config) if self.agent.mcp_config else None
+            ),
+        )
 
-        # Load plugins if specified
-        if self._plugin_specs:
-            logger.info(f"Loading {len(self._plugin_specs)} plugin(s)...")
-            self._resolved_plugins = []
+        # Store resolved plugins for persistence / deterministic resume
+        self._resolved_plugins = resolved.resolved_plugins or None
 
-            # Start with agent's existing context and MCP config
-            merged_context = self.agent.agent_context
-            merged_mcp = dict(self.agent.mcp_config) if self.agent.mcp_config else {}
-
-            for spec in self._plugin_specs:
-                # Fetch plugin and get resolved commit SHA
-                path, resolved_ref = fetch_plugin_with_resolution(
-                    source=spec.source,
-                    ref=spec.ref,
-                    repo_path=spec.repo_path,
+        # Update agent with merged skills and MCP config
+        has_new_skills = bool(resolved.skills)
+        has_new_mcp = bool(resolved.mcp_config)
+        if has_new_skills or has_new_mcp:
+            update: dict = {}
+            if has_new_skills:
+                ctx = self.agent.agent_context or AgentContext()
+                update["agent_context"] = ctx.model_copy(
+                    update={"skills": resolved.skills}
                 )
+            if has_new_mcp:
+                update["mcp_config"] = resolved.mcp_config
+            self.agent = self.agent.model_copy(update=update)
 
-                # Store resolved ref for persistence
-                resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
-                self._resolved_plugins.append(resolved)
-
-                # Load the plugin
-                plugin = Plugin.load(path)
-                logger.debug(
-                    f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
-                    + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
-                )
-
-                # Merge plugin contents
-                merged_context = plugin.add_skills_to(merged_context)
-                merged_mcp = merge_mcp_configs(merged_mcp, plugin.mcp_config)
-
-                # Collect hooks
-                if plugin.hooks and not plugin.hooks.is_empty():
-                    all_plugin_hooks.append(plugin.hooks)
-
-                # Collect agent definitions
-                if plugin.agents:
-                    all_plugin_agents.extend(plugin.agents)
-
-            # Update agent with merged content
-            self.agent = self.agent.model_copy(
-                update={
-                    "agent_context": merged_context,
-                    "mcp_config": merged_mcp,
-                }
-            )
-
-            # Also update the agent in _state so API responses reflect loaded plugins
             with self._state:
                 self._state.agent = self.agent
 
-            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
-
-        # Register file-based agents defined in plugins
-        if all_plugin_agents:
+        # Register plugin-provided agent definitions
+        if resolved.agents:
             register_plugin_agents(
-                agents=all_plugin_agents,
+                agents=resolved.agents,
                 work_dir=self.workspace.working_dir,
             )
 
-        # Combine explicit hook_config with plugin hooks
-        # Explicit hooks run first (before plugin hooks)
-        final_hook_config = self._pending_hook_config
-        if all_plugin_hooks:
-            plugin_hooks = HookConfig.merge(all_plugin_hooks)
-            if plugin_hooks is not None:
-                if final_hook_config is not None:
-                    final_hook_config = HookConfig.merge(
-                        [final_hook_config, plugin_hooks]
-                    )
-                else:
-                    final_hook_config = plugin_hooks
-
-        # Set up hook processor with the combined config
-        if final_hook_config is not None:
-            # Store final hook_config in state for observability
-            self._state.hook_config = final_hook_config
-
+        # Set up hook processor
+        if resolved.hooks is not None:
+            self._state.hook_config = resolved.hooks
             self._hook_processor, self._on_event = create_hook_callback(
-                hook_config=final_hook_config,
+                hook_config=resolved.hooks,
                 working_dir=str(self.workspace.working_dir),
                 session_id=str(self._state.id),
                 original_callback=self._base_callback,
@@ -417,7 +391,7 @@ class LocalConversation(BaseConversation):
             self._hook_processor.set_conversation_state(self._state)
             self._hook_processor.run_session_start()
 
-        self._plugins_loaded = True
+        self._extensions_loaded = True
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.
@@ -428,8 +402,8 @@ class LocalConversation(BaseConversation):
 
         Registration order (highest to lowest priority):
           1. Programmatic `register_agent()` calls (already in the registry)
-          2. Plugin agents (registered during plugin loading, i.e.,
-                in _ensure_plugins_loaded())
+          2. Plugin agents (registered during extension loading, i.e.,
+                in _ensure_extensions_loaded())
           3. Project-level file agents (`{project}/.agents/agents/*.md`,
                 then `{project}/.openhands/agents/*.md`)
           4. User-level file agents (`~/.agents/agents/*.md`,
@@ -439,14 +413,14 @@ class LocalConversation(BaseConversation):
         register_file_agents(self.workspace.working_dir)
 
     def _ensure_agent_ready(self) -> None:
-        """Ensure the agent is fully initialized with plugins and agents loaded.
+        """Ensure the agent is fully initialized with extensions and agents loaded.
 
         Performs one-time lazy initialization on the first `send_message()`
         or `run()` call.  The steps executed (in order) are:
 
-        1. Load plugins (merges skills, MCP config, and hooks).
+        1. Load extensions (merges skills, MCP config, and hooks).
         2. Register file-based agents into the agent registry.
-        3. Initialize the agent with complete plugin config and hooks.
+        3. Initialize the agent with complete extension config and hooks.
         4. Register LLMs in the LLM registry.
 
         This preserves the design principle that constructors should not perform
@@ -468,8 +442,8 @@ class LocalConversation(BaseConversation):
             if self._agent_ready:
                 return
 
-            # Load plugins first (merges skills, MCP config, hooks)
-            self._ensure_plugins_loaded()
+            # Load extensions first (merges skills, MCP config, hooks)
+            self._ensure_extensions_loaded()
 
             # register file-based agents
             self._register_file_based_agents()

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -18,6 +18,7 @@ from openhands.sdk.conversation.base import BaseConversation, ConversationStateP
 
 
 if TYPE_CHECKING:
+    from openhands.sdk.extensions.config import ExtensionConfig
     from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.conversation.events_list_base import EventsListBase
@@ -614,6 +615,7 @@ class RemoteConversation(BaseConversation):
         self,
         agent: AgentBase,
         workspace: RemoteWorkspace,
+        extension_config: "ExtensionConfig | None" = None,
         plugins: list | None = None,
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
@@ -636,8 +638,12 @@ class RemoteConversation(BaseConversation):
         Args:
             agent: Agent configuration (will be sent to the server)
             workspace: The working directory for agent operations and tool execution.
-            plugins: Optional list of plugins to load on the server. Each plugin
-                    is a PluginSource specifying source, ref, and repo_path.
+            extension_config: Declarative specification of all extensions to
+                load (skills, plugins, hooks). When provided, ``plugins`` and
+                ``hook_config`` are ignored — use the config object instead.
+                Serialized and sent to the server in the creation payload.
+            plugins: Optional list of plugins to load on the server. Ignored
+                when ``extension_config`` is provided.
             conversation_id: Optional existing conversation id to attach to
             callbacks: Optional callbacks to receive events (not yet streamed)
             max_iteration_per_run: Max iterations configured on server
@@ -648,7 +654,7 @@ class RemoteConversation(BaseConversation):
                       'monologue', 'alternating_pattern'. Values are integers
                       representing the number of repetitions before triggering.
             hook_config: Optional hook configuration sent to the server.
-                      All hooks are executed server-side.
+                Ignored when ``extension_config`` is provided.
             visualizer: Visualization configuration. Can be:
                        - ConversationVisualizerBase subclass: Class to instantiate
                          (default: ConversationVisualizer)
@@ -712,6 +718,16 @@ class RemoteConversation(BaseConversation):
             serialized_defs = [d.model_dump(mode="json") for d in agent_defs]
             logger.debug(f"Sending {len(serialized_defs)} agent_definitions to server")
 
+            # Derive effective plugins/hook_config from extension_config
+            # when provided; otherwise use the legacy parameters directly.
+            effective_plugins = plugins
+            effective_hook_config = hook_config
+            serialized_ext_config = None
+            if extension_config is not None:
+                effective_plugins = extension_config.plugins or None
+                effective_hook_config = extension_config.hook_config
+                serialized_ext_config = extension_config.model_dump()
+
             payload = {
                 "agent": agent.model_dump(
                     mode="json", context={"expose_secrets": True}
@@ -727,10 +743,20 @@ class RemoteConversation(BaseConversation):
                 "tool_module_qualnames": tool_qualnames,
                 # Include agent definitions for subagent registration on server
                 "agent_definitions": serialized_defs,
-                # Include plugins to load on server
-                "plugins": [p.model_dump() for p in plugins] if plugins else None,
-                # Include hook_config for server-side hooks
-                "hook_config": hook_config.model_dump() if hook_config else None,
+                # Include extension_config for server-side resolution
+                "extension_config": serialized_ext_config,
+                # Include plugins to load on server (legacy)
+                "plugins": (
+                    [p.model_dump() for p in effective_plugins]
+                    if effective_plugins
+                    else None
+                ),
+                # Include hook_config for server-side hooks (legacy)
+                "hook_config": (
+                    effective_hook_config.model_dump()
+                    if effective_hook_config
+                    else None
+                ),
                 # Include tags if provided
                 "tags": tags or {},
             }

--- a/openhands-sdk/openhands/sdk/subagent/AGENTS.md
+++ b/openhands-sdk/openhands/sdk/subagent/AGENTS.md
@@ -81,7 +81,7 @@ When a `LocalConversation` becomes ready, it establishes the following priority:
 
 This is the order implemented by:
 
-- `LocalConversation._ensure_plugins_loaded()` → registers plugin agents
+- `LocalConversation._ensure_extensions_loaded()` → registers plugin agents
 - `LocalConversation._register_file_based_agents()` → registers project/user file agents, then built-ins
 
 ### Deduplication rules inside file-based loading

--- a/tests/agent_server/test_conversation_service_plugin.py
+++ b/tests/agent_server/test_conversation_service_plugin.py
@@ -455,7 +455,7 @@ async def test_start_conversation_stores_both_hooks_and_plugins_for_lazy_merge(
             await conversation_service.start_conversation(request)
 
             # Verify both explicit hooks AND plugins are stored
-            # (merging happens lazily in LocalConversation._ensure_plugins_loaded)
+            # (merging happens lazily in LocalConversation._ensure_extensions_loaded)
             stored = mock_event_service_class.call_args.kwargs["stored"]
 
             # Explicit hook_config is stored as-is (not merged yet)

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -71,7 +71,7 @@ class TestLocalConversationPlugins:
     """Tests for plugin loading in LocalConversation.
 
     Note: Plugins are lazy-loaded on first run()/send_message() call.
-    Tests trigger _ensure_plugins_loaded() to verify loading behavior.
+    Tests trigger _ensure_extensions_loaded() to verify loading behavior.
     """
 
     def test_create_conversation_with_plugins(self, tmp_path: Path, basic_agent):
@@ -92,7 +92,7 @@ class TestLocalConversationPlugins:
         )
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         # Agent should have been updated with plugin skills
         assert conversation.agent.agent_context is not None
@@ -132,7 +132,7 @@ class TestLocalConversationPlugins:
         )
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         assert conversation.agent.agent_context is not None
         skill_names = [s.name for s in conversation.agent.agent_context.skills]
@@ -180,7 +180,7 @@ class TestLocalConversationPlugins:
         )
 
         # Hooks are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         # Both hook sources should be combined
         assert conversation._hook_processor is not None
@@ -206,14 +206,14 @@ class TestLocalConversationPlugins:
         )
 
         # Before loading, plugins should not be applied
-        assert conversation._plugins_loaded is False
+        assert conversation._extensions_loaded is False
         assert conversation.resolved_plugins is None
         assert conversation.agent.agent_context is None
 
         # After triggering load
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
-        assert conversation._plugins_loaded is True
+        assert conversation._extensions_loaded is True
         assert conversation.resolved_plugins is not None
         assert conversation.agent.agent_context is not None
 
@@ -305,7 +305,7 @@ class TestConversationFactoryPlugins:
         assert isinstance(conversation, LocalConversation)
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         assert conversation.agent.agent_context is not None
         skill_names = [s.name for s in conversation.agent.agent_context.skills]
@@ -332,7 +332,7 @@ class TestConversationFactoryPlugins:
         )
 
         # Plugins are lazy loaded - trigger loading
-        conversation._ensure_plugins_loaded()
+        conversation._ensure_extensions_loaded()
 
         assert conversation.agent.agent_context is not None
         assert len(conversation.agent.agent_context.skills) == 1
@@ -351,4 +351,155 @@ class TestConversationFactoryPlugins:
 
         # Should work without errors
         assert conversation is not None
+        conversation.close()
+
+
+class TestExtensionConfigWiring:
+    """Tests for ExtensionConfig integration with LocalConversation."""
+
+    def test_extension_config_with_plugins(self, tmp_path: Path, basic_agent):
+        """ExtensionConfig with plugins loads them during resolution."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        plugin_dir = create_test_plugin(
+            tmp_path / "plugin",
+            name="ext-plugin",
+            skills=[{"name": "ext-skill", "content": "From extension config"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        ext_config = ExtensionConfig(
+            plugins=[PluginSource(source=str(plugin_dir))],
+        )
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "ext-skill" in skill_names
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+        conversation.close()
+
+    def test_extension_config_overrides_legacy_params(
+        self, tmp_path: Path, basic_agent
+    ):
+        """When extension_config is provided, legacy plugins/hook_config are ignored."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        plugin_dir = create_test_plugin(
+            tmp_path / "ext-plugin",
+            name="ext-plugin",
+            skills=[{"name": "ext-skill", "content": "From config"}],
+        )
+        legacy_dir = create_test_plugin(
+            tmp_path / "legacy-plugin",
+            name="legacy-plugin",
+            skills=[{"name": "legacy-skill", "content": "From legacy"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        ext_config = ExtensionConfig(
+            plugins=[PluginSource(source=str(plugin_dir))],
+        )
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            plugins=[PluginSource(source=str(legacy_dir))],  # should be ignored
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "ext-skill" in skill_names
+        assert "legacy-skill" not in skill_names
+        conversation.close()
+
+    def test_extension_config_with_hook_config(self, tmp_path: Path, basic_agent):
+        """ExtensionConfig hook_config is applied to conversation state."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        hook_config = HookConfig(
+            session_start=[
+                HookMatcher(
+                    matcher="*",
+                    hooks=[HookDefinition(command="echo hello")],
+                )
+            ]
+        )
+        ext_config = ExtensionConfig(hook_config=hook_config)
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.state.hook_config is not None
+        assert len(conversation.state.hook_config.session_start) == 1
+        conversation.close()
+
+    def test_factory_accepts_extension_config(self, tmp_path: Path, basic_agent):
+        """Conversation factory forwards extension_config to LocalConversation."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        plugin_dir = create_test_plugin(
+            tmp_path / "plugin",
+            name="factory-plugin",
+            skills=[{"name": "factory-skill", "content": "From factory"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        ext_config = ExtensionConfig(
+            plugins=[PluginSource(source=str(plugin_dir))],
+        )
+        conversation = Conversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ext_config,
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "factory-skill" in skill_names
+        conversation.close()
+
+    def test_empty_extension_config_no_side_effects(self, tmp_path: Path, basic_agent):
+        """Empty ExtensionConfig doesn't modify the agent."""
+        from openhands.sdk.extensions.config import ExtensionConfig
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+
+        original_agent = basic_agent
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            extension_config=ExtensionConfig(),
+            visualizer=None,
+        )
+
+        conversation._ensure_extensions_loaded()
+
+        # Agent should be the same object (no model_copy)
+        assert conversation.agent is original_agent
         conversation.close()

--- a/tests/tools/delegate/test_delegation.py
+++ b/tests/tools/delegate/test_delegation.py
@@ -485,9 +485,9 @@ def test_spawn_passes_hook_config_to_sub_conversation():
     assert "Successfully spawned" in observation.text
     sub_conv = executor._sub_agents["h1"]
     # The sub-conversation should have the hook_config set
-    assert sub_conv._pending_hook_config is not None
-    assert len(sub_conv._pending_hook_config.pre_tool_use) == 1
-    assert sub_conv._pending_hook_config.pre_tool_use[0].matcher == "terminal"
+    assert sub_conv._extension_config.hook_config is not None
+    assert len(sub_conv._extension_config.hook_config.pre_tool_use) == 1
+    assert sub_conv._extension_config.hook_config.pre_tool_use[0].matcher == "terminal"
 
     _reset_registry_for_tests()
 

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -743,9 +743,11 @@ class TestTaskManagerHooks:
 
         sub_conv = task.conversation
         assert sub_conv is not None
-        assert sub_conv._pending_hook_config is not None
-        assert len(sub_conv._pending_hook_config.pre_tool_use) == 1
-        assert sub_conv._pending_hook_config.pre_tool_use[0].matcher == "terminal"
+        assert sub_conv._extension_config.hook_config is not None
+        assert len(sub_conv._extension_config.hook_config.pre_tool_use) == 1
+        assert (
+            sub_conv._extension_config.hook_config.pre_tool_use[0].matcher == "terminal"
+        )
 
     def test_create_task_no_hooks_passes_none(self, tmp_path):
         """When the agent definition has no hooks, hook_config should be None."""
@@ -759,7 +761,7 @@ class TestTaskManagerHooks:
 
         sub_conv = task.conversation
         assert sub_conv is not None
-        assert sub_conv._pending_hook_config is None
+        assert sub_conv._extension_config.hook_config is None
 
     def test_resume_task_passes_hook_config(self, tmp_path):
         """_resume_task should pass hooks from the agent definition."""
@@ -789,9 +791,9 @@ class TestTaskManagerHooks:
         )
         sub_conv = resumed.conversation
         assert sub_conv is not None
-        assert sub_conv._pending_hook_config is not None
-        assert len(sub_conv._pending_hook_config.post_tool_use) == 1
-        assert sub_conv._pending_hook_config.post_tool_use[0].matcher == "*"
+        assert sub_conv._extension_config.hook_config is not None
+        assert len(sub_conv._extension_config.hook_config.post_tool_use) == 1
+        assert sub_conv._extension_config.hook_config.post_tool_use[0].matcher == "*"
 
     def test_get_conversation_passes_hook_config(self, tmp_path):
         """_get_conversation should forward hook_config to LocalConversation."""
@@ -819,9 +821,11 @@ class TestTaskManagerHooks:
             hook_config=hook_config,
         )
 
-        assert conv._pending_hook_config is not None
-        assert len(conv._pending_hook_config.pre_tool_use) == 1
-        assert conv._pending_hook_config.pre_tool_use[0].matcher == "file_editor"
+        assert conv._extension_config.hook_config is not None
+        assert len(conv._extension_config.hook_config.pre_tool_use) == 1
+        assert (
+            conv._extension_config.hook_config.pre_tool_use[0].matcher == "file_editor"
+        )
 
     def test_get_conversation_without_hook_config(self, tmp_path):
         """_get_conversation without hook_config should leave it as None."""
@@ -839,7 +843,7 @@ class TestTaskManagerHooks:
             worker_agent=agent,
         )
 
-        assert conv._pending_hook_config is None
+        assert conv._extension_config.hook_config is None
 
 
 class TestTaskManagerPersistence:


### PR DESCRIPTION
## Summary

Wire `ExtensionConfig` into `Conversation` (local and remote) for centralized extension loading.

### Changes

**LocalConversation:**
- New `_extension_config` field replaces `_plugin_specs`/`_pending_hook_config`
- `_ensure_plugins_loaded()` renamed to `_ensure_extensions_loaded()`
- Delegates to `ExtensionConfig.resolve(work_dir)` then merges skills/mcp/hooks
- Backward-compatible: builds `ExtensionConfig` from legacy params when not provided

**Conversation factory & RemoteConversation:**
- All overloads accept `extension_config` kwarg
- `ExtensionConfig` exported from `openhands.sdk`

### Stack
Part of a `gh stack` — review bottom-up:
1. ⬇️ #2811 `feat/installed-extensions` → `main`
2. ⬇️ #2848 `refactor/mcp-merge-to-mcp-module` → `feat/installed-extensions`
3. ⬇️ #2858 `feat/extension-config-model`
4. **→ This PR** (#2859)
5. #2860 `feat/server-extension-config`

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._