### PR TITLE
fix(sdk/conversation): preserve prompt_cache_key for sub-agent LLMs

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -624,7 +624,11 @@ class LocalConversation(BaseConversation):
 
     def _pin_prompt_cache_key(self) -> None:
         # Pin the OpenAI prefix-cache shard to this conversation (#2904, #2918).
-        self.agent.llm._prompt_cache_key = str(self._state.id)
+        # Skip if a key is already set: sub-agent LLMs inherit the parent's
+        # via model_copy, and overwriting would put each sub-agent on its own
+        # shard, defeating cross-sub-agent cache reuse on OpenAI models.
+        if self.agent.llm._prompt_cache_key is None:
+            self.agent.llm._prompt_cache_key = str(self._state.id)
 
     def switch_profile(self, profile_name: str) -> None:
         """Switch the agent's LLM to a named profile.

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -371,6 +371,27 @@ class TestTaskManager:
         )
         assert conv._visualizer is None
 
+    def test_sub_agents_inherit_parent_prompt_cache_key(self, tmp_path):
+        """Sibling sub-agents share the parent's OpenAI prefix-cache shard."""
+        manager, parent = _manager_with_parent(tmp_path)
+        register_builtins_agents()
+        parent_key = parent.agent.llm._prompt_cache_key
+
+        sub_keys = []
+        for _ in range(2):
+            task_id, conversation_id = manager._generate_ids()
+            agent = manager._get_sub_agent("general-purpose")
+            conv = manager._get_conversation(
+                description=None,
+                max_iteration_per_run=500,
+                task_id=task_id,
+                conversation_id=conversation_id,
+                worker_agent=agent,
+            )
+            sub_keys.append(conv.agent.llm._prompt_cache_key)
+
+        assert sub_keys == [parent_key, parent_key]
+
 
 def _make_task_with_mock_conv(task_id: str, **conv_kwargs) -> Task:
     """Create a Task with a MagicMock conversation, bypassing Pydantic validation."""


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why
When the agent runs in sub-agent delegation mode, every sub-agent of the same type starts its first API call with 0% prompt-cache hit on OpenAI models, even when a previous sub-agent in the same run already wrote a cache entry for an identical static system prompt + tools. Each sub-agent re-pays the cache-write cost on its first turn, which is a major contributor to the cost gap between sub-agent mode and single-agent mode.
                        
Wire-level dumps confirmed the cause: LocalConversation._pin_prompt_cache_key() overwrites the LLM's _prompt_cache_key with the per-conversation UUID. Sub-agent LLMs are created via parent.llm.model_copy() (which preserves the parent's key as a private attribute), but the sub-conversation's __init__ then immediately re-pins, so each sibling sub-agent ships a different prompt_cache_key and lands on a different OpenAI cache shard. Anthropic was unaffected because its caching is content-keyed; OpenAI uses the key for shard routing.          

## Summary

- Skip _pin_prompt_cache_key when the LLM already has a key, so sub-agent LLMs keep the parent's key (inherited via model_copy) and siblings share a cache shard.                                                                      
- Top-level conversations and switch_profile are unaffected: the new LLM's key is None, so it still gets pinned to the conversation id.
- Added a regression test asserting two sibling sub-agents both inherit the parent's _prompt_cache_key. 

## Issue Number
#2972

## Experiment

Wrote a small repro that monkey-patches LLM.completion and LLM.responses to dump every outgoing payload + per-call cache_read_tokens / cache_write_tokens, then has a parent delegate to the same sub-agent type twice (two separate TaskActions, no resume). Ran it against and GPT-5.4.

```text
------- BEFORE
  call-001-parent-responses.json  cache_read=0  cache_write=0  prompt_cache_key=4969073f-6e5f-43fa-bc27-c51666800435
  call-002-parent-responses.json  cache_read=4224  cache_write=0  prompt_cache_key=4969073f-6e5f-43fa-bc27-c51666800435
  -> call-003-sub#1-responses.json  cache_read=0  cache_write=0  prompt_cache_key=24e4386e-f792-4eec-abc4-252144c1e67a
  call-004-parent-responses.json  cache_read=4480  cache_write=0  prompt_cache_key=4969073f-6e5f-43fa-bc27-c51666800435
  -> call-005-sub#2-responses.json  cache_read=0  cache_write=0  prompt_cache_key=7733aa61-d46c-447e-9360-d7de82648ce0
  call-006-parent-responses.json  cache_read=4864  cache_write=0  prompt_cache_key=4969073f-6e5f-43fa-bc27-c51666800435

------- AFTER
  call-001-parent-responses.json  cache_read=0  cache_write=0  prompt_cache_key=cf1e519a-6b9a-4103-bdd6-2e3e2f112a13
  -> call-002-sub#1-responses.json  cache_read=0  cache_write=0  prompt_cache_key=cf1e519a-6b9a-4103-bdd6-2e3e2f112a13
  call-003-parent-responses.json  cache_read=4224  cache_write=0  prompt_cache_key=cf1e519a-6b9a-4103-bdd6-2e3e2f112a13
  -> call-004-sub#2-responses.json  cache_read=2048  cache_write=0  prompt_cache_key=cf1e519a-6b9a-4103-bdd6-2e3e2f112a13
  call-005-parent-responses.json  cache_read=4608  cache_write=0  prompt_cache_key=cf1e519a-6b9a-4103-bdd6-2e3e2f112a13
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1de6244-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1de6244-python \
  ghcr.io/openhands/agent-server:1de6244-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1de6244-golang-amd64
ghcr.io/openhands/agent-server:1de6244-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1de6244-golang-arm64
ghcr.io/openhands/agent-server:1de6244-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1de6244-java-amd64
ghcr.io/openhands/agent-server:1de6244-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1de6244-java-arm64
ghcr.io/openhands/agent-server:1de6244-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1de6244-python-amd64
ghcr.io/openhands/agent-server:1de6244-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1de6244-python-arm64
ghcr.io/openhands/agent-server:1de6244-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1de6244-golang
ghcr.io/openhands/agent-server:1de6244-java
ghcr.io/openhands/agent-server:1de6244-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1de6244-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1de6244-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->