### PR TITLE
docs: align README setup notes with current repo workflow (qa fork test)

### DIFF
--- a/.github/workflows/qa-changes-by-openhands.yml
+++ b/.github/workflows/qa-changes-by-openhands.yml
@@ -11,7 +11,13 @@
 name: QA Changes by OpenHands [experimental]
 
 on:
+    # Use pull_request for same-repo PRs so workflow changes can self-verify in PRs.
     pull_request:
+        types: [opened, ready_for_review, labeled, review_requested]
+    # Use pull_request_target for fork PRs.
+    # The bot token used here is intentionally scoped to PR QA/comment operations,
+    # so the remaining blast radius is bounded even though PR content is untrusted.
+    pull_request_target:
         types: [opened, ready_for_review, labeled, review_requested]
 
 permissions:
@@ -21,16 +27,35 @@ permissions:
 
 jobs:
     qa-changes:
-        # Only run for same-repo PRs (secrets aren't available for forks).
-        # Trigger conditions mirror pr-review, but use the 'qa-this' label
-        # and openhands-agent reviewer request.
+        # Run on same-repo PRs via pull_request and on fork PRs via pull_request_target.
+        # Trigger when one of the following conditions is met:
+        #   1. A new non-draft PR is opened by a non-first-time contributor, OR
+        #   2. A draft PR is converted to ready for review by a non-first-time contributor, OR
+        #   3. The 'qa-this' label is added, OR
+        #   4. openhands-agent or all-hands-bot is requested as a reviewer
+        # Note: FIRST_TIME_CONTRIBUTOR and NONE PRs require manual trigger via label/reviewer request.
         if: |
-            github.event.pull_request.head.repo.full_name == github.repository && (
+            (
+                (
+                    github.event_name == 'pull_request' &&
+                    github.event.pull_request.head.repo.full_name == github.repository
+                ) ||
+                (
+                    github.event_name == 'pull_request_target' &&
+                    github.event.pull_request.head.repo.full_name != github.repository
+                )
+            ) &&
+            (
                 (github.event.action == 'opened' && github.event.pull_request.draft == false && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
                 (github.event.action == 'ready_for_review' && github.event.pull_request.author_association != 'FIRST_TIME_CONTRIBUTOR' && github.event.pull_request.author_association != 'NONE') ||
-                github.event.label.name == 'qa-this' ||
-                github.event.requested_reviewer.login == 'openhands-agent' ||
-                github.event.requested_reviewer.login == 'all-hands-bot'
+                (github.event.action == 'labeled' && github.event.label.name == 'qa-this') ||
+                (
+                    github.event.action == 'review_requested' &&
+                    (
+                        github.event.requested_reviewer.login == 'openhands-agent' ||
+                        github.event.requested_reviewer.login == 'all-hands-bot'
+                    )
+                )
             )
         concurrency:
             group: qa-changes-${{ github.event.pull_request.number }}

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ print("All done!")
 ```
 
 For installation instructions and detailed setup, see the [Getting Started Guide](https://docs.openhands.dev/sdk/getting-started).
+For local development from this repository, run `make build` to install the workspace dependencies and pre-commit hooks.
 
 ## Documentation
 
@@ -89,7 +90,7 @@ The documentation includes:
 - [Getting Started Guide](https://docs.openhands.dev/sdk/getting-started) - Installation and setup
 - [Architecture & Core Concepts](https://docs.openhands.dev/sdk/arch/overview) - Agents, tools, workspaces, and more
 - [Guides](https://docs.openhands.dev/sdk/guides/hello-world) - Hello World, custom tools, MCP, skills, and more
-- [API Reference](https://docs.openhands.dev/sdk/guides/agent-server/api-reference/server-details/alive) - Agent Server REST API documentation
+- [Agent Server API Reference](https://docs.openhands.dev/sdk/guides/agent-server/api-reference/server-details/alive) - REST API reference for the remote agent server
 
 ## Examples
 


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

This PR exists only to verify that the updated fork-compatible QA workflow triggers automatically when the base branch contains the QA fix.

## Summary

- mention `make build` in the README as the local repository setup command
- tighten the API-reference wording so it matches the linked Agent Server page

## Issue Number

N/A

## How to Test

I validated the edited file with:

```bash
uv run pre-commit run --files README.md
```

## Video/Screenshots

Not applicable for this docs-only change.

## Type

- [x] Docs / chore

## Notes

This PR targets `enable-fork-qa-workflow` specifically so the fork `pull_request_target` QA path can be verified before merge.

_This PR was created by an AI assistant (OpenHands) on behalf of the user._