### PR TITLE
docs(sdk): clarify tool call matching invariants

### DIFF
--- a/openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py
+++ b/openhands-sdk/openhands/sdk/context/view/properties/tool_call_matching.py
@@ -13,7 +13,14 @@ from openhands.sdk.event import (
 
 
 class ToolCallMatchingProperty(ViewPropertyBase):
-    """Actions and observations must be paired."""
+    """Actions and observations must be paired.
+
+    The view that eventually gets serialized for the LLM should contain exactly
+    one observation-like event for each action ``tool_call_id``. Some providers
+    (for example Anthropic tool use) require every ``tool_use`` to have one
+    corresponding ``tool_result`` in the immediately following user message, so
+    duplicate observation-like events are not safe to silently tolerate.
+    """
 
     def enforce(
         self,
@@ -77,6 +84,12 @@ class ToolCallMatchingProperty(ViewPropertyBase):
                 case ActionEvent():
                     pending_tool_call_ids.add(event.tool_call_id)
                 case ObservationBaseEvent():
+                    # Intentionally use remove(), not discard(): a second
+                    # observation-like event for the same tool_call_id means the
+                    # view has already violated the 1 action -> 1 result
+                    # invariant that downstream LLM APIs expect. That case must
+                    # be fixed by de-duplicating the view before serialization,
+                    # not by silently tolerating it here.
                     pending_tool_call_ids.remove(event.tool_call_id)
 
             if pending_tool_call_ids:


### PR DESCRIPTION
## Summary
- clarify that a view sent to the LLM must contain exactly one observation-like event per action `tool_call_id`
- document why duplicate observation-like events cannot be silently tolerated in `ToolCallMatchingProperty`
- note that the duplicate case must be fixed by de-duplicating the view before serialization

## Why
Anthropic tool use expects each `tool_use` to have a corresponding `tool_result` in the immediately following user message, so simply changing `remove()` to `discard()` would hide an invalid tool-history shape rather than fix it.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f50e510-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f50e510-python \
  ghcr.io/openhands/agent-server:f50e510-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f50e510-golang-amd64
ghcr.io/openhands/agent-server:f50e510-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f50e510-golang-arm64
ghcr.io/openhands/agent-server:f50e510-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f50e510-java-amd64
ghcr.io/openhands/agent-server:f50e510-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f50e510-java-arm64
ghcr.io/openhands/agent-server:f50e510-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f50e510-python-amd64
ghcr.io/openhands/agent-server:f50e510-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f50e510-python-arm64
ghcr.io/openhands/agent-server:f50e510-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f50e510-golang
ghcr.io/openhands/agent-server:f50e510-java
ghcr.io/openhands/agent-server:f50e510-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f50e510-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f50e510-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->