### PR TITLE
feat(sdk): allow Conversation.switch_profile to accept an inline LLM

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -297,7 +297,6 @@ async def set_conversation_security_analyzer(
 async def switch_conversation_profile(
     conversation_id: UUID,
     profile_name: str = Body(..., embed=True),
-    llm: LLM | None = Body(None, embed=True),  # noqa: B008
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> Success:
     """Switch the conversation's LLM profile to a named profile."""
@@ -306,7 +305,7 @@ async def switch_conversation_profile(
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     conversation = event_service.get_conversation()
     try:
-        conversation.switch_profile(profile_name, llm=llm)
+        conversation.switch_profile(profile_name)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -317,6 +316,28 @@ async def switch_conversation_profile(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
+    return Success()
+
+
+@conversation_router.post(
+    "/{conversation_id}/switch_llm",
+    responses={404: {"description": "Conversation not found"}},
+)
+async def switch_conversation_llm(
+    conversation_id: UUID,
+    llm: LLM = Body(..., embed=True),  # noqa: B008
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> Success:
+    """Swap the conversation's LLM to a caller-supplied object.
+
+    Used by app-servers that own the LLM directly and don't push profiles
+    to the agent-server's filesystem (see #3017).
+    """
+    event_service = await conversation_service.get_event_service(conversation_id)
+    if event_service is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    conversation = event_service.get_conversation()
+    conversation.switch_llm(llm)
     return Success()
 
 

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -297,6 +297,7 @@ async def set_conversation_security_analyzer(
 async def switch_conversation_profile(
     conversation_id: UUID,
     profile_name: str = Body(..., embed=True),
+    llm: LLM | None = Body(None, embed=True),  # noqa: B008
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> Success:
     """Switch the conversation's LLM profile to a named profile."""
@@ -305,7 +306,7 @@ async def switch_conversation_profile(
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     conversation = event_service.get_conversation()
     try:
-        conversation.switch_profile(profile_name)
+        conversation.switch_profile(profile_name, llm=llm)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -653,10 +653,10 @@ class LocalConversation(BaseConversation):
             new_llm = self.llm_registry.get(usage_id)
         except KeyError:
             if llm is not None:
-                new_llm = llm.model_copy(update={"usage_id": usage_id})
+                new_llm = llm
             else:
                 new_llm = self._profile_store.load(profile_name)
-                new_llm = new_llm.model_copy(update={"usage_id": usage_id})
+            new_llm = new_llm.model_copy(update={"usage_id": usage_id})
             self.llm_registry.add(new_llm)
         with self._state:
             self.agent = self.agent.model_copy(update={"llm": new_llm})

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -649,17 +649,15 @@ class LocalConversation(BaseConversation):
             ValueError: If the profile is corrupted or invalid.
         """
         usage_id = f"profile:{profile_name}"
-        if llm is not None:
-            new_llm = llm.model_copy(update={"usage_id": usage_id})
-            self.llm_registry._usage_to_llm.pop(usage_id, None)
-            self.llm_registry.add(new_llm)
-        else:
-            try:
-                new_llm = self.llm_registry.get(usage_id)
-            except KeyError:
+        try:
+            new_llm = self.llm_registry.get(usage_id)
+        except KeyError:
+            if llm is not None:
+                new_llm = llm.model_copy(update={"usage_id": usage_id})
+            else:
                 new_llm = self._profile_store.load(profile_name)
                 new_llm = new_llm.model_copy(update={"usage_id": usage_id})
-                self.llm_registry.add(new_llm)
+            self.llm_registry.add(new_llm)
         with self._state:
             self.agent = self.agent.model_copy(update={"llm": new_llm})
             self._state.agent = self.agent

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -632,17 +632,36 @@ class LocalConversation(BaseConversation):
         if self.agent.llm._prompt_cache_key is None:
             self.agent.llm._prompt_cache_key = str(self._state.id)
 
-    def switch_profile(self, profile_name: str, llm: LLM | None = None) -> None:
-        """Switch the agent's LLM to a named profile.
+    def switch_llm(self, llm: LLM) -> None:
+        """Swap the agent's LLM to the given object.
 
-        If ``llm`` is provided it is used directly (tagged as
-        ``profile:{profile_name}``) and the profile store is skipped.
-        Otherwise the profile is loaded from :class:`LLMProfileStore`
-        (cached in the registry after the first load).
+        The caller owns ``llm.usage_id``; it is the registry key. If an
+        entry with that key already exists, the cached LLM is reused and
+        the passed ``llm`` is dropped — matching the rest of the
+        registry's "first-write-wins" contract.
+
+        Args:
+            llm: LLM to install on the agent.
+        """
+        try:
+            new_llm = self.llm_registry.get(llm.usage_id)
+        except KeyError:
+            new_llm = llm
+            self.llm_registry.add(new_llm)
+        with self._state:
+            self.agent = self.agent.model_copy(update={"llm": new_llm})
+            self._state.agent = self.agent
+            self._pin_prompt_cache_key()
+
+    def switch_profile(self, profile_name: str) -> None:
+        """Switch the agent's LLM to a profile loaded from disk.
+
+        Loads the profile from :class:`LLMProfileStore` (cached in the
+        registry under ``profile:{profile_name}`` after first load) and
+        delegates the swap to :meth:`switch_llm`.
 
         Args:
             profile_name: Name of a profile previously saved via LLMProfileStore.
-            llm: Optional LLM to use directly, bypassing the profile store.
 
         Raises:
             FileNotFoundError: If the profile does not exist.
@@ -650,18 +669,11 @@ class LocalConversation(BaseConversation):
         """
         usage_id = f"profile:{profile_name}"
         try:
-            new_llm = self.llm_registry.get(usage_id)
+            cached = self.llm_registry.get(usage_id)
         except KeyError:
-            if llm is not None:
-                new_llm = llm
-            else:
-                new_llm = self._profile_store.load(profile_name)
-            new_llm = new_llm.model_copy(update={"usage_id": usage_id})
-            self.llm_registry.add(new_llm)
-        with self._state:
-            self.agent = self.agent.model_copy(update={"llm": new_llm})
-            self._state.agent = self.agent
-            self._pin_prompt_cache_key()
+            loaded = self._profile_store.load(profile_name)
+            cached = loaded.model_copy(update={"usage_id": usage_id})
+        self.switch_llm(cached)
 
     @observe(name="conversation.send_message")
     def send_message(self, message: str | Message, sender: str | None = None) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -632,26 +632,34 @@ class LocalConversation(BaseConversation):
         if self.agent.llm._prompt_cache_key is None:
             self.agent.llm._prompt_cache_key = str(self._state.id)
 
-    def switch_profile(self, profile_name: str) -> None:
+    def switch_profile(self, profile_name: str, llm: LLM | None = None) -> None:
         """Switch the agent's LLM to a named profile.
 
-        Loads the profile from the LLMProfileStore (cached in the registry
-        after the first load) and updates the agent and conversation state.
+        If ``llm`` is provided it is used directly (tagged as
+        ``profile:{profile_name}``) and the profile store is skipped.
+        Otherwise the profile is loaded from :class:`LLMProfileStore`
+        (cached in the registry after the first load).
 
         Args:
             profile_name: Name of a profile previously saved via LLMProfileStore.
+            llm: Optional LLM to use directly, bypassing the profile store.
 
         Raises:
             FileNotFoundError: If the profile does not exist.
             ValueError: If the profile is corrupted or invalid.
         """
         usage_id = f"profile:{profile_name}"
-        try:
-            new_llm = self.llm_registry.get(usage_id)
-        except KeyError:
-            new_llm = self._profile_store.load(profile_name)
-            new_llm = new_llm.model_copy(update={"usage_id": usage_id})
+        if llm is not None:
+            new_llm = llm.model_copy(update={"usage_id": usage_id})
+            self.llm_registry._usage_to_llm.pop(usage_id, None)
             self.llm_registry.add(new_llm)
+        else:
+            try:
+                new_llm = self.llm_registry.get(usage_id)
+            except KeyError:
+                new_llm = self._profile_store.load(profile_name)
+                new_llm = new_llm.model_copy(update={"usage_id": usage_id})
+                self.llm_registry.add(new_llm)
         with self._state:
             self.agent = self.agent.model_copy(update={"llm": new_llm})
             self._state.agent = self.agent

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1602,6 +1602,41 @@ def test_switch_conversation_profile_corrupted_profile(
         client.app.dependency_overrides.clear()
 
 
+def test_switch_conversation_profile_with_inline_llm(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """Inline llm body is forwarded to switch_profile, bypassing the store."""
+    mock_conversation = MagicMock()
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.get_conversation.return_value = mock_conversation
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    llm_payload = {
+        "model": "openai/gpt-4o",
+        "api_key": "sk-test",
+        "usage_id": "ignored",
+    }
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_profile",
+            json={"profile_name": "inline", "llm": llm_payload},
+        )
+
+        assert response.status_code == 200
+        mock_conversation.switch_profile.assert_called_once()
+        call_args = mock_conversation.switch_profile.call_args
+        assert call_args.args == ("inline",)
+        forwarded_llm = call_args.kwargs["llm"]
+        assert isinstance(forwarded_llm, LLM)
+        assert forwarded_llm.model == "openai/gpt-4o"
+    finally:
+        client.app.dependency_overrides.clear()
+
+
 def test_fork_conversation_success(
     client, mock_conversation_service, sample_conversation_info, sample_conversation_id
 ):

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1519,7 +1519,7 @@ def test_switch_conversation_profile_success(
             sample_conversation_id
         )
         mock_event_service.get_conversation.assert_called_once()
-        mock_conversation.switch_profile.assert_called_once_with("gpt", llm=None)
+        mock_conversation.switch_profile.assert_called_once_with("gpt")
     finally:
         client.app.dependency_overrides.clear()
 
@@ -1571,7 +1571,7 @@ def test_switch_conversation_profile_nonexistent_profile(
 
         assert response.status_code == 404
         assert "missing" in response.json()["detail"]
-        mock_conversation.switch_profile.assert_called_once_with("missing", llm=None)
+        mock_conversation.switch_profile.assert_called_once_with("missing")
     finally:
         client.app.dependency_overrides.clear()
 
@@ -1597,15 +1597,17 @@ def test_switch_conversation_profile_corrupted_profile(
 
         assert response.status_code == 400
         assert "Invalid profile format" in response.json()["detail"]
-        mock_conversation.switch_profile.assert_called_once_with("corrupted", llm=None)
+        mock_conversation.switch_profile.assert_called_once_with("corrupted")
     finally:
         client.app.dependency_overrides.clear()
 
 
-def test_switch_conversation_profile_with_inline_llm(
+def test_switch_conversation_llm_success(
     client, mock_conversation_service, mock_event_service, sample_conversation_id
 ):
-    """Inline llm body is forwarded to switch_profile, bypassing the store."""
+    """The /switch_llm endpoint forwards the inline LLM to switch_llm,
+    bypassing the profile store (#3017).
+    """
     mock_conversation = MagicMock()
     mock_conversation_service.get_event_service.return_value = mock_event_service
     mock_event_service.get_conversation.return_value = mock_conversation
@@ -1617,22 +1619,48 @@ def test_switch_conversation_profile_with_inline_llm(
     llm_payload = {
         "model": "openai/gpt-4o",
         "api_key": "sk-test",
-        "usage_id": "ignored",
+        "usage_id": "caller-supplied-id",
     }
 
     try:
         response = client.post(
-            f"/api/conversations/{sample_conversation_id}/switch_profile",
-            json={"profile_name": "inline", "llm": llm_payload},
+            f"/api/conversations/{sample_conversation_id}/switch_llm",
+            json={"llm": llm_payload},
         )
 
         assert response.status_code == 200
-        mock_conversation.switch_profile.assert_called_once()
-        call_args = mock_conversation.switch_profile.call_args
-        assert call_args.args == ("inline",)
-        forwarded_llm = call_args.kwargs["llm"]
+        mock_conversation.switch_llm.assert_called_once()
+        forwarded_llm = mock_conversation.switch_llm.call_args.args[0]
         assert isinstance(forwarded_llm, LLM)
         assert forwarded_llm.model == "openai/gpt-4o"
+        assert forwarded_llm.usage_id == "caller-supplied-id"
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_switch_conversation_llm_not_found(
+    client, mock_conversation_service, sample_conversation_id
+):
+    """The /switch_llm endpoint returns 404 when the conversation is missing."""
+    mock_conversation_service.get_event_service.return_value = None
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_llm",
+            json={
+                "llm": {
+                    "model": "openai/gpt-4o",
+                    "api_key": "sk-test",
+                    "usage_id": "x",
+                }
+            },
+        )
+
+        assert response.status_code == 404
     finally:
         client.app.dependency_overrides.clear()
 

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1519,7 +1519,7 @@ def test_switch_conversation_profile_success(
             sample_conversation_id
         )
         mock_event_service.get_conversation.assert_called_once()
-        mock_conversation.switch_profile.assert_called_once_with("gpt")
+        mock_conversation.switch_profile.assert_called_once_with("gpt", llm=None)
     finally:
         client.app.dependency_overrides.clear()
 
@@ -1571,7 +1571,7 @@ def test_switch_conversation_profile_nonexistent_profile(
 
         assert response.status_code == 404
         assert "missing" in response.json()["detail"]
-        mock_conversation.switch_profile.assert_called_once_with("missing")
+        mock_conversation.switch_profile.assert_called_once_with("missing", llm=None)
     finally:
         client.app.dependency_overrides.clear()
 
@@ -1597,7 +1597,7 @@ def test_switch_conversation_profile_corrupted_profile(
 
         assert response.status_code == 400
         assert "Invalid profile format" in response.json()["detail"]
-        mock_conversation.switch_profile.assert_called_once_with("corrupted")
+        mock_conversation.switch_profile.assert_called_once_with("corrupted", llm=None)
     finally:
         client.app.dependency_overrides.clear()
 

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -117,3 +117,109 @@ def test_switch_then_send_message(profile_store):
     # send_message triggers _ensure_agent_ready which re-registers agent LLMs;
     # the switched LLM must not cause a duplicate registration error.
     conv.send_message("hello")
+
+
+@pytest.fixture()
+def empty_profile_store(tmp_path, monkeypatch):
+    """Empty profile dir — simulates the agent-server sandbox where the
+    app-server has never uploaded profile JSON. This is the real failure
+    mode #3017 is fixing.
+    """
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    monkeypatch.setattr(llm_profile_store, "_DEFAULT_PROFILE_DIR", profile_dir)
+    return profile_dir
+
+
+def test_switch_profile_inline_llm_when_store_is_empty(empty_profile_store):
+    """Real app-server case: profile is unknown to the sandbox FS, the
+    app-server supplies the LLM inline, and the swap succeeds without a 404.
+    """
+    conv = _make_conversation()
+    inline = _make_llm("inline-model", "caller-supplied-id")
+
+    # Without `llm`, this would raise FileNotFoundError.
+    conv.switch_profile("from-app-server", llm=inline)
+
+    assert conv.agent.llm.model == "inline-model"
+    # State must agree — agent_server reads agent.llm via _state.
+    assert conv.state.agent.llm.model == "inline-model"
+    # usage_id is canonicalised so future store-path lookups hit the cache.
+    assert conv.agent.llm.usage_id == "profile:from-app-server"
+    assert conv.llm_registry.get("profile:from-app-server").model == "inline-model"
+    # Cache-key must be repinned (regression guard for #2918 on the new path).
+    assert conv.agent.llm._prompt_cache_key == str(conv.id)
+
+
+def test_switch_profile_inline_llm_then_send_message(empty_profile_store):
+    """Mirrors test_switch_then_send_message for the inline path.
+
+    send_message triggers _ensure_agent_ready, which re-registers agent LLMs
+    in the registry. The inline path adds an entry under
+    ``profile:{name}``; this must not collide with the agent's own LLM
+    re-registration on the next send_message().
+    """
+    conv = _make_conversation()
+    conv.switch_profile("from-app-server", llm=_make_llm("inline-model", "x"))
+    conv.send_message("hello")
+
+
+def test_switch_between_two_inline_profiles(empty_profile_store):
+    """The /model command flow: swap profile A inline, then profile B inline.
+
+    Each profile is registered under its own ``profile:{name}`` slot, so
+    consecutive inline swaps for *different* names must not collide in the
+    registry.
+    """
+    conv = _make_conversation()
+
+    conv.switch_profile("a", llm=_make_llm("model-a", "x"))
+    assert conv.agent.llm.model == "model-a"
+
+    conv.switch_profile("b", llm=_make_llm("model-b", "y"))
+    assert conv.agent.llm.model == "model-b"
+
+    # Switching back to "a" without re-supplying llm hits the cached entry.
+    conv.switch_profile("a")
+    assert conv.agent.llm.model == "model-a"
+
+
+def test_switch_profile_inline_llm_cache_wins_on_repeat_call(empty_profile_store):
+    """Locks in the chosen semantics: when ``profile:{name}`` is already
+    cached, the cached LLM wins and a fresh ``llm=`` is silently ignored.
+
+    This is symmetric with the store-path behaviour
+    (``test_switch_reuses_registry_entry``). Documenting it as a test
+    so a future refactor can't change the contract unnoticed.
+    """
+    conv = _make_conversation()
+
+    conv.switch_profile("inline", llm=_make_llm("first-model", "x"))
+    # Second call with a different LLM under the same profile name —
+    # registry cache is authoritative; the new LLM is dropped.
+    conv.switch_profile("inline", llm=_make_llm("second-model", "y"))
+
+    assert conv.agent.llm.model == "first-model"
+
+
+def test_switch_profile_inline_llm_does_not_consult_store(
+    empty_profile_store, monkeypatch
+):
+    """Inline LLM must not hit LLMProfileStore.load — even if the store
+    would otherwise have content. Guards against a regression where the
+    caller-authoritative path silently falls through to disk IO.
+    """
+    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+
+    calls: list[str] = []
+
+    def _spy_load(self, name):
+        calls.append(name)
+        raise FileNotFoundError(name)  # would 404 — must not be reached
+
+    monkeypatch.setattr(LLMProfileStore, "load", _spy_load)
+
+    conv = _make_conversation()
+    conv.switch_profile("inline", llm=_make_llm("inline-model", "x"))
+
+    assert calls == [], f"profile store was consulted: {calls}"

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -131,95 +131,84 @@ def empty_profile_store(tmp_path, monkeypatch):
     return profile_dir
 
 
-def test_switch_profile_inline_llm_when_store_is_empty(empty_profile_store):
-    """Real app-server case: profile is unknown to the sandbox FS, the
-    app-server supplies the LLM inline, and the swap succeeds without a 404.
+def test_switch_llm_swaps_when_store_empty(empty_profile_store):
+    """Real app-server case (#3017): profile is unknown to the sandbox FS,
+    the app-server supplies the LLM directly, and the swap succeeds.
     """
     conv = _make_conversation()
     inline = _make_llm("inline-model", "caller-supplied-id")
 
-    # Without `llm`, this would raise FileNotFoundError.
-    conv.switch_profile("from-app-server", llm=inline)
+    conv.switch_llm(inline)
 
     assert conv.agent.llm.model == "inline-model"
     # State must agree — agent_server reads agent.llm via _state.
     assert conv.state.agent.llm.model == "inline-model"
-    # usage_id is canonicalised so future store-path lookups hit the cache.
-    assert conv.agent.llm.usage_id == "profile:from-app-server"
-    assert conv.llm_registry.get("profile:from-app-server").model == "inline-model"
+    # Caller's usage_id is preserved as the registry key.
+    assert conv.agent.llm.usage_id == "caller-supplied-id"
+    assert conv.llm_registry.get("caller-supplied-id").model == "inline-model"
     # Cache-key must be repinned (regression guard for #2918 on the new path).
     assert conv.agent.llm._prompt_cache_key == str(conv.id)
 
 
-def test_switch_profile_inline_llm_then_send_message(empty_profile_store):
-    """Mirrors test_switch_then_send_message for the inline path.
-
-    send_message triggers _ensure_agent_ready, which re-registers agent LLMs
-    in the registry. The inline path adds an entry under
-    ``profile:{name}``; this must not collide with the agent's own LLM
+def test_switch_llm_then_send_message(empty_profile_store):
+    """send_message triggers _ensure_agent_ready, which re-registers agent
+    LLMs in the registry. switch_llm adds an entry under the caller's
+    usage_id; this must not collide with the agent's own LLM
     re-registration on the next send_message().
     """
     conv = _make_conversation()
-    conv.switch_profile("from-app-server", llm=_make_llm("inline-model", "x"))
+    conv.switch_llm(_make_llm("inline-model", "x"))
     conv.send_message("hello")
 
 
-def test_switch_between_two_inline_profiles(empty_profile_store):
-    """The /model command flow: swap profile A inline, then profile B inline.
-
-    Each profile is registered under its own ``profile:{name}`` slot, so
-    consecutive inline swaps for *different* names must not collide in the
-    registry.
+def test_switch_between_two_llms(empty_profile_store):
+    """Consecutive switch_llm calls under distinct usage_ids each register
+    their own slot and end up as the agent's LLM.
     """
     conv = _make_conversation()
 
-    conv.switch_profile("a", llm=_make_llm("model-a", "x"))
+    conv.switch_llm(_make_llm("model-a", "x"))
     assert conv.agent.llm.model == "model-a"
 
-    conv.switch_profile("b", llm=_make_llm("model-b", "y"))
+    conv.switch_llm(_make_llm("model-b", "y"))
     assert conv.agent.llm.model == "model-b"
 
-    # Switching back to "a" without re-supplying llm hits the cached entry.
-    conv.switch_profile("a")
-    assert conv.agent.llm.model == "model-a"
 
-
-def test_switch_profile_inline_llm_cache_wins_on_repeat_call(empty_profile_store):
-    """Locks in the chosen semantics: when ``profile:{name}`` is already
-    cached, the cached LLM wins and a fresh ``llm=`` is silently ignored.
-
-    This is symmetric with the store-path behaviour
-    (``test_switch_reuses_registry_entry``). Documenting it as a test
-    so a future refactor can't change the contract unnoticed.
+def test_switch_llm_does_not_consult_store(empty_profile_store, monkeypatch):
+    """switch_llm must not hit LLMProfileStore.load — the caller is
+    authoritative. Guards against a regression where the inline path
+    silently falls through to disk IO.
     """
-    conv = _make_conversation()
-
-    conv.switch_profile("inline", llm=_make_llm("first-model", "x"))
-    # Second call with a different LLM under the same profile name —
-    # registry cache is authoritative; the new LLM is dropped.
-    conv.switch_profile("inline", llm=_make_llm("second-model", "y"))
-
-    assert conv.agent.llm.model == "first-model"
-
-
-def test_switch_profile_inline_llm_does_not_consult_store(
-    empty_profile_store, monkeypatch
-):
-    """Inline LLM must not hit LLMProfileStore.load — even if the store
-    would otherwise have content. Guards against a regression where the
-    caller-authoritative path silently falls through to disk IO.
-    """
-    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-
     calls: list[str] = []
 
     def _spy_load(self, name):
         calls.append(name)
-        raise FileNotFoundError(name)  # would 404 — must not be reached
+        raise FileNotFoundError(name)
 
     monkeypatch.setattr(LLMProfileStore, "load", _spy_load)
 
     conv = _make_conversation()
-    conv.switch_profile("inline", llm=_make_llm("inline-model", "x"))
+    conv.switch_llm(_make_llm("inline-model", "x"))
 
     assert calls == [], f"profile store was consulted: {calls}"
+
+
+def test_switch_profile_delegates_to_switch_llm(profile_store, monkeypatch):
+    """switch_profile loads from disk and delegates to switch_llm; the LLM
+    handed off carries the canonical ``profile:{name}`` usage_id.
+    """
+    conv = _make_conversation()
+    seen: list[LLM] = []
+    real_switch_llm = conv.switch_llm
+
+    def _spy(llm):
+        seen.append(llm)
+        real_switch_llm(llm)
+
+    monkeypatch.setattr(conv, "switch_llm", _spy)
+
+    conv.switch_profile("fast")
+
+    assert len(seen) == 1
+    assert seen[0].usage_id == "profile:fast"
+    assert seen[0].model == "fast-model"


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

We refeer to #3017 for the details about the PR.


## Issue Number
Closes #3017.


## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:20cec0d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-20cec0d-python \
  ghcr.io/openhands/agent-server:20cec0d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:20cec0d-golang-amd64
ghcr.io/openhands/agent-server:20cec0d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:20cec0d-golang-arm64
ghcr.io/openhands/agent-server:20cec0d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:20cec0d-java-amd64
ghcr.io/openhands/agent-server:20cec0d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:20cec0d-java-arm64
ghcr.io/openhands/agent-server:20cec0d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:20cec0d-python-amd64
ghcr.io/openhands/agent-server:20cec0d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:20cec0d-python-arm64
ghcr.io/openhands/agent-server:20cec0d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:20cec0d-golang
ghcr.io/openhands/agent-server:20cec0d-java
ghcr.io/openhands/agent-server:20cec0d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `20cec0d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `20cec0d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->