### PR TITLE
docs: align README setup notes with current repo workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ print("All done!")
 ```
 
 For installation instructions and detailed setup, see the [Getting Started Guide](https://docs.openhands.dev/sdk/getting-started).
+For local development from this repository, run `make build` to install the workspace dependencies and pre-commit hooks.
 
 ## Documentation
 
@@ -89,7 +90,7 @@ The documentation includes:
 - [Getting Started Guide](https://docs.openhands.dev/sdk/getting-started) - Installation and setup
 - [Architecture & Core Concepts](https://docs.openhands.dev/sdk/arch/overview) - Agents, tools, workspaces, and more
 - [Guides](https://docs.openhands.dev/sdk/guides/hello-world) - Hello World, custom tools, MCP, skills, and more
-- [API Reference](https://docs.openhands.dev/sdk/guides/agent-server/api-reference/server-details/alive) - Agent Server REST API documentation
+- [Agent Server API Reference](https://docs.openhands.dev/sdk/guides/agent-server/api-reference/server-details/alive) - REST API reference for the remote agent server
 
 ## Examples
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Use a small documentation-only PR to verify that the fork PR reviewer automation now triggers automatically on a normal opened PR.

## Summary

- mention `make build` in the README as the local repository setup command
- tighten the API-reference wording so it matches the linked Agent Server page

## Issue Number

N/A

## How to Test

I validated the edited file with:

```bash
uv run pre-commit run --files README.md
```

## Video/Screenshots

Not applicable for this docs-only change.

## Type

- [x] Docs / chore

## Notes

This PR was created specifically to confirm that the fork-PR reviewer workflow self-triggers on `opened` after the recent workflow changes.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._