### PR TITLE
Change llm.base_url prominence from CRITICAL to MAJOR

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -179,7 +179,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     base_url: str | None = Field(
         default=None,
         description="Custom base URL.",
-        json_schema_extra=field_meta(SettingProminence.CRITICAL),
+        json_schema_extra=field_meta(SettingProminence.MAJOR),
     )
     api_version: str | None = Field(
         default=None,

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -74,7 +74,7 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
     assert llm_fields["llm.api_key"].label == "API Key"
     assert llm_fields["llm.api_key"].secret is True
     assert llm_fields["llm.api_key"].prominence is SettingProminence.CRITICAL
-    assert llm_fields["llm.base_url"].prominence is SettingProminence.CRITICAL
+    assert llm_fields["llm.base_url"].prominence is SettingProminence.MAJOR
 
     # Excluded fields must not appear
     assert "llm.fallback_strategy" not in llm_fields


### PR DESCRIPTION
## Why

The OpenHands frontend LLM settings page renders `base_url` **only** in the Advanced/All views — it is never shown in the Basic view (which uses the `ModelSelector` dropdown instead). Its schema prominence should therefore be `MAJOR` (visible at the Advanced tier), not `CRITICAL` (visible at the Basic tier).

After [OpenHands/OpenHands#14033](https://github.com/OpenHands/OpenHands/pull/14033) removed the `general` section (which contained the `agent` field at `MAJOR` prominence) from the LLM settings page, there are **zero** `MAJOR` fields left in the `llm` section. This causes `hasAdvancedSettings()` to return `false`, hiding the Advanced toggle button entirely — users can no longer access the custom model / base URL form.

## Changes

- `openhands-sdk/openhands/sdk/llm/llm.py`: Change `base_url` field prominence from `SettingProminence.CRITICAL` to `SettingProminence.MAJOR`
- `tests/sdk/test_settings.py`: Update the corresponding test assertion

## Effect

With `base_url` at `MAJOR`, the frontend's `hasAdvancedSettings()` finds a major field in the `llm` section and shows the Advanced toggle again. The Basic view continues to show only the provider/model selector and API key.

Related: [OpenHands/OpenHands#14013](https://github.com/OpenHands/OpenHands/pull/14013), [OpenHands/OpenHands#13986](https://github.com/OpenHands/OpenHands/issues/13986)

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a2524d63-db1d-41a2-87f5-63718700e10b)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c8d5060-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c8d5060-python \
  ghcr.io/openhands/agent-server:c8d5060-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c8d5060-golang-amd64
ghcr.io/openhands/agent-server:c8d5060-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c8d5060-golang-arm64
ghcr.io/openhands/agent-server:c8d5060-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c8d5060-java-amd64
ghcr.io/openhands/agent-server:c8d5060-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c8d5060-java-arm64
ghcr.io/openhands/agent-server:c8d5060-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c8d5060-python-amd64
ghcr.io/openhands/agent-server:c8d5060-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c8d5060-python-arm64
ghcr.io/openhands/agent-server:c8d5060-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c8d5060-golang
ghcr.io/openhands/agent-server:c8d5060-java
ghcr.io/openhands/agent-server:c8d5060-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c8d5060-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c8d5060-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->