### PR TITLE
fix(sdk): preserve critic api key serialization

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/impl/api/client.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/client.py
@@ -10,9 +10,12 @@ from pydantic import (
     Field,
     PrivateAttr,
     SecretStr,
+    field_serializer,
     field_validator,
 )
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
+
+from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
 
 from .chat_template import ChatTemplateRenderer
 
@@ -156,17 +159,17 @@ class CriticClient(BaseModel):
     # ---------------------
     @field_validator("api_key", mode="before")
     @classmethod
-    def _validate_and_convert_api_key(cls, v: str | SecretStr) -> SecretStr:
-        """Convert str to SecretStr and validate non-empty."""
-        if isinstance(v, SecretStr):
-            secret_value = v.get_secret_value()
-        else:
-            secret_value = v
-
-        if not secret_value or not secret_value.strip():
+    def _validate_and_convert_api_key(cls, v: str | SecretStr, info) -> SecretStr:
+        """Validate api_key and decrypt it when needed."""
+        secret = validate_secret(v, info)
+        if secret is None:
             raise ValueError("api_key must be non-empty")
+        return secret
 
-        return SecretStr(secret_value) if isinstance(v, str) else v
+    @field_serializer("api_key", when_used="always")
+    def _serialize_api_key(self, v: str | SecretStr, info):
+        secret = v if isinstance(v, SecretStr) else SecretStr(v)
+        return serialize_secret(secret, info)
 
     # ---------------------
     # Label helpers

--- a/tests/sdk/critic/test_critic_client.py
+++ b/tests/sdk/critic/test_critic_client.py
@@ -3,7 +3,10 @@
 import pytest
 from pydantic import SecretStr, ValidationError
 
+from openhands.sdk import LLM, Agent
+from openhands.sdk.critic.impl.api import APIBasedCritic
 from openhands.sdk.critic.impl.api.client import CriticClient
+from openhands.sdk.utils.cipher import Cipher
 
 
 def test_critic_client_with_str_api_key():
@@ -73,3 +76,67 @@ def test_critic_client_api_key_preserved_after_validation():
     client2 = CriticClient(api_key=secret_key)
     assert isinstance(client2.api_key, SecretStr)
     assert client2.api_key.get_secret_value() == "another_key_101112"
+
+
+def test_critic_client_api_key_exposed_with_context():
+    """Test that expose_secrets reveals the api_key for transport payloads."""
+    client = CriticClient(api_key="critic-secret")
+
+    dumped = client.model_dump(mode="json", context={"expose_secrets": True})
+
+    assert dumped["api_key"] == "critic-secret"
+
+
+def test_critic_client_api_key_encrypted_with_cipher():
+    """Test that cipher context encrypts and restores the api_key."""
+    cipher = Cipher(secret_key="test-secret-key")
+    client = CriticClient(api_key="critic-secret")
+
+    dumped = client.model_dump(mode="json", context={"cipher": cipher})
+
+    assert dumped["api_key"] != "critic-secret"
+    assert dumped["api_key"] != "**********"
+    restored = CriticClient.model_validate(dumped, context={"cipher": cipher})
+    assert isinstance(restored.api_key, SecretStr)
+    assert restored.api_key.get_secret_value() == "critic-secret"
+
+
+def test_agent_dump_exposes_nested_critic_api_key_with_context():
+    """Test that Agent serialization preserves critic api_key with context."""
+    agent = Agent(
+        llm=LLM(model="test-model", api_key=SecretStr("llm-secret")),
+        critic=APIBasedCritic(
+            api_key=SecretStr("critic-secret"),
+            server_url="https://critic.example.com",
+            model_name="critic",
+        ),
+    )
+
+    dumped = agent.model_dump(mode="json", context={"expose_secrets": True})
+
+    assert dumped["llm"]["api_key"] == "llm-secret"
+    assert dumped["critic"]["api_key"] == "critic-secret"
+
+
+def test_agent_dump_encrypts_nested_critic_api_key_with_cipher():
+    """Test that Agent serialization encrypts nested critic api_key with cipher."""
+    cipher = Cipher(secret_key="test-secret-key")
+    agent = Agent(
+        llm=LLM(model="test-model", api_key=SecretStr("llm-secret")),
+        critic=APIBasedCritic(
+            api_key=SecretStr("critic-secret"),
+            server_url="https://critic.example.com",
+            model_name="critic",
+        ),
+    )
+
+    dumped = agent.model_dump(mode="json", context={"cipher": cipher})
+
+    assert dumped["llm"]["api_key"] != "llm-secret"
+    assert dumped["critic"]["api_key"] != "critic-secret"
+    assert dumped["critic"]["api_key"] != "**********"
+
+    restored = Agent.model_validate(dumped, context={"cipher": cipher})
+    assert isinstance(restored.critic, APIBasedCritic)
+    assert isinstance(restored.critic.api_key, SecretStr)
+    assert restored.critic.api_key.get_secret_value() == "critic-secret"


### PR DESCRIPTION
## Summary

- Serialize `CriticClient.api_key` with the SDK shared secret serializer so `expose_secrets` preserves the key in transport payloads and `cipher` encrypts persisted state.
- Decrypt critic API keys from encrypted payloads when cipher context is available.
- Add regression coverage for direct critic serialization and nested `Agent` serialization.

## Root Cause

`LLM.api_key` already used the shared secret serializer, but `CriticClient.api_key` relied on Pydantic default `SecretStr` serialization. When an `Agent` was dumped with `context={"expose_secrets": True}`, the LLM key stayed available while the critic key became `"**********"`, causing persisted or forwarded critic configs to authenticate with the masked value.

## Validation

- `uv run pytest tests/sdk/critic/test_critic_client.py`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/critic/impl/api/client.py tests/sdk/critic/test_critic_client.py`

_This PR was created by an AI agent on behalf of Xingyao Wang._





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3509879-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3509879-python \
  ghcr.io/openhands/agent-server:3509879-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3509879-golang-amd64
ghcr.io/openhands/agent-server:3509879-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3509879-golang-arm64
ghcr.io/openhands/agent-server:3509879-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3509879-java-amd64
ghcr.io/openhands/agent-server:3509879-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3509879-java-arm64
ghcr.io/openhands/agent-server:3509879-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3509879-python-amd64
ghcr.io/openhands/agent-server:3509879-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3509879-python-arm64
ghcr.io/openhands/agent-server:3509879-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3509879-golang
ghcr.io/openhands/agent-server:3509879-java
ghcr.io/openhands/agent-server:3509879-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3509879-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3509879-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->