### PR TITLE
ci: rename eval dispatch token env vars

### DIFF
--- a/.github/workflows/cancel-eval.yml
+++ b/.github/workflows/cancel-eval.yml
@@ -28,14 +28,14 @@ jobs:
         steps:
             - name: Cancel evaluation job
               env:
-                  PAT_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
+                  DISPATCH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
                   RUN_ID: ${{ github.event.inputs.run_id }}
                   REASON: ${{ github.event.inputs.reason }}
               run: |-
                   set -euo pipefail
 
-                  if [ -z "$PAT_TOKEN" ]; then
-                    echo "Missing PAT token" >&2
+                  if [ -z "$DISPATCH_TOKEN" ]; then
+                    echo "Missing dispatch token" >&2
                     exit 1
                   fi
 
@@ -49,7 +49,7 @@ jobs:
                     '{ref: $ref, inputs: {run_id: $run_id, reason: $reason}}')
 
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
-                    -H "Authorization: token $PAT_TOKEN" \
+                    -H "Authorization: token $DISPATCH_TOKEN" \
                     -H "Accept: application/vnd.github+json" \
                     -d "$PAYLOAD" \
                     "https://api.github.com/repos/${EVAL_REPO}/actions/workflows/${EVAL_WORKFLOW}/dispatches")

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -257,17 +257,17 @@ jobs:
               env:
                   DEFAULT_MODEL: ${{ steps.load-models.outputs.default_model }}
                   ALLOWED_MODEL_IDS_JSON: ${{ steps.load-models.outputs.allowed_model_ids }}
-                  PAT_TOKEN_DEFAULT: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
+                  DISPATCH_TOKEN_DEFAULT: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH }}
               run: |
                   set -euo pipefail
 
-                  # Set PAT token for cross-repo workflow dispatch
-                  PAT_TOKEN="$PAT_TOKEN_DEFAULT"
-                  if [ -z "$PAT_TOKEN" ]; then
-                    echo "Missing PAT token" >&2
+                  # Set the token used for cross-repo workflow dispatch.
+                  DISPATCH_TOKEN="$DISPATCH_TOKEN_DEFAULT"
+                  if [ -z "$DISPATCH_TOKEN" ]; then
+                    echo "Missing dispatch token" >&2
                     exit 1
                   fi
-                  echo "PAT_TOKEN=$PAT_TOKEN" >> "$GITHUB_ENV"
+                  echo "DISPATCH_TOKEN=$DISPATCH_TOKEN" >> "$GITHUB_ENV"
 
                   # Determine eval limit and SDK SHA based on trigger
                   if [ "${{ github.event_name }}" = "pull_request_target" ]; then
@@ -390,7 +390,7 @@ jobs:
                     --arg triggered_by "$TRIGGERED_BY" \
                     '{ref: $ref, inputs: {sdk_commit: $sdk, sdk_workflow_run_id: $sdk_run_id, eval_limit: $eval_limit, models_json: ($models | tostring), trigger_reason: $reason, pr_number: $pr, benchmarks_branch: $benchmarks, extensions_branch: $extensions, benchmark: $benchmark, instance_ids: $instance_ids, num_infer_workers: $num_infer_workers, num_eval_workers: $num_eval_workers, enable_conversation_event_logging: $enable_conversation_event_logging, max_retries: $max_retries, tool_preset: $tool_preset, agent_type: $agent_type, partial_archive_url: $partial_archive_url, triggered_by: $triggered_by}}')
                   RESPONSE=$(curl -sS -o /tmp/dispatch.out -w "%{http_code}" -X POST \
-                    -H "Authorization: token $PAT_TOKEN" \
+                    -H "Authorization: token $DISPATCH_TOKEN" \
                     -H "Accept: application/vnd.github+json" \
                     -d "$PAYLOAD" \
                     "https://api.github.com/repos/${EVAL_REPO}/actions/workflows/${EVAL_WORKFLOW}/dispatches")


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The eval-dispatch workflows should stop referring to the cross-repo dispatch credential as `PAT_TOKEN`.

## Summary

- rename the environment variable in `run-eval.yml` from `PAT_TOKEN` to `DISPATCH_TOKEN`
- rename the environment variable in `cancel-eval.yml` from `PAT_TOKEN` to `DISPATCH_TOKEN`
- keep the secret source the same; this is a naming cleanup only

## Issue Number

N/A

## How to Test

- `cd /workspace/project/software-agent-sdk && PATH=$HOME/.local/bin:$PATH uv run pre-commit run --files .github/workflows/run-eval.yml .github/workflows/cancel-eval.yml`
- `grep -RIn 'PAT_TOKEN' /workspace/project/software-agent-sdk --exclude-dir=.git --exclude-dir=.venv`

## Video/Screenshots

N/A — workflow-only change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- This PR was created by an AI assistant (OpenHands) on behalf of the user.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cddf529-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cddf529-python \
  ghcr.io/openhands/agent-server:cddf529-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cddf529-golang-amd64
ghcr.io/openhands/agent-server:cddf529-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cddf529-golang-arm64
ghcr.io/openhands/agent-server:cddf529-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cddf529-java-amd64
ghcr.io/openhands/agent-server:cddf529-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cddf529-java-arm64
ghcr.io/openhands/agent-server:cddf529-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cddf529-python-amd64
ghcr.io/openhands/agent-server:cddf529-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cddf529-python-arm64
ghcr.io/openhands/agent-server:cddf529-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cddf529-golang
ghcr.io/openhands/agent-server:cddf529-java
ghcr.io/openhands/agent-server:cddf529-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cddf529-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cddf529-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->