### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH for eval dispatch

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -255,7 +255,7 @@ jobs:
               env:
                   DEFAULT_MODEL: ${{ steps.load-models.outputs.default_model }}
                   ALLOWED_MODEL_IDS_JSON: ${{ steps.load-models.outputs.allowed_model_ids }}
-                  PAT_TOKEN_DEFAULT: ${{ secrets.PAT_TOKEN }}
+                  PAT_TOKEN_DEFAULT: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
               run: |
                   set -euo pipefail
 


### PR DESCRIPTION
## Summary

- Replaces `secrets.PAT_TOKEN` with `secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH` in the "Resolve parameters" step of `run-eval.yml`
- `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH` is a fine-grained PAT with only `actions:write` on `OpenHands/evaluation` — no access to code, PRs, issues, or any other repo
- The internal `PAT_TOKEN` env var and curl auth header are unchanged — only the secret source changes

## Before merging

Add `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH` as a repo secret in `OpenHands/software-agent-sdk` with the value of the `OPENHANDS_BOT_PAT_TOKEN_EVAL_DISPATCH` fine-grained PAT.

Part of OpenHands/evaluation#428 (PAT_TOKEN blast radius reduction).

## Validation ✓

Successfully tested end-to-end dispatch with new PAT token:
- **SDK workflow**: https://github.com/OpenHands/software-agent-sdk/actions/runs/24689229192
- **Evaluation workflow**: https://github.com/OpenHands/evaluation/actions/runs/24689250885
- **Test**: gaia benchmark with 1 instance, model: claude-sonnet-4-5-20250929
- **Result**: Evaluation workflow successfully created and in_progress