### PR TITLE
fix(conversation): repin prompt_cache_key on switch_profile

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -189,8 +189,7 @@ class LocalConversation(BaseConversation):
             tags=tags,
         )
 
-        # Pin the OpenAI prefix-cache shard to this conversation (#2904).
-        self.agent.llm._prompt_cache_key = str(self._state.id)
+        self._pin_prompt_cache_key()
 
         # Default callback: persist every event to state
         def _default_callback(e):
@@ -600,6 +599,10 @@ class LocalConversation(BaseConversation):
         """
         return not isinstance(self.agent, ACPAgent)
 
+    def _pin_prompt_cache_key(self) -> None:
+        # Pin the OpenAI prefix-cache shard to this conversation (#2904, #2918).
+        self.agent.llm._prompt_cache_key = str(self._state.id)
+
     def switch_profile(self, profile_name: str) -> None:
         """Switch the agent's LLM to a named profile.
 
@@ -623,6 +626,7 @@ class LocalConversation(BaseConversation):
         with self._state:
             self.agent = self.agent.model_copy(update={"llm": new_llm})
             self._state.agent = self.agent
+            self._pin_prompt_cache_key()
 
     @observe(name="conversation.send_message")
     def send_message(self, message: str | Message, sender: str | None = None) -> None:

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -93,6 +93,23 @@ def test_switch_nonexistent_raises(profile_store):
     assert conv.state.agent.llm.model == "default-model"
 
 
+def test_switch_profile_preserves_prompt_cache_key(profile_store):
+    """Regression test for #2918: switch_profile must repin _prompt_cache_key."""
+    conv = _make_conversation()
+    expected = str(conv.id)
+    assert conv.agent.llm._prompt_cache_key == expected
+
+    conv.switch_profile("fast")
+    assert conv.agent.llm._prompt_cache_key == expected
+
+    conv.switch_profile("slow")
+    assert conv.agent.llm._prompt_cache_key == expected
+
+    # Switching back to a cached registry entry must still carry the key.
+    conv.switch_profile("fast")
+    assert conv.agent.llm._prompt_cache_key == expected
+
+
 def test_switch_then_send_message(profile_store):
     """switch_profile followed by send_message doesn't crash on registry collision."""
     conv = _make_conversation()


### PR DESCRIPTION
## What                                                                                                                                                                               

  Centralize _prompt_cache_key pinning in LocalConversation via a new _pin_prompt_cache_key() helper, called from both __init__ and switch_profile().                                
   
## Why                                                                                                                                                                                
                  
Fixes #2918. switch_profile() replaced self.agent.llm via model_copy() without repinning the key, so _prompt_cache_key became None on every mid-conversation LLM switch, reintroducing #2904 for all subsequent calls in that conversation (including via the agent-server /switch_profile route).
                                                                                                                                                                                     
## Changes         
- local_conversation.py: extract pin logic into _pin_prompt_cache_key(); call it from __init__ and from switch_profile() after the agent LLM swap.                                 
- tests/sdk/conversation/test_switch_model.py: add test_switch_profile_preserves_prompt_cache_key covering initial pin, fast→slow switch, and switching back to a cached registry entry.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f4e8817-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f4e8817-python \
  ghcr.io/openhands/agent-server:f4e8817-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f4e8817-golang-amd64
ghcr.io/openhands/agent-server:f4e8817-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f4e8817-golang-arm64
ghcr.io/openhands/agent-server:f4e8817-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f4e8817-java-amd64
ghcr.io/openhands/agent-server:f4e8817-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f4e8817-java-arm64
ghcr.io/openhands/agent-server:f4e8817-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f4e8817-python-amd64
ghcr.io/openhands/agent-server:f4e8817-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f4e8817-python-arm64
ghcr.io/openhands/agent-server:f4e8817-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f4e8817-golang
ghcr.io/openhands/agent-server:f4e8817-java
ghcr.io/openhands/agent-server:f4e8817-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f4e8817-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f4e8817-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->