### PR TITLE
fix(llm): pass stream_options to preserve cache token metrics in streaming mode

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1141,9 +1141,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 # cached_tokens, etc.) are not silently discarded by
                 # litellm's streaming handler.
                 if enable_streaming:
-                    kwargs.setdefault(
-                        "stream_options", {"include_usage": True}
-                    )
+                    kwargs.setdefault("stream_options", {"include_usage": True})
 
                 # Some providers need renames handled in _normalize_call_kwargs.
                 ret = litellm_completion(

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1136,6 +1136,15 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 )
                 api_key_value = self._get_litellm_api_key_value()
 
+                # When streaming, request usage in the final chunk so that
+                # detailed token breakdowns (prompt_tokens_details with
+                # cached_tokens, etc.) are not silently discarded by
+                # litellm's streaming handler.
+                if enable_streaming:
+                    kwargs.setdefault(
+                        "stream_options", {"include_usage": True}
+                    )
+
                 # Some providers need renames handled in _normalize_call_kwargs.
                 ret = litellm_completion(
                     model=self.model,

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -12,6 +12,8 @@ from litellm.types.utils import (
     Function,
     Message as LiteLLMMessage,
     ModelResponse,
+    ModelResponseStream,
+    PromptTokensDetailsWrapper,
     StreamingChoices,
     Usage,
 )
@@ -655,6 +657,116 @@ def test_llm_completion_function_call_vs_non_function_call_mode(mock_completion)
 
     # Non-native mode should not pass tools (they're handled via prompts)
     assert non_native_call_kwargs.get("tools") is None
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_llm_streaming_preserves_cache_read_tokens(mock_completion):
+    """Test that cache_read_tokens from prompt_tokens_details survive streaming.
+
+    Regression test for: when streaming through a LiteLLM proxy, the proxy
+    sends a final usage-only chunk (empty choices) with prompt_tokens_details
+    including cached_tokens.  If the SDK doesn't request
+    stream_options={"include_usage": True}, litellm's streaming handler
+    silently discards this chunk and falls back to calculate_total_usage()
+    which only keeps prompt_tokens/completion_tokens — losing
+    prompt_tokens_details.cached_tokens entirely.
+
+    This test creates realistic streaming chunks (as sent by a LiteLLM proxy)
+    including a usage-only final chunk with cached_tokens=4000 and lets the
+    real stream_chunk_builder reassemble them.  It verifies:
+    1. stream_options={"include_usage": True} is passed to litellm_completion
+    2. cache_read_tokens is correctly reported in the response metrics
+    """
+    # --- Simulate chunks as sent by a LiteLLM proxy ---
+    content_chunk = ModelResponseStream(
+        id="chatcmpl-test",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="Hello world", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="minimax/MiniMax-M2.5",
+        object="chat.completion.chunk",
+    )
+
+    finish_chunk = ModelResponseStream(
+        id="chatcmpl-test",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content=None, role=None),
+            )
+        ],
+        created=1234567890,
+        model="minimax/MiniMax-M2.5",
+        object="chat.completion.chunk",
+    )
+
+    # Final usage-only chunk (empty choices) — this is the chunk the proxy
+    # sends when stream_options={"include_usage": True} is set upstream.
+    usage_chunk = ModelResponseStream(
+        id="chatcmpl-test",
+        choices=[],
+        created=1234567890,
+        model="minimax/MiniMax-M2.5",
+        object="chat.completion.chunk",
+        usage=Usage(
+            prompt_tokens=5000,
+            completion_tokens=100,
+            total_tokens=5100,
+            prompt_tokens_details=PromptTokensDetailsWrapper(cached_tokens=4000),
+        ),
+    )
+
+    mock_stream = MagicMock(spec=CustomStreamWrapper)
+    mock_stream.__iter__.return_value = iter(
+        [content_chunk, finish_chunk, usage_chunk]
+    )
+    mock_completion.return_value = mock_stream
+
+    llm = LLM(
+        usage_id="test-llm",
+        model="minimax/MiniMax-M2.5",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+    )
+
+    received_chunks = []
+    messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    response = llm.completion(
+        messages=messages, stream=True, on_token=received_chunks.append
+    )
+
+    # The usage-only chunk must reach the SDK (not be discarded)
+    assert len(received_chunks) == 3
+
+    # stream_chunk_builder must preserve prompt_tokens_details
+    assert response.raw_response.usage is not None
+    assert response.raw_response.usage.prompt_tokens == 5000
+    assert response.raw_response.usage.completion_tokens == 100
+    assert response.raw_response.usage.prompt_tokens_details is not None
+    assert response.raw_response.usage.prompt_tokens_details.cached_tokens == 4000
+
+    # Telemetry must record cache_read_tokens from prompt_tokens_details
+    acc = response.metrics.accumulated_token_usage
+    assert acc is not None
+    assert acc.cache_read_tokens == 4000
+
+    # Verify stream_options={"include_usage": True} was passed to litellm
+    call_kwargs = mock_completion.call_args
+    assert call_kwargs is not None
+    actual_stream_options = call_kwargs.kwargs.get(
+        "stream_options"
+    ) or call_kwargs[1].get("stream_options")
+    assert actual_stream_options == {"include_usage": True}, (
+        f"Expected stream_options={{include_usage: True}}, got {actual_stream_options}"
+    )
 
 
 # This file focuses on LLM completion functionality, configuration options,

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -1,7 +1,7 @@
 """Tests for LLM completion functionality, configuration, and metrics tracking."""
 
 from collections.abc import Sequence
-from typing import ClassVar
+from typing import Any, ClassVar
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -723,9 +723,7 @@ def test_llm_streaming_preserves_cache_read_tokens(mock_completion):
     )
 
     mock_stream = MagicMock(spec=CustomStreamWrapper)
-    mock_stream.__iter__.return_value = iter(
-        [content_chunk, finish_chunk, usage_chunk]
-    )
+    mock_stream.__iter__.return_value = iter([content_chunk, finish_chunk, usage_chunk])
     mock_completion.return_value = mock_stream
 
     llm = LLM(
@@ -746,12 +744,15 @@ def test_llm_streaming_preserves_cache_read_tokens(mock_completion):
     # The usage-only chunk must reach the SDK (not be discarded)
     assert len(received_chunks) == 3
 
-    # stream_chunk_builder must preserve prompt_tokens_details
-    assert response.raw_response.usage is not None
-    assert response.raw_response.usage.prompt_tokens == 5000
-    assert response.raw_response.usage.completion_tokens == 100
-    assert response.raw_response.usage.prompt_tokens_details is not None
-    assert response.raw_response.usage.prompt_tokens_details.cached_tokens == 4000
+    # stream_chunk_builder must preserve prompt_tokens_details.
+    # ModelResponse stores 'usage' as an extra (dynamic) field, so pyright
+    # cannot see it statically — cast to Any for attribute access.
+    raw_resp: Any = response.raw_response
+    assert raw_resp.usage is not None
+    assert raw_resp.usage.prompt_tokens == 5000
+    assert raw_resp.usage.completion_tokens == 100
+    assert raw_resp.usage.prompt_tokens_details is not None
+    assert raw_resp.usage.prompt_tokens_details.cached_tokens == 4000
 
     # Telemetry must record cache_read_tokens from prompt_tokens_details
     acc = response.metrics.accumulated_token_usage
@@ -761,9 +762,9 @@ def test_llm_streaming_preserves_cache_read_tokens(mock_completion):
     # Verify stream_options={"include_usage": True} was passed to litellm
     call_kwargs = mock_completion.call_args
     assert call_kwargs is not None
-    actual_stream_options = call_kwargs.kwargs.get(
-        "stream_options"
-    ) or call_kwargs[1].get("stream_options")
+    actual_stream_options = call_kwargs.kwargs.get("stream_options") or call_kwargs[
+        1
+    ].get("stream_options")
     assert actual_stream_options == {"include_usage": True}, (
         f"Expected stream_options={{include_usage: True}}, got {actual_stream_options}"
     )


### PR DESCRIPTION
## Summary

Fixes #2896 — `cache_read_tokens` (and `cache_write_tokens`) are always reported as 0 when `stream=true`, even though prompt caching works correctly at the provider level.

**This is a display/reporting bug only** — actual caching at the provider still works and cost savings are realized, but cache hit rate monitoring, cost tracking dashboards, and telemetry are affected.

## Root Cause

When the SDK streams through a LiteLLM proxy:

1. The **proxy** auto-adds `stream_options={"include_usage": True}` to the upstream provider call, so the provider sends a final usage-only chunk with `prompt_tokens_details.cached_tokens`.

2. The **client-side litellm streaming handler** discards this usage-only chunk because the SDK doesn't pass `stream_options`:
   ```python
   # streaming_handler.py — usage-only chunk (empty choices)
   else:
       if (self.stream_options is not None
           and self.stream_options["include_usage"] is True):
           return model_response  # ← Not taken
       return  # ← Silently discarded!
   ```

3. The handler falls back to `calculate_total_usage()` which **only keeps `prompt_tokens` and `completion_tokens`**, dropping `prompt_tokens_details` (which contains `cached_tokens`).

## Fix

A one-line change in `_transport_call()`: when streaming is enabled, set `stream_options={"include_usage": True}` by default. This ensures the client-side streaming handler doesn't discard the usage-only chunk, and `prompt_tokens_details.cached_tokens` survives through `stream_chunk_builder` into telemetry metrics.

Uses `setdefault` so callers can override if needed.

## Test

Added `test_llm_streaming_preserves_cache_read_tokens` which:
- Creates realistic streaming chunks including a usage-only final chunk with `cached_tokens=4000` (simulating what a LiteLLM proxy sends)
- Lets the real `stream_chunk_builder` reassemble them (not mocked)
- Verifies `stream_options={"include_usage": True}` is passed to `litellm_completion`
- Verifies `cache_read_tokens=4000` appears in `response.metrics.accumulated_token_usage`
- Verifies `prompt_tokens_details.cached_tokens=4000` is preserved in `response.raw_response.usage`

The test **fails before the fix** (`stream_options` is `None`) and **passes after**.

## Verification

```
$ python -m pytest tests/sdk/llm/ --ignore=tests/sdk/llm/auth/test_openai.py
======================= 626 passed, 8 warnings in 24.86s =======================
```

All 626 LLM tests pass (1 pre-existing failure in `auth/test_openai.py` unrelated to this change).

---
_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/522f25f1-77c5-4871-a1c0-cb8b352145a2)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c90a3ee-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c90a3ee-python \
  ghcr.io/openhands/agent-server:c90a3ee-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c90a3ee-golang-amd64
ghcr.io/openhands/agent-server:c90a3ee-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c90a3ee-golang-arm64
ghcr.io/openhands/agent-server:c90a3ee-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c90a3ee-java-amd64
ghcr.io/openhands/agent-server:c90a3ee-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c90a3ee-java-arm64
ghcr.io/openhands/agent-server:c90a3ee-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c90a3ee-python-amd64
ghcr.io/openhands/agent-server:c90a3ee-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c90a3ee-python-arm64
ghcr.io/openhands/agent-server:c90a3ee-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c90a3ee-golang
ghcr.io/openhands/agent-server:c90a3ee-java
ghcr.io/openhands/agent-server:c90a3ee-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c90a3ee-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c90a3ee-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->