### PR TITLE
chore: use OPENHANDS_BOT_GITHUB_PAT_PUBLIC in public-repo workflows

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -200,7 +200,7 @@ jobs:
             - name: Run task
               env:
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   PYTHONPATH: ''
               run: |
                   echo "Running agent script: $AGENT_SCRIPT_URL"

--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Trigger docs repo sync
               uses: peter-evans/repository-dispatch@v4
               with:
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   repository: OpenHands/docs
                   event-type: update
                   client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'

--- a/.github/workflows/pr-artifacts.yml
+++ b/.github/workflows/pr-artifacts.yml
@@ -38,7 +38,7 @@ jobs:
               if: steps.check-fork.outputs.is_fork == 'false'
               with:
                   ref: ${{ github.event.pull_request.head.ref }}
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
 
             - name: Remove .pr/ directory
               id: remove

--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -53,5 +53,5 @@ jobs:
                   # picks up the sub-agent code (extensions#164 not yet on main)
                   extensions-version: feat/pr-review-sub-agent-delegation
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -24,7 +24,7 @@ jobs:
             - name: Checkout repository
               uses: actions/checkout@v6
               with:
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
 
             - name: Install uv
               uses: astral-sh/setup-uv@v7
@@ -69,7 +69,7 @@ jobs:
 
             - name: Create Pull Request
               env:
-                  GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+                  GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
               run: |
                   cat > pr_body.txt << 'EOF'
                   ## Release v${{ inputs.version }}

--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -50,5 +50,5 @@ jobs:
                   # EXPERIMENTAL: use the feature branch of extensions
                   extensions-version: feat/qa-changes-plugin
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
-                  github-token: ${{ secrets.PAT_TOKEN }}
+                  github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}

--- a/.github/workflows/todo-management.yml
+++ b/.github/workflows/todo-management.yml
@@ -130,7 +130,7 @@ jobs:
               uses: actions/checkout@v6
               with:
                   fetch-depth: 0
-                  token: ${{ secrets.PAT_TOKEN }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
 
             - name: Switch to feature branch with TODO management files
               run: |
@@ -170,7 +170,7 @@ jobs:
                   LLM_MODEL: litellm_proxy/claude-sonnet-4-5-20250929
                   LLM_BASE_URL: https://llm-proxy.app.all-hands.dev
                   LLM_API_KEY: ${{ secrets.LLM_API_KEY }}
-                  GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+                  GITHUB_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   GITHUB_REPOSITORY: ${{ github.repository }}
                   TODO_FILE: ${{ matrix.todo.file }}
                   TODO_LINE: ${{ matrix.todo.line }}

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -24,7 +24,7 @@ jobs:
             (github.event.workflow_run.conclusion == 'success' &&
              github.event.workflow_run.event == 'release')
         env:
-            GH_TOKEN: ${{ secrets.PAT_TOKEN }}
+            GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
         steps:
             - name: Checkout
               uses: actions/checkout@v6


### PR DESCRIPTION
## Summary

Replaces `secrets.PAT_TOKEN` with `secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC` in 8 public-repo automation workflows.

`OPENHANDS_BOT_GITHUB_PAT_PUBLIC` is a fine-grained PAT scoped to public repos only (`contents+pull-requests+issues:write` on 9 public repos). A compromise of any of these workflows cannot reach private infrastructure.

## Workflows changed

- `assign-reviews.yml`
- `deploy-docs.yml`
- `pr-artifacts.yml`
- `pr-review-by-openhands.yml`
- `prepare-release.yml`
- `qa-changes-by-openhands.yml`
- `todo-management.yml`
- `version-bump-prs.yml`

`run-eval.yml` is unchanged — it already uses `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH`.

## Before merging

Add `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` as a repo secret in `OpenHands/software-agent-sdk` with the value of the `OPENHANDS_BOT_PAT_TOKEN_PUBLIC` fine-grained PAT.

Part of OpenHands/evaluation#428 (PAT_TOKEN blast radius reduction).
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:06d604d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-06d604d-python \
  ghcr.io/openhands/agent-server:06d604d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:06d604d-golang-amd64
ghcr.io/openhands/agent-server:06d604d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:06d604d-golang-arm64
ghcr.io/openhands/agent-server:06d604d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:06d604d-java-amd64
ghcr.io/openhands/agent-server:06d604d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:06d604d-java-arm64
ghcr.io/openhands/agent-server:06d604d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:06d604d-python-amd64
ghcr.io/openhands/agent-server:06d604d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:06d604d-python-arm64
ghcr.io/openhands/agent-server:06d604d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:06d604d-golang
ghcr.io/openhands/agent-server:06d604d-java
ghcr.io/openhands/agent-server:06d604d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `06d604d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `06d604d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->