### PR TITLE
feat(acp): secrets in agent_context — prompt awareness + subprocess injection

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -56,6 +56,7 @@ from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
 from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
+from openhands.sdk.secret import SecretSource
 from openhands.sdk.tool import Tool  # noqa: TC002
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishObservation
 
@@ -885,6 +886,20 @@ class ACPAgent(AgentBase):
         env = default_environment()
         env.update(os.environ)
         env.update(self.acp_env)
+        # Inject secrets from agent_context. acp_env entries take precedence
+        # (already set above), so we only fill keys not already present.
+        # SecretSource.get_value() is synchronous; calling it here is safe
+        # because _start_acp_server is a regular (non-async) method.
+        if self.agent_context and self.agent_context.secrets:
+            for name, secret in self.agent_context.secrets.items():
+                if name not in env:
+                    value = (
+                        secret.get_value()
+                        if isinstance(secret, SecretSource)
+                        else str(secret)
+                    )
+                    if value:
+                        env[name] = value
         # Strip CLAUDECODE so nested Claude Code instances don't refuse to start
         env.pop("CLAUDECODE", None)
 

--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -95,7 +95,7 @@ class AgentContext(BaseModel):
             "Values can be either strings or SecretSource instances "
             "(str | SecretSource)."
         ),
-        json_schema_extra={"acp_compatible": False},
+        json_schema_extra={"acp_compatible": True},
     )
     current_datetime: datetime | str | None = Field(
         default_factory=datetime.now,
@@ -316,20 +316,24 @@ class AgentContext(BaseModel):
 
         ACP servers own their tools, MCP servers, hooks, and execution model, so
         this adapter only emits prompt-only context.  Unsupported AgentContext
-        semantics (e.g. secrets) are rejected by
-        :meth:`validate_acp_compatibility`.
+        fields are rejected by :meth:`validate_acp_compatibility`.
 
         The rendering reuses :meth:`get_system_message_suffix` with the same
         ``system_message_suffix.j2`` template so that ACP agents receive the
-        identical prompt layout as the general agent (minus secrets).
+        identical prompt layout as the regular agent.  This includes the
+        ``<CUSTOM_SECRETS>`` block when secrets are present, informing the ACP
+        subprocess which environment variables are available.  The actual secret
+        values are injected into the subprocess environment by
+        ``ACPAgent._start_acp_server``; the prompt block only advertises their
+        names so the agent knows to use them.
 
         ``user_message_suffix`` is a compatible field but is not emitted here
         because ``LocalConversation`` already applies it through
         ``event.to_llm_message()``; including it would duplicate it.
         """
         self.validate_acp_compatibility()
-        # ACP doesn't support secrets (enforced above) and has no model-specific
-        # skill filtering, so we delegate to the shared renderer with no extras.
+        # No model-specific skill filtering for ACP — delegate to the shared
+        # renderer which also renders the <CUSTOM_SECRETS> block from secrets.
         return self.get_system_message_suffix()
 
     def get_user_message_suffix(

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -934,14 +934,6 @@ class ACPAgentSettings(BaseModel):
             ).model_dump(),
         },
     )
-    agent_context: AgentContext | None = Field(
-        default=None,
-        description=(
-            "Optional prompt-only context injected into each ACP user turn. "
-            "Secrets in agent_context are resolved to plain strings and injected "
-            "into the subprocess environment at start time."
-        ),
-    )
     llm: LLM = Field(
         default_factory=_default_llm_settings,
         description=(
@@ -1002,7 +994,6 @@ class ACPAgentSettings(BaseModel):
             acp_model=self.acp_model,
             acp_session_mode=self.acp_session_mode,
             acp_prompt_timeout=self.acp_prompt_timeout,
-            agent_context=self.agent_context,
         )
 
 

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -934,6 +934,14 @@ class ACPAgentSettings(BaseModel):
             ).model_dump(),
         },
     )
+    agent_context: AgentContext | None = Field(
+        default=None,
+        description=(
+            "Optional prompt-only context injected into each ACP user turn. "
+            "Secrets in agent_context are resolved to plain strings and injected "
+            "into the subprocess environment at start time."
+        ),
+    )
     llm: LLM = Field(
         default_factory=_default_llm_settings,
         description=(
@@ -994,6 +1002,7 @@ class ACPAgentSettings(BaseModel):
             acp_model=self.acp_model,
             acp_session_mode=self.acp_session_mode,
             acp_prompt_timeout=self.acp_prompt_timeout,
+            agent_context=self.agent_context,
         )
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -211,13 +211,15 @@ class TestACPAgentValidation:
 
         self._init_with_patches(agent, tmp_path)
 
-    def test_rejects_unsupported_agent_context_at_init(self, tmp_path):
+    def test_allows_agent_context_with_secrets(self, tmp_path):
+        """Secrets are now ACP-compatible: they are injected into the subprocess
+        env by _start_acp_server and advertised in the prompt via <CUSTOM_SECRETS>."""
         agent = ACPAgent(
             acp_command=["echo"],
             agent_context=AgentContext(secrets={"GITHUB_TOKEN": "ghp_secret"}),
         )
-        with pytest.raises(NotImplementedError, match="secrets"):
-            self._init_with_patches(agent, tmp_path)
+        # Should not raise
+        self._init_with_patches(agent, tmp_path)
 
     def test_agent_context_to_acp_prompt_context(self):
         context = AgentContext(
@@ -261,11 +263,30 @@ class TestACPAgentValidation:
         assert prompt is not None
         assert "<CURRENT_DATETIME>" in prompt
 
-    def test_agent_context_to_acp_prompt_context_rejects_secrets(self):
-        context = AgentContext(secrets={"GITHUB_TOKEN": "ghp_secret"})
+    def test_agent_context_to_acp_prompt_context_includes_secrets(self):
+        """Secrets appear in the ACP prompt as a <CUSTOM_SECRETS> block so the
+        ACP subprocess knows which environment variables are available."""
+        from openhands.sdk.secret import StaticSecret
+        from pydantic import SecretStr
 
-        with pytest.raises(NotImplementedError, match="secrets"):
-            context.to_acp_prompt_context()
+        context = AgentContext(
+            secrets={
+                "GITHUB_TOKEN": StaticSecret(
+                    value=SecretStr("ghp_secret"),
+                    description="GitHub authentication token",
+                ),
+                "MY_API_KEY": StaticSecret(value=SecretStr("key123")),
+            },
+            current_datetime=None,
+        )
+
+        prompt = context.to_acp_prompt_context()
+
+        assert prompt is not None
+        assert "<CUSTOM_SECRETS>" in prompt
+        assert "$GITHUB_TOKEN" in prompt
+        assert "GitHub authentication token" in prompt
+        assert "$MY_API_KEY" in prompt
 
     def test_agent_context_to_acp_prompt_context_includes_legacy_repo_skills(self):
         context = AgentContext(
@@ -3291,3 +3312,127 @@ class TestACPSessionIdPersistence:
         assert kwargs["cwd"] == str(workspace)
         conn2.new_session.assert_not_awaited()
         assert agent2._session_id == "roundtrip-sess"
+
+
+class TestACPSecretsEnvInjection:
+    """Tests for secret injection into the ACP subprocess environment.
+
+    Secrets passed via ``agent_context.secrets`` must land in the subprocess
+    env so the ACP server (Claude Code, Codex CLI, etc.) can use them.
+    ``acp_env`` entries take precedence over agent_context secrets.
+    """
+
+    @staticmethod
+    def _make_conn():
+        conn = MagicMock()
+        init_response = MagicMock()
+        init_response.agent_info = MagicMock()
+        init_response.agent_info.name = "claude-agent-acp"
+        init_response.agent_info.version = "1.0"
+        init_response.auth_methods = []
+        conn.initialize = AsyncMock(return_value=init_response)
+        new_response = MagicMock()
+        new_response.session_id = "sess-1"
+        conn.new_session = AsyncMock(return_value=new_response)
+        conn.load_session = AsyncMock(return_value=MagicMock())
+        conn.set_session_mode = AsyncMock()
+        conn.set_session_model = AsyncMock()
+        conn.authenticate = AsyncMock()
+        conn.close = AsyncMock()
+        return conn
+
+    @staticmethod
+    def _run_start_capturing_env(agent, tmp_path) -> dict:
+        """Run _start_acp_server and return the env dict passed to the subprocess."""
+        from contextlib import ExitStack
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        captured: dict = {}
+        conn = TestACPSecretsEnvInjection._make_conn()
+
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+
+        async def _fake_create_subprocess_exec(*_args, env=None, **_kwargs):
+            captured.update(env or {})
+            return mock_process
+
+        async def _fake_filter(_src, _dst):
+            return None
+
+        state = _make_state(tmp_path)
+        agent._executor = AsyncExecutor()
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                    new=_fake_create_subprocess_exec,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                    return_value=conn,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                    new=_fake_filter,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.StreamReader",
+                    return_value=MagicMock(),
+                )
+            )
+            agent._start_acp_server(state)
+
+        return captured
+
+    def test_static_secret_injected_into_subprocess_env(self, tmp_path):
+        """A StaticSecret in agent_context.secrets lands in the subprocess env."""
+        from openhands.sdk.secret import StaticSecret
+        from pydantic import SecretStr
+
+        agent = _make_agent(
+            agent_context=AgentContext(
+                secrets={
+                    "GITHUB_TOKEN": StaticSecret(
+                        value=SecretStr("ghp_test123"),
+                        description="GitHub token",
+                    )
+                }
+            )
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+        assert env.get("GITHUB_TOKEN") == "ghp_test123"
+
+    def test_acp_env_takes_precedence_over_agent_context_secret(self, tmp_path):
+        """An explicit acp_env entry wins over the same key in agent_context.secrets."""
+        from openhands.sdk.secret import StaticSecret
+        from pydantic import SecretStr
+
+        agent = _make_agent(
+            acp_env={"MY_TOKEN": "acp-env-wins"},
+            agent_context=AgentContext(
+                secrets={"MY_TOKEN": StaticSecret(value=SecretStr("secret-panel"))}
+            ),
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+        assert env.get("MY_TOKEN") == "acp-env-wins"
+
+    def test_none_value_secret_not_injected(self, tmp_path):
+        """A StaticSecret with value=None is not added to the subprocess env."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(
+            agent_context=AgentContext(
+                secrets={"ABSENT_SECRET": StaticSecret(value=None)}
+            )
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+        assert "ABSENT_SECRET" not in env

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -266,8 +266,9 @@ class TestACPAgentValidation:
     def test_agent_context_to_acp_prompt_context_includes_secrets(self):
         """Secrets appear in the ACP prompt as a <CUSTOM_SECRETS> block so the
         ACP subprocess knows which environment variables are available."""
-        from openhands.sdk.secret import StaticSecret
         from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
 
         context = AgentContext(
             secrets={
@@ -3345,6 +3346,7 @@ class TestACPSecretsEnvInjection:
     def _run_start_capturing_env(agent, tmp_path) -> dict:
         """Run _start_acp_server and return the env dict passed to the subprocess."""
         from contextlib import ExitStack
+
         from openhands.sdk.utils.async_executor import AsyncExecutor
 
         captured: dict = {}
@@ -3395,8 +3397,9 @@ class TestACPSecretsEnvInjection:
 
     def test_static_secret_injected_into_subprocess_env(self, tmp_path):
         """A StaticSecret in agent_context.secrets lands in the subprocess env."""
-        from openhands.sdk.secret import StaticSecret
         from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
             agent_context=AgentContext(
@@ -3413,8 +3416,9 @@ class TestACPSecretsEnvInjection:
 
     def test_acp_env_takes_precedence_over_agent_context_secret(self, tmp_path):
         """An explicit acp_env entry wins over the same key in agent_context.secrets."""
-        from openhands.sdk.secret import StaticSecret
         from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
             acp_env={"MY_TOKEN": "acp-env-wins"},
@@ -3436,3 +3440,17 @@ class TestACPSecretsEnvInjection:
         )
         env = self._run_start_capturing_env(agent, tmp_path)
         assert "ABSENT_SECRET" not in env
+
+    def test_empty_string_secret_not_injected(self, tmp_path):
+        """Empty string secrets are not injected into the subprocess env."""
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(
+            agent_context=AgentContext(
+                secrets={"EMPTY_SECRET": StaticSecret(value=SecretStr(""))}
+            )
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+        assert "EMPTY_SECRET" not in env


### PR DESCRIPTION
## Summary

Builds on #2946 (which added ACP-compatible prompt extensions to \`AgentContext\`).

PR #2946 explicitly marked \`AgentContext.secrets\` as \`acp_compatible: False\` because at the time ACP agents had no secret injection at all. This PR lifts that restriction now that user secrets are being plumbed to ACP agents (OpenHands/OpenHands#14171).

Two halves are wired:

**Prompt awareness** — \`to_acp_prompt_context()\` now includes the \`<CUSTOM_SECRETS>\` block when \`agent_context.secrets\` is non-empty, rendered by the same \`system_message_suffix.j2\` template the regular agent uses. The ACP subprocess sees the names and descriptions of available env vars in its first user turn, exactly as the regular OpenHands agent does via its system prompt.

**Subprocess injection** — \`_start_acp_server\` iterates \`agent_context.secrets\`, calls \`SecretSource.get_value()\` for each entry, and injects the resolved string into the subprocess env. Keys already present in \`acp_env\` take precedence. \`SecretSource.get_value()\` is synchronous; calling it here is safe because \`_start_acp_server\` is a regular non-async method.

The app-server sets \`agent_context\` directly on the \`ACPAgent\` instance after \`create_agent()\` — no settings-model changes needed since \`ACPAgent\` inherits \`agent_context\` from \`AgentBase\`.

## Changes

- \`agent_context.py\`: \`secrets\` field flipped to \`acp_compatible: True\`; \`to_acp_prompt_context()\` docstring updated
- \`acp_agent.py\`: secrets resolved + injected in \`_start_acp_server\`; \`SecretSource\` promoted to top-level import
- Updated tests: \`test_rejects_unsupported_agent_context_at_init\` → \`test_allows_agent_context_with_secrets\`; \`test_agent_context_to_acp_prompt_context_rejects_secrets\` → \`test_agent_context_to_acp_prompt_context_includes_secrets\`
- New test class \`TestACPSecretsEnvInjection\` covering env injection, priority ordering, and empty-string suppression

## Test plan

- [x] \`TestACPSecretsEnvInjection::test_secrets_injected_into_subprocess_env\`
- [x] \`TestACPSecretsEnvInjection::test_acp_env_takes_precedence_over_agent_context_secrets\`
- [x] \`TestACPSecretsEnvInjection::test_empty_string_secret_not_injected\`
- [x] \`test_allows_agent_context_with_secrets\`
- [x] \`test_agent_context_to_acp_prompt_context_includes_secrets\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c9ec6b3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c9ec6b3-python \
  ghcr.io/openhands/agent-server:c9ec6b3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c9ec6b3-golang-amd64
ghcr.io/openhands/agent-server:c9ec6b3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c9ec6b3-golang-arm64
ghcr.io/openhands/agent-server:c9ec6b3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c9ec6b3-java-amd64
ghcr.io/openhands/agent-server:c9ec6b3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c9ec6b3-java-arm64
ghcr.io/openhands/agent-server:c9ec6b3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c9ec6b3-python-amd64
ghcr.io/openhands/agent-server:c9ec6b3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c9ec6b3-python-arm64
ghcr.io/openhands/agent-server:c9ec6b3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c9ec6b3-golang
ghcr.io/openhands/agent-server:c9ec6b3-java
ghcr.io/openhands/agent-server:c9ec6b3-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c9ec6b3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c9ec6b3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->