### PR TITLE
fix(state): warn when falling back to InMemoryFileStore without persistence_dir

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -304,11 +304,16 @@ class ConversationState(OpenHandsModel):
             ValueError: If conversation ID or tools mismatch on restore
             ValidationError: If agent or other fields fail Pydantic validation
         """
-        file_store = (
-            LocalFileStore(persistence_dir, cache_limit_size=max_iterations)
-            if persistence_dir
-            else InMemoryFileStore()
-        )
+        if persistence_dir:
+            file_store = LocalFileStore(
+                persistence_dir, cache_limit_size=max_iterations
+            )
+        else:
+            logger.warning(
+                "No persistence_dir provided; falling back to InMemoryFileStore. "
+                "EventLog data will not persist across requests."
+            )
+            file_store = InMemoryFileStore()
 
         try:
             base_text = file_store.read(BASE_STATE)

--- a/tests/sdk/conversation/test_directories.py
+++ b/tests/sdk/conversation/test_directories.py
@@ -1,5 +1,6 @@
 """Tests for conversation directory handling."""
 
+import logging
 import os
 import tempfile
 import uuid
@@ -140,3 +141,23 @@ def test_conversation_factory_persistence_dir_only(mock_agent):
         # persistence_dir should include conversation ID subdirectory
         expected_dir = os.path.join(persistence_dir, conversation.state.id.hex)
         assert conversation.state.persistence_dir == expected_dir
+
+
+def test_no_persistence_dir_logs_warning(mock_agent, caplog):
+    """Test that a warning is logged when no persistence_dir is provided."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        working_dir = Path(temp_dir) / "work"
+        working_dir.mkdir()
+
+        with caplog.at_level(logging.WARNING):
+            ConversationState.create(
+                id=uuid.uuid4(),
+                agent=mock_agent,
+                workspace=LocalWorkspace(working_dir=working_dir),
+            )
+
+        assert any(
+            "No persistence_dir provided; falling back to InMemoryFileStore"
+            in record.message
+            for record in caplog.records
+        )


### PR DESCRIPTION
Closes #2915

## What

When `persistence_dir` is not provided, `ConversationState` silently falls back to `InMemoryFileStore`. Users deploying to environments without persistent volumes (e.g. Cloud Run) get no indication that their EventLog data won't persist.

## Fix

Added `logger.warning()` before constructing the fallback `InMemoryFileStore`, so the misconfiguration is immediately visible in logs.

## Test

Added `test_no_persistence_dir_logs_warning` that verifies the warning message appears when no `persistence_dir` is provided.

cc @VascoSch92