### PR TITLE
test(agent-server): cover split-brain conversation resume

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_lease.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_lease.py
@@ -1,0 +1,170 @@
+import json
+import time
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from pathlib import Path
+
+from filelock import FileLock
+
+from openhands.sdk import get_logger
+
+
+logger = get_logger(__name__)
+
+LEASE_FILE_NAME = "owner_lease.json"
+LEASE_LOCK_FILE_NAME = ".owner_lease.lock"
+DEFAULT_LEASE_TTL_SECONDS = 45.0
+
+
+@dataclass(frozen=True)
+class LeaseClaim:
+    generation: int
+    takeover: bool
+
+
+class ConversationLeaseHeldError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        conversation_dir: Path,
+        owner_instance_id: str,
+        expires_at: float,
+    ) -> None:
+        self.conversation_dir = conversation_dir
+        self.owner_instance_id = owner_instance_id
+        self.expires_at = expires_at
+        super().__init__(
+            f"conversation lease is held by {owner_instance_id} until {expires_at}"
+        )
+
+
+class ConversationOwnershipLostError(RuntimeError):
+    def __init__(
+        self,
+        *,
+        conversation_dir: Path,
+        owner_instance_id: str,
+        generation: int,
+    ) -> None:
+        self.conversation_dir = conversation_dir
+        self.owner_instance_id = owner_instance_id
+        self.generation = generation
+        super().__init__(
+            "conversation ownership was lost before the write completed"
+        )
+
+
+class ConversationLease:
+    def __init__(
+        self,
+        *,
+        conversation_dir: Path,
+        owner_instance_id: str,
+        ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS,
+    ) -> None:
+        self._conversation_dir = conversation_dir
+        self._owner_instance_id = owner_instance_id
+        self._ttl_seconds = ttl_seconds
+        self._lease_path = conversation_dir / LEASE_FILE_NAME
+        self._lock_path = conversation_dir / LEASE_LOCK_FILE_NAME
+
+    def claim(self) -> LeaseClaim:
+        self._conversation_dir.mkdir(parents=True, exist_ok=True)
+        with FileLock(str(self._lock_path)):
+            now = time.time()
+            payload = self._read_payload()
+            if payload is not None:
+                current_owner = str(payload["owner_instance_id"])
+                current_generation = int(payload["generation"])
+                expires_at = float(payload["expires_at"])
+                if (
+                    current_owner != self._owner_instance_id
+                    and expires_at > now
+                ):
+                    raise ConversationLeaseHeldError(
+                        conversation_dir=self._conversation_dir,
+                        owner_instance_id=current_owner,
+                        expires_at=expires_at,
+                    )
+                same_owner = current_owner == self._owner_instance_id
+                generation = (
+                    current_generation if same_owner else current_generation + 1
+                )
+                takeover = not same_owner
+            else:
+                generation = 1
+                takeover = False
+            self._write_payload(
+                generation=generation,
+                expires_at=now + self._ttl_seconds,
+            )
+            return LeaseClaim(generation=generation, takeover=takeover)
+
+    def renew(self, generation: int) -> None:
+        with FileLock(str(self._lock_path)):
+            self._assert_owner_locked(generation)
+            self._write_payload(
+                generation=generation,
+                expires_at=time.time() + self._ttl_seconds,
+            )
+
+    @contextmanager
+    def guarded_write(self, generation: int) -> Iterator[None]:
+        with FileLock(str(self._lock_path)):
+            self._assert_owner_locked(generation)
+            yield
+
+
+
+    def release(self, generation: int) -> None:
+        with FileLock(str(self._lock_path)):
+            payload = self._read_payload()
+            if payload is None:
+                return
+            if (
+                str(payload["owner_instance_id"]) != self._owner_instance_id
+                or int(payload["generation"]) != generation
+            ):
+                return
+            self._lease_path.unlink(missing_ok=True)
+
+    def _assert_owner_locked(self, generation: int) -> None:
+        payload = self._read_payload()
+        if payload is None:
+            raise ConversationOwnershipLostError(
+                conversation_dir=self._conversation_dir,
+                owner_instance_id=self._owner_instance_id,
+                generation=generation,
+            )
+        if (
+            str(payload["owner_instance_id"]) != self._owner_instance_id
+            or int(payload["generation"]) != generation
+        ):
+            raise ConversationOwnershipLostError(
+                conversation_dir=self._conversation_dir,
+                owner_instance_id=self._owner_instance_id,
+                generation=generation,
+            )
+
+    def _read_payload(self) -> dict[str, object] | None:
+        if not self._lease_path.exists():
+            return None
+        try:
+            return json.loads(self._lease_path.read_text())
+        except Exception:
+            logger.warning(
+                "Failed to parse conversation lease file; treating as stale: %s",
+                self._lease_path,
+            )
+            return None
+
+    def _write_payload(self, *, generation: int, expires_at: float) -> None:
+        payload = {
+            "owner_instance_id": self._owner_instance_id,
+            "generation": generation,
+            "expires_at": expires_at,
+        }
+        tmp_path = self._lease_path.with_suffix(".tmp")
+        tmp_path.write_text(json.dumps(payload))
+        tmp_path.replace(self._lease_path)

--- a/openhands-agent-server/openhands/agent_server/conversation_lease.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_lease.py
@@ -4,6 +4,7 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TypedDict
 
 from filelock import FileLock
 
@@ -21,6 +22,12 @@ DEFAULT_LEASE_TTL_SECONDS = 45.0
 class LeaseClaim:
     generation: int
     takeover: bool
+
+
+class LeasePayload(TypedDict):
+    owner_instance_id: str
+    generation: int
+    expires_at: float
 
 
 class ConversationLeaseHeldError(RuntimeError):
@@ -50,9 +57,7 @@ class ConversationOwnershipLostError(RuntimeError):
         self.conversation_dir = conversation_dir
         self.owner_instance_id = owner_instance_id
         self.generation = generation
-        super().__init__(
-            "conversation ownership was lost before the write completed"
-        )
+        super().__init__("conversation ownership was lost before the write completed")
 
 
 class ConversationLease:
@@ -75,13 +80,10 @@ class ConversationLease:
             now = time.time()
             payload = self._read_payload()
             if payload is not None:
-                current_owner = str(payload["owner_instance_id"])
-                current_generation = int(payload["generation"])
-                expires_at = float(payload["expires_at"])
-                if (
-                    current_owner != self._owner_instance_id
-                    and expires_at > now
-                ):
+                current_owner = payload["owner_instance_id"]
+                current_generation = payload["generation"]
+                expires_at = payload["expires_at"]
+                if current_owner != self._owner_instance_id and expires_at > now:
                     raise ConversationLeaseHeldError(
                         conversation_dir=self._conversation_dir,
                         owner_instance_id=current_owner,
@@ -115,16 +117,14 @@ class ConversationLease:
             self._assert_owner_locked(generation)
             yield
 
-
-
     def release(self, generation: int) -> None:
         with FileLock(str(self._lock_path)):
             payload = self._read_payload()
             if payload is None:
                 return
             if (
-                str(payload["owner_instance_id"]) != self._owner_instance_id
-                or int(payload["generation"]) != generation
+                payload["owner_instance_id"] != self._owner_instance_id
+                or payload["generation"] != generation
             ):
                 return
             self._lease_path.unlink(missing_ok=True)
@@ -138,8 +138,8 @@ class ConversationLease:
                 generation=generation,
             )
         if (
-            str(payload["owner_instance_id"]) != self._owner_instance_id
-            or int(payload["generation"]) != generation
+            payload["owner_instance_id"] != self._owner_instance_id
+            or payload["generation"] != generation
         ):
             raise ConversationOwnershipLostError(
                 conversation_dir=self._conversation_dir,
@@ -147,11 +147,29 @@ class ConversationLease:
                 generation=generation,
             )
 
-    def _read_payload(self) -> dict[str, object] | None:
+    def _read_payload(self) -> LeasePayload | None:
         if not self._lease_path.exists():
             return None
         try:
-            return json.loads(self._lease_path.read_text())
+            raw_payload = json.loads(self._lease_path.read_text())
+            if not isinstance(raw_payload, dict):
+                raise ValueError("lease payload must be an object")
+
+            owner_instance_id = raw_payload.get("owner_instance_id")
+            generation = raw_payload.get("generation")
+            expires_at = raw_payload.get("expires_at")
+            if not isinstance(owner_instance_id, str):
+                raise ValueError("lease owner_instance_id must be a string")
+            if not isinstance(generation, int):
+                raise ValueError("lease generation must be an integer")
+            if not isinstance(expires_at, int | float):
+                raise ValueError("lease expires_at must be numeric")
+
+            return LeasePayload(
+                owner_instance_id=owner_instance_id,
+                generation=generation,
+                expires_at=float(expires_at),
+            )
         except Exception:
             logger.warning(
                 "Failed to parse conversation lease file; treating as stale: %s",

--- a/openhands-agent-server/openhands/agent_server/conversation_lease.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_lease.py
@@ -61,6 +61,13 @@ class ConversationOwnershipLostError(RuntimeError):
 
 
 class ConversationLease:
+    """Coordinate conversation ownership across multiple service instances.
+
+    The lease file stores the active owner, a monotonically increasing
+    generation, and an expiry timestamp so stale owners can be fenced off after
+    a takeover.
+    """
+
     def __init__(
         self,
         *,
@@ -75,6 +82,7 @@ class ConversationLease:
         self._lock_path = conversation_dir / LEASE_LOCK_FILE_NAME
 
     def claim(self) -> LeaseClaim:
+        """Claim or renew ownership of the conversation directory."""
         self._conversation_dir.mkdir(parents=True, exist_ok=True)
         with FileLock(str(self._lock_path)):
             now = time.time()
@@ -104,6 +112,7 @@ class ConversationLease:
             return LeaseClaim(generation=generation, takeover=takeover)
 
     def renew(self, generation: int) -> None:
+        """Extend the current lease while keeping the same generation."""
         with FileLock(str(self._lock_path)):
             self._assert_owner_locked(generation)
             self._write_payload(
@@ -113,11 +122,13 @@ class ConversationLease:
 
     @contextmanager
     def guarded_write(self, generation: int) -> Iterator[None]:
+        """Hold the lease lock while verifying ownership for a disk write."""
         with FileLock(str(self._lock_path)):
             self._assert_owner_locked(generation)
             yield
 
     def release(self, generation: int) -> None:
+        """Release the lease if this instance still owns the generation."""
         with FileLock(str(self._lock_path)):
             payload = self._read_payload()
             if payload is None:

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -732,6 +732,7 @@ class ConversationService:
         self.conversations_dir.mkdir(parents=True, exist_ok=True)
         self._event_services = {}
         for conversation_dir in self.conversations_dir.iterdir():
+            stored: StoredConversation | None = None
             try:
                 meta_file = conversation_dir / "meta.json"
                 if not meta_file.exists():
@@ -779,9 +780,12 @@ class ConversationService:
                     )
                 await self._start_event_service(stored)
             except ConversationLeaseHeldError as exc:
+                conversation_id = (
+                    stored.id if stored is not None else conversation_dir.name
+                )
                 logger.info(
                     "Skipping active conversation %s owned by %s until %s",
-                    stored.id,
+                    conversation_id,
                     exc.owner_instance_id,
                     exc.expires_at,
                 )

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -10,6 +10,7 @@ import httpx
 from pydantic import BaseModel
 
 from openhands.agent_server.config import Config, WebhookSpec
+from openhands.agent_server.conversation_lease import ConversationLeaseHeldError
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import (
     ACPConversationInfo,
@@ -159,6 +160,7 @@ class ConversationService:
     webhook_specs: list[WebhookSpec] = field(default_factory=list)
     session_api_key: str | None = field(default=None)
     cipher: Cipher | None = None
+    owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_webhook_subscribers: list["ConversationWebhookSubscriber"] = field(
         default_factory=list, init=False
@@ -776,6 +778,13 @@ class ConversationService:
                         context=f"resuming conversation {stored.id}",
                     )
                 await self._start_event_service(stored)
+            except ConversationLeaseHeldError as exc:
+                logger.info(
+                    "Skipping active conversation %s owned by %s until %s",
+                    stored.id,
+                    exc.owner_instance_id,
+                    exc.expires_at,
+                )
             except Exception:
                 logger.exception(
                     f"error_loading_event_service:{conversation_dir}", stack_info=True
@@ -825,6 +834,7 @@ class ConversationService:
             stored=stored,
             conversations_dir=self.conversations_dir,
             cipher=self.cipher,
+            owner_instance_id=self.owner_instance_id,
         )
         # Create subscribers...
         await event_service.subscribe_to_events(_EventSubscriber(service=event_service))

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -601,14 +601,12 @@ class EventService:
         # the pod during long conn.prompt() calls.
         self._setup_acp_activity_heartbeat(self._conversation.agent)
 
-        # Only convert an in-progress tool call into an error when this service
-        # had to take over an expired lease. A clean restart should fence off the
-        # old owner first; otherwise duplicate observation-like events can leak in.
+        # Any conversation loaded from disk with RUNNING status is stale. Active
+        # split-brain resumes are prevented earlier by the lease claim itself, so if
+        # we made it this far there is no live owner and the interrupted tool call
+        # should be surfaced back to the agent.
         state = self._conversation.state
-        if (
-            lease_claim.takeover
-            and state.execution_status == ConversationExecutionStatus.RUNNING
-        ):
+        if state.execution_status == ConversationExecutionStatus.RUNNING:
             state.execution_status = ConversationExecutionStatus.ERROR
             unmatched_actions = ConversationState.get_unmatched_actions(state.events)
             if unmatched_actions:

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,10 +1,14 @@
 import asyncio
-from contextlib import suppress
+from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from uuid import UUID
+from uuid import UUID, uuid4
 
+from openhands.agent_server.conversation_lease import (
+    ConversationLease,
+    ConversationOwnershipLostError,
+)
 from openhands.agent_server.models import (
     ConfirmationResponseRequest,
     EventPage,
@@ -31,6 +35,9 @@ from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
 
 
+LEASE_RENEW_INTERVAL_SECONDS = 15.0
+
+
 logger = get_logger(__name__)
 
 
@@ -44,11 +51,15 @@ class EventService:
     stored: StoredConversation
     conversations_dir: Path
     cipher: Cipher | None = None
+    owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     _conversation: LocalConversation | None = field(default=None, init=False)
     _pub_sub: PubSub[Event] = field(default_factory=lambda: PubSub[Event](), init=False)
     _run_task: asyncio.Task | None = field(default=None, init=False)
     _run_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _callback_wrapper: AsyncCallbackWrapper | None = field(default=None, init=False)
+    _lease: ConversationLease | None = field(default=None, init=False)
+    _lease_generation: int | None = field(default=None, init=False)
+    _lease_task: asyncio.Task | None = field(default=None, init=False)
 
     @property
     def conversation_dir(self):
@@ -64,14 +75,40 @@ class EventService:
         )
 
     async def save_meta(self):
-        meta_file = self.conversation_dir / "meta.json"
-        meta_file.write_text(
-            self.stored.model_dump_json(
-                context={
-                    "cipher": self.cipher,
-                }
+        with self._guard_write():
+            meta_file = self.conversation_dir / "meta.json"
+            meta_file.write_text(
+                self.stored.model_dump_json(
+                    context={
+                        "cipher": self.cipher,
+                    }
+                )
             )
-        )
+
+    def _guard_write(self):
+        if self._lease is None or self._lease_generation is None:
+            return nullcontext()
+        return self._lease.guarded_write(self._lease_generation)
+
+    async def _renew_lease_loop(self) -> None:
+        if self._lease is None or self._lease_generation is None:
+            return
+        try:
+            while True:
+                await asyncio.sleep(LEASE_RENEW_INTERVAL_SECONDS)
+                self._lease.renew(self._lease_generation)
+        except asyncio.CancelledError:
+            raise
+        except ConversationOwnershipLostError:
+            logger.warning(
+                "Conversation lease lost while renewing: %s",
+                self.stored.id,
+            )
+        except Exception:
+            logger.exception(
+                "Failed to renew conversation lease for %s",
+                self.stored.id,
+            )
 
     def get_conversation(self):
         if not self._conversation:
@@ -466,6 +503,12 @@ class EventService:
 
         # self.stored contains an Agent configuration we can instantiate
         self.conversation_dir.mkdir(parents=True, exist_ok=True)
+        self._lease = ConversationLease(
+            conversation_dir=self.conversation_dir,
+            owner_instance_id=self.owner_instance_id,
+        )
+        lease_claim = self._lease.claim()
+        self._lease_generation = lease_claim.generation
         workspace = self.stored.workspace
         assert isinstance(workspace, LocalWorkspace)
         Path(workspace.working_dir).mkdir(parents=True, exist_ok=True)
@@ -540,6 +583,8 @@ class EventService:
         conversation.set_confirmation_policy(self.stored.confirmation_policy)
         conversation.set_security_analyzer(self.stored.security_analyzer)
         self._conversation = conversation
+        self._conversation._state.set_write_guard(self._guard_write)
+        self._lease_task = asyncio.create_task(self._renew_lease_loop())
 
         # Register state change callback to automatically publish updates
         self._conversation._state.set_on_state_change(self._conversation._on_event)
@@ -556,12 +601,15 @@ class EventService:
         # the pod during long conn.prompt() calls.
         self._setup_acp_activity_heartbeat(self._conversation.agent)
 
-        # If the execution_status was "running" while serialized, then the
-        # conversation can't possibly be running - something is wrong
+        # Only convert an in-progress tool call into an error when this service
+        # had to take over an expired lease. A clean restart should fence off the
+        # old owner first; otherwise duplicate observation-like events can leak in.
         state = self._conversation.state
-        if state.execution_status == ConversationExecutionStatus.RUNNING:
+        if (
+            lease_claim.takeover
+            and state.execution_status == ConversationExecutionStatus.RUNNING
+        ):
             state.execution_status = ConversationExecutionStatus.ERROR
-            # Add error event for the first unmatched action to inform the agent
             unmatched_actions = ConversationState.get_unmatched_actions(state.events)
             if unmatched_actions:
                 first_action = unmatched_actions[0]
@@ -692,11 +740,22 @@ class EventService:
         )
 
     async def close(self):
+        if self._lease_task is not None:
+            self._lease_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._lease_task
+            self._lease_task = None
+
         await self._pub_sub.close()
         if self._conversation:
             loop = asyncio.get_running_loop()
             await loop.run_in_executor(None, self._conversation.close)
             self._conversation = None
+
+        if self._lease is not None and self._lease_generation is not None:
+            self._lease.release(self._lease_generation)
+        self._lease_generation = None
+        self._lease = None
 
     async def generate_title(
         self, llm: "LLM | None" = None, max_length: int = 50
@@ -789,7 +848,13 @@ class EventService:
         return self
 
     async def __aexit__(self, exc_type, exc_value, traceback):
-        await self.save_meta()
+        try:
+            await self.save_meta()
+        except ConversationOwnershipLostError:
+            logger.info(
+                "Skipping meta save after ownership loss for conversation %s",
+                self.stored.id,
+            )
         await self.close()
 
     def is_open(self) -> bool:

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -75,7 +75,7 @@ class EventService:
         )
 
     async def save_meta(self):
-        with self._guard_write():
+        with self._write_guard():
             meta_file = self.conversation_dir / "meta.json"
             meta_file.write_text(
                 self.stored.model_dump_json(
@@ -85,7 +85,7 @@ class EventService:
                 )
             )
 
-    def _guard_write(self):
+    def _write_guard(self):
         if self._lease is None or self._lease_generation is None:
             return nullcontext()
         return self._lease.guarded_write(self._lease_generation)
@@ -583,7 +583,7 @@ class EventService:
         conversation.set_confirmation_policy(self.stored.confirmation_policy)
         conversation.set_security_analyzer(self.stored.security_analyzer)
         self._conversation = conversation
-        self._conversation._state.set_write_guard(self._guard_write)
+        self._conversation._state.set_write_guard(self._write_guard)
         self._lease_task = asyncio.create_task(self._renew_lease_loop())
 
         # Register state change callback to automatically publish updates

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -1,7 +1,7 @@
 # state.py
 import operator
 from collections.abc import Callable, Iterator
-from contextlib import AbstractContextManager
+from contextlib import AbstractContextManager, nullcontext
 from typing import SupportsIndex, overload
 
 from openhands.sdk.conversation.events_list_base import EventsListBase
@@ -139,13 +139,12 @@ class EventLog(EventsListBase):
                     )
 
                 payload = event.model_dump_json(exclude_none=True)
-                if self._write_guard is None:
+                write_guard = (
+                    nullcontext() if self._write_guard is None else self._write_guard()
+                )
+                with write_guard:
                     target_path = self._path(self._length, event_id=evt_id)
                     self._fs.write(target_path, payload)
-                else:
-                    with self._write_guard():
-                        target_path = self._path(self._length, event_id=evt_id)
-                        self._fs.write(target_path, payload)
                 self._idx_to_id[self._length] = evt_id
                 self._id_to_idx[evt_id] = self._length
                 self._length += 1

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -1,6 +1,7 @@
 # state.py
 import operator
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
+from contextlib import AbstractContextManager
 from typing import SupportsIndex, overload
 
 from openhands.sdk.conversation.events_list_base import EventsListBase
@@ -37,6 +38,7 @@ class EventLog(EventsListBase):
     _dir: str
     _length: int
     _lock_path: str
+    _write_guard: Callable[[], AbstractContextManager[None]] | None
 
     def __init__(self, fs: FileStore, dir_path: str = EVENTS_DIR) -> None:
         self._fs = fs
@@ -44,7 +46,14 @@ class EventLog(EventsListBase):
         self._id_to_idx: dict[EventID, int] = {}
         self._idx_to_id: dict[int, EventID] = {}
         self._lock_path = f"{dir_path}/{LOCK_FILE_NAME}"
+        self._write_guard = None
         self._length = self._scan_and_build_index()
+
+    def set_write_guard(
+        self,
+        write_guard: Callable[[], AbstractContextManager[None]] | None,
+    ) -> None:
+        self._write_guard = write_guard
 
     def get_index(self, event_id: EventID) -> int:
         """Return the integer index for a given event_id."""
@@ -129,8 +138,14 @@ class EventLog(EventsListBase):
                         f"{existing_idx}"
                     )
 
-                target_path = self._path(self._length, event_id=evt_id)
-                self._fs.write(target_path, event.model_dump_json(exclude_none=True))
+                payload = event.model_dump_json(exclude_none=True)
+                if self._write_guard is None:
+                    target_path = self._path(self._length, event_id=evt_id)
+                    self._fs.write(target_path, payload)
+                else:
+                    with self._write_guard():
+                        target_path = self._path(self._length, event_id=evt_id)
+                        self._fs.write(target_path, payload)
                 self._idx_to_id[self._length] = evt_id
                 self._id_to_idx[evt_id] = self._length
                 self._length += 1

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -1,6 +1,7 @@
 # state.py
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from contextlib import AbstractContextManager
 from enum import Enum
 from pathlib import Path
 from typing import Any, Self
@@ -211,6 +212,9 @@ class ConversationState(OpenHandsModel):
     _on_state_change: ConversationCallbackType | None = PrivateAttr(
         default=None
     )  # callback for state changes
+    _write_guard: Callable[[], AbstractContextManager[None]] | None = PrivateAttr(
+        default=None
+    )
     _lock: FIFOLock = PrivateAttr(
         default_factory=FIFOLock
     )  # FIFO lock for thread safety
@@ -235,6 +239,13 @@ class ConversationState(OpenHandsModel):
         """
         self._on_state_change = callback
 
+    def set_write_guard(
+        self,
+        write_guard: Callable[[], AbstractContextManager[None]] | None,
+    ) -> None:
+        self._write_guard = write_guard
+        self._events.set_write_guard(write_guard)
+
     # ===== Base snapshot helpers (same FileStore usage you had) =====
     def _save_base_state(self, fs: FileStore) -> None:
         """
@@ -253,7 +264,11 @@ class ConversationState(OpenHandsModel):
                 "preserve secrets."
             )
         payload = self.model_dump_json(exclude_none=True, context=context)
-        fs.write(BASE_STATE, payload)
+        if self._write_guard is None:
+            fs.write(BASE_STATE, payload)
+        else:
+            with self._write_guard():
+                fs.write(BASE_STATE, payload)
 
     # ===== Factory: open-or-create (no load/save methods needed) =====
     @classmethod

--- a/tests/agent_server/test_conversation_lease.py
+++ b/tests/agent_server/test_conversation_lease.py
@@ -1,0 +1,134 @@
+import json
+import time
+from pathlib import Path
+from typing import cast
+
+import pytest
+
+from openhands.agent_server.conversation_lease import (
+    LEASE_FILE_NAME,
+    ConversationLease,
+    ConversationLeaseHeldError,
+    ConversationOwnershipLostError,
+    LeasePayload,
+)
+
+
+def _read_lease_payload(conversation_dir: Path) -> LeasePayload:
+    return cast(
+        LeasePayload,
+        json.loads((conversation_dir / LEASE_FILE_NAME).read_text()),
+    )
+
+
+def _expire_lease(conversation_dir: Path) -> None:
+    lease_path = conversation_dir / LEASE_FILE_NAME
+    payload = json.loads(lease_path.read_text())
+    payload["expires_at"] = 0
+    lease_path.write_text(json.dumps(payload))
+
+
+def test_claim_and_renew_persist_same_owner_generation(tmp_path: Path) -> None:
+    conversation_dir = tmp_path / "conversation"
+    lease = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="primary",
+        ttl_seconds=0.2,
+    )
+
+    claim = lease.claim()
+    first_payload = _read_lease_payload(conversation_dir)
+
+    time.sleep(0.01)
+    lease.renew(claim.generation)
+    renewed_payload = _read_lease_payload(conversation_dir)
+
+    repeated_claim = lease.claim()
+    repeated_payload = _read_lease_payload(conversation_dir)
+
+    assert claim.generation == 1
+    assert claim.takeover is False
+    assert first_payload["owner_instance_id"] == "primary"
+    assert renewed_payload["generation"] == 1
+    assert renewed_payload["expires_at"] > first_payload["expires_at"]
+    assert repeated_claim.generation == 1
+    assert repeated_claim.takeover is False
+    assert repeated_payload["owner_instance_id"] == "primary"
+    assert repeated_payload["generation"] == 1
+
+
+def test_claim_rejects_different_owner_while_lease_is_live(tmp_path: Path) -> None:
+    conversation_dir = tmp_path / "conversation"
+    primary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="primary",
+    )
+    secondary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="secondary",
+    )
+
+    primary.claim()
+
+    with pytest.raises(ConversationLeaseHeldError) as exc_info:
+        secondary.claim()
+
+    assert exc_info.value.conversation_dir == conversation_dir
+    assert exc_info.value.owner_instance_id == "primary"
+
+
+def test_takeover_bumps_generation_and_blocks_stale_owner_writes(
+    tmp_path: Path,
+) -> None:
+    conversation_dir = tmp_path / "conversation"
+    primary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="primary",
+    )
+    secondary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="secondary",
+    )
+
+    primary_claim = primary.claim()
+    _expire_lease(conversation_dir)
+
+    secondary_claim = secondary.claim()
+    payload = _read_lease_payload(conversation_dir)
+
+    assert secondary_claim.generation == primary_claim.generation + 1
+    assert secondary_claim.takeover is True
+    assert payload["owner_instance_id"] == "secondary"
+    assert payload["generation"] == secondary_claim.generation
+
+    with pytest.raises(ConversationOwnershipLostError):
+        primary.renew(primary_claim.generation)
+
+    with pytest.raises(ConversationOwnershipLostError):
+        with primary.guarded_write(primary_claim.generation):
+            pass
+
+    with secondary.guarded_write(secondary_claim.generation):
+        assert _read_lease_payload(conversation_dir)["owner_instance_id"] == "secondary"
+
+
+def test_release_keeps_new_owner_lease_intact_after_takeover(tmp_path: Path) -> None:
+    conversation_dir = tmp_path / "conversation"
+    primary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="primary",
+    )
+    secondary = ConversationLease(
+        conversation_dir=conversation_dir,
+        owner_instance_id="secondary",
+    )
+
+    primary_claim = primary.claim()
+    _expire_lease(conversation_dir)
+    secondary_claim = secondary.claim()
+
+    primary.release(primary_claim.generation)
+    assert (conversation_dir / LEASE_FILE_NAME).exists()
+
+    secondary.release(secondary_claim.generation)
+    assert not (conversation_dir / LEASE_FILE_NAME).exists()

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -128,6 +128,8 @@ async def test_second_service_does_not_resume_active_running_conversation(tmp_pa
 
     async with ConversationService(conversations_dir=conversations_dir) as primary:
         conversation_info, _ = await primary.start_conversation(request)
+        assert primary._event_services is not None
+
         primary_event_service = primary._event_services[conversation_info.id]
         primary_state = await primary_event_service.get_state()
 
@@ -138,6 +140,7 @@ async def test_second_service_does_not_resume_active_running_conversation(tmp_pa
         async with ConversationService(
             conversations_dir=conversations_dir,
         ) as secondary:
+            assert secondary._event_services is not None
             assert conversation_info.id not in secondary._event_services
 
             primary_state.events.append(
@@ -176,6 +179,7 @@ async def test_stale_owner_cannot_append_after_lease_takeover(tmp_path):
 
     async with ConversationService(conversations_dir=conversations_dir) as primary:
         conversation_info, _ = await primary.start_conversation(request)
+        assert primary._event_services is not None
         primary_event_service = primary._event_services[conversation_info.id]
         primary_state = await primary_event_service.get_state()
 
@@ -187,6 +191,7 @@ async def test_stale_owner_cannot_append_after_lease_takeover(tmp_path):
         async with ConversationService(
             conversations_dir=conversations_dir,
         ) as secondary:
+            assert secondary._event_services is not None
             secondary_event_service = secondary._event_services[conversation_info.id]
             secondary_state = await secondary_event_service.get_state()
 
@@ -211,9 +216,6 @@ async def test_stale_owner_cannot_append_after_lease_takeover(tmp_path):
 
             with pytest.raises(ConversationOwnershipLostError):
                 primary_state.execution_status = ConversationExecutionStatus.ERROR
-
-
-
 
 
 class TestConversationServiceSearchConversations:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
 from pydantic import SecretStr
 
 from openhands.agent_server.conversation_service import (
@@ -32,11 +33,15 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.event import ActionEvent, AgentErrorEvent, ObservationEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.llm import MessageToolCall, TextContent
 from openhands.sdk.secret import SecretSource, StaticSecret
 from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.workspace import LocalWorkspace
+from openhands.tools.terminal.definition import TerminalAction, TerminalObservation
 
 
 @pytest.fixture
@@ -61,6 +66,29 @@ def sample_stored_conversation():
     )
 
 
+def _create_running_terminal_action(tool_call_id: str = "call_1") -> ActionEvent:
+    tool_call = MessageToolCall.from_chat_tool_call(
+        ChatCompletionMessageToolCall(
+            id=tool_call_id,
+            type="function",
+            function=Function(
+                name="terminal",
+                arguments='{"command": "sleep 30"}',
+            ),
+        )
+    )
+    return ActionEvent(
+        thought=[TextContent(text="run sleep")],
+        action=TerminalAction(command="sleep 30"),
+        tool_name="terminal",
+        tool_call_id=tool_call_id,
+        tool_call=tool_call,
+        llm_response_id="response_1",
+        security_risk=SecurityRisk.LOW,
+        summary="run sleep",
+    )
+
+
 @pytest.fixture
 def conversation_service():
     """Create a ConversationService instance for testing."""
@@ -71,6 +99,56 @@ def conversation_service():
         # Initialize the _event_services dict to simulate an active service
         service._event_services = {}
         yield service
+
+
+@pytest.mark.asyncio
+async def test_second_service_does_not_resume_active_running_conversation(tmp_path):
+    """A second service should not attach to a live running conversation."""
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(request)
+        primary_event_service = primary._event_services[conversation_info.id]
+        primary_state = await primary_event_service.get_state()
+
+        running_action = _create_running_terminal_action()
+        primary_state.events.append(running_action)
+        primary_state.execution_status = ConversationExecutionStatus.RUNNING
+
+        async with ConversationService(
+            conversations_dir=conversations_dir,
+        ) as secondary:
+            assert conversation_info.id not in secondary._event_services
+
+            primary_state.events.append(
+                ObservationEvent(
+                    observation=TerminalObservation.from_text(
+                        "done",
+                        command="sleep 30",
+                        exit_code=0,
+                    ),
+                    action_id=running_action.id,
+                    tool_name="terminal",
+                    tool_call_id=running_action.tool_call_id,
+                )
+            )
+
+        events = primary_state.events[:]
+        assert [type(event).__name__ for event in events] == [
+            "ActionEvent",
+            "ConversationStateUpdateEvent",
+            "ObservationEvent",
+        ]
+        assert not any(isinstance(event, AgentErrorEvent) for event in events)
+
 
 
 class TestConversationServiceSearchConversations:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import json
 import tempfile
 import threading
 import time
@@ -11,6 +12,10 @@ import pytest
 from litellm.types.utils import ChatCompletionMessageToolCall, Function
 from pydantic import SecretStr
 
+from openhands.agent_server.conversation_lease import (
+    LEASE_FILE_NAME,
+    ConversationOwnershipLostError,
+)
 from openhands.agent_server.conversation_service import (
     AutoTitleSubscriber,
     ConversationContractMismatchError,
@@ -89,6 +94,13 @@ def _create_running_terminal_action(tool_call_id: str = "call_1") -> ActionEvent
     )
 
 
+def _expire_conversation_lease(conversations_dir: Path, conversation_id) -> None:
+    lease_path = conversations_dir / conversation_id.hex / LEASE_FILE_NAME
+    payload = json.loads(lease_path.read_text())
+    payload["expires_at"] = 0
+    lease_path.write_text(json.dumps(payload))
+
+
 @pytest.fixture
 def conversation_service():
     """Create a ConversationService instance for testing."""
@@ -148,6 +160,59 @@ async def test_second_service_does_not_resume_active_running_conversation(tmp_pa
             "ObservationEvent",
         ]
         assert not any(isinstance(event, AgentErrorEvent) for event in events)
+
+
+@pytest.mark.asyncio
+async def test_stale_owner_cannot_append_after_lease_takeover(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(request)
+        primary_event_service = primary._event_services[conversation_info.id]
+        primary_state = await primary_event_service.get_state()
+
+        running_action = _create_running_terminal_action()
+        primary_state.events.append(running_action)
+        primary_state.execution_status = ConversationExecutionStatus.RUNNING
+        _expire_conversation_lease(conversations_dir, conversation_info.id)
+
+        async with ConversationService(
+            conversations_dir=conversations_dir,
+        ) as secondary:
+            secondary_event_service = secondary._event_services[conversation_info.id]
+            secondary_state = await secondary_event_service.get_state()
+
+            assert any(
+                isinstance(event, AgentErrorEvent)
+                for event in secondary_state.events[:]
+            )
+
+            with pytest.raises(ConversationOwnershipLostError):
+                primary_state.events.append(
+                    ObservationEvent(
+                        observation=TerminalObservation.from_text(
+                            "late result",
+                            command="sleep 30",
+                            exit_code=0,
+                        ),
+                        action_id=running_action.id,
+                        tool_name="terminal",
+                        tool_call_id=running_action.tool_call_id,
+                    )
+                )
+
+            with pytest.raises(ConversationOwnershipLostError):
+                primary_state.execution_status = ConversationExecutionStatus.ERROR
+
+
 
 
 


### PR DESCRIPTION
## Summary
- add a regression test that uses a real temp-dir persisted conversation
- reproduce a second ConversationService resuming a still-running conversation from the same persistence dir
- show the primary owner can still append the late ObservationEvent after the secondary service attaches

## Validation
- `uv run ruff check tests/agent_server/test_conversation_service.py`
- `uv run pytest tests/agent_server/test_conversation_service.py -k second_service_does_not_resume_active_running_conversation -q` *(fails on current main, by design)*

_This PR was created by an AI assistant (OpenHands) on behalf of the user._





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0302cc6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0302cc6-python \
  ghcr.io/openhands/agent-server:0302cc6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0302cc6-golang-amd64
ghcr.io/openhands/agent-server:0302cc6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0302cc6-golang-arm64
ghcr.io/openhands/agent-server:0302cc6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0302cc6-java-amd64
ghcr.io/openhands/agent-server:0302cc6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0302cc6-java-arm64
ghcr.io/openhands/agent-server:0302cc6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0302cc6-python-amd64
ghcr.io/openhands/agent-server:0302cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0302cc6-python-arm64
ghcr.io/openhands/agent-server:0302cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0302cc6-golang
ghcr.io/openhands/agent-server:0302cc6-java
ghcr.io/openhands/agent-server:0302cc6-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0302cc6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0302cc6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->