### PR TITLE
fix(ci): pass extensions-version so sub-agent review script is used

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -49,6 +49,9 @@ jobs:
                   review-style: roasted
                   # Enable experimental sub-agent delegation for file-level reviews
                   use-sub-agents: 'true'
+                  # Must match the branch in `uses:` so the script checkout
+                  # picks up the sub-agent code (extensions#164 not yet on main)
+                  extensions-version: feat/pr-review-sub-agent-delegation
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.PAT_TOKEN }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Problem

The PR review workflow points to `@feat/pr-review-sub-agent-delegation` for the action definition and sets `use-sub-agents: true`, but the action's `action.yml` checks out the extensions repo at `extensions-version` (which defaults to `main`) for the actual Python script it runs:

```yaml
# action.yml checks out at the extensions-version input (default: main)
- uses: actions/checkout@v4
  with:
    repository: OpenHands/extensions
    ref: ${{ inputs.extensions-version }}   # <-- defaults to "main"
    path: extensions

# Then runs the script from that checkout
- run: python ../extensions/plugins/pr-review/scripts/agent_script.py
```

Since [OpenHands/extensions#164](https://github.com/OpenHands/extensions/pull/164) hasn't been merged to `main` yet, the script that actually executes is the **old `main` branch version** (~928 lines) which has no sub-agent code — not the feature branch version (~1062 lines).

**Evidence from [PR #2886](https://github.com/OpenHands/software-agent-sdk/pull/2886) CI logs:**
- `USE_SUB_AGENTS=true` is set ✅
- Action downloaded from `@feat/pr-review-sub-agent-delegation` ✅
- But no "Sub-agent delegation enabled" log message appears ❌
- Agent created with only `[terminal, file_editor, task_tracker]` — no `TaskToolSet` ❌
- Only a single conversation ran (no sub-agent delegation) ❌

## Fix

Explicitly pass `extensions-version: feat/pr-review-sub-agent-delegation` so the checkout matches the action branch and the sub-agent code is available at runtime.

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6ab7bab9-29d1-42d0-810b-c555dc07ed8c)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ad109e1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ad109e1-python \
  ghcr.io/openhands/agent-server:ad109e1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ad109e1-golang-amd64
ghcr.io/openhands/agent-server:ad109e1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ad109e1-golang-arm64
ghcr.io/openhands/agent-server:ad109e1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ad109e1-java-amd64
ghcr.io/openhands/agent-server:ad109e1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ad109e1-java-arm64
ghcr.io/openhands/agent-server:ad109e1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ad109e1-python-amd64
ghcr.io/openhands/agent-server:ad109e1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ad109e1-python-arm64
ghcr.io/openhands/agent-server:ad109e1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ad109e1-golang
ghcr.io/openhands/agent-server:ad109e1-java
ghcr.io/openhands/agent-server:ad109e1-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ad109e1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ad109e1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->