### PR TITLE
ci: use MAINTAINERS as reviewer assignment fallback

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -122,16 +122,26 @@ jobs:
 
                 For each PR that truly has NO reviewers:
                 1) Read git blame for changed files to identify recent, active contributors.
-                2) From those candidates, ONLY consider maintainers — repository collaborators with write access or higher. Verify via the GitHub API before
-                requesting review:
+                2) From those blame-derived candidates, ONLY consider maintainers who are repository collaborators with write access or higher. Verify that
+                with the GitHub API before requesting review:
                    - Preferred: GET /repos/{owner}/{repo}/collaborators (no permission filter). Filter client-side using either:
                      role_name in ["write", "maintain", "admin"] OR permissions.push || permissions.admin. Note: paginate if > 30 collaborators.
                    - Alternative: GET /repos/{owner}/{repo}/collaborators/{username}/permission and accept if permission in {push, maintain, admin}.
-                3) If multiple maintainers qualify, avoid assigning too many reviews to any single one.
-                4) Request review from exactly one maintainer and add this message:
+                3) If one or more blame-derived maintainers qualify, request review from exactly one of them. Prefer the maintainer with the lowest current
+                review load. Add this message:
 
                 [Automatic Post]: I have assigned {reviewer} as a reviewer based on git blame information.
                 Thanks in advance for the help!
+
+                4) If no blame-derived maintainer qualifies, read the MAINTAINERS file in the repository root. Parse usernames from lines starting with
+                "- @username" and treat that file as the canonical list of active maintainers.
+                5) From that MAINTAINERS list, keep only users who still have write access or higher via the GitHub API, exclude the PR author, and request
+                review from exactly one of them, again preferring the maintainer with the lowest current review load. Add this message:
+
+                [Automatic Post]: I have assigned {reviewer} as a reviewer based on the repository MAINTAINERS file.
+                Thanks in advance for the help!
+
+                6) If neither path yields a qualified maintainer, do not request review from anyone and do not fall back to a broader collaborator pool.
 
             LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929
             LLM_BASE_URL: https://llm-proxy.app.all-hands.dev


### PR DESCRIPTION
## Summary
- keep the first reviewer-selection path blame-based plus collaborator permission filtering
- add a second fallback path that reads the repo-root `MAINTAINERS` file as the canonical active maintainer list
- stop the workflow from falling back to a broader collaborator pool when neither path yields a qualified maintainer
- use a distinct automatic comment when the MAINTAINERS fallback path is used

## Motivation
The current `Assign Reviews` workflow can end up assigning a least-loaded write collaborator even when no blame-derived maintainer qualifies. This change makes the fallback explicit and anchored to the repository's active maintainer list.

## Evidence
- `uv run pre-commit run --files .github/workflows/assign-reviews.yml`

_AI note: this PR was created by OpenHands on behalf of @enyst._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e5c012cb-c08f-4f9f-bb07-0b1cce1e5262)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:900db18-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-900db18-python \
  ghcr.io/openhands/agent-server:900db18-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:900db18-golang-amd64
ghcr.io/openhands/agent-server:900db18-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:900db18-golang-arm64
ghcr.io/openhands/agent-server:900db18-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:900db18-java-amd64
ghcr.io/openhands/agent-server:900db18-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:900db18-java-arm64
ghcr.io/openhands/agent-server:900db18-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:900db18-python-amd64
ghcr.io/openhands/agent-server:900db18-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:900db18-python-arm64
ghcr.io/openhands/agent-server:900db18-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:900db18-golang
ghcr.io/openhands/agent-server:900db18-java
ghcr.io/openhands/agent-server:900db18-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `900db18-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `900db18-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->