### PR TITLE
fix: graceful PTY reader thread shutdown to prevent 'Bad file descriptor' error

### DIFF
--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -78,6 +78,7 @@ class SubprocessTerminal(TerminalInterface):
     output_lock: threading.Lock
     reader_thread: threading.Thread | None
     _current_command_running: bool
+    _stop_reader: bool
 
     def __init__(
         self,
@@ -95,6 +96,7 @@ class SubprocessTerminal(TerminalInterface):
         self.output_lock = threading.Lock()
         self.reader_thread = None
         self._current_command_running = False
+        self._stop_reader = False
         self.shell_path = shell_path
 
     # ------------------------- Lifecycle -------------------------
@@ -197,6 +199,9 @@ class SubprocessTerminal(TerminalInterface):
         if self._closed:
             return
 
+        # Signal reader thread to stop before closing fd to prevent race condition
+        self._stop_reader = True
+
         try:
             if self.process:
                 # Try a graceful exit
@@ -251,34 +256,39 @@ class SubprocessTerminal(TerminalInterface):
         if fd is None:
             return
 
-        try:
-            while True:
-                # Exit early if process died
-                if self.process and self.process.poll() is not None:
-                    break
+        while not self._stop_reader:
+            # Exit early if process died
+            if self.process and self.process.poll() is not None:
+                break
 
-                # Use select to avoid busy spin
+            # Use select to avoid busy spin; wrap in try-except to handle
+            # the case where fd is closed during shutdown
+            try:
                 r, _, _ = select.select([fd], [], [], 0.1)
-                if not r:
-                    continue
+            except (OSError, ValueError):
+                # fd closed or invalid during shutdown - exit gracefully
+                break
 
-                try:
-                    chunk = os.read(fd, 4096)
-                    if not chunk:
-                        break  # EOF
-                    # Normalize newlines; PTY typically uses \n already
-                    text = chunk.decode("utf-8", errors="replace")
-                    with self.output_lock:
-                        # Store one line per buffer item to make deque truncation work
-                        self._add_text_to_buffer(text)
-                except OSError:
-                    # Would-block or FD closed
-                    continue
-                except Exception as e:
-                    logger.debug(f"Error reading PTY output: {e}")
+            if not r:
+                continue
+
+            try:
+                chunk = os.read(fd, 4096)
+                if not chunk:
+                    break  # EOF
+                # Normalize newlines; PTY typically uses \n already
+                text = chunk.decode("utf-8", errors="replace")
+                with self.output_lock:
+                    # Store one line per buffer item to make deque truncation work
+                    self._add_text_to_buffer(text)
+            except OSError:
+                # Would-block or FD closed - exit gracefully during shutdown
+                if self._stop_reader:
                     break
-        except Exception as e:
-            logger.error(f"PTY reader thread error: {e}", exc_info=True)
+                continue
+            except Exception as e:
+                logger.debug(f"Error reading PTY output: {e}")
+                break
 
     def _add_text_to_buffer(self, text: str) -> None:
         """Add text to buffer, ensuring one line per buffer item."""


### PR DESCRIPTION
## Summary

Fixes the "PTY reader thread error: Bad file descriptor" error that appears when the OpenHands CLI exits.

## Problem

When the CLI exits, the PTY terminal's `close()` method closes the master file descriptor while the reader thread is still running. This causes a race condition where:

1. `close()` calls `os.close(self._pty_master_fd)` 
2. The reader thread is in the middle of (or about to call) `select.select([fd], [], [], 0.1)`
3. `select()` throws `OSError: [Errno 9] Bad file descriptor`

This produces the error message:
```
[04/26/26 17:20:46] ERROR    PTY reader thread error: [Errno 9] Bad file descriptor   subprocess_terminal.py:261
```

## Solution

Added a `_stop_reader` flag to gracefully signal the reader thread to stop:

1. Added `_stop_reader: bool` instance variable (initialized to `False`)
2. In `close()`: set `self._stop_reader = True` **before** closing the fd
3. In `_read_output_continuously_pty()`:
   - Check `_stop_reader` flag in the while loop condition
   - Wrap `select()` in try-except to catch `OSError`/`ValueError` when fd is closed
   - On OSError from `os.read()`, check `_stop_reader` to exit gracefully

This ensures the reader thread exits cleanly without logging spurious errors.

## Testing

- [x] Syntax check passes
- [x] Manual testing with CLI exit

## Related

Fixes issue reported in OpenHands/OpenHands-CLI

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3c5f55ac-c95e-492d-83ad-02aa46fea8c4)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3e07431-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3e07431-python \
  ghcr.io/openhands/agent-server:3e07431-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3e07431-golang-amd64
ghcr.io/openhands/agent-server:3e07431-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3e07431-golang-arm64
ghcr.io/openhands/agent-server:3e07431-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3e07431-java-amd64
ghcr.io/openhands/agent-server:3e07431-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3e07431-java-arm64
ghcr.io/openhands/agent-server:3e07431-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3e07431-python-amd64
ghcr.io/openhands/agent-server:3e07431-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3e07431-python-arm64
ghcr.io/openhands/agent-server:3e07431-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3e07431-golang
ghcr.io/openhands/agent-server:3e07431-java
ghcr.io/openhands/agent-server:3e07431-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3e07431-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3e07431-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->