### PR TITLE
feat(sdk): auto-discover project-scoped .mcp.json

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,6 +106,8 @@ When reviewing code, provide constructive feedback:
 - `SettingsFieldSchema` intentionally does not export a `required` flag. If a consumer needs nullability semantics, inspect the underlying Python typing rather than inferring from SDK defaults.
 - `AgentSettings.tools` is part of the exported settings schema so the schema stays aligned with the settings payload that round-trips through `AgentSettings` and drives `create_agent()`.
 - `AgentSettings.mcp_config` now uses FastMCP's typed `MCPConfig` at runtime. When serializing settings back to plain data (e.g. `model_dump()` or `create_agent()`), keep the output compact with `exclude_none=True, exclude_defaults=True` so callers still see the familiar `.mcp.json`-style dict shape.
+- `LocalConversation` auto-discovers project-scoped MCP config from the Git repo root (falling back to the workspace dir) before plugin loading. Discovery order is `{project}/.openhands/.mcp.json` then `{project}/.mcp.json`, and merge precedence is `project < agent/user < plugins`.
+
 - Persisted SDK settings should use the direct `model_dump()` shape with a top-level `schema_version`; avoid adding wrapped payload formats or legacy migration shims in `openhands/sdk/settings/model.py`.
 - Because persisted settings are not in production yet, prefer removing temporary compatibility fields and serializers outright instead of carrying legacy settings shims in the SDK.
 - Do not expose settings schema versions as public `CURRENT_PERSISTED_VERSION` class constants on `AgentSettings` or `ConversationSettings`; keep versioning internal to the `schema_version` field/defaults and private module constants.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -3,6 +3,7 @@ import copy
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
+from typing import Any
 
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
@@ -53,6 +54,7 @@ from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
+from openhands.sdk.skills.utils import load_mcp_config
 from openhands.sdk.subagent import (
     AgentDefinition,
     register_file_agents,
@@ -64,6 +66,44 @@ from openhands.sdk.workspace import LocalWorkspace
 
 
 logger = get_logger(__name__)
+
+_PROJECT_MCP_CONFIG_PATHS = (
+    Path(".openhands") / ".mcp.json",
+    Path(".mcp.json"),
+)
+
+
+def _find_git_repo_root(path: Path) -> Path | None:
+    for candidate in (path, *path.parents):
+        if (candidate / ".git").exists():
+            return candidate
+    return None
+
+
+def _find_project_mcp_config(path: Path) -> Path | None:
+    project_root = _find_git_repo_root(path.resolve()) or path.resolve()
+    for candidate in _PROJECT_MCP_CONFIG_PATHS:
+        config_path = project_root / candidate
+        if config_path.is_file():
+            return config_path
+    return None
+
+
+def _merge_mcp_configs(
+    base: dict[str, Any],
+    overlay: dict[str, Any],
+) -> dict[str, Any]:
+    if not base:
+        return dict(overlay)
+    if not overlay:
+        return dict(base)
+
+    result = {**base, **overlay}
+    base_servers = base.get("mcpServers", {})
+    overlay_servers = overlay.get("mcpServers", {})
+    if base_servers or overlay_servers:
+        result["mcpServers"] = {**base_servers, **overlay_servers}
+    return result
 
 
 class LocalConversation(BaseConversation):
@@ -411,6 +451,24 @@ class LocalConversation(BaseConversation):
         )
         return fork_conv
 
+    def _load_project_mcp_config(self) -> dict[str, Any]:
+        mcp_json = _find_project_mcp_config(Path(self.workspace.working_dir))
+        if mcp_json is None:
+            return {}
+
+        try:
+            config = load_mcp_config(mcp_json)
+        except Exception as e:
+            logger.warning(f"Failed to load project MCP config from {mcp_json}: {e}")
+            return {}
+
+        server_names = list(config.get("mcpServers", {}).keys())
+        logger.info(
+            f"Loaded project MCP config from {mcp_json} "
+            f"with {len(server_names)} server(s): {server_names}"
+        )
+        return config
+
     def _ensure_plugins_loaded(self) -> None:
         """Lazy load plugins and set up hooks on first use.
 
@@ -431,15 +489,16 @@ class LocalConversation(BaseConversation):
 
         all_plugin_hooks: list[HookConfig] = []
         all_plugin_agents: list[AgentDefinition] = []
+        merged_context = self.agent.agent_context
+        merged_mcp = _merge_mcp_configs(
+            self._load_project_mcp_config(),
+            self.agent.mcp_config,
+        )
 
         # Load plugins if specified
         if self._plugin_specs:
             logger.info(f"Loading {len(self._plugin_specs)} plugin(s)...")
             self._resolved_plugins = []
-
-            # Start with agent's existing context and MCP config
-            merged_context = self.agent.agent_context
-            merged_mcp = dict(self.agent.mcp_config) if self.agent.mcp_config else {}
 
             for spec in self._plugin_specs:
                 # Fetch plugin and get resolved commit SHA
@@ -472,7 +531,12 @@ class LocalConversation(BaseConversation):
                 if plugin.agents:
                     all_plugin_agents.extend(plugin.agents)
 
-            # Update agent with merged content
+            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
+
+        if (
+            merged_context != self.agent.agent_context
+            or merged_mcp != self.agent.mcp_config
+        ):
             self.agent = self.agent.model_copy(
                 update={
                     "agent_context": merged_context,
@@ -480,11 +544,9 @@ class LocalConversation(BaseConversation):
                 }
             )
 
-            # Also update the agent in _state so API responses reflect loaded plugins
+            # Also update the agent in _state so API responses reflect loaded config
             with self._state:
                 self._state.agent = self.agent
-
-            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
 
         # Register file-based agents defined in plugins
         if all_plugin_agents:

--- a/tests/sdk/conversation/local/test_project_mcp_config.py
+++ b/tests/sdk/conversation/local/test_project_mcp_config.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.plugin import PluginSource
+from openhands.sdk.testing import TestLLM
+
+
+def _create_agent(mcp_config: dict | None = None) -> Agent:
+    return Agent(
+        llm=TestLLM.from_messages(
+            [
+                Message(
+                    role="assistant",
+                    content=[TextContent(text="ok")],
+                )
+            ],
+            model="test-model",
+        ),
+        tools=[],
+        include_default_tools=[],
+        mcp_config=mcp_config or {},
+    )
+
+
+def _create_plugin(plugin_dir: Path, mcp_config: dict) -> Path:
+    manifest_dir = plugin_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": plugin_dir.name,
+                "version": "1.0.0",
+                "description": f"Test plugin {plugin_dir.name}",
+            }
+        )
+    )
+    (plugin_dir / ".mcp.json").write_text(json.dumps(mcp_config))
+    return plugin_dir
+
+
+def test_project_mcp_config_loads_from_repo_root_for_subdirectory_workspace(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"repo-root": {"command": "repo-root"}}})
+    )
+    workspace = tmp_path / "subdir"
+    workspace.mkdir()
+
+    conversation = LocalConversation(
+        agent=_create_agent(),
+        workspace=workspace,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["repo-root"]["command"]
+        == "repo-root"
+    )
+    conversation.close()
+
+
+def test_project_mcp_config_prefers_dot_openhands_file_over_repo_root(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"shared": {"command": "repo-root"}}})
+    )
+    openhands_dir = tmp_path / ".openhands"
+    openhands_dir.mkdir()
+    (openhands_dir / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"shared": {"command": "preferred"}}})
+    )
+
+    conversation = LocalConversation(
+        agent=_create_agent(),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["shared"]["command"] == "preferred"
+    )
+    conversation.close()
+
+
+def test_project_mcp_config_expands_environment_variables(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "env-server": {
+                        "type": "http",
+                        "url": "${MCP_URL:-https://default.example.com}/mcp",
+                        "headers": {
+                            "Authorization": "Bearer ${API_TOKEN}",
+                        },
+                    }
+                }
+            }
+        )
+    )
+    monkeypatch.setenv("API_TOKEN", "secret-token")
+
+    conversation = LocalConversation(
+        agent=_create_agent(),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    config = conversation.agent.mcp_config["mcpServers"]["env-server"]
+    assert config["url"] == "https://default.example.com/mcp"
+    assert config["headers"]["Authorization"] == "Bearer secret-token"
+    conversation.close()
+
+
+def test_agent_mcp_config_overrides_project_mcp_config(tmp_path: Path) -> None:
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps({"mcpServers": {"shared": {"command": "project"}}})
+    )
+
+    conversation = LocalConversation(
+        agent=_create_agent({"mcpServers": {"shared": {"command": "agent-override"}}}),
+        workspace=tmp_path,
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["shared"]["command"]
+        == "agent-override"
+    )
+    conversation.close()
+
+
+def test_plugin_mcp_config_overrides_project_and_agent_mcp_config(
+    tmp_path: Path,
+) -> None:
+    (tmp_path / ".mcp.json").write_text(
+        json.dumps(
+            {
+                "mcpServers": {
+                    "shared": {"command": "project"},
+                    "project-only": {"command": "project-only"},
+                }
+            }
+        )
+    )
+    plugin_dir = _create_plugin(
+        tmp_path / "plugin",
+        {"mcpServers": {"shared": {"command": "plugin-override"}}},
+    )
+
+    conversation = LocalConversation(
+        agent=_create_agent({"mcpServers": {"shared": {"command": "agent-override"}}}),
+        workspace=tmp_path,
+        plugins=[PluginSource(source=str(plugin_dir))],
+        visualizer=None,
+    )
+    conversation._ensure_plugins_loaded()
+
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["shared"]["command"]
+        == "plugin-override"
+    )
+    assert (
+        conversation.agent.mcp_config["mcpServers"]["project-only"]["command"]
+        == "project-only"
+    )
+    conversation.close()


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Conversations started inside a project cannot inherit repo-shared MCP server configuration today, so teams have no version-controlled project-level `.mcp.json` that applies automatically. The follow-up issue discussion also raised credential-handling concerns, so this change keeps project configs on the same `.mcp.json` loading path as existing skill/plugin MCP config and preserves the intended precedence order.

## Summary

- auto-discover `{project}/.openhands/.mcp.json` first, then `{project}/.mcp.json`, using the git repo root when the workspace is a subdirectory
- merge project MCP config before agent/user config and before plugin config so precedence is `project < agent/user < plugins`
- add focused `LocalConversation` tests covering repo-root discovery, `.openhands` precedence, env expansion, and merge precedence

## Issue Number

Closes #2754

## How to Test

- `uv run pre-commit run --files AGENTS.md openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py tests/sdk/conversation/local/test_project_mcp_config.py`
- `uv run pytest tests/sdk/conversation/local/test_project_mcp_config.py tests/sdk/conversation/test_local_conversation_plugins.py`
- Expected result: both commands pass; pytest reports `13 passed`

## Video/Screenshots

N/A (SDK/backend change)

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Related MCP credential work: #2900 is already merged and protects serialized `mcp_config`; #2873 is open and currently approved, and would extend `.mcp.json` variable expansion to conversation-scoped secrets.
- This PR intentionally routes project config through `load_mcp_config()` so project-scoped files stay aligned with the existing MCP config format and credential expansion path.
- Recommended credential posture for project-scoped files remains: commit server definitions, prefer `${VAR}`/`${VAR:-default}` (and future conversation-secret expansion) for secrets, and avoid hard-coding long-lived credentials in version control.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2a0c6de5-f4ed-4926-a96a-c78846f2f85d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:908ce76-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-908ce76-python \
  ghcr.io/openhands/agent-server:908ce76-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:908ce76-golang-amd64
ghcr.io/openhands/agent-server:908ce76-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:908ce76-golang-arm64
ghcr.io/openhands/agent-server:908ce76-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:908ce76-java-amd64
ghcr.io/openhands/agent-server:908ce76-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:908ce76-java-arm64
ghcr.io/openhands/agent-server:908ce76-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:908ce76-python-amd64
ghcr.io/openhands/agent-server:908ce76-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:908ce76-python-arm64
ghcr.io/openhands/agent-server:908ce76-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:908ce76-golang
ghcr.io/openhands/agent-server:908ce76-java
ghcr.io/openhands/agent-server:908ce76-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `908ce76-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `908ce76-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->