### PR TITLE
fix(agent-server): isolate tmux temp dirs per server instance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,8 @@ When reviewing code, provide constructive feedback:
 - Workspace-wide uv resolver guardrails belong in the repository root `[tool.uv]` table. When `exclude-newer` is configured there, `uv lock` persists it into the root `uv.lock` `[options]` section as both an absolute cutoff and `exclude-newer-span`, and `uv sync --frozen` continues to use that locked workspace state.
 - `pr-review-by-openhands` delegates to `OpenHands/extensions/plugins/pr-review@main`. Repo-specific reviewer instructions live in `.agents/skills/custom-codereview-guide.md`, and because task-trigger matching is substring-based, that `/codereview` skill is also auto-injected for the workflow's `/codereview-roasted` prompt.
 - The duplicate-issue automation scripts should validate `owner/repo` arguments before interpolating GitHub API paths, handle per-issue auto-close failures without aborting the whole batch, and keep `app_conversation_id` paths unquoted because OpenHands conversation IDs are already canonicalized for those endpoints.
+- `agent-server` now defaults `TMUX_TMPDIR` to a per-process directory under the system temp dir (`openhands-agent-server-<pid>`) when the environment variable is unset. This isolates tmux sockets/cleanup across concurrent server instances while still respecting an explicit `TMUX_TMPDIR` override.
+
 - Auto-title generation should not re-read `ConversationState.events` from a background task triggered by a freshly received `MessageEvent`; extract message text synchronously from the incoming event and then reuse shared title helpers (`extract_message_text`, `generate_title_from_message`) to avoid persistence-order races.
 
 

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -1,7 +1,10 @@
 import asyncio
+import os
+import tempfile
 import traceback
 from collections.abc import AsyncIterator, Sequence
 from contextlib import asynccontextmanager
+from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
@@ -51,6 +54,25 @@ from openhands.tools.terminal.constants import TMUX_SOCKET_NAME
 logger = get_logger(__name__)
 
 
+def _default_server_tmux_tmpdir() -> Path:
+    return Path(tempfile.gettempdir()) / f"openhands-agent-server-{os.getpid()}"
+
+
+def _ensure_server_tmux_tmpdir() -> tuple[Path, bool]:
+    existing = os.getenv("TMUX_TMPDIR")
+    if existing:
+        return Path(existing), False
+
+    tmux_tmpdir = _default_server_tmux_tmpdir()
+    tmux_tmpdir.mkdir(parents=True, exist_ok=True)
+    os.environ["TMUX_TMPDIR"] = str(tmux_tmpdir)
+    logger.info(
+        "TMUX_TMPDIR not set; defaulting to per-server tmux directory %s",
+        tmux_tmpdir,
+    )
+    return tmux_tmpdir, True
+
+
 def _cleanup_stale_tmux_sessions() -> None:
     """Clean up any stale tmux sessions on server startup.
 
@@ -83,101 +105,108 @@ def _cleanup_stale_tmux_sessions() -> None:
 
 @asynccontextmanager
 async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
-    # Clean up stale tmux sessions from previous server runs
-    _cleanup_stale_tmux_sessions()
+    tmux_tmpdir, tmux_tmpdir_was_defaulted = _ensure_server_tmux_tmpdir()
+    try:
+        # Clean up stale tmux sessions from previous server runs
+        _cleanup_stale_tmux_sessions()
 
-    service = get_default_conversation_service()
-    vscode_service = get_vscode_service()
-    desktop_service = get_desktop_service()
-    tool_preload_service = get_tool_preload_service()
+        service = get_default_conversation_service()
+        vscode_service = get_vscode_service()
+        desktop_service = get_desktop_service()
+        tool_preload_service = get_tool_preload_service()
 
-    # Define async functions for starting each service
-    async def start_vscode_service():
-        if vscode_service is not None:
-            vscode_started = await vscode_service.start()
-            if vscode_started:
-                logger.info("VSCode service started successfully")
+        # Define async functions for starting each service
+        async def start_vscode_service():
+            if vscode_service is not None:
+                vscode_started = await vscode_service.start()
+                if vscode_started:
+                    logger.info("VSCode service started successfully")
+                else:
+                    logger.warning(
+                        "VSCode service failed to start, continuing without VSCode"
+                    )
             else:
-                logger.warning(
-                    "VSCode service failed to start, continuing without VSCode"
-                )
-        else:
-            logger.info("VSCode service is disabled")
+                logger.info("VSCode service is disabled")
 
-    async def start_desktop_service():
-        if desktop_service is not None:
-            desktop_started = await desktop_service.start()
-            if desktop_started:
-                logger.info("Desktop service started successfully")
+        async def start_desktop_service():
+            if desktop_service is not None:
+                desktop_started = await desktop_service.start()
+                if desktop_started:
+                    logger.info("Desktop service started successfully")
+                else:
+                    logger.warning(
+                        "Desktop service failed to start, continuing without desktop"
+                    )
             else:
-                logger.warning(
-                    "Desktop service failed to start, continuing without desktop"
-                )
-        else:
-            logger.info("Desktop service is disabled")
+                logger.info("Desktop service is disabled")
 
-    async def start_tool_preload_service():
-        if tool_preload_service is not None:
-            tool_preload_started = await tool_preload_service.start()
-            if tool_preload_started:
-                logger.info("Tool preload service started successfully")
+        async def start_tool_preload_service():
+            if tool_preload_service is not None:
+                tool_preload_started = await tool_preload_service.start()
+                if tool_preload_started:
+                    logger.info("Tool preload service started successfully")
+                else:
+                    logger.warning("Tool preload service failed to start - skipping")
             else:
-                logger.warning("Tool preload service failed to start - skipping")
-        else:
-            logger.info("Tool preload service is disabled")
+                logger.info("Tool preload service is disabled")
 
-    # Start all services concurrently
-    results = await asyncio.gather(
-        start_vscode_service(),
-        start_desktop_service(),
-        start_tool_preload_service(),
-        return_exceptions=True,
-    )
-
-    # Check for any exceptions during initialization
-    exceptions = [r for r in results if isinstance(r, Exception)]
-    if exceptions:
-        logger.error(
-            "Service initialization failed with %d exception(s): %s",
-            len(exceptions),
-            exceptions,
+        # Start all services concurrently
+        results = await asyncio.gather(
+            start_vscode_service(),
+            start_desktop_service(),
+            start_tool_preload_service(),
+            return_exceptions=True,
         )
-        # Re-raise the first exception to prevent server from starting
-        raise RuntimeError(
-            f"Server initialization failed with {len(exceptions)} exception(s)"
-        ) from exceptions[0]
 
-    # Mark initialization as complete - now the /ready endpoint will return 200
-    # and Kubernetes readiness probes will pass
-    mark_initialization_complete()
-    logger.info("Server initialization complete - ready to serve requests")
-
-    async with service:
-        # Store the initialized service in app state for dependency injection
-        api.state.conversation_service = service
-        try:
-            yield
-        finally:
-            # Define async functions for stopping each service
-            async def stop_vscode_service():
-                if vscode_service is not None:
-                    await vscode_service.stop()
-
-            async def stop_desktop_service():
-                if desktop_service is not None:
-                    await desktop_service.stop()
-
-            async def stop_tool_preload_service():
-                if tool_preload_service is not None:
-                    await tool_preload_service.stop()
-
-            # Stop all services concurrently
-            await asyncio.gather(
-                stop_vscode_service(),
-                stop_desktop_service(),
-                stop_tool_preload_service(),
-                return_exceptions=True,
+        # Check for any exceptions during initialization
+        exceptions = [r for r in results if isinstance(r, Exception)]
+        if exceptions:
+            logger.error(
+                "Service initialization failed with %d exception(s): %s",
+                len(exceptions),
+                exceptions,
             )
+            # Re-raise the first exception to prevent server from starting
+            raise RuntimeError(
+                f"Server initialization failed with {len(exceptions)} exception(s)"
+            ) from exceptions[0]
+
+        # Mark initialization as complete - now the /ready endpoint will return 200
+        # and Kubernetes readiness probes will pass
+        mark_initialization_complete()
+        logger.info("Server initialization complete - ready to serve requests")
+
+        async with service:
+            # Store the initialized service in app state for dependency injection
+            api.state.conversation_service = service
+            try:
+                yield
+            finally:
+                # Define async functions for stopping each service
+                async def stop_vscode_service():
+                    if vscode_service is not None:
+                        await vscode_service.stop()
+
+                async def stop_desktop_service():
+                    if desktop_service is not None:
+                        await desktop_service.stop()
+
+                async def stop_tool_preload_service():
+                    if tool_preload_service is not None:
+                        await tool_preload_service.stop()
+
+                # Stop all services concurrently
+                await asyncio.gather(
+                    stop_vscode_service(),
+                    stop_desktop_service(),
+                    stop_tool_preload_service(),
+                    return_exceptions=True,
+                )
+    finally:
+        if tmux_tmpdir_was_defaulted and os.environ.get("TMUX_TMPDIR") == str(
+            tmux_tmpdir
+        ):
+            os.environ.pop("TMUX_TMPDIR", None)
 
 
 def _get_root_path(config: Config) -> str:

--- a/tests/agent_server/test_api.py
+++ b/tests/agent_server/test_api.py
@@ -1,6 +1,7 @@
 """Tests for the agent server API functionality."""
 
 import asyncio
+import os
 import tempfile
 import warnings
 from pathlib import Path
@@ -10,7 +11,13 @@ import pytest
 from deprecation import DeprecatedWarning
 from fastapi.testclient import TestClient
 
-from openhands.agent_server.api import _get_root_path, api_lifespan, create_app
+from openhands.agent_server.api import (
+    _default_server_tmux_tmpdir,
+    _ensure_server_tmux_tmpdir,
+    _get_root_path,
+    api_lifespan,
+    create_app,
+)
 from openhands.agent_server.config import Config
 
 
@@ -18,6 +25,41 @@ from openhands.agent_server.config import Config
 def clear_web_url_env(monkeypatch):
     monkeypatch.delenv("OH_WEB_URL", raising=False)
     monkeypatch.delenv("RUNTIME_URL", raising=False)
+    monkeypatch.delenv("TMUX_TMPDIR", raising=False)
+
+
+def test_default_server_tmux_tmpdir_uses_current_pid(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "openhands.agent_server.api.tempfile.gettempdir", lambda: str(tmp_path)
+    )
+
+    assert _default_server_tmux_tmpdir() == (
+        tmp_path / f"openhands-agent-server-{os.getpid()}"
+    )
+
+
+def test_ensure_server_tmux_tmpdir_defaults_per_process_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "openhands.agent_server.api.tempfile.gettempdir", lambda: str(tmp_path)
+    )
+
+    tmux_tmpdir, was_defaulted = _ensure_server_tmux_tmpdir()
+
+    assert was_defaulted is True
+    assert tmux_tmpdir == tmp_path / f"openhands-agent-server-{os.getpid()}"
+    assert tmux_tmpdir.is_dir()
+    assert os.environ["TMUX_TMPDIR"] == str(tmux_tmpdir)
+
+
+def test_ensure_server_tmux_tmpdir_respects_existing_env(tmp_path, monkeypatch):
+    existing = tmp_path / "custom-tmux"
+    monkeypatch.setenv("TMUX_TMPDIR", str(existing))
+
+    tmux_tmpdir, was_defaulted = _ensure_server_tmux_tmpdir()
+
+    assert was_defaulted is False
+    assert tmux_tmpdir == existing
+    assert not existing.exists()
 
 
 class TestStaticFilesServing:
@@ -362,6 +404,35 @@ class TestServiceParallelization:
 
             # Verify conversation service was set up
             assert mock_app.state.conversation_service == mock_conversation_service
+
+    async def test_lifespan_defaults_and_restores_tmux_tmpdir(
+        self, tmp_path, monkeypatch
+    ):
+        """Test that lifespan defaults TMUX_TMPDIR per server instance."""
+        monkeypatch.setattr(
+            "openhands.agent_server.api.tempfile.gettempdir", lambda: str(tmp_path)
+        )
+        mock_conversation_service = AsyncMock()
+
+        with (
+            patch(
+                "openhands.agent_server.api.get_default_conversation_service",
+                return_value=mock_conversation_service,
+            ),
+            patch("openhands.agent_server.api.get_vscode_service", return_value=None),
+            patch("openhands.agent_server.api.get_desktop_service", return_value=None),
+            patch(
+                "openhands.agent_server.api.get_tool_preload_service", return_value=None
+            ),
+        ):
+            mock_app = AsyncMock()
+            mock_app.state = AsyncMock()
+            expected_tmux_tmpdir = tmp_path / f"openhands-agent-server-{os.getpid()}"
+
+            async with api_lifespan(mock_app):
+                assert os.environ["TMUX_TMPDIR"] == str(expected_tmux_tmpdir)
+
+            assert "TMUX_TMPDIR" not in os.environ
 
 
 class TestRootPath:


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Starting a second `agent-server` in the same sandbox can collide with an existing server's tmux state because current releases share the default tmux namespace when `TMUX_TMPDIR` is unset. In practice this can break live terminal sessions with errors like:

`Error executing tool 'terminal': ['no server running on /tmp/tmux-10001/openhands']`

This patch makes the default tmux directory per-server-instance so startup cleanup and terminal sessions are isolated across concurrent `agent-server` processes unless an operator explicitly overrides `TMUX_TMPDIR`.

## Summary

- default `TMUX_TMPDIR` to a per-process directory (`.../openhands-agent-server-<pid>`) when it is unset
- run tmux startup cleanup and terminal activity inside that per-server tmux directory while preserving explicit `TMUX_TMPDIR` overrides
- add regression coverage for helper behavior and lifespan setup/teardown

## Issue Number

Closes #2965

## How to Test

### Reproduction evidence before the fix

I used an uploaded real conversation history from OpenHands Cloud (`conversation_36192ab845544cdd95d8f335af75e0f4.zip`) that showed a previously healthy terminal session failing mid-run with:

`Error executing tool 'terminal': ['no server running on /tmp/tmux-10001/openhands']`

I also confirmed matching Datadog hits in evaluation (`service:eval-agent-server`) for the same error string, plus the existing upstream issue report in #2965.

### Validation after the fix

Run targeted tests:

```bash
uv run pytest tests/agent_server/test_api.py -q
```

Expected result:

```text
38 passed, 1 warning in 2.82s
```

Run pre-commit on the touched files:

```bash
uv run pre-commit run --files AGENTS.md openhands-agent-server/openhands/agent_server/api.py tests/agent_server/test_api.py
```

Expected result:

```text
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
Check import dependency rules............................................Passed
Check Tool subclass registration.........................................Passed
```

Run a direct lifespan proof to verify the default tmux directory is process-scoped and restored afterward:

```bash
uv run python - <<'PY'
import asyncio, os, tempfile
from pathlib import Path
from unittest.mock import AsyncMock, patch
from openhands.agent_server.api import api_lifespan

async def main():
    tmp = tempfile.mkdtemp(prefix='tmux-proof-')
    mock_conversation_service = AsyncMock()
    mock_app = AsyncMock()
    mock_app.state = AsyncMock()
    with (
        patch('openhands.agent_server.api.tempfile.gettempdir', lambda: tmp),
        patch('openhands.agent_server.api.get_default_conversation_service', return_value=mock_conversation_service),
        patch('openhands.agent_server.api.get_vscode_service', return_value=None),
        patch('openhands.agent_server.api.get_desktop_service', return_value=None),
        patch('openhands.agent_server.api.get_tool_preload_service', return_value=None),
    ):
        print('before', os.environ.get('TMUX_TMPDIR'))
        async with api_lifespan(mock_app):
            current = Path(os.environ['TMUX_TMPDIR'])
            print('during', current)
            print('expected', Path(tmp) / f'openhands-agent-server-{os.getpid()}')
            print('exists', current.is_dir())
        print('after', os.environ.get('TMUX_TMPDIR'))

asyncio.run(main())
PY
```

Observed result:

```text
before None
during /tmp/tmux-proof-.../openhands-agent-server-3054
expected /tmp/tmux-proof-.../openhands-agent-server-3054
exists True
after None
```

## Video/Screenshots

N/A (backend-only change)

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- This only addresses tmux namespace collisions. Shared `conversations_path` ownership conflicts are tracked separately in #2966.
- This PR was created by an AI agent (OpenHands) on behalf of the user.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dceefd8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dceefd8-python \
  ghcr.io/openhands/agent-server:dceefd8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dceefd8-golang-amd64
ghcr.io/openhands/agent-server:dceefd8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dceefd8-golang-arm64
ghcr.io/openhands/agent-server:dceefd8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dceefd8-java-amd64
ghcr.io/openhands/agent-server:dceefd8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dceefd8-java-arm64
ghcr.io/openhands/agent-server:dceefd8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dceefd8-python-amd64
ghcr.io/openhands/agent-server:dceefd8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dceefd8-python-arm64
ghcr.io/openhands/agent-server:dceefd8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dceefd8-golang
ghcr.io/openhands/agent-server:dceefd8-java
ghcr.io/openhands/agent-server:dceefd8-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dceefd8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dceefd8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->