### PR TITLE
fix(llm): pin prompt_cache_key to conversation id

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -189,6 +189,9 @@ class LocalConversation(BaseConversation):
             tags=tags,
         )
 
+        # Pin the OpenAI prefix-cache shard to this conversation (#2904).
+        self.agent.llm._prompt_cache_key = str(self._state.id)
+
         # Default callback: persist every event to state
         def _default_callback(e):
             # This callback runs while holding the conversation state's lock

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -450,6 +450,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     _telemetry: Telemetry | None = PrivateAttr(default=None)
     _is_subscription: bool = PrivateAttr(default=False)
     _litellm_provider: str | None = PrivateAttr(default=None)
+    _prompt_cache_key: str | None = PrivateAttr(default=None)
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="ignore", arbitrary_types_allowed=True

--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -84,4 +84,7 @@ def select_chat_options(
     if llm.litellm_extra_body:
         out["extra_body"] = llm.litellm_extra_body
 
+    if llm._prompt_cache_key:
+        out["prompt_cache_key"] = llm._prompt_cache_key
+
     return out

--- a/openhands-sdk/openhands/sdk/llm/options/responses_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/responses_options.py
@@ -71,4 +71,7 @@ def select_responses_options(
     if llm.litellm_extra_body:
         out["extra_body"] = llm.litellm_extra_body
 
+    if llm._prompt_cache_key:
+        out["prompt_cache_key"] = llm._prompt_cache_key
+
     return out

--- a/tests/sdk/conversation/local/test_conversation_id.py
+++ b/tests/sdk/conversation/local/test_conversation_id.py
@@ -77,3 +77,10 @@ def test_conversation_id_persists():
 
     # Check that the ID hasn't changed
     assert conversation.id == original_id
+
+
+def test_conversation_pins_llm_prompt_cache_key_to_id():
+    """Regression test for #2904."""
+    agent = ConversationIdDummyAgent()
+    conversation = Conversation(agent=agent)
+    assert agent.llm._prompt_cache_key == str(conversation.id)

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass
 from typing import Any
 
+from openhands.sdk.llm import LLM
 from openhands.sdk.llm.options.chat_options import select_chat_options
 
 
@@ -17,6 +18,7 @@ class DummyLLM:
     litellm_extra_body: dict[str, Any] | None = None
     # Align with LLM default; only emitted for models that support it
     prompt_cache_retention: str | None = "24h"
+    _prompt_cache_key: str | None = None
 
 
 def test_opus_4_5_uses_reasoning_effort_and_strips_temp_top_p():
@@ -177,3 +179,20 @@ def test_extended_thinking_budget_clamped_below_max_tokens():
         "budget_tokens": 500,
     }
     assert out.get("max_tokens") == 1000
+
+
+def test_chat_options_forwards_prompt_cache_key_when_set():
+    """Regression test for #2904."""
+    llm = LLM(model="gpt-4o")
+    llm._prompt_cache_key = "conv-abc123"
+    assert (
+        select_chat_options(llm, user_kwargs={}, has_tools=True).get("prompt_cache_key")
+        == "conv-abc123"
+    )
+
+
+def test_chat_options_omits_prompt_cache_key_when_unset():
+    llm = LLM(model="gpt-4o")
+    assert "prompt_cache_key" not in select_chat_options(
+        llm, user_kwargs={}, has_tools=True
+    )

--- a/tests/sdk/llm/test_responses_parsing_and_kwargs.py
+++ b/tests/sdk/llm/test_responses_parsing_and_kwargs.py
@@ -246,3 +246,22 @@ def test_chat_and_responses_options_prompt_cache_retention_gpt_5_plus_and_non_gp
 
     opts_other_resp = select_responses_options(llm_other, {}, include=None, store=None)
     assert "prompt_cache_retention" not in opts_other_resp
+
+
+def test_responses_options_forwards_prompt_cache_key_when_set():
+    """Regression test for #2904."""
+    llm = LLM(model="openai/gpt-5.1")
+    llm._prompt_cache_key = "conv-abc123"
+    assert (
+        select_responses_options(llm, {}, include=None, store=None).get(
+            "prompt_cache_key"
+        )
+        == "conv-abc123"
+    )
+
+
+def test_responses_options_omits_prompt_cache_key_when_unset():
+    llm = LLM(model="openai/gpt-5.1")
+    assert "prompt_cache_key" not in select_responses_options(
+        llm, {}, include=None, store=None
+    )


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary
- The SDK never sent `prompt_cache_key` on Responses or Chat Completions calls, so LiteLLM-proxied traffic scatters across OpenAI backends and the prefix cache can't warm up. On a 500-instance SWE-bench run this showed as a 38.8%  
  cache-hit rate and ~$481 of avoidable cost vs. the codex baseline at 94.8% (#2904).
- Adds `_prompt_cache_key` as a `PrivateAttr` on `LLM`, pins it to `str(state.id)` at `LocalConversation.__init__`, and forwards it from both `select_responses_options` and `select_chat_options` — mirroring how OpenAI's own `codex`
   client sets `prompt_cache_key = conversation_id` unconditionally.                                                                                                                                                                     
- Net change: ~7 lines in 4 source files. No new config field, no behavior change when the attr is unset.

## Issue Number
#2904 

## How to Test

We should run an eval before merging and see if caching is working.


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:df3bc47-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-df3bc47-python \
  ghcr.io/openhands/agent-server:df3bc47-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:df3bc47-golang-amd64
ghcr.io/openhands/agent-server:df3bc47-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:df3bc47-golang-arm64
ghcr.io/openhands/agent-server:df3bc47-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:df3bc47-java-amd64
ghcr.io/openhands/agent-server:df3bc47-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:df3bc47-java-arm64
ghcr.io/openhands/agent-server:df3bc47-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:df3bc47-python-amd64
ghcr.io/openhands/agent-server:df3bc47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:df3bc47-python-arm64
ghcr.io/openhands/agent-server:df3bc47-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:df3bc47-golang
ghcr.io/openhands/agent-server:df3bc47-java
ghcr.io/openhands/agent-server:df3bc47-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `df3bc47-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `df3bc47-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->