### PR TITLE
fix(sdk): lazy-load startup imports

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ When reviewing code, provide constructive feedback:
 - Workspace-wide uv resolver guardrails belong in the repository root `[tool.uv]` table. When `exclude-newer` is configured there, `uv lock` persists it into the root `uv.lock` `[options]` section as both an absolute cutoff and `exclude-newer-span`, and `uv sync --frozen` continues to use that locked workspace state.
 - `pr-review-by-openhands` delegates to `OpenHands/extensions/plugins/pr-review@main`. Repo-specific reviewer instructions live in `.agents/skills/custom-codereview-guide.md`, and because task-trigger matching is substring-based, that `/codereview` skill is also auto-injected for the workflow's `/codereview-roasted` prompt.
 - Auto-title generation should not re-read `ConversationState.events` from a background task triggered by a freshly received `MessageEvent`; extract message text synchronously from the incoming event and then reuse shared title helpers (`extract_message_text`, `generate_title_from_message`) to avoid persistence-order races.
+- CLI startup is highly sensitive to eager SDK imports. Keep `openhands.sdk.__init__` and package-level `__init__.py` exports lazy so `import openhands.sdk` stays a lightweight banner/version path; guard this with `tests/sdk/test_lazy_imports.py`.
+
 
 
 ## Package-specific guidance

--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -1,100 +1,10 @@
-from importlib.metadata import PackageNotFoundError, version
+from __future__ import annotations
 
-from openhands.sdk.agent import (
-    Agent,
-    AgentBase,
-)
+from importlib.metadata import PackageNotFoundError, version
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 from openhands.sdk.banner import _print_banner
-from openhands.sdk.context import AgentContext
-from openhands.sdk.context.condenser import (
-    LLMSummarizingCondenser,
-)
-from openhands.sdk.conversation import (
-    BaseConversation,
-    Conversation,
-    ConversationCallbackType,
-    ConversationExecutionStatus,
-    LocalConversation,
-    RemoteConversation,
-)
-from openhands.sdk.conversation.conversation_stats import ConversationStats
-from openhands.sdk.event import Event, HookExecutionEvent, LLMConvertibleEvent
-from openhands.sdk.event.llm_convertible import MessageEvent
-from openhands.sdk.io import FileStore, LocalFileStore
-from openhands.sdk.llm import (
-    LLM,
-    FallbackStrategy,
-    ImageContent,
-    LLMProfileStore,
-    LLMRegistry,
-    LLMStreamChunk,
-    Message,
-    RedactedThinkingBlock,
-    RegistryEvent,
-    TextContent,
-    ThinkingBlock,
-    TokenCallbackType,
-    TokenUsage,
-)
-from openhands.sdk.logger import get_logger
-from openhands.sdk.mcp import (
-    MCPClient,
-    MCPToolDefinition,
-    MCPToolObservation,
-    create_mcp_tools,
-)
-from openhands.sdk.plugin import Plugin
-from openhands.sdk.settings import (
-    ACPAgentSettings,
-    AgentSettings,
-    AgentSettingsConfig,
-    CondenserSettings,
-    ConversationSettings,
-    LLMAgentSettings,
-    SettingsChoice,
-    SettingsFieldSchema,
-    SettingsSchema,
-    SettingsSectionSchema,
-    VerificationSettings,
-    default_agent_settings,
-    export_agent_settings_schema,
-    export_settings_schema,
-    validate_agent_settings,
-)
-from openhands.sdk.settings.metadata import (
-    SettingProminence,
-    SettingsFieldMetadata,
-    SettingsSectionMetadata,
-    field_meta,
-)
-from openhands.sdk.skills import (
-    load_project_skills,
-    load_skills_from_dir,
-    load_user_skills,
-)
-from openhands.sdk.subagent import (
-    agent_definition_to_factory,
-    load_agents_from_dir,
-    load_project_agents,
-    load_user_agents,
-    register_agent,
-)
-from openhands.sdk.tool import (
-    Action,
-    Observation,
-    Tool,
-    ToolDefinition,
-    list_registered_tools,
-    register_tool,
-    resolve_tool,
-)
-from openhands.sdk.utils import page_iterator
-from openhands.sdk.workspace import (
-    AsyncRemoteWorkspace,
-    LocalWorkspace,
-    RemoteWorkspace,
-    Workspace,
-)
 
 
 try:
@@ -102,7 +12,7 @@ try:
 except PackageNotFoundError:
     __version__ = "0.0.0"  # fallback for editable/unbuilt environments
 
-# Print startup banner
+# Print the startup banner before importing the rest of the SDK surface.
 _print_banner(__version__)
 
 __all__ = [
@@ -183,3 +93,107 @@ __all__ = [
     "page_iterator",
     "__version__",
 ]
+
+_LAZY_IMPORTS = {
+    "LLM": (".llm.llm", "LLM"),
+    "LLMRegistry": (".llm.llm_registry", "LLMRegistry"),
+    "LLMProfileStore": (".llm.llm_profile_store", "LLMProfileStore"),
+    "LLMStreamChunk": (".llm.streaming", "LLMStreamChunk"),
+    "FallbackStrategy": (".llm.fallback_strategy", "FallbackStrategy"),
+    "TokenCallbackType": (".llm.streaming", "TokenCallbackType"),
+    "TokenUsage": (".llm.utils.metrics", "TokenUsage"),
+    "ConversationStats": (".conversation.conversation_stats", "ConversationStats"),
+    "RegistryEvent": (".llm.llm_registry", "RegistryEvent"),
+    "Message": (".llm.message", "Message"),
+    "TextContent": (".llm.message", "TextContent"),
+    "ImageContent": (".llm.message", "ImageContent"),
+    "ThinkingBlock": (".llm.message", "ThinkingBlock"),
+    "RedactedThinkingBlock": (".llm.message", "RedactedThinkingBlock"),
+    "Tool": (".tool.spec", "Tool"),
+    "ToolDefinition": (".tool.tool", "ToolDefinition"),
+    "AgentBase": (".agent.base", "AgentBase"),
+    "Agent": (".agent.agent", "Agent"),
+    "Action": (".tool.schema", "Action"),
+    "Observation": (".tool.schema", "Observation"),
+    "MCPClient": (".mcp.client", "MCPClient"),
+    "MCPToolDefinition": (".mcp.tool", "MCPToolDefinition"),
+    "MCPToolObservation": (".mcp.definition", "MCPToolObservation"),
+    "MessageEvent": (".event.llm_convertible", "MessageEvent"),
+    "HookExecutionEvent": (".event.hook_execution", "HookExecutionEvent"),
+    "create_mcp_tools": (".mcp.utils", "create_mcp_tools"),
+    "get_logger": (".logger.logger", "get_logger"),
+    "Conversation": (".conversation.conversation", "Conversation"),
+    "BaseConversation": (".conversation.base", "BaseConversation"),
+    "LocalConversation": (".conversation.impl.local_conversation", "LocalConversation"),
+    "RemoteConversation": (
+        ".conversation.impl.remote_conversation",
+        "RemoteConversation",
+    ),
+    "ConversationExecutionStatus": (
+        ".conversation.state",
+        "ConversationExecutionStatus",
+    ),
+    "ConversationCallbackType": (".conversation.types", "ConversationCallbackType"),
+    "Event": (".event.base", "Event"),
+    "LLMConvertibleEvent": (".event.base", "LLMConvertibleEvent"),
+    "AgentContext": (".context.agent_context", "AgentContext"),
+    "LLMSummarizingCondenser": (
+        ".context.condenser.llm_summarizing_condenser",
+        "LLMSummarizingCondenser",
+    ),
+    "CondenserSettings": (".settings.model", "CondenserSettings"),
+    "ConversationSettings": (".settings.model", "ConversationSettings"),
+    "VerificationSettings": (".settings.model", "VerificationSettings"),
+    "ACPAgentSettings": (".settings.model", "ACPAgentSettings"),
+    "AgentSettings": (".settings.model", "AgentSettings"),
+    "AgentSettingsConfig": (".settings.model", "AgentSettingsConfig"),
+    "LLMAgentSettings": (".settings.model", "LLMAgentSettings"),
+    "default_agent_settings": (".settings.model", "default_agent_settings"),
+    "export_agent_settings_schema": (
+        ".settings.model",
+        "export_agent_settings_schema",
+    ),
+    "validate_agent_settings": (".settings.model", "validate_agent_settings"),
+    "SettingsChoice": (".settings.model", "SettingsChoice"),
+    "SettingProminence": (".settings.metadata", "SettingProminence"),
+    "SettingsFieldMetadata": (".settings.metadata", "SettingsFieldMetadata"),
+    "SettingsFieldSchema": (".settings.model", "SettingsFieldSchema"),
+    "SettingsSchema": (".settings.model", "SettingsSchema"),
+    "SettingsSectionMetadata": (
+        ".settings.metadata",
+        "SettingsSectionMetadata",
+    ),
+    "SettingsSectionSchema": (".settings.model", "SettingsSectionSchema"),
+    "export_settings_schema": (".settings.model", "export_settings_schema"),
+    "field_meta": (".settings.metadata", "field_meta"),
+    "FileStore": (".io.base", "FileStore"),
+    "LocalFileStore": (".io.local", "LocalFileStore"),
+    "Plugin": (".plugin.plugin", "Plugin"),
+    "register_tool": (".tool.registry", "register_tool"),
+    "resolve_tool": (".tool.registry", "resolve_tool"),
+    "list_registered_tools": (".tool.registry", "list_registered_tools"),
+    "Workspace": (".workspace.workspace", "Workspace"),
+    "LocalWorkspace": (".workspace.local", "LocalWorkspace"),
+    "RemoteWorkspace": (".workspace.remote", "RemoteWorkspace"),
+    "AsyncRemoteWorkspace": (".workspace.remote", "AsyncRemoteWorkspace"),
+    "register_agent": (".subagent.registry", "register_agent"),
+    "load_project_agents": (".subagent.load", "load_project_agents"),
+    "load_user_agents": (".subagent.load", "load_user_agents"),
+    "load_agents_from_dir": (".subagent.load", "load_agents_from_dir"),
+    "agent_definition_to_factory": (
+        ".subagent.registry",
+        "agent_definition_to_factory",
+    ),
+    "load_project_skills": (".skills.skill", "load_project_skills"),
+    "load_skills_from_dir": (".skills.skill", "load_skills_from_dir"),
+    "load_user_skills": (".skills.skill", "load_user_skills"),
+    "page_iterator": (".utils.paging", "page_iterator"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -1,10 +1,99 @@
 from __future__ import annotations
 
 from importlib.metadata import PackageNotFoundError, version
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 from openhands.sdk.banner import _print_banner
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.agent.agent import Agent
+    from openhands.sdk.agent.base import AgentBase
+    from openhands.sdk.context.agent_context import AgentContext
+    from openhands.sdk.context.condenser.llm_summarizing_condenser import (
+        LLMSummarizingCondenser,
+    )
+    from openhands.sdk.conversation.base import BaseConversation
+    from openhands.sdk.conversation.conversation import Conversation
+    from openhands.sdk.conversation.conversation_stats import ConversationStats
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation
+    from openhands.sdk.conversation.state import ConversationExecutionStatus
+    from openhands.sdk.conversation.types import ConversationCallbackType
+    from openhands.sdk.event.base import Event, LLMConvertibleEvent
+    from openhands.sdk.event.hook_execution import HookExecutionEvent
+    from openhands.sdk.event.llm_convertible import MessageEvent
+    from openhands.sdk.io.base import FileStore
+    from openhands.sdk.io.local import LocalFileStore
+    from openhands.sdk.llm.fallback_strategy import FallbackStrategy
+    from openhands.sdk.llm.llm import LLM
+    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+    from openhands.sdk.llm.llm_registry import LLMRegistry, RegistryEvent
+    from openhands.sdk.llm.message import (
+        ImageContent,
+        Message,
+        RedactedThinkingBlock,
+        TextContent,
+        ThinkingBlock,
+    )
+    from openhands.sdk.llm.streaming import LLMStreamChunk, TokenCallbackType
+    from openhands.sdk.llm.utils.metrics import TokenUsage
+    from openhands.sdk.logger.logger import get_logger
+    from openhands.sdk.mcp.client import MCPClient
+    from openhands.sdk.mcp.definition import MCPToolObservation
+    from openhands.sdk.mcp.tool import MCPToolDefinition
+    from openhands.sdk.mcp.utils import create_mcp_tools
+    from openhands.sdk.plugin.plugin import Plugin
+    from openhands.sdk.settings.metadata import (
+        SettingProminence,
+        SettingsFieldMetadata,
+        SettingsSectionMetadata,
+        field_meta,
+    )
+    from openhands.sdk.settings.model import (
+        ACPAgentSettings,
+        AgentSettings,
+        AgentSettingsConfig,
+        CondenserSettings,
+        ConversationSettings,
+        LLMAgentSettings,
+        SettingsChoice,
+        SettingsFieldSchema,
+        SettingsSchema,
+        SettingsSectionSchema,
+        VerificationSettings,
+        default_agent_settings,
+        export_agent_settings_schema,
+        export_settings_schema,
+        validate_agent_settings,
+    )
+    from openhands.sdk.skills.skill import (
+        load_project_skills,
+        load_skills_from_dir,
+        load_user_skills,
+    )
+    from openhands.sdk.subagent.load import (
+        load_agents_from_dir,
+        load_project_agents,
+        load_user_agents,
+    )
+    from openhands.sdk.subagent.registry import (
+        agent_definition_to_factory,
+        register_agent,
+    )
+    from openhands.sdk.tool.registry import (
+        list_registered_tools,
+        register_tool,
+        resolve_tool,
+    )
+    from openhands.sdk.tool.schema import Action, Observation
+    from openhands.sdk.tool.spec import Tool
+    from openhands.sdk.tool.tool import ToolDefinition
+    from openhands.sdk.utils.paging import page_iterator
+    from openhands.sdk.workspace.local import LocalWorkspace
+    from openhands.sdk.workspace.remote import AsyncRemoteWorkspace, RemoteWorkspace
+    from openhands.sdk.workspace.workspace import Workspace
 
 
 try:

--- a/openhands-sdk/openhands/sdk/_lazy_imports.py
+++ b/openhands-sdk/openhands/sdk/_lazy_imports.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from importlib import import_module
+from typing import Any
+
+
+def import_lazy_symbol(
+    module_name: str,
+    module_globals: dict[str, Any],
+    lazy_imports: dict[str, tuple[str, str]],
+    name: str,
+) -> Any:
+    """Import and cache a lazily exported symbol."""
+    try:
+        import_path, attr_name = lazy_imports[name]
+    except KeyError as exc:
+        raise AttributeError(
+            f"module {module_name!r} has no attribute {name!r}"
+        ) from exc
+
+    value = getattr(import_module(import_path, module_name), attr_name)
+    module_globals[name] = value
+    return value
+
+
+def lazy_dir(module_globals: dict[str, Any], exports: list[str]) -> list[str]:
+    """Return module attributes plus lazily exported symbols for ``dir()``."""
+    return sorted(set(module_globals) | set(exports))

--- a/openhands-sdk/openhands/sdk/context/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/__init__.py
@@ -1,18 +1,8 @@
-from openhands.sdk.context.agent_context import AgentContext
-from openhands.sdk.context.prompts import render_template
+from __future__ import annotations
 
-# Import from canonical location (openhands.sdk.skills)
-from openhands.sdk.skills import (
-    BaseTrigger,
-    KeywordTrigger,
-    Skill,
-    SkillKnowledge,
-    SkillValidationError,
-    TaskTrigger,
-    load_project_skills,
-    load_skills_from_dir,
-    load_user_skills,
-)
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
@@ -28,3 +18,25 @@ __all__ = [
     "render_template",
     "SkillValidationError",
 ]
+
+_LAZY_IMPORTS = {
+    "AgentContext": (".agent_context", "AgentContext"),
+    "Skill": ("..skills.skill", "Skill"),
+    "BaseTrigger": ("..skills.trigger", "BaseTrigger"),
+    "KeywordTrigger": ("..skills.trigger", "KeywordTrigger"),
+    "TaskTrigger": ("..skills.trigger", "TaskTrigger"),
+    "SkillKnowledge": ("..skills.types", "SkillKnowledge"),
+    "load_skills_from_dir": ("..skills.skill", "load_skills_from_dir"),
+    "load_user_skills": ("..skills.skill", "load_user_skills"),
+    "load_project_skills": ("..skills.skill", "load_project_skills"),
+    "render_template": (".prompts", "render_template"),
+    "SkillValidationError": ("..skills.exceptions", "SkillValidationError"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/context/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/__init__.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from ..skills.exceptions import SkillValidationError
+    from ..skills.skill import (
+        Skill,
+        load_project_skills,
+        load_skills_from_dir,
+        load_user_skills,
+    )
+    from ..skills.trigger import BaseTrigger, KeywordTrigger, TaskTrigger
+    from ..skills.types import SkillKnowledge
+    from .agent_context import AgentContext
+    from .prompts import render_template
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/context/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/skills/__init__.py
@@ -11,7 +11,35 @@ Migration guide:
     from openhands.sdk.skills import Skill, load_skills_from_dir
 """
 
+from typing import TYPE_CHECKING
+
 from openhands.sdk.utils.deprecation import warn_deprecated
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.skills import (
+        RESOURCE_DIRECTORIES,
+        BaseTrigger,
+        InputMetadata,
+        KeywordTrigger,
+        Skill,
+        SkillContentResponse,
+        SkillError,
+        SkillInfo,
+        SkillKnowledge,
+        SkillResources,
+        SkillResponse,
+        SkillValidationError,
+        TaskTrigger,
+        discover_skill_resources,
+        load_available_skills,
+        load_project_skills,
+        load_public_skills,
+        load_skills_from_dir,
+        load_user_skills,
+        to_prompt,
+        validate_skill_name,
+    )
 
 
 def __getattr__(name: str):

--- a/openhands-sdk/openhands/sdk/conversation/__init__.py
+++ b/openhands-sdk/openhands/sdk/conversation/__init__.py
@@ -1,30 +1,8 @@
-from openhands.sdk.conversation.base import BaseConversation
-from openhands.sdk.conversation.conversation import Conversation
-from openhands.sdk.conversation.event_store import EventLog
-from openhands.sdk.conversation.events_list_base import EventsListBase
-from openhands.sdk.conversation.exceptions import WebSocketConnectionError
-from openhands.sdk.conversation.impl.local_conversation import LocalConversation
-from openhands.sdk.conversation.impl.remote_conversation import RemoteConversation
-from openhands.sdk.conversation.resource_lock_manager import (
-    ResourceLockManager,
-    ResourceLockTimeout,
-)
-from openhands.sdk.conversation.response_utils import get_agent_final_response
-from openhands.sdk.conversation.secret_registry import SecretRegistry
-from openhands.sdk.conversation.state import (
-    ConversationExecutionStatus,
-    ConversationState,
-)
-from openhands.sdk.conversation.stuck_detector import StuckDetector
-from openhands.sdk.conversation.types import (
-    ConversationCallbackType,
-    ConversationTags,
-    ConversationTokenCallbackType,
-)
-from openhands.sdk.conversation.visualizer import (
-    ConversationVisualizerBase,
-    DefaultConversationVisualizer,
-)
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
@@ -48,3 +26,36 @@ __all__ = [
     "get_agent_final_response",
     "WebSocketConnectionError",
 ]
+
+_LAZY_IMPORTS = {
+    "Conversation": (".conversation", "Conversation"),
+    "BaseConversation": (".base", "BaseConversation"),
+    "ConversationState": (".state", "ConversationState"),
+    "ConversationExecutionStatus": (".state", "ConversationExecutionStatus"),
+    "ConversationCallbackType": (".types", "ConversationCallbackType"),
+    "ConversationTags": (".types", "ConversationTags"),
+    "ConversationTokenCallbackType": (".types", "ConversationTokenCallbackType"),
+    "DefaultConversationVisualizer": (
+        ".visualizer",
+        "DefaultConversationVisualizer",
+    ),
+    "ConversationVisualizerBase": (".visualizer", "ConversationVisualizerBase"),
+    "SecretRegistry": (".secret_registry", "SecretRegistry"),
+    "StuckDetector": (".stuck_detector", "StuckDetector"),
+    "EventLog": (".event_store", "EventLog"),
+    "ResourceLockManager": (".resource_lock_manager", "ResourceLockManager"),
+    "ResourceLockTimeout": (".resource_lock_manager", "ResourceLockTimeout"),
+    "LocalConversation": (".impl.local_conversation", "LocalConversation"),
+    "RemoteConversation": (".impl.remote_conversation", "RemoteConversation"),
+    "EventsListBase": (".events_list_base", "EventsListBase"),
+    "get_agent_final_response": (".response_utils", "get_agent_final_response"),
+    "WebSocketConnectionError": (".exceptions", "WebSocketConnectionError"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/conversation/__init__.py
+++ b/openhands-sdk/openhands/sdk/conversation/__init__.py
@@ -1,8 +1,32 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .base import BaseConversation
+    from .conversation import Conversation
+    from .event_store import EventLog
+    from .events_list_base import EventsListBase
+    from .exceptions import WebSocketConnectionError
+    from .impl.local_conversation import LocalConversation
+    from .impl.remote_conversation import RemoteConversation
+    from .resource_lock_manager import ResourceLockManager, ResourceLockTimeout
+    from .response_utils import get_agent_final_response
+    from .secret_registry import SecretRegistry
+    from .state import ConversationExecutionStatus, ConversationState
+    from .stuck_detector import StuckDetector
+    from .types import (
+        ConversationCallbackType,
+        ConversationTags,
+        ConversationTokenCallbackType,
+    )
+    from .visualizer import (
+        ConversationVisualizerBase,
+        DefaultConversationVisualizer,
+    )
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/event/__init__.py
+++ b/openhands-sdk/openhands/sdk/event/__init__.py
@@ -1,8 +1,35 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .acp_tool_call import ACPToolCallEvent
+    from .base import Event, LLMConvertibleEvent
+    from .condenser import (
+        Condensation,
+        CondensationRequest,
+        CondensationSummaryEvent,
+    )
+    from .conversation_state import ConversationStateUpdateEvent
+    from .hook_execution import HookExecutionEvent
+    from .llm_completion_log import LLMCompletionLogEvent
+    from .llm_convertible import (
+        ActionEvent,
+        AgentErrorEvent,
+        MessageEvent,
+        ObservationBaseEvent,
+        ObservationEvent,
+        RejectionSource,
+        SystemPromptEvent,
+        UserRejectObservation,
+    )
+    from .streaming_delta import StreamingDeltaEvent
+    from .token import TokenEvent
+    from .types import EventID, ToolCallID
+    from .user_action import PauseEvent
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/event/__init__.py
+++ b/openhands-sdk/openhands/sdk/event/__init__.py
@@ -1,27 +1,8 @@
-from openhands.sdk.event.acp_tool_call import ACPToolCallEvent
-from openhands.sdk.event.base import Event, LLMConvertibleEvent
-from openhands.sdk.event.condenser import (
-    Condensation,
-    CondensationRequest,
-    CondensationSummaryEvent,
-)
-from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
-from openhands.sdk.event.hook_execution import HookExecutionEvent
-from openhands.sdk.event.llm_completion_log import LLMCompletionLogEvent
-from openhands.sdk.event.llm_convertible import (
-    ActionEvent,
-    AgentErrorEvent,
-    MessageEvent,
-    ObservationBaseEvent,
-    ObservationEvent,
-    RejectionSource,
-    SystemPromptEvent,
-    UserRejectObservation,
-)
-from openhands.sdk.event.streaming_delta import StreamingDeltaEvent
-from openhands.sdk.event.token import TokenEvent
-from openhands.sdk.event.types import EventID, ToolCallID
-from openhands.sdk.event.user_action import PauseEvent
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
@@ -48,3 +29,39 @@ __all__ = [
     "EventID",
     "ToolCallID",
 ]
+
+_LAZY_IMPORTS = {
+    "ACPToolCallEvent": (".acp_tool_call", "ACPToolCallEvent"),
+    "Event": (".base", "Event"),
+    "LLMConvertibleEvent": (".base", "LLMConvertibleEvent"),
+    "SystemPromptEvent": (".llm_convertible", "SystemPromptEvent"),
+    "ActionEvent": (".llm_convertible", "ActionEvent"),
+    "TokenEvent": (".token", "TokenEvent"),
+    "ObservationEvent": (".llm_convertible", "ObservationEvent"),
+    "ObservationBaseEvent": (".llm_convertible", "ObservationBaseEvent"),
+    "MessageEvent": (".llm_convertible", "MessageEvent"),
+    "AgentErrorEvent": (".llm_convertible", "AgentErrorEvent"),
+    "UserRejectObservation": (".llm_convertible", "UserRejectObservation"),
+    "RejectionSource": (".llm_convertible", "RejectionSource"),
+    "PauseEvent": (".user_action", "PauseEvent"),
+    "StreamingDeltaEvent": (".streaming_delta", "StreamingDeltaEvent"),
+    "Condensation": (".condenser", "Condensation"),
+    "CondensationRequest": (".condenser", "CondensationRequest"),
+    "CondensationSummaryEvent": (".condenser", "CondensationSummaryEvent"),
+    "ConversationStateUpdateEvent": (
+        ".conversation_state",
+        "ConversationStateUpdateEvent",
+    ),
+    "HookExecutionEvent": (".hook_execution", "HookExecutionEvent"),
+    "LLMCompletionLogEvent": (".llm_completion_log", "LLMCompletionLogEvent"),
+    "EventID": (".types", "EventID"),
+    "ToolCallID": (".types", "ToolCallID"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/io/__init__.py
+++ b/openhands-sdk/openhands/sdk/io/__init__.py
@@ -1,6 +1,22 @@
-from .base import FileStore
-from .local import LocalFileStore
-from .memory import InMemoryFileStore
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = ["LocalFileStore", "FileStore", "InMemoryFileStore"]
+
+_LAZY_IMPORTS = {
+    "LocalFileStore": (".local", "LocalFileStore"),
+    "FileStore": (".base", "FileStore"),
+    "InMemoryFileStore": (".memory", "InMemoryFileStore"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/io/__init__.py
+++ b/openhands-sdk/openhands/sdk/io/__init__.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .base import FileStore
+    from .local import LocalFileStore
+    from .memory import InMemoryFileStore
 
 
 __all__ = ["LocalFileStore", "FileStore", "InMemoryFileStore"]

--- a/openhands-sdk/openhands/sdk/llm/__init__.py
+++ b/openhands-sdk/openhands/sdk/llm/__init__.py
@@ -1,8 +1,40 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .auth import (
+        OPENAI_CODEX_MODELS,
+        CredentialStore,
+        OAuthCredentials,
+        OpenAISubscriptionAuth,
+    )
+    from .fallback_strategy import FallbackStrategy
+    from .llm import LLM
+    from .llm_profile_store import LLMProfileStore
+    from .llm_registry import LLMRegistry, RegistryEvent
+    from .llm_response import LLMResponse
+    from .message import (
+        ImageContent,
+        Message,
+        MessageToolCall,
+        ReasoningItemModel,
+        RedactedThinkingBlock,
+        TextContent,
+        ThinkingBlock,
+        content_to_str,
+    )
+    from .router import RouterLLM
+    from .streaming import LLMStreamChunk, TokenCallbackType
+    from .utils.metrics import Metrics, MetricsSnapshot, TokenUsage
+    from .utils.unverified_models import (
+        UNVERIFIED_MODELS_EXCLUDING_BEDROCK,
+        get_unverified_models,
+    )
+    from .utils.verified_models import VERIFIED_MODELS
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/llm/__init__.py
+++ b/openhands-sdk/openhands/sdk/llm/__init__.py
@@ -1,41 +1,15 @@
-from openhands.sdk.llm.auth import (
-    OPENAI_CODEX_MODELS,
-    CredentialStore,
-    OAuthCredentials,
-    OpenAISubscriptionAuth,
-)
-from openhands.sdk.llm.fallback_strategy import FallbackStrategy
-from openhands.sdk.llm.llm import LLM
-from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-from openhands.sdk.llm.llm_registry import LLMRegistry, RegistryEvent
-from openhands.sdk.llm.llm_response import LLMResponse
-from openhands.sdk.llm.message import (
-    ImageContent,
-    Message,
-    MessageToolCall,
-    ReasoningItemModel,
-    RedactedThinkingBlock,
-    TextContent,
-    ThinkingBlock,
-    content_to_str,
-)
-from openhands.sdk.llm.router import RouterLLM
-from openhands.sdk.llm.streaming import LLMStreamChunk, TokenCallbackType
-from openhands.sdk.llm.utils.metrics import Metrics, MetricsSnapshot, TokenUsage
-from openhands.sdk.llm.utils.unverified_models import (
-    UNVERIFIED_MODELS_EXCLUDING_BEDROCK,
-    get_unverified_models,
-)
-from openhands.sdk.llm.utils.verified_models import VERIFIED_MODELS
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
-    # Auth
     "CredentialStore",
     "OAuthCredentials",
     "OpenAISubscriptionAuth",
     "OPENAI_CODEX_MODELS",
-    # Core
     "FallbackStrategy",
     "LLMResponse",
     "LLM",
@@ -43,7 +17,6 @@ __all__ = [
     "LLMProfileStore",
     "RouterLLM",
     "RegistryEvent",
-    # Messages
     "Message",
     "MessageToolCall",
     "TextContent",
@@ -52,15 +25,53 @@ __all__ = [
     "RedactedThinkingBlock",
     "ReasoningItemModel",
     "content_to_str",
-    # Streaming
     "LLMStreamChunk",
     "TokenCallbackType",
-    # Metrics
     "Metrics",
     "MetricsSnapshot",
     "TokenUsage",
-    # Models
     "VERIFIED_MODELS",
     "UNVERIFIED_MODELS_EXCLUDING_BEDROCK",
     "get_unverified_models",
 ]
+
+_LAZY_IMPORTS = {
+    "CredentialStore": (".auth", "CredentialStore"),
+    "OAuthCredentials": (".auth", "OAuthCredentials"),
+    "OpenAISubscriptionAuth": (".auth", "OpenAISubscriptionAuth"),
+    "OPENAI_CODEX_MODELS": (".auth", "OPENAI_CODEX_MODELS"),
+    "FallbackStrategy": (".fallback_strategy", "FallbackStrategy"),
+    "LLMResponse": (".llm_response", "LLMResponse"),
+    "LLM": (".llm", "LLM"),
+    "LLMRegistry": (".llm_registry", "LLMRegistry"),
+    "LLMProfileStore": (".llm_profile_store", "LLMProfileStore"),
+    "RouterLLM": (".router", "RouterLLM"),
+    "RegistryEvent": (".llm_registry", "RegistryEvent"),
+    "Message": (".message", "Message"),
+    "MessageToolCall": (".message", "MessageToolCall"),
+    "TextContent": (".message", "TextContent"),
+    "ImageContent": (".message", "ImageContent"),
+    "ThinkingBlock": (".message", "ThinkingBlock"),
+    "RedactedThinkingBlock": (".message", "RedactedThinkingBlock"),
+    "ReasoningItemModel": (".message", "ReasoningItemModel"),
+    "content_to_str": (".message", "content_to_str"),
+    "LLMStreamChunk": (".streaming", "LLMStreamChunk"),
+    "TokenCallbackType": (".streaming", "TokenCallbackType"),
+    "Metrics": (".utils.metrics", "Metrics"),
+    "MetricsSnapshot": (".utils.metrics", "MetricsSnapshot"),
+    "TokenUsage": (".utils.metrics", "TokenUsage"),
+    "VERIFIED_MODELS": (".utils.verified_models", "VERIFIED_MODELS"),
+    "UNVERIFIED_MODELS_EXCLUDING_BEDROCK": (
+        ".utils.unverified_models",
+        "UNVERIFIED_MODELS_EXCLUDING_BEDROCK",
+    ),
+    "get_unverified_models": (".utils.unverified_models", "get_unverified_models"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/mcp/__init__.py
+++ b/openhands-sdk/openhands/sdk/mcp/__init__.py
@@ -1,15 +1,10 @@
 """MCP (Model Context Protocol) integration for agent-sdk."""
 
-from openhands.sdk.mcp.client import MCPClient
-from openhands.sdk.mcp.definition import MCPToolAction, MCPToolObservation
-from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
-from openhands.sdk.mcp.tool import (
-    MCPToolDefinition,
-    MCPToolExecutor,
-)
-from openhands.sdk.mcp.utils import (
-    create_mcp_tools,
-)
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
@@ -22,3 +17,22 @@ __all__ = [
     "MCPError",
     "MCPTimeoutError",
 ]
+
+_LAZY_IMPORTS = {
+    "MCPClient": (".client", "MCPClient"),
+    "MCPToolDefinition": (".tool", "MCPToolDefinition"),
+    "MCPToolAction": (".definition", "MCPToolAction"),
+    "MCPToolObservation": (".definition", "MCPToolObservation"),
+    "MCPToolExecutor": (".tool", "MCPToolExecutor"),
+    "create_mcp_tools": (".utils", "create_mcp_tools"),
+    "MCPError": (".exceptions", "MCPError"),
+    "MCPTimeoutError": (".exceptions", "MCPTimeoutError"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/mcp/__init__.py
+++ b/openhands-sdk/openhands/sdk/mcp/__init__.py
@@ -2,9 +2,17 @@
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .client import MCPClient
+    from .definition import MCPToolAction, MCPToolObservation
+    from .exceptions import MCPError, MCPTimeoutError
+    from .tool import MCPToolDefinition, MCPToolExecutor
+    from .utils import create_mcp_tools
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/plugin/__init__.py
+++ b/openhands-sdk/openhands/sdk/plugin/__init__.py
@@ -17,9 +17,51 @@ importing them from here will emit a deprecation warning.
 from __future__ import annotations
 
 from importlib import import_module
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.marketplace import (
+        Marketplace,
+        MarketplaceEntry,
+        MarketplaceMetadata,
+        MarketplaceOwner,
+        MarketplacePluginEntry,
+        MarketplacePluginSource,
+    )
+
+    from .fetch import PluginFetchError, fetch_plugin_with_resolution
+    from .installed import (
+        InstalledPluginInfo,
+        InstalledPluginsMetadata,
+        disable_plugin,
+        enable_plugin,
+        get_installed_plugin,
+        get_installed_plugins_dir,
+        install_plugin,
+        list_installed_plugins,
+        load_installed_plugins,
+        uninstall_plugin,
+        update_plugin,
+    )
+    from .loader import load_plugins
+    from .plugin import Plugin
+    from .source import (
+        GitHubURLComponents,
+        is_local_path,
+        parse_github_url,
+        resolve_source_path,
+        validate_source_path,
+    )
+    from .types import (
+        CommandDefinition,
+        PluginAuthor,
+        PluginManifest,
+        PluginSource,
+        ResolvedPluginSource,
+    )
 
 
 _DEPRECATED_MARKETPLACE_IMPORTS = {

--- a/openhands-sdk/openhands/sdk/plugin/__init__.py
+++ b/openhands-sdk/openhands/sdk/plugin/__init__.py
@@ -14,82 +14,58 @@ They are still importable from this module for backward compatibility, but
 importing them from here will emit a deprecation warning.
 """
 
+from __future__ import annotations
+
+from importlib import import_module
 from typing import Any
 
-# Import marketplace classes from new location for internal use
-# (no deprecation warning since we're importing from the canonical location)
-from openhands.sdk.marketplace import (
-    Marketplace as _Marketplace,
-    MarketplaceEntry as _MarketplaceEntry,
-    MarketplaceMetadata as _MarketplaceMetadata,
-    MarketplaceOwner as _MarketplaceOwner,
-    MarketplacePluginEntry as _MarketplacePluginEntry,
-    MarketplacePluginSource as _MarketplacePluginSource,
-)
-from openhands.sdk.plugin.fetch import (
-    PluginFetchError,
-    fetch_plugin_with_resolution,
-)
-from openhands.sdk.plugin.installed import (
-    InstalledPluginInfo,
-    InstalledPluginsMetadata,
-    disable_plugin,
-    enable_plugin,
-    get_installed_plugin,
-    get_installed_plugins_dir,
-    install_plugin,
-    list_installed_plugins,
-    load_installed_plugins,
-    uninstall_plugin,
-    update_plugin,
-)
-from openhands.sdk.plugin.loader import load_plugins
-from openhands.sdk.plugin.plugin import Plugin
-from openhands.sdk.plugin.source import (
-    GitHubURLComponents,
-    is_local_path,
-    parse_github_url,
-    resolve_source_path,
-    validate_source_path,
-)
-from openhands.sdk.plugin.types import (
-    CommandDefinition,
-    PluginAuthor,
-    PluginManifest,
-    PluginSource,
-    ResolvedPluginSource,
-)
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
-# Deprecated marketplace names that trigger warnings when accessed
-_DEPRECATED_MARKETPLACE_NAMES = {
-    "Marketplace": _Marketplace,
-    "MarketplaceEntry": _MarketplaceEntry,
-    "MarketplaceMetadata": _MarketplaceMetadata,
-    "MarketplaceOwner": _MarketplaceOwner,
-    "MarketplacePluginEntry": _MarketplacePluginEntry,
-    "MarketplacePluginSource": _MarketplacePluginSource,
+_DEPRECATED_MARKETPLACE_IMPORTS = {
+    "Marketplace": ("openhands.sdk.marketplace", "Marketplace"),
+    "MarketplaceEntry": ("openhands.sdk.marketplace", "MarketplaceEntry"),
+    "MarketplaceMetadata": ("openhands.sdk.marketplace", "MarketplaceMetadata"),
+    "MarketplaceOwner": ("openhands.sdk.marketplace", "MarketplaceOwner"),
+    "MarketplacePluginEntry": (
+        "openhands.sdk.marketplace",
+        "MarketplacePluginEntry",
+    ),
+    "MarketplacePluginSource": (
+        "openhands.sdk.marketplace",
+        "MarketplacePluginSource",
+    ),
 }
 
-
-def __getattr__(name: str) -> Any:
-    """Provide deprecated marketplace names with warnings."""
-    if name in _DEPRECATED_MARKETPLACE_NAMES:
-        from openhands.sdk.utils.deprecation import warn_deprecated
-
-        warn_deprecated(
-            f"Importing {name} from openhands.sdk.plugin",
-            deprecated_in="1.16.0",
-            removed_in="1.19.0",
-            details="Import from openhands.sdk.marketplace instead.",
-            stacklevel=3,
-        )
-        return _DEPRECATED_MARKETPLACE_NAMES[name]
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-
+_LAZY_IMPORTS = {
+    "Plugin": (".plugin", "Plugin"),
+    "PluginFetchError": (".fetch", "PluginFetchError"),
+    "fetch_plugin_with_resolution": (".fetch", "fetch_plugin_with_resolution"),
+    "InstalledPluginInfo": (".installed", "InstalledPluginInfo"),
+    "InstalledPluginsMetadata": (".installed", "InstalledPluginsMetadata"),
+    "disable_plugin": (".installed", "disable_plugin"),
+    "enable_plugin": (".installed", "enable_plugin"),
+    "get_installed_plugin": (".installed", "get_installed_plugin"),
+    "get_installed_plugins_dir": (".installed", "get_installed_plugins_dir"),
+    "install_plugin": (".installed", "install_plugin"),
+    "list_installed_plugins": (".installed", "list_installed_plugins"),
+    "load_installed_plugins": (".installed", "load_installed_plugins"),
+    "uninstall_plugin": (".installed", "uninstall_plugin"),
+    "update_plugin": (".installed", "update_plugin"),
+    "load_plugins": (".loader", "load_plugins"),
+    "GitHubURLComponents": (".source", "GitHubURLComponents"),
+    "is_local_path": (".source", "is_local_path"),
+    "parse_github_url": (".source", "parse_github_url"),
+    "resolve_source_path": (".source", "resolve_source_path"),
+    "validate_source_path": (".source", "validate_source_path"),
+    "CommandDefinition": (".types", "CommandDefinition"),
+    "PluginAuthor": (".types", "PluginAuthor"),
+    "PluginManifest": (".types", "PluginManifest"),
+    "PluginSource": (".types", "PluginSource"),
+    "ResolvedPluginSource": (".types", "ResolvedPluginSource"),
+}
 
 __all__ = [
-    # Plugin classes
     "Plugin",
     "PluginFetchError",
     "PluginManifest",
@@ -97,23 +73,19 @@ __all__ = [
     "PluginSource",
     "ResolvedPluginSource",
     "CommandDefinition",
-    # Plugin loading
     "load_plugins",
     "fetch_plugin_with_resolution",
-    # Marketplace classes (deprecated - import from openhands.sdk.marketplace)
     "Marketplace",
     "MarketplaceEntry",
     "MarketplaceOwner",
     "MarketplacePluginEntry",
     "MarketplacePluginSource",
     "MarketplaceMetadata",
-    # Source path utilities
     "GitHubURLComponents",
     "parse_github_url",
     "is_local_path",
     "validate_source_path",
     "resolve_source_path",
-    # Installed plugins management
     "InstalledPluginInfo",
     "InstalledPluginsMetadata",
     "install_plugin",
@@ -126,3 +98,25 @@ __all__ = [
     "disable_plugin",
     "update_plugin",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in _DEPRECATED_MARKETPLACE_IMPORTS:
+        from openhands.sdk.utils.deprecation import warn_deprecated
+
+        warn_deprecated(
+            f"Importing {name} from openhands.sdk.plugin",
+            deprecated_in="1.16.0",
+            removed_in="1.19.0",
+            details="Import from openhands.sdk.marketplace instead.",
+            stacklevel=3,
+        )
+        module_name, attr_name = _DEPRECATED_MARKETPLACE_IMPORTS[name]
+        value = getattr(import_module(module_name), attr_name)
+        globals()[name] = value
+        return value
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/skills/__init__.py
@@ -32,72 +32,18 @@ This module provides the unified API for working with skills:
 - `to_prompt` - Generate XML prompt block for available skills
 """
 
-# Exceptions
-from openhands.sdk.skills.exceptions import SkillError, SkillValidationError
+from __future__ import annotations
 
-# Fetch utilities
-from openhands.sdk.skills.fetch import SkillFetchError, fetch_skill_with_resolution
+from typing import Any
 
-# Installed skills management
-from openhands.sdk.skills.installed import (
-    InstalledSkillInfo,
-    InstalledSkillsMetadata,
-    disable_skill,
-    enable_skill,
-    get_installed_skill,
-    get_installed_skills_dir,
-    install_skill,
-    install_skills_from_marketplace,
-    list_installed_skills,
-    load_installed_skills,
-    uninstall_skill,
-    update_skill,
-)
-
-# Core skill model and loading
-from openhands.sdk.skills.skill import (
-    Skill,
-    SkillInfo,
-    SkillResources,
-    load_available_skills,
-    load_project_skills,
-    load_public_skills,
-    load_skills_from_dir,
-    load_user_skills,
-    to_prompt,
-)
-
-# Triggers
-from openhands.sdk.skills.trigger import (
-    BaseTrigger,
-    KeywordTrigger,
-    TaskTrigger,
-)
-
-# Types
-from openhands.sdk.skills.types import (
-    InputMetadata,
-    SkillContentResponse,
-    SkillKnowledge,
-    SkillResponse,
-)
-
-# Utilities
-from openhands.sdk.skills.utils import (
-    RESOURCE_DIRECTORIES,
-    discover_skill_resources,
-    validate_skill_name,
-)
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
-    # Exceptions
     "SkillError",
     "SkillValidationError",
-    # Fetch
     "SkillFetchError",
     "fetch_skill_with_resolution",
-    # Installed skills management
     "InstalledSkillInfo",
     "InstalledSkillsMetadata",
     "install_skill",
@@ -110,7 +56,6 @@ __all__ = [
     "enable_skill",
     "disable_skill",
     "update_skill",
-    # Core skill model and loading
     "Skill",
     "SkillInfo",
     "SkillResources",
@@ -120,17 +65,63 @@ __all__ = [
     "load_public_skills",
     "load_available_skills",
     "to_prompt",
-    # Triggers
     "BaseTrigger",
     "KeywordTrigger",
     "TaskTrigger",
-    # Types
     "SkillKnowledge",
     "InputMetadata",
     "SkillResponse",
     "SkillContentResponse",
-    # Utilities
     "discover_skill_resources",
     "RESOURCE_DIRECTORIES",
     "validate_skill_name",
 ]
+
+_LAZY_IMPORTS = {
+    "SkillError": (".exceptions", "SkillError"),
+    "SkillValidationError": (".exceptions", "SkillValidationError"),
+    "SkillFetchError": (".fetch", "SkillFetchError"),
+    "fetch_skill_with_resolution": (".fetch", "fetch_skill_with_resolution"),
+    "InstalledSkillInfo": (".installed", "InstalledSkillInfo"),
+    "InstalledSkillsMetadata": (".installed", "InstalledSkillsMetadata"),
+    "install_skill": (".installed", "install_skill"),
+    "install_skills_from_marketplace": (
+        ".installed",
+        "install_skills_from_marketplace",
+    ),
+    "uninstall_skill": (".installed", "uninstall_skill"),
+    "list_installed_skills": (".installed", "list_installed_skills"),
+    "load_installed_skills": (".installed", "load_installed_skills"),
+    "get_installed_skills_dir": (".installed", "get_installed_skills_dir"),
+    "get_installed_skill": (".installed", "get_installed_skill"),
+    "enable_skill": (".installed", "enable_skill"),
+    "disable_skill": (".installed", "disable_skill"),
+    "update_skill": (".installed", "update_skill"),
+    "Skill": (".skill", "Skill"),
+    "SkillInfo": (".skill", "SkillInfo"),
+    "SkillResources": (".skill", "SkillResources"),
+    "load_skills_from_dir": (".skill", "load_skills_from_dir"),
+    "load_project_skills": (".skill", "load_project_skills"),
+    "load_user_skills": (".skill", "load_user_skills"),
+    "load_public_skills": (".skill", "load_public_skills"),
+    "load_available_skills": (".skill", "load_available_skills"),
+    "to_prompt": (".skill", "to_prompt"),
+    "BaseTrigger": (".trigger", "BaseTrigger"),
+    "KeywordTrigger": (".trigger", "KeywordTrigger"),
+    "TaskTrigger": (".trigger", "TaskTrigger"),
+    "SkillKnowledge": (".types", "SkillKnowledge"),
+    "InputMetadata": (".types", "InputMetadata"),
+    "SkillResponse": (".types", "SkillResponse"),
+    "SkillContentResponse": (".types", "SkillContentResponse"),
+    "discover_skill_resources": (".utils", "discover_skill_resources"),
+    "RESOURCE_DIRECTORIES": (".utils", "RESOURCE_DIRECTORIES"),
+    "validate_skill_name": (".utils", "validate_skill_name"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/skills/__init__.py
@@ -34,9 +34,51 @@ This module provides the unified API for working with skills:
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .exceptions import SkillError, SkillValidationError
+    from .fetch import SkillFetchError, fetch_skill_with_resolution
+    from .installed import (
+        InstalledSkillInfo,
+        InstalledSkillsMetadata,
+        disable_skill,
+        enable_skill,
+        get_installed_skill,
+        get_installed_skills_dir,
+        install_skill,
+        install_skills_from_marketplace,
+        list_installed_skills,
+        load_installed_skills,
+        uninstall_skill,
+        update_skill,
+    )
+    from .skill import (
+        Skill,
+        SkillInfo,
+        SkillResources,
+        load_available_skills,
+        load_project_skills,
+        load_public_skills,
+        load_skills_from_dir,
+        load_user_skills,
+        to_prompt,
+    )
+    from .trigger import BaseTrigger, KeywordTrigger, TaskTrigger
+    from .types import (
+        InputMetadata,
+        SkillContentResponse,
+        SkillKnowledge,
+        SkillResponse,
+    )
+    from .utils import (
+        RESOURCE_DIRECTORIES,
+        discover_skill_resources,
+        validate_skill_name,
+    )
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/tool/__init__.py
+++ b/openhands-sdk/openhands/sdk/tool/__init__.py
@@ -1,8 +1,22 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .builtins import BUILT_IN_TOOL_CLASSES, BUILT_IN_TOOLS, FinishTool, ThinkTool
+    from .registry import list_registered_tools, register_tool, resolve_tool
+    from .schema import Action, Observation
+    from .spec import Tool
+    from .tool import (
+        DeclaredResources,
+        ExecutableTool,
+        ToolAnnotations,
+        ToolDefinition,
+        ToolExecutor,
+    )
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/tool/__init__.py
+++ b/openhands-sdk/openhands/sdk/tool/__init__.py
@@ -1,26 +1,8 @@
-from openhands.sdk.tool.builtins import (
-    BUILT_IN_TOOL_CLASSES,
-    BUILT_IN_TOOLS,
-    FinishTool,
-    ThinkTool,
-)
-from openhands.sdk.tool.registry import (
-    list_registered_tools,
-    register_tool,
-    resolve_tool,
-)
-from openhands.sdk.tool.schema import (
-    Action,
-    Observation,
-)
-from openhands.sdk.tool.spec import Tool
-from openhands.sdk.tool.tool import (
-    DeclaredResources,
-    ExecutableTool,
-    ToolAnnotations,
-    ToolDefinition,
-    ToolExecutor,
-)
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
@@ -40,3 +22,29 @@ __all__ = [
     "resolve_tool",
     "list_registered_tools",
 ]
+
+_LAZY_IMPORTS = {
+    "DeclaredResources": (".tool", "DeclaredResources"),
+    "Tool": (".spec", "Tool"),
+    "ToolDefinition": (".tool", "ToolDefinition"),
+    "ToolAnnotations": (".tool", "ToolAnnotations"),
+    "ToolExecutor": (".tool", "ToolExecutor"),
+    "ExecutableTool": (".tool", "ExecutableTool"),
+    "Action": (".schema", "Action"),
+    "Observation": (".schema", "Observation"),
+    "FinishTool": (".builtins", "FinishTool"),
+    "ThinkTool": (".builtins", "ThinkTool"),
+    "BUILT_IN_TOOLS": (".builtins", "BUILT_IN_TOOLS"),
+    "BUILT_IN_TOOL_CLASSES": (".builtins", "BUILT_IN_TOOL_CLASSES"),
+    "register_tool": (".registry", "register_tool"),
+    "resolve_tool": (".registry", "resolve_tool"),
+    "list_registered_tools": (".registry", "list_registered_tools"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/openhands-sdk/openhands/sdk/workspace/__init__.py
+++ b/openhands-sdk/openhands/sdk/workspace/__init__.py
@@ -1,8 +1,16 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
+
+
+if TYPE_CHECKING:
+    from .base import BaseWorkspace
+    from .local import LocalWorkspace
+    from .models import CommandResult, FileOperationResult, PlatformType, TargetType
+    from .remote import AsyncRemoteWorkspace, RemoteWorkspace
+    from .workspace import Workspace
 
 
 __all__ = [

--- a/openhands-sdk/openhands/sdk/workspace/__init__.py
+++ b/openhands-sdk/openhands/sdk/workspace/__init__.py
@@ -1,8 +1,8 @@
-from .base import BaseWorkspace
-from .local import LocalWorkspace
-from .models import CommandResult, FileOperationResult, PlatformType, TargetType
-from .remote import AsyncRemoteWorkspace, RemoteWorkspace
-from .workspace import Workspace
+from __future__ import annotations
+
+from typing import Any
+
+from openhands.sdk._lazy_imports import import_lazy_symbol, lazy_dir
 
 
 __all__ = [
@@ -16,3 +16,23 @@ __all__ = [
     "TargetType",
     "Workspace",
 ]
+
+_LAZY_IMPORTS = {
+    "AsyncRemoteWorkspace": (".remote", "AsyncRemoteWorkspace"),
+    "BaseWorkspace": (".base", "BaseWorkspace"),
+    "CommandResult": (".models", "CommandResult"),
+    "FileOperationResult": (".models", "FileOperationResult"),
+    "LocalWorkspace": (".local", "LocalWorkspace"),
+    "PlatformType": (".models", "PlatformType"),
+    "RemoteWorkspace": (".remote", "RemoteWorkspace"),
+    "TargetType": (".models", "TargetType"),
+    "Workspace": (".workspace", "Workspace"),
+}
+
+
+def __getattr__(name: str) -> Any:
+    return import_lazy_symbol(__name__, globals(), _LAZY_IMPORTS, name)
+
+
+def __dir__() -> list[str]:
+    return lazy_dir(globals(), __all__)

--- a/tests/sdk/test_lazy_imports.py
+++ b/tests/sdk/test_lazy_imports.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from collections.abc import Iterable
+
+
+def _run_python(code: str) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env["OPENHANDS_SUPPRESS_BANNER"] = "1"
+    return subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        check=True,
+        env=env,
+        text=True,
+    )
+
+
+def _loaded_modules(stdout: str) -> set[str]:
+    return set(json.loads(stdout))
+
+
+def _assert_present(modules: set[str], names: Iterable[str]) -> None:
+    for name in names:
+        assert name in modules
+
+
+def _assert_absent(modules: set[str], names: Iterable[str]) -> None:
+    for name in names:
+        assert name not in modules
+
+
+def test_import_openhands_sdk_keeps_heavy_modules_lazy() -> None:
+    result = _run_python(
+        "import json, sys; import openhands.sdk; "
+        "print(json.dumps(sorted(name for name in sys.modules "
+        'if name.startswith(("openhands.sdk", "litellm", "fastmcp", "lmnr")))))'
+    )
+
+    modules = _loaded_modules(result.stdout)
+
+    _assert_present(
+        modules,
+        {
+            "openhands.sdk",
+            "openhands.sdk._lazy_imports",
+            "openhands.sdk.banner",
+        },
+    )
+    _assert_absent(
+        modules,
+        {
+            "litellm",
+            "fastmcp",
+            "lmnr",
+            "openhands.sdk.agent",
+            "openhands.sdk.agent.agent",
+            "openhands.sdk.conversation",
+            "openhands.sdk.event",
+            "openhands.sdk.llm",
+            "openhands.sdk.logger",
+            "openhands.sdk.mcp",
+            "openhands.sdk.plugin",
+            "openhands.sdk.skills",
+            "openhands.sdk.tool",
+        },
+    )
+
+
+def test_importing_lightweight_llm_exports_does_not_import_llm_runtime() -> None:
+    result = _run_python(
+        "import json, sys; from openhands.sdk.llm import Message, TextContent; "
+        "print(json.dumps(sorted(name for name in sys.modules "
+        'if name.startswith(("openhands.sdk.llm", "litellm")))))'
+    )
+
+    modules = _loaded_modules(result.stdout)
+
+    _assert_present(
+        modules,
+        {
+            "openhands.sdk.llm",
+            "openhands.sdk.llm.message",
+        },
+    )
+    _assert_absent(
+        modules,
+        {
+            "openhands.sdk.llm.llm",
+        },
+    )


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

CLI startup investigation found that `import openhands.sdk` was still setting the floor for first paint because `openhands.sdk.__init__` eagerly imported large swaths of the SDK before the banner and prompt path became usable. This PR trims that path and adds a regression guard.

## Summary

- lazy-load the public `openhands.sdk` surface and print the banner before heavy imports
- make several SDK package `__init__.py` modules resolve exports lazily instead of importing whole subsystems up front
- add `tests/sdk/test_lazy_imports.py` plus an `AGENTS.md` memory note to keep the fast startup path covered

## Issue Number

Closes #2930.

## How to Test

Before this patch, running:

```bash
uv run python -X importtime -c 'import openhands.sdk'
```

locally reported about:

```text
7908792 us cum | openhands.sdk
```

After this patch, the same command reports about:

```text
32799 us cum | openhands.sdk
```

Additional verification run on this branch:

```bash
uv run pytest tests/sdk/test_lazy_imports.py tests/sdk/test_settings.py tests/sdk/tool/test_registry.py tests/sdk/conversation/test_conversation_execution_status_enum.py tests/sdk/agent/test_agent_init_state_invariants.py tests/sdk/plugin/test_source.py tests/sdk/skills/test_load_project_skills.py tests/sdk/mcp/test_mcp_observation.py -q
```

Result:

```text
77 passed, 8 warnings in 2.55s
```

I also ran pre-commit on all changed files:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/__init__.py openhands-sdk/openhands/sdk/_lazy_imports.py openhands-sdk/openhands/sdk/context/__init__.py openhands-sdk/openhands/sdk/conversation/__init__.py openhands-sdk/openhands/sdk/event/__init__.py openhands-sdk/openhands/sdk/io/__init__.py openhands-sdk/openhands/sdk/llm/__init__.py openhands-sdk/openhands/sdk/mcp/__init__.py openhands-sdk/openhands/sdk/plugin/__init__.py openhands-sdk/openhands/sdk/skills/__init__.py openhands-sdk/openhands/sdk/tool/__init__.py openhands-sdk/openhands/sdk/workspace/__init__.py tests/sdk/test_lazy_imports.py
```

## Video/Screenshots

N/A for this import/startup profiling change.

## Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- I cross-linked OpenHands/OpenHands-CLI#574 because that bridge / local agent-server architecture would also help with this class of startup bottleneck.
- I first tried to push to `smolpaws/software-agent-sdk` as requested in the issue thread, but did not have permission, so this PR uses a branch in `OpenHands/software-agent-sdk` instead.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/25c62f4f-9dd1-4a66-bbe1-b5516de28a91)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b0e245c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b0e245c-python \
  ghcr.io/openhands/agent-server:b0e245c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b0e245c-golang-amd64
ghcr.io/openhands/agent-server:b0e245c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b0e245c-golang-arm64
ghcr.io/openhands/agent-server:b0e245c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b0e245c-java-amd64
ghcr.io/openhands/agent-server:b0e245c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b0e245c-java-arm64
ghcr.io/openhands/agent-server:b0e245c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b0e245c-python-amd64
ghcr.io/openhands/agent-server:b0e245c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b0e245c-python-arm64
ghcr.io/openhands/agent-server:b0e245c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b0e245c-golang
ghcr.io/openhands/agent-server:b0e245c-java
ghcr.io/openhands/agent-server:b0e245c-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b0e245c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b0e245c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->