### PR TITLE
fix(acp): show the real model in logs and serialized state

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -116,9 +116,17 @@ _ACTIVITY_SIGNAL_INTERVAL: float = 30.0
 _TERMINAL_TOOL_CALL_STATUSES: frozenset[str] = frozenset({"completed", "failed"})
 
 
+# Stable identifier stamped onto the sentinel LLM so downstream code
+# (e.g. title_utils) can detect "this LLM cannot be called" without
+# relying on the model name — which we overwrite with the real model
+# once ``acp_model`` is known, so logs and serialized state show the
+# actual model rather than "acp-managed".
+ACP_SENTINEL_USAGE_ID = "acp-managed"
+
+
 def _make_dummy_llm() -> LLM:
     """Create a dummy LLM that should never be called directly."""
-    return LLM(model="acp-managed")
+    return LLM(model="acp-managed", usage_id=ACP_SENTINEL_USAGE_ID)
 
 
 # ---------------------------------------------------------------------------
@@ -657,10 +665,13 @@ class ACPAgent(AgentBase):
 
     def model_post_init(self, __context: object) -> None:
         super().model_post_init(__context)
-        # Propagate the actual model name to metrics so that cost/token
-        # entries are attributed to the real model, not the sentinel
-        # "acp-managed" placeholder.
+        # Propagate the actual model name to the sentinel LLM and its
+        # metrics so that logs, serialized state, and cost/token entries
+        # show the real model instead of the "acp-managed" placeholder.
+        # The ACP-sentinel marker lives on ``llm.usage_id`` and is
+        # independent of the model name.
         if self.acp_model:
+            self.llm.model = self.acp_model
             self.llm.metrics.model_name = self.acp_model
             if self.llm.metrics.accumulated_token_usage is not None:
                 self.llm.metrics.accumulated_token_usage.model = self.acp_model

--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -161,7 +161,10 @@ def generate_title_from_message(
     message: str, llm: LLM | None = None, max_length: int = 50
 ) -> str:
     """Generate a title from an already-extracted user message."""
-    llm_to_use = None if llm and llm.model == "acp-managed" else llm
+    # Skip the ACP sentinel LLM — it has no credentials and cannot be
+    # called. Detected via ``usage_id`` so the real model name can still
+    # appear in logs and serialized state.
+    llm_to_use = None if llm and llm.usage_id == "acp-managed" else llm
 
     if llm_to_use:
         llm_title = generate_title_with_llm(message, llm_to_use, max_length)

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -1660,10 +1660,11 @@ class TestAutoTitle:
         title: str | None = None,
         title_llm_profile: str | None = None,
         llm_model: str = "gpt-4o",
+        llm_usage_id: str = "test-llm",
     ) -> AsyncMock:
         stored = StoredConversation(
             id=uuid4(),
-            agent=Agent(llm=LLM(model=llm_model, usage_id="test-llm"), tools=[]),
+            agent=Agent(llm=LLM(model=llm_model, usage_id=llm_usage_id), tools=[]),
             workspace=LocalWorkspace(working_dir="workspace/project"),
             confirmation_policy=NeverConfirm(),
             initial_message=None,
@@ -1888,7 +1889,7 @@ class TestAutoTitle:
     @pytest.mark.asyncio
     async def test_autotitle_falls_back_for_acp_managed_llm(self):
         """ACP-managed agents with no title profile → truncation fallback."""
-        service = self._make_service(llm_model="acp-managed")
+        service = self._make_service(llm_usage_id="acp-managed")
         subscriber = AutoTitleSubscriber(service=service)
 
         await subscriber(self._user_message_event("Fix the login bug"))

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -105,6 +105,18 @@ class TestACPAgentInstantiation:
             agent.llm.metrics.accumulated_token_usage.model == "gemini-3-flash-preview"
         )
 
+    def test_acp_model_propagated_to_llm_model(self):
+        """acp_model overrides the sentinel model name so logs/state show
+        the real model. The ACP-sentinel marker lives on usage_id."""
+        agent = _make_agent(acp_model="claude-opus-4-6")
+        assert agent.llm.model == "claude-opus-4-6"
+        assert agent.llm.usage_id == "acp-managed"
+
+    def test_sentinel_usage_id_without_acp_model(self):
+        agent = _make_agent()
+        assert agent.llm.model == "acp-managed"
+        assert agent.llm.usage_id == "acp-managed"
+
     def test_no_acp_model_keeps_sentinel(self):
         """Without acp_model, metrics.model_name remains the sentinel value."""
         agent = _make_agent()


### PR DESCRIPTION
## Summary

Split the ACP sentinel LLM's two concerns. Today `LLM(model="acp-managed")` is both the placeholder shown everywhere AND the signal that tells `title_utils` "don't call this — it has no credentials." That means logs, serialized agent state, and any tool that reads `agent.llm.model` sees `"acp-managed"` even when a real `acp_model` is configured.

This PR:

- Stamps the sentinel marker on `llm.usage_id = "acp-managed"` instead — a field that is internal, never shown to the ACP server, and independent of the model name.
- Overwrites `llm.model` with `self.acp_model` in `ACPAgent.model_post_init()` when `acp_model` is set, so the rest of the system sees the actual model in logs and state dumps.
- Switches `title_utils` to detect the sentinel via `usage_id` instead of `model`.

Zero behavior change when `acp_model` isn't set — `llm.model` stays `"acp-managed"`.

## Test plan

- [x] `uv run pytest tests/sdk/agent/test_acp_agent.py` — 158 passed
- [x] `uv run pytest tests/agent_server/test_conversation_service.py::TestAutoTitle::test_autotitle_falls_back_for_acp_managed_llm` — passes with the new `usage_id`-based signal
- Added `test_acp_model_propagated_to_llm_model` and `test_sentinel_usage_id_without_acp_model` to lock in the contract.

Part of #2471.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:55faae1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-55faae1-python \
  ghcr.io/openhands/agent-server:55faae1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:55faae1-golang-amd64
ghcr.io/openhands/agent-server:55faae1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:55faae1-golang-arm64
ghcr.io/openhands/agent-server:55faae1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:55faae1-java-amd64
ghcr.io/openhands/agent-server:55faae1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:55faae1-java-arm64
ghcr.io/openhands/agent-server:55faae1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:55faae1-python-amd64
ghcr.io/openhands/agent-server:55faae1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:55faae1-python-arm64
ghcr.io/openhands/agent-server:55faae1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:55faae1-golang
ghcr.io/openhands/agent-server:55faae1-java
ghcr.io/openhands/agent-server:55faae1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `55faae1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `55faae1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->