### PR TITLE
feat(settings): rename agent_kind discriminator from 'llm' to 'openhands'

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/metadata.py
+++ b/openhands-sdk/openhands/sdk/settings/metadata.py
@@ -28,7 +28,7 @@ class SettingsFieldMetadata(BaseModel):
     depends_on: tuple[str, ...] = ()
     variant: str | None = None
     """When set, the field only applies to the named ``AgentSettings``
-    variant (``"llm"`` or ``"acp"``). Fields with ``variant=None`` are
+    variant (``"openhands"`` or ``"acp"``). Fields with ``variant=None`` are
     shown regardless of the active ``agent_kind``."""
 
 

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -578,7 +578,7 @@ class ConversationSettings(BaseModel):
         return request_type(**self._start_request_kwargs(**kwargs))
 
 
-AgentKind = Literal["llm", "acp"]
+AgentKind = Literal["openhands", "acp"]
 
 ACPServerKind = Literal["claude-code", "codex", "gemini-cli", "custom"]
 """Known ACP backend servers the GUI can pick from.
@@ -606,11 +606,11 @@ class LLMAgentSettings(BaseModel):
     """
 
     schema_version: int = Field(default=AGENT_SETTINGS_SCHEMA_VERSION, ge=1)
-    agent_kind: Literal["llm"] = Field(
-        default="llm",
+    agent_kind: Literal["openhands"] = Field(
+        default="openhands",
         description=(
-            "Discriminator for the ``AgentSettings`` union. ``'llm'`` selects a "
-            "standard LLM-backed agent."
+            "Discriminator for the ``AgentSettings`` union. ``'openhands'`` selects "
+            "the standard built-in OpenHands agent."
         ),
     )
     agent: str = Field(
@@ -620,7 +620,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
                 label="Agent",
                 prominence=SettingProminence.MAJOR,
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -631,7 +631,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
                 key="llm",
                 label="LLM",
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -642,7 +642,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
                 label="Tools",
                 prominence=SettingProminence.MAJOR,
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -653,7 +653,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
                 label="Enable sub-agents",
                 prominence=SettingProminence.MAJOR,
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -664,7 +664,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
                 label="MCP configuration",
                 prominence=SettingProminence.MINOR,
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -679,7 +679,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
                 key="condenser",
                 label="Condenser",
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -690,7 +690,7 @@ class LLMAgentSettings(BaseModel):
             SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
                 key="verification",
                 label="Verification",
-                variant="llm",
+                variant="openhands",
             ).model_dump()
         },
     )
@@ -998,21 +998,21 @@ class ACPAgentSettings(BaseModel):
 
 
 def _agent_settings_discriminator(value: Any) -> str:
-    """Discriminator for :data:`AgentSettingsConfig` — defaults to ``'llm'``.
+    """Discriminator for :data:`AgentSettingsConfig` — defaults to ``'openhands'``.
 
     Existing persisted payloads predate ``agent_kind`` and carry only
-    LLM-agent fields. Treating a missing discriminator as ``'llm'`` lets
+    LLM-agent fields. Treating a missing discriminator as ``'openhands'`` lets
     those payloads validate without a migration.
     """
     if isinstance(value, BaseModel):
-        return getattr(value, "agent_kind", "llm")
+        return getattr(value, "agent_kind", "openhands")
     if isinstance(value, dict):
-        return value.get("agent_kind", "llm")
-    return "llm"
+        return value.get("agent_kind", "openhands")
+    return "openhands"
 
 
 AgentSettingsConfig = Annotated[
-    Annotated[LLMAgentSettings, Tag("llm")] | Annotated[ACPAgentSettings, Tag("acp")],
+    Annotated[LLMAgentSettings, Tag("openhands")] | Annotated[ACPAgentSettings, Tag("acp")],
     Discriminator(_agent_settings_discriminator),
 ]
 """Discriminated union over the agent-settings variants.
@@ -1159,7 +1159,7 @@ def export_agent_settings_schema() -> SettingsSchema:
                     if field.key not in seen_keys:
                         existing.fields.append(field)
 
-    _merge(llm_schema, default_variant="llm")
+    _merge(llm_schema, default_variant="openhands")
     _merge(acp_schema, default_variant="acp")
 
     return SettingsSchema(model_name="AgentSettings", sections=merged_sections)

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -240,8 +240,8 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
 
     by_keyvariant = {(s.key, s.variant): s for s in schema.sections}
 
-    # Shared general section contains LLM-only top-level fields with
-    # field-level variant="llm" tags (so they hide on the ACP page).
+    # Shared general section contains OpenHands-only top-level fields with
+    # field-level variant="openhands" tags (so they hide on the ACP page).
     general = by_keyvariant.get(("general", None))
     assert general is not None
     general_keys = {f.key for f in general.fields}
@@ -250,14 +250,14 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
     # injects the discriminator on save.
     assert "agent_kind" not in general_keys
     for f in general.fields:
-        assert f.variant == "llm", (
-            f"expected field {f.key} variant=llm, got {f.variant}"
+        assert f.variant == "openhands", (
+            f"expected field {f.key} variant=openhands, got {f.variant}"
         )
 
-    # LLM-variant sections.
-    assert ("llm", "llm") in by_keyvariant
-    assert ("condenser", "llm") in by_keyvariant
-    assert ("verification", "llm") in by_keyvariant
+    # OpenHands-variant sections.
+    assert ("llm", "openhands") in by_keyvariant
+    assert ("condenser", "openhands") in by_keyvariant
+    assert ("verification", "openhands") in by_keyvariant
 
     # ACP-variant sections.
     acp_section = by_keyvariant.get(("acp", "acp"))
@@ -286,13 +286,13 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_default_agent_settings_returns_llm_variant() -> None:
+def test_default_agent_settings_returns_openhands_variant() -> None:
     s = default_agent_settings()
     assert isinstance(s, LLMAgentSettings)
-    assert s.agent_kind == "llm"
+    assert s.agent_kind == "openhands"
 
 
-def test_validate_agent_settings_defaults_to_llm_when_discriminator_missing() -> None:
+def test_validate_agent_settings_defaults_to_openhands_when_discriminator_missing() -> None:
     """Existing persisted payloads predate ``agent_kind`` — they must round-trip."""
     v = validate_agent_settings({"llm": {"model": "test-model"}})
     assert isinstance(v, LLMAgentSettings)
@@ -300,8 +300,8 @@ def test_validate_agent_settings_defaults_to_llm_when_discriminator_missing() ->
 
 
 def test_validate_agent_settings_dispatches_on_agent_kind() -> None:
-    llm = validate_agent_settings({"agent_kind": "llm", "llm": {"model": "m"}})
-    assert isinstance(llm, LLMAgentSettings)
+    openhands = validate_agent_settings({"agent_kind": "openhands", "llm": {"model": "m"}})
+    assert isinstance(openhands, LLMAgentSettings)
 
     acp = validate_agent_settings(
         {
@@ -319,7 +319,7 @@ def test_agent_settings_from_persisted_migrates_v0_llm_payload() -> None:
 
     assert isinstance(settings, LLMAgentSettings)
     assert settings.schema_version == 1
-    assert settings.agent_kind == "llm"
+    assert settings.agent_kind == "openhands"
     assert settings.llm.model == "test-model"
 
 
@@ -542,7 +542,7 @@ def test_legacy_agent_settings_still_instantiates_as_llm_variant() -> None:
 
     # It remains a LLMAgentSettings subclass so existing code paths work.
     assert isinstance(settings, LLMAgentSettings)
-    assert settings.agent_kind == "llm"
+    assert settings.agent_kind == "openhands"
     assert settings.llm.model == "test-model"
 
 


### PR DESCRIPTION
## Summary

- The two agent types are **OpenHands** (the built-in agent) and **ACP** (an external agent via the Agent Client Protocol)
- Using `'llm'` as the `agent_kind` discriminator was a leaky implementation detail — it described the mechanism, not the agent type
- Rename to `'openhands'` so the discriminator pair is semantically `'openhands' | 'acp'`

## Changes

- `AgentKind`: `Literal["llm", "acp"]` → `Literal["openhands", "acp"]`
- `LLMAgentSettings.agent_kind`: `Literal["llm"]` → `Literal["openhands"]`
- All `variant="llm"` section/field metadata → `variant="openhands"`
- `Tag("llm")` in `AgentSettingsConfig` union → `Tag("openhands")`
- `_agent_settings_discriminator` default fallback → `"openhands"`
- `export_agent_settings_schema` `default_variant` → `"openhands"`

No backwards compatibility shim — this discriminator has not shipped in a release yet.

## Test plan

- [ ] All existing settings tests pass (`tests/sdk/test_settings.py`)
- [ ] `default_agent_settings()` returns `agent_kind == "openhands"`
- [ ] `validate_agent_settings({"agent_kind": "openhands", ...})` produces `LLMAgentSettings`
- [ ] `validate_agent_settings({...})` (no `agent_kind`) still defaults to `LLMAgentSettings`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1c409e7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1c409e7-python \
  ghcr.io/openhands/agent-server:1c409e7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1c409e7-golang-amd64
ghcr.io/openhands/agent-server:1c409e7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1c409e7-golang-arm64
ghcr.io/openhands/agent-server:1c409e7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1c409e7-java-amd64
ghcr.io/openhands/agent-server:1c409e7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1c409e7-java-arm64
ghcr.io/openhands/agent-server:1c409e7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1c409e7-python-amd64
ghcr.io/openhands/agent-server:1c409e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1c409e7-python-arm64
ghcr.io/openhands/agent-server:1c409e7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1c409e7-golang
ghcr.io/openhands/agent-server:1c409e7-java
ghcr.io/openhands/agent-server:1c409e7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1c409e7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1c409e7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->