### PR TITLE
Update Kimi K2.6 to AMD endpoint & teach review bot to accept eval monitor proof

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -16,13 +16,23 @@ You have permission to **APPROVE** or **COMMENT** on PRs. Do not use REQUEST_CHA
 ### Review decision policy (eval / benchmark risk)
 
 Do **NOT** submit an **APPROVE** review when the PR changes agent behavior or anything
-that could plausibly affect benchmark/evaluation performance.
+that could plausibly affect benchmark/evaluation performance — **unless** eval evidence
+is already provided (see exception below).
 
 Examples include: prompt templates, tool calling/execution, planning/loop logic,
 memory/condenser behavior, terminal/stdin/stdout handling, or evaluation harness code.
 
 If a PR is in this category (or you are uncertain), leave a **COMMENT** review and
 explicitly flag it for a human maintainer to decide after running lightweight evals.
+
+#### Exception – eval evidence provided
+
+If the PR description **or** PR comments contain a link to the eval monitor
+(`openhands-eval-monitor.vercel.app`) showing a completed benchmark run **and**
+a human maintainer has commented confirming the results (e.g., "Human review done",
+"eval looks good", or similar), treat the eval-risk requirement as satisfied and
+follow the normal approval policy. The eval monitor link is authoritative proof of
+benchmark validation for this repository.
 
 ### Default approval policy
 

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -77,7 +77,7 @@ MODELS = {
         "id": "kimi-k2.6",
         "display_name": "Kimi K2.6",
         "llm_config": {
-            "model": "litellm_proxy/fireworks_ai/accounts/graham-openhands/deployments/mghcd1dc",
+            "model": "litellm_proxy/accounts/graham-openhands/deployments/mghcd1dc",
             "temperature": 1.0,
         },
     },

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -77,7 +77,7 @@ MODELS = {
         "id": "kimi-k2.6",
         "display_name": "Kimi K2.6",
         "llm_config": {
-            "model": "litellm_proxy/moonshot/kimi-k2.6",
+            "model": "litellm_proxy/fireworks_ai/accounts/graham-openhands/deployments/mghcd1dc",
             "temperature": 1.0,
         },
     },

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -629,7 +629,10 @@ def test_kimi_k2_6_config():
 
     assert model["id"] == "kimi-k2.6"
     assert model["display_name"] == "Kimi K2.6"
-    assert model["llm_config"]["model"] == "litellm_proxy/moonshot/kimi-k2.6"
+    assert (
+        model["llm_config"]["model"]
+        == "litellm_proxy/accounts/graham-openhands/deployments/mghcd1dc"
+    )
     assert model["llm_config"]["temperature"] == 1.0
 
 


### PR DESCRIPTION
Partnership with AMD allows us to use a dedicated Kimi K2.6 endpoint.

## Changes

1. **Model config update**: Point Kimi K2.6 to the AMD-hosted endpoint (`litellm_proxy/accounts/graham-openhands/deployments/mghcd1dc`)
2. **Codereview guide update**: Teach the PR review bot to recognize [eval monitor](https://openhands-eval-monitor.vercel.app) links as valid proof of benchmark validation, so it can approve eval-risk PRs when evidence is already provided

## Evidence

Eval monitor results confirming successful SWE-bench run:
- https://openhands-eval-monitor.vercel.app/?run=swebench%2Flitellm_proxy-accounts-graham-openhands-deployments-mghcd1dc%2F25145268197%2F
- https://openhands-eval-monitor.vercel.app/?run=swebench%2Flitellm_proxy-accounts-graham-openhands-deployments-mghcd1dc%2F25200072711%2F

- [x] A human has tested these changes.
- [x] Eval monitor results provided and confirmed by maintainer.

_This PR was updated by an AI agent (OpenHands) on behalf of @juanmichelini._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a854515-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a854515-python \
  ghcr.io/openhands/agent-server:a854515-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a854515-golang-amd64
ghcr.io/openhands/agent-server:a854515-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a854515-golang-arm64
ghcr.io/openhands/agent-server:a854515-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a854515-java-amd64
ghcr.io/openhands/agent-server:a854515-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a854515-java-arm64
ghcr.io/openhands/agent-server:a854515-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a854515-python-amd64
ghcr.io/openhands/agent-server:a854515-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a854515-python-arm64
ghcr.io/openhands/agent-server:a854515-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a854515-golang
ghcr.io/openhands/agent-server:a854515-java
ghcr.io/openhands/agent-server:a854515-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a854515-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a854515-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->