### PR TITLE
fix(acp): derive vision capability from ACP provider, not sentinel LLM

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -155,7 +155,6 @@ _DEFAULT_BYPASS_MODE = "full-access"
 #     src/thread.rs: build_prompt_items() image → UserInput::Image
 _ACP_VISION_PROVIDER_MARKERS: dict[str, bool] = {
     "claude-agent-acp": True,
-    "claude-code-acp": True,  # legacy name, kept for completeness
     "gemini-cli": True,
     "codex-acp": True,
 }

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -803,13 +803,17 @@ class ACPAgent(AgentBase):
     def supports_vision(self) -> bool:
         """Whether the wrapped ACP server forwards images to a vision model.
 
-        The sentinel ``self.llm`` uses ``model="acp-managed"`` which LiteLLM
-        does not recognise, so the base-class ``llm.vision_is_active()``
-        always returns False for ACP agents. Resolve the real capability
-        from the ACP server identity (launch command or the agent name
-        reported by InitializeResponse) instead. Unknown servers fall back
-        to False so we don't silently send images a server may drop.
+        When ``acp_model`` is set, ``self.llm.model`` carries the real
+        model name so ``llm.vision_is_active()`` gives an authoritative
+        answer via LiteLLM — honour the user's explicit model choice even
+        if it's a non-vision variant.
+
+        Without ``acp_model``, the ACP server picks a default we can't
+        see from here, so fall back to the server's identity: all three
+        ACP servers OpenHands supports default to vision-capable models.
         """
+        if self.acp_model:
+            return self.llm.vision_is_active()
         probe = f"{self._agent_name} {' '.join(self.acp_command)}".lower()
         return any(marker in probe for marker in _VISION_CAPABLE_ACP_SERVERS)
 

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -142,40 +142,21 @@ _BYPASS_MODE_MAP: dict[str, str] = {
 }
 _DEFAULT_BYPASS_MODE = "full-access"
 
-# ACP server identifier substrings → whether the server forwards ACP
-# ImageContentBlock prompts to a vision-capable underlying model.
-#
-# Verified against upstream source (all declare prompt_capabilities.image=true
-# and map ContentBlock::Image to their provider's native image format):
-#   claude-agent-acp → Claude Sonnet/Opus/Haiku 3.5+ (vision)
+# ACP servers known to forward ImageContentBlock prompts to a vision-capable
+# underlying model. Verified against upstream source — all declare
+# prompt_capabilities.image=true and map ContentBlock::Image to their
+# provider's native image format:
+#   claude-agent-acp → Claude Sonnet/Opus/Haiku 3.5+
 #     src/acp-agent.ts: promptToClaude() case "image"
-#   gemini-cli       → Gemini 1.5/2.x Pro/Flash (vision)
+#   gemini-cli       → Gemini 1.5/2.x Pro/Flash
 #     packages/cli/src/acp/acpClient.ts: #resolvePrompt() case "image"
-#   codex-acp        → GPT-5 family via Codex CLI (vision)
+#   codex-acp        → GPT-5 family via Codex CLI
 #     src/thread.rs: build_prompt_items() image → UserInput::Image
-_ACP_VISION_PROVIDER_MARKERS: dict[str, bool] = {
-    "claude-agent-acp": True,
-    "gemini-cli": True,
-    "codex-acp": True,
-}
-
-
-def _acp_command_supports_vision(command: list[str], agent_name: str) -> bool:
-    """Return True if the ACP server forwards inline images to a vision model.
-
-    Matches on either the runtime agent name from InitializeResponse (when
-    available) or the configured launch command (always available). Falls
-    back to False for unknown servers so we do not silently send images a
-    server may drop.
-    """
-    haystacks: list[str] = []
-    if agent_name:
-        haystacks.append(agent_name.lower())
-    haystacks.append(" ".join(command).lower())
-    for marker, supports in _ACP_VISION_PROVIDER_MARKERS.items():
-        if any(marker in h for h in haystacks):
-            return supports
-    return False
+_VISION_CAPABLE_ACP_SERVERS: tuple[str, ...] = (
+    "claude-agent-acp",
+    "gemini-cli",
+    "codex-acp",
+)
 
 
 # ACP auth method ID → environment variable that supplies the credential.
@@ -826,9 +807,11 @@ class ACPAgent(AgentBase):
         does not recognise, so the base-class ``llm.vision_is_active()``
         always returns False for ACP agents. Resolve the real capability
         from the ACP server identity (launch command or the agent name
-        reported by InitializeResponse) instead.
+        reported by InitializeResponse) instead. Unknown servers fall back
+        to False so we don't silently send images a server may drop.
         """
-        return _acp_command_supports_vision(self.acp_command, self._agent_name)
+        probe = f"{self._agent_name} {' '.join(self.acp_command)}".lower()
+        return any(marker in probe for marker in _VISION_CAPABLE_ACP_SERVERS)
 
     def get_all_llms(self) -> Generator[LLM]:
         yield self.llm

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -142,23 +142,6 @@ _BYPASS_MODE_MAP: dict[str, str] = {
 }
 _DEFAULT_BYPASS_MODE = "full-access"
 
-# ACP servers known to forward ImageContentBlock prompts to a vision-capable
-# underlying model. Verified against upstream source — all declare
-# prompt_capabilities.image=true and map ContentBlock::Image to their
-# provider's native image format:
-#   claude-agent-acp → Claude Sonnet/Opus/Haiku 3.5+
-#     src/acp-agent.ts: promptToClaude() case "image"
-#   gemini-cli       → Gemini 1.5/2.x Pro/Flash
-#     packages/cli/src/acp/acpClient.ts: #resolvePrompt() case "image"
-#   codex-acp        → GPT-5 family via Codex CLI
-#     src/thread.rs: build_prompt_items() image → UserInput::Image
-_VISION_CAPABLE_ACP_SERVERS: tuple[str, ...] = (
-    "claude-agent-acp",
-    "gemini-cli",
-    "codex-acp",
-)
-
-
 # ACP auth method ID → environment variable that supplies the credential.
 # When the server reports auth_methods, we pick the first method whose
 # required env var is set.
@@ -799,23 +782,6 @@ class ACPAgent(AgentBase):
     def agent_version(self) -> str:
         """Version of the ACP server (from InitializeResponse.agent_info)."""
         return self._agent_version
-
-    def supports_vision(self) -> bool:
-        """Whether the wrapped ACP server forwards images to a vision model.
-
-        When ``acp_model`` is set, ``self.llm.model`` carries the real
-        model name so ``llm.vision_is_active()`` gives an authoritative
-        answer via LiteLLM — honour the user's explicit model choice even
-        if it's a non-vision variant.
-
-        Without ``acp_model``, the ACP server picks a default we can't
-        see from here, so fall back to the server's identity: all three
-        ACP servers OpenHands supports default to vision-capable models.
-        """
-        if self.acp_model:
-            return self.llm.vision_is_active()
-        probe = f"{self._agent_name} {' '.join(self.acp_command)}".lower()
-        return any(marker in probe for marker in _VISION_CAPABLE_ACP_SERVERS)
 
     def get_all_llms(self) -> Generator[LLM]:
         yield self.llm

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -142,6 +142,43 @@ _BYPASS_MODE_MAP: dict[str, str] = {
 }
 _DEFAULT_BYPASS_MODE = "full-access"
 
+# ACP server identifier substrings → whether the server forwards ACP
+# ImageContentBlock prompts to a vision-capable underlying model.
+#
+# Verified against upstream source (all declare prompt_capabilities.image=true
+# and map ContentBlock::Image to their provider's native image format):
+#   claude-agent-acp → Claude Sonnet/Opus/Haiku 3.5+ (vision)
+#     src/acp-agent.ts: promptToClaude() case "image"
+#   gemini-cli       → Gemini 1.5/2.x Pro/Flash (vision)
+#     packages/cli/src/acp/acpClient.ts: #resolvePrompt() case "image"
+#   codex-acp        → GPT-5 family via Codex CLI (vision)
+#     src/thread.rs: build_prompt_items() image → UserInput::Image
+_ACP_VISION_PROVIDER_MARKERS: dict[str, bool] = {
+    "claude-agent-acp": True,
+    "claude-code-acp": True,  # legacy name, kept for completeness
+    "gemini-cli": True,
+    "codex-acp": True,
+}
+
+
+def _acp_command_supports_vision(command: list[str], agent_name: str) -> bool:
+    """Return True if the ACP server forwards inline images to a vision model.
+
+    Matches on either the runtime agent name from InitializeResponse (when
+    available) or the configured launch command (always available). Falls
+    back to False for unknown servers so we do not silently send images a
+    server may drop.
+    """
+    haystacks: list[str] = []
+    if agent_name:
+        haystacks.append(agent_name.lower())
+    haystacks.append(" ".join(command).lower())
+    for marker, supports in _ACP_VISION_PROVIDER_MARKERS.items():
+        if any(marker in h for h in haystacks):
+            return supports
+    return False
+
+
 # ACP auth method ID → environment variable that supplies the credential.
 # When the server reports auth_methods, we pick the first method whose
 # required env var is set.
@@ -782,6 +819,17 @@ class ACPAgent(AgentBase):
     def agent_version(self) -> str:
         """Version of the ACP server (from InitializeResponse.agent_info)."""
         return self._agent_version
+
+    def supports_vision(self) -> bool:
+        """Whether the wrapped ACP server forwards images to a vision model.
+
+        The sentinel ``self.llm`` uses ``model="acp-managed"`` which LiteLLM
+        does not recognise, so the base-class ``llm.vision_is_active()``
+        always returns False for ACP agents. Resolve the real capability
+        from the ACP server identity (launch command or the agent name
+        reported by InitializeResponse) instead.
+        """
+        return _acp_command_supports_vision(self.acp_command, self._agent_name)
 
     def get_all_llms(self) -> Generator[LLM]:
         yield self.llm

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -253,6 +253,16 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         """Returns the name of the Agent."""
         return self.__class__.__name__
 
+    def supports_vision(self) -> bool:
+        """Whether this agent can consume image content in user messages.
+
+        Default: delegate to the configured LLM. Subclasses (notably
+        ACPAgent) override this when the effective vision capability is
+        not derivable from ``self.llm.model`` — e.g. a sentinel model
+        that LiteLLM does not recognise.
+        """
+        return self.llm.vision_is_active()
+
     @property
     def static_system_message(self) -> str:
         """Compute the static portion of the system message.

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -256,10 +256,9 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
     def supports_vision(self) -> bool:
         """Whether this agent can consume image content in user messages.
 
-        Default: delegate to the configured LLM. Subclasses (notably
-        ACPAgent) override this when the effective vision capability is
-        not derivable from ``self.llm.model`` — e.g. a sentinel model
-        that LiteLLM does not recognise.
+        Delegates to the configured LLM. ACPAgent shares this default —
+        its post-init writes ``acp_model`` into ``self.llm.model`` so
+        the LiteLLM capability lookup lands on the real model.
         """
         return self.llm.vision_is_active()
 

--- a/openhands-tools/openhands/tools/file_editor/definition.py
+++ b/openhands-tools/openhands/tools/file_editor/definition.py
@@ -229,11 +229,7 @@ class FileEditorTool(ToolDefinition[FileEditorAction, FileEditorObservation]):
         base_description = "\n".join(description_lines[:2])  # First two lines
         remaining_description = "\n".join(description_lines[2:])  # Rest of description
 
-        # Add image viewing line if the agent supports vision. Delegates to
-        # ``agent.supports_vision()`` so ACPAgent can override — its sentinel
-        # LLM ("acp-managed") is unknown to LiteLLM and would otherwise
-        # report False even when the wrapped server forwards images to a
-        # vision-capable model.
+        # Add image viewing line if the agent supports vision
         if conv_state.agent.supports_vision():
             tool_description = (
                 f"{base_description}\n"

--- a/openhands-tools/openhands/tools/file_editor/definition.py
+++ b/openhands-tools/openhands/tools/file_editor/definition.py
@@ -229,8 +229,12 @@ class FileEditorTool(ToolDefinition[FileEditorAction, FileEditorObservation]):
         base_description = "\n".join(description_lines[:2])  # First two lines
         remaining_description = "\n".join(description_lines[2:])  # Rest of description
 
-        # Add image viewing line if LLM supports vision
-        if conv_state.agent.llm.vision_is_active():
+        # Add image viewing line if the agent supports vision. Delegates to
+        # ``agent.supports_vision()`` so ACPAgent can override — its sentinel
+        # LLM ("acp-managed") is unknown to LiteLLM and would otherwise
+        # report False even when the wrapped server forwards images to a
+        # vision-capable model.
+        if conv_state.agent.supports_vision():
             tool_description = (
                 f"{base_description}\n"
                 "* If `path` is an image file (.png, .jpg, .jpeg, .gif, .webp, "

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2119,12 +2119,32 @@ class TestACPAgentSupportsVision:
         assert agent.supports_vision() is False
 
     def test_vision_not_derived_from_sentinel_llm(self):
-        # The sentinel ``acp-managed`` model is unknown to LiteLLM, so
-        # the base-class llm.vision_is_active() reports False. The
-        # ACPAgent override must still return True for known providers.
+        # Without acp_model, llm.model stays "acp-managed" (unknown to
+        # LiteLLM), so the base-class llm.vision_is_active() reports
+        # False. The ACPAgent override must still return True for known
+        # providers via the server-identity fallback.
         agent = ACPAgent(acp_command=["npx", "-y", "claude-agent-acp"])
         assert agent.llm.vision_is_active() is False
         assert agent.supports_vision() is True
+
+    def test_explicit_acp_model_honours_llm_vision_check(self):
+        # When acp_model is set, llm.model carries the real model name
+        # (via ACPAgent.model_post_init) so we trust LiteLLM's answer —
+        # even when the server marker says vision-capable, the user's
+        # explicit non-vision model choice wins.
+        vision_agent = ACPAgent(
+            acp_command=["npx", "-y", "claude-agent-acp"],
+            acp_model="claude-sonnet-4-5",
+        )
+        assert vision_agent.llm.vision_is_active() is True
+        assert vision_agent.supports_vision() is True
+
+        text_only_agent = ACPAgent(
+            acp_command=["codex-acp"],
+            acp_model="gpt-3.5-turbo",
+        )
+        assert text_only_agent.llm.vision_is_active() is False
+        assert text_only_agent.supports_vision() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -13,7 +13,6 @@ from acp.exceptions import RequestError as ACPRequestError
 
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
-    _acp_command_supports_vision,
     _build_session_meta,
     _estimate_cost_from_tokens,
     _extract_token_usage,
@@ -2081,80 +2080,41 @@ class TestResolveBypassMode:
 
 
 # ---------------------------------------------------------------------------
-# _acp_command_supports_vision + ACPAgent.supports_vision()
+# ACPAgent.supports_vision()
 # ---------------------------------------------------------------------------
 
 
-class TestACPCommandSupportsVision:
+class TestACPAgentSupportsVision:
     """All three ACP providers OpenHands supports — claude-agent-acp,
     gemini-cli, codex-acp — declare prompt_capabilities.image=true and
     forward images to a vision-capable underlying model."""
 
-    def test_claude_agent_acp_command(self):
-        assert (
-            _acp_command_supports_vision(
-                ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
-                "",
-            )
-            is True
-        )
-
-    def test_claude_agent_acp_from_agent_name(self):
-        assert _acp_command_supports_vision(["/some/opaque/binary"], "claude-agent-acp")
-        assert _acp_command_supports_vision([], "claude-agent-acp")
-
-    def test_gemini_cli_command(self):
-        assert (
-            _acp_command_supports_vision(["gemini-cli", "--experimental-acp"], "")
-            is True
-        )
-
-    def test_gemini_cli_from_agent_name(self):
-        assert _acp_command_supports_vision(["node", "server.js"], "gemini-cli")
-
-    def test_codex_acp_command(self):
-        assert _acp_command_supports_vision(["codex-acp"], "") is True
-
-    def test_codex_acp_from_agent_name(self):
-        assert _acp_command_supports_vision([], "codex-acp")
-
-    def test_agent_name_takes_precedence_over_generic_command(self):
-        # A user can launch any of our three servers via ``node`` or a
-        # local path; the agent name from InitializeResponse still lets
-        # us identify the provider.
-        assert (
-            _acp_command_supports_vision(
-                ["/usr/local/bin/node", "/opt/server.js"],
-                "claude-agent-acp",
-            )
-            is True
-        )
-
-    def test_unknown_server_defaults_to_false(self):
-        # Safe default: unknown servers may silently drop image blocks,
-        # so advertise no-vision rather than send content that gets lost.
-        assert _acp_command_supports_vision(["some-random-acp-server"], "") is False
-
-    def test_empty_inputs_default_to_false(self):
-        assert _acp_command_supports_vision([], "") is False
-
-
-class TestACPAgentSupportsVision:
-    def test_claude_agent_supports_vision(self):
+    def test_claude_agent_via_command(self):
         agent = ACPAgent(
             acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
         )
         assert agent.supports_vision() is True
 
-    def test_gemini_cli_supports_vision(self):
+    def test_gemini_cli_via_command(self):
         agent = ACPAgent(acp_command=["gemini-cli", "--experimental-acp"])
         assert agent.supports_vision() is True
 
-    def test_codex_acp_supports_vision(self):
+    def test_codex_acp_via_command(self):
         agent = ACPAgent(acp_command=["codex-acp"])
         assert agent.supports_vision() is True
 
-    def test_unknown_acp_server_does_not_claim_vision(self):
+    def test_agent_name_resolves_opaque_launcher(self):
+        # A user can launch any of our three servers via ``node`` or a
+        # local path; the agent name from InitializeResponse still lets
+        # us identify the provider.
+        agent = ACPAgent(acp_command=["/usr/local/bin/node", "/opt/server.js"])
+        assert agent.supports_vision() is False
+        agent._agent_name = "claude-agent-acp"
+        assert agent.supports_vision() is True
+
+    def test_unknown_acp_server_defaults_to_false(self):
+        # Unknown servers may silently drop image blocks, so advertise
+        # no-vision rather than send content that gets lost.
         agent = ACPAgent(acp_command=["echo", "test"])
         assert agent.supports_vision() is False
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -13,6 +13,7 @@ from acp.exceptions import RequestError as ACPRequestError
 
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
+    _acp_command_supports_vision,
     _build_session_meta,
     _estimate_cost_from_tokens,
     _extract_token_usage,
@@ -2077,6 +2078,93 @@ class TestResolveBypassMode:
 
     def test_empty_name_defaults_to_full_access(self):
         assert _resolve_bypass_mode("") == "full-access"
+
+
+# ---------------------------------------------------------------------------
+# _acp_command_supports_vision + ACPAgent.supports_vision()
+# ---------------------------------------------------------------------------
+
+
+class TestACPCommandSupportsVision:
+    """All three ACP providers OpenHands supports — claude-agent-acp,
+    gemini-cli, codex-acp — declare prompt_capabilities.image=true and
+    forward images to a vision-capable underlying model."""
+
+    def test_claude_agent_acp_command(self):
+        assert (
+            _acp_command_supports_vision(
+                ["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+                "",
+            )
+            is True
+        )
+
+    def test_claude_agent_acp_from_agent_name(self):
+        assert _acp_command_supports_vision(["/some/opaque/binary"], "claude-agent-acp")
+        assert _acp_command_supports_vision([], "claude-agent-acp")
+
+    def test_gemini_cli_command(self):
+        assert (
+            _acp_command_supports_vision(["gemini-cli", "--experimental-acp"], "")
+            is True
+        )
+
+    def test_gemini_cli_from_agent_name(self):
+        assert _acp_command_supports_vision(["node", "server.js"], "gemini-cli")
+
+    def test_codex_acp_command(self):
+        assert _acp_command_supports_vision(["codex-acp"], "") is True
+
+    def test_codex_acp_from_agent_name(self):
+        assert _acp_command_supports_vision([], "codex-acp")
+
+    def test_agent_name_takes_precedence_over_generic_command(self):
+        # A user can launch any of our three servers via ``node`` or a
+        # local path; the agent name from InitializeResponse still lets
+        # us identify the provider.
+        assert (
+            _acp_command_supports_vision(
+                ["/usr/local/bin/node", "/opt/server.js"],
+                "claude-agent-acp",
+            )
+            is True
+        )
+
+    def test_unknown_server_defaults_to_false(self):
+        # Safe default: unknown servers may silently drop image blocks,
+        # so advertise no-vision rather than send content that gets lost.
+        assert _acp_command_supports_vision(["some-random-acp-server"], "") is False
+
+    def test_empty_inputs_default_to_false(self):
+        assert _acp_command_supports_vision([], "") is False
+
+
+class TestACPAgentSupportsVision:
+    def test_claude_agent_supports_vision(self):
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
+        )
+        assert agent.supports_vision() is True
+
+    def test_gemini_cli_supports_vision(self):
+        agent = ACPAgent(acp_command=["gemini-cli", "--experimental-acp"])
+        assert agent.supports_vision() is True
+
+    def test_codex_acp_supports_vision(self):
+        agent = ACPAgent(acp_command=["codex-acp"])
+        assert agent.supports_vision() is True
+
+    def test_unknown_acp_server_does_not_claim_vision(self):
+        agent = ACPAgent(acp_command=["echo", "test"])
+        assert agent.supports_vision() is False
+
+    def test_vision_not_derived_from_sentinel_llm(self):
+        # The sentinel ``acp-managed`` model is unknown to LiteLLM, so
+        # the base-class llm.vision_is_active() reports False. The
+        # ACPAgent override must still return True for known providers.
+        agent = ACPAgent(acp_command=["npx", "-y", "claude-agent-acp"])
+        assert agent.llm.vision_is_active() is False
+        assert agent.supports_vision() is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2085,66 +2085,25 @@ class TestResolveBypassMode:
 
 
 class TestACPAgentSupportsVision:
-    """All three ACP providers OpenHands supports — claude-agent-acp,
-    gemini-cli, codex-acp — declare prompt_capabilities.image=true and
-    forward images to a vision-capable underlying model."""
+    """ACPAgent inherits AgentBase.supports_vision(), which delegates to
+    llm.vision_is_active(). ACPAgent.model_post_init() writes acp_model
+    into llm.model, so LiteLLM resolves the real capability for the
+    configured model."""
 
-    def test_claude_agent_via_command(self):
+    def test_vision_capable_model(self):
         agent = ACPAgent(
-            acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
-        )
-        assert agent.supports_vision() is True
-
-    def test_gemini_cli_via_command(self):
-        agent = ACPAgent(acp_command=["gemini-cli", "--experimental-acp"])
-        assert agent.supports_vision() is True
-
-    def test_codex_acp_via_command(self):
-        agent = ACPAgent(acp_command=["codex-acp"])
-        assert agent.supports_vision() is True
-
-    def test_agent_name_resolves_opaque_launcher(self):
-        # A user can launch any of our three servers via ``node`` or a
-        # local path; the agent name from InitializeResponse still lets
-        # us identify the provider.
-        agent = ACPAgent(acp_command=["/usr/local/bin/node", "/opt/server.js"])
-        assert agent.supports_vision() is False
-        agent._agent_name = "claude-agent-acp"
-        assert agent.supports_vision() is True
-
-    def test_unknown_acp_server_defaults_to_false(self):
-        # Unknown servers may silently drop image blocks, so advertise
-        # no-vision rather than send content that gets lost.
-        agent = ACPAgent(acp_command=["echo", "test"])
-        assert agent.supports_vision() is False
-
-    def test_vision_not_derived_from_sentinel_llm(self):
-        # Without acp_model, llm.model stays "acp-managed" (unknown to
-        # LiteLLM), so the base-class llm.vision_is_active() reports
-        # False. The ACPAgent override must still return True for known
-        # providers via the server-identity fallback.
-        agent = ACPAgent(acp_command=["npx", "-y", "claude-agent-acp"])
-        assert agent.llm.vision_is_active() is False
-        assert agent.supports_vision() is True
-
-    def test_explicit_acp_model_honours_llm_vision_check(self):
-        # When acp_model is set, llm.model carries the real model name
-        # (via ACPAgent.model_post_init) so we trust LiteLLM's answer —
-        # even when the server marker says vision-capable, the user's
-        # explicit non-vision model choice wins.
-        vision_agent = ACPAgent(
-            acp_command=["npx", "-y", "claude-agent-acp"],
+            acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
             acp_model="claude-sonnet-4-5",
         )
-        assert vision_agent.llm.vision_is_active() is True
-        assert vision_agent.supports_vision() is True
+        assert agent.supports_vision() is True
 
-        text_only_agent = ACPAgent(
+    def test_non_vision_model_is_honoured(self):
+        # User's explicit non-vision model choice wins.
+        agent = ACPAgent(
             acp_command=["codex-acp"],
             acp_model="gpt-3.5-turbo",
         )
-        assert text_only_agent.llm.vision_is_active() is False
-        assert text_only_agent.supports_vision() is False
+        assert agent.supports_vision() is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/file_editor/test_file_editor_tool.py
+++ b/tests/tools/file_editor/test_file_editor_tool.py
@@ -340,14 +340,15 @@ def test_file_editor_tool_image_viewing_line_with_vision_disabled():
 
 
 def test_file_editor_tool_image_viewing_line_for_acp_agent():
-    """ACPAgent advertises vision based on the wrapped provider, not its
-    sentinel LLM. All three providers OpenHands supports (claude-agent-acp,
-    gemini-cli, codex-acp) forward images to vision-capable models."""
+    """ACPAgent resolves vision capability through its configured acp_model,
+    which ACPAgent.model_post_init() writes into llm.model so LiteLLM can
+    look up the capability — same path as a regular Agent."""
     from openhands.sdk.agent.acp_agent import ACPAgent
 
     with tempfile.TemporaryDirectory() as temp_dir:
         agent = ACPAgent(
-            acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
+            acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"],
+            acp_model="claude-sonnet-4-5",
         )
         conv_state = ConversationState.create(
             id=uuid4(),

--- a/tests/tools/file_editor/test_file_editor_tool.py
+++ b/tests/tools/file_editor/test_file_editor_tool.py
@@ -337,3 +337,28 @@ def test_file_editor_tool_image_viewing_line_with_vision_disabled():
         # Check that the image viewing line is NOT included in description
         assert "is an image file" not in tool.description
         assert "displays the image content" not in tool.description
+
+
+def test_file_editor_tool_image_viewing_line_for_acp_agent():
+    """ACPAgent advertises vision based on the wrapped provider, not its
+    sentinel LLM. All three providers OpenHands supports (claude-agent-acp,
+    gemini-cli, codex-acp) forward images to vision-capable models."""
+    from openhands.sdk.agent.acp_agent import ACPAgent
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
+        )
+        conv_state = ConversationState.create(
+            id=uuid4(),
+            agent=agent,
+            workspace=LocalWorkspace(working_dir=temp_dir),
+        )
+
+        tools = FileEditorTool.create(conv_state)
+        tool = tools[0]
+
+        assert (
+            "If `path` is an image file (.png, .jpg, .jpeg, .gif, .webp, .bmp)"
+            in tool.description
+        )


### PR DESCRIPTION
## Summary

When OpenHands runs an ACPAgent, the sentinel `LLM(model="acp-managed")` is unknown to LiteLLM, so `agent.llm.vision_is_active()` returns False. Tools that gate behaviour on vision support — notably `FileEditorTool`, which hides its image-view affordance — therefore never advertised image reading even when the wrapped ACP server forwards images to a vision-capable model (all three providers OpenHands supports do).

This PR adds the missing abstraction and relies on #2881 (already merged) to do the real work:

1. **`AgentBase.supports_vision()`** — new method that delegates to `self.llm.vision_is_active()`. A clean hook for tools and for future agent subclasses.
2. **`FileEditorTool.create`** — switches from `conv_state.agent.llm.vision_is_active()` to `conv_state.agent.supports_vision()`.

No ACPAgent override is needed: #2881 already writes `acp_model` into `self.llm.model` in `model_post_init()`, so the base-class delegation lands on the real model name and LiteLLM resolves the capability correctly. A non-vision `acp_model` correctly reports no-vision.

## Test plan

- [x] `uv run pytest tests/sdk/agent/test_acp_agent.py tests/tools/file_editor/test_file_editor_tool.py` — 169 passed
- New tests: `TestACPAgentSupportsVision` covers both a vision-capable and a non-vision `acp_model`; `test_file_editor_tool_image_viewing_line_for_acp_agent` covers the end-to-end path.

Part of #2471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:992a671-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-992a671-python \
  ghcr.io/openhands/agent-server:992a671-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:992a671-golang-amd64
ghcr.io/openhands/agent-server:992a671-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:992a671-golang-arm64
ghcr.io/openhands/agent-server:992a671-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:992a671-java-amd64
ghcr.io/openhands/agent-server:992a671-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:992a671-java-arm64
ghcr.io/openhands/agent-server:992a671-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:992a671-python-amd64
ghcr.io/openhands/agent-server:992a671-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:992a671-python-arm64
ghcr.io/openhands/agent-server:992a671-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:992a671-golang
ghcr.io/openhands/agent-server:992a671-java
ghcr.io/openhands/agent-server:992a671-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `992a671-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `992a671-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->