### PR TITLE
Add kimi-k2.6 model to resolve_model_config.py

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -71,6 +71,15 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # https://www.kimi.com/blog/kimi-k2-6
+    "kimi-k2.6": {
+        "id": "kimi-k2.6",
+        "display_name": "Kimi K2.6",
+        "llm_config": {
+            "model": "litellm_proxy/moonshot/kimi-k2.6",
+            "temperature": 1.0,
+        },
+    },
     # https://www.alibabacloud.com/help/en/model-studio/deep-thinking
     "qwen3-max-thinking": {
         "id": "qwen3-max-thinking",

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -179,6 +179,7 @@ FORCE_STRING_SERIALIZER_MODELS: list[str] = [
 SEND_REASONING_CONTENT_MODELS: list[str] = [
     "kimi-k2-thinking",
     "kimi-k2.5",
+    "kimi-k2.6",
     "openrouter/minimax-m2",  # MiniMax-M2 via OpenRouter (interleaved thinking)
     "deepseek/deepseek-reasoner",
 ]

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -621,3 +621,13 @@ def test_claude_opus_4_7_config():
     assert model["id"] == "claude-opus-4-7"
     assert model["display_name"] == "Claude Opus 4.7"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-7"
+
+
+def test_kimi_k2_6_config():
+    """Test that kimi-k2.6 has correct configuration."""
+    model = MODELS["kimi-k2.6"]
+
+    assert model["id"] == "kimi-k2.6"
+    assert model["display_name"] == "Kimi K2.6"
+    assert model["llm_config"]["model"] == "litellm_proxy/moonshot/kimi-k2.6"
+    assert model["llm_config"]["temperature"] == 1.0


### PR DESCRIPTION
## Summary
Adds the Kimi K2.6 model (https://www.kimi.com/blog/kimi-k2-6) to the evaluation model configurations.

## Changes
- Added `kimi-k2.6` model configuration with temperature 1.0 (reasoning model)
- Added `kimi-k2.6` to `SEND_REASONING_CONTENT_MODELS` in model_features.py
- Added `test_kimi_k2_6_config()` test function

## Configuration
- Model ID: kimi-k2.6
- Provider: moonshot
- Temperature: 1.0 - Required for reasoning models per ADDINGMODEL.md guidelines
- Uses `litellm_proxy/moonshot/kimi-k2.6`

Fixes #2893

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/da62f04f-2a6e-4318-bafb-20e335d0408d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e47067a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e47067a-python \
  ghcr.io/openhands/agent-server:e47067a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e47067a-golang-amd64
ghcr.io/openhands/agent-server:e47067a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e47067a-golang-arm64
ghcr.io/openhands/agent-server:e47067a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e47067a-java-amd64
ghcr.io/openhands/agent-server:e47067a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e47067a-java-arm64
ghcr.io/openhands/agent-server:e47067a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e47067a-python-amd64
ghcr.io/openhands/agent-server:e47067a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e47067a-python-arm64
ghcr.io/openhands/agent-server:e47067a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e47067a-golang
ghcr.io/openhands/agent-server:e47067a-java
ghcr.io/openhands/agent-server:e47067a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e47067a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e47067a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->