### PR TITLE
fix: fix version-bump-prs workflow PyPI propagation delay

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -53,6 +53,12 @@ jobs:
                   fi
                   echo "📦 Creating version bump PRs for version: $VERSION"
 
+            - name: Install uv
+              uses: astral-sh/setup-uv@v7
+              with:
+                  version: latest
+                  python-version: '3.12'
+
             - name: Wait for packages to be available on PyPI
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
@@ -71,37 +77,31 @@ jobs:
 
                   echo "⏳ Waiting for packages to be available on PyPI..."
 
+                  # Use uv pip compile --dry-run to verify packages are resolvable
+                  # via the Simple API (the same index uv add uses).
+                  # The JSON API propagates faster than the Simple API, so a curl
+                  # check alone is insufficient.
                   for PKG in "${PACKAGES[@]}"; do
                     echo "Checking $PKG==$VERSION..."
                     ATTEMPT=1
                     while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
-                      # Check if the package version is available on PyPI
-                      HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" \
-                        "https://pypi.org/pypi/$PKG/$VERSION/json")
-
-                      if [ "$HTTP_CODE" = "200" ]; then
-                        echo "✅ $PKG==$VERSION is available on PyPI"
+                      if uv pip compile --no-cache --python-version 3.12 - <<< "$PKG==$VERSION" > /dev/null 2>&1; then
+                        echo "✅ $PKG==$VERSION is resolvable on PyPI"
                         break
                       fi
 
-                      echo "  Attempt $ATTEMPT/$MAX_ATTEMPTS: $PKG==$VERSION not yet available (HTTP $HTTP_CODE), waiting ${SLEEP_SECONDS}s..."
+                      echo "  Attempt $ATTEMPT/$MAX_ATTEMPTS: $PKG==$VERSION not yet resolvable, waiting ${SLEEP_SECONDS}s..."
                       sleep $SLEEP_SECONDS
                       ATTEMPT=$((ATTEMPT + 1))
                     done
 
                     if [ $ATTEMPT -gt $MAX_ATTEMPTS ]; then
-                      echo "❌ Timeout waiting for $PKG==$VERSION to be available on PyPI"
+                      echo "❌ Timeout waiting for $PKG==$VERSION to be resolvable on PyPI"
                       exit 1
                     fi
                   done
 
-                  echo "✅ All packages are available on PyPI!"
-
-            - name: Install uv
-              uses: astral-sh/setup-uv@v7
-              with:
-                  version: latest
-                  python-version: '3.12'
+                  echo "✅ All packages are resolvable on PyPI!"
 
             - name: Install Poetry
               run: |
@@ -138,10 +138,11 @@ jobs:
                   fi
 
                   # OpenHands-CLI currently requires Python 3.12, so resolve with that interpreter.
-                  # Override exclude-newer so uv can find the just-published packages
-                  # (the target repo's lockfile may have an older cutoff date).
-                  UV_EXCLUDE_NEWER="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-                    uv add --python 3.12 --refresh \
+                  # The target repo uses exclude-newer-package to exempt openhands-sdk/tools
+                  # from its 7-day freshness guardrail, so no UV_EXCLUDE_NEWER override
+                  # is needed — doing so would actually break the per-package exemptions.
+                  # We use --no-cache to avoid stale index data from just-published packages.
+                  uv add --python 3.12 --no-cache \
                     "openhands-sdk==$VERSION" \
                     "openhands-tools==$VERSION"
 


### PR DESCRIPTION
## Problem

The `version-bump-prs` workflow has been **failing on every release since v1.17.0** (April 13), meaning no version bump PRs have been automatically created for the last ~7 releases (v1.17.0 through v1.19.0).

### Root Cause

Two interrelated issues:

1. **PyPI CDN propagation delay**: The workflow checks package availability using PyPI's JSON API (`/pypi/PKG/VERSION/json`), which propagates quickly. However, `uv add` uses PyPI's Simple API for resolution, which has a slower CDN cache (~2-3 min delay). Packages pass the availability check but then fail `uv` resolution just seconds later.

2. **UV_EXCLUDE_NEWER breaks per-package exemptions**: [PR #2817](https://github.com/OpenHands/software-agent-sdk/pull/2817) tried to fix this by adding `UV_EXCLUDE_NEWER` as an env var override, but this overrides the \*entire\* exclude-newer config from the target repo's `pyproject.toml`, including the `exclude-newer-package` exemptions that allow freshly-published openhands-sdk/tools to be resolved immediately.

### Fix

- **Move `Install uv` step** before the PyPI wait step
- **Replace curl-based JSON API check** with `uv pip compile --no-cache`, which verifies packages via the same Simple API that `uv add` uses — the workflow won't proceed until packages are actually resolvable by uv
- **Remove `UV_EXCLUDE_NEWER` override** from the openhands-cli step; rely on the target repo's `exclude-newer-package` exemptions instead (which worked correctly before PR #2817)
- **Use `--no-cache`** instead of `--refresh` to ensure completely fresh index data

### Timeline of Failures

| Release | Date | Failure |
|---------|------|---------|
| v1.17.0 | Apr 13 | `uv add` can't find newly published package |
| v1.18.0 | Apr 21 | Same |
| v1.18.1 | Apr 23 | Same |
| v1.19.0 | Apr 27 | Same |

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5a865aa-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5a865aa-python \
  ghcr.io/openhands/agent-server:5a865aa-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5a865aa-golang-amd64
ghcr.io/openhands/agent-server:5a865aa-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5a865aa-golang-arm64
ghcr.io/openhands/agent-server:5a865aa-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5a865aa-java-amd64
ghcr.io/openhands/agent-server:5a865aa-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5a865aa-java-arm64
ghcr.io/openhands/agent-server:5a865aa-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5a865aa-python-amd64
ghcr.io/openhands/agent-server:5a865aa-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5a865aa-python-arm64
ghcr.io/openhands/agent-server:5a865aa-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5a865aa-golang
ghcr.io/openhands/agent-server:5a865aa-java
ghcr.io/openhands/agent-server:5a865aa-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5a865aa-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5a865aa-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->