### PR TITLE
Add missing models from openhands-index-results benchmark

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -24,8 +24,10 @@ VERIFIED_ANTHROPIC_MODELS = [
     "claude-sonnet-4-5-20250929",
     "claude-haiku-4-5-20251001",
     "claude-opus-4-5-20251101",
+    "claude-opus-4-5",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-sonnet-4-5",
     "claude-sonnet-4-6",
     "claude-sonnet-4-20250514",
     "claude-opus-4-20250514",
@@ -49,10 +51,14 @@ VERIFIED_MISTRAL_MODELS = [
 
 VERIFIED_GEMINI_MODELS = [
     "gemini-3.1-pro-preview",
+    "gemini-3.1-pro",
+    "gemini-3-flash",
+    "gemini-3-pro",
 ]
 
 VERIFIED_DEEPSEEK_MODELS = [
     "deepseek-chat",
+    "deepseek-v3.2-reasoner",
 ]
 
 VERIFIED_MOONSHOT_MODELS = [
@@ -61,29 +67,60 @@ VERIFIED_MOONSHOT_MODELS = [
 ]
 
 VERIFIED_MINIMAX_MODELS = [
+    "minimax-m2.1",
     "minimax-m2.5",
     "minimax-m2.7",
 ]
 
+VERIFIED_GLM_MODELS = [
+    "glm-4.7",
+    "glm-5",
+    "glm-5.1",
+]
+
+VERIFIED_NVIDIA_MODELS = [
+    "nemotron-3-nano",
+    "nemotron-3-super",
+]
+
+VERIFIED_QWEN_MODELS = [
+    "qwen3-6-plus",
+    "qwen3-coder-480b",
+]
+
 VERIFIED_OPENHANDS_MODELS = [
+    "claude-opus-4-5",
+    "claude-opus-4-5-20251101",
     "claude-opus-4-6",
     "claude-opus-4-7",
+    "claude-sonnet-4-5",
     "claude-sonnet-4-6",
     "gpt-5.4",
     "gpt-5.2",
     "gpt-5.2-codex",
+    "minimax-m2.1",
     "minimax-m2.5",
     "minimax-m2.7",
+    "gemini-3.1-pro",
     "gemini-3.1-pro-preview",
+    "gemini-3-flash",
+    "gemini-3-pro",
     "deepseek-chat",
+    "deepseek-v3.2-reasoner",
     "kimi-k2-thinking",
     "kimi-k2.5",
     "devstral-medium-2512",
     "devstral-2512",
-    "claude-opus-4-5-20251101",
     "gpt-5.1-codex-max",
     "gpt-5.1-codex",
     "gpt-5.1",
+    "glm-4.7",
+    "glm-5",
+    "glm-5.1",
+    "nemotron-3-nano",
+    "nemotron-3-super",
+    "qwen3-6-plus",
+    "qwen3-coder-480b",
 ]
 
 
@@ -96,4 +133,7 @@ VERIFIED_MODELS = {
     "deepseek": VERIFIED_DEEPSEEK_MODELS,
     "moonshot": VERIFIED_MOONSHOT_MODELS,
     "minimax": VERIFIED_MINIMAX_MODELS,
+    "glm": VERIFIED_GLM_MODELS,
+    "nvidia": VERIFIED_NVIDIA_MODELS,
+    "qwen": VERIFIED_QWEN_MODELS,
 }


### PR DESCRIPTION
## Summary

Added completed benchmark models from [openhands-index-results](https://github.com/OpenHands/openhands-index-results/blob/d49993e83b84285ff3e3052209fbc29d39718549/complete-models.json) that were missing from `verified_models.py`.

### New Models Added

**Anthropic models:**
- `claude-opus-4-5`
- `claude-sonnet-4-5`

**Gemini models:**
- `gemini-3.1-pro`
- `gemini-3-flash`
- `gemini-3-pro`

**DeepSeek models:**
- `deepseek-v3.2-reasoner`

**MiniMax models:**
- `minimax-m2.1`

**GLM models (new provider):**
- `glm-4.7`
- `glm-5`
- `glm-5.1`

**NVIDIA models (new provider):**
- `nemotron-3-nano`
- `nemotron-3-super`

**Qwen models (new provider):**
- `qwen3-6-plus`
- `qwen3-coder-480b`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/725aa117-8bf9-4dea-8b23-bc1d6f7594c4)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1c316bd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1c316bd-python \
  ghcr.io/openhands/agent-server:1c316bd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1c316bd-golang-amd64
ghcr.io/openhands/agent-server:1c316bd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1c316bd-golang-arm64
ghcr.io/openhands/agent-server:1c316bd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1c316bd-java-amd64
ghcr.io/openhands/agent-server:1c316bd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1c316bd-java-arm64
ghcr.io/openhands/agent-server:1c316bd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1c316bd-python-amd64
ghcr.io/openhands/agent-server:1c316bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1c316bd-python-arm64
ghcr.io/openhands/agent-server:1c316bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1c316bd-golang
ghcr.io/openhands/agent-server:1c316bd-java
ghcr.io/openhands/agent-server:1c316bd-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1c316bd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1c316bd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->