### PR TITLE
Set temperature to 0.0 for claude-opus-4-7

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -117,6 +117,7 @@ MODELS = {
         "display_name": "Claude Opus 4.7",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-opus-4-7",
+            "temperature": 0.0,
         },
     },
     "claude-sonnet-4-6": {


### PR DESCRIPTION
Set temperature to 0.0 for claude-opus-4-7 to match other Claude Opus models (claude-4.5-opus, claude-4.6-opus).

This PR was created by an AI assistant (OpenHands) on behalf of the user.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/0d4f60e7-38b2-483b-b3ca-84d60a90b555)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b6ae19d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b6ae19d-python \
  ghcr.io/openhands/agent-server:b6ae19d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b6ae19d-golang-amd64
ghcr.io/openhands/agent-server:b6ae19d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b6ae19d-golang-arm64
ghcr.io/openhands/agent-server:b6ae19d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b6ae19d-java-amd64
ghcr.io/openhands/agent-server:b6ae19d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b6ae19d-java-arm64
ghcr.io/openhands/agent-server:b6ae19d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b6ae19d-python-amd64
ghcr.io/openhands/agent-server:b6ae19d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b6ae19d-python-arm64
ghcr.io/openhands/agent-server:b6ae19d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b6ae19d-golang
ghcr.io/openhands/agent-server:b6ae19d-java
ghcr.io/openhands/agent-server:b6ae19d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b6ae19d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b6ae19d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->