### PR TITLE
Persist ACP session id across agent-server restarts

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -572,6 +572,20 @@ class ACPAgent(AgentBase):
             "If None, the server picks its default."
         ),
     )
+    acp_session_id: str | None = Field(
+        default=None,
+        description=(
+            "ACP server's session identifier.  Persisted so that restarting "
+            "the agent-server replays the ACP subprocess's prior context via "
+            "``load_session`` instead of starting from scratch.  When the ACP "
+            "server no longer recognises the id (e.g. on-disk state was wiped, "
+            "or the conversation resumed on a host that never saw it), the "
+            "load silently falls back to ``new_session`` and the field is "
+            "rewritten with the fresh id.  Note: ACP servers key their "
+            "persistence by ``cwd``, so resuming in a different working "
+            "directory may miss the prior session."
+        ),
+    )
 
     def model_post_init(self, __context: object) -> None:
         super().model_post_init(__context)
@@ -845,14 +859,37 @@ class ACPAgent(AgentBase):
                         [m.id for m in auth_methods],
                     )
 
-            # Build _meta content for session options (e.g. model selection).
-            # Extra kwargs to new_session() become the _meta dict in the
-            # JSON-RPC request — do NOT wrap in _meta= (that double-nests).
-            session_meta = _build_session_meta(agent_name, self.acp_model)
+            # Resume the prior ACP session if we have its id.  If the server
+            # has forgotten it (state wiped, new host, etc.) fall through to
+            # new_session so the conversation still starts cleanly.
+            session_id: str | None = None
+            if self.acp_session_id is not None:
+                try:
+                    await conn.load_session(
+                        cwd=working_dir,
+                        session_id=self.acp_session_id,
+                        mcp_servers=[],
+                    )
+                    session_id = self.acp_session_id
+                    logger.info(
+                        "Resumed ACP session: %s (cwd=%s)",
+                        session_id,
+                        working_dir,
+                    )
+                except ACPRequestError as e:
+                    logger.warning(
+                        "ACP load_session(%s) failed (%s); starting a fresh session",
+                        self.acp_session_id,
+                        e,
+                    )
 
-            # Create a new session
-            response = await conn.new_session(cwd=working_dir, **session_meta)
-            session_id = response.session_id
+            if session_id is None:
+                # Build _meta content for session options (e.g. model selection).
+                # Extra kwargs to new_session() become the _meta dict in the
+                # JSON-RPC request — do NOT wrap in _meta= (that double-nests).
+                session_meta = _build_session_meta(agent_name, self.acp_model)
+                response = await conn.new_session(cwd=working_dir, **session_meta)
+                session_id = response.session_id
             await _maybe_set_session_model(
                 conn,
                 agent_name,
@@ -882,6 +919,11 @@ class ACPAgent(AgentBase):
             self._agent_version,
         ) = result
         self._working_dir = working_dir
+        # Persist the ACP session id on the (frozen) model so a subsequent
+        # model_dump() → model_validate() round-trip can resume via
+        # load_session instead of starting from scratch.
+        if self.acp_session_id != self._session_id:
+            object.__setattr__(self, "acp_session_id", self._session_id)
 
     @observe(name="acp_agent.step", ignore_inputs=["conversation", "on_event"])
     def step(

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -752,18 +752,22 @@ class ACPAgent(AgentBase):
 
         self._initialized = True
 
-        # Persist agent info + the ACP session id in agent_state.  Keeping the
-        # session id here (rather than on the frozen ACPAgent model) means
-        # ConversationState's existing base_state.json persistence carries it
-        # across agent-server restarts, and ``_start_acp_server`` on the next
-        # launch reads it back to call ``load_session`` instead of starting
-        # from scratch.  ACP servers key their persistence by ``cwd``, so
-        # resuming in a different working directory may miss the prior session.
+        # Persist agent info + the ACP session id + its cwd in agent_state.
+        # Keeping these here (rather than on the frozen ACPAgent model) means
+        # ConversationState's existing base_state.json persistence carries
+        # them across agent-server restarts, and ``_start_acp_server`` on the
+        # next launch reads them back to call ``load_session`` instead of
+        # starting from scratch.  We record ``acp_session_cwd`` alongside the
+        # id because ACP servers key their persistence by ``cwd``: resuming
+        # in a different working directory would at best silently miss the
+        # prior session and at worst load a different session that happens to
+        # exist at the new cwd.
         state.agent_state = {
             **state.agent_state,
             "acp_agent_name": self._agent_name,
             "acp_agent_version": self._agent_version,
             "acp_session_id": self._session_id,
+            "acp_session_cwd": self._working_dir,
         }
 
     def _start_acp_server(self, state: ConversationState) -> None:
@@ -786,7 +790,23 @@ class ACPAgent(AgentBase):
         # Prior ACP session id — survives agent-server restarts via
         # ConversationState.agent_state (serialized into base_state.json).
         # Its presence is the signal to resume; its absence means fresh start.
+        # ACP servers key persistence by ``cwd``; if the workspace moved we
+        # drop the id so we don't accidentally resume (or silently load) a
+        # session the server associates with a different directory.
         prior_session_id: str | None = state.agent_state.get("acp_session_id")
+        prior_session_cwd: str | None = state.agent_state.get("acp_session_cwd")
+        if prior_session_id is not None and prior_session_cwd not in (
+            None,
+            working_dir,
+        ):
+            logger.warning(
+                "ACP session %s was created with cwd=%s; current cwd=%s differs, "
+                "starting a fresh session instead of resuming",
+                prior_session_id,
+                prior_session_cwd,
+                working_dir,
+            )
+            prior_session_id = None
 
         async def _init() -> tuple[Any, Any, Any, str, str, str]:
             # Spawn the subprocess directly so we can install a
@@ -859,6 +879,12 @@ class ACPAgent(AgentBase):
             # Resume the prior ACP session if we have its id.  If the server
             # has forgotten it (state wiped, new host, etc.) fall through to
             # new_session so the conversation still starts cleanly.
+            #
+            # We only swallow ACPRequestError here: that is the protocol-level
+            # "I don't know this session" signal and is recoverable by
+            # starting fresh.  Transport failures (broken pipe, EOF, timeout,
+            # subprocess crash) propagate — there is no working connection to
+            # fall back on, and the outer init_state handler cleans up.
             session_id: str | None = None
             if prior_session_id is not None:
                 try:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -572,20 +572,6 @@ class ACPAgent(AgentBase):
             "If None, the server picks its default."
         ),
     )
-    acp_session_id: str | None = Field(
-        default=None,
-        description=(
-            "ACP server's session identifier.  Persisted so that restarting "
-            "the agent-server replays the ACP subprocess's prior context via "
-            "``load_session`` instead of starting from scratch.  When the ACP "
-            "server no longer recognises the id (e.g. on-disk state was wiped, "
-            "or the conversation resumed on a host that never saw it), the "
-            "load silently falls back to ``new_session`` and the field is "
-            "rewritten with the fresh id.  Note: ACP servers key their "
-            "persistence by ``cwd``, so resuming in a different working "
-            "directory may miss the prior session."
-        ),
-    )
 
     def model_post_init(self, __context: object) -> None:
         super().model_post_init(__context)
@@ -766,12 +752,18 @@ class ACPAgent(AgentBase):
 
         self._initialized = True
 
-        # Store agent info in agent_state so it's accessible from remote
-        # conversations (PrivateAttrs aren't serialized in state updates).
+        # Persist agent info + the ACP session id in agent_state.  Keeping the
+        # session id here (rather than on the frozen ACPAgent model) means
+        # ConversationState's existing base_state.json persistence carries it
+        # across agent-server restarts, and ``_start_acp_server`` on the next
+        # launch reads it back to call ``load_session`` instead of starting
+        # from scratch.  ACP servers key their persistence by ``cwd``, so
+        # resuming in a different working directory may miss the prior session.
         state.agent_state = {
             **state.agent_state,
             "acp_agent_name": self._agent_name,
             "acp_agent_version": self._agent_version,
+            "acp_session_id": self._session_id,
         }
 
     def _start_acp_server(self, state: ConversationState) -> None:
@@ -790,6 +782,11 @@ class ACPAgent(AgentBase):
         args = list(self.acp_command[1:]) + list(self.acp_args)
 
         working_dir = str(state.workspace.working_dir)
+
+        # Prior ACP session id — survives agent-server restarts via
+        # ConversationState.agent_state (serialized into base_state.json).
+        # Its presence is the signal to resume; its absence means fresh start.
+        prior_session_id: str | None = state.agent_state.get("acp_session_id")
 
         async def _init() -> tuple[Any, Any, Any, str, str, str]:
             # Spawn the subprocess directly so we can install a
@@ -863,14 +860,14 @@ class ACPAgent(AgentBase):
             # has forgotten it (state wiped, new host, etc.) fall through to
             # new_session so the conversation still starts cleanly.
             session_id: str | None = None
-            if self.acp_session_id is not None:
+            if prior_session_id is not None:
                 try:
                     await conn.load_session(
                         cwd=working_dir,
-                        session_id=self.acp_session_id,
+                        session_id=prior_session_id,
                         mcp_servers=[],
                     )
-                    session_id = self.acp_session_id
+                    session_id = prior_session_id
                     logger.info(
                         "Resumed ACP session: %s (cwd=%s)",
                         session_id,
@@ -879,7 +876,7 @@ class ACPAgent(AgentBase):
                 except ACPRequestError as e:
                     logger.warning(
                         "ACP load_session(%s) failed (%s); starting a fresh session",
-                        self.acp_session_id,
+                        prior_session_id,
                         e,
                     )
 
@@ -919,11 +916,6 @@ class ACPAgent(AgentBase):
             self._agent_version,
         ) = result
         self._working_dir = working_dir
-        # Persist the ACP session id on the (frozen) model so a subsequent
-        # model_dump() → model_validate() round-trip can resume via
-        # load_session instead of starting from scratch.
-        if self.acp_session_id != self._session_id:
-            object.__setattr__(self, "acp_session_id", self._session_id)
 
     @observe(name="acp_agent.step", ignore_inputs=["conversation", "on_event"])
     def step(

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -8,6 +8,7 @@ import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from acp.exceptions import RequestError as ACPRequestError
 
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
@@ -2104,3 +2105,153 @@ class TestSerializeToolContent:
         d = {"type": "content", "text": "world"}
         result = _serialize_tool_content([model, d])
         assert result == [{"type": "diff", "path": "b.py"}, d]
+
+
+# ---------------------------------------------------------------------------
+# acp_session_id persistence (issue #2867)
+# ---------------------------------------------------------------------------
+
+
+class TestACPSessionIdPersistence:
+    """Verify that acp_session_id round-trips through serialization and that
+    _start_acp_server picks between new_session and load_session based on it.
+    """
+
+    @staticmethod
+    def _patched_start_acp_server(agent, state, *, conn):
+        """Invoke the real _start_acp_server with ACP transport layers mocked.
+
+        Returns the mock connection so callers can inspect which ACP methods
+        were awaited.
+        """
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return mock_process
+
+        async def _fake_filter(_src, _dst):
+            return None
+
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent._executor = AsyncExecutor()
+        with (
+            patch(
+                "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                new=_fake_create_subprocess_exec,
+            ),
+            patch(
+                "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                return_value=conn,
+            ),
+            patch(
+                "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                new=_fake_filter,
+            ),
+            patch(
+                "openhands.sdk.agent.acp_agent.asyncio.StreamReader",
+                return_value=MagicMock(),
+            ),
+        ):
+            agent._start_acp_server(state)
+
+    @staticmethod
+    def _make_conn(
+        *,
+        new_session_id: str = "sess-new",
+        load_exc: Exception | None = None,
+    ):
+        conn = MagicMock()
+
+        init_response = MagicMock()
+        init_response.agent_info = MagicMock()
+        init_response.agent_info.name = "claude-agent-acp"
+        init_response.agent_info.version = "1.0"
+        init_response.auth_methods = []
+        conn.initialize = AsyncMock(return_value=init_response)
+
+        new_response = MagicMock()
+        new_response.session_id = new_session_id
+        conn.new_session = AsyncMock(return_value=new_response)
+
+        if load_exc is not None:
+            conn.load_session = AsyncMock(side_effect=load_exc)
+        else:
+            conn.load_session = AsyncMock(return_value=MagicMock())
+
+        conn.set_session_mode = AsyncMock()
+        conn.set_session_model = AsyncMock()
+        conn.authenticate = AsyncMock()
+        conn.close = AsyncMock()
+        return conn
+
+    def test_default_session_id_is_none(self):
+        agent = _make_agent()
+        assert agent.acp_session_id is None
+
+    def test_first_launch_calls_new_session(self, tmp_path):
+        """Without a stored id, _start_acp_server must call new_session."""
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = self._make_conn(new_session_id="fresh-sess")
+
+        self._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.new_session.assert_awaited_once()
+        conn.load_session.assert_not_awaited()
+        assert agent.acp_session_id == "fresh-sess"
+        assert agent._session_id == "fresh-sess"
+
+    def test_session_id_survives_model_dump_roundtrip(self, tmp_path):
+        """After first launch, model_dump() → model_validate() keeps the id."""
+        agent = ACPAgent(acp_command=["npx", "-y", "claude-agent-acp"])
+        state = _make_state(tmp_path)
+        conn = self._make_conn(new_session_id="survive-sess")
+
+        self._patched_start_acp_server(agent, state, conn=conn)
+
+        dumped = agent.model_dump_json()
+        restored = AgentBase.model_validate_json(dumped)
+
+        assert isinstance(restored, ACPAgent)
+        assert restored.acp_session_id == "survive-sess"
+
+    def test_second_launch_calls_load_session(self, tmp_path):
+        """With a stored id, _start_acp_server must call load_session."""
+        agent = _make_agent(acp_session_id="stored-sess")
+        state = _make_state(tmp_path)
+        conn = self._make_conn()
+
+        self._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        _, kwargs = conn.load_session.call_args
+        assert kwargs["session_id"] == "stored-sess"
+        assert kwargs["cwd"] == str(tmp_path)
+        conn.new_session.assert_not_awaited()
+        assert agent.acp_session_id == "stored-sess"
+        assert agent._session_id == "stored-sess"
+
+    def test_load_session_failure_falls_back_to_new_session(self, tmp_path):
+        """ACPRequestError on load_session → new_session is called, id rewritten."""
+        agent = _make_agent(acp_session_id="stale-sess")
+        state = _make_state(tmp_path)
+        conn = self._make_conn(
+            new_session_id="replacement-sess",
+            load_exc=ACPRequestError(-32602, "unknown session"),
+        )
+
+        self._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_awaited_once()
+        assert agent.acp_session_id == "replacement-sess"
+        assert agent._session_id == "replacement-sess"
+
+    def test_serialization_includes_acp_session_id_field(self):
+        """acp_session_id is part of the serialized model, not a PrivateAttr."""
+        agent = _make_agent(acp_session_id="ser-sess")
+        data = json.loads(agent.model_dump_json())
+        assert data["acp_session_id"] == "ser-sess"

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2108,22 +2108,19 @@ class TestSerializeToolContent:
 
 
 # ---------------------------------------------------------------------------
-# acp_session_id persistence (issue #2867)
+# ACP session resume via ConversationState.agent_state (issue #2867)
 # ---------------------------------------------------------------------------
 
 
 class TestACPSessionIdPersistence:
-    """Verify that acp_session_id round-trips through serialization and that
-    _start_acp_server picks between new_session and load_session based on it.
+    """Verify that the ACP session id is stashed in ``state.agent_state`` on
+    first launch and that _start_acp_server reads it back on resume to drive
+    load_session vs. new_session.
     """
 
     @staticmethod
     def _patched_start_acp_server(agent, state, *, conn):
-        """Invoke the real _start_acp_server with ACP transport layers mocked.
-
-        Returns the mock connection so callers can inspect which ACP methods
-        were awaited.
-        """
+        """Invoke the real _start_acp_server with ACP transport layers mocked."""
         mock_process = MagicMock()
         mock_process.stdin = MagicMock()
         mock_process.stdout = MagicMock()
@@ -2187,12 +2184,13 @@ class TestACPSessionIdPersistence:
         conn.close = AsyncMock()
         return conn
 
-    def test_default_session_id_is_none(self):
-        agent = _make_agent()
-        assert agent.acp_session_id is None
+    def test_fresh_state_has_no_session_id(self, tmp_path):
+        """A fresh ConversationState holds no session id under agent_state."""
+        state = _make_state(tmp_path)
+        assert "acp_session_id" not in state.agent_state
 
     def test_first_launch_calls_new_session(self, tmp_path):
-        """Without a stored id, _start_acp_server must call new_session."""
+        """Empty agent_state → _start_acp_server calls new_session only."""
         agent = _make_agent()
         state = _make_state(tmp_path)
         conn = self._make_conn(new_session_id="fresh-sess")
@@ -2201,27 +2199,34 @@ class TestACPSessionIdPersistence:
 
         conn.new_session.assert_awaited_once()
         conn.load_session.assert_not_awaited()
-        assert agent.acp_session_id == "fresh-sess"
         assert agent._session_id == "fresh-sess"
 
-    def test_session_id_survives_model_dump_roundtrip(self, tmp_path):
-        """After first launch, model_dump() → model_validate() keeps the id."""
-        agent = ACPAgent(acp_command=["npx", "-y", "claude-agent-acp"])
+    def test_init_state_writes_session_id_into_agent_state(self, tmp_path):
+        """init_state lands the session id in state.agent_state so
+        ConversationState's base_state.json persistence carries it forward.
+        """
+        agent = _make_agent()
         state = _make_state(tmp_path)
-        conn = self._make_conn(new_session_id="survive-sess")
 
-        self._patched_start_acp_server(agent, state, conn=conn)
+        # Short-circuit _start_acp_server: pretend the ACP handshake ran and
+        # populated the runtime attrs that init_state reads afterwards.
+        def _fake_start(self, _state):
+            self._session_id = "end-to-end-sess"
+            self._agent_name = "claude-agent-acp"
+            self._agent_version = "1.0"
 
-        dumped = agent.model_dump_json()
-        restored = AgentBase.model_validate_json(dumped)
+        with patch.object(ACPAgent, "_start_acp_server", _fake_start):
+            agent.init_state(state, on_event=lambda _: None)
 
-        assert isinstance(restored, ACPAgent)
-        assert restored.acp_session_id == "survive-sess"
+        assert state.agent_state["acp_session_id"] == "end-to-end-sess"
+        assert state.agent_state["acp_agent_name"] == "claude-agent-acp"
+        assert state.agent_state["acp_agent_version"] == "1.0"
 
-    def test_second_launch_calls_load_session(self, tmp_path):
-        """With a stored id, _start_acp_server must call load_session."""
-        agent = _make_agent(acp_session_id="stored-sess")
+    def test_resume_reads_session_id_from_agent_state(self, tmp_path):
+        """Prior session id in agent_state → load_session is called with it."""
+        agent = _make_agent()
         state = _make_state(tmp_path)
+        state.agent_state = {**state.agent_state, "acp_session_id": "stored-sess"}
         conn = self._make_conn()
 
         self._patched_start_acp_server(agent, state, conn=conn)
@@ -2231,13 +2236,13 @@ class TestACPSessionIdPersistence:
         assert kwargs["session_id"] == "stored-sess"
         assert kwargs["cwd"] == str(tmp_path)
         conn.new_session.assert_not_awaited()
-        assert agent.acp_session_id == "stored-sess"
         assert agent._session_id == "stored-sess"
 
     def test_load_session_failure_falls_back_to_new_session(self, tmp_path):
-        """ACPRequestError on load_session → new_session is called, id rewritten."""
-        agent = _make_agent(acp_session_id="stale-sess")
+        """ACPRequestError on load_session → new_session is called."""
+        agent = _make_agent()
         state = _make_state(tmp_path)
+        state.agent_state = {**state.agent_state, "acp_session_id": "stale-sess"}
         conn = self._make_conn(
             new_session_id="replacement-sess",
             load_exc=ACPRequestError(-32602, "unknown session"),
@@ -2247,11 +2252,13 @@ class TestACPSessionIdPersistence:
 
         conn.load_session.assert_awaited_once()
         conn.new_session.assert_awaited_once()
-        assert agent.acp_session_id == "replacement-sess"
         assert agent._session_id == "replacement-sess"
 
-    def test_serialization_includes_acp_session_id_field(self):
-        """acp_session_id is part of the serialized model, not a PrivateAttr."""
-        agent = _make_agent(acp_session_id="ser-sess")
+    def test_session_id_not_on_serialized_agent(self):
+        """Session id must not leak onto the agent model — it lives in
+        ConversationState.agent_state, not on the frozen ACPAgent.
+        """
+        agent = _make_agent()
         data = json.loads(agent.model_dump_json())
-        assert data["acp_session_id"] == "ser-sess"
+        assert "acp_session_id" not in data
+        assert not hasattr(agent, "acp_session_id")

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2119,8 +2119,12 @@ class TestACPSessionIdPersistence:
     """
 
     @staticmethod
-    def _patched_start_acp_server(agent, state, *, conn):
-        """Invoke the real _start_acp_server with ACP transport layers mocked."""
+    def _transport_patches(conn):
+        """Context manager stacking the transport-layer mocks that let
+        _start_acp_server run without spawning a real subprocess.
+        """
+        from contextlib import ExitStack
+
         mock_process = MagicMock()
         mock_process.stdin = MagicMock()
         mock_process.stdout = MagicMock()
@@ -2131,27 +2135,40 @@ class TestACPSessionIdPersistence:
         async def _fake_filter(_src, _dst):
             return None
 
-        from openhands.sdk.utils.async_executor import AsyncExecutor
-
-        agent._executor = AsyncExecutor()
-        with (
+        stack = ExitStack()
+        stack.enter_context(
             patch(
                 "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
                 new=_fake_create_subprocess_exec,
-            ),
+            )
+        )
+        stack.enter_context(
             patch(
                 "openhands.sdk.agent.acp_agent.ClientSideConnection",
                 return_value=conn,
-            ),
+            )
+        )
+        stack.enter_context(
             patch(
                 "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
                 new=_fake_filter,
-            ),
+            )
+        )
+        stack.enter_context(
             patch(
                 "openhands.sdk.agent.acp_agent.asyncio.StreamReader",
                 return_value=MagicMock(),
-            ),
-        ):
+            )
+        )
+        return stack
+
+    @staticmethod
+    def _patched_start_acp_server(agent, state, *, conn):
+        """Invoke the real _start_acp_server with ACP transport layers mocked."""
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent._executor = AsyncExecutor()
+        with TestACPSessionIdPersistence._transport_patches(conn):
             agent._start_acp_server(state)
 
     @staticmethod
@@ -2321,3 +2338,130 @@ class TestACPSessionIdPersistence:
         conn.load_session.assert_awaited_once()
         conn.new_session.assert_not_awaited()
         assert agent._session_id == "legacy-sess"
+
+    def test_fallback_replacement_id_lands_in_agent_state(self, tmp_path):
+        """When load_session fails and new_session runs, init_state must
+        overwrite state.agent_state['acp_session_id'] with the new id so
+        the next restart doesn't keep trying to resume the stale one.
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "stale-sess",
+            "acp_session_cwd": str(tmp_path),
+        }
+        conn = self._make_conn(
+            new_session_id="replacement-sess",
+            load_exc=ACPRequestError(-32602, "unknown session"),
+        )
+
+        agent._executor = AsyncExecutor()
+        with self._transport_patches(conn):
+            agent.init_state(state, on_event=lambda _: None)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_awaited_once()
+        assert state.agent_state["acp_session_id"] == "replacement-sess"
+        assert state.agent_state["acp_session_cwd"] == str(tmp_path)
+
+    def test_resume_path_still_applies_session_mode_and_model(self, tmp_path):
+        """load_session must be followed by the same set_session_model and
+        set_session_mode calls as new_session, so a resumed session honours
+        acp_model overrides and the bypass-permissions mode.
+        """
+        agent = _make_agent(acp_model="claude-opus-4-6")
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "stored-sess",
+            "acp_session_cwd": str(tmp_path),
+        }
+        # Name the server "codex-acp" so _maybe_set_session_model routes
+        # acp_model through conn.set_session_model (claude-acp uses _meta,
+        # which only applies on new_session and so wouldn't exercise the
+        # protocol-level override on the resume path).
+        conn = self._make_conn()
+        conn.initialize.return_value.agent_info.name = "codex-acp"
+        conn.initialize.return_value.auth_methods = []
+
+        self._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_not_awaited()
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="claude-opus-4-6",
+            session_id="stored-sess",
+        )
+        conn.set_session_mode.assert_awaited_once_with(
+            mode_id="full-access",
+            session_id="stored-sess",
+        )
+
+    def test_roundtrip_via_conversation_state_persistence(self, tmp_path):
+        """End-to-end round-trip through ConversationState persistence:
+
+        1. First Conversation with persistence_dir → init_state runs,
+           new_session is called, ``state.agent_state["acp_session_id"]`` is
+           written, autosave flushes ``base_state.json`` to disk.
+        2. Fresh ACPAgent + Conversation pointed at the same persistence_dir
+           and id → ConversationState.create() restores ``base_state.json``
+           so ``agent_state["acp_session_id"]`` survives; init_state on the
+           resumed state triggers ``load_session`` with that id.
+        """
+        import uuid as _uuid
+
+        from openhands.sdk.conversation import Conversation
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        persistence_dir = tmp_path / "persist"
+        conv_id = _uuid.uuid4()
+        workspace = tmp_path / "work"
+        workspace.mkdir()
+
+        conn1 = self._make_conn(new_session_id="roundtrip-sess")
+        agent1 = _make_agent()
+        agent1._executor = AsyncExecutor()
+        with self._transport_patches(conn1):
+            conv1 = Conversation(
+                agent=agent1,
+                workspace=str(workspace),
+                persistence_dir=str(persistence_dir),
+                conversation_id=conv_id,
+                delete_on_close=False,
+                visualizer=None,
+            )
+            conv1._ensure_agent_ready()
+            assert conv1.state.agent_state["acp_session_id"] == "roundtrip-sess"
+            conv1.close()
+
+        conn1.new_session.assert_awaited_once()
+        conn1.load_session.assert_not_awaited()
+
+        # Fresh ACPAgent with no runtime knowledge of the prior session.
+        conn2 = self._make_conn()
+        agent2 = _make_agent()
+        agent2._executor = AsyncExecutor()
+        with self._transport_patches(conn2):
+            conv2 = Conversation(
+                agent=agent2,
+                workspace=str(workspace),
+                persistence_dir=str(persistence_dir),
+                conversation_id=conv_id,
+                delete_on_close=True,
+                visualizer=None,
+            )
+            conv2._ensure_agent_ready()
+            # base_state.json restored the id into agent_state.
+            assert conv2.state.agent_state["acp_session_id"] == "roundtrip-sess"
+            conv2.close()
+
+        # Second launch took the load_session branch with the persisted id.
+        conn2.load_session.assert_awaited_once()
+        _, kwargs = conn2.load_session.call_args
+        assert kwargs["session_id"] == "roundtrip-sess"
+        assert kwargs["cwd"] == str(workspace)
+        conn2.new_session.assert_not_awaited()
+        assert agent2._session_id == "roundtrip-sess"

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2282,9 +2282,7 @@ class TestACPSessionIdPersistence:
         assert state.agent_state["acp_session_id"] == "sess-123"
         assert state.agent_state["acp_session_cwd"] == str(tmp_path)
 
-    def test_cwd_mismatch_skips_load_and_calls_new_session(
-        self, tmp_path, caplog
-    ):
+    def test_cwd_mismatch_skips_load_and_calls_new_session(self, tmp_path, caplog):
         """If the stored cwd differs from the current workspace cwd, resume
         is skipped and new_session runs instead — so we never silently load
         a session that the ACP server associated with a different directory.
@@ -2305,8 +2303,7 @@ class TestACPSessionIdPersistence:
         conn.new_session.assert_awaited_once()
         assert agent._session_id == "fresh-sess"
         assert any(
-            "cwd=/some/other/place" in rec.message
-            and "differs" in rec.message
+            "cwd=/some/other/place" in rec.message and "differs" in rec.message
             for rec in caplog.records
         ), "expected a warning explaining the cwd mismatch"
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2262,3 +2262,65 @@ class TestACPSessionIdPersistence:
         data = json.loads(agent.model_dump_json())
         assert "acp_session_id" not in data
         assert not hasattr(agent, "acp_session_id")
+
+    def test_init_state_writes_cwd_alongside_session_id(self, tmp_path):
+        """init_state records the cwd the session was created under so a later
+        resume can reject cwd mismatches (ACP keys persistence by cwd).
+        """
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+
+        def _fake_start(self, _state):
+            self._session_id = "sess-123"
+            self._agent_name = "claude-agent-acp"
+            self._agent_version = "1.0"
+            self._working_dir = str(tmp_path)
+
+        with patch.object(ACPAgent, "_start_acp_server", _fake_start):
+            agent.init_state(state, on_event=lambda _: None)
+
+        assert state.agent_state["acp_session_id"] == "sess-123"
+        assert state.agent_state["acp_session_cwd"] == str(tmp_path)
+
+    def test_cwd_mismatch_skips_load_and_calls_new_session(
+        self, tmp_path, caplog
+    ):
+        """If the stored cwd differs from the current workspace cwd, resume
+        is skipped and new_session runs instead — so we never silently load
+        a session that the ACP server associated with a different directory.
+        """
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            **state.agent_state,
+            "acp_session_id": "old-sess",
+            "acp_session_cwd": "/some/other/place",
+        }
+        conn = self._make_conn(new_session_id="fresh-sess")
+
+        with caplog.at_level("WARNING"):
+            self._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_not_awaited()
+        conn.new_session.assert_awaited_once()
+        assert agent._session_id == "fresh-sess"
+        assert any(
+            "cwd=/some/other/place" in rec.message
+            and "differs" in rec.message
+            for rec in caplog.records
+        ), "expected a warning explaining the cwd mismatch"
+
+    def test_resume_without_stored_cwd_still_works(self, tmp_path):
+        """Legacy state written by an earlier version has acp_session_id but
+        no acp_session_cwd — resume should still proceed (best-effort).
+        """
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        state.agent_state = {**state.agent_state, "acp_session_id": "legacy-sess"}
+        conn = self._make_conn()
+
+        self._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        conn.new_session.assert_not_awaited()
+        assert agent._session_id == "legacy-sess"


### PR DESCRIPTION
## Summary

- Persists the ACP server's session id in `ConversationState.agent_state` (keyed by `"acp_session_id"`), next to the existing `acp_agent_name` / `acp_agent_version` entries and matching the pattern used by `CriticMixin` (`openhands-sdk/openhands/sdk/agent/critic_mixin.py:127`). That dict is already serialized into `base_state.json` and autosaved, so session id survives agent-server restarts for free.
- `_start_acp_server` reads `state.agent_state["acp_session_id"]` to decide between `conn.load_session(...)` (resume) and `conn.new_session(...)` (fresh). `init_state` writes the resolved id back on every launch.
- `ACPRequestError` on `load_session` (e.g. server wiped state, new host, or different `cwd` — ACP servers key persistence by cwd) falls back to `new_session` and overwrites the stale id.

No new fields on the frozen `ACPAgent` model. No `object.__setattr__` dance. The SDK code is protocol-agnostic (works for `claude-agent-acp`, `codex-acp`, `gemini-cli` — each advertises `loadSession: true`).

Closes #2867

## Test plan

- [x] `uv run pytest tests/sdk/agent/test_acp_agent.py` — all 126 tests pass (120 existing + 6 new).
- [x] New `TestACPSessionIdPersistence` suite asserts:
  - fresh `ConversationState` has no `acp_session_id` in `agent_state`
  - empty `agent_state` → `new_session` called, not `load_session`, and `_session_id` set
  - `init_state` end-to-end populates `state.agent_state["acp_session_id"]` (plus `acp_agent_name` and `acp_agent_version`)
  - pre-populated `agent_state["acp_session_id"]` → `load_session` called with that id + current `cwd`, `new_session` not called
  - `ACPRequestError` on `load_session` falls back to `new_session`
  - session id does not leak onto the serialized `ACPAgent` model
- [x] `uv run ruff check` + `uv run pyright` on the touched files — clean.
- [x] **Real end-to-end integration against `claude-agent-acp`** — `/tmp/acp_sdk_resume_integration.py` runs two independent `Conversation` objects sharing a `persistence_dir`, stores "periwinkle" in the first, reopens with a fresh `ACPAgent` in the second, and the model recalls "periwinkle". Log confirms `Resumed ACP session: c7fba12a-…` on the second launch instead of `new_session`.
- [ ] Per-server smoke (`codex-acp`, `gemini-cli`) — worth a quick check before merge; the SDK code is protocol-agnostic but each server's on-disk persistence differs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c37e6f8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c37e6f8-python \
  ghcr.io/openhands/agent-server:c37e6f8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c37e6f8-golang-amd64
ghcr.io/openhands/agent-server:c37e6f8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c37e6f8-golang-arm64
ghcr.io/openhands/agent-server:c37e6f8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c37e6f8-java-amd64
ghcr.io/openhands/agent-server:c37e6f8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c37e6f8-java-arm64
ghcr.io/openhands/agent-server:c37e6f8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c37e6f8-python-amd64
ghcr.io/openhands/agent-server:c37e6f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c37e6f8-python-arm64
ghcr.io/openhands/agent-server:c37e6f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c37e6f8-golang
ghcr.io/openhands/agent-server:c37e6f8-java
ghcr.io/openhands/agent-server:c37e6f8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c37e6f8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c37e6f8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->