### PR TITLE
feat(settings): add from_persisted loaders

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from enum import Enum
 from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, get_args, get_origin
@@ -296,6 +296,92 @@ _RequestT = TypeVar("_RequestT")
 AGENT_SETTINGS_SCHEMA_VERSION = 1
 CONVERSATION_SETTINGS_SCHEMA_VERSION = 1
 
+PersistedSettingsMigrator = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+def _copy_persisted_payload(data: Any) -> dict[str, Any]:
+    if isinstance(data, BaseModel):
+        payload = data.model_dump(mode="json")
+        if not isinstance(payload, dict):
+            raise TypeError("Persisted settings payload must serialize to a mapping.")
+        return payload
+    if isinstance(data, Mapping):
+        return dict(data)
+    raise TypeError("Persisted settings payload must be a mapping or BaseModel.")
+
+
+def _apply_persisted_migrations(
+    data: Any,
+    *,
+    current_version: int,
+    migrations: dict[int, PersistedSettingsMigrator],
+    payload_name: str,
+) -> dict[str, Any]:
+    payload = _copy_persisted_payload(data)
+    version_raw = payload.get("schema_version", 0)
+    if version_raw is None:
+        version = 0
+    elif isinstance(version_raw, int) and not isinstance(version_raw, bool):
+        version = version_raw
+    else:
+        raise TypeError(
+            f"{payload_name} schema_version must be an integer, got "
+            f"{type(version_raw).__name__}."
+        )
+
+    if version < 0:
+        raise ValueError(f"{payload_name} schema_version must be non-negative.")
+    if version > current_version:
+        raise ValueError(
+            f"{payload_name} schema_version {version} is newer than supported "
+            f"version {current_version}."
+        )
+
+    while version < current_version:
+        migrate = migrations.get(version)
+        if migrate is None:
+            raise ValueError(
+                f"No migration registered for {payload_name} schema_version {version}."
+            )
+        payload = migrate(dict(payload))
+        next_version = payload.get("schema_version")
+        if not isinstance(next_version, int) or isinstance(next_version, bool):
+            raise ValueError(
+                f"Migration for {payload_name} schema_version {version} did not "
+                "produce a valid integer schema_version."
+            )
+        if next_version <= version:
+            raise ValueError(
+                f"Migration for {payload_name} schema_version {version} did not "
+                "advance the schema_version."
+            )
+        version = next_version
+
+    return payload
+
+
+def _migrate_agent_settings_v0_to_v1(payload: dict[str, Any]) -> dict[str, Any]:
+    migrated = dict(payload)
+    migrated["schema_version"] = 1
+    migrated.setdefault("agent_kind", _agent_settings_discriminator(migrated))
+    return migrated
+
+
+def _migrate_conversation_settings_v0_to_v1(
+    payload: dict[str, Any],
+) -> dict[str, Any]:
+    migrated = dict(payload)
+    migrated["schema_version"] = 1
+    return migrated
+
+
+_AGENT_SETTINGS_MIGRATIONS: dict[int, PersistedSettingsMigrator] = {
+    0: _migrate_agent_settings_v0_to_v1,
+}
+_CONVERSATION_SETTINGS_MIGRATIONS: dict[int, PersistedSettingsMigrator] = {
+    0: _migrate_conversation_settings_v0_to_v1,
+}
+
 
 class ConversationSettings(BaseModel):
     schema_version: int = Field(default=CONVERSATION_SETTINGS_SCHEMA_VERSION, ge=1)
@@ -400,6 +486,17 @@ class ConversationSettings(BaseModel):
     def export_schema(cls) -> SettingsSchema:
         """Export a structured schema describing configurable conversation settings."""
         return export_settings_schema(cls)
+
+    @classmethod
+    def from_persisted(cls, data: Any) -> ConversationSettings:
+        """Load persisted conversation settings, applying any schema migrations."""
+        payload = _apply_persisted_migrations(
+            data,
+            current_version=CONVERSATION_SETTINGS_SCHEMA_VERSION,
+            migrations=_CONVERSATION_SETTINGS_MIGRATIONS,
+            payload_name="ConversationSettings",
+        )
+        return cls.model_validate(payload)
 
     def _build_confirmation_policy(self):
         from openhands.sdk.security.confirmation_policy import (
@@ -960,6 +1057,17 @@ class AgentSettings(LLMAgentSettings):
     Scheduled for removal in v1.22.0 (5 minor releases after the
     discriminated-union landing in v1.17.1).
     """
+
+    @classmethod
+    def from_persisted(cls, data: Any) -> LLMAgentSettings | ACPAgentSettings:
+        """Load persisted agent settings, applying any schema migrations."""
+        payload = _apply_persisted_migrations(
+            data,
+            current_version=AGENT_SETTINGS_SCHEMA_VERSION,
+            migrations=_AGENT_SETTINGS_MIGRATIONS,
+            payload_name="AgentSettings",
+        )
+        return validate_agent_settings(payload)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         from openhands.sdk.utils.deprecation import warn_deprecated

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1,5 +1,6 @@
 import warnings
 
+import pytest
 from fastmcp.mcp_config import MCPConfig
 from pydantic import SecretStr
 
@@ -303,6 +304,47 @@ def test_validate_agent_settings_dispatches_on_agent_kind() -> None:
     )
     assert isinstance(acp, ACPAgentSettings)
     assert acp.acp_command == ["npx", "-y", "claude-agent-acp"]
+
+
+def test_agent_settings_from_persisted_migrates_v0_llm_payload() -> None:
+    settings = AgentSettings.from_persisted({"llm": {"model": "test-model"}})
+
+    assert isinstance(settings, LLMAgentSettings)
+    assert settings.schema_version == 1
+    assert settings.agent_kind == "llm"
+    assert settings.llm.model == "test-model"
+
+
+def test_agent_settings_from_persisted_dispatches_current_acp_payload() -> None:
+    settings = AgentSettings.from_persisted(
+        {
+            "schema_version": 1,
+            "agent_kind": "acp",
+            "acp_command": ["npx", "-y", "claude-agent-acp"],
+            "acp_model": "claude-opus-4-6",
+        }
+    )
+
+    assert isinstance(settings, ACPAgentSettings)
+    assert settings.schema_version == 1
+    assert settings.acp_command == ["npx", "-y", "claude-agent-acp"]
+
+
+def test_agent_settings_from_persisted_rejects_newer_schema_version() -> None:
+    with pytest.raises(ValueError, match="newer than supported version 1"):
+        AgentSettings.from_persisted({"schema_version": 2, "llm": {"model": "m"}})
+
+
+def test_conversation_settings_from_persisted_migrates_v0_payload() -> None:
+    settings = ConversationSettings.from_persisted({"max_iterations": 42})
+
+    assert settings.schema_version == 1
+    assert settings.max_iterations == 42
+
+
+def test_conversation_settings_from_persisted_rejects_newer_schema_version() -> None:
+    with pytest.raises(ValueError, match="newer than supported version 1"):
+        ConversationSettings.from_persisted({"schema_version": 2})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add persisted-settings migration helpers that upgrade versioned settings payloads before validation
- expose `AgentSettings.from_persisted(...)` and `ConversationSettings.from_persisted(...)` for consumers loading stored settings
- cover v0 migration and unsupported future-version failures in unit tests

## Testing
- `uv run pytest tests/sdk/test_settings.py -q`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/settings/model.py tests/sdk/test_settings.py`

Closes #2788

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:054bbd4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-054bbd4-python \
  ghcr.io/openhands/agent-server:054bbd4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:054bbd4-golang-amd64
ghcr.io/openhands/agent-server:054bbd4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:054bbd4-golang-arm64
ghcr.io/openhands/agent-server:054bbd4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:054bbd4-java-amd64
ghcr.io/openhands/agent-server:054bbd4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:054bbd4-java-arm64
ghcr.io/openhands/agent-server:054bbd4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:054bbd4-python-amd64
ghcr.io/openhands/agent-server:054bbd4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:054bbd4-python-arm64
ghcr.io/openhands/agent-server:054bbd4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:054bbd4-golang
ghcr.io/openhands/agent-server:054bbd4-java
ghcr.io/openhands/agent-server:054bbd4-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `054bbd4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `054bbd4-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->