### PR TITLE
Add device-code login for OpenAI subscriptions

### DIFF
--- a/examples/01_standalone_sdk/35_subscription_login.py
+++ b/examples/01_standalone_sdk/35_subscription_login.py
@@ -5,6 +5,7 @@ to access OpenAI's Codex models without consuming API credits.
 
 The subscription_login() method handles:
 - OAuth PKCE authentication flow
+- Device-code authentication for remote/headless environments
 - Credential caching (~/.openhands/auth/)
 - Automatic token refresh
 
@@ -16,21 +17,44 @@ Supported models:
 
 Requirements:
 - Active ChatGPT Plus or Pro subscription
-- Browser access for initial OAuth login
+- Browser access for initial OAuth login, or another browser/device for
+  device-code login
+
+Environment variables:
+- OPENHANDS_SUBSCRIPTION_MODEL: Model to use (default: gpt-5.2-codex)
+- OPENHANDS_SUBSCRIPTION_AUTH_METHOD: "browser" or "device_code"
+  (default: browser)
+- OPENHANDS_SUBSCRIPTION_FORCE_LOGIN: Set to "1" to force fresh login
+- SUBSCRIPTION_LOGIN_ONLY: Set to "1" to verify login without running an agent
 """
 
 import os
+from typing import Literal
 
 from openhands.sdk import LLM, Agent, Conversation, Tool
 from openhands.tools.file_editor import FileEditorTool
 from openhands.tools.terminal import TerminalTool
 
 
+AuthMethod = Literal["browser", "device_code"]
+
+
 # First time: Opens browser for OAuth login
 # Subsequent calls: Reuses cached credentials (auto-refreshes if expired)
+model = os.getenv("OPENHANDS_SUBSCRIPTION_MODEL", "gpt-5.2-codex")
+auth_method_env = os.getenv("OPENHANDS_SUBSCRIPTION_AUTH_METHOD", "browser")
+if auth_method_env not in ("browser", "device_code"):
+    raise ValueError(
+        "OPENHANDS_SUBSCRIPTION_AUTH_METHOD must be 'browser' or 'device_code'"
+    )
+auth_method: AuthMethod = auth_method_env
+force_login = os.getenv("OPENHANDS_SUBSCRIPTION_FORCE_LOGIN") == "1"
+
 llm = LLM.subscription_login(
     vendor="openai",
-    model="gpt-5.2-codex",  # or "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"
+    model=model,  # or "gpt-5.2", "gpt-5.1-codex-max", "gpt-5.1-codex-mini"
+    auth_method=auth_method,
+    force_login=force_login,
 )
 
 # Alternative: Force a fresh login (useful if credentials are stale)
@@ -40,9 +64,23 @@ llm = LLM.subscription_login(
 # llm = LLM.subscription_login(
 #     vendor="openai", model="gpt-5.2-codex", open_browser=False
 # )
+#
+# Alternative: Use device-code login for remote/headless environments
+# llm = LLM.subscription_login(
+#     vendor="openai",
+#     model="gpt-5.2-codex",
+#     auth_method="device_code",
+#     force_login=True,
+# )
 
 # Verify subscription mode is active
 print(f"Using subscription mode: {llm.is_subscription}")
+print(f"Model: {llm.model}")
+print(f"Auth method: {auth_method}")
+
+if os.getenv("SUBSCRIPTION_LOGIN_ONLY") == "1":
+    print("Login verified; skipping agent run because SUBSCRIPTION_LOGIN_ONLY=1.")
+    raise SystemExit(0)
 
 # Use the LLM with an agent as usual
 agent = Agent(

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -15,6 +15,7 @@ import sys
 import threading
 import time
 import webbrowser
+from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlencode
@@ -40,6 +41,7 @@ if TYPE_CHECKING:
 # Supported vendors for subscription-based authentication.
 # Add new vendors here as they become supported.
 SupportedVendor = Literal["openai"]
+OpenAIAuthMethod = Literal["browser", "device_code"]
 
 logger = get_logger(__name__)
 
@@ -122,6 +124,7 @@ JWKS_URL = f"{ISSUER}/.well-known/jwks.json"
 CODEX_API_ENDPOINT = "https://chatgpt.com/backend-api/codex/responses"
 DEFAULT_OAUTH_PORT = 1455
 OAUTH_TIMEOUT_SECONDS = 300  # 5 minutes
+DEVICE_CODE_TIMEOUT_SECONDS = 900  # 15 minutes
 JWKS_CACHE_TTL_SECONDS = 3600  # 1 hour
 
 # Models available via ChatGPT subscription (not API)
@@ -273,6 +276,83 @@ async def _exchange_code_for_tokens(
         return response.json()
 
 
+@dataclass(frozen=True)
+class DeviceCode:
+    """OpenAI device authorization details."""
+
+    verification_url: str
+    user_code: str
+    device_auth_id: str
+    interval: int
+
+
+async def _request_device_code() -> DeviceCode:
+    """Request a device code for headless ChatGPT sign-in."""
+    async with AsyncClient() as client:
+        response = await client.post(
+            f"{ISSUER}/api/accounts/deviceauth/usercode",
+            json={"client_id": CLIENT_ID},
+            headers={"Content-Type": "application/json"},
+        )
+        if not response.is_success:
+            if response.status_code == 404:
+                raise RuntimeError(
+                    "Device code login is not enabled for this OpenAI server. "
+                    "Use browser login instead."
+                )
+            raise RuntimeError(
+                f"Device code request failed with status {response.status_code}"
+            )
+
+        data = response.json()
+
+    try:
+        interval = int(str(data.get("interval", 5)).strip())
+        user_code = data.get("user_code") or data.get("usercode")
+        device_auth_id = data["device_auth_id"]
+    except (KeyError, TypeError, ValueError) as exc:
+        raise RuntimeError("Invalid device code response from OpenAI") from exc
+
+    if not user_code or not isinstance(user_code, str):
+        raise RuntimeError("Invalid device code response from OpenAI")
+
+    return DeviceCode(
+        verification_url=f"{ISSUER}/codex/device",
+        user_code=user_code,
+        device_auth_id=device_auth_id,
+        interval=max(interval, 1),
+    )
+
+
+async def _poll_device_code(device_code: DeviceCode) -> dict[str, Any]:
+    """Poll until OpenAI issues an authorization code for a device login."""
+    deadline = time.monotonic() + DEVICE_CODE_TIMEOUT_SECONDS
+
+    async with AsyncClient() as client:
+        while time.monotonic() < deadline:
+            response = await client.post(
+                f"{ISSUER}/api/accounts/deviceauth/token",
+                json={
+                    "device_auth_id": device_code.device_auth_id,
+                    "user_code": device_code.user_code,
+                },
+                headers={"Content-Type": "application/json"},
+            )
+
+            if response.is_success:
+                return response.json()
+
+            if response.status_code in (403, 404):
+                await asyncio.sleep(
+                    min(device_code.interval, max(0, deadline - time.monotonic()))
+                )
+                continue
+
+            raise RuntimeError(f"Device auth failed with status {response.status_code}")
+
+    raise RuntimeError("Device auth timed out after 15 minutes")
+
+
 async def _refresh_access_token(refresh_token: str) -> dict[str, Any]:
     """Refresh the access token using a refresh token."""
     async with AsyncClient() as client:
@@ -396,15 +476,22 @@ class OpenAISubscriptionAuth:
         )
         return updated
 
-    async def login(self, open_browser: bool = True) -> OAuthCredentials:
+    async def login(
+        self,
+        open_browser: bool = True,
+        auth_method: OpenAIAuthMethod = "browser",
+    ) -> OAuthCredentials:
         """Perform OAuth login flow.
 
-        This starts a local HTTP server to handle the OAuth callback,
-        opens the browser for user authentication, and waits for the
-        callback with the authorization code.
+        The browser method starts a local HTTP server to handle the OAuth
+        callback, opens the browser for user authentication, and waits for the
+        callback with the authorization code. The device-code method prints a
+        URL and one-time code, then polls until the browser-side authorization
+        completes.
 
         Args:
             open_browser: Whether to automatically open the browser.
+            auth_method: Login method to use: "browser" or "device_code".
 
         Returns:
             The obtained OAuth credentials.
@@ -412,6 +499,11 @@ class OpenAISubscriptionAuth:
         Raises:
             RuntimeError: If the OAuth flow fails or times out.
         """
+        if auth_method == "device_code":
+            return await self._login_with_device_code()
+        if auth_method != "browser":
+            raise ValueError(f"Unsupported OpenAI auth method: {auth_method}")
+
         code_verifier, code_challenge = _generate_pkce()
         state = generate_token(32)
         redirect_uri = f"http://localhost:{self._oauth_port}/auth/callback"
@@ -526,6 +618,46 @@ class OpenAISubscriptionAuth:
         finally:
             await runner.cleanup()
 
+    async def _login_with_device_code(self) -> OAuthCredentials:
+        """Perform device-code OAuth login flow."""
+        device_code = await _request_device_code()
+        logger.info(
+            "Open this URL in your browser and enter the one-time code:\n"
+            f"{device_code.verification_url}\n\n"
+            f"Code: {device_code.user_code}\n\n"
+            "Device codes are a common phishing target. Never share this code."
+        )
+        print(
+            "\nOpen this URL in your browser and sign in to ChatGPT:\n"
+            f"{device_code.verification_url}\n\n"
+            f"Enter code: {device_code.user_code}\n\n"
+            "Device codes are a common phishing target. Never share this code.\n"
+        )
+
+        code_response = await _poll_device_code(device_code)
+        try:
+            authorization_code = code_response["authorization_code"]
+            code_verifier = code_response["code_verifier"]
+        except KeyError as exc:
+            raise RuntimeError("Invalid device token response from OpenAI") from exc
+
+        tokens = await _exchange_code_for_tokens(
+            authorization_code,
+            f"{ISSUER}/deviceauth/callback",
+            code_verifier,
+        )
+
+        expires_at = int(time.time() * 1000) + (tokens.get("expires_in", 3600) * 1000)
+        credentials = OAuthCredentials(
+            vendor=self.vendor,
+            access_token=tokens["access_token"],
+            refresh_token=tokens["refresh_token"],
+            expires_at=expires_at,
+        )
+        self._credential_store.save(credentials)
+        logger.info("OpenAI device-code login successful")
+        return credentials
+
     def logout(self) -> bool:
         """Remove stored credentials.
 
@@ -616,6 +748,7 @@ async def subscription_login_async(
     model: str = "gpt-5.2-codex",
     force_login: bool = False,
     open_browser: bool = True,
+    auth_method: OpenAIAuthMethod = "browser",
     skip_consent: bool = False,
     **llm_kwargs: Any,
 ) -> LLM:
@@ -629,6 +762,7 @@ async def subscription_login_async(
         model: The model to use.
         force_login: If True, always perform a fresh login.
         open_browser: Whether to automatically open the browser for login.
+        auth_method: Login method to use: "browser" or "device_code".
         skip_consent: If True, skip the consent prompt (for programmatic use
             where consent has been obtained through other means).
         **llm_kwargs: Additional arguments to pass to LLM constructor.
@@ -665,7 +799,7 @@ async def subscription_login_async(
             raise RuntimeError("User declined to continue with ChatGPT sign-in")
 
     # Perform login
-    creds = await auth.login(open_browser=open_browser)
+    creds = await auth.login(open_browser=open_browser, auth_method=auth_method)
     return auth.create_llm(model=model, credentials=creds, **llm_kwargs)
 
 
@@ -674,6 +808,7 @@ def subscription_login(
     model: str = "gpt-5.2-codex",
     force_login: bool = False,
     open_browser: bool = True,
+    auth_method: OpenAIAuthMethod = "browser",
     skip_consent: bool = False,
     **llm_kwargs: Any,
 ) -> LLM:
@@ -687,6 +822,7 @@ def subscription_login(
             model=model,
             force_login=force_login,
             open_browser=open_browser,
+            auth_method=auth_method,
             skip_consent=skip_consent,
             **llm_kwargs,
         )

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -30,6 +30,7 @@ from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secr
 
 if TYPE_CHECKING:  # type hints only, avoid runtime import cycle
     from openhands.sdk.llm.auth import SupportedVendor
+    from openhands.sdk.llm.auth.openai import OpenAIAuthMethod
     from openhands.sdk.tool.tool import ToolDefinition
 
 from openhands.sdk.llm.auth.openai import transform_for_subscription
@@ -1583,6 +1584,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         model: str,
         force_login: bool = False,
         open_browser: bool = True,
+        auth_method: OpenAIAuthMethod = "browser",
         **llm_kwargs,
     ) -> LLM:
         """Authenticate with a subscription service and return an LLM instance.
@@ -1609,6 +1611,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 credentials exist.
             open_browser: Whether to automatically open the browser for the
                 OAuth login flow.
+            auth_method: Login method to use: "browser" or "device_code".
             **llm_kwargs: Additional arguments to pass to the LLM constructor.
 
         Returns:
@@ -1636,5 +1639,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             model=model,
             force_login=force_login,
             open_browser=open_browser,
+            auth_method=auth_method,
             **llm_kwargs,
         )

--- a/tests/sdk/llm/auth/test_openai.py
+++ b/tests/sdk/llm/auth/test_openai.py
@@ -6,6 +6,7 @@ integration test requirements.
 """
 
 import time
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -16,6 +17,7 @@ from openhands.sdk.llm.auth.openai import (
     CONSENT_BANNER,
     ISSUER,
     OPENAI_CODEX_MODELS,
+    DeviceCode,
     OpenAISubscriptionAuth,
     _build_authorize_url,
     _display_consent_and_confirm,
@@ -23,6 +25,8 @@ from openhands.sdk.llm.auth.openai import (
     _get_consent_marker_path,
     _has_acknowledged_consent,
     _mark_consent_acknowledged,
+    _poll_device_code,
+    _request_device_code,
 )
 
 
@@ -201,6 +205,170 @@ def test_openai_subscription_auth_create_llm_success(tmp_path):
     assert llm.extra_headers is not None
     # Uses codex_cli_rs to match official Codex CLI for compatibility
     assert llm.extra_headers.get("originator") == "codex_cli_rs"
+
+
+class _FakeAsyncClient:
+    def __init__(self, responses):
+        self.responses = list(responses)
+        self.posts = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def post(self, url, **kwargs):
+        self.posts.append((url, kwargs))
+        response = self.responses.pop(0)
+        if isinstance(response, Exception):
+            raise response
+        return response
+
+
+def _response(status_code=200, payload=None):
+    return SimpleNamespace(
+        status_code=status_code,
+        is_success=200 <= status_code < 300,
+        json=lambda: payload or {},
+    )
+
+
+@pytest.mark.asyncio
+async def test_request_device_code_success():
+    """Test requesting an OpenAI device code."""
+    fake_client = _FakeAsyncClient(
+        [
+            _response(
+                payload={
+                    "device_auth_id": "device-auth-123",
+                    "user_code": "ABCD-1234",
+                    "interval": "2",
+                }
+            )
+        ]
+    )
+
+    with patch("openhands.sdk.llm.auth.openai.AsyncClient", return_value=fake_client):
+        device_code = await _request_device_code()
+
+    assert device_code == DeviceCode(
+        verification_url=f"{ISSUER}/codex/device",
+        user_code="ABCD-1234",
+        device_auth_id="device-auth-123",
+        interval=2,
+    )
+    assert fake_client.posts == [
+        (
+            f"{ISSUER}/api/accounts/deviceauth/usercode",
+            {
+                "json": {"client_id": CLIENT_ID},
+                "headers": {"Content-Type": "application/json"},
+            },
+        )
+    ]
+
+
+@pytest.mark.asyncio
+async def test_poll_device_code_retries_pending_then_succeeds():
+    """Test polling the OpenAI device auth token endpoint."""
+    fake_client = _FakeAsyncClient(
+        [
+            _response(status_code=403),
+            _response(
+                payload={
+                    "authorization_code": "auth-code",
+                    "code_verifier": "verifier",
+                    "code_challenge": "challenge",
+                }
+            ),
+        ]
+    )
+    device_code = DeviceCode(
+        verification_url=f"{ISSUER}/codex/device",
+        user_code="ABCD-1234",
+        device_auth_id="device-auth-123",
+        interval=1,
+    )
+
+    with (
+        patch("openhands.sdk.llm.auth.openai.AsyncClient", return_value=fake_client),
+        patch("openhands.sdk.llm.auth.openai.asyncio.sleep", new_callable=AsyncMock),
+    ):
+        result = await _poll_device_code(device_code)
+
+    assert result["authorization_code"] == "auth-code"
+    assert fake_client.posts == [
+        (
+            f"{ISSUER}/api/accounts/deviceauth/token",
+            {
+                "json": {
+                    "device_auth_id": "device-auth-123",
+                    "user_code": "ABCD-1234",
+                },
+                "headers": {"Content-Type": "application/json"},
+            },
+        ),
+        (
+            f"{ISSUER}/api/accounts/deviceauth/token",
+            {
+                "json": {
+                    "device_auth_id": "device-auth-123",
+                    "user_code": "ABCD-1234",
+                },
+                "headers": {"Content-Type": "application/json"},
+            },
+        ),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_openai_subscription_auth_login_device_code(tmp_path):
+    """Test device-code login stores OAuth credentials."""
+    store = CredentialStore(credentials_dir=tmp_path)
+    auth = OpenAISubscriptionAuth(credential_store=store)
+    device_code = DeviceCode(
+        verification_url=f"{ISSUER}/codex/device",
+        user_code="ABCD-1234",
+        device_auth_id="device-auth-123",
+        interval=1,
+    )
+
+    with (
+        patch(
+            "openhands.sdk.llm.auth.openai._request_device_code",
+            new_callable=AsyncMock,
+        ) as mock_request,
+        patch(
+            "openhands.sdk.llm.auth.openai._poll_device_code",
+            new_callable=AsyncMock,
+        ) as mock_poll,
+        patch(
+            "openhands.sdk.llm.auth.openai._exchange_code_for_tokens",
+            new_callable=AsyncMock,
+        ) as mock_exchange,
+    ):
+        mock_request.return_value = device_code
+        mock_poll.return_value = {
+            "authorization_code": "auth-code",
+            "code_verifier": "verifier",
+            "code_challenge": "challenge",
+        }
+        mock_exchange.return_value = {
+            "access_token": "access",
+            "refresh_token": "refresh",
+            "expires_in": 3600,
+        }
+
+        credentials = await auth.login(auth_method="device_code")
+
+    assert credentials.access_token == "access"
+    assert store.get("openai") is not None
+    mock_exchange.assert_called_once_with(
+        "auth-code",
+        f"{ISSUER}/deviceauth/callback",
+        "verifier",
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add device-code authentication for OpenAI subscription login while keeping browser OAuth as the default.
- Thread the auth method through LLM.subscription_login and OpenAISubscriptionAuth.login.
- Update the subscription example so remote/headless users can select device-code login with environment variables.
- Add tests for device-code request, polling, and credential persistence.

## Validation
- uv run ruff check examples/01_standalone_sdk/35_subscription_login.py openhands-sdk/openhands/sdk/llm/auth/openai.py openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/auth/test_openai.py
- uv run pytest tests/sdk/llm/test_subscription_mode.py tests/sdk/llm/auth/test_openai.py -q
- Manually verified that the real OpenAI device-code endpoint returns a verification URL, user code, device auth id, and polling interval.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:888fea8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-888fea8-python \
  ghcr.io/openhands/agent-server:888fea8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:888fea8-golang-amd64
ghcr.io/openhands/agent-server:888fea8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:888fea8-golang-arm64
ghcr.io/openhands/agent-server:888fea8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:888fea8-java-amd64
ghcr.io/openhands/agent-server:888fea8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:888fea8-java-arm64
ghcr.io/openhands/agent-server:888fea8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:888fea8-python-amd64
ghcr.io/openhands/agent-server:888fea8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:888fea8-python-arm64
ghcr.io/openhands/agent-server:888fea8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:888fea8-golang
ghcr.io/openhands/agent-server:888fea8-java
ghcr.io/openhands/agent-server:888fea8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `888fea8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `888fea8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->