### PR TITLE
feat: add LMNR_USE_HTTP option to force HTTP transport for Laminar

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -32,6 +32,18 @@ def _get_int_env(key: str) -> int | None:
     return None
 
 
+def _get_bool_env(key: str) -> bool:
+    """Read an environment variable as a boolean.
+
+    Returns True if the value is 'true', '1', 'yes', 'on' (case-insensitive).
+    Returns False otherwise.
+    """
+    val = get_env(key)
+    if val is None:
+        return False
+    return val.lower() in ("true", "1", "yes", "on")
+
+
 def maybe_init_laminar():
     """Initialize Laminar if the environment variables are set.
 
@@ -53,14 +65,20 @@ def maybe_init_laminar():
     LMNR_BASE_URL=https://api.lmnr.ai  # optional, defaults to https://api.lmnr.ai
     LMNR_HTTP_PORT=8000
     LMNR_GRPC_PORT=8001
+
+    To force HTTP instead of gRPC for Laminar communication:
+    LMNR_USE_HTTP=true  # or 1, yes, on
     """
     base_url = get_env("LMNR_BASE_URL") or None
+    force_http = _get_bool_env("LMNR_USE_HTTP")
+
     if should_enable_observability():
         if _is_otel_backend_laminar():
             Laminar.initialize(
                 base_url=base_url,
                 http_port=_get_int_env("LMNR_HTTP_PORT"),
                 grpc_port=_get_int_env("LMNR_GRPC_PORT"),
+                force_http=force_http,
             )
         else:
             # Do not enable browser session replays for non-laminar backends
@@ -70,6 +88,7 @@ def maybe_init_laminar():
                     Instruments.PATCHRIGHT,
                     Instruments.PLAYWRIGHT,
                 ],
+                force_http=force_http,
             )
         litellm.callbacks.append(LaminarLiteLLMCallback())
     else:

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -67,10 +67,10 @@ def maybe_init_laminar():
     LMNR_GRPC_PORT=8001
 
     To force HTTP instead of gRPC for Laminar communication:
-    LMNR_USE_HTTP=true  # or 1, yes, on
+    LMNR_FORCE_HTTP=true  # or 1, yes, on
     """
     base_url = get_env("LMNR_BASE_URL") or None
-    force_http = _get_bool_env("LMNR_USE_HTTP")
+    force_http = _get_bool_env("LMNR_FORCE_HTTP")
 
     if should_enable_observability():
         if _is_otel_backend_laminar():

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -165,7 +165,7 @@ def test_get_bool_env(env_value, expected):
 
 
 @pytest.mark.parametrize(
-    ("use_http_value", "expected_force_http"),
+    ("force_http_value", "expected_force_http"),
     [
         ("true", True),
         ("1", True),
@@ -174,17 +174,17 @@ def test_get_bool_env(env_value, expected):
         (None, False),
     ],
 )
-def test_lmnr_use_http_passed_to_laminar(use_http_value, expected_force_http):
-    """Test that LMNR_USE_HTTP is correctly passed to Laminar.initialize."""
+def test_lmnr_force_http_passed_to_laminar(force_http_value, expected_force_http):
+    """Test that LMNR_FORCE_HTTP is correctly passed to Laminar.initialize."""
     original_key = os.environ.get("LMNR_PROJECT_API_KEY")
-    original_use_http = os.environ.get("LMNR_USE_HTTP")
+    original_force_http = os.environ.get("LMNR_FORCE_HTTP")
 
     try:
         os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
-        if use_http_value is not None:
-            os.environ["LMNR_USE_HTTP"] = use_http_value
-        elif "LMNR_USE_HTTP" in os.environ:
-            del os.environ["LMNR_USE_HTTP"]
+        if force_http_value is not None:
+            os.environ["LMNR_FORCE_HTTP"] = force_http_value
+        elif "LMNR_FORCE_HTTP" in os.environ:
+            del os.environ["LMNR_FORCE_HTTP"]
 
         with patch("openhands.sdk.observability.laminar.Laminar") as mock_laminar:
             with patch("openhands.sdk.observability.laminar.LaminarLiteLLMCallback"):
@@ -204,7 +204,7 @@ def test_lmnr_use_http_passed_to_laminar(use_http_value, expected_force_http):
             os.environ["LMNR_PROJECT_API_KEY"] = original_key
         elif "LMNR_PROJECT_API_KEY" in os.environ:
             del os.environ["LMNR_PROJECT_API_KEY"]
-        if original_use_http is not None:
-            os.environ["LMNR_USE_HTTP"] = original_use_http
-        elif "LMNR_USE_HTTP" in os.environ:
-            del os.environ["LMNR_USE_HTTP"]
+        if original_force_http is not None:
+            os.environ["LMNR_FORCE_HTTP"] = original_force_http
+        elif "LMNR_FORCE_HTTP" in os.environ:
+            del os.environ["LMNR_FORCE_HTTP"]

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -1,5 +1,6 @@
 """Tests for Laminar observability configuration."""
 
+import os
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -89,8 +90,6 @@ def test_lmnr_base_url_passed_to_laminar():
 
 def test_lmnr_base_url_not_passed_when_empty():
     """Test that base_url is None when LMNR_BASE_URL is not set."""
-    import os
-
     # Save original values
     original_base_url = os.environ.get("LMNR_BASE_URL")
     original_key = os.environ.get("LMNR_PROJECT_API_KEY")
@@ -124,3 +123,88 @@ def test_lmnr_base_url_not_passed_when_empty():
             os.environ["LMNR_PROJECT_API_KEY"] = original_key
         elif "LMNR_PROJECT_API_KEY" in os.environ:
             del os.environ["LMNR_PROJECT_API_KEY"]
+
+
+@pytest.mark.parametrize(
+    ("env_value", "expected"),
+    [
+        ("true", True),
+        ("True", True),
+        ("TRUE", True),
+        ("1", True),
+        ("yes", True),
+        ("YES", True),
+        ("on", True),
+        ("ON", True),
+        ("false", False),
+        ("0", False),
+        ("no", False),
+        ("", False),
+        (None, False),
+    ],
+)
+def test_get_bool_env(env_value, expected):
+    """Test that _get_bool_env correctly parses boolean environment variables."""
+    original = os.environ.get("TEST_BOOL_VAR")
+
+    try:
+        if env_value is not None:
+            os.environ["TEST_BOOL_VAR"] = env_value
+        elif "TEST_BOOL_VAR" in os.environ:
+            del os.environ["TEST_BOOL_VAR"]
+
+        from openhands.sdk.observability.laminar import _get_bool_env
+
+        result = _get_bool_env("TEST_BOOL_VAR")
+        assert result == expected
+    finally:
+        if original is not None:
+            os.environ["TEST_BOOL_VAR"] = original
+        elif "TEST_BOOL_VAR" in os.environ:
+            del os.environ["TEST_BOOL_VAR"]
+
+
+@pytest.mark.parametrize(
+    ("use_http_value", "expected_force_http"),
+    [
+        ("true", True),
+        ("1", True),
+        ("false", False),
+        ("0", False),
+        (None, False),
+    ],
+)
+def test_lmnr_use_http_passed_to_laminar(use_http_value, expected_force_http):
+    """Test that LMNR_USE_HTTP is correctly passed to Laminar.initialize."""
+    original_key = os.environ.get("LMNR_PROJECT_API_KEY")
+    original_use_http = os.environ.get("LMNR_USE_HTTP")
+
+    try:
+        os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+        if use_http_value is not None:
+            os.environ["LMNR_USE_HTTP"] = use_http_value
+        elif "LMNR_USE_HTTP" in os.environ:
+            del os.environ["LMNR_USE_HTTP"]
+
+        with patch("openhands.sdk.observability.laminar.Laminar") as mock_laminar:
+            with patch("openhands.sdk.observability.laminar.LaminarLiteLLMCallback"):
+                with patch(
+                    "openhands.sdk.observability.laminar.litellm"
+                ) as mock_litellm:
+                    mock_laminar.is_initialized.return_value = False
+                    mock_litellm.callbacks = MagicMock()
+                    from openhands.sdk.observability.laminar import maybe_init_laminar
+
+                    maybe_init_laminar()
+
+                    call_kwargs = mock_laminar.initialize.call_args.kwargs
+                    assert call_kwargs.get("force_http") == expected_force_http
+    finally:
+        if original_key is not None:
+            os.environ["LMNR_PROJECT_API_KEY"] = original_key
+        elif "LMNR_PROJECT_API_KEY" in os.environ:
+            del os.environ["LMNR_PROJECT_API_KEY"]
+        if original_use_http is not None:
+            os.environ["LMNR_USE_HTTP"] = original_use_http
+        elif "LMNR_USE_HTTP" in os.environ:
+            del os.environ["LMNR_USE_HTTP"]


### PR DESCRIPTION
## Summary

This PR adds support for the `LMNR_USE_HTTP` environment variable to allow forcing HTTP instead of gRPC for Laminar communication.

## Motivation

In certain deployment environments (e.g., behind certain proxies or ingress configurations), gRPC connectivity may have issues. This change provides a configuration option to force HTTP transport as a fallback.

## Changes

- **Added** `_get_bool_env()` helper function to parse boolean environment variables
- **Added** support for `LMNR_USE_HTTP` environment variable
- **Updated** `maybe_init_laminar()` to pass `force_http` parameter to `Laminar.initialize()`
- **Added** comprehensive tests for the new functionality
- **Improved** code quality by moving `os` import to top of test file

## Usage

```bash
# Force HTTP transport for Laminar
export LMNR_USE_HTTP=true  # or 1, yes, on
```

## Testing

- Added parametrized tests for `_get_bool_env()` wit- Added parametrized tests for `_get_bool_env()` wit- Added parametrized tests for `_get_bor initialization
- All pre-commit checks pass (format, lint, type check)