### PR TITLE
fix: ensure background threads have registered event loop in AsyncExecutor

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/async_executor.py
+++ b/openhands-sdk/openhands/sdk/utils/async_executor.py
@@ -29,7 +29,7 @@ class AsyncExecutor:
     def _ensure_portal(self):
         with self._lock:
             if self._portal is None:
-                self._portal_cm = start_blocking_portal()
+                self._portal_cm = start_blocking_portal(backend="asyncio")
                 self._portal = self._portal_cm.__enter__()
                 # Register atexit handler to ensure cleanup on interpreter shutdown
                 if not self._atexit_registered:
@@ -57,14 +57,20 @@ class AsyncExecutor:
     ) -> Any:
         """
         Run a coroutine or async function from sync code.
-
-        Args:
-            awaitable_or_fn: coroutine or async function
-            *args: positional arguments (only used if awaitable_or_fn is a function)
-            timeout: optional timeout in seconds
-            **kwargs: keyword arguments (only used if awaitable_or_fn is a function)
         """
         portal = self._ensure_portal()
+
+        # Ensure the current thread has access to the portal's loop
+        # This fixes errors in sub-agents and libraries that call asyncio.get_event_loop()
+        try:
+            import asyncio
+            asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                # If no loop is running in this thread, associate it with the portal's loop
+                asyncio.set_event_loop(portal._event_loop)
+            except Exception:
+                pass
 
         # Construct coroutine
         if inspect.iscoroutine(awaitable_or_fn):


### PR DESCRIPTION
**Problem:** Libraries that rely on `asyncio.get_event_loop()` (like `litellm` or `httpx`) crash when called from OpenHands' background worker threads because those threads lack a registered loop, even when the portal loop is running.

**Solution:** 
1. Forced the `BlockingPortal` to use the `asyncio` backend.
2. In `run_async`, automatically associate the current worker thread with the portal's event loop if no loop is already running.

**Testing:** Verified that subagents (which initialize their own async stacks) can now run in CLI mode without `RuntimeError: no running event loop`.