### PR TITLE
Add GPT-5.5 model configuration

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -183,6 +183,14 @@ MODELS = {
             "reasoning_effort": "high",
         },
     },
+    "gpt-5.5": {
+        "id": "gpt-5.5",
+        "display_name": "GPT-5.5",
+        "llm_config": {
+            "model": "litellm_proxy/openai/gpt-5.5",
+            "reasoning_effort": "high",
+        },
+    },
     "minimax-m2": {
         "id": "minimax-m2",
         "display_name": "MiniMax M2",

--- a/openhands-sdk/openhands/sdk/llm/utils/model_prompt_spec.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_prompt_spec.py
@@ -38,9 +38,15 @@ _MODEL_VARIANT_PATTERNS: dict[str, tuple[tuple[str, tuple[str, ...]], ...]] = {
     "openai_gpt": (
         (
             "gpt-5-codex",
-            ("gpt-5-codex", "gpt-5.1-codex", "gpt-5.2-codex", "gpt-5.3-codex"),
+            (
+                "gpt-5-codex",
+                "gpt-5.1-codex",
+                "gpt-5.2-codex",
+                "gpt-5.3-codex",
+                "gpt-5.5-codex",
+            ),
         ),
-        ("gpt-5", ("gpt-5", "gpt-5.1", "gpt-5.2", "gpt-5.4")),
+        ("gpt-5", ("gpt-5", "gpt-5.1", "gpt-5.2", "gpt-5.4", "gpt-5.5")),
     ),
 }
 

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -631,3 +631,13 @@ def test_kimi_k2_6_config():
     assert model["display_name"] == "Kimi K2.6"
     assert model["llm_config"]["model"] == "litellm_proxy/moonshot/kimi-k2.6"
     assert model["llm_config"]["temperature"] == 1.0
+
+
+def test_gpt_5_5_config():
+    """Test that gpt-5.5 has correct configuration."""
+    model = MODELS["gpt-5.5"]
+
+    assert model["id"] == "gpt-5.5"
+    assert model["display_name"] == "GPT-5.5"
+    assert model["llm_config"]["model"] == "litellm_proxy/openai/gpt-5.5"
+    assert model["llm_config"]["reasoning_effort"] == "high"


### PR DESCRIPTION
## Summary
Adds the `gpt-5.5` model to resolve_model_config.py.

## Changes
- Added gpt-5.5 to MODELS dictionary in resolve_model_config.py
- Added gpt-5.5 to variant patterns in model_prompt_spec.py
- Added test_gpt_5_5_config() test function
- Added gpt-5.5-codex to GPT variant detection patterns

## Configuration
- Model ID: gpt-5.5
- Provider: OpenAI
- Temperature: default (None)
- reasoning_effort: high - GPT-5.5 is a reasoning model that supports this parameter

## Testing
- Unit tests passed: `pytest tests/cross/test_resolve_model_config.py -v` (34 passed)
- Pre-commit checks passed: `pre-commit run --files ...`

## Reference
- OpenAI announcement: https://openai.com/index/introducing-gpt-5-5/
- Following ADDINGMODEL.md guidelines

Fixes #2932

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/91325093-a0f1-4daa-9a43-c39724793692)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:14b6940-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-14b6940-python \
  ghcr.io/openhands/agent-server:14b6940-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:14b6940-golang-amd64
ghcr.io/openhands/agent-server:14b6940-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:14b6940-golang-arm64
ghcr.io/openhands/agent-server:14b6940-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:14b6940-java-amd64
ghcr.io/openhands/agent-server:14b6940-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:14b6940-java-arm64
ghcr.io/openhands/agent-server:14b6940-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:14b6940-python-amd64
ghcr.io/openhands/agent-server:14b6940-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:14b6940-python-arm64
ghcr.io/openhands/agent-server:14b6940-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:14b6940-golang
ghcr.io/openhands/agent-server:14b6940-java
ghcr.io/openhands/agent-server:14b6940-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `14b6940-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `14b6940-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->