### PR TITLE
fix(llm): preserve telemetry callbacks across LLM re-validation

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -526,18 +526,22 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         if self.aws_region_name:
             os.environ["AWS_REGION_NAME"] = self.aws_region_name
 
-        # Metrics + Telemetry wiring
+        # Metrics + Telemetry wiring. Guard both: this validator re-runs whenever
+        # the LLM is passed into another Pydantic model (e.g. RegistryEvent),
+        # and replacing _telemetry would silently drop any callback callers
+        # have attached via telemetry.set_*_callback().
         if self._metrics is None:
             self._metrics = Metrics(model_name=self.model)
 
-        self._telemetry = Telemetry(
-            model_name=self.model,
-            log_enabled=self.log_completions,
-            log_dir=self.log_completions_folder if self.log_completions else None,
-            input_cost_per_token=self.input_cost_per_token,
-            output_cost_per_token=self.output_cost_per_token,
-            metrics=self._metrics,
-        )
+        if self._telemetry is None:
+            self._telemetry = Telemetry(
+                model_name=self.model,
+                log_enabled=self.log_completions,
+                log_dir=self.log_completions_folder if self.log_completions else None,
+                input_cost_per_token=self.input_cost_per_token,
+                output_cost_per_token=self.output_cost_per_token,
+                metrics=self._metrics,
+            )
 
         # Tokenizer
         if self.custom_tokenizer:

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -82,6 +82,7 @@ def mock_llm() -> LLM:
     mock_llm.output_cost_per_token = None
 
     mock_llm._metrics = None
+    mock_llm._telemetry = None
 
     # Helper method to set mock response content
     def set_mock_response_content(content: str):

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1174,6 +1174,33 @@ def test_conversation_stats_restore_then_track():
         assert stats.get_combined_metrics().accumulated_cost == 10.25
 
 
+def test_telemetry_callback_preserved_across_revalidation():
+    """Telemetry callbacks must survive validators re-running on the LLM.
+
+    Wrapping an LLM in another Pydantic model (e.g. RegistryEvent) re-runs the
+    LLM's `mode="after"` validators. Before this fix, _set_env_side_effects
+    rebuilt _telemetry unconditionally, silently dropping any callback wired
+    via telemetry.set_*_callback() — which broke real-time stats streaming
+    from the agent server (no `key="stats"` events were ever emitted after
+    the first agent step).
+    """
+    llm = LLM(
+        model="openai/gpt-4o",
+        api_key=SecretStr("test-key"),
+        usage_id="agent",
+    )
+    fired: list[bool] = []
+    llm.telemetry.set_stats_update_callback(lambda: fired.append(True))
+    telemetry_before = llm._telemetry
+
+    RegistryEvent(llm=llm)
+
+    assert llm._telemetry is telemetry_before
+    assert llm.telemetry._stats_update_callback is not None
+    llm.telemetry._stats_update_callback()
+    assert fired == [True]
+
+
 # max_output_tokens Capping Tests
 
 


### PR DESCRIPTION
## Summary
- When an LLM instance is passed into another Pydantic model (e.g. `RegistryEvent(llm=llm)`), its `mode="after"` validators run again. `LLM._set_env_side_effects` was unconditionally rebuilding `self._telemetry`, silently dropping any callback wired via `telemetry.set_*_callback()`.
- In production this severed the agent-server's stats-streaming link: `EventService._setup_stats_streaming()` attached `_stats_update_callback` during `start()`, but `LocalConversation._ensure_agent_ready()` later called `LLMRegistry.add(llm)` → `RegistryEvent(llm=llm)`, which wiped the callback. From that point on, `Telemetry.on_response()` skipped the callback and no `ConversationStateUpdateEvent(key="stats")` was ever emitted — leaving downstream consumers (e.g. `/api/v1/conversation/{id}/events/search`) with an empty `usage_to_metrics`.
- Guard `_telemetry` construction the same way `_metrics` already is. Both are private state attached after first init; neither should be rebuilt by re-validation.

Closes OpenHands/OpenHands#14039.

## Test plan
- [x] New regression test `test_telemetry_callback_preserved_across_revalidation` — fails on `main`, passes with this fix. It exercises the exact `RegistryEvent(llm=llm)` path that triggers the bug.
- [x] `uv run pytest tests/sdk/llm tests/sdk/conversation` — 625 passed.
- [x] `uv run pre-commit run --files <changed>` — all checks pass (ruff, pyright, etc.).

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2008015-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2008015-python \
  ghcr.io/openhands/agent-server:2008015-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2008015-golang-amd64
ghcr.io/openhands/agent-server:2008015-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2008015-golang-arm64
ghcr.io/openhands/agent-server:2008015-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2008015-java-amd64
ghcr.io/openhands/agent-server:2008015-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2008015-java-arm64
ghcr.io/openhands/agent-server:2008015-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2008015-python-amd64
ghcr.io/openhands/agent-server:2008015-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2008015-python-arm64
ghcr.io/openhands/agent-server:2008015-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2008015-golang
ghcr.io/openhands/agent-server:2008015-java
ghcr.io/openhands/agent-server:2008015-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2008015-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2008015-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->