### PR TITLE
Add cancel-eval workflow to kill evaluation jobs

### DIFF
--- a/.github/workflows/cancel-eval.yml
+++ b/.github/workflows/cancel-eval.yml
@@ -1,0 +1,62 @@
+name: Cancel Eval
+
+run-name: Cancel Eval (${{ inputs.run_id }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_id:
+        description: "Workflow run ID to cancel"
+        required: true
+        type: string
+      reason:
+        description: "Reason for cancellation"
+        required: false
+        type: string
+
+env:
+  EVAL_REPO: OpenHands/evaluation
+  EVAL_WORKFLOW: kill-eval-job.yml
+
+permissions:
+  contents: read
+
+jobs:
+  cancel-eval:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Cancel evaluation job
+        env:
+          PAT_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
+          RUN_ID: ${{ github.event.inputs.run_id }}
+          REASON: ${{ github.event.inputs.reason }}
+        run: |
+          set -euo pipefail
+
+          if [ -z "$PAT_TOKEN" ]; then
+            echo "Missing PAT token" >&2
+            exit 1
+          fi
+
+          echo "Canceling evaluation workflow run: $RUN_ID"
+
+          # Dispatch kill workflow in evaluation repo
+          PAYLOAD=$(jq -n \
+            --arg ref "main" \
+            --arg run_id "$RUN_ID" \
+            --arg reason "$REASON" \
+            '{ref: $ref, inputs: {run_id: $run_id, reason: $reason}}')
+
+          RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
+            -H "Authorization: token $PAT_TOKEN" \
+            -H "Accept: application/vnd.github+json" \
+            -d "$PAYLOAD" \
+            "https://api.github.com/repos/${EVAL_REPO}/actions/workflows/${EVAL_WORKFLOW}/dispatches")
+
+          if [ "$RESPONSE" != "204" ]; then
+            echo "Dispatch failed (status $RESPONSE):" >&2
+            cat /tmp/dispatch.out >&2
+            exit 1
+          fi
+
+          echo "Cancellation dispatched successfully for run: $RUN_ID"

--- a/.github/workflows/cancel-eval.yml
+++ b/.github/workflows/cancel-eval.yml
@@ -1,62 +1,63 @@
+---
 name: Cancel Eval
 
 run-name: Cancel Eval (${{ inputs.run_id }})
 
 on:
-  workflow_dispatch:
-    inputs:
-      run_id:
-        description: "Workflow run ID to cancel"
-        required: true
-        type: string
-      reason:
-        description: "Reason for cancellation"
-        required: false
-        type: string
+    workflow_dispatch:
+        inputs:
+            run_id:
+                description: Workflow run ID to cancel
+                required: true
+                type: string
+            reason:
+                description: Reason for cancellation
+                required: false
+                type: string
 
 env:
-  EVAL_REPO: OpenHands/evaluation
-  EVAL_WORKFLOW: kill-eval-job.yml
+    EVAL_REPO: OpenHands/evaluation
+    EVAL_WORKFLOW: kill-eval-job.yml
 
 permissions:
-  contents: read
+    contents: read
 
 jobs:
-  cancel-eval:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Cancel evaluation job
-        env:
-          PAT_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
-          RUN_ID: ${{ github.event.inputs.run_id }}
-          REASON: ${{ github.event.inputs.reason }}
-        run: |
-          set -euo pipefail
+    cancel-eval:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Cancel evaluation job
+              env:
+                  PAT_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
+                  RUN_ID: ${{ github.event.inputs.run_id }}
+                  REASON: ${{ github.event.inputs.reason }}
+              run: |-
+                  set -euo pipefail
 
-          if [ -z "$PAT_TOKEN" ]; then
-            echo "Missing PAT token" >&2
-            exit 1
-          fi
+                  if [ -z "$PAT_TOKEN" ]; then
+                    echo "Missing PAT token" >&2
+                    exit 1
+                  fi
 
-          echo "Canceling evaluation workflow run: $RUN_ID"
+                  echo "Canceling evaluation workflow run: $RUN_ID"
 
-          # Dispatch kill workflow in evaluation repo
-          PAYLOAD=$(jq -n \
-            --arg ref "main" \
-            --arg run_id "$RUN_ID" \
-            --arg reason "$REASON" \
-            '{ref: $ref, inputs: {run_id: $run_id, reason: $reason}}')
+                  # Dispatch kill workflow in evaluation repo
+                  PAYLOAD=$(jq -n \
+                    --arg ref "main" \
+                    --arg run_id "$RUN_ID" \
+                    --arg reason "$REASON" \
+                    '{ref: $ref, inputs: {run_id: $run_id, reason: $reason}}')
 
-          RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
-            -H "Authorization: token $PAT_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            -d "$PAYLOAD" \
-            "https://api.github.com/repos/${EVAL_REPO}/actions/workflows/${EVAL_WORKFLOW}/dispatches")
+                  RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
+                    -H "Authorization: token $PAT_TOKEN" \
+                    -H "Accept: application/vnd.github+json" \
+                    -d "$PAYLOAD" \
+                    "https://api.github.com/repos/${EVAL_REPO}/actions/workflows/${EVAL_WORKFLOW}/dispatches")
 
-          if [ "$RESPONSE" != "204" ]; then
-            echo "Dispatch failed (status $RESPONSE):" >&2
-            cat /tmp/dispatch.out >&2
-            exit 1
-          fi
+                  if [ "$RESPONSE" != "204" ]; then
+                    echo "Dispatch failed (status $RESPONSE):" >&2
+                    cat /tmp/dispatch.out >&2
+                    exit 1
+                  fi
 
-          echo "Cancellation dispatched successfully for run: $RUN_ID"
+                  echo "Cancellation dispatched successfully for run: $RUN_ID"


### PR DESCRIPTION
## Summary

Adds a new `cancel-eval.yml` workflow that allows users with write access to cancel running evaluation jobs by dispatching the `kill-eval-job.yml` workflow in `OpenHands/evaluation`.

## Changes

- Added `.github/workflows/cancel-eval.yml` - A new workflow that:
  - Takes a `run_id` input (required) to identify the evaluation job to cancel
  - Takes an optional `reason` input for cancellation notes
  - Uses the same `PAT_TOKEN` secret (`OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH`) as `run-eval.yml`
  - Dispatches `kill-eval-job.yml` in the `OpenHands/evaluation` repository

## Security

- Only users with **write access** can trigger this workflow (via `workflow_dispatch`)
- Uses minimal permissions (`contents: read`)
- Same authentication mechanism as the existing `run-eval.yml` workflow
- No new security risks introduced

## Usage

```bash
# Via CLI
gh workflow run cancel-eval.yml -f run_id=1234567890 -f reason="PR closed"

# Via GitHub UI
https://github.com/OpenHands/software-agent-sdk/actions/workflows/cancel-eval.yml
```

This PR was created by an AI assistant (OpenHands) on behalf of the user.

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fe568da6-030b-433f-831a-70d3e3a0efa0)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d31d039-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d31d039-python \
  ghcr.io/openhands/agent-server:d31d039-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d31d039-golang-amd64
ghcr.io/openhands/agent-server:d31d039-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d31d039-golang-arm64
ghcr.io/openhands/agent-server:d31d039-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d31d039-java-amd64
ghcr.io/openhands/agent-server:d31d039-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d31d039-java-arm64
ghcr.io/openhands/agent-server:d31d039-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d31d039-python-amd64
ghcr.io/openhands/agent-server:d31d039-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d31d039-python-arm64
ghcr.io/openhands/agent-server:d31d039-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d31d039-golang
ghcr.io/openhands/agent-server:d31d039-java
ghcr.io/openhands/agent-server:d31d039-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d31d039-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d31d039-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->