### PR TITLE
nit(sdk/critic): delete dead code

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/impl/api/critic.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/critic.py
@@ -51,7 +51,6 @@ class APIBasedCritic(CriticBase, CriticClient):
                 "APIBasedCritic requires tools to be defined in SystemPromptEvent. "
                 "Ensure your agent configuration includes tool definitions."
             )
-            raise ValueError("Tools are required for APIBasedCritic evaluation")
 
         # This will only retain events that are kept by the condenser
         view = View.from_events(events)


### PR DESCRIPTION
Small PR to delete dead-code in the critic

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b805d9a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b805d9a-python \
  ghcr.io/openhands/agent-server:b805d9a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b805d9a-golang-amd64
ghcr.io/openhands/agent-server:b805d9a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b805d9a-golang-arm64
ghcr.io/openhands/agent-server:b805d9a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b805d9a-java-amd64
ghcr.io/openhands/agent-server:b805d9a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b805d9a-java-arm64
ghcr.io/openhands/agent-server:b805d9a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b805d9a-python-amd64
ghcr.io/openhands/agent-server:b805d9a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b805d9a-python-arm64
ghcr.io/openhands/agent-server:b805d9a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b805d9a-golang
ghcr.io/openhands/agent-server:b805d9a-java
ghcr.io/openhands/agent-server:b805d9a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b805d9a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b805d9a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->