### PR TITLE
feat: add repository cloning and skill loading methods to OpenHandsCloudWorkspace

### DIFF
--- a/openhands-workspace/openhands/workspace/__init__.py
+++ b/openhands-workspace/openhands/workspace/__init__.py
@@ -7,6 +7,7 @@ from openhands.sdk.workspace import PlatformType, TargetType
 from .apptainer import ApptainerWorkspace
 from .cloud import (
     CloneResult,
+    GitProvider,
     OpenHandsCloudWorkspace,
     RepoMapping,
     RepoSource,
@@ -24,6 +25,7 @@ __all__ = [
     "CloneResult",
     "DockerDevWorkspace",
     "DockerWorkspace",
+    "GitProvider",
     "OpenHandsCloudWorkspace",
     "PlatformType",
     "RepoMapping",

--- a/openhands-workspace/openhands/workspace/__init__.py
+++ b/openhands-workspace/openhands/workspace/__init__.py
@@ -5,7 +5,12 @@ from typing import TYPE_CHECKING
 from openhands.sdk.workspace import PlatformType, TargetType
 
 from .apptainer import ApptainerWorkspace
-from .cloud import OpenHandsCloudWorkspace
+from .cloud import (
+    CloneResult,
+    OpenHandsCloudWorkspace,
+    RepoMapping,
+    RepoSource,
+)
 from .docker import DockerWorkspace
 from .remote_api import APIRemoteWorkspace
 
@@ -16,10 +21,13 @@ if TYPE_CHECKING:
 __all__ = [
     "APIRemoteWorkspace",
     "ApptainerWorkspace",
+    "CloneResult",
     "DockerDevWorkspace",
     "DockerWorkspace",
     "OpenHandsCloudWorkspace",
     "PlatformType",
+    "RepoMapping",
+    "RepoSource",
     "TargetType",
 ]
 

--- a/openhands-workspace/openhands/workspace/cloud/__init__.py
+++ b/openhands-workspace/openhands/workspace/cloud/__init__.py
@@ -1,6 +1,14 @@
 """OpenHands Cloud workspace implementation."""
 
+from .repo import CloneResult, RepoMapping, RepoSource, clone_repos, get_repos_context
 from .workspace import OpenHandsCloudWorkspace
 
 
-__all__ = ["OpenHandsCloudWorkspace"]
+__all__ = [
+    "CloneResult",
+    "OpenHandsCloudWorkspace",
+    "RepoMapping",
+    "RepoSource",
+    "clone_repos",
+    "get_repos_context",
+]

--- a/openhands-workspace/openhands/workspace/cloud/__init__.py
+++ b/openhands-workspace/openhands/workspace/cloud/__init__.py
@@ -1,11 +1,19 @@
 """OpenHands Cloud workspace implementation."""
 
-from .repo import CloneResult, RepoMapping, RepoSource, clone_repos, get_repos_context
+from .repo import (
+    CloneResult,
+    GitProvider,
+    RepoMapping,
+    RepoSource,
+    clone_repos,
+    get_repos_context,
+)
 from .workspace import OpenHandsCloudWorkspace
 
 
 __all__ = [
     "CloneResult",
+    "GitProvider",
     "OpenHandsCloudWorkspace",
     "RepoMapping",
     "RepoSource",

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -153,7 +153,7 @@ class RepoSource(BaseModel):
         if not detected and not self.provider:
             raise ValueError(
                 f"Short URL format '{self.url}' requires explicit 'provider' field. "
-                "Use: {\"url\": \"owner/repo\", \"provider\": \"github\"} "
+                'Use: {"url": "owner/repo", "provider": "github"} '
                 "or provide a full URL like https://github.com/owner/repo"
             )
         return self

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -302,7 +302,7 @@ def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
     # Handle full URLs - inject authentication only if hostname matches exactly
     if token:
         parsed = urllib.parse.urlparse(url)
-        if parsed.netloc == base_url:
+        if parsed.netloc.lower() == base_url:
             # Replace only the first occurrence to prevent double injection
             return url.replace(
                 f"https://{base_url}", f"https://{auth_prefix}{base_url}", 1

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -1,0 +1,384 @@
+"""Repository cloning and management utilities for OpenHands Cloud workspace.
+
+This module provides utilities for cloning git repositories and loading
+skills from them when running inside an OpenHands Cloud sandbox.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from openhands.sdk.logger import get_logger
+
+
+if TYPE_CHECKING:
+    pass
+
+
+logger = get_logger(__name__)
+
+
+# Clone timeout in seconds (5 minutes per repo)
+CLONE_TIMEOUT = 300
+
+
+class RepoSource(BaseModel):
+    """Repository source specification for cloning.
+
+    Repositories are cloned during automation setup and skills (AGENTS.md,
+    .agents/skills/, etc.) are automatically loaded from each cloned repo.
+
+    Examples:
+        >>> # Simple string URL
+        >>> RepoSource(url="owner/repo")
+
+        >>> # Full URL with ref
+        >>> RepoSource(url="https://github.com/owner/repo", ref="main")
+
+        >>> # From dict
+        >>> RepoSource.model_validate({"url": "owner/repo", "ref": "v1.0.0"})
+
+        >>> # From string (via model_validator)
+        >>> RepoSource.model_validate("owner/repo")
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    url: str = Field(
+        ...,
+        description=(
+            "Repository identifier. Can be 'owner/repo' format (assumes GitHub) "
+            "or a full URL (https://github.com/owner/repo, https://gitlab.com/owner/repo)."
+        ),
+    )
+    ref: str | None = Field(
+        default=None,
+        description="Optional branch, tag, or commit SHA to checkout.",
+    )
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_string_input(cls, data: Any) -> Any:
+        """Allow passing just a URL string instead of full object."""
+        if isinstance(data, str):
+            return {"url": data}
+        return data
+
+    @field_validator("url")
+    @classmethod
+    def validate_url(cls, v: str) -> str:
+        """Validate URL format to provide early feedback."""
+        # Allow owner/repo format (e.g., "owner/repo", "my-org/my-repo.git")
+        owner_repo_pattern = re.compile(r"^[\w-]+/[\w.-]+$")
+        if owner_repo_pattern.match(v):
+            return v
+        # Allow full git URLs
+        if v.startswith(("http://", "https://", "git@")):
+            return v
+        raise ValueError(
+            "URL must be 'owner/repo' format or a valid git URL "
+            "(https://, http://, or git@)"
+        )
+
+
+@dataclass
+class RepoMapping:
+    """Mapping information for a cloned repository."""
+
+    url: str
+    dir_name: str
+    local_path: str
+    ref: str | None = None
+
+
+@dataclass
+class CloneResult:
+    """Result of repository cloning operations."""
+
+    success_count: int
+    failed_repos: list[str]
+    repo_mappings: dict[str, RepoMapping] = field(default_factory=dict)
+
+
+def _is_commit_sha(ref: str | None) -> bool:
+    """Check if ref looks like a git commit SHA."""
+    if not ref:
+        return False
+    return bool(re.match(r"^[0-9a-f]{7,40}$", ref, re.IGNORECASE))
+
+
+def _extract_repo_name(url: str) -> str:
+    """Extract repository name from URL for use as directory name.
+
+    Examples:
+        >>> _extract_repo_name("owner/repo")
+        'repo'
+        >>> _extract_repo_name("https://github.com/owner/repo.git")
+        'repo'
+        >>> _extract_repo_name("git@github.com:owner/repo.git")
+        'repo'
+    """
+    # Remove trailing .git
+    url = re.sub(r"\.git$", "", url)
+
+    # Handle git@host:owner/repo format
+    if url.startswith("git@"):
+        url = url.split(":")[-1]
+
+    # Handle https://host/owner/repo format
+    if "://" in url:
+        url = url.split("://")[-1]
+
+    # Get the last path component (repo name)
+    parts = url.rstrip("/").split("/")
+    return parts[-1] if parts else "repo"
+
+
+def _sanitize_dir_name(name: str) -> str:
+    """Sanitize a string for use as a directory name.
+
+    Replaces invalid characters with underscores and ensures the name is safe.
+    """
+    # Replace characters that are problematic in file paths
+    sanitized = re.sub(r"[<>:\"/\\|?*\x00-\x1f]", "_", name)
+    # Remove leading/trailing dots and spaces
+    sanitized = sanitized.strip(". ")
+    # Ensure non-empty
+    return sanitized if sanitized else "repo"
+
+
+def _get_unique_dir_name(base_name: str, existing_dirs: set[str]) -> str:
+    """Get a unique directory name, appending _N if needed.
+
+    Args:
+        base_name: The desired directory name
+        existing_dirs: Set of already-used directory names
+
+    Returns:
+        A unique directory name (base_name or base_name_1, base_name_2, etc.)
+    """
+    if base_name not in existing_dirs:
+        return base_name
+
+    # Find next available suffix
+    counter = 1
+    while f"{base_name}_{counter}" in existing_dirs:
+        counter += 1
+    return f"{base_name}_{counter}"
+
+
+def _build_clone_url(
+    url: str, github_token: str | None, gitlab_token: str | None
+) -> str:
+    """Build authenticated clone URL based on the repository URL."""
+    # Handle owner/repo format (assume GitHub)
+    if "://" not in url and "/" in url and not url.startswith("git@"):
+        if github_token:
+            return f"https://{github_token}@github.com/{url}.git"
+        return f"https://github.com/{url}.git"
+
+    # Handle full URLs
+    if "github.com" in url:
+        if github_token:
+            return url.replace(
+                "https://github.com", f"https://{github_token}@github.com"
+            )
+        return url
+    elif "gitlab.com" in url:
+        if gitlab_token:
+            return url.replace(
+                "https://gitlab.com", f"https://oauth2:{gitlab_token}@gitlab.com"
+            )
+        return url
+
+    # Return as-is for other URLs
+    return url
+
+
+def _mask_url(url: str) -> str:
+    """Remove credentials from URL for display."""
+    if "://" not in url:
+        return url
+    return url.split("://")[0] + "://" + url.split("://")[-1].split("@")[-1]
+
+
+def _mask_tokens(text: str, github_token: str | None, gitlab_token: str | None) -> str:
+    """Mask tokens in text for safe logging."""
+    if github_token:
+        text = text.replace(github_token, "***")
+    if gitlab_token:
+        text = text.replace(gitlab_token, "***")
+    return text
+
+
+def clone_repos(
+    repos: list[RepoSource],
+    target_dir: Path,
+    github_token: str | None = None,
+    gitlab_token: str | None = None,
+    mapping_file: Path | None = None,
+) -> CloneResult:
+    """Clone repositories to the target directory.
+
+    Clones repos to meaningful directory names (e.g., 'openhands-cli' instead of
+    'repo_0'). Optionally writes a repos_mapping.json file with the URL → local
+    path mapping.
+
+    Args:
+        repos: List of RepoSource configurations
+        target_dir: Directory to clone repositories into
+        github_token: Optional GitHub token for authentication
+        gitlab_token: Optional GitLab token for authentication
+        mapping_file: Optional path to write repo mapping JSON file
+
+    Returns:
+        CloneResult with success count, failed repos, and repo mapping
+    """
+    if not repos:
+        logger.info("[clone] No repositories to clone")
+        return CloneResult(success_count=0, failed_repos=[], repo_mappings={})
+
+    logger.info(f"[clone] Cloning {len(repos)} repository(ies)...")
+
+    # Create target directory
+    target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Track used directory names to handle collisions
+    used_dir_names: set[str] = set()
+    failed_repos: list[str] = []
+    repo_mappings: dict[str, RepoMapping] = {}
+    success_count = 0
+
+    for repo in repos:
+        url = repo.url
+        ref = repo.ref
+
+        if not url:
+            logger.warning("[clone] Skipping repo: no URL specified")
+            continue
+
+        # Determine directory name from repo URL
+        raw_name = _extract_repo_name(url)
+        safe_name = _sanitize_dir_name(raw_name)
+        dir_name = _get_unique_dir_name(safe_name, used_dir_names)
+        used_dir_names.add(dir_name)
+
+        dest = target_dir / dir_name
+        clone_url = _build_clone_url(url, github_token, gitlab_token)
+        display_url = _mask_url(url)
+
+        # Build git clone command
+        # Note: --depth 1 with --branch only works for branches/tags, not SHAs.
+        # For SHA refs, we do a full clone then checkout the specific commit.
+        if _is_commit_sha(ref):
+            # Full clone for SHA refs (shallow clone can't fetch arbitrary commits)
+            cmd = ["git", "clone", clone_url, str(dest)]
+            needs_checkout = True
+        else:
+            # Shallow clone for branches/tags
+            cmd = ["git", "clone", "--depth", "1"]
+            if ref:
+                cmd.extend(["--branch", ref])
+            cmd.extend([clone_url, str(dest)])
+            needs_checkout = False
+
+        logger.info(f"[clone] Cloning {display_url} -> {dest.name}/")
+
+        try:
+            result = subprocess.run(
+                cmd, capture_output=True, text=True, timeout=CLONE_TIMEOUT
+            )
+            if result.returncode != 0:
+                error_msg = _mask_tokens(result.stderr, github_token, gitlab_token)
+                logger.warning(f"[clone] Failed to clone {display_url}: {error_msg}")
+                failed_repos.append(display_url)
+                continue
+
+            # Checkout specific SHA if needed
+            if needs_checkout and ref:
+                checkout_result = subprocess.run(
+                    ["git", "-C", str(dest), "checkout", ref],
+                    capture_output=True,
+                    text=True,
+                    timeout=30,
+                )
+                if checkout_result.returncode != 0:
+                    logger.warning(
+                        f"[clone] Failed to checkout {ref}: {checkout_result.stderr}"
+                    )
+                    failed_repos.append(display_url)
+                    continue
+
+            logger.info(f"[clone] Successfully cloned {display_url} -> {dir_name}/")
+            success_count += 1
+
+            # Record mapping
+            repo_mappings[url] = RepoMapping(
+                url=url,
+                dir_name=dir_name,
+                local_path=str(dest),
+                ref=ref,
+            )
+
+        except subprocess.TimeoutExpired:
+            logger.warning(f"[clone] Clone timed out for {display_url}")
+            failed_repos.append(display_url)
+            continue
+
+    # Write mapping file if requested
+    if mapping_file and repo_mappings:
+        mapping_data = {
+            url: {
+                "dir_name": m.dir_name,
+                "local_path": m.local_path,
+                "ref": m.ref,
+            }
+            for url, m in repo_mappings.items()
+        }
+        with open(mapping_file, "w") as f:
+            json.dump(mapping_data, f, indent=2)
+        logger.info(f"[clone] Wrote repository mapping to {mapping_file.name}")
+
+    logger.info(f"[clone] Cloned {success_count}/{len(repos)} repositories")
+    if failed_repos:
+        logger.warning(f"[clone] FAILED repos: {', '.join(failed_repos)}")
+
+    return CloneResult(
+        success_count=success_count,
+        failed_repos=failed_repos,
+        repo_mappings=repo_mappings,
+    )
+
+
+def get_repos_context(repo_mappings: dict[str, RepoMapping]) -> str:
+    """Generate a context string describing cloned repositories for the agent.
+
+    Args:
+        repo_mappings: Dictionary mapping URLs to RepoMapping objects
+
+    Returns:
+        Markdown-formatted string with repository mapping, or empty string if no repos.
+    """
+    if not repo_mappings:
+        return ""
+
+    lines = [
+        "## Cloned Repositories",
+        "",
+        "The following repositories have been cloned to your workspace:",
+        "",
+    ]
+
+    for url, mapping in repo_mappings.items():
+        ref_str = f" (ref: {mapping.ref})" if mapping.ref else ""
+        lines.append(f"- `{url}`{ref_str} → `{mapping.local_path}/`")
+
+    lines.append("")
+    return "\n".join(lines)

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -6,7 +6,6 @@ skills from them when running inside an OpenHands Cloud sandbox.
 
 from __future__ import annotations
 
-import json
 import re
 import subprocess
 from dataclasses import dataclass, field
@@ -318,7 +317,6 @@ def clone_repos(
     repos: list[RepoSource],
     target_dir: Path,
     token_fetcher: TokenFetcher | None = None,
-    mapping_file: Path | None = None,
 ) -> CloneResult:
     """Clone repositories to the target directory.
 
@@ -331,7 +329,6 @@ def clone_repos(
         target_dir: Directory to clone repositories into
         token_fetcher: Callable that takes a token name (e.g., 'github_token')
             and returns the token value, or None if not available
-        mapping_file: Optional path to write repo mapping JSON file
 
     Returns:
         CloneResult with success count, failed repos, and repo mapping
@@ -445,20 +442,6 @@ def clone_repos(
             logger.warning(f"[clone] Clone timed out for {display_url}")
             failed_repos.append(display_url)
             continue
-
-    # Write mapping file if requested
-    if mapping_file and repo_mappings:
-        mapping_data = {
-            url: {
-                "dir_name": m.dir_name,
-                "local_path": m.local_path,
-                "ref": m.ref,
-            }
-            for url, m in repo_mappings.items()
-        }
-        with open(mapping_file, "w") as f:
-            json.dump(mapping_data, f, indent=2)
-        logger.info(f"[clone] Wrote repository mapping to {mapping_file.name}")
 
     logger.info(f"[clone] Cloned {success_count}/{len(repos)} repositories")
     if failed_repos:

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -347,6 +347,9 @@ def _checkout_sha(dest: Path, sha: str) -> bool:
 
     On failure, cleans up the cloned directory to prevent orphaned directories
     that block retry attempts.
+
+    Note: We don't use `--` separator because the sha parameter is validated
+    by _is_commit_sha() to be 7+ hex characters, making flag injection impossible.
     """
     result = subprocess.run(
         ["git", "-C", str(dest), "checkout", sha],

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -250,49 +250,33 @@ def _get_unique_dir_name(base_name: str, existing_dirs: set[str]) -> str:
     return f"{base_name}_{counter}"
 
 
+# Provider configurations: (base_url, token_format)
+# token_format uses {token} placeholder
+_PROVIDER_CONFIG: dict[GitProvider, tuple[str, str]] = {
+    GitProvider.GITHUB: ("github.com", "{token}@"),
+    GitProvider.GITLAB: ("gitlab.com", "oauth2:{token}@"),
+    GitProvider.BITBUCKET: ("bitbucket.org", "x-token-auth:{token}@"),
+}
+
+
 def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
-    """Build authenticated clone URL based on the repository URL and provider.
-
-    Args:
-        url: Repository URL or owner/repo format
-        provider: Git hosting provider
-        token: Authentication token for the provider (may be None)
-
-    Returns:
-        Clone URL with authentication if token is available
-    """
-    # Handle owner/repo format - construct full URL based on provider
-    if "://" not in url and "/" in url and not url.startswith("git@"):
-        if provider == GitProvider.GITHUB:
-            base_url = "github.com"
-            if token:
-                return f"https://{token}@{base_url}/{url}.git"
-            return f"https://{base_url}/{url}.git"
-        elif provider == GitProvider.GITLAB:
-            base_url = "gitlab.com"
-            if token:
-                return f"https://oauth2:{token}@{base_url}/{url}.git"
-            return f"https://{base_url}/{url}.git"
-        elif provider == GitProvider.BITBUCKET:
-            base_url = "bitbucket.org"
-            if token:
-                return f"https://x-token-auth:{token}@{base_url}/{url}.git"
-            return f"https://{base_url}/{url}.git"
-
-    # Handle full URLs - inject authentication
-    if not token:
+    """Build authenticated clone URL based on the repository URL and provider."""
+    config = _PROVIDER_CONFIG.get(provider)
+    if not config:
         return url
 
-    if provider == GitProvider.GITHUB and "github.com" in url:
-        return url.replace("https://github.com", f"https://{token}@github.com")
-    elif provider == GitProvider.GITLAB and "gitlab.com" in url:
-        return url.replace("https://gitlab.com", f"https://oauth2:{token}@gitlab.com")
-    elif provider == GitProvider.BITBUCKET and "bitbucket.org" in url:
-        return url.replace(
-            "https://bitbucket.org", f"https://x-token-auth:{token}@bitbucket.org"
-        )
+    base_url, token_format = config
+    auth_prefix = token_format.format(token=token) if token else ""
 
-    # Return as-is for other URLs or unrecognized patterns
+    # Handle owner/repo format - construct full URL
+    is_short_format = "://" not in url and "/" in url and not url.startswith("git@")
+    if is_short_format:
+        return f"https://{auth_prefix}{base_url}/{url}.git"
+
+    # Handle full URLs - inject authentication
+    if token and base_url in url:
+        return url.replace(f"https://{base_url}", f"https://{auth_prefix}{base_url}")
+
     return url
 
 
@@ -313,16 +297,64 @@ def _mask_token(text: str, token: str | None) -> str:
 TokenFetcher = Any  # Callable[[str], str | None] - fetches token by name
 
 
+def _clone_single_repo(
+    repo: RepoSource,
+    dest: Path,
+    token: str | None,
+) -> bool:
+    """Clone a single repository. Returns True on success."""
+    url, ref = repo.url, repo.ref
+    provider = repo.get_provider()
+    clone_url = _build_clone_url(url, provider, token)
+    display_url = _mask_url(url)
+
+    # Build git clone command
+    # SHA refs need full clone + checkout; branches/tags can use shallow clone
+    is_sha = _is_commit_sha(ref)
+    if is_sha:
+        cmd = ["git", "clone", clone_url, str(dest)]
+    else:
+        cmd = ["git", "clone", "--depth", "1"]
+        if ref:
+            cmd.extend(["--branch", ref])
+        cmd.extend([clone_url, str(dest)])
+
+    logger.info(f"[clone] Cloning {display_url} ({provider.value}) -> {dest.name}/")
+
+    try:
+        result = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=CLONE_TIMEOUT
+        )
+        if result.returncode != 0:
+            logger.warning(f"[clone] Failed: {_mask_token(result.stderr, token)}")
+            return False
+
+        # Checkout specific SHA if needed
+        if is_sha and ref:
+            checkout = subprocess.run(
+                ["git", "-C", str(dest), "checkout", ref],
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+            if checkout.returncode != 0:
+                logger.warning(f"[clone] Failed to checkout {ref}: {checkout.stderr}")
+                return False
+
+        logger.info(f"[clone] Success: {display_url} -> {dest.name}/")
+        return True
+
+    except subprocess.TimeoutExpired:
+        logger.warning(f"[clone] Timed out: {display_url}")
+        return False
+
+
 def clone_repos(
     repos: list[RepoSource],
     target_dir: Path,
     token_fetcher: TokenFetcher | None = None,
 ) -> CloneResult:
     """Clone repositories to the target directory.
-
-    Clones repos to meaningful directory names (e.g., 'openhands-cli' instead of
-    'repo_0'). Uses the provider specified in each RepoSource to determine which
-    authentication token to use.
 
     Args:
         repos: List of RepoSource configurations (each specifies provider)
@@ -338,119 +370,51 @@ def clone_repos(
         return CloneResult(success_count=0, failed_repos=[], repo_mappings={})
 
     logger.info(f"[clone] Cloning {len(repos)} repository(ies)...")
-
-    # Create target directory
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    # Cache fetched tokens to avoid repeated API calls
+    # Cache tokens to avoid repeated API calls
     token_cache: dict[str, str | None] = {}
 
-    def get_token(token_name: str) -> str | None:
-        """Get token from cache or fetch it."""
-        if token_name not in token_cache:
-            if token_fetcher:
-                token_cache[token_name] = token_fetcher(token_name)
-            else:
-                token_cache[token_name] = None
-        return token_cache[token_name]
+    def get_token(name: str) -> str | None:
+        if name not in token_cache:
+            token_cache[name] = token_fetcher(name) if token_fetcher else None
+        return token_cache[name]
 
-    # Track used directory names to handle collisions
-    used_dir_names: set[str] = set()
-    failed_repos: list[str] = []
-    repo_mappings: dict[str, RepoMapping] = {}
-    success_count = 0
+    used_dirs: set[str] = set()
+    failed: list[str] = []
+    mappings: dict[str, RepoMapping] = {}
 
     for repo in repos:
-        url = repo.url
-        ref = repo.ref
-
-        if not url:
-            logger.warning("[clone] Skipping repo: no URL specified")
+        if not repo.url:
             continue
 
-        # Get provider and token for this specific repo
-        provider = repo.get_provider()
-        token_name = repo.get_token_name()
-        token = get_token(token_name)
-
-        logger.debug(f"[clone] Repo {url} using provider {provider.value}")
-
-        # Determine directory name from repo URL
-        raw_name = _extract_repo_name(url)
-        safe_name = _sanitize_dir_name(raw_name)
-        dir_name = _get_unique_dir_name(safe_name, used_dir_names)
-        used_dir_names.add(dir_name)
-
+        # Get unique directory name
+        dir_name = _get_unique_dir_name(
+            _sanitize_dir_name(_extract_repo_name(repo.url)), used_dirs
+        )
+        used_dirs.add(dir_name)
         dest = target_dir / dir_name
-        clone_url = _build_clone_url(url, provider, token)
-        display_url = _mask_url(url)
 
-        # Build git clone command
-        # Note: --depth 1 with --branch only works for branches/tags, not SHAs.
-        # For SHA refs, we do a full clone then checkout the specific commit.
-        if _is_commit_sha(ref):
-            # Full clone for SHA refs (shallow clone can't fetch arbitrary commits)
-            cmd = ["git", "clone", clone_url, str(dest)]
-            needs_checkout = True
-        else:
-            # Shallow clone for branches/tags
-            cmd = ["git", "clone", "--depth", "1"]
-            if ref:
-                cmd.extend(["--branch", ref])
-            cmd.extend([clone_url, str(dest)])
-            needs_checkout = False
-
-        logger.info(f"[clone] Cloning {display_url} ({provider.value}) -> {dest.name}/")
-
-        try:
-            result = subprocess.run(
-                cmd, capture_output=True, text=True, timeout=CLONE_TIMEOUT
-            )
-            if result.returncode != 0:
-                error_msg = _mask_token(result.stderr, token)
-                logger.warning(f"[clone] Failed to clone {display_url}: {error_msg}")
-                failed_repos.append(display_url)
-                continue
-
-            # Checkout specific SHA if needed
-            if needs_checkout and ref:
-                checkout_result = subprocess.run(
-                    ["git", "-C", str(dest), "checkout", ref],
-                    capture_output=True,
-                    text=True,
-                    timeout=30,
-                )
-                if checkout_result.returncode != 0:
-                    logger.warning(
-                        f"[clone] Failed to checkout {ref}: {checkout_result.stderr}"
-                    )
-                    failed_repos.append(display_url)
-                    continue
-
-            logger.info(f"[clone] Successfully cloned {display_url} -> {dir_name}/")
-            success_count += 1
-
-            # Record mapping
-            repo_mappings[url] = RepoMapping(
-                url=url,
+        # Clone with provider-specific token
+        token = get_token(repo.get_token_name())
+        if _clone_single_repo(repo, dest, token):
+            mappings[repo.url] = RepoMapping(
+                url=repo.url,
                 dir_name=dir_name,
                 local_path=str(dest),
-                ref=ref,
+                ref=repo.ref,
             )
+        else:
+            failed.append(_mask_url(repo.url))
 
-        except subprocess.TimeoutExpired:
-            logger.warning(f"[clone] Clone timed out for {display_url}")
-            failed_repos.append(display_url)
-            continue
-
-    logger.info(f"[clone] Cloned {success_count}/{len(repos)} repositories")
-    if failed_repos:
-        logger.warning(f"[clone] FAILED repos: {', '.join(failed_repos)}")
+    logger.info(f"[clone] Cloned {len(mappings)}/{len(repos)} repositories")
+    if failed:
+        logger.warning(f"[clone] Failed: {', '.join(failed)}")
 
     return CloneResult(
-        success_count=success_count,
-        failed_repos=failed_repos,
-        repo_mappings=repo_mappings,
+        success_count=len(mappings),
+        failed_repos=failed,
+        repo_mappings=mappings,
     )
 
 

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -10,8 +10,9 @@ import json
 import re
 import subprocess
 from dataclasses import dataclass, field
+from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
@@ -29,18 +30,69 @@ logger = get_logger(__name__)
 CLONE_TIMEOUT = 300
 
 
+class GitProvider(str, Enum):
+    """Supported git hosting providers."""
+
+    GITHUB = "github"
+    GITLAB = "gitlab"
+    BITBUCKET = "bitbucket"
+    AZURE = "azure"
+
+
+# Mapping of provider to secret name used in sandbox settings
+PROVIDER_TOKEN_NAMES: dict[GitProvider, str] = {
+    GitProvider.GITHUB: "github_token",
+    GitProvider.GITLAB: "gitlab_token",
+    GitProvider.BITBUCKET: "bitbucket_token",
+    GitProvider.AZURE: "azure_token",
+}
+
+# Mapping of URL patterns to providers for auto-detection
+PROVIDER_URL_PATTERNS: dict[str, GitProvider] = {
+    "github.com": GitProvider.GITHUB,
+    "gitlab.com": GitProvider.GITLAB,
+    "bitbucket.org": GitProvider.BITBUCKET,
+    "dev.azure.com": GitProvider.AZURE,
+    "visualstudio.com": GitProvider.AZURE,
+}
+
+
+def _detect_provider_from_url(url: str) -> GitProvider | None:
+    """Detect git provider from URL patterns.
+
+    Args:
+        url: Repository URL or owner/repo format
+
+    Returns:
+        Detected GitProvider or None if not recognized
+    """
+    url_lower = url.lower()
+    for pattern, provider in PROVIDER_URL_PATTERNS.items():
+        if pattern in url_lower:
+            return provider
+    return None
+
+
 class RepoSource(BaseModel):
     """Repository source specification for cloning.
 
     Repositories are cloned during automation setup and skills (AGENTS.md,
     .agents/skills/, etc.) are automatically loaded from each cloned repo.
 
+    The provider field specifies which git hosting service the repo belongs to,
+    which determines which authentication token to use for cloning. If not
+    specified, the provider is auto-detected from the URL (defaulting to GitHub
+    for owner/repo format).
+
     Examples:
-        >>> # Simple string URL
+        >>> # Simple string URL (defaults to GitHub)
         >>> RepoSource(url="owner/repo")
 
-        >>> # Full URL with ref
+        >>> # Full URL with ref (provider auto-detected)
         >>> RepoSource(url="https://github.com/owner/repo", ref="main")
+
+        >>> # GitLab repo with explicit provider
+        >>> RepoSource(url="owner/repo", provider="gitlab")
 
         >>> # From dict
         >>> RepoSource.model_validate({"url": "owner/repo", "ref": "v1.0.0"})
@@ -54,13 +106,22 @@ class RepoSource(BaseModel):
     url: str = Field(
         ...,
         description=(
-            "Repository identifier. Can be 'owner/repo' format (assumes GitHub) "
+            "Repository identifier. Can be 'owner/repo' format "
             "or a full URL (https://github.com/owner/repo, https://gitlab.com/owner/repo)."
         ),
     )
     ref: str | None = Field(
         default=None,
         description="Optional branch, tag, or commit SHA to checkout.",
+    )
+    provider: Literal["github", "gitlab", "bitbucket", "azure"] | None = Field(
+        default=None,
+        description=(
+            "Git hosting provider (github, gitlab, bitbucket, azure). "
+            "Used to determine which authentication token to use. "
+            "If not specified, auto-detected from URL "
+            "(defaults to github for owner/repo format)."
+        ),
     )
 
     @model_validator(mode="before")
@@ -86,6 +147,26 @@ class RepoSource(BaseModel):
             "URL must be 'owner/repo' format or a valid git URL "
             "(https://, http://, or git@)"
         )
+
+    def get_provider(self) -> GitProvider:
+        """Get the git provider for this repo.
+
+        Returns the explicitly set provider, or auto-detects from URL.
+        Defaults to GitHub for owner/repo format without explicit provider.
+        """
+        if self.provider:
+            return GitProvider(self.provider)
+
+        detected = _detect_provider_from_url(self.url)
+        if detected:
+            return detected
+
+        # Default to GitHub for owner/repo format
+        return GitProvider.GITHUB
+
+    def get_token_name(self) -> str:
+        """Get the secret name for this repo's authentication token."""
+        return PROVIDER_TOKEN_NAMES[self.get_provider()]
 
 
 @dataclass
@@ -174,31 +255,65 @@ def _get_unique_dir_name(base_name: str, existing_dirs: set[str]) -> str:
     return f"{base_name}_{counter}"
 
 
-def _build_clone_url(
-    url: str, github_token: str | None, gitlab_token: str | None
-) -> str:
-    """Build authenticated clone URL based on the repository URL."""
-    # Handle owner/repo format (assume GitHub)
+def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
+    """Build authenticated clone URL based on the repository URL and provider.
+
+    Args:
+        url: Repository URL or owner/repo format
+        provider: Git hosting provider
+        token: Authentication token for the provider (may be None)
+
+    Returns:
+        Clone URL with authentication if token is available
+    """
+    # Handle owner/repo format - construct full URL based on provider
     if "://" not in url and "/" in url and not url.startswith("git@"):
-        if github_token:
-            return f"https://{github_token}@github.com/{url}.git"
-        return f"https://github.com/{url}.git"
+        if provider == GitProvider.GITHUB:
+            base_url = "github.com"
+            if token:
+                return f"https://{token}@{base_url}/{url}.git"
+            return f"https://{base_url}/{url}.git"
+        elif provider == GitProvider.GITLAB:
+            base_url = "gitlab.com"
+            if token:
+                return f"https://oauth2:{token}@{base_url}/{url}.git"
+            return f"https://{base_url}/{url}.git"
+        elif provider == GitProvider.BITBUCKET:
+            base_url = "bitbucket.org"
+            if token:
+                return f"https://x-token-auth:{token}@{base_url}/{url}.git"
+            return f"https://{base_url}/{url}.git"
+        elif provider == GitProvider.AZURE:
+            # Azure DevOps uses organization/project/_git/repo format
+            # For owner/repo format, assume it's org/repo
+            if token:
+                return f"https://{token}@dev.azure.com/{url}"
+            return f"https://dev.azure.com/{url}"
 
-    # Handle full URLs
-    if "github.com" in url:
-        if github_token:
-            return url.replace(
-                "https://github.com", f"https://{github_token}@github.com"
-            )
-        return url
-    elif "gitlab.com" in url:
-        if gitlab_token:
-            return url.replace(
-                "https://gitlab.com", f"https://oauth2:{gitlab_token}@gitlab.com"
-            )
+    # Handle full URLs - inject authentication
+    if not token:
         return url
 
-    # Return as-is for other URLs
+    if provider == GitProvider.GITHUB and "github.com" in url:
+        return url.replace("https://github.com", f"https://{token}@github.com")
+    elif provider == GitProvider.GITLAB and "gitlab.com" in url:
+        return url.replace("https://gitlab.com", f"https://oauth2:{token}@gitlab.com")
+    elif provider == GitProvider.BITBUCKET and "bitbucket.org" in url:
+        return url.replace(
+            "https://bitbucket.org", f"https://x-token-auth:{token}@bitbucket.org"
+        )
+    elif provider == GitProvider.AZURE and (
+        "dev.azure.com" in url or "visualstudio.com" in url
+    ):
+        if "dev.azure.com" in url:
+            return url.replace(
+                "https://dev.azure.com", f"https://{token}@dev.azure.com"
+            )
+        else:
+            # Handle legacy visualstudio.com URLs
+            return url.replace("https://", f"https://{token}@")
+
+    # Return as-is for other URLs or unrecognized patterns
     return url
 
 
@@ -209,33 +324,33 @@ def _mask_url(url: str) -> str:
     return url.split("://")[0] + "://" + url.split("://")[-1].split("@")[-1]
 
 
-def _mask_tokens(text: str, github_token: str | None, gitlab_token: str | None) -> str:
-    """Mask tokens in text for safe logging."""
-    if github_token:
-        text = text.replace(github_token, "***")
-    if gitlab_token:
-        text = text.replace(gitlab_token, "***")
+def _mask_token(text: str, token: str | None) -> str:
+    """Mask token in text for safe logging."""
+    if token:
+        text = text.replace(token, "***")
     return text
+
+
+TokenFetcher = Any  # Callable[[str], str | None] - fetches token by name
 
 
 def clone_repos(
     repos: list[RepoSource],
     target_dir: Path,
-    github_token: str | None = None,
-    gitlab_token: str | None = None,
+    token_fetcher: TokenFetcher | None = None,
     mapping_file: Path | None = None,
 ) -> CloneResult:
     """Clone repositories to the target directory.
 
     Clones repos to meaningful directory names (e.g., 'openhands-cli' instead of
-    'repo_0'). Optionally writes a repos_mapping.json file with the URL → local
-    path mapping.
+    'repo_0'). Uses the provider specified in each RepoSource to determine which
+    authentication token to use.
 
     Args:
-        repos: List of RepoSource configurations
+        repos: List of RepoSource configurations (each specifies provider)
         target_dir: Directory to clone repositories into
-        github_token: Optional GitHub token for authentication
-        gitlab_token: Optional GitLab token for authentication
+        token_fetcher: Callable that takes a token name (e.g., 'github_token')
+            and returns the token value, or None if not available
         mapping_file: Optional path to write repo mapping JSON file
 
     Returns:
@@ -249,6 +364,18 @@ def clone_repos(
 
     # Create target directory
     target_dir.mkdir(parents=True, exist_ok=True)
+
+    # Cache fetched tokens to avoid repeated API calls
+    token_cache: dict[str, str | None] = {}
+
+    def get_token(token_name: str) -> str | None:
+        """Get token from cache or fetch it."""
+        if token_name not in token_cache:
+            if token_fetcher:
+                token_cache[token_name] = token_fetcher(token_name)
+            else:
+                token_cache[token_name] = None
+        return token_cache[token_name]
 
     # Track used directory names to handle collisions
     used_dir_names: set[str] = set()
@@ -264,6 +391,13 @@ def clone_repos(
             logger.warning("[clone] Skipping repo: no URL specified")
             continue
 
+        # Get provider and token for this specific repo
+        provider = repo.get_provider()
+        token_name = repo.get_token_name()
+        token = get_token(token_name)
+
+        logger.debug(f"[clone] Repo {url} using provider {provider.value}")
+
         # Determine directory name from repo URL
         raw_name = _extract_repo_name(url)
         safe_name = _sanitize_dir_name(raw_name)
@@ -271,7 +405,7 @@ def clone_repos(
         used_dir_names.add(dir_name)
 
         dest = target_dir / dir_name
-        clone_url = _build_clone_url(url, github_token, gitlab_token)
+        clone_url = _build_clone_url(url, provider, token)
         display_url = _mask_url(url)
 
         # Build git clone command
@@ -289,14 +423,14 @@ def clone_repos(
             cmd.extend([clone_url, str(dest)])
             needs_checkout = False
 
-        logger.info(f"[clone] Cloning {display_url} -> {dest.name}/")
+        logger.info(f"[clone] Cloning {display_url} ({provider.value}) -> {dest.name}/")
 
         try:
             result = subprocess.run(
                 cmd, capture_output=True, text=True, timeout=CLONE_TIMEOUT
             )
             if result.returncode != 0:
-                error_msg = _mask_tokens(result.stderr, github_token, gitlab_token)
+                error_msg = _mask_token(result.stderr, token)
                 logger.warning(f"[clone] Failed to clone {display_url}: {error_msg}")
                 failed_repos.append(display_url)
                 continue

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -36,7 +36,6 @@ class GitProvider(str, Enum):
     GITHUB = "github"
     GITLAB = "gitlab"
     BITBUCKET = "bitbucket"
-    AZURE = "azure"
 
 
 # Mapping of provider to secret name used in sandbox settings
@@ -44,7 +43,6 @@ PROVIDER_TOKEN_NAMES: dict[GitProvider, str] = {
     GitProvider.GITHUB: "github_token",
     GitProvider.GITLAB: "gitlab_token",
     GitProvider.BITBUCKET: "bitbucket_token",
-    GitProvider.AZURE: "azure_token",
 }
 
 # Mapping of URL patterns to providers for auto-detection
@@ -52,8 +50,6 @@ PROVIDER_URL_PATTERNS: dict[str, GitProvider] = {
     "github.com": GitProvider.GITHUB,
     "gitlab.com": GitProvider.GITLAB,
     "bitbucket.org": GitProvider.BITBUCKET,
-    "dev.azure.com": GitProvider.AZURE,
-    "visualstudio.com": GitProvider.AZURE,
 }
 
 
@@ -114,10 +110,10 @@ class RepoSource(BaseModel):
         default=None,
         description="Optional branch, tag, or commit SHA to checkout.",
     )
-    provider: Literal["github", "gitlab", "bitbucket", "azure"] | None = Field(
+    provider: Literal["github", "gitlab", "bitbucket"] | None = Field(
         default=None,
         description=(
-            "Git hosting provider (github, gitlab, bitbucket, azure). "
+            "Git hosting provider (github, gitlab, bitbucket). "
             "Used to determine which authentication token to use. "
             "If not specified, auto-detected from URL "
             "(defaults to github for owner/repo format)."
@@ -283,12 +279,6 @@ def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
             if token:
                 return f"https://x-token-auth:{token}@{base_url}/{url}.git"
             return f"https://{base_url}/{url}.git"
-        elif provider == GitProvider.AZURE:
-            # Azure DevOps uses organization/project/_git/repo format
-            # For owner/repo format, assume it's org/repo
-            if token:
-                return f"https://{token}@dev.azure.com/{url}"
-            return f"https://dev.azure.com/{url}"
 
     # Handle full URLs - inject authentication
     if not token:
@@ -302,16 +292,6 @@ def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
         return url.replace(
             "https://bitbucket.org", f"https://x-token-auth:{token}@bitbucket.org"
         )
-    elif provider == GitProvider.AZURE and (
-        "dev.azure.com" in url or "visualstudio.com" in url
-    ):
-        if "dev.azure.com" in url:
-            return url.replace(
-                "https://dev.azure.com", f"https://{token}@dev.azure.com"
-            )
-        else:
-            # Handle legacy visualstudio.com URLs
-            return url.replace("https://", f"https://{token}@")
 
     # Return as-is for other URLs or unrecognized patterns
     return url

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import re
 import subprocess
+import urllib.parse
 from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
@@ -52,16 +53,26 @@ PROVIDER_URL_PATTERNS: dict[str, GitProvider] = {
 def _detect_provider_from_url(url: str) -> GitProvider | None:
     """Detect git provider from URL patterns.
 
+    Uses proper URL parsing to prevent false positives from malicious URLs
+    like 'https://github.com.evil.com/repo'.
+
     Args:
         url: Repository URL or owner/repo format
 
     Returns:
         Detected GitProvider or None if not recognized
     """
-    url_lower = url.lower()
-    for pattern, provider in PROVIDER_URL_PATTERNS.items():
-        if pattern in url_lower:
-            return provider
+    try:
+        parsed = urllib.parse.urlparse(url)
+        hostname = parsed.netloc.lower()
+        # Handle git@ format: git@github.com:owner/repo
+        if not hostname and url.startswith("git@"):
+            hostname = url.split("@")[1].split(":")[0].lower()
+        for pattern, provider in PROVIDER_URL_PATTERNS.items():
+            if hostname == pattern:
+                return provider
+    except Exception:
+        pass
     return None
 
 
@@ -209,8 +220,8 @@ def _extract_repo_name(url: str) -> str:
         >>> _extract_repo_name("git@github.com:owner/repo.git")
         'repo'
     """
-    # Remove trailing .git
-    url = re.sub(r"\.git$", "", url)
+    # Remove trailing .git (with or without trailing slash)
+    url = re.sub(r"\.git/?$", "", url)
 
     # Handle git@host:owner/repo format
     if url.startswith("git@"):
@@ -268,7 +279,10 @@ _PROVIDER_CONFIG: dict[GitProvider, tuple[str, str]] = {
 
 
 def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
-    """Build authenticated clone URL based on the repository URL and provider."""
+    """Build authenticated clone URL based on the repository URL and provider.
+
+    Uses proper URL parsing to prevent token injection into malicious URLs.
+    """
     config = _PROVIDER_CONFIG.get(provider)
     if not config:
         return url
@@ -281,9 +295,14 @@ def _build_clone_url(url: str, provider: GitProvider, token: str | None) -> str:
     if is_short_format:
         return f"https://{auth_prefix}{base_url}/{url}.git"
 
-    # Handle full URLs - inject authentication
-    if token and base_url in url:
-        return url.replace(f"https://{base_url}", f"https://{auth_prefix}{base_url}")
+    # Handle full URLs - inject authentication only if hostname matches exactly
+    if token:
+        parsed = urllib.parse.urlparse(url)
+        if parsed.netloc == base_url:
+            # Replace only the first occurrence to prevent double injection
+            return url.replace(
+                f"https://{base_url}", f"https://{auth_prefix}{base_url}", 1
+            )
 
     return url
 
@@ -373,9 +392,13 @@ class _TokenCache:
 
     def get(self, token_name: str) -> str | None:
         if token_name not in self._cache:
-            self._cache[token_name] = (
-                self._fetcher(token_name) if self._fetcher else None
-            )
+            try:
+                self._cache[token_name] = (
+                    self._fetcher(token_name) if self._fetcher else None
+                )
+            except Exception as e:
+                logger.warning(f"Failed to fetch token '{token_name}': {e}")
+                self._cache[token_name] = None
         return self._cache[token_name]
 
 
@@ -408,28 +431,34 @@ def clone_repos(
     mappings: dict[str, RepoMapping] = {}
 
     for repo in repos:
-        if not repo.url:
-            continue
+        try:
+            if not repo.url:
+                continue
 
-        # Determine unique directory name
-        base_name = _sanitize_dir_name(_extract_repo_name(repo.url))
-        dir_name = _get_unique_dir_name(base_name, used_dirs)
-        used_dirs.add(dir_name)
-        dest = target_dir / dir_name
+            # Determine unique directory name
+            base_name = _sanitize_dir_name(_extract_repo_name(repo.url))
+            dir_name = _get_unique_dir_name(base_name, used_dirs)
+            used_dirs.add(dir_name)
+            dest = target_dir / dir_name
 
-        # Clone with provider-specific token
-        token = tokens.get(repo.get_token_name())
-        success = _clone_single_repo(repo, dest, token)
+            # Clone with provider-specific token
+            token = tokens.get(repo.get_token_name())
+            success = _clone_single_repo(repo, dest, token)
 
-        if success:
-            mappings[repo.url] = RepoMapping(
-                url=repo.url,
-                dir_name=dir_name,
-                local_path=str(dest),
-                ref=repo.ref,
-            )
-        else:
-            failed.append(_mask_url(repo.url))
+            if success:
+                mappings[repo.url] = RepoMapping(
+                    url=repo.url,
+                    dir_name=dir_name,
+                    local_path=str(dest),
+                    ref=repo.ref,
+                )
+            else:
+                failed.append(_mask_url(repo.url))
+        except Exception as e:
+            # Don't let one bad repo stop the entire batch
+            display_url = _mask_url(repo.url) if repo.url else "<unknown>"
+            logger.warning(f"[clone] Error processing {display_url}: {e}")
+            failed.append(display_url)
 
     logger.info(f"[clone] Cloned {len(mappings)}/{len(repos)} repositories")
     if failed:

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -8,18 +8,15 @@ from __future__ import annotations
 
 import re
 import subprocess
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import Any, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from openhands.sdk.logger import get_logger
-
-
-if TYPE_CHECKING:
-    pass
 
 
 logger = get_logger(__name__)
@@ -305,59 +302,81 @@ def _mask_token(text: str, token: str | None) -> str:
     return text
 
 
-TokenFetcher = Any  # Callable[[str], str | None] - fetches token by name
+# Type for functions that fetch tokens by name (e.g., "github_token" -> token value)
+TokenFetcher = Callable[[str], str | None]
 
 
-def _clone_single_repo(
-    repo: RepoSource,
-    dest: Path,
-    token: str | None,
-) -> bool:
+def _build_clone_command(clone_url: str, dest: Path, ref: str | None) -> list[str]:
+    """Build the git clone command."""
+    # SHA refs need full clone; branches/tags can use shallow clone
+    if _is_commit_sha(ref):
+        return ["git", "clone", clone_url, str(dest)]
+
+    cmd = ["git", "clone", "--depth", "1"]
+    if ref:
+        cmd.extend(["--branch", ref])
+    cmd.extend([clone_url, str(dest)])
+    return cmd
+
+
+def _checkout_sha(dest: Path, sha: str) -> bool:
+    """Checkout a specific SHA after full clone. Returns True on success."""
+    result = subprocess.run(
+        ["git", "-C", str(dest), "checkout", sha],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if result.returncode != 0:
+        logger.warning(f"[clone] Failed to checkout {sha}: {result.stderr}")
+        return False
+    return True
+
+
+def _clone_single_repo(repo: RepoSource, dest: Path, token: str | None) -> bool:
     """Clone a single repository. Returns True on success."""
-    url, ref = repo.url, repo.ref
     provider = repo.get_provider()
-    clone_url = _build_clone_url(url, provider, token)
-    display_url = _mask_url(url)
-
-    # Build git clone command
-    # SHA refs need full clone + checkout; branches/tags can use shallow clone
-    is_sha = _is_commit_sha(ref)
-    if is_sha:
-        cmd = ["git", "clone", clone_url, str(dest)]
-    else:
-        cmd = ["git", "clone", "--depth", "1"]
-        if ref:
-            cmd.extend(["--branch", ref])
-        cmd.extend([clone_url, str(dest)])
+    clone_url = _build_clone_url(repo.url, provider, token)
+    display_url = _mask_url(repo.url)
 
     logger.info(f"[clone] Cloning {display_url} ({provider.value}) -> {dest.name}/")
+
+    cmd = _build_clone_command(clone_url, dest, repo.ref)
 
     try:
         result = subprocess.run(
             cmd, capture_output=True, text=True, timeout=CLONE_TIMEOUT
         )
-        if result.returncode != 0:
-            logger.warning(f"[clone] Failed: {_mask_token(result.stderr, token)}")
-            return False
-
-        # Checkout specific SHA if needed
-        if is_sha and ref:
-            checkout = subprocess.run(
-                ["git", "-C", str(dest), "checkout", ref],
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
-            if checkout.returncode != 0:
-                logger.warning(f"[clone] Failed to checkout {ref}: {checkout.stderr}")
-                return False
-
-        logger.info(f"[clone] Success: {display_url} -> {dest.name}/")
-        return True
-
     except subprocess.TimeoutExpired:
         logger.warning(f"[clone] Timed out: {display_url}")
         return False
+
+    if result.returncode != 0:
+        logger.warning(f"[clone] Failed: {_mask_token(result.stderr, token)}")
+        return False
+
+    # For SHA refs, we did a full clone and need to checkout the specific commit
+    if _is_commit_sha(repo.ref) and repo.ref:
+        if not _checkout_sha(dest, repo.ref):
+            return False
+
+    logger.info(f"[clone] Success: {display_url} -> {dest.name}/")
+    return True
+
+
+class _TokenCache:
+    """Simple cache for provider tokens to avoid repeated API calls."""
+
+    def __init__(self, fetcher: TokenFetcher | None):
+        self._fetcher = fetcher
+        self._cache: dict[str, str | None] = {}
+
+    def get(self, token_name: str) -> str | None:
+        if token_name not in self._cache:
+            self._cache[token_name] = (
+                self._fetcher(token_name) if self._fetcher else None
+            )
+        return self._cache[token_name]
 
 
 def clone_repos(
@@ -383,14 +402,7 @@ def clone_repos(
     logger.info(f"[clone] Cloning {len(repos)} repository(ies)...")
     target_dir.mkdir(parents=True, exist_ok=True)
 
-    # Cache tokens to avoid repeated API calls
-    token_cache: dict[str, str | None] = {}
-
-    def get_token(name: str) -> str | None:
-        if name not in token_cache:
-            token_cache[name] = token_fetcher(name) if token_fetcher else None
-        return token_cache[name]
-
+    tokens = _TokenCache(token_fetcher)
     used_dirs: set[str] = set()
     failed: list[str] = []
     mappings: dict[str, RepoMapping] = {}
@@ -399,16 +411,17 @@ def clone_repos(
         if not repo.url:
             continue
 
-        # Get unique directory name
-        dir_name = _get_unique_dir_name(
-            _sanitize_dir_name(_extract_repo_name(repo.url)), used_dirs
-        )
+        # Determine unique directory name
+        base_name = _sanitize_dir_name(_extract_repo_name(repo.url))
+        dir_name = _get_unique_dir_name(base_name, used_dirs)
         used_dirs.add(dir_name)
         dest = target_dir / dir_name
 
         # Clone with provider-specific token
-        token = get_token(repo.get_token_name())
-        if _clone_single_repo(repo, dest, token):
+        token = tokens.get(repo.get_token_name())
+        success = _clone_single_repo(repo, dest, token)
+
+        if success:
             mappings[repo.url] = RepoMapping(
                 url=repo.url,
                 dir_name=dir_name,

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -7,6 +7,7 @@ skills from them when running inside an OpenHands Cloud sandbox.
 from __future__ import annotations
 
 import re
+import shutil
 import subprocess
 import urllib.parse
 from collections.abc import Callable
@@ -136,17 +137,20 @@ class RepoSource(BaseModel):
     @field_validator("url")
     @classmethod
     def validate_url(cls, v: str) -> str:
-        """Validate URL format."""
+        """Validate URL format and normalize HTTP to HTTPS."""
         # Allow owner/repo format (e.g., "owner/repo", "my-org/my-repo.git")
         owner_repo_pattern = re.compile(r"^[\w-]+/[\w.-]+$")
         if owner_repo_pattern.match(v):
             return v
-        # Allow full git URLs
-        if v.startswith(("http://", "https://", "git@")):
+        # Normalize HTTP to HTTPS for security (token injection requires HTTPS)
+        if v.startswith("http://"):
+            logger.warning(f"Converting HTTP URL to HTTPS for security: {v}")
+            v = "https://" + v[7:]
+        # Allow HTTPS, git@, and file:// URLs (file:// for testing)
+        if v.startswith(("https://", "git@", "file://")):
             return v
         raise ValueError(
-            "URL must be 'owner/repo' format or a valid git URL "
-            "(https://, http://, or git@)"
+            "URL must be 'owner/repo' format or a valid git URL (https:// or git@)"
         )
 
     @model_validator(mode="after")
@@ -339,7 +343,11 @@ def _build_clone_command(clone_url: str, dest: Path, ref: str | None) -> list[st
 
 
 def _checkout_sha(dest: Path, sha: str) -> bool:
-    """Checkout a specific SHA after full clone. Returns True on success."""
+    """Checkout a specific SHA after full clone. Returns True on success.
+
+    On failure, cleans up the cloned directory to prevent orphaned directories
+    that block retry attempts.
+    """
     result = subprocess.run(
         ["git", "-C", str(dest), "checkout", sha],
         capture_output=True,
@@ -348,17 +356,25 @@ def _checkout_sha(dest: Path, sha: str) -> bool:
     )
     if result.returncode != 0:
         logger.warning(f"[clone] Failed to checkout {sha}: {result.stderr}")
+        # Clean up to prevent orphaned directory blocking retry attempts
+        shutil.rmtree(dest, ignore_errors=True)
         return False
     return True
 
 
 def _clone_single_repo(repo: RepoSource, dest: Path, token: str | None) -> bool:
     """Clone a single repository. Returns True on success."""
-    provider = repo.get_provider()
-    clone_url = _build_clone_url(repo.url, provider, token)
-    display_url = _mask_url(repo.url)
+    try:
+        provider = repo.get_provider()
+        clone_url = _build_clone_url(repo.url, provider, token)
+        provider_str = provider.value
+    except ValueError:
+        # No provider detected (e.g., file:// URLs) - use URL as-is
+        clone_url = repo.url
+        provider_str = "local"
 
-    logger.info(f"[clone] Cloning {display_url} ({provider.value}) -> {dest.name}/")
+    display_url = _mask_url(repo.url)
+    logger.info(f"[clone] Cloning {display_url} ({provider_str}) -> {dest.name}/")
 
     cmd = _build_clone_command(clone_url, dest, repo.ref)
 
@@ -422,7 +438,21 @@ def clone_repos(
         logger.info("[clone] No repositories to clone")
         return CloneResult(success_count=0, failed_repos=[], repo_mappings={})
 
-    logger.info(f"[clone] Cloning {len(repos)} repository(ies)...")
+    # Deduplicate repos by URL to prevent orphaned directories
+    seen_urls: set[str] = set()
+    unique_repos: list[RepoSource] = []
+    for repo in repos:
+        if repo.url and repo.url not in seen_urls:
+            seen_urls.add(repo.url)
+            unique_repos.append(repo)
+        elif repo.url:
+            logger.warning(f"[clone] Skipping duplicate URL: {_mask_url(repo.url)}")
+
+    if not unique_repos:
+        logger.info("[clone] No repositories to clone after deduplication")
+        return CloneResult(success_count=0, failed_repos=[], repo_mappings={})
+
+    logger.info(f"[clone] Cloning {len(unique_repos)} repository(ies)...")
     target_dir.mkdir(parents=True, exist_ok=True)
 
     tokens = _TokenCache(token_fetcher)
@@ -430,9 +460,10 @@ def clone_repos(
     failed: list[str] = []
     mappings: dict[str, RepoMapping] = {}
 
-    for repo in repos:
+    for repo in unique_repos:
         try:
             if not repo.url:
+                logger.warning("[clone] Skipping repo with empty URL")
                 continue
 
             # Determine unique directory name
@@ -441,8 +472,12 @@ def clone_repos(
             used_dirs.add(dir_name)
             dest = target_dir / dir_name
 
-            # Clone with provider-specific token
-            token = tokens.get(repo.get_token_name())
+            # Clone with provider-specific token (None if provider unknown)
+            try:
+                token = tokens.get(repo.get_token_name())
+            except ValueError:
+                # No provider (e.g., file:// URLs) - proceed without token
+                token = None
             success = _clone_single_repo(repo, dest, token)
 
             if success:
@@ -460,7 +495,7 @@ def clone_repos(
             logger.warning(f"[clone] Error processing {display_url}: {e}")
             failed.append(display_url)
 
-    logger.info(f"[clone] Cloned {len(mappings)}/{len(repos)} repositories")
+    logger.info(f"[clone] Cloned {len(mappings)}/{len(unique_repos)} repositories")
     if failed:
         logger.warning(f"[clone] Failed: {', '.join(failed)}")
 

--- a/openhands-workspace/openhands/workspace/cloud/repo.py
+++ b/openhands-workspace/openhands/workspace/cloud/repo.py
@@ -68,6 +68,11 @@ def _detect_provider_from_url(url: str) -> GitProvider | None:
     return None
 
 
+def _is_short_url_format(url: str) -> bool:
+    """Check if URL is the short 'owner/repo' format (no protocol)."""
+    return "://" not in url and not url.startswith("git@")
+
+
 class RepoSource(BaseModel):
     """Repository source specification for cloning.
 
@@ -75,25 +80,19 @@ class RepoSource(BaseModel):
     .agents/skills/, etc.) are automatically loaded from each cloned repo.
 
     The provider field specifies which git hosting service the repo belongs to,
-    which determines which authentication token to use for cloning. If not
-    specified, the provider is auto-detected from the URL (defaulting to GitHub
-    for owner/repo format).
+    which determines which authentication token to use for cloning.
+
+    For full URLs (https://github.com/...), the provider is auto-detected.
+    For short format (owner/repo), the provider field is required.
 
     Examples:
-        >>> # Simple string URL (defaults to GitHub)
-        >>> RepoSource(url="owner/repo")
+        >>> # Full URL - provider auto-detected
+        >>> RepoSource(url="https://github.com/owner/repo")
+        >>> RepoSource(url="https://gitlab.com/owner/repo", ref="main")
 
-        >>> # Full URL with ref (provider auto-detected)
-        >>> RepoSource(url="https://github.com/owner/repo", ref="main")
-
-        >>> # GitLab repo with explicit provider
-        >>> RepoSource(url="owner/repo", provider="gitlab")
-
-        >>> # From dict
-        >>> RepoSource.model_validate({"url": "owner/repo", "ref": "v1.0.0"})
-
-        >>> # From string (via model_validator)
-        >>> RepoSource.model_validate("owner/repo")
+        >>> # Short format - provider required
+        >>> RepoSource(url="owner/repo", provider="github")
+        >>> RepoSource(url="owner/repo", provider="gitlab", ref="v1.0.0")
     """
 
     model_config = ConfigDict(extra="forbid")
@@ -101,8 +100,8 @@ class RepoSource(BaseModel):
     url: str = Field(
         ...,
         description=(
-            "Repository identifier. Can be 'owner/repo' format "
-            "or a full URL (https://github.com/owner/repo, https://gitlab.com/owner/repo)."
+            "Repository URL. Can be a full URL (https://github.com/owner/repo) "
+            "or short format (owner/repo). Short format requires 'provider' field."
         ),
     )
     ref: str | None = Field(
@@ -113,9 +112,8 @@ class RepoSource(BaseModel):
         default=None,
         description=(
             "Git hosting provider (github, gitlab, bitbucket). "
-            "Used to determine which authentication token to use. "
-            "If not specified, auto-detected from URL "
-            "(defaults to github for owner/repo format)."
+            "Required for short URL format (owner/repo). "
+            "Auto-detected for full URLs."
         ),
     )
 
@@ -130,7 +128,7 @@ class RepoSource(BaseModel):
     @field_validator("url")
     @classmethod
     def validate_url(cls, v: str) -> str:
-        """Validate URL format to provide early feedback."""
+        """Validate URL format."""
         # Allow owner/repo format (e.g., "owner/repo", "my-org/my-repo.git")
         owner_repo_pattern = re.compile(r"^[\w-]+/[\w.-]+$")
         if owner_repo_pattern.match(v):
@@ -143,12 +141,25 @@ class RepoSource(BaseModel):
             "(https://, http://, or git@)"
         )
 
-    def get_provider(self) -> GitProvider:
-        """Get the git provider for this repo.
+    @model_validator(mode="after")
+    def validate_provider_required_for_short_urls(self) -> RepoSource:
+        """Require explicit provider for ambiguous short URL format."""
+        if not _is_short_url_format(self.url):
+            # Full URL - provider can be auto-detected
+            return self
 
-        Returns the explicitly set provider, or auto-detects from URL.
-        Defaults to GitHub for owner/repo format without explicit provider.
-        """
+        # Short format - check if provider is specified or detectable
+        detected = _detect_provider_from_url(self.url)
+        if not detected and not self.provider:
+            raise ValueError(
+                f"Short URL format '{self.url}' requires explicit 'provider' field. "
+                "Use: {\"url\": \"owner/repo\", \"provider\": \"github\"} "
+                "or provide a full URL like https://github.com/owner/repo"
+            )
+        return self
+
+    def get_provider(self) -> GitProvider:
+        """Get the git provider for this repo."""
         if self.provider:
             return GitProvider(self.provider)
 
@@ -156,8 +167,8 @@ class RepoSource(BaseModel):
         if detected:
             return detected
 
-        # Default to GitHub for owner/repo format
-        return GitProvider.GITHUB
+        # This shouldn't happen if validation passed
+        raise ValueError(f"Cannot determine provider for URL: {self.url}")
 
     def get_token_name(self) -> str:
         """Get the secret name for this repo's authentication token."""

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -930,21 +930,17 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         else:
             target_path = target_dir
 
-        # Fetch tokens from secrets
-        github_token = self._get_secret_value("github_token")
-        gitlab_token = self._get_secret_value("gitlab_token")
-
         # Determine mapping file path
         mapping_file = (
             target_path / "repos_mapping.json" if write_mapping_file else None
         )
 
-        # Clone repositories
+        # Clone repositories using _get_secret_value as token fetcher
+        # This fetches tokens lazily based on each repo's provider
         return clone_repos(
             repos=normalized_repos,
             target_dir=target_path,
-            github_token=github_token,
-            gitlab_token=gitlab_token,
+            token_fetcher=self._get_secret_value,
             mapping_file=mapping_file,
         )
 

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -10,7 +10,7 @@ from urllib.request import urlopen
 
 import httpx
 import tenacity
-from pydantic import Field, PrivateAttr
+from pydantic import Field, PrivateAttr, ValidationError
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.workspace.remote.base import RemoteWorkspace
@@ -844,6 +844,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
         Unlike get_secrets() which returns LookupSecret references, this method
         fetches the actual secret value for use in operations like git cloning.
+        Retries up to 3 times on transient failures.
 
         Args:
             name: Name of the secret to fetch (e.g., "github_token", "gitlab_token")
@@ -859,10 +860,20 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             logger.warning(f"Invalid secret name: {name}")
             return None
 
-        try:
-            resp = self._send_settings_request(
+        # Use retry logic for transient failures
+        @tenacity.retry(
+            stop=tenacity.stop_after_attempt(_MAX_RETRIES),
+            wait=tenacity.wait_exponential(multiplier=1, min=1, max=5),
+            retry=tenacity.retry_if_exception(_is_retryable_error),
+            reraise=True,
+        )
+        def _fetch_secret() -> httpx.Response:
+            return self._send_settings_request(
                 "GET", f"{self._settings_base_url}/secrets/{name}"
             )
+
+        try:
+            resp = _fetch_secret()
             return resp.text
         except httpx.HTTPStatusError as e:
             if e.response.status_code == 404:
@@ -920,12 +931,15 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         # Normalize repos to RepoSource objects using model_validate
         # This ensures consistent validation for all input formats
         normalized_repos: list[RepoSource] = []
-        for repo in repos:
-            if isinstance(repo, RepoSource):
-                normalized_repos.append(repo)
-            else:
-                # model_validate handles both dicts and strings (via model_validator)
-                normalized_repos.append(RepoSource.model_validate(repo))
+        try:
+            for repo in repos:
+                if isinstance(repo, RepoSource):
+                    normalized_repos.append(repo)
+                else:
+                    # model_validate handles dicts and strings via model_validator
+                    normalized_repos.append(RepoSource.model_validate(repo))
+        except ValidationError as e:
+            raise ValueError(f"Invalid repository specification: {e}") from e
 
         # Determine target directory
         if target_dir is None:
@@ -978,6 +992,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         """Call the agent-server /api/skills endpoint.
 
         Returns list of skill dicts, or empty list on error.
+        Retries up to 3 times on transient failures.
         """
         payload = {
             "load_public": load_public,
@@ -993,7 +1008,14 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         if self._session_api_key:
             headers["X-Session-API-Key"] = self._session_api_key
 
-        try:
+        # Use retry logic for transient failures
+        @tenacity.retry(
+            stop=tenacity.stop_after_attempt(_MAX_RETRIES),
+            wait=tenacity.wait_exponential(multiplier=1, min=1, max=5),
+            retry=tenacity.retry_if_exception(_is_retryable_error),
+            reraise=True,
+        )
+        def _fetch_skills() -> httpx.Response:
             with httpx.Client(timeout=timeout) as client:
                 resp = client.post(
                     f"{self.host}/api/skills",
@@ -1001,9 +1023,13 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
                     headers=headers,
                 )
                 resp.raise_for_status()
-                data = resp.json()
-                logger.debug(f"Agent-server sources: {data.get('sources', {})}")
-                return data.get("skills", [])
+                return resp
+
+        try:
+            resp = _fetch_skills()
+            data = resp.json()
+            logger.debug(f"Agent-server sources: {data.get('sources', {})}")
+            return data.get("skills", [])
         except httpx.HTTPStatusError as e:
             logger.error(f"Agent-server HTTP error {e.response.status_code}")
             return []
@@ -1147,6 +1173,13 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             ...     agent = agent.model_copy(update={"agent_context": context})
         """
         from openhands.sdk.context import AgentContext
+
+        # Validate workspace is ready for API calls
+        if not self.host or not self._sandbox_id:
+            raise RuntimeError(
+                "Workspace not initialized. Ensure the workspace is started "
+                "before loading skills."
+            )
 
         logger.info("Loading skills via agent-server...")
         logger.debug(f"Agent-server URL: {self.host}")

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -1175,7 +1175,8 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         from openhands.sdk.context import AgentContext
 
         # Validate workspace is ready for API calls
-        if not self.host or not self._sandbox_id:
+        # Note: self.host defaults to "undefined" so check for that too
+        if not self.host or self.host == "undefined" or not self._sandbox_id:
             raise RuntimeError(
                 "Workspace not initialized. Ensure the workspace is started "
                 "before loading skills."
@@ -1227,7 +1228,8 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
         if triggers:
             # Determine trigger type based on content (same logic as OpenHands)
-            if any(t.startswith("/") for t in triggers):
+            # Note: Validate elements are strings before calling .startswith()
+            if any(isinstance(t, str) and t.startswith("/") for t in triggers):
                 trigger = TaskTrigger(triggers=triggers)
             else:
                 trigger = KeywordTrigger(keywords=triggers)

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from urllib.request import urlopen
 
@@ -14,10 +15,14 @@ from pydantic import Field, PrivateAttr
 from openhands.sdk.logger import get_logger
 from openhands.sdk.workspace.remote.base import RemoteWorkspace
 
+from .repo import CloneResult, RepoMapping, RepoSource, clone_repos, get_repos_context
+
 
 if TYPE_CHECKING:
+    from openhands.sdk.context import AgentContext
     from openhands.sdk.llm.llm import LLM
     from openhands.sdk.secret import LookupSecret
+    from openhands.sdk.skills import Skill
 
 
 logger = get_logger(__name__)
@@ -831,3 +836,358 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
                 logger.info(f"Completion callback sent ({status}): {resp.status_code}")
         except Exception as e:
             logger.warning(f"Completion callback failed: {e}")
+
+    # --- Repository Cloning Methods ---
+
+    def _get_secret_value(self, name: str) -> str | None:
+        """Fetch a secret value directly from the sandbox settings API.
+
+        Unlike get_secrets() which returns LookupSecret references, this method
+        fetches the actual secret value for use in operations like git cloning.
+
+        Args:
+            name: Name of the secret to fetch (e.g., "github_token", "gitlab_token")
+
+        Returns:
+            The secret value as a string, or None if not found or an error occurred.
+        """
+        if not self._sandbox_id or not self._session_api_key:
+            return None
+
+        try:
+            resp = self._send_settings_request(
+                "GET", f"{self._settings_base_url}/secrets/{name}"
+            )
+            return resp.text
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                logger.debug(f"Secret '{name}' not found")
+            else:
+                logger.warning(f"Failed to fetch secret '{name}': {e}")
+            return None
+        except Exception as e:
+            logger.warning(f"Error fetching secret '{name}': {e}")
+            return None
+
+    def clone_repos(
+        self,
+        repos: list[RepoSource] | list[dict[str, Any]] | list[str],
+        target_dir: str | Path | None = None,
+        write_mapping_file: bool = True,
+    ) -> CloneResult:
+        """Clone repositories to the workspace directory.
+
+        Clones specified repositories to meaningful directory names (e.g.,
+        'openhands-cli' instead of 'repo_0'). Automatically fetches GitHub
+        and GitLab tokens from the user's secrets for authentication.
+
+        Args:
+            repos: List of repositories to clone. Can be:
+                - List of RepoSource objects
+                - List of dicts with 'url' and optional 'ref' keys
+                - List of URL strings (e.g., "owner/repo")
+            target_dir: Directory to clone into. Defaults to self.working_dir.
+            write_mapping_file: If True, writes repos_mapping.json to target_dir.
+
+        Returns:
+            CloneResult containing:
+                - success_count: Number of successfully cloned repos
+                - failed_repos: List of repo URLs that failed to clone
+                - repo_mappings: Dict mapping URLs to RepoMapping objects
+
+        Example:
+            >>> with OpenHandsCloudWorkspace(...) as workspace:
+            ...     # Clone a single repo
+            ...     result = workspace.clone_repos(["owner/repo"])
+            ...
+            ...     # Clone multiple repos with refs
+            ...     result = workspace.clone_repos([
+            ...         {"url": "owner/repo1", "ref": "main"},
+            ...         {"url": "owner/repo2", "ref": "v1.0.0"},
+            ...     ])
+            ...
+            ...     # Access cloned repo paths
+            ...     for url, mapping in result.repo_mappings.items():
+            ...         print(f"{url} -> {mapping.local_path}")
+        """
+        # Normalize repos to RepoSource objects
+        normalized_repos: list[RepoSource] = []
+        for repo in repos:
+            if isinstance(repo, RepoSource):
+                normalized_repos.append(repo)
+            elif isinstance(repo, dict):
+                normalized_repos.append(RepoSource.model_validate(repo))
+            elif isinstance(repo, str):
+                normalized_repos.append(RepoSource(url=repo))
+            else:
+                raise ValueError(f"Invalid repo specification: {repo}")
+
+        # Determine target directory
+        if target_dir is None:
+            target_path = Path(self.working_dir)
+        elif isinstance(target_dir, str):
+            target_path = Path(target_dir)
+        else:
+            target_path = target_dir
+
+        # Fetch tokens from secrets
+        github_token = self._get_secret_value("github_token")
+        gitlab_token = self._get_secret_value("gitlab_token")
+
+        # Determine mapping file path
+        mapping_file = (
+            target_path / "repos_mapping.json" if write_mapping_file else None
+        )
+
+        # Clone repositories
+        return clone_repos(
+            repos=normalized_repos,
+            target_dir=target_path,
+            github_token=github_token,
+            gitlab_token=gitlab_token,
+            mapping_file=mapping_file,
+        )
+
+    def get_repos_context(
+        self, repo_mappings: dict[str, RepoMapping] | None = None
+    ) -> str:
+        """Generate context string describing cloned repositories for the agent.
+
+        This method produces a markdown-formatted string that can be prepended
+        to agent prompts to inform the agent about available repositories.
+
+        Args:
+            repo_mappings: Dict mapping URLs to RepoMapping objects. If None,
+                attempts to read from repos_mapping.json in working_dir.
+
+        Returns:
+            Markdown-formatted context string, or empty string if no repos.
+
+        Example:
+            >>> with OpenHandsCloudWorkspace(...) as workspace:
+            ...     result = workspace.clone_repos(["owner/repo"])
+            ...     context = workspace.get_repos_context(result.repo_mappings)
+            ...     prompt = f"{context}\\n\\n{user_prompt}"
+        """
+        if repo_mappings is not None:
+            return get_repos_context(repo_mappings)
+
+        # Try to load from mapping file in working_dir
+        mapping_file = Path(self.working_dir) / "repos_mapping.json"
+        if not mapping_file.exists():
+            return ""
+
+        try:
+            with open(mapping_file) as f:
+                data = json.load(f)
+            # Convert to RepoMapping objects
+            mappings = {
+                url: RepoMapping(
+                    url=url,
+                    dir_name=info["dir_name"],
+                    local_path=info["local_path"],
+                    ref=info.get("ref"),
+                )
+                for url, info in data.items()
+            }
+            return get_repos_context(mappings)
+        except (json.JSONDecodeError, OSError, KeyError) as e:
+            logger.warning(f"Failed to read repos_mapping.json: {e}")
+            return ""
+
+    # --- Skill Loading Methods ---
+
+    def load_skills_from_agent_server(
+        self,
+        project_dirs: list[str | Path] | None = None,
+        load_public: bool = True,
+        load_user: bool = True,
+        load_project: bool = True,
+        load_org: bool = True,
+        timeout: float = 60.0,
+    ) -> tuple[list[Skill], AgentContext | None]:
+        """Load skills via the local agent-server's /api/skills endpoint.
+
+        This method calls the agent-server running inside the sandbox to load
+        skills from all configured sources, mirroring how V1 conversations
+        load skills in OpenHands.
+
+        When project_dirs is provided (e.g., directories of cloned repos),
+        project skills are loaded from EACH directory separately and merged.
+        Skills are deduplicated by name, with later directories taking
+        precedence over earlier ones.
+
+        Args:
+            project_dirs: List of directories to load project skills from.
+                If None, uses self.working_dir only.
+            load_public: Load public skills from OpenHands/extensions repo.
+            load_user: Load user skills from ~/.openhands/skills/.
+            load_project: Load project skills from workspace directories.
+            load_org: Load organization-level skills.
+            timeout: Request timeout in seconds.
+
+        Returns:
+            Tuple of (list of Skill objects, AgentContext or None).
+            The AgentContext is pre-configured with loaded skills and
+            load_public_skills=False to avoid duplicates.
+
+        Example:
+            >>> with OpenHandsCloudWorkspace(...) as workspace:
+            ...     # Load all skills using working_dir
+            ...     skills, context = workspace.load_skills_from_agent_server()
+            ...
+            ...     # Load skills from cloned repos
+            ...     result = workspace.clone_repos(["owner/repo1", "owner/repo2"])
+            ...     repo_dirs = [m.local_path for m in result.repo_mappings.values()]
+            ...     skills, context = workspace.load_skills_from_agent_server(
+            ...         project_dirs=repo_dirs
+            ...     )
+            ...
+            ...     # Use with agent
+            ...     agent = agent.model_copy(update={"agent_context": context})
+        """
+        from openhands.sdk.context import AgentContext
+
+        logger.info("Loading skills via agent-server...")
+        logger.debug(f"Agent-server URL: {self.host}")
+
+        # Use dict to deduplicate skills by name (later skills override earlier)
+        skills_by_name: dict[str, dict[str, Any]] = {}
+
+        def call_skills_api(project_dir: str | None, **kwargs: Any) -> list[dict]:
+            """Call the agent-server /api/skills endpoint."""
+            payload = {
+                "load_public": kwargs.get("load_public", False),
+                "load_user": kwargs.get("load_user", False),
+                "load_project": kwargs.get("load_project", False),
+                "load_org": kwargs.get("load_org", False),
+                "project_dir": project_dir,
+                "org_config": None,
+                "sandbox_config": None,
+            }
+
+            headers = {"Content-Type": "application/json"}
+            if self._session_api_key:
+                headers["X-Session-API-Key"] = self._session_api_key
+
+            try:
+                with httpx.Client(timeout=timeout) as client:
+                    resp = client.post(
+                        f"{self.host}/api/skills",
+                        json=payload,
+                        headers=headers,
+                    )
+                    resp.raise_for_status()
+                    data = resp.json()
+                    skills = data.get("skills", [])
+                    sources = data.get("sources", {})
+                    logger.debug(f"Agent-server sources: {sources}")
+                    return skills
+            except httpx.HTTPStatusError as e:
+                logger.error(f"Agent-server HTTP error {e.response.status_code}")
+                return []
+            except Exception as e:
+                logger.error(f"Failed to connect to agent-server: {e}")
+                return []
+
+        # Determine project directories
+        if project_dirs:
+            # Multiple directories provided - load project skills from each
+            dirs = [str(d) if isinstance(d, Path) else d for d in project_dirs]
+
+            # First: load public/user/org skills (not project-specific)
+            logger.debug("Loading public/user/org skills...")
+            global_skills = call_skills_api(
+                project_dir=self.working_dir,
+                load_public=load_public,
+                load_user=load_user,
+                load_project=False,
+                load_org=load_org,
+            )
+            for skill_data in global_skills:
+                name = skill_data.get("name", "unknown")
+                skills_by_name[name] = skill_data
+
+            # Then: load project skills from each directory
+            if load_project:
+                for dir_path in dirs:
+                    logger.debug(f"Loading project skills from {dir_path}...")
+                    proj_skills = call_skills_api(
+                        project_dir=dir_path,
+                        load_public=False,
+                        load_user=False,
+                        load_project=True,
+                        load_org=False,
+                    )
+                    for skill_data in proj_skills:
+                        name = skill_data.get("name", "unknown")
+                        # Later directories override earlier ones
+                        skills_by_name[name] = skill_data
+        else:
+            # Single working_dir - load all skills from it
+            logger.debug("Loading all skills from working_dir...")
+            all_skills = call_skills_api(
+                project_dir=self.working_dir,
+                load_public=load_public,
+                load_user=load_user,
+                load_project=load_project,
+                load_org=load_org,
+            )
+            for skill_data in all_skills:
+                name = skill_data.get("name", "unknown")
+                skills_by_name[name] = skill_data
+
+        # Convert to SDK Skill objects
+        loaded_skills: list[Skill] = []
+        for skill_data in skills_by_name.values():
+            try:
+                skill = self._convert_skill_data_to_skill(skill_data)
+                loaded_skills.append(skill)
+            except Exception as e:
+                skill_name = skill_data.get("name", "unknown")
+                logger.warning(f"Failed to convert skill {skill_name}: {e}")
+
+        logger.info(f"Loaded {len(loaded_skills)} skills")
+        if loaded_skills:
+            logger.debug(f"Skills: {[s.name for s in loaded_skills]}")
+
+        # Create AgentContext with loaded skills
+        # Set load_public_skills=False to avoid duplicates since we already loaded them
+        if loaded_skills:
+            agent_context = AgentContext(skills=loaded_skills, load_public_skills=False)
+        else:
+            # Fall back to public skills if agent-server was unavailable
+            logger.warning("No skills loaded, falling back to public skills")
+            agent_context = AgentContext(skills=[], load_public_skills=True)
+
+        return loaded_skills, agent_context
+
+    def _convert_skill_data_to_skill(self, skill_data: dict[str, Any]) -> Skill:
+        """Convert skill dict from API response to SDK Skill object.
+
+        Args:
+            skill_data: Dict with name, content, triggers, source, description, etc.
+
+        Returns:
+            Skill object
+        """
+        from openhands.sdk.skills import KeywordTrigger, Skill, TaskTrigger
+
+        trigger = None
+        triggers = skill_data.get("triggers", [])
+
+        if triggers:
+            # Determine trigger type based on content (same logic as OpenHands)
+            if any(t.startswith("/") for t in triggers):
+                trigger = TaskTrigger(triggers=triggers)
+            else:
+                trigger = KeywordTrigger(keywords=triggers)
+
+        return Skill(
+            name=skill_data.get("name", "unknown"),
+            content=skill_data.get("content", ""),
+            trigger=trigger,
+            source=skill_data.get("source"),
+            description=skill_data.get("description"),
+            is_agentskills_format=skill_data.get("is_agentskills_format", False),
+        )

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -873,21 +873,19 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         self,
         repos: list[RepoSource] | list[dict[str, Any]] | list[str],
         target_dir: str | Path | None = None,
-        write_mapping_file: bool = True,
     ) -> CloneResult:
         """Clone repositories to the workspace directory.
 
         Clones specified repositories to meaningful directory names (e.g.,
-        'openhands-cli' instead of 'repo_0'). Automatically fetches GitHub
-        and GitLab tokens from the user's secrets for authentication.
+        'openhands-cli' instead of 'repo_0'). Automatically fetches GitHub,
+        GitLab, and Bitbucket tokens from the user's secrets for authentication.
 
         Args:
             repos: List of repositories to clone. Can be:
                 - List of RepoSource objects
-                - List of dicts with 'url' and optional 'ref' keys
+                - List of dicts with 'url' and optional 'ref'/'provider' keys
                 - List of URL strings (e.g., "owner/repo")
             target_dir: Directory to clone into. Defaults to self.working_dir.
-            write_mapping_file: If True, writes repos_mapping.json to target_dir.
 
         Returns:
             CloneResult containing:
@@ -904,6 +902,12 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             ...     result = workspace.clone_repos([
             ...         {"url": "owner/repo1", "ref": "main"},
             ...         {"url": "owner/repo2", "ref": "v1.0.0"},
+            ...     ])
+            ...
+            ...     # Clone from different providers
+            ...     result = workspace.clone_repos([
+            ...         {"url": "owner/repo1"},  # GitHub (default)
+            ...         {"url": "owner/repo2", "provider": "gitlab"},
             ...     ])
             ...
             ...     # Access cloned repo paths
@@ -930,31 +934,23 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         else:
             target_path = target_dir
 
-        # Determine mapping file path
-        mapping_file = (
-            target_path / "repos_mapping.json" if write_mapping_file else None
-        )
-
         # Clone repositories using _get_secret_value as token fetcher
         # This fetches tokens lazily based on each repo's provider
         return clone_repos(
             repos=normalized_repos,
             target_dir=target_path,
             token_fetcher=self._get_secret_value,
-            mapping_file=mapping_file,
         )
 
-    def get_repos_context(
-        self, repo_mappings: dict[str, RepoMapping] | None = None
-    ) -> str:
+    def get_repos_context(self, repo_mappings: dict[str, RepoMapping]) -> str:
         """Generate context string describing cloned repositories for the agent.
 
         This method produces a markdown-formatted string that can be prepended
         to agent prompts to inform the agent about available repositories.
 
         Args:
-            repo_mappings: Dict mapping URLs to RepoMapping objects. If None,
-                attempts to read from repos_mapping.json in working_dir.
+            repo_mappings: Dict mapping URLs to RepoMapping objects, typically
+                obtained from CloneResult.repo_mappings after calling clone_repos().
 
         Returns:
             Markdown-formatted context string, or empty string if no repos.
@@ -965,31 +961,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             ...     context = workspace.get_repos_context(result.repo_mappings)
             ...     prompt = f"{context}\\n\\n{user_prompt}"
         """
-        if repo_mappings is not None:
-            return get_repos_context(repo_mappings)
-
-        # Try to load from mapping file in working_dir
-        mapping_file = Path(self.working_dir) / "repos_mapping.json"
-        if not mapping_file.exists():
-            return ""
-
-        try:
-            with open(mapping_file) as f:
-                data = json.load(f)
-            # Convert to RepoMapping objects
-            mappings = {
-                url: RepoMapping(
-                    url=url,
-                    dir_name=info["dir_name"],
-                    local_path=info["local_path"],
-                    ref=info.get("ref"),
-                )
-                for url, info in data.items()
-            }
-            return get_repos_context(mappings)
-        except (json.JSONDecodeError, OSError, KeyError) as e:
-            logger.warning(f"Failed to read repos_mapping.json: {e}")
-            return ""
+        return get_repos_context(repo_mappings)
 
     # --- Skill Loading Methods ---
 

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -883,8 +883,9 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         Args:
             repos: List of repositories to clone. Can be:
                 - List of RepoSource objects
-                - List of dicts with 'url' and optional 'ref'/'provider' keys
-                - List of URL strings (e.g., "owner/repo")
+                - List of dicts with 'url', optional 'ref', and 'provider' keys
+                - List of full URL strings (e.g., "https://github.com/owner/repo")
+                Note: Short URLs (owner/repo) require explicit 'provider' field.
             target_dir: Directory to clone into. Defaults to self.working_dir.
 
         Returns:
@@ -895,36 +896,31 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
         Example:
             >>> with OpenHandsCloudWorkspace(...) as workspace:
-            ...     # Clone a single repo
-            ...     result = workspace.clone_repos(["owner/repo"])
-            ...
-            ...     # Clone multiple repos with refs
+            ...     # Clone with full URLs (provider auto-detected)
             ...     result = workspace.clone_repos([
-            ...         {"url": "owner/repo1", "ref": "main"},
-            ...         {"url": "owner/repo2", "ref": "v1.0.0"},
+            ...         "https://github.com/owner/repo1",
+            ...         {"url": "https://gitlab.com/owner/repo2", "ref": "main"},
             ...     ])
             ...
-            ...     # Clone from different providers
+            ...     # Clone with short URLs (provider required)
             ...     result = workspace.clone_repos([
-            ...         {"url": "owner/repo1"},  # GitHub (default)
-            ...         {"url": "owner/repo2", "provider": "gitlab"},
+            ...         {"url": "owner/repo1", "provider": "github"},
+            ...         {"url": "owner/repo2", "provider": "gitlab", "ref": "v1.0"},
             ...     ])
             ...
             ...     # Access cloned repo paths
             ...     for url, mapping in result.repo_mappings.items():
             ...         print(f"{url} -> {mapping.local_path}")
         """
-        # Normalize repos to RepoSource objects
+        # Normalize repos to RepoSource objects using model_validate
+        # This ensures consistent validation for all input formats
         normalized_repos: list[RepoSource] = []
         for repo in repos:
             if isinstance(repo, RepoSource):
                 normalized_repos.append(repo)
-            elif isinstance(repo, dict):
-                normalized_repos.append(RepoSource.model_validate(repo))
-            elif isinstance(repo, str):
-                normalized_repos.append(RepoSource(url=repo))
             else:
-                raise ValueError(f"Invalid repo specification: {repo}")
+                # model_validate handles both dicts and strings (via model_validator)
+                normalized_repos.append(RepoSource.model_validate(repo))
 
         # Determine target directory
         if target_dir is None:

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -854,6 +854,11 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         if not self._sandbox_id or not self._session_api_key:
             return None
 
+        # Validate secret name to prevent path traversal
+        if not name or "/" in name or ".." in name:
+            logger.warning(f"Invalid secret name: {name}")
+            return None
+
         try:
             resp = self._send_settings_request(
                 "GET", f"{self._settings_base_url}/secrets/{name}"
@@ -871,7 +876,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
     def clone_repos(
         self,
-        repos: list[RepoSource] | list[dict[str, Any]] | list[str],
+        repos: list[RepoSource | dict[str, Any] | str],
         target_dir: str | Path | None = None,
     ) -> CloneResult:
         """Clone repositories to the workspace directory.
@@ -1100,7 +1105,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         load_project: bool = True,
         load_org: bool = True,
         timeout: float = 60.0,
-    ) -> tuple[list[Skill], AgentContext | None]:
+    ) -> tuple[list[Skill], AgentContext]:
         """Load skills via the local agent-server's /api/skills endpoint.
 
         This method calls the agent-server running inside the sandbox to load
@@ -1122,9 +1127,9 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             timeout: Request timeout in seconds.
 
         Returns:
-            Tuple of (list of Skill objects, AgentContext or None).
+            Tuple of (list of Skill objects, AgentContext).
             The AgentContext is pre-configured with loaded skills and
-            load_public_skills=False to avoid duplicates.
+            load_public_skills=False to avoid duplicates (or True if no skills loaded).
 
         Example:
             >>> with OpenHandsCloudWorkspace(...) as workspace:

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -961,6 +961,137 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
     # --- Skill Loading Methods ---
 
+    def _call_skills_api(
+        self,
+        project_dir: str,
+        load_public: bool = False,
+        load_user: bool = False,
+        load_project: bool = False,
+        load_org: bool = False,
+        timeout: float = 60.0,
+    ) -> list[dict[str, Any]]:
+        """Call the agent-server /api/skills endpoint.
+
+        Returns list of skill dicts, or empty list on error.
+        """
+        payload = {
+            "load_public": load_public,
+            "load_user": load_user,
+            "load_project": load_project,
+            "load_org": load_org,
+            "project_dir": project_dir,
+            "org_config": None,
+            "sandbox_config": None,
+        }
+
+        headers: dict[str, str] = {"Content-Type": "application/json"}
+        if self._session_api_key:
+            headers["X-Session-API-Key"] = self._session_api_key
+
+        try:
+            with httpx.Client(timeout=timeout) as client:
+                resp = client.post(
+                    f"{self.host}/api/skills",
+                    json=payload,
+                    headers=headers,
+                )
+                resp.raise_for_status()
+                data = resp.json()
+                logger.debug(f"Agent-server sources: {data.get('sources', {})}")
+                return data.get("skills", [])
+        except httpx.HTTPStatusError as e:
+            logger.error(f"Agent-server HTTP error {e.response.status_code}")
+            return []
+        except Exception as e:
+            logger.error(f"Failed to connect to agent-server: {e}")
+            return []
+
+    def _add_skills_to_dict(
+        self,
+        skills_by_name: dict[str, dict[str, Any]],
+        skill_list: list[dict[str, Any]],
+    ) -> None:
+        """Add skills to dict, keyed by name (later values override)."""
+        for skill_data in skill_list:
+            name = skill_data.get("name", "unknown")
+            skills_by_name[name] = skill_data
+
+    def _load_skills_multi_dir(
+        self,
+        project_dirs: list[str],
+        load_public: bool,
+        load_user: bool,
+        load_project: bool,
+        load_org: bool,
+        timeout: float,
+    ) -> dict[str, dict[str, Any]]:
+        """Load skills when multiple project directories are specified."""
+        skills_by_name: dict[str, dict[str, Any]] = {}
+
+        # Load global skills (public/user/org) once
+        logger.debug("Loading public/user/org skills...")
+        global_skills = self._call_skills_api(
+            project_dir=self.working_dir,
+            load_public=load_public,
+            load_user=load_user,
+            load_project=False,
+            load_org=load_org,
+            timeout=timeout,
+        )
+        self._add_skills_to_dict(skills_by_name, global_skills)
+
+        # Load project skills from each directory
+        if not load_project:
+            return skills_by_name
+
+        for dir_path in project_dirs:
+            logger.debug(f"Loading project skills from {dir_path}...")
+            proj_skills = self._call_skills_api(
+                project_dir=dir_path,
+                load_project=True,
+                timeout=timeout,
+            )
+            self._add_skills_to_dict(skills_by_name, proj_skills)
+
+        return skills_by_name
+
+    def _load_skills_single_dir(
+        self,
+        load_public: bool,
+        load_user: bool,
+        load_project: bool,
+        load_org: bool,
+        timeout: float,
+    ) -> dict[str, dict[str, Any]]:
+        """Load all skills from the working directory."""
+        logger.debug("Loading all skills from working_dir...")
+        all_skills = self._call_skills_api(
+            project_dir=self.working_dir,
+            load_public=load_public,
+            load_user=load_user,
+            load_project=load_project,
+            load_org=load_org,
+            timeout=timeout,
+        )
+
+        skills_by_name: dict[str, dict[str, Any]] = {}
+        self._add_skills_to_dict(skills_by_name, all_skills)
+        return skills_by_name
+
+    def _convert_skills_dict_to_list(
+        self, skills_by_name: dict[str, dict[str, Any]]
+    ) -> list[Skill]:
+        """Convert skill dicts to SDK Skill objects."""
+        loaded_skills: list[Skill] = []
+        for skill_data in skills_by_name.values():
+            try:
+                skill = self._convert_skill_data_to_skill(skill_data)
+                loaded_skills.append(skill)
+            except Exception as e:
+                skill_name = skill_data.get("name", "unknown")
+                logger.warning(f"Failed to convert skill {skill_name}: {e}")
+        return loaded_skills
+
     def load_skills_from_agent_server(
         self,
         project_dirs: list[str | Path] | None = None,
@@ -1015,112 +1146,28 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         logger.info("Loading skills via agent-server...")
         logger.debug(f"Agent-server URL: {self.host}")
 
-        # Use dict to deduplicate skills by name (later skills override earlier)
-        skills_by_name: dict[str, dict[str, Any]] = {}
-
-        def call_skills_api(project_dir: str | None, **kwargs: Any) -> list[dict]:
-            """Call the agent-server /api/skills endpoint."""
-            payload = {
-                "load_public": kwargs.get("load_public", False),
-                "load_user": kwargs.get("load_user", False),
-                "load_project": kwargs.get("load_project", False),
-                "load_org": kwargs.get("load_org", False),
-                "project_dir": project_dir,
-                "org_config": None,
-                "sandbox_config": None,
-            }
-
-            headers = {"Content-Type": "application/json"}
-            if self._session_api_key:
-                headers["X-Session-API-Key"] = self._session_api_key
-
-            try:
-                with httpx.Client(timeout=timeout) as client:
-                    resp = client.post(
-                        f"{self.host}/api/skills",
-                        json=payload,
-                        headers=headers,
-                    )
-                    resp.raise_for_status()
-                    data = resp.json()
-                    skills = data.get("skills", [])
-                    sources = data.get("sources", {})
-                    logger.debug(f"Agent-server sources: {sources}")
-                    return skills
-            except httpx.HTTPStatusError as e:
-                logger.error(f"Agent-server HTTP error {e.response.status_code}")
-                return []
-            except Exception as e:
-                logger.error(f"Failed to connect to agent-server: {e}")
-                return []
-
-        # Determine project directories
+        # Load skills based on whether multiple project dirs are specified
         if project_dirs:
-            # Multiple directories provided - load project skills from each
             dirs = [str(d) if isinstance(d, Path) else d for d in project_dirs]
-
-            # First: load public/user/org skills (not project-specific)
-            logger.debug("Loading public/user/org skills...")
-            global_skills = call_skills_api(
-                project_dir=self.working_dir,
-                load_public=load_public,
-                load_user=load_user,
-                load_project=False,
-                load_org=load_org,
+            skills_by_name = self._load_skills_multi_dir(
+                dirs, load_public, load_user, load_project, load_org, timeout
             )
-            for skill_data in global_skills:
-                name = skill_data.get("name", "unknown")
-                skills_by_name[name] = skill_data
-
-            # Then: load project skills from each directory
-            if load_project:
-                for dir_path in dirs:
-                    logger.debug(f"Loading project skills from {dir_path}...")
-                    proj_skills = call_skills_api(
-                        project_dir=dir_path,
-                        load_public=False,
-                        load_user=False,
-                        load_project=True,
-                        load_org=False,
-                    )
-                    for skill_data in proj_skills:
-                        name = skill_data.get("name", "unknown")
-                        # Later directories override earlier ones
-                        skills_by_name[name] = skill_data
         else:
-            # Single working_dir - load all skills from it
-            logger.debug("Loading all skills from working_dir...")
-            all_skills = call_skills_api(
-                project_dir=self.working_dir,
-                load_public=load_public,
-                load_user=load_user,
-                load_project=load_project,
-                load_org=load_org,
+            skills_by_name = self._load_skills_single_dir(
+                load_public, load_user, load_project, load_org, timeout
             )
-            for skill_data in all_skills:
-                name = skill_data.get("name", "unknown")
-                skills_by_name[name] = skill_data
 
         # Convert to SDK Skill objects
-        loaded_skills: list[Skill] = []
-        for skill_data in skills_by_name.values():
-            try:
-                skill = self._convert_skill_data_to_skill(skill_data)
-                loaded_skills.append(skill)
-            except Exception as e:
-                skill_name = skill_data.get("name", "unknown")
-                logger.warning(f"Failed to convert skill {skill_name}: {e}")
+        loaded_skills = self._convert_skills_dict_to_list(skills_by_name)
 
         logger.info(f"Loaded {len(loaded_skills)} skills")
         if loaded_skills:
             logger.debug(f"Skills: {[s.name for s in loaded_skills]}")
 
-        # Create AgentContext with loaded skills
-        # Set load_public_skills=False to avoid duplicates since we already loaded them
+        # Create AgentContext - fall back to public skills if none loaded
         if loaded_skills:
             agent_context = AgentContext(skills=loaded_skills, load_public_skills=False)
         else:
-            # Fall back to public skills if agent-server was unavailable
             logger.warning("No skills loaded, falling back to public skills")
             agent_context = AgentContext(skills=[], load_public_skills=True)
 

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -1,6 +1,5 @@
 """Tests for repository cloning and skill loading in OpenHandsCloudWorkspace."""
 
-import json
 import tempfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -394,24 +393,6 @@ class TestCloneRepos:
             assert "gitlab_token" in fetched_tokens
 
     @patch("subprocess.run")
-    def test_write_mapping_file(self, mock_run):
-        """Test writing repos_mapping.json file."""
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            tmppath = Path(tmpdir)
-            repos = [RepoSource(url="owner/repo")]
-            mapping_file = tmppath / "repos_mapping.json"
-
-            clone_repos(repos, tmppath, mapping_file=mapping_file)
-
-            assert mapping_file.exists()
-            with open(mapping_file) as f:
-                data = json.load(f)
-            assert "owner/repo" in data
-            assert data["owner/repo"]["dir_name"] == "repo"
-
-    @patch("subprocess.run")
     def test_directory_name_collision(self, mock_run):
         """Test handling of directory name collisions."""
         mock_run.return_value = MagicMock(returncode=0, stderr="")
@@ -527,34 +508,3 @@ class TestCloudWorkspaceRepoMethods:
             context = workspace.get_repos_context(mappings)
             assert "## Cloned Repositories" in context
             assert "`owner/repo`" in context
-
-    def test_get_repos_context_from_file(self):
-        """Test get_repos_context reading from repos_mapping.json."""
-        from openhands.workspace import OpenHandsCloudWorkspace
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            # Create mapping file
-            mapping_file = Path(tmpdir) / "repos_mapping.json"
-            mapping_data = {
-                "owner/repo": {
-                    "dir_name": "repo",
-                    "local_path": f"{tmpdir}/repo",
-                    "ref": "main",
-                }
-            }
-            with open(mapping_file, "w") as f:
-                json.dump(mapping_data, f)
-
-            with patch.object(
-                OpenHandsCloudWorkspace, "model_post_init", lambda self, ctx: None
-            ):
-                workspace = OpenHandsCloudWorkspace(
-                    cloud_api_url="https://test.com",
-                    cloud_api_key="test-key",
-                    local_agent_server_mode=True,
-                )
-                workspace.working_dir = tmpdir
-
-                context = workspace.get_repos_context()
-                assert "## Cloned Repositories" in context
-                assert "`owner/repo`" in context

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -125,15 +125,10 @@ class TestProviderDetection:
             == GitProvider.BITBUCKET
         )
 
-    def test_detect_azure(self):
-        assert (
-            _detect_provider_from_url("https://dev.azure.com/o/p/_git/r")
-            == GitProvider.AZURE
-        )
-
     def test_detect_unknown(self):
         assert _detect_provider_from_url("https://example.com/o/r") is None
         assert _detect_provider_from_url("owner/repo") is None
+        assert _detect_provider_from_url("https://dev.azure.com/o/p/_git/r") is None
 
 
 class TestHelperFunctions:

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -468,10 +468,12 @@ class TestCloudWorkspaceRepoMethods:
             workspace.working_dir = "/workspace/project"
 
             # Full URLs don't need provider
-            workspace.clone_repos([
-                "https://github.com/owner/repo1",
-                "https://github.com/owner/repo2",
-            ])
+            workspace.clone_repos(
+                [
+                    "https://github.com/owner/repo1",
+                    "https://github.com/owner/repo2",
+                ]
+            )
 
             mock_clone.assert_called_once()
             call_args = mock_clone.call_args
@@ -506,9 +508,9 @@ class TestCloudWorkspaceRepoMethods:
             workspace.working_dir = "/workspace/project"
 
             # Short URL with provider specified
-            workspace.clone_repos([
-                {"url": "owner/repo", "ref": "main", "provider": "github"}
-            ])
+            workspace.clone_repos(
+                [{"url": "owner/repo", "ref": "main", "provider": "github"}]
+            )
 
             mock_clone.assert_called_once()
             call_args = mock_clone.call_args

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -25,88 +25,104 @@ from openhands.workspace.cloud.repo import (
 class TestRepoSource:
     """Tests for RepoSource model."""
 
-    def test_simple_url(self):
-        """Test RepoSource with simple owner/repo URL."""
-        repo = RepoSource(url="owner/repo")
-        assert repo.url == "owner/repo"
-        assert repo.ref is None
+    # --- Short URL format (requires provider) ---
 
-    def test_url_with_ref(self):
-        """Test RepoSource with URL and ref."""
-        repo = RepoSource(url="owner/repo", ref="main")
+    def test_short_url_with_provider(self):
+        """Test RepoSource with short URL and explicit provider."""
+        repo = RepoSource(url="owner/repo", provider="github")
+        assert repo.url == "owner/repo"
+        assert repo.provider == "github"
+        assert repo.get_provider() == GitProvider.GITHUB
+
+    def test_short_url_with_ref_and_provider(self):
+        """Test RepoSource with short URL, ref, and provider."""
+        repo = RepoSource(url="owner/repo", ref="main", provider="gitlab")
         assert repo.url == "owner/repo"
         assert repo.ref == "main"
+        assert repo.get_provider() == GitProvider.GITLAB
 
-    def test_full_https_url(self):
-        """Test RepoSource with full HTTPS URL."""
+    def test_short_url_without_provider_rejected(self):
+        """Test that short URL without provider is rejected."""
+        with pytest.raises(ValueError, match="requires explicit 'provider' field"):
+            RepoSource(url="owner/repo")
+
+    def test_short_url_string_without_provider_rejected(self):
+        """Test that string input without provider is rejected."""
+        with pytest.raises(ValueError, match="requires explicit 'provider' field"):
+            RepoSource.model_validate("owner/repo")
+
+    def test_short_url_dict_without_provider_rejected(self):
+        """Test that dict input without provider is rejected."""
+        with pytest.raises(ValueError, match="requires explicit 'provider' field"):
+            RepoSource.model_validate({"url": "owner/repo", "ref": "v1.0"})
+
+    # --- Full URL format (provider auto-detected) ---
+
+    def test_full_https_url_github(self):
+        """Test RepoSource with full GitHub HTTPS URL."""
         repo = RepoSource(url="https://github.com/owner/repo")
         assert repo.url == "https://github.com/owner/repo"
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.GITHUB
+
+    def test_full_https_url_gitlab(self):
+        """Test RepoSource with full GitLab HTTPS URL."""
+        repo = RepoSource(url="https://gitlab.com/owner/repo")
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.GITLAB
+
+    def test_full_https_url_bitbucket(self):
+        """Test RepoSource with full Bitbucket HTTPS URL."""
+        repo = RepoSource(url="https://bitbucket.org/owner/repo")
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.BITBUCKET
 
     def test_git_ssh_url(self):
-        """Test RepoSource with git SSH URL."""
+        """Test RepoSource with git SSH URL (contains github.com)."""
         repo = RepoSource(url="git@github.com:owner/repo.git")
         assert repo.url == "git@github.com:owner/repo.git"
+        assert repo.get_provider() == GitProvider.GITHUB
 
-    def test_string_normalization(self):
-        """Test that string input is normalized to RepoSource."""
-        repo = RepoSource.model_validate("owner/repo")
-        assert repo.url == "owner/repo"
-        assert repo.ref is None
+    # --- Provider field behavior ---
 
-    def test_dict_normalization(self):
-        """Test that dict input is validated."""
-        repo = RepoSource.model_validate({"url": "owner/repo", "ref": "v1.0"})
-        assert repo.url == "owner/repo"
-        assert repo.ref == "v1.0"
+    def test_provider_explicit_overrides_detection(self):
+        """Test that explicit provider is used even with full URL."""
+        # User explicitly says gitlab even though URL is github
+        # This could be intentional (mirror, etc.)
+        repo = RepoSource(url="https://github.com/owner/repo", provider="gitlab")
+        assert repo.get_provider() == GitProvider.GITLAB
+
+    def test_provider_github_token_name(self):
+        """Test GitHub token name."""
+        repo = RepoSource(url="owner/repo", provider="github")
+        assert repo.get_token_name() == "github_token"
+
+    def test_provider_gitlab_token_name(self):
+        """Test GitLab token name."""
+        repo = RepoSource(url="owner/repo", provider="gitlab")
+        assert repo.get_token_name() == "gitlab_token"
+
+    def test_provider_bitbucket_token_name(self):
+        """Test Bitbucket token name."""
+        repo = RepoSource(url="owner/repo", provider="bitbucket")
+        assert repo.get_token_name() == "bitbucket_token"
+
+    # --- URL validation ---
 
     def test_invalid_url_rejected(self):
         """Test that invalid URLs are rejected."""
         with pytest.raises(ValueError, match="URL must be"):
-            RepoSource(url="invalid-url-format")
+            RepoSource(url="invalid-url-format", provider="github")
 
     def test_url_with_dots_allowed(self):
         """Test that URLs with dots in repo name are allowed."""
-        repo = RepoSource(url="owner/repo.name")
+        repo = RepoSource(url="owner/repo.name", provider="github")
         assert repo.url == "owner/repo.name"
 
     def test_url_with_dashes_allowed(self):
         """Test that URLs with dashes are allowed."""
-        repo = RepoSource(url="my-org/my-repo")
+        repo = RepoSource(url="my-org/my-repo", provider="github")
         assert repo.url == "my-org/my-repo"
-
-    def test_provider_explicit(self):
-        """Test explicit provider specification."""
-        repo = RepoSource(url="owner/repo", provider="gitlab")
-        assert repo.provider == "gitlab"
-        assert repo.get_provider() == GitProvider.GITLAB
-        assert repo.get_token_name() == "gitlab_token"
-
-    def test_provider_auto_detect_github(self):
-        """Test auto-detection of GitHub provider."""
-        repo = RepoSource(url="https://github.com/owner/repo")
-        assert repo.provider is None
-        assert repo.get_provider() == GitProvider.GITHUB
-        assert repo.get_token_name() == "github_token"
-
-    def test_provider_auto_detect_gitlab(self):
-        """Test auto-detection of GitLab provider."""
-        repo = RepoSource(url="https://gitlab.com/owner/repo")
-        assert repo.provider is None
-        assert repo.get_provider() == GitProvider.GITLAB
-        assert repo.get_token_name() == "gitlab_token"
-
-    def test_provider_auto_detect_bitbucket(self):
-        """Test auto-detection of Bitbucket provider."""
-        repo = RepoSource(url="https://bitbucket.org/owner/repo")
-        assert repo.provider is None
-        assert repo.get_provider() == GitProvider.BITBUCKET
-        assert repo.get_token_name() == "bitbucket_token"
-
-    def test_provider_default_github(self):
-        """Test that owner/repo format defaults to GitHub."""
-        repo = RepoSource(url="owner/repo")
-        assert repo.provider is None
-        assert repo.get_provider() == GitProvider.GITHUB
 
 
 class TestProviderDetection:
@@ -301,7 +317,7 @@ class TestCloneRepos:
         mock_run.return_value = MagicMock(returncode=0, stderr="")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            repos = [RepoSource(url="owner/repo")]
+            repos = [RepoSource(url="owner/repo", provider="github")]
             result = clone_repos(repos, Path(tmpdir))
 
             assert result.success_count == 1
@@ -310,12 +326,24 @@ class TestCloneRepos:
             assert result.repo_mappings["owner/repo"].dir_name == "repo"
 
     @patch("subprocess.run")
+    def test_successful_clone_full_url(self, mock_run):
+        """Test successful clone with full URL (no provider needed)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [RepoSource(url="https://github.com/owner/repo")]
+            result = clone_repos(repos, Path(tmpdir))
+
+            assert result.success_count == 1
+            assert "https://github.com/owner/repo" in result.repo_mappings
+
+    @patch("subprocess.run")
     def test_clone_with_ref(self, mock_run):
         """Test clone with branch/tag ref."""
         mock_run.return_value = MagicMock(returncode=0, stderr="")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            repos = [RepoSource(url="owner/repo", ref="main")]
+            repos = [RepoSource(url="owner/repo", ref="main", provider="github")]
             clone_repos(repos, Path(tmpdir))
 
             # Check that --branch was included in command
@@ -329,7 +357,7 @@ class TestCloneRepos:
         mock_run.return_value = MagicMock(returncode=0, stderr="")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            repos = [RepoSource(url="owner/repo", ref="abc1234567")]
+            repos = [RepoSource(url="owner/repo", ref="abc1234567", provider="github")]
             clone_repos(repos, Path(tmpdir))
 
             # Should have been called twice: clone + checkout
@@ -341,7 +369,7 @@ class TestCloneRepos:
         mock_run.return_value = MagicMock(returncode=1, stderr="Clone failed")
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            repos = [RepoSource(url="owner/repo")]
+            repos = [RepoSource(url="owner/repo", provider="github")]
             result = clone_repos(repos, Path(tmpdir))
 
             assert result.success_count == 0
@@ -359,7 +387,7 @@ class TestCloneRepos:
             return None
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            repos = [RepoSource(url="owner/repo")]
+            repos = [RepoSource(url="owner/repo", provider="github")]
             clone_repos(
                 repos,
                 Path(tmpdir),
@@ -383,7 +411,7 @@ class TestCloneRepos:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repos = [
-                RepoSource(url="owner/repo1"),  # GitHub (default)
+                RepoSource(url="owner/repo1", provider="github"),
                 RepoSource(url="owner/repo2", provider="gitlab"),
             ]
             clone_repos(repos, Path(tmpdir), token_fetcher=token_fetcher)
@@ -400,8 +428,8 @@ class TestCloneRepos:
         with tempfile.TemporaryDirectory() as tmpdir:
             # Two repos with same name should get unique directories
             repos = [
-                RepoSource(url="owner1/utils"),
-                RepoSource(url="owner2/utils"),
+                RepoSource(url="owner1/utils", provider="github"),
+                RepoSource(url="owner2/utils", provider="github"),
             ]
             result = clone_repos(repos, Path(tmpdir))
 
@@ -421,8 +449,8 @@ class TestCloudWorkspaceRepoMethods:
         "_get_secret_value",
         return_value=None,
     )
-    def test_clone_repos_string_list(self, mock_secret, mock_clone):
-        """Test clone_repos with list of URL strings."""
+    def test_clone_repos_full_url_list(self, mock_secret, mock_clone):
+        """Test clone_repos with list of full URL strings."""
         from openhands.workspace import OpenHandsCloudWorkspace
 
         mock_clone.return_value = CloneResult(0, [], {})
@@ -439,7 +467,11 @@ class TestCloudWorkspaceRepoMethods:
             workspace._session_api_key = "test-session"
             workspace.working_dir = "/workspace/project"
 
-            workspace.clone_repos(["owner/repo1", "owner/repo2"])
+            # Full URLs don't need provider
+            workspace.clone_repos([
+                "https://github.com/owner/repo1",
+                "https://github.com/owner/repo2",
+            ])
 
             mock_clone.assert_called_once()
             call_args = mock_clone.call_args
@@ -473,7 +505,10 @@ class TestCloudWorkspaceRepoMethods:
             workspace._session_api_key = "test-session"
             workspace.working_dir = "/workspace/project"
 
-            workspace.clone_repos([{"url": "owner/repo", "ref": "main"}])
+            # Short URL with provider specified
+            workspace.clone_repos([
+                {"url": "owner/repo", "ref": "main", "provider": "github"}
+            ])
 
             mock_clone.assert_called_once()
             call_args = mock_clone.call_args
@@ -481,6 +516,7 @@ class TestCloudWorkspaceRepoMethods:
             assert len(repos) == 1
             assert repos[0].url == "owner/repo"
             assert repos[0].ref == "main"
+            assert repos[0].provider == "github"
 
     def test_get_repos_context_from_mappings(self):
         """Test get_repos_context with explicit mappings."""

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -9,9 +9,11 @@ import pytest
 
 from openhands.workspace.cloud.repo import (
     CloneResult,
+    GitProvider,
     RepoMapping,
     RepoSource,
     _build_clone_url,
+    _detect_provider_from_url,
     _extract_repo_name,
     _get_unique_dir_name,
     _is_commit_sha,
@@ -73,6 +75,66 @@ class TestRepoSource:
         repo = RepoSource(url="my-org/my-repo")
         assert repo.url == "my-org/my-repo"
 
+    def test_provider_explicit(self):
+        """Test explicit provider specification."""
+        repo = RepoSource(url="owner/repo", provider="gitlab")
+        assert repo.provider == "gitlab"
+        assert repo.get_provider() == GitProvider.GITLAB
+        assert repo.get_token_name() == "gitlab_token"
+
+    def test_provider_auto_detect_github(self):
+        """Test auto-detection of GitHub provider."""
+        repo = RepoSource(url="https://github.com/owner/repo")
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.GITHUB
+        assert repo.get_token_name() == "github_token"
+
+    def test_provider_auto_detect_gitlab(self):
+        """Test auto-detection of GitLab provider."""
+        repo = RepoSource(url="https://gitlab.com/owner/repo")
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.GITLAB
+        assert repo.get_token_name() == "gitlab_token"
+
+    def test_provider_auto_detect_bitbucket(self):
+        """Test auto-detection of Bitbucket provider."""
+        repo = RepoSource(url="https://bitbucket.org/owner/repo")
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.BITBUCKET
+        assert repo.get_token_name() == "bitbucket_token"
+
+    def test_provider_default_github(self):
+        """Test that owner/repo format defaults to GitHub."""
+        repo = RepoSource(url="owner/repo")
+        assert repo.provider is None
+        assert repo.get_provider() == GitProvider.GITHUB
+
+
+class TestProviderDetection:
+    """Tests for provider detection from URLs."""
+
+    def test_detect_github(self):
+        assert _detect_provider_from_url("https://github.com/o/r") == GitProvider.GITHUB
+
+    def test_detect_gitlab(self):
+        assert _detect_provider_from_url("https://gitlab.com/o/r") == GitProvider.GITLAB
+
+    def test_detect_bitbucket(self):
+        assert (
+            _detect_provider_from_url("https://bitbucket.org/o/r")
+            == GitProvider.BITBUCKET
+        )
+
+    def test_detect_azure(self):
+        assert (
+            _detect_provider_from_url("https://dev.azure.com/o/p/_git/r")
+            == GitProvider.AZURE
+        )
+
+    def test_detect_unknown(self):
+        assert _detect_provider_from_url("https://example.com/o/r") is None
+        assert _detect_provider_from_url("owner/repo") is None
+
 
 class TestHelperFunctions:
     """Tests for helper functions in repo module."""
@@ -129,30 +191,46 @@ class TestHelperFunctions:
         existing = {"repo", "repo_1", "repo_2"}
         assert _get_unique_dir_name("repo", existing) == "repo_3"
 
-    def test_build_clone_url_owner_repo_no_token(self):
+    def test_build_clone_url_github_owner_repo_no_token(self):
         """Test building clone URL from owner/repo without token."""
-        url = _build_clone_url("owner/repo", None, None)
+        url = _build_clone_url("owner/repo", GitProvider.GITHUB, None)
         assert url == "https://github.com/owner/repo.git"
 
-    def test_build_clone_url_owner_repo_with_github_token(self):
+    def test_build_clone_url_github_owner_repo_with_token(self):
         """Test building clone URL from owner/repo with GitHub token."""
-        url = _build_clone_url("owner/repo", "ghtoken123", None)
+        url = _build_clone_url("owner/repo", GitProvider.GITHUB, "ghtoken123")
         assert url == "https://ghtoken123@github.com/owner/repo.git"
 
     def test_build_clone_url_github_https_with_token(self):
         """Test building clone URL from GitHub HTTPS URL with token."""
-        url = _build_clone_url("https://github.com/owner/repo", "ghtoken123", None)
+        url = _build_clone_url(
+            "https://github.com/owner/repo", GitProvider.GITHUB, "ghtoken123"
+        )
         assert url == "https://ghtoken123@github.com/owner/repo"
 
-    def test_build_clone_url_gitlab_with_token(self):
+    def test_build_clone_url_gitlab_owner_repo_with_token(self):
+        """Test building clone URL from owner/repo for GitLab with token."""
+        url = _build_clone_url("owner/repo", GitProvider.GITLAB, "gltoken123")
+        assert url == "https://oauth2:gltoken123@gitlab.com/owner/repo.git"
+
+    def test_build_clone_url_gitlab_https_with_token(self):
         """Test building clone URL from GitLab URL with token."""
-        url = _build_clone_url("https://gitlab.com/owner/repo", None, "gltoken123")
+        url = _build_clone_url(
+            "https://gitlab.com/owner/repo", GitProvider.GITLAB, "gltoken123"
+        )
         assert url == "https://oauth2:gltoken123@gitlab.com/owner/repo"
 
-    def test_build_clone_url_other_host(self):
-        """Test building clone URL from other hosts (returns as-is)."""
-        url = _build_clone_url("https://bitbucket.org/owner/repo", "gh", "gl")
-        assert url == "https://bitbucket.org/owner/repo"
+    def test_build_clone_url_bitbucket_with_token(self):
+        """Test building clone URL for Bitbucket with token."""
+        url = _build_clone_url("owner/repo", GitProvider.BITBUCKET, "bbtoken123")
+        assert url == "https://x-token-auth:bbtoken123@bitbucket.org/owner/repo.git"
+
+    def test_build_clone_url_no_token_passthrough(self):
+        """Test that full URLs without token pass through unchanged."""
+        url = _build_clone_url(
+            "https://github.com/owner/repo", GitProvider.GITHUB, None
+        )
+        assert url == "https://github.com/owner/repo"
 
 
 class TestGetReposContext:
@@ -244,7 +322,7 @@ class TestCloneRepos:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repos = [RepoSource(url="owner/repo", ref="main")]
-            result = clone_repos(repos, Path(tmpdir))
+            clone_repos(repos, Path(tmpdir))
 
             # Check that --branch was included in command
             call_args = mock_run.call_args[0][0]
@@ -258,7 +336,7 @@ class TestCloneRepos:
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repos = [RepoSource(url="owner/repo", ref="abc1234567")]
-            result = clone_repos(repos, Path(tmpdir))
+            clone_repos(repos, Path(tmpdir))
 
             # Should have been called twice: clone + checkout
             assert mock_run.call_count == 2
@@ -277,21 +355,48 @@ class TestCloneRepos:
             assert result.repo_mappings == {}
 
     @patch("subprocess.run")
-    def test_clone_with_tokens(self, mock_run):
-        """Test clone with authentication tokens."""
+    def test_clone_with_token_fetcher(self, mock_run):
+        """Test clone with token fetcher callback."""
         mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        def token_fetcher(name: str) -> str | None:
+            if name == "github_token":
+                return "ghtoken123"
+            return None
 
         with tempfile.TemporaryDirectory() as tmpdir:
             repos = [RepoSource(url="owner/repo")]
-            result = clone_repos(
+            clone_repos(
                 repos,
                 Path(tmpdir),
-                github_token="ghtoken123",
+                token_fetcher=token_fetcher,
             )
 
             # Check that token was included in clone URL
             call_args = mock_run.call_args[0][0]
             assert any("ghtoken123" in str(arg) for arg in call_args)
+
+    @patch("subprocess.run")
+    def test_clone_with_provider_specific_token(self, mock_run):
+        """Test clone fetches correct token based on provider."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        fetched_tokens = []
+
+        def token_fetcher(name: str) -> str | None:
+            fetched_tokens.append(name)
+            return f"token_for_{name}"
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [
+                RepoSource(url="owner/repo1"),  # GitHub (default)
+                RepoSource(url="owner/repo2", provider="gitlab"),
+            ]
+            clone_repos(repos, Path(tmpdir), token_fetcher=token_fetcher)
+
+            # Should have fetched github_token and gitlab_token
+            assert "github_token" in fetched_tokens
+            assert "gitlab_token" in fetched_tokens
 
     @patch("subprocess.run")
     def test_write_mapping_file(self, mock_run):

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -546,3 +546,129 @@ class TestCloudWorkspaceRepoMethods:
             context = workspace.get_repos_context(mappings)
             assert "## Cloned Repositories" in context
             assert "`owner/repo`" in context
+
+
+class TestCloneReposIntegration:
+    """Integration tests for clone_repos using real git operations.
+
+    These tests exercise actual git cloning behavior rather than mocking subprocess.
+    Uses a small local git repository as a fixture to avoid network dependencies.
+    """
+
+    @pytest.fixture
+    def local_git_repo(self, tmp_path):
+        """Create a minimal local git repo for testing."""
+        import subprocess
+
+        repo_dir = tmp_path / "test_repo"
+        repo_dir.mkdir()
+
+        # Initialize git repo
+        subprocess.run(["git", "init"], cwd=repo_dir, capture_output=True, check=True)
+        subprocess.run(
+            ["git", "config", "user.email", "test@test.com"],
+            cwd=repo_dir,
+            capture_output=True,
+            check=True,
+        )
+        subprocess.run(
+            ["git", "config", "user.name", "Test"],
+            cwd=repo_dir,
+            capture_output=True,
+            check=True,
+        )
+
+        # Create a file and commit
+        (repo_dir / "README.md").write_text("# Test Repo")
+        subprocess.run(
+            ["git", "add", "README.md"], cwd=repo_dir, capture_output=True, check=True
+        )
+        subprocess.run(
+            ["git", "commit", "-m", "Initial commit"],
+            cwd=repo_dir,
+            capture_output=True,
+            check=True,
+        )
+
+        # Create a tag
+        subprocess.run(
+            ["git", "tag", "v1.0.0"], cwd=repo_dir, capture_output=True, check=True
+        )
+
+        # Get the commit SHA
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            cwd=repo_dir,
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        commit_sha = result.stdout.strip()
+
+        return {"path": repo_dir, "sha": commit_sha}
+
+    def test_clone_local_repo(self, local_git_repo, tmp_path):
+        """Test cloning a local git repository."""
+        target_dir = tmp_path / "cloned"
+        repo_url = f"file://{local_git_repo['path']}"
+
+        repos = [RepoSource(url=repo_url)]
+        result = clone_repos(repos, target_dir)
+
+        assert result.success_count == 1
+        assert len(result.failed_repos) == 0
+        assert repo_url in result.repo_mappings
+
+        # Verify the repo was actually cloned
+        cloned_path = Path(result.repo_mappings[repo_url].local_path)
+        assert cloned_path.exists()
+        assert (cloned_path / "README.md").exists()
+        assert (cloned_path / "README.md").read_text() == "# Test Repo"
+
+    def test_clone_with_tag_ref(self, local_git_repo, tmp_path):
+        """Test cloning with a specific tag ref."""
+        target_dir = tmp_path / "cloned"
+        repo_url = f"file://{local_git_repo['path']}"
+
+        repos = [RepoSource(url=repo_url, ref="v1.0.0")]
+        result = clone_repos(repos, target_dir)
+
+        assert result.success_count == 1
+        cloned_path = Path(result.repo_mappings[repo_url].local_path)
+        assert cloned_path.exists()
+
+    def test_clone_with_sha_ref(self, local_git_repo, tmp_path):
+        """Test cloning with a specific commit SHA."""
+        target_dir = tmp_path / "cloned"
+        repo_url = f"file://{local_git_repo['path']}"
+        sha = local_git_repo["sha"]
+
+        repos = [RepoSource(url=repo_url, ref=sha)]
+        result = clone_repos(repos, target_dir)
+
+        assert result.success_count == 1
+        cloned_path = Path(result.repo_mappings[repo_url].local_path)
+        assert cloned_path.exists()
+
+    def test_clone_invalid_url_fails(self, tmp_path):
+        """Test that invalid URLs are handled gracefully."""
+        target_dir = tmp_path / "cloned"
+
+        repos = [RepoSource(url="file:///nonexistent/repo")]
+        result = clone_repos(repos, target_dir)
+
+        assert result.success_count == 0
+        assert len(result.failed_repos) == 1
+
+    def test_clone_duplicate_urls_deduplicated(self, local_git_repo, tmp_path):
+        """Test that duplicate URLs are deduplicated."""
+        target_dir = tmp_path / "cloned"
+        repo_url = f"file://{local_git_repo['path']}"
+
+        # Same URL twice
+        repos = [RepoSource(url=repo_url), RepoSource(url=repo_url)]
+        result = clone_repos(repos, target_dir)
+
+        # Should only clone once
+        assert result.success_count == 1
+        assert len(result.repo_mappings) == 1

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -1,0 +1,460 @@
+"""Tests for repository cloning and skill loading in OpenHandsCloudWorkspace."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from openhands.workspace.cloud.repo import (
+    CloneResult,
+    RepoMapping,
+    RepoSource,
+    _build_clone_url,
+    _extract_repo_name,
+    _get_unique_dir_name,
+    _is_commit_sha,
+    _sanitize_dir_name,
+    clone_repos,
+    get_repos_context,
+)
+
+
+class TestRepoSource:
+    """Tests for RepoSource model."""
+
+    def test_simple_url(self):
+        """Test RepoSource with simple owner/repo URL."""
+        repo = RepoSource(url="owner/repo")
+        assert repo.url == "owner/repo"
+        assert repo.ref is None
+
+    def test_url_with_ref(self):
+        """Test RepoSource with URL and ref."""
+        repo = RepoSource(url="owner/repo", ref="main")
+        assert repo.url == "owner/repo"
+        assert repo.ref == "main"
+
+    def test_full_https_url(self):
+        """Test RepoSource with full HTTPS URL."""
+        repo = RepoSource(url="https://github.com/owner/repo")
+        assert repo.url == "https://github.com/owner/repo"
+
+    def test_git_ssh_url(self):
+        """Test RepoSource with git SSH URL."""
+        repo = RepoSource(url="git@github.com:owner/repo.git")
+        assert repo.url == "git@github.com:owner/repo.git"
+
+    def test_string_normalization(self):
+        """Test that string input is normalized to RepoSource."""
+        repo = RepoSource.model_validate("owner/repo")
+        assert repo.url == "owner/repo"
+        assert repo.ref is None
+
+    def test_dict_normalization(self):
+        """Test that dict input is validated."""
+        repo = RepoSource.model_validate({"url": "owner/repo", "ref": "v1.0"})
+        assert repo.url == "owner/repo"
+        assert repo.ref == "v1.0"
+
+    def test_invalid_url_rejected(self):
+        """Test that invalid URLs are rejected."""
+        with pytest.raises(ValueError, match="URL must be"):
+            RepoSource(url="invalid-url-format")
+
+    def test_url_with_dots_allowed(self):
+        """Test that URLs with dots in repo name are allowed."""
+        repo = RepoSource(url="owner/repo.name")
+        assert repo.url == "owner/repo.name"
+
+    def test_url_with_dashes_allowed(self):
+        """Test that URLs with dashes are allowed."""
+        repo = RepoSource(url="my-org/my-repo")
+        assert repo.url == "my-org/my-repo"
+
+
+class TestHelperFunctions:
+    """Tests for helper functions in repo module."""
+
+    def test_is_commit_sha_valid(self):
+        """Test detection of valid commit SHAs."""
+        assert _is_commit_sha("abc1234") is True
+        assert (
+            _is_commit_sha("abc1234567890abcdef1234567890abcdef12") is True
+        )  # 40 chars
+        assert _is_commit_sha("ABC1234") is True  # Case insensitive
+
+    def test_is_commit_sha_invalid(self):
+        """Test detection of invalid commit SHAs."""
+        assert _is_commit_sha(None) is False
+        assert _is_commit_sha("main") is False
+        assert _is_commit_sha("v1.0.0") is False
+        assert _is_commit_sha("abc123") is False  # Too short
+        assert _is_commit_sha("xyz1234") is False  # Invalid hex chars
+
+    def test_extract_repo_name_owner_repo(self):
+        """Test extracting repo name from owner/repo format."""
+        assert _extract_repo_name("owner/repo") == "repo"
+        assert _extract_repo_name("my-org/my-repo") == "my-repo"
+
+    def test_extract_repo_name_https_url(self):
+        """Test extracting repo name from HTTPS URLs."""
+        assert _extract_repo_name("https://github.com/owner/repo") == "repo"
+        assert _extract_repo_name("https://github.com/owner/repo.git") == "repo"
+        assert _extract_repo_name("https://gitlab.com/owner/repo") == "repo"
+
+    def test_extract_repo_name_ssh_url(self):
+        """Test extracting repo name from SSH URLs."""
+        assert _extract_repo_name("git@github.com:owner/repo.git") == "repo"
+        assert _extract_repo_name("git@gitlab.com:owner/repo") == "repo"
+
+    def test_sanitize_dir_name(self):
+        """Test directory name sanitization."""
+        assert _sanitize_dir_name("repo") == "repo"
+        assert _sanitize_dir_name("my-repo") == "my-repo"
+        assert _sanitize_dir_name("my.repo") == "my.repo"
+        assert _sanitize_dir_name("repo/name") == "repo_name"  # Invalid char
+        assert _sanitize_dir_name("...repo...") == "repo"  # Trim dots
+        assert _sanitize_dir_name("") == "repo"  # Empty -> default
+
+    def test_get_unique_dir_name(self):
+        """Test unique directory name generation."""
+        existing: set[str] = set()
+        assert _get_unique_dir_name("repo", existing) == "repo"
+
+        existing = {"repo"}
+        assert _get_unique_dir_name("repo", existing) == "repo_1"
+
+        existing = {"repo", "repo_1", "repo_2"}
+        assert _get_unique_dir_name("repo", existing) == "repo_3"
+
+    def test_build_clone_url_owner_repo_no_token(self):
+        """Test building clone URL from owner/repo without token."""
+        url = _build_clone_url("owner/repo", None, None)
+        assert url == "https://github.com/owner/repo.git"
+
+    def test_build_clone_url_owner_repo_with_github_token(self):
+        """Test building clone URL from owner/repo with GitHub token."""
+        url = _build_clone_url("owner/repo", "ghtoken123", None)
+        assert url == "https://ghtoken123@github.com/owner/repo.git"
+
+    def test_build_clone_url_github_https_with_token(self):
+        """Test building clone URL from GitHub HTTPS URL with token."""
+        url = _build_clone_url("https://github.com/owner/repo", "ghtoken123", None)
+        assert url == "https://ghtoken123@github.com/owner/repo"
+
+    def test_build_clone_url_gitlab_with_token(self):
+        """Test building clone URL from GitLab URL with token."""
+        url = _build_clone_url("https://gitlab.com/owner/repo", None, "gltoken123")
+        assert url == "https://oauth2:gltoken123@gitlab.com/owner/repo"
+
+    def test_build_clone_url_other_host(self):
+        """Test building clone URL from other hosts (returns as-is)."""
+        url = _build_clone_url("https://bitbucket.org/owner/repo", "gh", "gl")
+        assert url == "https://bitbucket.org/owner/repo"
+
+
+class TestGetReposContext:
+    """Tests for get_repos_context function."""
+
+    def test_empty_mappings(self):
+        """Test that empty mappings return empty string."""
+        assert get_repos_context({}) == ""
+
+    def test_single_repo(self):
+        """Test context generation for single repo."""
+        mappings = {
+            "owner/repo": RepoMapping(
+                url="owner/repo",
+                dir_name="repo",
+                local_path="/workspace/project/repo",
+                ref=None,
+            )
+        }
+        context = get_repos_context(mappings)
+        assert "## Cloned Repositories" in context
+        assert "`owner/repo`" in context
+        assert "`/workspace/project/repo/`" in context
+
+    def test_repo_with_ref(self):
+        """Test context generation for repo with ref."""
+        mappings = {
+            "owner/repo": RepoMapping(
+                url="owner/repo",
+                dir_name="repo",
+                local_path="/workspace/project/repo",
+                ref="main",
+            )
+        }
+        context = get_repos_context(mappings)
+        assert "(ref: main)" in context
+
+    def test_multiple_repos(self):
+        """Test context generation for multiple repos."""
+        mappings = {
+            "owner/repo1": RepoMapping(
+                url="owner/repo1",
+                dir_name="repo1",
+                local_path="/workspace/project/repo1",
+                ref=None,
+            ),
+            "owner/repo2": RepoMapping(
+                url="owner/repo2",
+                dir_name="repo2",
+                local_path="/workspace/project/repo2",
+                ref="v1.0",
+            ),
+        }
+        context = get_repos_context(mappings)
+        assert "`owner/repo1`" in context
+        assert "`owner/repo2`" in context
+        assert "(ref: v1.0)" in context
+
+
+class TestCloneRepos:
+    """Tests for clone_repos function."""
+
+    def test_empty_repos_list(self):
+        """Test cloning with empty repos list."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            result = clone_repos([], Path(tmpdir))
+            assert result.success_count == 0
+            assert result.failed_repos == []
+            assert result.repo_mappings == {}
+
+    @patch("subprocess.run")
+    def test_successful_clone(self, mock_run):
+        """Test successful repo clone."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [RepoSource(url="owner/repo")]
+            result = clone_repos(repos, Path(tmpdir))
+
+            assert result.success_count == 1
+            assert result.failed_repos == []
+            assert "owner/repo" in result.repo_mappings
+            assert result.repo_mappings["owner/repo"].dir_name == "repo"
+
+    @patch("subprocess.run")
+    def test_clone_with_ref(self, mock_run):
+        """Test clone with branch/tag ref."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [RepoSource(url="owner/repo", ref="main")]
+            result = clone_repos(repos, Path(tmpdir))
+
+            # Check that --branch was included in command
+            call_args = mock_run.call_args[0][0]
+            assert "--branch" in call_args
+            assert "main" in call_args
+
+    @patch("subprocess.run")
+    def test_clone_with_sha_ref(self, mock_run):
+        """Test clone with SHA ref (needs full clone + checkout)."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [RepoSource(url="owner/repo", ref="abc1234567")]
+            result = clone_repos(repos, Path(tmpdir))
+
+            # Should have been called twice: clone + checkout
+            assert mock_run.call_count == 2
+
+    @patch("subprocess.run")
+    def test_clone_failure(self, mock_run):
+        """Test handling of clone failure."""
+        mock_run.return_value = MagicMock(returncode=1, stderr="Clone failed")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [RepoSource(url="owner/repo")]
+            result = clone_repos(repos, Path(tmpdir))
+
+            assert result.success_count == 0
+            assert len(result.failed_repos) == 1
+            assert result.repo_mappings == {}
+
+    @patch("subprocess.run")
+    def test_clone_with_tokens(self, mock_run):
+        """Test clone with authentication tokens."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repos = [RepoSource(url="owner/repo")]
+            result = clone_repos(
+                repos,
+                Path(tmpdir),
+                github_token="ghtoken123",
+            )
+
+            # Check that token was included in clone URL
+            call_args = mock_run.call_args[0][0]
+            assert any("ghtoken123" in str(arg) for arg in call_args)
+
+    @patch("subprocess.run")
+    def test_write_mapping_file(self, mock_run):
+        """Test writing repos_mapping.json file."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tmppath = Path(tmpdir)
+            repos = [RepoSource(url="owner/repo")]
+            mapping_file = tmppath / "repos_mapping.json"
+
+            clone_repos(repos, tmppath, mapping_file=mapping_file)
+
+            assert mapping_file.exists()
+            with open(mapping_file) as f:
+                data = json.load(f)
+            assert "owner/repo" in data
+            assert data["owner/repo"]["dir_name"] == "repo"
+
+    @patch("subprocess.run")
+    def test_directory_name_collision(self, mock_run):
+        """Test handling of directory name collisions."""
+        mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Two repos with same name should get unique directories
+            repos = [
+                RepoSource(url="owner1/utils"),
+                RepoSource(url="owner2/utils"),
+            ]
+            result = clone_repos(repos, Path(tmpdir))
+
+            dir_names = [m.dir_name for m in result.repo_mappings.values()]
+            assert "utils" in dir_names
+            assert "utils_1" in dir_names
+
+
+class TestCloudWorkspaceRepoMethods:
+    """Tests for OpenHandsCloudWorkspace repo methods."""
+
+    @patch("openhands.workspace.cloud.workspace.clone_repos")
+    @patch.object(
+        __import__(
+            "openhands.workspace.cloud.workspace", fromlist=["OpenHandsCloudWorkspace"]
+        ).OpenHandsCloudWorkspace,
+        "_get_secret_value",
+        return_value=None,
+    )
+    def test_clone_repos_string_list(self, mock_secret, mock_clone):
+        """Test clone_repos with list of URL strings."""
+        from openhands.workspace import OpenHandsCloudWorkspace
+
+        mock_clone.return_value = CloneResult(0, [], {})
+
+        with patch.object(
+            OpenHandsCloudWorkspace, "model_post_init", lambda self, ctx: None
+        ):
+            workspace = OpenHandsCloudWorkspace(
+                cloud_api_url="https://test.com",
+                cloud_api_key="test-key",
+                local_agent_server_mode=True,
+            )
+            workspace._sandbox_id = "test-sandbox"
+            workspace._session_api_key = "test-session"
+            workspace.working_dir = "/workspace/project"
+
+            workspace.clone_repos(["owner/repo1", "owner/repo2"])
+
+            mock_clone.assert_called_once()
+            call_args = mock_clone.call_args
+            repos = call_args.kwargs["repos"]
+            assert len(repos) == 2
+            assert all(isinstance(r, RepoSource) for r in repos)
+
+    @patch("openhands.workspace.cloud.workspace.clone_repos")
+    @patch.object(
+        __import__(
+            "openhands.workspace.cloud.workspace", fromlist=["OpenHandsCloudWorkspace"]
+        ).OpenHandsCloudWorkspace,
+        "_get_secret_value",
+        return_value=None,
+    )
+    def test_clone_repos_dict_list(self, mock_secret, mock_clone):
+        """Test clone_repos with list of dicts."""
+        from openhands.workspace import OpenHandsCloudWorkspace
+
+        mock_clone.return_value = CloneResult(0, [], {})
+
+        with patch.object(
+            OpenHandsCloudWorkspace, "model_post_init", lambda self, ctx: None
+        ):
+            workspace = OpenHandsCloudWorkspace(
+                cloud_api_url="https://test.com",
+                cloud_api_key="test-key",
+                local_agent_server_mode=True,
+            )
+            workspace._sandbox_id = "test-sandbox"
+            workspace._session_api_key = "test-session"
+            workspace.working_dir = "/workspace/project"
+
+            workspace.clone_repos([{"url": "owner/repo", "ref": "main"}])
+
+            mock_clone.assert_called_once()
+            call_args = mock_clone.call_args
+            repos = call_args.kwargs["repos"]
+            assert len(repos) == 1
+            assert repos[0].url == "owner/repo"
+            assert repos[0].ref == "main"
+
+    def test_get_repos_context_from_mappings(self):
+        """Test get_repos_context with explicit mappings."""
+        from openhands.workspace import OpenHandsCloudWorkspace
+
+        with patch.object(
+            OpenHandsCloudWorkspace, "model_post_init", lambda self, ctx: None
+        ):
+            workspace = OpenHandsCloudWorkspace(
+                cloud_api_url="https://test.com",
+                cloud_api_key="test-key",
+                local_agent_server_mode=True,
+            )
+            workspace.working_dir = "/workspace/project"
+
+            mappings = {
+                "owner/repo": RepoMapping(
+                    url="owner/repo",
+                    dir_name="repo",
+                    local_path="/workspace/project/repo",
+                    ref="main",
+                )
+            }
+
+            context = workspace.get_repos_context(mappings)
+            assert "## Cloned Repositories" in context
+            assert "`owner/repo`" in context
+
+    def test_get_repos_context_from_file(self):
+        """Test get_repos_context reading from repos_mapping.json."""
+        from openhands.workspace import OpenHandsCloudWorkspace
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            # Create mapping file
+            mapping_file = Path(tmpdir) / "repos_mapping.json"
+            mapping_data = {
+                "owner/repo": {
+                    "dir_name": "repo",
+                    "local_path": f"{tmpdir}/repo",
+                    "ref": "main",
+                }
+            }
+            with open(mapping_file, "w") as f:
+                json.dump(mapping_data, f)
+
+            with patch.object(
+                OpenHandsCloudWorkspace, "model_post_init", lambda self, ctx: None
+            ):
+                workspace = OpenHandsCloudWorkspace(
+                    cloud_api_url="https://test.com",
+                    cloud_api_key="test-key",
+                    local_agent_server_mode=True,
+                )
+                workspace.working_dir = tmpdir
+
+                context = workspace.get_repos_context()
+                assert "## Cloned Repositories" in context
+                assert "`owner/repo`" in context

--- a/tests/workspace/test_cloud_workspace_repos.py
+++ b/tests/workspace/test_cloud_workspace_repos.py
@@ -338,20 +338,6 @@ class TestCloneRepos:
             assert "https://github.com/owner/repo" in result.repo_mappings
 
     @patch("subprocess.run")
-    def test_clone_with_ref(self, mock_run):
-        """Test clone with branch/tag ref."""
-        mock_run.return_value = MagicMock(returncode=0, stderr="")
-
-        with tempfile.TemporaryDirectory() as tmpdir:
-            repos = [RepoSource(url="owner/repo", ref="main", provider="github")]
-            clone_repos(repos, Path(tmpdir))
-
-            # Check that --branch was included in command
-            call_args = mock_run.call_args[0][0]
-            assert "--branch" in call_args
-            assert "main" in call_args
-
-    @patch("subprocess.run")
     def test_clone_with_sha_ref(self, mock_run):
         """Test clone with SHA ref (needs full clone + checkout)."""
         mock_run.return_value = MagicMock(returncode=0, stderr="")
@@ -627,6 +613,8 @@ class TestCloneReposIntegration:
 
     def test_clone_with_tag_ref(self, local_git_repo, tmp_path):
         """Test cloning with a specific tag ref."""
+        import subprocess
+
         target_dir = tmp_path / "cloned"
         repo_url = f"file://{local_git_repo['path']}"
 
@@ -637,8 +625,19 @@ class TestCloneReposIntegration:
         cloned_path = Path(result.repo_mappings[repo_url].local_path)
         assert cloned_path.exists()
 
+        # Verify the tag was actually checked out
+        tag_result = subprocess.run(
+            ["git", "-C", str(cloned_path), "describe", "--tags", "--exact-match"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert tag_result.stdout.strip() == "v1.0.0"
+
     def test_clone_with_sha_ref(self, local_git_repo, tmp_path):
         """Test cloning with a specific commit SHA."""
+        import subprocess
+
         target_dir = tmp_path / "cloned"
         repo_url = f"file://{local_git_repo['path']}"
         sha = local_git_repo["sha"]
@@ -649,6 +648,15 @@ class TestCloneReposIntegration:
         assert result.success_count == 1
         cloned_path = Path(result.repo_mappings[repo_url].local_path)
         assert cloned_path.exists()
+
+        # Verify the SHA was actually checked out
+        sha_result = subprocess.run(
+            ["git", "-C", str(cloned_path), "rev-parse", "HEAD"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        assert sha_result.stdout.strip() == sha
 
     def test_clone_invalid_url_fails(self, tmp_path):
         """Test that invalid URLs are handled gracefully."""


### PR DESCRIPTION
## Summary

Add new methods to `OpenHandsCloudWorkspace` for repository cloning and skill loading, moving this functionality from the automation service to the SDK layer.

This PR addresses feedback on [automation#51](https://github.com/OpenHands/automation/pull/51) to move repo cloning and skill loading utilities into the SDK, where they can be reused by automation presets and other SDK users.

## Changes

### New Methods on `OpenHandsCloudWorkspace`

| Method | Description |
|--------|-------------|
| `clone_repos(repos)` | Clone repositories using git tokens from user secrets |
| `load_skills_from_agent_server(project_dirs)` | Load skills via agent-server `/api/skills` endpoint |
| `get_repos_context(repo_mappings)` | Generate markdown context string for cloned repos |
| `_get_secret_value(name)` | Fetch raw secret value (internal, for git tokens) |

### New Models (`openhands.workspace.cloud.repo`)

| Model/Class | Description |
|-------------|-------------|
| `GitProvider` | Enum for supported git providers: `github`, `gitlab`, `bitbucket` |
| `RepoSource` | Pydantic model for repo specification (url, ref, provider) |
| `RepoMapping` | Dataclass for mapping info (url, dir_name, local_path, ref) |
| `CloneResult` | Dataclass for clone operation results |

### Provider Detection & Validation

The `RepoSource` model uses **explicit provider validation** for short URLs:

| URL Format | Provider Required? | Example |
|------------|-------------------|---------|
| Full URL (`https://github.com/...`) | No, auto-detected | `RepoSource(url="https://github.com/owner/repo")` |
| Full URL (`https://gitlab.com/...`) | No, auto-detected | `RepoSource(url="https://gitlab.com/owner/repo")` |
| Short URL (`owner/repo`) | **Yes, required** | `RepoSource(url="owner/repo", provider="github")` |

**Why?** Short URLs are ambiguous - they could be GitHub, GitLab, or Bitbucket. Rather than silently defaulting to GitHub (which could cause confusing auth failures), we require explicit provider specification.

### Token Handling

Each provider uses a different authentication format:

| Provider | Token Secret Name | Clone URL Format |
|----------|------------------|------------------|
| GitHub | `github_token` | `https://{token}@github.com/...` |
| GitLab | `gitlab_token` | `https://oauth2:{token}@gitlab.com/...` |
| Bitbucket | `bitbucket_token` | `https://x-token-auth:{token}@bitbucket.org/...` |

### Workspace Features

- **Token fetching**: Automatically fetches appropriate token from sandbox settings API based on provider
- **Meaningful directory names**: Clones to repo name (e.g., `openhands-cli/`) instead of generic names
- **Collision handling**: Appends `_N` suffix for duplicate repo names
- **Multi-repo skill loading**: Loads project skills from EACH cloned repo directory
- **Skill conversion**: Converts agent-server API response to SDK `Skill` objects

## Usage Examples

```python
with OpenHandsCloudWorkspace(
    local_agent_server_mode=True,
    cloud_api_url=api_url,
    cloud_api_key=api_key,
) as workspace:
    # Clone with full URLs (provider auto-detected)
    result = workspace.clone_repos([
        "https://github.com/owner/repo1",
        {"url": "https://gitlab.com/owner/repo2", "ref": "main"},
    ])

    # Clone with short URLs (provider required)
    result = workspace.clone_repos([
        {"url": "owner/repo1", "provider": "github"},
        {"url": "owner/repo2", "provider": "gitlab", "ref": "v1.0"},
    ])

    # Get context for agent prompt
    context = workspace.get_repos_context(result.repo_mappings)
```

### Error Messages

Short URLs without provider give a clear error:
```
ValueError: Short URL format 'owner/repo' requires explicit 'provider' field. 
Use: {"url": "owner/repo", "provider": "github"} 
or provide a full URL like https://github.com/owner/repo
```

## Tests

- 50 unit tests covering:
  - RepoSource validation (short URLs rejected without provider, full URLs auto-detect)
  - Provider detection from URLs
  - Clone URL building for all providers
  - Token handling per provider
  - Directory naming and collision handling
  - Workspace method integration

---

*This PR was created by an AI assistant (OpenHands).*











<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6364f06-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6364f06-python \
  ghcr.io/openhands/agent-server:6364f06-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6364f06-golang-amd64
ghcr.io/openhands/agent-server:6364f06-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6364f06-golang-arm64
ghcr.io/openhands/agent-server:6364f06-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6364f06-java-amd64
ghcr.io/openhands/agent-server:6364f06-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6364f06-java-arm64
ghcr.io/openhands/agent-server:6364f06-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6364f06-python-amd64
ghcr.io/openhands/agent-server:6364f06-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6364f06-python-arm64
ghcr.io/openhands/agent-server:6364f06-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6364f06-golang
ghcr.io/openhands/agent-server:6364f06-java
ghcr.io/openhands/agent-server:6364f06-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6364f06-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6364f06-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->