### PR TITLE
feat(sdk): auto-discover project-scoped .mcp.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ When reviewing code, provide constructive feedback:
 - `SettingsFieldSchema` intentionally does not export a `required` flag. If a consumer needs nullability semantics, inspect the underlying Python typing rather than inferring from SDK defaults.
 - `AgentSettings.tools` is part of the exported settings schema so the schema stays aligned with the settings payload that round-trips through `AgentSettings` and drives `create_agent()`.
 - `AgentSettings.mcp_config` now uses FastMCP's typed `MCPConfig` at runtime. When serializing settings back to plain data (e.g. `model_dump()` or `create_agent()`), keep the output compact with `exclude_none=True, exclude_defaults=True` so callers still see the familiar `.mcp.json`-style dict shape.
+- `LocalConversation` now auto-discovers project-scoped MCP config from the Git repo root (falling back to the workspace dir) before plugin loading. Discovery order is `{project}/.openhands/.mcp.json` then `{project}/.mcp.json`, with env-var expansion handled by `load_mcp_config()` and merge precedence `project < agent/user < plugins`.
+
 - Persisted SDK settings should use the direct `model_dump()` shape with a top-level `schema_version`; avoid adding wrapped payload formats or legacy migration shims in `openhands/sdk/settings/model.py`.
 - Because persisted settings are not in production yet, prefer removing temporary compatibility fields and serializers outright instead of carrying legacy settings shims in the SDK.
 - Do not expose settings schema versions as public `CURRENT_PERSISTED_VERSION` class constants on `AgentSettings` or `ConversationSettings`; keep versioning internal to the `schema_version` field/defaults and private module constants.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -3,6 +3,7 @@ import copy
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
@@ -53,6 +54,7 @@ from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
+from openhands.sdk.skills.utils import load_mcp_config
 from openhands.sdk.subagent import (
     AgentDefinition,
     register_file_agents,
@@ -64,6 +66,46 @@ from openhands.sdk.workspace import LocalWorkspace
 
 
 logger = get_logger(__name__)
+_PROJECT_MCP_CONFIG_PATHS = (
+    Path(".openhands") / ".mcp.json",
+    Path(".mcp.json"),
+)
+
+
+def _find_git_repo_root(path: Path) -> Path | None:
+    for candidate in (path, *path.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _find_project_mcp_config(path: Path) -> Path | None:
+    project_root = _find_git_repo_root(path.resolve()) or path.resolve()
+    for candidate in _PROJECT_MCP_CONFIG_PATHS:
+        config_path = project_root / candidate
+        if config_path.is_file():
+            return config_path
+    return None
+
+
+def _merge_mcp_configs(
+    base: dict[str, Any],
+    overlay: dict[str, Any],
+) -> dict[str, Any]:
+    if not base:
+        return dict(overlay)
+    if not overlay:
+        return dict(base)
+
+    result = {**base, **overlay}
+    base_servers = base.get("mcpServers", {})
+    overlay_servers = overlay.get("mcpServers", {})
+    if base_servers or overlay_servers:
+        result["mcpServers"] = {
+            **base_servers,
+            **overlay_servers,
+        }
+    return result
 
 
 class LocalConversation(BaseConversation):
@@ -412,6 +454,24 @@ class LocalConversation(BaseConversation):
         )
         return fork_conv
 
+    def _load_project_mcp_config(self) -> dict[str, Any]:
+        mcp_json = _find_project_mcp_config(Path(self.workspace.working_dir))
+        if mcp_json is None:
+            return {}
+
+        try:
+            config = load_mcp_config(mcp_json)
+        except Exception as e:
+            logger.warning(f"Failed to load project MCP config from {mcp_json}: {e}")
+            return {}
+
+        server_names = list(config.get("mcpServers", {}).keys())
+        logger.info(
+            f"Loaded project MCP config from {mcp_json} "
+            f"with {len(server_names)} server(s): {server_names}"
+        )
+        return config
+
     def _ensure_plugins_loaded(self) -> None:
         """Lazy load plugins and set up hooks on first use.
 
@@ -432,15 +492,16 @@ class LocalConversation(BaseConversation):
 
         all_plugin_hooks: list[HookConfig] = []
         all_plugin_agents: list[AgentDefinition] = []
+        merged_context = self.agent.agent_context
+        merged_mcp = _merge_mcp_configs(
+            self._load_project_mcp_config(),
+            self.agent.mcp_config,
+        )
 
         # Load plugins if specified
         if self._plugin_specs:
             logger.info(f"Loading {len(self._plugin_specs)} plugin(s)...")
             self._resolved_plugins = []
-
-            # Start with agent's existing context and MCP config
-            merged_context = self.agent.agent_context
-            merged_mcp = dict(self.agent.mcp_config) if self.agent.mcp_config else {}
 
             for spec in self._plugin_specs:
                 # Fetch plugin and get resolved commit SHA
@@ -473,7 +534,12 @@ class LocalConversation(BaseConversation):
                 if plugin.agents:
                     all_plugin_agents.extend(plugin.agents)
 
-            # Update agent with merged content
+            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
+
+        if (
+            merged_context != self.agent.agent_context
+            or merged_mcp != self.agent.mcp_config
+        ):
             self.agent = self.agent.model_copy(
                 update={
                     "agent_context": merged_context,
@@ -481,11 +547,9 @@ class LocalConversation(BaseConversation):
                 }
             )
 
-            # Also update the agent in _state so API responses reflect loaded plugins
+            # Also update the agent in _state so API responses reflect loaded config
             with self._state:
                 self._state.agent = self.agent
-
-            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
 
         # Register file-based agents defined in plugins
         if all_plugin_agents:

--- a/tests/sdk/conversation/local/test_project_mcp_config.py
+++ b/tests/sdk/conversation/local/test_project_mcp_config.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.plugin import PluginSource
+from openhands.sdk.testing import TestLLM
+
+
+def _create_agent(mcp_config: dict | None = None) -> Agent:
+    return Agent(
+        llm=TestLLM.from_messages(
+            [
+                Message(
+                    role="assistant",
+                    content=[TextContent(text="ok")],
+                )
+            ],
+            model="test-model",
+        ),
+        tools=[],
+        include_default_tools=[],
+        mcp_config=mcp_config or {},
+    )
+
+
+def _create_plugin(plugin_dir: Path, mcp_config: dict) -> Path:
+    manifest_dir = plugin_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": plugin_dir.name,
+                "version": "1.0.0",
+                "description": f"Test plugin {plugin_dir.name}",
+            }
+        )
+    )
+    (plugin_dir / ".mcp.json").write_text(json.dumps(mcp_config))
+    return plugin_dir
+
+
+def test_project_mcp_config_loads_from_repo_root_for_subdirectory_workspace(
+    tmp_path: Path,
+):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"repo-root": {"command": "repo-root"}}})
+    )
+    workspace = tmp_path / "subdir"
+    workspace.mkdir()
+
+    conversation = LocalConversation(
+        agent=_create_agent(),
+        workspace=workspace,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["repo-root"]["command"]
+        == "repo-root"
+    )
+    conversation.close()
+
+
+def test_project_mcp_config_prefers_dot_openhands_file_over_repo_root(tmp_path: Path):
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"shared": {"command": "repo-root"}}})
+    )
+    openhands_dir = tmp_path / ".openhands"
+    openhands_dir.mkdir()
+    (openhands_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"shared": {"command": "preferred"}}})
+    )
+
+    conversation = LocalConversation(
+        agent=_create_agent(),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["shared"]["command"] == "preferred"
+    )
+    conversation.close()
+
+
+def test_project_mcp_config_expands_environment_variables(
+    tmp_path: Path,
+    monkeypatch,
+):
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "env-server": {
+                        "type": "http",
+                        "url": "${MCP_URL:-https://default.example.com}/mcp",
+                        "headers": {
+                            "Authorization": "Bearer ${API_TOKEN}",
+                        },
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("API_TOKEN", "secret-token")
+
+    conversation = LocalConversation(
+        agent=_create_agent(),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    config = conversation.agent.mcp_config["mcpServers"]["env-server"]
+    assert config["url"] == "https://default.example.com/mcp"
+    assert config["headers"]["Authorization"] == "Bearer secret-token"
+    conversation.close()
+
+
+def test_agent_mcp_config_overrides_project_mcp_config(tmp_path: Path):
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"shared": {"command": "project"}}})
+    )
+
+    conversation = LocalConversation(
+        agent=_create_agent({"mcpServers": {"shared": {"command": "agent-override"}}}),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["shared"]["command"]
+        == "agent-override"
+    )
+    conversation.close()
+
+
+def test_plugin_mcp_config_overrides_project_and_agent_mcp_config(tmp_path: Path):
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "shared": {"command": "project"},
+                    "project-only": {"command": "project-only"},
+                }
+            }
+        )
+    )
+    plugin_dir = _create_plugin(
+        tmp_path / "plugin",
+        {"mcpServers": {"shared": {"command": "plugin-override"}}},
+    )
+
+    conversation = LocalConversation(
+        agent=_create_agent({"mcpServers": {"shared": {"command": "agent-override"}}}),
+        workspace=tmp_path,
+        plugins=[PluginSource(source=str(plugin_dir))],
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["shared"]["command"]
+        == "plugin-override"
+    )
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["project-only"]["command"]
+        == "project-only"
+    )
+    conversation.close()


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

- Conversations started inside a project could not inherit repo-shared MCP server config, so teams had no way to commit a shared `.mcp.json` alongside their code.
- Issue #2754 also asked for a comparison with Claude Code, Codex, and Gemini CLI; I posted that research directly on the issue.

## Summary

- Auto-discover project MCP config from the Git repo root (falling back to the workspace dir), preferring `.openhands/.mcp.json` over `.mcp.json`.
- Merge project MCP config before agent/user MCP config and before plugin MCP config so higher-priority sources still override shared servers.
- Add focused `LocalConversation` tests covering repo-root discovery, `.openhands` precedence, env expansion, and merge precedence.

## Issue Number

Closes #2754

## How to Test

- `make build`
- `uv run pytest tests/sdk/conversation/local/test_project_mcp_config.py tests/sdk/conversation/test_local_conversation_plugins.py`
- Expected result: `13 passed`

## Video/Screenshots

- N/A for this SDK-only change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- I also posted the cross-project MCP / trust / credentials comparison requested in the issue comments.
- This keeps the SDK behavior Claude-compatible for repo-scoped `.mcp.json`; UX-level approval or trust prompts can still be layered above conversation creation if desired.

_This pull request was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1e7eb23d-2af7-4aec-b229-915c947b26e3)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:95c216f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-95c216f-python \
  ghcr.io/openhands/agent-server:95c216f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:95c216f-golang-amd64
ghcr.io/openhands/agent-server:95c216f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:95c216f-golang-arm64
ghcr.io/openhands/agent-server:95c216f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:95c216f-java-amd64
ghcr.io/openhands/agent-server:95c216f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:95c216f-java-arm64
ghcr.io/openhands/agent-server:95c216f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:95c216f-python-amd64
ghcr.io/openhands/agent-server:95c216f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:95c216f-python-arm64
ghcr.io/openhands/agent-server:95c216f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:95c216f-golang
ghcr.io/openhands/agent-server:95c216f-java
ghcr.io/openhands/agent-server:95c216f-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `95c216f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `95c216f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->