### PR TITLE
Make VERIFIED_OPENHANDS_MODELS the union of all provider lists

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -88,44 +88,7 @@ VERIFIED_QWEN_MODELS = [
     "qwen3-coder-480b",
 ]
 
-VERIFIED_OPENHANDS_MODELS = [
-    "claude-opus-4-5",
-    "claude-opus-4-5-20251101",
-    "claude-opus-4-6",
-    "claude-opus-4-7",
-    "claude-sonnet-4-5",
-    "claude-sonnet-4-6",
-    "gpt-5.4",
-    "gpt-5.2",
-    "gpt-5.2-codex",
-    "minimax-m2.1",
-    "minimax-m2.5",
-    "minimax-m2.7",
-    "gemini-3.1-pro",
-    "gemini-3.1-pro-preview",
-    "gemini-3-flash",
-    "gemini-3-pro",
-    "deepseek-chat",
-    "deepseek-v3.2-reasoner",
-    "kimi-k2-thinking",
-    "kimi-k2.5",
-    "devstral-medium-2512",
-    "devstral-2512",
-    "gpt-5.1-codex-max",
-    "gpt-5.1-codex",
-    "gpt-5.1",
-    "glm-4.7",
-    "glm-5",
-    "glm-5.1",
-    "nemotron-3-nano",
-    "nemotron-3-super",
-    "qwen3-6-plus",
-    "qwen3-coder-480b",
-]
-
-
-VERIFIED_MODELS = {
-    "openhands": VERIFIED_OPENHANDS_MODELS,
+_PROVIDER_VERIFIED_MODELS = {
     "anthropic": VERIFIED_ANTHROPIC_MODELS,
     "openai": VERIFIED_OPENAI_MODELS,
     "mistral": VERIFIED_MISTRAL_MODELS,
@@ -137,3 +100,12 @@ VERIFIED_MODELS = {
     "nvidia": VERIFIED_NVIDIA_MODELS,
     "qwen": VERIFIED_QWEN_MODELS,
 }
+
+# The OpenHands provider aggregates every model verified in any upstream provider,
+# so adding a model to any provider list automatically makes it available via
+# OpenHands as well.  Do NOT maintain a separate manual list here.
+VERIFIED_OPENHANDS_MODELS = sorted(
+    {m for models in _PROVIDER_VERIFIED_MODELS.values() for m in models}
+)
+
+VERIFIED_MODELS = {"openhands": VERIFIED_OPENHANDS_MODELS, **_PROVIDER_VERIFIED_MODELS}

--- a/tests/sdk/llm/test_model_list.py
+++ b/tests/sdk/llm/test_model_list.py
@@ -83,17 +83,19 @@ def test_list_bedrock_models_with_boto3(monkeypatch):
     assert result == ["bedrock/anthropic.claude-3"]
 
 
-def test_openhands_models_all_have_provider_list():
-    """Every model in VERIFIED_OPENHANDS_MODELS must also appear in at least one
-    provider-specific list so that the UI can display it under its actual provider.
+def test_openhands_models_equals_union_of_all_providers():
+    """VERIFIED_OPENHANDS_MODELS must be exactly the union of every other
+    provider's verified list so that any model verified in *any* provider
+    is also available through the OpenHands provider.
     """
-    provider_models = set()
+    all_provider_models = set()
     for provider, models in VERIFIED_MODELS.items():
         if provider == "openhands":
             continue
-        provider_models.update(models)
+        all_provider_models.update(models)
 
-    missing = [m for m in VERIFIED_OPENHANDS_MODELS if m not in provider_models]
-    assert not missing, (
-        f"Models in VERIFIED_OPENHANDS_MODELS missing from any provider list: {missing}"
+    assert set(VERIFIED_OPENHANDS_MODELS) == all_provider_models, (
+        "VERIFIED_OPENHANDS_MODELS must be the union of all provider lists."
+        f" Extra: {set(VERIFIED_OPENHANDS_MODELS) - all_provider_models},"
+        f" Missing: {all_provider_models - set(VERIFIED_OPENHANDS_MODELS)}"
     )


### PR DESCRIPTION
## Summary

Compute `VERIFIED_OPENHANDS_MODELS` automatically as the sorted union of every other provider's verified model list, so adding a model to **any** provider list automatically makes it available through the OpenHands provider.

This replaces the manually maintained list that could drift out of sync with the individual provider lists.

## Changes

- **`openhands-sdk/openhands/sdk/llm/utils/verified_models.py`**: Replace the hand-maintained `VERIFIED_OPENHANDS_MODELS` list with a computed set comprehension over all provider lists. Added a comment explaining the intent so future contributors don't re-introduce a manual list.
- **`tests/sdk/llm/test_model_list.py`**: Updated the test to assert exact equality (the OpenHands set == the union of all provider sets), rather than just a subset check.

Fixes #3005

---

_This PR was created by an AI agent (OpenHands) on behalf of juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/59b7893f-becd-4a32-be4c-ed9dead5b5fa)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6f32bd2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6f32bd2-python \
  ghcr.io/openhands/agent-server:6f32bd2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6f32bd2-golang-amd64
ghcr.io/openhands/agent-server:6f32bd2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6f32bd2-golang-arm64
ghcr.io/openhands/agent-server:6f32bd2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6f32bd2-java-amd64
ghcr.io/openhands/agent-server:6f32bd2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6f32bd2-java-arm64
ghcr.io/openhands/agent-server:6f32bd2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6f32bd2-python-amd64
ghcr.io/openhands/agent-server:6f32bd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6f32bd2-python-arm64
ghcr.io/openhands/agent-server:6f32bd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6f32bd2-golang
ghcr.io/openhands/agent-server:6f32bd2-java
ghcr.io/openhands/agent-server:6f32bd2-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6f32bd2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6f32bd2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->