### PR TITLE
feat(mcp): add MCPInitializationError for graceful CLI recovery

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -29,6 +29,7 @@ from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.model_prompt_spec import get_model_prompt_spec
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp import create_mcp_tools
+from openhands.sdk.mcp.exceptions import MCPInitializationError
 from openhands.sdk.tool import (
     BUILT_IN_TOOL_CLASSES,
     BUILT_IN_TOOLS,
@@ -470,8 +471,20 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
 
             # Collect results as they complete
             for future in futures:
-                result = future.result()
-                tools.extend(result)
+                try:
+                    result = future.result()
+                    tools.extend(result)
+                except MCPInitializationError:
+                    # Re-raise MCPInitializationError as-is for CLI to handle
+                    raise
+                except Exception as e:
+                    # Wrap other MCP-related exceptions
+                    if self.mcp_config and "MCP" in type(e).__name__:
+                        raise MCPInitializationError(
+                            f"Failed to initialize MCP tools: {e}",
+                            cause=e,
+                        ) from e
+                    raise
 
         logger.info(
             f"Loaded {len(tools)} tools from spec: {[tool.name for tool in tools]}"

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -53,6 +53,7 @@ from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
+from openhands.sdk.mcp.exceptions import MCPInitializationError
 from openhands.sdk.skills.utils import expand_mcp_variables
 from openhands.sdk.subagent import (
     AgentDefinition,
@@ -487,13 +488,19 @@ class LocalConversation(BaseConversation):
         if merged_mcp:
             # Pass the registry's lookup method as a callback - secrets are retrieved
             # lazily, one at a time, only when actually referenced in the config
-            merged_mcp = expand_mcp_variables(
-                merged_mcp,
-                {},
-                get_secret=self._state.secret_registry.get_secret_value,
-                expand_defaults=True,
-            )
-            logger.debug("Expanded MCP config variables")
+            try:
+                merged_mcp = expand_mcp_variables(
+                    merged_mcp,
+                    {},
+                    get_secret=self._state.secret_registry.get_secret_value,
+                    expand_defaults=True,
+                )
+                logger.debug("Expanded MCP config variables")
+            except Exception as e:
+                raise MCPInitializationError(
+                    f"Failed to expand MCP configuration variables: {e}",
+                    cause=e,
+                ) from e
 
         # Update agent with merged content only if we have plugins or MCP config
         # Skip update when nothing changed to avoid unnecessary agent state mutations

--- a/openhands-sdk/openhands/sdk/mcp/__init__.py
+++ b/openhands-sdk/openhands/sdk/mcp/__init__.py
@@ -21,4 +21,6 @@ __all__ = [
     "create_mcp_tools",
     "MCPError",
     "MCPTimeoutError",
+    # MCPInitializationError is intentionally NOT exported here to avoid
+    # circular imports. Import it directly from openhands.sdk.mcp.exceptions
 ]

--- a/openhands-sdk/openhands/sdk/mcp/exceptions.py
+++ b/openhands-sdk/openhands/sdk/mcp/exceptions.py
@@ -7,6 +7,24 @@ class MCPError(Exception):
     pass
 
 
+class MCPInitializationError(MCPError):
+    """Exception raised when MCP initialization fails.
+
+    This exception is raised during MCP initialization when:
+    - MCP config serialization fails (e.g., Pydantic models not converted to dicts)
+    - MCP config validation fails
+    - Variable expansion in MCP config fails
+    - MCP server connection fails
+
+    CLI applications can catch this to offer graceful degradation,
+    e.g., retrying without MCP servers.
+    """
+
+    def __init__(self, message: str, cause: Exception | None = None):
+        self.cause = cause
+        super().__init__(message)
+
+
 class MCPTimeoutError(MCPError):
     """Exception raised when MCP operations timeout."""
 

--- a/openhands-sdk/openhands/sdk/skills/utils.py
+++ b/openhands-sdk/openhands/sdk/skills/utils.py
@@ -69,6 +69,23 @@ def find_mcp_config(skill_dir: Path) -> Path | None:
     return None
 
 
+def _serialize_for_json(obj: object) -> object:
+    """Recursively convert Pydantic models to dicts for JSON serialization.
+
+    This handles the case where MCP config contains Pydantic model objects
+    (RemoteMCPServer, StdioMCPServer) instead of plain dicts.
+    """
+    # Check for Pydantic v2 model_dump method
+    model_dump = getattr(obj, "model_dump", None)
+    if callable(model_dump):
+        return model_dump()
+    elif isinstance(obj, dict):
+        return {k: _serialize_for_json(v) for k, v in obj.items()}
+    elif isinstance(obj, list):
+        return [_serialize_for_json(item) for item in obj]
+    return obj
+
+
 def expand_mcp_variables(
     config: dict,
     variables: dict[str, str],
@@ -89,7 +106,9 @@ def expand_mcp_variables(
     4. Default value (if specified and expand_defaults=True)
 
     Args:
-        config: MCP configuration dictionary.
+        config: MCP configuration dictionary. May contain Pydantic model objects
+            (e.g., RemoteMCPServer, StdioMCPServer) which will be converted to
+            dicts before JSON serialization.
         variables: Dictionary of variable names to values (e.g., SKILL_ROOT).
         get_secret: Callback to look up a secret by name. We use a callback
             rather than a dict to avoid extracting all secrets into plain text.
@@ -101,8 +120,10 @@ def expand_mcp_variables(
     Returns:
         Configuration with variables expanded.
     """
+    # Convert Pydantic models to dicts before JSON serialization
+    serializable_config = _serialize_for_json(config)
     # Convert to JSON string for easy replacement
-    config_str = json.dumps(config)
+    config_str = json.dumps(serializable_config)
 
     # Pattern for ${VAR} or ${VAR:-default}
     var_pattern = re.compile(r"\$\{([a-zA-Z_][a-zA-Z0-9_]*)(?::-([^}]*))?\}")

--- a/tests/sdk/skills/test_mcp_config_expansion.py
+++ b/tests/sdk/skills/test_mcp_config_expansion.py
@@ -197,6 +197,38 @@ class TestExpandMcpVariables:
 
         assert result["mcpServers"]["test-server"]["url"] == "/path/api"
 
+    def test_expand_with_pydantic_mcp_server_objects(self):
+        """Test that Pydantic MCP server objects are properly serialized.
+
+        When MCP config contains Pydantic models (RemoteMCPServer, StdioMCPServer)
+        instead of plain dicts, they should be converted to dicts automatically.
+        This regression test covers the fix for:
+        TypeError: Object of type RemoteMCPServer is not JSON serializable
+        """
+        from fastmcp.mcp_config import RemoteMCPServer, StdioMCPServer
+
+        config = {
+            "mcpServers": {
+                "Notion": RemoteMCPServer(
+                    url="https://mcp.notion.com/mcp",
+                    headers={},
+                    auth="oauth",
+                ),
+                "fetch": StdioMCPServer(
+                    command="uvx",
+                    args=["mcp-server-fetch"],
+                ),
+            }
+        }
+
+        # This should not raise TypeError
+        result = expand_mcp_variables(config, {})
+
+        # Verify the result is a plain dict with expected values
+        assert result["mcpServers"]["Notion"]["url"] == "https://mcp.notion.com/mcp"
+        assert result["mcpServers"]["fetch"]["command"] == "uvx"
+        assert result["mcpServers"]["fetch"]["args"] == ["mcp-server-fetch"]
+
 
 class TestLoadMcpConfigWithSecrets:
     """Tests for load_mcp_config function with secrets."""


### PR DESCRIPTION
## Summary

Add `MCPInitializationError` exception that is raised when MCP initialization fails during the first message to an agent. This allows CLI applications to catch this specific exception and offer graceful degradation (e.g., retry without MCP servers).

## Problem

When MCP initialization fails (e.g., serialization errors, connection failures, config validation), the error bubbles up as a generic exception. CLI applications cannot easily distinguish MCP failures from other errors, making it difficult to implement graceful recovery.

## Solution

1. **Add `MCPInitializationError`** to `openhands.sdk.mcp.exceptions`:
   - Inherits from `MCPError`
   - Includes a `cause` attribute that preserves the original exception for debugging
   - Intentionally NOT exported from `mcp/__init__.py` to avoid circular imports

2. **Wrap MCP initialization points**:
   - `expand_mcp_variables` errors in `local_conversation.py`
   - `create_mcp_tools` errors in `agent/base.py`

3. **Fix Pydantic serialization** (same fix as #2962):
   - Add `_serialize_for_json()` helper to handle Pydantic MCP server objects

## Usage by CLI

The CLI can now catch this specific exception:

```python
from openhands.sdk.mcp.exceptions import MCPInitializationError

try:
    conversation.send_message(message)
except MCPInitializationError as e:
    logger.warning(f"MCP initialization failed: {e}")
    # Retry without MCP
    agent = agent.model_copy(update={"mcp_config": None})
    conversation.send_message(message)
```

## Testing

- Added test for Pydantic MCP server object serialization
- All 15 MCP config expansion tests pass

## Related

- Fixes the serialization bug also addressed in #2962
- Enables CLI graceful degradation discussed in user feedback

---

*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/234d1dbb-0a23-4281-a8ba-02d9c477692d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2c303d7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2c303d7-python \
  ghcr.io/openhands/agent-server:2c303d7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2c303d7-golang-amd64
ghcr.io/openhands/agent-server:2c303d7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2c303d7-golang-arm64
ghcr.io/openhands/agent-server:2c303d7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2c303d7-java-amd64
ghcr.io/openhands/agent-server:2c303d7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2c303d7-java-arm64
ghcr.io/openhands/agent-server:2c303d7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2c303d7-python-amd64
ghcr.io/openhands/agent-server:2c303d7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2c303d7-python-arm64
ghcr.io/openhands/agent-server:2c303d7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2c303d7-golang
ghcr.io/openhands/agent-server:2c303d7-java
ghcr.io/openhands/agent-server:2c303d7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2c303d7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2c303d7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->