### PR TITLE
fix: pin ACP npm package versions in agent-server Dockerfile

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -126,9 +126,9 @@ RUN set -eux; \
     PATH="$ACP_NODE_DIR/bin:$PATH"; \
     node --version; \
     npm install -g \
-      @agentclientprotocol/claude-agent-acp \
-      @zed-industries/codex-acp \
-      @google/gemini-cli; \
+      @agentclientprotocol/claude-agent-acp@0.30.0 \
+      @zed-industries/codex-acp@0.11.1 \
+      @google/gemini-cli@0.38.0; \
     # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
     # This ensures the ACP binary's #!/usr/bin/env node shebang resolves to
     # Node 22, while the repo's own node (NVM/system) stays untouched for tests.


### PR DESCRIPTION
## Problem

The agent-server Dockerfile installs three ACP CLIs without version pins:

```dockerfile
npm install -g \
  @agentclientprotocol/claude-agent-acp \
  @zed-industries/codex-acp \
  @google/gemini-cli
```

`@google/gemini-cli` 0.39.0 was published on 2026-04-23 and introduced bundled ripgrep binaries via Node.js SEA, growing the package to ~89 MB unpacked. Any postinstall failure under `set -eux` aborts the entire Docker build.

The SDK builder image for a given SDK SHA is cached in ghcr.io and skipped on subsequent runs via `remote_image_exists()`. This masked the issue for swebench/gaia on April 23 (their builder images were already cached), but the next cold builder rebuild — triggered by any new SDK commit — will hit the same `@google/gemini-cli` 0.39.0 problem.

## Fix

Pin all three packages to the last known-good stable versions:

| Package | Pinned version | Published |
|---------|---------------|-----------|
| `@agentclientprotocol/claude-agent-acp` | `0.30.0` | 2026-04-20 |
| `@zed-industries/codex-acp` | `0.11.1` | 2026-03-31 |
| `@google/gemini-cli` | `0.38.0` | 2026-04-12 |

Mirrors the same fix applied to `benchmarks/utils/Dockerfile.agent-layer-commit0` in OpenHands/benchmarks#693 (which addresses the immediate commit0 build failure in OpenHands/evaluation#523).

## AI disclosure

This PR was prepared by Claude Sonnet 4.6 on behalf of @simonrosenberg.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4787189-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4787189-python \
  ghcr.io/openhands/agent-server:4787189-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4787189-golang-amd64
ghcr.io/openhands/agent-server:4787189-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4787189-golang-arm64
ghcr.io/openhands/agent-server:4787189-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4787189-java-amd64
ghcr.io/openhands/agent-server:4787189-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4787189-java-arm64
ghcr.io/openhands/agent-server:4787189-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4787189-python-amd64
ghcr.io/openhands/agent-server:4787189-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4787189-python-arm64
ghcr.io/openhands/agent-server:4787189-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4787189-golang
ghcr.io/openhands/agent-server:4787189-java
ghcr.io/openhands/agent-server:4787189-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4787189-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4787189-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->