### PR TITLE
fix(skills): Load installed skills in load_user_skills()

### DIFF
--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -729,6 +729,10 @@ def load_user_skills() -> list[Skill]:
     with earlier entries in USER_SKILLS_DIRS taking precedence for duplicate
     names.
 
+    Also loads enabled installed skills from ~/.openhands/skills/installed/
+    (managed via install_skill/uninstall_skill). Installed skills have lower
+    precedence than user skills from the directories above.
+
     Returns:
         List of Skill objects loaded from user directories.
         Returns empty list if no skills found or loading fails.
@@ -737,6 +741,17 @@ def load_user_skills() -> list[Skill]:
     seen_names: set[str] = set()
 
     _load_and_merge_from_dirs(USER_SKILLS_DIRS, seen_names, all_skills, "user skills")
+
+    # Load enabled installed skills (lower precedence than user skills)
+    try:
+        from openhands.sdk.skills.installed import load_installed_skills
+
+        for skill in load_installed_skills():
+            if skill.name not in seen_names:
+                seen_names.add(skill.name)
+                all_skills.append(skill)
+    except Exception as e:
+        logger.warning(f"Failed to load installed skills: {e}")
 
     logger.debug(
         f"Loaded {len(all_skills)} user skills: {[s.name for s in all_skills]}"

--- a/tests/sdk/skills/test_load_user_skills.py
+++ b/tests/sdk/skills/test_load_user_skills.py
@@ -9,8 +9,11 @@ from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.skills import (
     KeywordTrigger,
     Skill,
+    installed,
     load_user_skills,
+    skill,
 )
+from openhands.sdk.skills.installed import disable_skill, install_skill
 
 
 @pytest.fixture
@@ -304,5 +307,91 @@ def test_agent_context_explicit_skill_takes_precedence(temp_user_skills_dir):
         assert len(context.skills) == 1
         # Explicit skill should be used, not the user skill
         assert context.skills[0].content == "Explicit skill content."
+    finally:
+        skill.USER_SKILLS_DIRS = original_dirs
+
+
+def test_load_user_skills_includes_installed_skills(tmp_path, monkeypatch):
+    """Test that load_user_skills also loads enabled installed skills."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    installed_dir = tmp_path / "skills" / "installed"
+    installed_dir.mkdir()
+
+    # Create and install a skill
+    source_dir = tmp_path / "my-installed-skill"
+    source_dir.mkdir()
+    (source_dir / "SKILL.md").write_text(
+        "---\nname: my-installed-skill\ndescription: Installed skill\n---\n"
+        "Installed skill content."
+    )
+    install_skill(str(source_dir), installed_dir=installed_dir)
+
+    original_dirs = skill.USER_SKILLS_DIRS
+    try:
+        skill.USER_SKILLS_DIRS = [skills_dir]
+        monkeypatch.setattr(installed, "DEFAULT_INSTALLED_SKILLS_DIR", installed_dir)
+        skills = load_user_skills()
+        skill_names = {s.name for s in skills}
+        assert "my-installed-skill" in skill_names
+    finally:
+        skill.USER_SKILLS_DIRS = original_dirs
+
+
+def test_load_user_skills_user_skill_takes_precedence_over_installed(
+    tmp_path, monkeypatch
+):
+    """Test that user skills take precedence over installed skills."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    installed_dir = tmp_path / "skills" / "installed"
+    installed_dir.mkdir()
+
+    # Create a user skill
+    (skills_dir / "duplicate.md").write_text("---\nname: duplicate\n---\nUser version.")
+
+    # Install a skill with the same name
+    source_dir = tmp_path / "duplicate"
+    source_dir.mkdir()
+    (source_dir / "SKILL.md").write_text(
+        "---\nname: duplicate\ndescription: dup\n---\nInstalled version."
+    )
+    install_skill(str(source_dir), installed_dir=installed_dir)
+
+    original_dirs = skill.USER_SKILLS_DIRS
+    try:
+        skill.USER_SKILLS_DIRS = [skills_dir]
+        monkeypatch.setattr(installed, "DEFAULT_INSTALLED_SKILLS_DIR", installed_dir)
+        skills = load_user_skills()
+        dupes = [s for s in skills if s.name == "duplicate"]
+        assert len(dupes) == 1
+        assert dupes[0].content == "User version."
+    finally:
+        skill.USER_SKILLS_DIRS = original_dirs
+
+
+def test_load_user_skills_disabled_installed_skill_excluded(tmp_path, monkeypatch):
+    """Test that disabled installed skills are not loaded."""
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    installed_dir = tmp_path / "skills" / "installed"
+    installed_dir.mkdir()
+
+    # Install and disable a skill
+    source_dir = tmp_path / "disabled-skill"
+    source_dir.mkdir()
+    (source_dir / "SKILL.md").write_text(
+        "---\nname: disabled-skill\ndescription: test\n---\nContent."
+    )
+    install_skill(str(source_dir), installed_dir=installed_dir)
+    disable_skill("disabled-skill", installed_dir=installed_dir)
+
+    original_dirs = skill.USER_SKILLS_DIRS
+    try:
+        skill.USER_SKILLS_DIRS = [skills_dir]
+        monkeypatch.setattr(installed, "DEFAULT_INSTALLED_SKILLS_DIR", installed_dir)
+        skills = load_user_skills()
+        skill_names = {s.name for s in skills}
+        assert "disabled-skill" not in skill_names
     finally:
         skill.USER_SKILLS_DIRS = original_dirs


### PR DESCRIPTION
- [x] A human has tested these changes.

  ---

  ## Why

  `install_skill()` writes skills to `~/.openhands/skills/installed/<name>/SKILL.md`, but `load_user_skills()` only scans one level deep under `~/.openhands/skills/` via `find_skill_md_directories()`. Installed skills are silently not loaded into the agent context.

  ## Summary

  - Add `load_installed_skills()` call at the end of `load_user_skills()` to merge enabled installed skills with lower precedence than user skills
  - Add 3 tests: installed skill is loaded, user skill takes precedence over installed, disabled installed skill is excluded

  ## Issue Number

  Fixes #2882

  ## How to Test

  ```bash
  uv run pytest tests/sdk/skills/test_load_user_skills.py -v
```

##  Manual verification:

  1. Create a test skill: mkdir -p /tmp/pirate-mode && echo -e "---\nname: pirate-mode\ndescription: test\n---\n# Test" > /tmp/pirate-mode/SKILL.md
  2. Install it: python -c "from openhands.sdk.skills import install_skill; install_skill('/tmp/pirate-mode')"
  3. Verify it loads: python -c "from openhands.sdk.skills.skill import load_user_skills; print([s.name for s in load_user_skills()])"
  4. pirate-mode should appear in the list

 ## Video/Screenshots

  N/A — backend-only change, verified via tests.

##  Type

  - [x] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Breaking change
  - [ ] Docs / chore

 ## Notes

  - Uses lazy import (from openhands.sdk.skills.installed import load_installed_skills) inside the function to avoid circular imports.
  - Installed skills have lower precedence: if a user has a skill with the same name in ~/.openhands/skills/, the user version wins.
  - Disabled installed skills (via disable_skill()) are correctly excluded.