### PR TITLE
feat(settings): add api_key_env_var property to ACPAgentSettings

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -955,6 +955,25 @@ class ACPAgentSettings(BaseModel):
         """Export a structured schema describing configurable ACP settings."""
         return export_settings_schema(cls)
 
+    @property
+    def api_key_env_var(self) -> str | None:
+        """Env var name the ACP subprocess expects for its API key.
+
+        Returns ``None`` for ``'custom'`` servers — users manage credentials
+        entirely via :attr:`acp_env` in that case.
+
+        Mapping:
+        - ``claude-code``  → ``ANTHROPIC_API_KEY``
+        - ``codex``        → ``OPENAI_API_KEY``
+        - ``gemini-cli``   → ``GEMINI_API_KEY``
+        - ``custom``       → ``None``
+        """
+        return {
+            "claude-code": "ANTHROPIC_API_KEY",
+            "codex": "OPENAI_API_KEY",
+            "gemini-cli": "GEMINI_API_KEY",
+        }.get(self.acp_server)
+
     def resolve_acp_command(self) -> list[str]:
         """Return the effective subprocess command for this settings block.
 

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -519,6 +519,18 @@ def test_acp_custom_server_with_command_resolves() -> None:
     assert settings.resolve_acp_command() == ["bin", "--flag"]
 
 
+def test_acp_api_key_env_var_maps_known_servers() -> None:
+    assert (
+        ACPAgentSettings(acp_server="claude-code").api_key_env_var
+        == "ANTHROPIC_API_KEY"
+    )
+    assert ACPAgentSettings(acp_server="codex").api_key_env_var == "OPENAI_API_KEY"
+    assert ACPAgentSettings(acp_server="gemini-cli").api_key_env_var == "GEMINI_API_KEY"
+    assert (
+        ACPAgentSettings(acp_server="custom", acp_command=["x"]).api_key_env_var is None
+    )
+
+
 # ---------------------------------------------------------------------------
 # Legacy ``AgentSettings`` compatibility
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds `ACPAgentSettings.api_key_env_var` property that returns the environment variable name the ACP subprocess expects for its API key
- Callers no longer need a local switch on `acp_server` to inject credentials correctly

## Mapping

| `acp_server` | env var |
|---|---|
| `claude-code` | `ANTHROPIC_API_KEY` |
| `codex` | `OPENAI_API_KEY` |
| `gemini-cli` | `GEMINI_API_KEY` |
| `custom` | `None` — user manages via `acp_env` |

## Test plan

- [x] `test_acp_api_key_env_var_maps_known_servers` covers all four cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)