### PR TITLE
chore: point pr-review workflow to extensions@main

### DIFF
--- a/.github/workflows/pr-review-by-openhands.yml
+++ b/.github/workflows/pr-review-by-openhands.yml
@@ -40,18 +40,12 @@ jobs:
         runs-on: ubuntu-24.04
         steps:
             - name: Run PR Review
-              # TODO: Revert to @main after OpenHands/extensions#164 is merged
-              uses: OpenHands/extensions/plugins/pr-review@feat/pr-review-sub-agent-delegation
+              uses: OpenHands/extensions/plugins/pr-review@main
               with:
                   llm-model: litellm_proxy/claude-sonnet-4-5-20250929
                   llm-base-url: https://llm-proxy.app.all-hands.dev
-                  # Review style: roasted (other option: standard)
-                  review-style: roasted
                   # Enable experimental sub-agent delegation for file-level reviews
                   use-sub-agents: 'true'
-                  # Must match the branch in `uses:` so the script checkout
-                  # picks up the sub-agent code (extensions#164 not yet on main)
-                  extensions-version: feat/pr-review-sub-agent-delegation
                   llm-api-key: ${{ secrets.LLM_API_KEY }}
                   github-token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
                   lmnr-api-key: ${{ secrets.LMNR_SKILLS_API_KEY }}


### PR DESCRIPTION
## Why

[OpenHands/extensions#164](https://github.com/OpenHands/extensions/pull/164) (sub-agent delegation for file-level reviews) has been merged to `main`. The pr-review workflow was temporarily pinned to the feature branch — this PR reverts it to `@main`.

## Summary

- Update `uses:` from `@feat/pr-review-sub-agent-delegation` → `@main`
- Remove the `extensions-version` input (no longer needed — the feature branch pin was only required while #164 was unmerged)
- Remove the deprecated `review-style` input (was already ignored per extensions#164)
- Keep `use-sub-agents: 'true'` — the sub-agent delegation code is now on main

## Notes

This resolves the TODO comment that was left in the workflow file by [PR #2839](https://github.com/OpenHands/software-agent-sdk/pull/2839):
> `# TODO: Revert to @main after OpenHands/extensions#164 is merged`

_This PR was created by an AI assistant (OpenHands) on behalf of a user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4f5abe9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4f5abe9-python \
  ghcr.io/openhands/agent-server:4f5abe9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4f5abe9-golang-amd64
ghcr.io/openhands/agent-server:4f5abe9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4f5abe9-golang-arm64
ghcr.io/openhands/agent-server:4f5abe9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4f5abe9-java-amd64
ghcr.io/openhands/agent-server:4f5abe9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4f5abe9-java-arm64
ghcr.io/openhands/agent-server:4f5abe9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4f5abe9-python-amd64
ghcr.io/openhands/agent-server:4f5abe9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4f5abe9-python-arm64
ghcr.io/openhands/agent-server:4f5abe9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4f5abe9-golang
ghcr.io/openhands/agent-server:4f5abe9-java
ghcr.io/openhands/agent-server:4f5abe9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4f5abe9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4f5abe9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->