### PR TITLE
proposal: serialize mcp_config as sanitized deprecated projection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ When reviewing code, provide constructive feedback:
 - Workspace-wide uv resolver guardrails belong in the repository root `[tool.uv]` table. When `exclude-newer` is configured there, `uv lock` persists it into the root `uv.lock` `[options]` section as both an absolute cutoff and `exclude-newer-span`, and `uv sync --frozen` continues to use that locked workspace state.
 - `pr-review-by-openhands` delegates to `OpenHands/extensions/plugins/pr-review@main`. Repo-specific reviewer instructions live in `.agents/skills/custom-codereview-guide.md`, and because task-trigger matching is substring-based, that `/codereview` skill is also auto-injected for the workflow's `/codereview-roasted` prompt.
 - Auto-title generation should not re-read `ConversationState.events` from a background task triggered by a freshly received `MessageEvent`; extract message text synchronously from the incoming event and then reuse shared title helpers (`extract_message_text`, `generate_title_from_message`) to avoid persistence-order races.
+- `AgentBase.mcp_config` may hold expanded runtime secrets, so public/default serialization should expose only a sanitized projection. Internal transport code that truly needs the runnable config must opt in explicitly via `model_dump(context={"raw_mcp_config": True})` rather than relying on the default serialized payload.
+
 
 
 ## Package-specific guidance

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -477,7 +477,10 @@ class ConversationService:
         # construct StoredConversation, not sent over the network.
         stored = StoredConversation(
             id=conversation_id,
-            **request.model_dump(mode="json", context={"expose_secrets": True}),
+            **request.model_dump(
+                mode="json",
+                context={"expose_secrets": True, "raw_mcp_config": True},
+            ),
         )
         event_service = await self._start_event_service(stored)
         initial_message = request.initial_message

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -469,7 +469,9 @@ class EventService:
         Path(workspace.working_dir).mkdir(parents=True, exist_ok=True)
         agent_cls = type(self.stored.agent)
         agent = agent_cls.model_validate(
-            self.stored.agent.model_dump(context={"expose_secrets": True}),
+            self.stored.agent.model_dump(
+                context={"expose_secrets": True, "raw_mcp_config": True}
+            ),
         )
 
         # Create LocalConversation with plugins and hook_config.

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -13,6 +13,8 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    SerializationInfo,
+    field_serializer,
     model_validator,
 )
 
@@ -41,6 +43,25 @@ if TYPE_CHECKING:
         ConversationCallbackType,
         ConversationTokenCallbackType,
     )
+
+
+_MCP_CONFIG_SERIALIZATION_DEPRECATED_IN = "1.17.0"
+_MCP_CONFIG_SERIALIZATION_REMOVED_IN = "1.22.0"
+_REDACTED_MCP_CONFIG_VALUE = "<redacted>"
+
+
+def _sanitize_mcp_config_for_serialization(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            key: _sanitize_mcp_config_for_serialization(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_sanitize_mcp_config_for_serialization(item) for item in value]
+    if isinstance(value, str):
+        return _REDACTED_MCP_CONFIG_VALUE
+    return value
+
 
 logger = get_logger(__name__)
 
@@ -83,16 +104,33 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
     )
     mcp_config: dict[str, Any] = Field(
         default_factory=dict,
-        description="Optional MCP configuration dictionary to create MCP tools.",
+        description=(
+            "Optional MCP configuration dictionary to create MCP tools. "
+            "Serialized output is sanitized for safety and should not be used as "
+            "runnable MCP configuration. Deprecated since "
+            f"v{_MCP_CONFIG_SERIALIZATION_DEPRECATED_IN} and scheduled for removal "
+            f"in v{_MCP_CONFIG_SERIALIZATION_REMOVED_IN}."
+        ),
         examples=[
             {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-server-fetch"]}}}
         ],
-        exclude=True,  # Exclude from serialization to prevent secret leakage
-        # mcp_config may contain expanded secrets (e.g., API tokens in env vars).
-        # Since MCP tools are created at runtime and verified via the tools list
-        # on resume, there's no need to persist the config. Excluding it prevents
-        # secrets from leaking to disk, WebSocket events, and API responses.
+        json_schema_extra={
+            "deprecated": True,
+            "x-deprecated-in": _MCP_CONFIG_SERIALIZATION_DEPRECATED_IN,
+            "x-removed-in": _MCP_CONFIG_SERIALIZATION_REMOVED_IN,
+        },
     )
+
+    @field_serializer("mcp_config", when_used="always")
+    def _serialize_mcp_config(
+        self,
+        value: dict[str, Any],
+        info: SerializationInfo,
+    ) -> dict[str, Any]:
+        if info.context and info.context.get("raw_mcp_config"):
+            return value
+        return _sanitize_mcp_config_for_serialization(value)
+
     filter_tools_regex: str | None = Field(
         default=None,
         description="Optional regex to filter the tools available to the agent by name."

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -720,7 +720,8 @@ class RemoteConversation(BaseConversation):
 
             payload = {
                 "agent": agent.model_dump(
-                    mode="json", context={"expose_secrets": True}
+                    mode="json",
+                    context={"expose_secrets": True, "raw_mcp_config": True},
                 ),
                 "initial_message": None,
                 "max_iterations": max_iteration_per_run,

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -59,16 +59,43 @@ def test_mcp_tool_serialization():
     assert loaded.model_dump_json() == dumped
 
 
-def test_agent_serialization_excludes_mcp_config_for_security() -> None:
-    """Test that mcp_config is excluded from serialization for security.
+def test_agent_serialization_sanitizes_mcp_config_for_security() -> None:
+    """Test that serialized mcp_config keeps shape but redacts string values."""
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {
+        "mcpServers": {
+            "dummy": {
+                "command": "echo",
+                "args": ["dummy-mcp"],
+                "env": {"API_TOKEN": "secret-value"},
+            },
+        }
+    }
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
 
-    mcp_config may contain expanded secrets (e.g., API tokens in env vars)
-    after variable expansion. To prevent secret leakage to disk, WebSocket,
-    and API responses, mcp_config is excluded from serialization by default.
+    assert agent.mcp_config == mcp_config
 
-    See: https://github.com/OpenHands/software-agent-sdk/pull/2873
-    """
-    # Create a simple LLM instance and agent with mcp_config
+    agent_dump = agent.model_dump(mode="json")
+    serialized_mcp_config = agent_dump["mcp_config"]
+
+    assert serialized_mcp_config == {
+        "mcpServers": {
+            "dummy": {
+                "command": "<redacted>",
+                "args": ["<redacted>"],
+                "env": {"API_TOKEN": "<redacted>"},
+            }
+        }
+    }
+
+    agent_json = agent.model_dump_json()
+    deserialized_agent = AgentBase.model_validate_json(agent_json)
+
+    assert isinstance(deserialized_agent, Agent)
+    assert deserialized_agent.mcp_config == serialized_mcp_config
+
+
+def test_agent_serialization_preserves_raw_mcp_config_for_transport() -> None:
     llm = LLM(model="test-model", usage_id="test-llm")
     mcp_config = {
         "mcpServers": {
@@ -77,22 +104,18 @@ def test_agent_serialization_excludes_mcp_config_for_security() -> None:
     }
     agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
 
-    # mcp_config should be accessible in memory
-    assert agent.mcp_config == mcp_config
+    raw_dump = agent.model_dump(mode="json", context={"raw_mcp_config": True})
 
-    # But should be EXCLUDED from serialization
-    agent_dump = agent.model_dump()
-    assert agent_dump.get("mcp_config") is None, (
-        "mcp_config should be excluded from serialization to prevent secret leakage"
-    )
+    assert raw_dump["mcp_config"] == mcp_config
 
-    # Serialization round-trip should work (mcp_config defaults to empty dict)
-    agent_json = agent.model_dump_json()
-    deserialized_agent = AgentBase.model_validate_json(agent_json)
 
-    assert isinstance(deserialized_agent, Agent)
-    # Deserialized agent has default empty mcp_config (not the original)
-    assert deserialized_agent.mcp_config == {}
+def test_agent_json_schema_marks_serialized_mcp_config_deprecated() -> None:
+    schema = Agent.model_json_schema()
+    mcp_config_schema = schema["properties"]["mcp_config"]
+
+    assert mcp_config_schema["deprecated"] is True
+    assert mcp_config_schema["x-deprecated-in"] == "1.17.0"
+    assert mcp_config_schema["x-removed-in"] == "1.22.0"
 
 
 def test_agent_supports_polymorphic_field_json_serialization() -> None:

--- a/tests/sdk/conversation/test_mcp_secrets_serialization_leak.py
+++ b/tests/sdk/conversation/test_mcp_secrets_serialization_leak.py
@@ -254,26 +254,20 @@ class TestMcpConfigPreservation:
             "mcp_config should retain secrets in memory for runtime use"
         )
 
-    def test_non_secret_mcp_config_values_persist(self, tmp_path):
-        """Verify that non-secret parts of mcp_config are preserved.
-
-        Commands, args, and other non-sensitive config should still
-        be serialized normally.
-        """
+    def test_non_secret_mcp_config_shape_is_sanitized(self, tmp_path):
+        """Verify serialization keeps the MCP shape but redacts string values."""
         llm = LLM(model="test-model", api_key=SecretStr("test-key"))
         mcp_config = {
             "mcpServers": {
                 "fetch": {
                     "command": "uvx",
                     "args": ["mcp-server-fetch"],
-                    # No env/secrets - should be fully preserved
                 }
             }
         }
         agent = Agent(llm=llm, mcp_config=mcp_config)
 
         workspace = LocalWorkspace(working_dir=str(tmp_path / "workspace"))
-        # Create state (triggers persistence)
         _ = ConversationState.create(
             id=uuid.uuid4(),
             agent=agent,
@@ -288,8 +282,11 @@ class TestMcpConfigPreservation:
         agent_data = persisted_json.get("agent", {})
         persisted_mcp_config = agent_data.get("mcp_config", {})
 
-        # Non-sensitive config should be preserved
-        # (This test may need adjustment based on the chosen fix strategy)
-        assert "mcpServers" in persisted_mcp_config or persisted_mcp_config == {}, (
-            "Non-secret mcp_config should be preserved or explicitly cleared"
-        )
+        assert persisted_mcp_config == {
+            "mcpServers": {
+                "fetch": {
+                    "command": "<redacted>",
+                    "args": ["<redacted>"],
+                }
+            }
+        }


### PR DESCRIPTION
## Summary

This proposal keeps the serialized `mcp_config` field present, but changes it from a runnable config dump into a **sanitized projection**:

- keep the field in serialized payloads to avoid the current contract break
- redact string leaf values recursively so expanded secrets cannot leak
- mark the serialized field as deprecated in schema metadata with a 5-minor-release runway (`v1.17.0` → `v1.22.0`)
- preserve the raw runtime config only for explicit internal transport paths via `model_dump(context={"raw_mcp_config": True})`

## Why this version

I aimed for the smallest change that addresses both concerns:

1. **Security**: public/default serialization no longer exposes expanded MCP secrets
2. **Compatibility**: clients still see `mcp_config` in the response shape instead of the field disappearing outright

This keeps the public contract additive while making it clear that serialized `mcp_config` is no longer the runnable source of truth.

## Changes

- `AgentBase.mcp_config`
  - remove `exclude=True`
  - add a serializer that preserves nested shape but redacts string values
  - add JSON-schema deprecation metadata and explicit removal target
- internal transport
  - pass `raw_mcp_config=True` for remote conversation startup / in-memory server handoff so the live runtime still gets the real config where explicitly intended
- tests
  - update serialization leak tests to assert sanitized shape
  - add coverage for the raw transport override and schema deprecation metadata

## Validation

Ran:

```bash
uv run pytest tests/sdk/agent/test_agent_serialization.py tests/sdk/conversation/test_mcp_secrets_serialization_leak.py tests/sdk/conversation/test_local_conversation_plugins.py tests/sdk/skills/test_mcp_config_expansion.py tests/sdk/plugin/test_plugin_loading.py tests/sdk/plugin/test_plugin_loader.py tests/sdk/conversation/test_secrets_manager.py -k 'mcp or secret or serialization'
uv run pytest tests/agent_server/test_conversation_service.py::TestConversationServiceStartConversation::test_start_conversation_with_secrets tests/agent_server/test_conversation_service.py::TestConversationServiceStartConversation::test_start_conversation_without_secrets -q
uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/base.py openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py openhands-agent-server/openhands/agent_server/conversation_service.py openhands-agent-server/openhands/agent_server/event_service.py tests/sdk/agent/test_agent_serialization.py tests/sdk/conversation/test_mcp_secrets_serialization_leak.py
```

## Notes

This proposal intentionally stays minimal. It does **not** try to reconstruct provenance inside an already-expanded MCP config. Instead it treats serialized `mcp_config` as a safe public projection and keeps raw config transport opt-in.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
