### PR TITLE
Add encryption support for mcp_config field in AgentBase

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import os
 import re
 import sys
@@ -13,6 +14,11 @@ from pydantic import (
     ConfigDict,
     Field,
     PrivateAttr,
+    SecretStr,
+    SerializationInfo,
+    ValidationInfo,
+    field_serializer,
+    model_serializer,
     model_validator,
 )
 
@@ -41,6 +47,7 @@ if TYPE_CHECKING:
         ConversationCallbackType,
         ConversationTokenCallbackType,
     )
+    from openhands.sdk.utils.cipher import Cipher
 
 logger = get_logger(__name__)
 
@@ -196,6 +203,123 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
                 "'system_prompt_filename'. Use one or the other."
             )
         return data
+
+    @model_validator(mode="before")
+    @classmethod
+    def _decrypt_mcp_config(cls, data: Any, info: ValidationInfo) -> Any:
+        """Decrypt encrypted_mcp_config if present and cipher is in context.
+
+        Handles backward compatibility:
+        - If encrypted_mcp_config exists and cipher is present: decrypt and
+          set mcp_config
+        - If mcp_config exists directly: use it as-is (plaintext or
+          expose_secrets case)
+        - If neither exists: default empty dict will be used
+        """
+        if not isinstance(data, dict):
+            return data
+
+        encrypted = data.pop("encrypted_mcp_config", None)
+        if encrypted is None:
+            return data
+
+        # If no cipher in context, we can't decrypt - the encrypted value is lost
+        if not info.context or not info.context.get("cipher"):
+            logger.warning(
+                "Found encrypted_mcp_config but no cipher in context - "
+                "MCP configuration will be lost. Provide a cipher to preserve it."
+            )
+            return data
+
+        cipher: Cipher = info.context["cipher"]
+        decrypted = cipher.decrypt(encrypted)
+        if decrypted is None:
+            logger.warning(
+                "Failed to decrypt mcp_config (cipher mismatch or corruption) - "
+                "MCP configuration will be lost."
+            )
+            return data
+
+        try:
+            data["mcp_config"] = json.loads(decrypted.get_secret_value())
+        except json.JSONDecodeError as e:
+            logger.warning(f"Failed to parse decrypted mcp_config as JSON: {e}")
+
+        return data
+
+    @field_serializer("mcp_config", when_used="always")
+    def _serialize_mcp_config(self, v: dict[str, Any], info) -> dict[str, Any] | None:
+        """Serialize mcp_config with encryption or redaction.
+
+        - If a cipher is provided in context: returns None (encrypted_mcp_config
+          is populated separately via model serializer)
+        - If expose_secrets flag is True in context: returns the config as-is
+        - Otherwise: returns None to redact sensitive MCP configuration
+        """
+        if not v:
+            # Empty config - nothing to protect
+            return v
+
+        # If cipher is present, we'll encrypt instead (handled in model dump)
+        if info.context and info.context.get("cipher"):
+            return None
+
+        # If expose_secrets is True, return the config as-is
+        if info.context and info.context.get("expose_secrets"):
+            return v
+
+        # Default: redact by returning None
+        return None
+
+    @model_serializer(mode="wrap")
+    def _serialize_with_encrypted_mcp(self, handler, info: SerializationInfo):
+        """Serialize the agent, handling mcp_config encryption.
+
+        This serializer also handles polymorphic serialization for subclasses
+        (like ACPAgent) by delegating to model_dump when the handler is not
+        for the actual class.
+
+        When a cipher is present in context and mcp_config has content:
+        - Encrypts mcp_config as JSON and stores in encrypted_mcp_config
+        - Removes the None mcp_config from output
+        """
+        if isinstance(self, dict):
+            # Sometimes pydantic passes a dict in here.
+            return self
+
+        # Check if handler is for the current (actual) class
+        handler_str = str(handler)
+        _, handler_class = handler_str.split("=", 1)
+        handler_class = handler_class[:-1]  # Remove trailing )
+
+        if handler_class != self.__class__.__name__:
+            # Handler is for a base class, delegate to model_dump for proper
+            # subclass serialization (e.g., ACPAgent fields)
+            result = self.model_dump(
+                mode=info.mode,
+                context=info.context,
+                by_alias=info.by_alias,
+                exclude_unset=info.exclude_unset,
+                exclude_defaults=info.exclude_defaults,
+                exclude_none=info.exclude_none,
+                round_trip=info.round_trip,
+                serialize_as_any=info.serialize_as_any,
+            )
+        else:
+            result = handler(self)
+
+        # Add encrypted_mcp_config if cipher is present and mcp_config has content
+        if self.mcp_config and info.context and info.context.get("cipher"):
+            cipher: Cipher = info.context["cipher"]
+            json_str = json.dumps(self.mcp_config)
+            encrypted = cipher.encrypt(SecretStr(json_str))
+            if encrypted:
+                result["encrypted_mcp_config"] = encrypted
+            # Remove the None mcp_config if present (cleaner output)
+            if "mcp_config" in result and result["mcp_config"] is None:
+                del result["mcp_config"]
+
+        return result
 
     condenser: CondenserBase | None = Field(
         default=None,

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -288,24 +288,27 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # - expose_secrets=True: keep as-is (explicitly requested)
         # - cipher present: encrypt and store in encrypted_mcp_config, omit original
         # - default: omit (redact sensitive data)
-        if self.mcp_config:  # Only process non-empty configs
-            if info.context and info.context.get("expose_secrets"):
-                # Keep mcp_config as-is (already in result from handler)
-                pass
-            elif info.context and info.context.get("cipher"):
-                # Encrypt and add encrypted_mcp_config
-                cipher: Cipher = info.context["cipher"]
-                json_str = json.dumps(self.mcp_config)
-                encrypted = cipher.encrypt(SecretStr(json_str))
-                if encrypted:
-                    result["encrypted_mcp_config"] = encrypted
-                # Remove plaintext mcp_config
-                result.pop("mcp_config", None)
-            else:
-                # Default: redact by omitting
-                result.pop("mcp_config", None)
+        if not self.mcp_config:  # Only process non-empty configs
+            result.pop("mcp_config", None)
+            return result
+        elif info.context and info.context.get("expose_secrets"):
+            # Keep mcp_config as-is (already in result from handler)
+            return result
+        elif info.context and info.context.get("cipher"):
+            # Encrypt and add encrypted_mcp_config
+            cipher: Cipher = info.context["cipher"]
+            json_str = json.dumps(self.mcp_config)
+            encrypted = cipher.encrypt(SecretStr(json_str))
+            if encrypted:
+                result["encrypted_mcp_config"] = encrypted
+            # Remove plaintext mcp_config
+            result.pop("mcp_config", None)
+            return result
+        else:
+            # Default: redact by omitting
+            result.pop("mcp_config", None)
+            return result
 
-        return result
 
     condenser: CondenserBase | None = Field(
         default=None,

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -283,7 +283,7 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             result = handler(self)
 
         # Handle mcp_config based on context:
-        # - Empty config: keep as-is (nothing sensitive)
+        # - Empty config: omit (nothing sensitive)
         # - expose_secrets=True: keep as-is (explicitly requested)
         # - cipher present: encrypt and store in encrypted_mcp_config, omit original
         # - default: omit (redact sensitive data)

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -217,7 +217,7 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         """
         if not isinstance(data, dict):
             return data
-
+        # - Empty config: omit (default value, nothing to protect)
         encrypted = data.pop("encrypted_mcp_config", None)
         if encrypted is None:
             return data

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -17,7 +17,6 @@ from pydantic import (
     SecretStr,
     SerializationInfo,
     ValidationInfo,
-    field_serializer,
     model_serializer,
     model_validator,
 )
@@ -247,41 +246,17 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
 
         return data
 
-    @field_serializer("mcp_config", when_used="always")
-    def _serialize_mcp_config(self, v: dict[str, Any], info) -> dict[str, Any] | None:
-        """Serialize mcp_config with encryption or redaction.
-
-        - If a cipher is provided in context: returns None (encrypted_mcp_config
-          is populated separately via model serializer)
-        - If expose_secrets flag is True in context: returns the config as-is
-        - Otherwise: returns None to redact sensitive MCP configuration
-        """
-        if not v:
-            # Empty config - nothing to protect
-            return v
-
-        # If cipher is present, we'll encrypt instead (handled in model dump)
-        if info.context and info.context.get("cipher"):
-            return None
-
-        # If expose_secrets is True, return the config as-is
-        if info.context and info.context.get("expose_secrets"):
-            return v
-
-        # Default: redact by returning None
-        return None
-
     @model_serializer(mode="wrap")
-    def _serialize_with_encrypted_mcp(self, handler, info: SerializationInfo):
-        """Serialize the agent, handling mcp_config encryption.
+    def _serialize_with_mcp_handling(self, handler, info: SerializationInfo):
+        """Serialize the agent, handling mcp_config encryption/redaction.
 
-        This serializer also handles polymorphic serialization for subclasses
-        (like ACPAgent) by delegating to model_dump when the handler is not
-        for the actual class.
+        This serializer handles:
+        1. Polymorphic serialization for subclasses (e.g., ACPAgent)
+        2. mcp_config encryption when cipher is in context
+        3. mcp_config redaction (omission) when neither cipher nor expose_secrets
 
-        When a cipher is present in context and mcp_config has content:
-        - Encrypts mcp_config as JSON and stores in encrypted_mcp_config
-        - Removes the None mcp_config from output
+        The mcp_config handling is done here (not in a field_serializer) to avoid
+        changing the field's schema type, which would break REST API compatibility.
         """
         if isinstance(self, dict):
             # Sometimes pydantic passes a dict in here.
@@ -308,19 +283,27 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         else:
             result = handler(self)
 
-        # Add encrypted_mcp_config if cipher is present and mcp_config has content
-        if self.mcp_config and info.context and info.context.get("cipher"):
-            cipher: Cipher = info.context["cipher"]
-            json_str = json.dumps(self.mcp_config)
-            encrypted = cipher.encrypt(SecretStr(json_str))
-            if encrypted:
-                result["encrypted_mcp_config"] = encrypted
-
-        # Redact by omitting: remove mcp_config if it was set to None by the
-        # field serializer (either due to cipher encryption or default redaction).
-        # This preserves the REST API contract (field is optional, not nullable).
-        if "mcp_config" in result and result["mcp_config"] is None:
-            del result["mcp_config"]
+        # Handle mcp_config based on context:
+        # - Empty config: keep as-is (nothing sensitive)
+        # - expose_secrets=True: keep as-is (explicitly requested)
+        # - cipher present: encrypt and store in encrypted_mcp_config, omit original
+        # - default: omit (redact sensitive data)
+        if self.mcp_config:  # Only process non-empty configs
+            if info.context and info.context.get("expose_secrets"):
+                # Keep mcp_config as-is (already in result from handler)
+                pass
+            elif info.context and info.context.get("cipher"):
+                # Encrypt and add encrypted_mcp_config
+                cipher: Cipher = info.context["cipher"]
+                json_str = json.dumps(self.mcp_config)
+                encrypted = cipher.encrypt(SecretStr(json_str))
+                if encrypted:
+                    result["encrypted_mcp_config"] = encrypted
+                # Remove plaintext mcp_config
+                result.pop("mcp_config", None)
+            else:
+                # Default: redact by omitting
+                result.pop("mcp_config", None)
 
         return result
 

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -37,7 +37,7 @@ from openhands.sdk.tool import (
     resolve_tool,
 )
 from openhands.sdk.tool.builtins import InvokeSkillTool
-from openhands.sdk.utils.models import DiscriminatedUnionMixin
+from openhands.sdk.utils.models import DiscriminatedUnionMixin, get_handler_class_name
 
 
 if TYPE_CHECKING:
@@ -263,9 +263,8 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             return self
 
         # Check if handler is for the current (actual) class
-        handler_str = str(handler)
-        _, handler_class = handler_str.split("=", 1)
-        handler_class = handler_class[:-1]  # Remove trailing )
+        # See get_handler_class_name() for details on the fragile string parsing
+        handler_class = get_handler_class_name(handler)
 
         if handler_class != self.__class__.__name__:
             # Handler is for a base class, delegate to model_dump for proper
@@ -308,7 +307,6 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             # Default: redact by omitting
             result.pop("mcp_config", None)
             return result
-
 
     condenser: CondenserBase | None = Field(
         default=None,

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -315,9 +315,12 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             encrypted = cipher.encrypt(SecretStr(json_str))
             if encrypted:
                 result["encrypted_mcp_config"] = encrypted
-            # Remove the None mcp_config if present (cleaner output)
-            if "mcp_config" in result and result["mcp_config"] is None:
-                del result["mcp_config"]
+
+        # Redact by omitting: remove mcp_config if it was set to None by the
+        # field serializer (either due to cipher encryption or default redaction).
+        # This preserves the REST API contract (field is optional, not nullable).
+        if "mcp_config" in result and result["mcp_config"] is None:
+            del result["mcp_config"]
 
         return result
 

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -291,9 +291,6 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         if not self.mcp_config:  # Only process non-empty configs
             result.pop("mcp_config", None)
             return result
-        elif info.context and info.context.get("expose_secrets"):
-            # Keep mcp_config as-is (already in result from handler)
-            return result
         elif info.context and info.context.get("cipher"):
             # Encrypt and add encrypted_mcp_config
             cipher: Cipher = info.context["cipher"]
@@ -303,6 +300,9 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
                 result["encrypted_mcp_config"] = encrypted
             # Remove plaintext mcp_config
             result.pop("mcp_config", None)
+            return result
+        elif info.context and info.context.get("expose_secrets"):
+            # Keep mcp_config as-is (already in result from handler)
             return result
         else:
             # Default: redact by omitting

--- a/openhands-sdk/openhands/sdk/utils/models.py
+++ b/openhands-sdk/openhands/sdk/utils/models.py
@@ -43,6 +43,35 @@ def _is_abstract(type_: type) -> bool:
         return False
 
 
+def get_handler_class_name(handler: SerializerFunctionWrapHandler) -> str:
+    """Extract the class name from a Pydantic serializer handler's repr string.
+
+    WARNING: This is a fragile approach that relies on Pydantic's internal
+    repr format for SerializerFunctionWrapHandler. The handler is a Pydantic
+    wrapper around a Rust function that provides no public API for determining
+    which class it serializes. Parsing the repr string is the only available
+    mechanism.
+
+    Expected format: `SerializationCallable(serializer=<ClassName>)`
+
+    If Pydantic changes this format, multiple unit tests will fail immediately,
+    including tests in test_discriminated_union.py that verify serialization
+    behavior across the class hierarchy.
+
+    Args:
+        handler: The Pydantic serializer function wrap handler
+
+    Returns:
+        The class name extracted from the handler's repr string
+    """
+    repr_str = str(handler)
+    # Format is `SerializationCallable(serializer=<NAME>)`
+    # Get everything after =
+    _, name = repr_str.split("=", 1)
+    # Cut off the trailing )
+    return name[:-1]
+
+
 def kind_of(obj) -> str:
     """Get the string value for the kind tag"""
     if isinstance(obj, dict):
@@ -175,31 +204,12 @@ class DiscriminatedUnionMixin(OpenHandsModel):
     def _is_handler_for_current_class(
         self, handler: SerializerFunctionWrapHandler
     ) -> bool:
-        """Check if the handler is for this class by parsing its repr string.
+        """Check if the handler is for this class.
 
-        WARNING: This is a fragile approach that relies on Pydantic's internal
-        repr format for SerializerFunctionWrapHandler. The handler is a Pydantic
-        wrapper around a Rust function that provides no public API for determining
-        which class it serializes. Parsing the repr string is the only available
-        mechanism.
-
-        Expected format: `SerializationCallable(serializer=<ClassName>)`
-
-        If Pydantic changes this format, multiple unit tests will fail immediately,
-        including tests in test_discriminated_union.py that verify serialization
-        behavior across the class hierarchy.
+        See get_handler_class_name() for details on the fragile string parsing
+        this relies on.
         """
-        # should be in the format `SerializationCallable(serializer=<NAME>)`
-        repr_str = str(handler)
-
-        # Get everything after =
-        _, name = repr_str.split("=", 1)
-
-        # Cut off the )
-        name = name[:-1]
-
-        result = self.__class__.__name__ == name
-        return result
+        return self.__class__.__name__ == get_handler_class_name(handler)
 
     @classmethod
     def __get_pydantic_json_schema__(

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -59,7 +59,7 @@ def test_mcp_tool_serialization():
     assert loaded.model_dump_json() == dumped
 
 
-def test_agent_serialization_should_include_mcp_tool() -> None:
+def test_mcp_config_exposed_with_expose_secrets_context() -> None:
     """Test mcp_config serialization with expose_secrets=True context."""
     # Create a simple LLM instance and agent with empty tools
     llm = LLM(model="test-model", usage_id="test-llm")

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -335,15 +335,15 @@ def test_include_default_tools_deserialization_from_dict() -> None:
 
 
 def test_mcp_config_redacted_by_default() -> None:
-    """Test that mcp_config is redacted (None) when serialized without context."""
+    """Test that mcp_config is omitted when serialized without context."""
 
     llm = LLM(model="test-model", usage_id="test-llm")
     mcp_config = {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-fetch"]}}}
     agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
 
-    # Serialize without any context - should redact mcp_config
+    # Serialize without any context - should omit mcp_config entirely
     agent_dump = agent.model_dump()
-    assert agent_dump.get("mcp_config") is None
+    assert "mcp_config" not in agent_dump  # Omitted, not None
     assert "encrypted_mcp_config" not in agent_dump
 
 
@@ -371,8 +371,8 @@ def test_mcp_config_encrypted_with_cipher_context() -> None:
     # Serialize with cipher - should have encrypted_mcp_config
     agent_dump = agent.model_dump(context={"cipher": cipher})
 
-    # mcp_config should be None, encrypted_mcp_config should be present
-    assert "mcp_config" not in agent_dump or agent_dump.get("mcp_config") is None
+    # mcp_config should be omitted, encrypted_mcp_config should be present
+    assert "mcp_config" not in agent_dump  # Omitted, not None
     assert "encrypted_mcp_config" in agent_dump
     assert isinstance(agent_dump["encrypted_mcp_config"], str)
 

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -60,6 +60,7 @@ def test_mcp_tool_serialization():
 
 
 def test_agent_serialization_should_include_mcp_tool() -> None:
+    """Test mcp_config serialization with expose_secrets=True context."""
     # Create a simple LLM instance and agent with empty tools
     llm = LLM(model="test-model", usage_id="test-llm")
     mcp_config = {
@@ -69,17 +70,17 @@ def test_agent_serialization_should_include_mcp_tool() -> None:
     }
     agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
 
-    # Serialize to JSON (excluding non-serializable fields)
-    agent_dump = agent.model_dump()
+    # Serialize to JSON with expose_secrets=True to include mcp_config
+    agent_dump = agent.model_dump(context={"expose_secrets": True})
     assert agent_dump.get("mcp_config") == mcp_config
-    agent_json = agent.model_dump_json()
+    agent_json = agent.model_dump_json(context={"expose_secrets": True})
 
     # Deserialize from JSON using the base class
     deserialized_agent = AgentBase.model_validate_json(agent_json)
 
     # Should deserialize to the correct type and have same core fields
     assert isinstance(deserialized_agent, Agent)
-    assert deserialized_agent.model_dump_json() == agent.model_dump_json()
+    assert deserialized_agent.mcp_config == mcp_config
 
 
 def test_agent_supports_polymorphic_field_json_serialization() -> None:
@@ -326,3 +327,156 @@ def test_include_default_tools_deserialization_from_dict() -> None:
     # Should have ThinkTool
     assert isinstance(agent, Agent)
     assert agent.include_default_tools == ["ThinkTool"]
+
+
+# ============================================================================
+# MCP Config Encryption/Decryption Tests
+# ============================================================================
+
+
+def test_mcp_config_redacted_by_default() -> None:
+    """Test that mcp_config is redacted (None) when serialized without context."""
+
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-fetch"]}}}
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
+
+    # Serialize without any context - should redact mcp_config
+    agent_dump = agent.model_dump()
+    assert agent_dump.get("mcp_config") is None
+    assert "encrypted_mcp_config" not in agent_dump
+
+
+def test_mcp_config_exposed_with_expose_secrets_context() -> None:
+    """Test that mcp_config is included when expose_secrets=True."""
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-fetch"]}}}
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
+
+    # Serialize with expose_secrets=True - should include mcp_config
+    agent_dump = agent.model_dump(context={"expose_secrets": True})
+    assert agent_dump.get("mcp_config") == mcp_config
+    assert "encrypted_mcp_config" not in agent_dump
+
+
+def test_mcp_config_encrypted_with_cipher_context() -> None:
+    """Test that mcp_config is encrypted when cipher is in context."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-fetch"]}}}
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
+    cipher = Cipher(secret_key="test-encryption-key")
+
+    # Serialize with cipher - should have encrypted_mcp_config
+    agent_dump = agent.model_dump(context={"cipher": cipher})
+
+    # mcp_config should be None, encrypted_mcp_config should be present
+    assert "mcp_config" not in agent_dump or agent_dump.get("mcp_config") is None
+    assert "encrypted_mcp_config" in agent_dump
+    assert isinstance(agent_dump["encrypted_mcp_config"], str)
+
+
+def test_mcp_config_encryption_decryption_roundtrip() -> None:
+    """Test full roundtrip: encrypt on serialize, decrypt on deserialize."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {
+        "mcpServers": {
+            "fetch": {"command": "uvx", "args": ["mcp-fetch"]},
+            "git": {"command": "uvx", "args": ["mcp-git", "--repo", "/tmp/test"]},
+        }
+    }
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
+    cipher = Cipher(secret_key="test-encryption-key-roundtrip")
+
+    # Serialize with cipher
+    agent_json = agent.model_dump_json(context={"cipher": cipher})
+
+    # Deserialize with same cipher
+    restored_agent = AgentBase.model_validate_json(
+        agent_json, context={"cipher": cipher}
+    )
+
+    # mcp_config should be restored correctly
+    assert isinstance(restored_agent, Agent)
+    assert restored_agent.mcp_config == mcp_config
+
+
+def test_mcp_config_decryption_without_cipher_logs_warning() -> None:
+    """Test that deserializing encrypted_mcp_config without cipher logs warning."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {"mcpServers": {"fetch": {"command": "uvx"}}}
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
+    cipher = Cipher(secret_key="test-key")
+
+    # Serialize with cipher
+    agent_json = agent.model_dump_json(context={"cipher": cipher})
+
+    # Deserialize WITHOUT cipher - mcp_config should be empty (lost)
+    restored_agent = AgentBase.model_validate_json(agent_json)
+
+    assert isinstance(restored_agent, Agent)
+    # mcp_config should be empty dict (default) since we couldn't decrypt
+    assert restored_agent.mcp_config == {}
+
+
+def test_mcp_config_decryption_with_wrong_cipher() -> None:
+    """Test that decryption with wrong cipher gracefully fails."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    llm = LLM(model="test-model", usage_id="test-llm")
+    mcp_config = {"mcpServers": {"fetch": {"command": "uvx"}}}
+    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
+
+    cipher_a = Cipher(secret_key="cipher-key-a")
+    cipher_b = Cipher(secret_key="cipher-key-b")
+
+    # Serialize with cipher_a
+    agent_json = agent.model_dump_json(context={"cipher": cipher_a})
+
+    # Deserialize with cipher_b - decryption fails gracefully
+    restored_agent = AgentBase.model_validate_json(
+        agent_json, context={"cipher": cipher_b}
+    )
+
+    assert isinstance(restored_agent, Agent)
+    # mcp_config should be empty (decryption failed)
+    assert restored_agent.mcp_config == {}
+
+
+def test_mcp_config_backward_compatibility_plaintext() -> None:
+    """Test that agents serialized with plaintext mcp_config still work."""
+    # Simulate old-format JSON with plaintext mcp_config
+    mcp_config = {"mcpServers": {"fetch": {"command": "uvx", "args": ["fetch"]}}}
+    agent_dict = {
+        "llm": {"model": "test-model", "usage_id": "test-llm"},
+        "tools": [],
+        "mcp_config": mcp_config,
+        "kind": "Agent",
+    }
+
+    # Deserialize - should work without cipher
+    agent = AgentBase.model_validate(agent_dict)
+
+    assert isinstance(agent, Agent)
+    assert agent.mcp_config == mcp_config
+
+
+def test_mcp_config_empty_not_encrypted() -> None:
+    """Test that empty mcp_config doesn't create encrypted_mcp_config."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    llm = LLM(model="test-model", usage_id="test-llm")
+    agent = Agent(llm=llm, tools=[], mcp_config={})  # Empty config
+    cipher = Cipher(secret_key="test-key")
+
+    # Serialize with cipher - should NOT have encrypted_mcp_config for empty
+    agent_dump = agent.model_dump(context={"cipher": cipher})
+
+    # Empty dict should serialize as empty dict, not encrypted
+    assert agent_dump.get("mcp_config") == {}
+    assert "encrypted_mcp_config" not in agent_dump

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -465,6 +465,6 @@ def test_mcp_config_empty_not_encrypted() -> None:
     # Serialize with cipher - should NOT have encrypted_mcp_config for empty
     agent_dump = agent.model_dump(context={"cipher": cipher})
 
-    # Empty dict should serialize as empty dict, not encrypted
-    assert agent_dump.get("mcp_config") == {}
+    # Empty dict is omitted entirely (default value), not serialized or encrypted
+    assert "mcp_config" not in agent_dump
     assert "encrypted_mcp_config" not in agent_dump

--- a/tests/sdk/agent/test_agent_serialization.py
+++ b/tests/sdk/agent/test_agent_serialization.py
@@ -347,18 +347,6 @@ def test_mcp_config_redacted_by_default() -> None:
     assert "encrypted_mcp_config" not in agent_dump
 
 
-def test_mcp_config_exposed_with_expose_secrets_context() -> None:
-    """Test that mcp_config is included when expose_secrets=True."""
-    llm = LLM(model="test-model", usage_id="test-llm")
-    mcp_config = {"mcpServers": {"fetch": {"command": "uvx", "args": ["mcp-fetch"]}}}
-    agent = Agent(llm=llm, tools=[], mcp_config=cast(dict[str, object], mcp_config))
-
-    # Serialize with expose_secrets=True - should include mcp_config
-    agent_dump = agent.model_dump(context={"expose_secrets": True})
-    assert agent_dump.get("mcp_config") == mcp_config
-    assert "encrypted_mcp_config" not in agent_dump
-
-
 def test_mcp_config_encrypted_with_cipher_context() -> None:
     """Test that mcp_config is encrypted when cipher is in context."""
     from openhands.sdk.utils.cipher import Cipher


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [x] A human has tested these changes.

---

## Why

The `mcp_config` field in `AgentBase` contains sensitive data (MCP server configurations may include API keys, tokens, etc.). Currently, this data is serialized in plaintext, which could lead to accidental exposure of secrets in persisted conversation state.

This PR applies the same encryption/redaction logic used for `StaticSecret.value` to the `mcp_config` field, ensuring sensitive MCP configuration is protected during serialization.

## Summary

- Add `model_validator` to decrypt `encrypted_mcp_config` during deserialization (the key is serialization-only, not a model field)
- Add `field_serializer` for `mcp_config` with encryption/redaction logic based on context
- Add `model_serializer` to handle encryption and polymorphic serialization for subclasses (e.g., ACPAgent)
- **Redact by omitting**: When `mcp_config` is redacted (no context or cipher context), the field is omitted entirely rather than set to `null`, preserving REST API backward compatibility
- Add comprehensive tests for all encryption/decryption scenarios

## Issue Number

N/A

## How to Test

Run the mcp_config serialization tests:

```bash
uv run pytest tests/sdk/agent/test_agent_serialization.py -v -k "mcp_config"
```

**Test output showing all 8 new tests pass:**
```
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_redacted_by_default PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_exposed_with_expose_secrets_context PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_encrypted_with_cipher_context PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_encryption_decryption_roundtrip PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_decryption_without_cipher_logs_warning PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_decryption_with_wrong_cipher PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_backward_compatibility_plaintext PASSED
tests/sdk/agent/test_agent_serialization.py::test_mcp_config_empty_not_encrypted PASSED

8 passed
```

Also run broader agent tests to verify no regressions:
```bash
uv run pytest tests/sdk/agent/test_agent_serialization.py tests/sdk/agent/test_acp_agent.py tests/sdk/conversation/local/test_state_serialization.py -v
```

**Result: 200 passed**

## Video/Screenshots

**I tested this with my local version of OpenHands - Events sent to the client no longer include the MCP Config:**
<img width="784" height="595" alt="image" src="https://github.com/user-attachments/assets/7096d614-07c7-452d-88fd-a290b00e9c6e" />
<img width="950" height="546" alt="image" src="https://github.com/user-attachments/assets/9cd68ded-94c8-4c5f-b234-a186616c1db4" />

**Stopping / Restarting the Conversation works, and the MCP Config still works after restart:**
<img width="526" height="368" alt="image" src="https://github.com/user-attachments/assets/16500562-3ff2-4390-9841-8aaa0dcc45e1" />
<img width="776" height="616" alt="image" src="https://github.com/user-attachments/assets/def143db-111e-475e-8014-9bb2ecea6a6a" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

### Behavior Summary

| Serialization Context | `mcp_config` Behavior |
|----------------------|----------------------|
| No context | **Omitted** (preserves REST API contract) |
| `{"expose_secrets": True}` | Exposed as plaintext |
| `{"cipher": cipher}` | **Omitted**, `encrypted_mcp_config` added |

| Deserialization Context | Handling |
|------------------------|----------|
| `encrypted_mcp_config` + cipher | Decrypted to `mcp_config` |
| `encrypted_mcp_config` + no cipher | Lost (warning logged) |
| `encrypted_mcp_config` + wrong cipher | Lost (warning logged) |
| `mcp_config` (plaintext) | Used directly (backward compatible) |

### Design Notes

1. **`encrypted_mcp_config` is a serialization-only key**, not a model field. The `model_validator` pops it from input data before Pydantic processes it, and the `model_serializer` adds it directly to the output dict. This keeps the model definition clean.

2. **Redaction by omission** (not `null`): When `mcp_config` is redacted, the field is removed from output entirely. This preserves the existing REST API contract where `mcp_config` is optional but not nullable, avoiding breaking changes for generated clients.

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*










<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cac22d3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cac22d3-python \
  ghcr.io/openhands/agent-server:cac22d3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cac22d3-golang-amd64
ghcr.io/openhands/agent-server:cac22d3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cac22d3-golang-arm64
ghcr.io/openhands/agent-server:cac22d3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cac22d3-java-amd64
ghcr.io/openhands/agent-server:cac22d3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cac22d3-java-arm64
ghcr.io/openhands/agent-server:cac22d3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cac22d3-python-amd64
ghcr.io/openhands/agent-server:cac22d3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cac22d3-python-arm64
ghcr.io/openhands/agent-server:cac22d3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cac22d3-golang
ghcr.io/openhands/agent-server:cac22d3-java
ghcr.io/openhands/agent-server:cac22d3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cac22d3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cac22d3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->