### PR TITLE
ci: support fork PR QA workflow

### DIFF
--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -11,7 +11,13 @@
 name: QA Changes by OpenHands [experimental]
 
 on:
+    # Use pull_request for same-repo PRs so workflow changes can self-verify in PRs.
     pull_request:
+        types: [opened, ready_for_review, labeled, review_requested]
+    # Use pull_request_target for fork PRs.
+    # The bot token used here is intentionally scoped to PR QA/comment operations,
+    # so the remaining blast radius is bounded even though PR content is untrusted.
+    pull_request_target:
         types: [opened, ready_for_review, labeled, review_requested]
 
 permissions:
@@ -21,16 +27,35 @@ permissions:
 
 jobs:
     qa-changes:
-        # Only run for same-repo PRs (secrets aren't available for forks).
-        # Trigger conditions mirror pr-review, but use the 'qa-this' label
-        # and openhands-agent reviewer request.
+        # Run on same-repo PRs via pull_request and on fork PRs via pull_request_target.
+        # Trigger when one of the following conditions is met:
+        #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+        #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
+        #   3. The 'qa-this' label is added, OR
+        #   4. openhands-agent or all-hands-bot is requested as a reviewer
+        # Note: FIRST_TIME_CONTRIBUTOR and NONE PRs require manual trigger via label/reviewer request.
         if: |
-            github.event.pull_request.head.repo.full_name == github.repository && (
+            (
+                (
+                    github.event_name == 'pull_request' &&
+                    github.event.pull_request.head.repo.full_name == github.repository
+                ) ||
+                (
+                    github.event_name == 'pull_request_target' &&
+                    github.event.pull_request.head.repo.full_name != github.repository
+                )
+            ) &&
+            (
                 (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
                 (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
-                github.event.label.name == 'qa-this' ||
-                github.event.requested_reviewer.login == 'openhands-agent' ||
-                github.event.requested_reviewer.login == 'all-hands-bot'
+                (github.event.action == 'labeled' && github.event.label.name == 'qa-this') ||
+                (
+                    github.event.action == 'review_requested' &&
+                    (
+                        github.event.requested_reviewer.login == 'openhands-agent' ||
+                        github.event.requested_reviewer.login == 'all-hands-bot'
+                    )
+                )
             )
         concurrency:
             group: qa-changes-${{ github.event.pull_request.number }}


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The merged fork-PR review change fixed `pr-review`, but the QA workflow on `main` still only listened to same-repo `pull_request` events. A fork PR from `smolpaws` reproduced that gap immediately: review ran on `pull_request_target`, while QA only ran the `pull_request` path and skipped.

## Summary

- add `pull_request_target` routing for fork PRs in the QA workflow
- align the QA `if:` conditions with the reviewer workflow
- add a plain-English trigger summary so the routing logic is easier to audit

## Issue Number

N/A

## How to Test

I validated the workflow file with:

```bash
uv run pre-commit run --files .github/workflows/qa-changes-by-openhands.yml
```

I also reproduced the problem on fork PR `#2952`, where:
- `PR Review by OpenHands` started on `pull_request_target`
- `QA Changes by OpenHands [experimental]` only ran on `pull_request` and skipped

## Video/Screenshots

Not applicable for this workflow-only change.

## Type

- [x] Docs / chore

## Notes

After this PR is pushed, the plan is to open a second fork PR against this branch to verify that QA now self-triggers on the fork path too.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1c458cf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1c458cf-python \
  ghcr.io/openhands/agent-server:1c458cf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1c458cf-golang-amd64
ghcr.io/openhands/agent-server:1c458cf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1c458cf-golang-arm64
ghcr.io/openhands/agent-server:1c458cf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1c458cf-java-amd64
ghcr.io/openhands/agent-server:1c458cf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1c458cf-java-arm64
ghcr.io/openhands/agent-server:1c458cf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1c458cf-python-amd64
ghcr.io/openhands/agent-server:1c458cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1c458cf-python-arm64
ghcr.io/openhands/agent-server:1c458cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1c458cf-golang
ghcr.io/openhands/agent-server:1c458cf-java
ghcr.io/openhands/agent-server:1c458cf-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1c458cf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1c458cf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->