### PR TITLE
Support LMNR_BASE_URL when set

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -49,13 +49,16 @@ def maybe_init_laminar():
     OTEL_EXPORTER=otlp_http # or otlp_grpc
     ```
 
-    For self-hosted Laminar, set the ports via environment variables:
+    For self-hosted Laminar, set the base URL and ports via environment variables:
+    LMNR_BASE_URL=https://api.lmnr.ai  # optional, defaults to https://api.lmnr.ai
     LMNR_HTTP_PORT=8000
     LMNR_GRPC_PORT=8001
     """
+    base_url = get_env("LMNR_BASE_URL") or None
     if should_enable_observability():
         if _is_otel_backend_laminar():
             Laminar.initialize(
+                base_url=base_url,
                 http_port=_get_int_env("LMNR_HTTP_PORT"),
                 grpc_port=_get_int_env("LMNR_GRPC_PORT"),
             )

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -1,0 +1,126 @@
+"""Tests for Laminar observability configuration."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("https://custom.lmnr.ai", "https://custom.lmnr.ai"),
+        ("http://localhost:8080", "http://localhost:8080"),
+        ("", None),
+        (None, None),
+    ],
+)
+def test_lmnr_base_url_parsing(env_value, expected):
+    """Test that LMNR_BASE_URL is correctly parsed and passed to Laminar."""
+    import os
+
+    # Save original value
+    original = os.environ.get("LMNR_BASE_URL")
+    original_key = os.environ.get("LMNR_PROJECT_API_KEY")
+
+    try:
+        # Set up environment
+        os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+        if env_value is not None:
+            os.environ["LMNR_BASE_URL"] = env_value
+        elif "LMNR_BASE_URL" in os.environ:
+            del os.environ["LMNR_BASE_URL"]
+
+        from openhands.sdk.observability.laminar import get_env
+
+        result = get_env("LMNR_BASE_URL")
+        if expected is None:
+            assert result is None or result == ""
+        else:
+            assert result == expected
+    finally:
+        # Restore original values
+        if original is not None:
+            os.environ["LMNR_BASE_URL"] = original
+        elif "LMNR_BASE_URL" in os.environ:
+            del os.environ["LMNR_BASE_URL"]
+        if original_key is not None:
+            os.environ["LMNR_PROJECT_API_KEY"] = original_key
+        elif "LMNR_PROJECT_API_KEY" in os.environ:
+            del os.environ["LMNR_PROJECT_API_KEY"]
+
+
+def test_lmnr_base_url_passed_to_laminar():
+    """Test that LMNR_BASE_URL is correctly passed to Laminar.initialize."""
+    import os
+
+    # Save original values
+    original_base_url = os.environ.get("LMNR_BASE_URL")
+    original_key = os.environ.get("LMNR_PROJECT_API_KEY")
+
+    try:
+        os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+        os.environ["LMNR_BASE_URL"] = "https://custom.lmnr.ai"
+
+        with patch("openhands.sdk.observability.laminar.Laminar") as mock_laminar:
+            with patch("openhands.sdk.observability.laminar.LaminarLiteLLMCallback"):
+                with patch(
+                    "openhands.sdk.observability.laminar.litellm"
+                ) as mock_litellm:
+                    mock_laminar.is_initialized.return_value = False
+                    mock_litellm.callbacks = MagicMock()
+                    from openhands.sdk.observability.laminar import maybe_init_laminar
+
+                    maybe_init_laminar()
+
+                    # Check that Laminar.initialize was called with base_url
+                    call_kwargs = mock_laminar.initialize.call_args.kwargs
+                    assert call_kwargs.get("base_url") == "https://custom.lmnr.ai"
+    finally:
+        # Restore original values
+        if original_base_url is not None:
+            os.environ["LMNR_BASE_URL"] = original_base_url
+        elif "LMNR_BASE_URL" in os.environ:
+            del os.environ["LMNR_BASE_URL"]
+        if original_key is not None:
+            os.environ["LMNR_PROJECT_API_KEY"] = original_key
+        elif "LMNR_PROJECT_API_KEY" in os.environ:
+            del os.environ["LMNR_PROJECT_API_KEY"]
+
+
+def test_lmnr_base_url_not_passed_when_empty():
+    """Test that base_url is None when LMNR_BASE_URL is not set."""
+    import os
+
+    # Save original values
+    original_base_url = os.environ.get("LMNR_BASE_URL")
+    original_key = os.environ.get("LMNR_PROJECT_API_KEY")
+
+    try:
+        os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+        if "LMNR_BASE_URL" in os.environ:
+            del os.environ["LMNR_BASE_URL"]
+
+        with patch("openhands.sdk.observability.laminar.Laminar") as mock_laminar:
+            with patch("openhands.sdk.observability.laminar.LaminarLiteLLMCallback"):
+                with patch(
+                    "openhands.sdk.observability.laminar.litellm"
+                ) as mock_litellm:
+                    mock_laminar.is_initialized.return_value = False
+                    mock_litellm.callbacks = MagicMock()
+                    from openhands.sdk.observability.laminar import maybe_init_laminar
+
+                    maybe_init_laminar()
+
+                    # Check that Laminar.initialize was called with base_url=None
+                    call_kwargs = mock_laminar.initialize.call_args.kwargs
+                    assert call_kwargs.get("base_url") is None
+    finally:
+        # Restore original values
+        if original_base_url is not None:
+            os.environ["LMNR_BASE_URL"] = original_base_url
+        elif "LMNR_BASE_URL" in os.environ:
+            del os.environ["LMNR_BASE_URL"]
+        if original_key is not None:
+            os.environ["LMNR_PROJECT_API_KEY"] = original_key
+        elif "LMNR_PROJECT_API_KEY" in os.environ:
+            del os.environ["LMNR_PROJECT_API_KEY"]


### PR DESCRIPTION
## Summary

This PR adds support for the `LMNR_BASE_URL` environment variable to allow users to point to any laminar API server instead of the default `https://api.lmnr.ai`.

## Changes

- **Modified `openhands-sdk/openhands/sdk/observability/laminar.py`**:
  - Added support for `LMNR_BASE_URL` environment variable
  - When `LMNR_BASE_URL` is set, it is passed to `Laminar.initialize()` as `base_url`
  - When `LMNR_BASE_URL` is not set (empty or None), `base_url` is `None`, allowing Laminar to use its own default

## Behavior

| LMNR_BASE_URL | Result |
|--------------|--------|
| Set (e.g., `https://custom.lmnr.ai`) | Uses the custom URL |
| Not set / Empty / None | Uses Laminar's default (`https://api.lmnr.ai`) |

## Testing

Added tests in `tests/sdk/observability/test_laminar.py` to verify:
- `LMNR_BASE_URL` is correctly parsed
- Custom URL is passed to `Laminar.initialize()`
- Empty/unset URL results in `base_url=None`

## Example Usage

```bash
# For self-hosted Laminar
export LMNR_BASE_URL=https://api.my-laminar-instance.com
export LMNR_PROJECT_API_KEY=your-api-key
```

Fixes #2950

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b64502eb-d7fb-407e-988b-2fbd5e83d756)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7f5e615-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7f5e615-python \
  ghcr.io/openhands/agent-server:7f5e615-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7f5e615-golang-amd64
ghcr.io/openhands/agent-server:7f5e615-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7f5e615-golang-arm64
ghcr.io/openhands/agent-server:7f5e615-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7f5e615-java-amd64
ghcr.io/openhands/agent-server:7f5e615-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7f5e615-java-arm64
ghcr.io/openhands/agent-server:7f5e615-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7f5e615-python-amd64
ghcr.io/openhands/agent-server:7f5e615-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7f5e615-python-arm64
ghcr.io/openhands/agent-server:7f5e615-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7f5e615-golang
ghcr.io/openhands/agent-server:7f5e615-java
ghcr.io/openhands/agent-server:7f5e615-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7f5e615-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7f5e615-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->