### PR TITLE
Add conversation_id to automation completion callback

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -768,6 +768,9 @@ class RemoteConversation(BaseConversation):
                 )
             self._id = uuid.UUID(cid)
 
+            # Register the conversation ID with the workspace for callbacks
+            workspace.register_conversation(str(self._id))
+
         # Initialize the remote state
         self._state = RemoteState(
             self._client,

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -768,7 +768,6 @@ class RemoteConversation(BaseConversation):
                 )
             self._id = uuid.UUID(cid)
 
-            # Register the conversation ID with the workspace for callbacks
             workspace.register_conversation(str(self._id))
 
         # Initialize the remote state

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -180,25 +180,3 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
             NotImplementedError: If the workspace type does not support resuming.
         """
         raise NotImplementedError(f"{type(self).__name__} does not support resume()")
-
-    def register_conversation(self, conversation_id: str) -> None:
-        """Register a conversation ID with this workspace.
-
-        Called by RemoteConversation after creation to associate the conversation
-        with the workspace. Subclasses can override to track conversation IDs
-        for callbacks or other purposes.
-
-        Args:
-            conversation_id: The conversation ID to register
-        """
-        # Default implementation is a no-op
-        pass
-
-    @property
-    def conversation_id(self) -> str | None:
-        """Get the most recently registered conversation ID.
-
-        Returns:
-            The conversation ID if one has been registered, None otherwise.
-        """
-        return None

--- a/openhands-sdk/openhands/sdk/workspace/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/base.py
@@ -180,3 +180,25 @@ class BaseWorkspace(DiscriminatedUnionMixin, ABC):
             NotImplementedError: If the workspace type does not support resuming.
         """
         raise NotImplementedError(f"{type(self).__name__} does not support resume()")
+
+    def register_conversation(self, conversation_id: str) -> None:
+        """Register a conversation ID with this workspace.
+
+        Called by RemoteConversation after creation to associate the conversation
+        with the workspace. Subclasses can override to track conversation IDs
+        for callbacks or other purposes.
+
+        Args:
+            conversation_id: The conversation ID to register
+        """
+        # Default implementation is a no-op
+        pass
+
+    @property
+    def conversation_id(self) -> str | None:
+        """Get the most recently registered conversation ID.
+
+        Returns:
+            The conversation ID if one has been registered, None otherwise.
+        """
+        return None

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -210,3 +210,25 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             Dictionary of tag key-value pairs, or None if no default tags.
         """
         return None
+
+    def register_conversation(self, conversation_id: str) -> None:
+        """Register a conversation ID with this workspace.
+
+        Called by RemoteConversation after creation to associate the conversation
+        with the workspace. Subclasses can override to track conversation IDs
+        for callbacks or other purposes.
+
+        Args:
+            conversation_id: The conversation ID to register
+        """
+        # Default implementation is a no-op
+        pass
+
+    @property
+    def conversation_id(self) -> str | None:
+        """Get the most recently registered conversation ID.
+
+        Returns:
+            The conversation ID if one has been registered, None otherwise.
+        """
+        return None

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -151,6 +151,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
     _exposed_urls: list[dict[str, Any]] | None = PrivateAttr(default=None)
     _automation_callback_url: str | None = PrivateAttr(default=None)
     _automation_run_id: str | None = PrivateAttr(default=None)
+    _conversation_id: str | None = PrivateAttr(default=None)
 
     @property
     def default_conversation_tags(self) -> dict[str, str]:
@@ -796,6 +797,28 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
         return response
 
+    def register_conversation(self, conversation_id: str) -> None:
+        """Register a conversation ID with this workspace.
+
+        Called by RemoteConversation after creation to associate the conversation
+        with the workspace. The conversation ID is included in the completion
+        callback sent to the automation service.
+
+        Args:
+            conversation_id: The conversation ID to register
+        """
+        self._conversation_id = conversation_id
+        logger.debug(f"Registered conversation: {conversation_id}")
+
+    @property
+    def conversation_id(self) -> str | None:
+        """Get the registered conversation ID.
+
+        Returns:
+            The conversation ID if one has been registered, None otherwise.
+        """
+        return self._conversation_id
+
     def __del__(self) -> None:
         self.cleanup()
 
@@ -813,6 +836,9 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
 
         Called by ``__exit__`` before ``cleanup()``.  Does nothing when
         ``AUTOMATION_CALLBACK_URL`` env var was not set.
+
+        Includes ``conversation_id`` in the payload if one was registered via
+        ``register_conversation()``.
         """
         try:
             callback_url = self._automation_callback_url
@@ -828,6 +854,10 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             payload["run_id"] = self._automation_run_id
         if exc_val is not None:
             payload["error"] = str(exc_val)
+
+        # Include conversation_id if one was registered
+        if self._conversation_id:
+            payload["conversation_id"] = self._conversation_id
 
         try:
             headers = {"Authorization": f"Bearer {self.cloud_api_key}"}

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -856,7 +856,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             payload["error"] = str(exc_val)
 
         # Include conversation_id if one was registered
-        if self._conversation_id:
+        if self._conversation_id is not None:
             payload["conversation_id"] = self._conversation_id
 
         try:

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -1321,3 +1321,25 @@ class TestRemoteConversation:
             conversation.execute_tool("any_tool", mock_action)
 
         assert "not yet supported for RemoteConversation" in str(exc_info.value)
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
+    def test_remote_conversation_calls_register_conversation(self, mock_ws_client):
+        """Test RemoteConversation.__init__ calls workspace.register_conversation."""
+        conversation_id = str(uuid.uuid4())
+        self.setup_mock_client(conversation_id=conversation_id)
+
+        mock_ws_instance = Mock()
+        mock_ws_client.return_value = mock_ws_instance
+
+        # Patch register_conversation at the class level to verify it gets called
+        with patch.object(RemoteWorkspace, "register_conversation") as mock_register:
+            # Create RemoteConversation - this should call register_conversation
+            _conversation = RemoteConversation(
+                agent=self.agent,
+                workspace=self.workspace,
+            )
+
+            # Verify register_conversation was called with the conversation ID
+            mock_register.assert_called_once_with(conversation_id)

--- a/tests/workspace/test_cloud_workspace.py
+++ b/tests/workspace/test_cloud_workspace.py
@@ -579,3 +579,79 @@ def test_callback_failure_does_not_raise(monkeypatch):
 
         # Should not raise
         ws.__exit__(None, None, None)
+
+
+# --- conversation_id registration tests ---
+
+
+def test_register_conversation_sets_conversation_id():
+    """register_conversation sets the _conversation_id attribute."""
+    ws = _make_local_workspace()
+
+    ws.register_conversation("conv-123")
+
+    assert ws._conversation_id == "conv-123"
+    assert ws.conversation_id == "conv-123"
+
+
+def test_conversation_id_property_returns_none_initially():
+    """conversation_id property returns None when no conversation registered."""
+    ws = _make_local_workspace()
+
+    assert ws.conversation_id is None
+
+
+def test_callback_includes_conversation_id_when_registered(monkeypatch):
+    """Callback payload includes conversation_id when registered."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
+    ws = _make_local_workspace()
+
+    # Register a conversation
+    ws.register_conversation("conv-xyz")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        ws.__exit__(None, None, None)
+
+        # Check the POST payload includes conversation_id
+        mock_client.post.assert_called_once()
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "COMPLETED"
+        assert payload["run_id"] == "run-42"
+        assert payload["conversation_id"] == "conv-xyz"
+
+
+def test_callback_omits_conversation_id_when_not_registered(monkeypatch):
+    """Callback payload omits conversation_id when not registered."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
+    ws = _make_local_workspace()
+
+    # Do not register a conversation
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        ws.__exit__(None, None, None)
+
+        # Check the POST payload does NOT include conversation_id
+        mock_client.post.assert_called_once()
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "COMPLETED"
+        assert "conversation_id" not in payload


### PR DESCRIPTION
## Summary

This PR enables the automation service to correlate runs with their associated conversations by including `conversation_id` in the completion callback payload.

## Changes

### `openhands-sdk/openhands/sdk/workspace/base.py`

- Added `register_conversation(conversation_id: str)` method (no-op in base class)
- Added `conversation_id` property (returns None in base class)

### `openhands-workspace/openhands/workspace/cloud/workspace.py`

- Added `_conversation_id` private attribute
- Implemented `register_conversation()` to store the conversation ID
- Implemented `conversation_id` property to return the stored ID
- Updated `_send_completion_callback()` to include `conversation_id` in the payload when registered

### `openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py`

- Added call to `workspace.register_conversation(str(self._id))` after conversation creation

### `tests/workspace/test_cloud_workspace.py`

- Added 4 new tests:
  - `test_register_conversation_sets_conversation_id`
  - `test_conversation_id_property_returns_none_initially`
  - `test_callback_includes_conversation_id_when_registered`
  - `test_callback_omits_conversation_id_when_not_registered`

## How it works

1. When a `RemoteConversation` is created, it calls `workspace.register_conversation(conversation_id)` after receiving the ID from the server
2. `OpenHandsCloudWorkspace` stores this ID in `_conversation_id`
3. On workspace exit, `_send_completion_callback()` includes the registered `conversation_id` in the payload
4. The automation service receives the callback and stores the `conversation_id` on the run record

This approach is simple and direct - no API queries needed, and the conversation ID is captured immediately upon creation.

## Related

This change works together with frontend changes in the automation service repo to add clickable links to automation run entries that open the associated conversation.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fc0ff4a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fc0ff4a-python \
  ghcr.io/openhands/agent-server:fc0ff4a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fc0ff4a-golang-amd64
ghcr.io/openhands/agent-server:fc0ff4a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fc0ff4a-golang-arm64
ghcr.io/openhands/agent-server:fc0ff4a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fc0ff4a-java-amd64
ghcr.io/openhands/agent-server:fc0ff4a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fc0ff4a-java-arm64
ghcr.io/openhands/agent-server:fc0ff4a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fc0ff4a-python-amd64
ghcr.io/openhands/agent-server:fc0ff4a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:fc0ff4a-python-arm64
ghcr.io/openhands/agent-server:fc0ff4a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:fc0ff4a-golang
ghcr.io/openhands/agent-server:fc0ff4a-java
ghcr.io/openhands/agent-server:fc0ff4a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fc0ff4a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fc0ff4a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->