### PR TITLE
ci: auto-create GitHub release when release PR is merged

### DIFF
--- a/.agents/skills/sdk-release/SKILL.md
+++ b/.agents/skills/sdk-release/SKILL.md
@@ -163,7 +163,6 @@ When the release PR is merged, the following happens automatically:
    - `openhands-agent-server`
 3. **`version-bump-prs.yml`** triggers after successful PyPI publish and
    creates downstream version bump PRs.
-4. **Slack notification** is sent automatically by the version-bump workflow.
 
 ### ⏸ Checkpoint — Verify PyPI Publication
 
@@ -176,6 +175,10 @@ done
 ```
 
 All should return `200`.
+
+## Phase 7: Post-Release Announcements
+
+Send a Slack notification to announce the release. This is a human step.
 
 See `references/post-release-checklist.md` for details on reviewing
 downstream PRs and handling any issues.
@@ -194,3 +197,4 @@ downstream PRs and handling any issues.
 - [ ] _(Automated)_ Packages published to PyPI
 - [ ] _(Automated)_ Downstream version bump PRs created
 - [ ] Verify packages appear on PyPI
+- [ ] Send Slack notification announcing the release

--- a/.agents/skills/sdk-release/SKILL.md
+++ b/.agents/skills/sdk-release/SKILL.md
@@ -178,7 +178,18 @@ All should return `200`.
 
 ## Phase 7: Post-Release Announcements
 
-Send a Slack notification to announce the release. This is a human step.
+After the automated pipeline completes, compose a Slack message for the
+human to post, including links to the downstream version bump PRs:
+
+```
+🚀 *SDK v<version> published to PyPI!*
+
+Version bump PRs:
+• <https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands>
+• <https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands-CLI>
+
+Release: <https://github.com/OpenHands/software-agent-sdk/releases/tag/v<version>|v<version>>
+```
 
 See `references/post-release-checklist.md` for details on reviewing
 downstream PRs and handling any issues.
@@ -197,4 +208,4 @@ downstream PRs and handling any issues.
 - [ ] _(Automated)_ Packages published to PyPI
 - [ ] _(Automated)_ Downstream version bump PRs created
 - [ ] Verify packages appear on PyPI
-- [ ] Send Slack notification announcing the release
+- [ ] Send Slack message with downstream version bump PR links

--- a/.agents/skills/sdk-release/SKILL.md
+++ b/.agents/skills/sdk-release/SKILL.md
@@ -140,6 +140,8 @@ drops should block the release.
 
 > **🚨 STOP — Do NOT merge without explicit human approval.**
 > Present the CI status summary and ask the human to confirm before merging.
+> Merging is effectively irreversible — it automatically triggers the full
+> release pipeline (GitHub release → PyPI publish → downstream version bumps).
 
 Once the human approves:
 
@@ -147,54 +149,33 @@ Once the human approves:
 gh pr merge <PR_NUMBER> --repo OpenHands/software-agent-sdk --merge
 ```
 
-## Phase 6: Create and Publish the GitHub Release
+## Phase 6: Automated Release Pipeline (no action needed)
 
-> **🚨 STOP — Do NOT create or publish a release without explicit human
-> approval.** Publishing is irreversible — it triggers PyPI publication.
-> Present the release details and ask the human to confirm.
+When the release PR is merged, the following happens automatically:
 
-Navigate to <https://github.com/OpenHands/software-agent-sdk/releases/new>
-and:
-
-1. **Tag**: `v<version>` (create new tag)
-2. **Target branch**: `rel-<version>` (or `main` after merge)
-3. Click **Auto-generate release notes**
-4. Review the notes, then click **Publish release**
-
-Publishing the release automatically triggers the `pypi-release.yml`
-workflow, which builds and publishes all four packages to PyPI:
-- `openhands-sdk`
-- `openhands-tools`
-- `openhands-workspace`
-- `openhands-agent-server`
+1. **`create-release.yml`** detects the merged `rel-*` branch, creates a
+   GitHub release with tag `v<version>` and auto-generated release notes.
+2. **`pypi-release.yml`** triggers on the published release and publishes
+   all four packages to PyPI:
+   - `openhands-sdk`
+   - `openhands-tools`
+   - `openhands-workspace`
+   - `openhands-agent-server`
+3. **`version-bump-prs.yml`** triggers after successful PyPI publish and
+   creates downstream version bump PRs.
+4. **Slack notification** is sent automatically by the version-bump workflow.
 
 ### ⏸ Checkpoint — Verify PyPI Publication
 
 ```bash
-# Check each package is available
+# Check each package is available (allow a few minutes for indexing)
 for pkg in openhands-sdk openhands-tools openhands-workspace openhands-agent-server; do
   curl -s -o /dev/null -w "$pkg: %{http_code}\n" \
     "https://pypi.org/pypi/$pkg/<version>/json"
 done
 ```
 
-All should return `200`. Allow a few minutes for PyPI indexing.
-
-## Phase 7: Post-Release — Notify the Team
-
-After PyPI publication, the `version-bump-prs.yml` workflow automatically
-creates downstream version bump PRs. Compose a Slack message for the human
-to post, including links to those PRs:
-
-```
-🚀 *SDK v<version> published to PyPI!*
-
-Version bump PRs:
-• <https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands>
-• <https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands-CLI>
-
-Release: <https://github.com/OpenHands/software-agent-sdk/releases/tag/v<version>|v<version>>
-```
+All should return `200`.
 
 See `references/post-release-checklist.md` for details on reviewing
 downstream PRs and handling any issues.
@@ -209,7 +190,7 @@ downstream PRs and handling any issues.
 - [ ] Example tests pass
 - [ ] (Optional) Evaluation run shows no regressions
 - [ ] **🚨 Get human approval**, then merge the release PR
-- [ ] **🚨 Get human approval**, then create GitHub release with tag `v<version>`
-- [ ] Auto-generate release notes and publish
+- [ ] _(Automated)_ GitHub release created with auto-generated notes
+- [ ] _(Automated)_ Packages published to PyPI
+- [ ] _(Automated)_ Downstream version bump PRs created
 - [ ] Verify packages appear on PyPI
-- [ ] Send Slack message with downstream version bump PR links

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -47,17 +47,36 @@ jobs:
                     echo "exists=false" >> "$GITHUB_OUTPUT"
                   fi
 
+            - name: Find previous release tag
+              if: steps.check.outputs.exists == 'false'
+              id: prev_tag
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  PREV_TAG=$(gh release list --repo "${{ github.repository }}" \
+                    --exclude-drafts --exclude-pre-releases --limit 1 \
+                    --json tagName --jq '.[0].tagName')
+                  echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
+                  echo "📌 Previous release tag: ${PREV_TAG:-<none>}"
+
             - name: Create GitHub Release
               if: steps.check.outputs.exists == 'false'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
                   VERSION: ${{ steps.version.outputs.version }}
+                  PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
               run: |
+                  NOTES_FLAG=()
+                  if [ -n "$PREV_TAG" ]; then
+                    NOTES_FLAG=(--notes-start-tag "$PREV_TAG")
+                  fi
+
                   gh release create "v${VERSION}" \
                     --repo "${{ github.repository }}" \
                     --target "${{ github.event.pull_request.merge_commit_sha }}" \
                     --title "v${VERSION}" \
-                    --generate-notes
+                    --generate-notes \
+                    "${NOTES_FLAG[@]}"
 
                   echo "✅ Release v${VERSION} created!"
                   echo "🔗 https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -55,7 +55,7 @@ jobs:
               run: |
                   gh release create "v${VERSION}" \
                     --repo "${{ github.repository }}" \
-                    --target main \
+                    --target "${{ github.event.pull_request.merge_commit_sha }}" \
                     --title "v${VERSION}" \
                     --generate-notes
 

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,74 @@
+---
+name: Create GitHub Release
+
+# Automatically create a GitHub release when a release PR is merged into main.
+# This bridges the gap between merging the release PR and the pypi-release
+# workflow (which triggers on release published).
+
+on:
+    pull_request:
+        types: [closed]
+        branches: [main]
+
+jobs:
+    create-release:
+        # Only run when a release PR is merged (not just closed)
+        if: >
+            github.event.pull_request.merged == true &&
+            startsWith(github.event.pull_request.head.ref, 'rel-')
+        runs-on: ubuntu-24.04
+        permissions:
+            contents: write
+        steps:
+            - name: Extract version from branch name
+              id: version
+              run: |
+                  BRANCH="${{ github.event.pull_request.head.ref }}"
+                  VERSION="${BRANCH#rel-}"
+
+                  if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+                    echo "❌ Could not extract valid version from branch: $BRANCH"
+                    exit 1
+                  fi
+
+                  echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+                  echo "📦 Version: $VERSION"
+
+            - name: Check release does not already exist
+              id: check
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  if gh release view "v${VERSION}" --repo "${{ github.repository }}" > /dev/null 2>&1; then
+                    echo "⚠️ Release v${VERSION} already exists, skipping"
+                    echo "exists=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "exists=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+            - name: Create GitHub Release
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh release create "v${VERSION}" \
+                    --repo "${{ github.repository }}" \
+                    --target main \
+                    --title "v${VERSION}" \
+                    --generate-notes
+
+                  echo "✅ Release v${VERSION} created!"
+                  echo "🔗 https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
+
+            - name: Summary
+              env:
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  echo "## ✅ Release v${VERSION} Created" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Tag**: v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- **Release**: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
+                  echo "" >> "$GITHUB_STEP_SUMMARY"
+                  echo "The \`pypi-release.yml\` workflow will now publish packages to PyPI." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -82,22 +82,13 @@ jobs:
                   - [ ] Integration tests pass (tagged with `integration-test`)
                   - [ ] Behavior tests pass (tagged with `behavior-test`)
                   - [ ] Example tests pass (tagged with `test-examples`)
-                  - [ ] Draft release created at https://github.com/OpenHands/software-agent-sdk/releases/new
-                    - [ ] Select tag: `v${{ inputs.version }}`
-                    - [ ] Select branch: `${{ env.BRANCH_NAME }}`
-                    - [ ] Auto-generate release notes
-                    - [ ] Publish release (PyPI will auto-publish)
                   - [ ] Evaluation on OpenHands Index
 
-                  ### Next Steps
-                  1. Review the version changes
-                  2. Address any deprecation deadlines
-                  3. Ensure integration tests pass
-                  4. Ensure behavior tests pass
-                  5. Ensure example tests pass
-                  6. Create and publish the release
-
-                  Once the release is published on GitHub, the PyPI packages will be automatically published via the `pypi-release.yml` workflow.
+                  ### What happens on merge
+                  When this PR is merged, the `create-release.yml` workflow will automatically:
+                  1. Create a GitHub release with tag `v${{ inputs.version }}` and auto-generated notes
+                  2. Trigger `pypi-release.yml` to publish all packages to PyPI
+                  3. Trigger `version-bump-prs.yml` to create downstream version bump PRs
                   EOF
 
                   gh pr create \
@@ -128,5 +119,4 @@ jobs:
                   echo "### Next Steps:" >> $GITHUB_STEP_SUMMARY
                   echo "1. Review the PR and address any deprecation deadlines" >> $GITHUB_STEP_SUMMARY
                   echo "2. Wait for integration, behavior, and example tests to pass" >> $GITHUB_STEP_SUMMARY
-                  echo "3. Create and publish the release on GitHub" >> $GITHUB_STEP_SUMMARY
-                  echo "4. PyPI will automatically publish when the release is created" >> $GITHUB_STEP_SUMMARY
+                  echo "3. Merge the PR — a GitHub release and PyPI publish will happen automatically" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary

Automates the manual "create GitHub release" step that currently sits between merging the release PR and PyPI publication.

### New workflow: `create-release.yml`

Triggers when a `rel-*` branch PR is merged into `main`. It:
1. Extracts the version from the branch name (e.g., `rel-1.19.1` → `1.19.1`)
2. Validates the version format
3. Skips if a release already exists (idempotent)
4. Creates a GitHub release with tag `v<version>`, targeting `main`, with auto-generated release notes

This chains into the existing pipeline:
```
merge release PR → create-release.yml → pypi-release.yml → version-bump-prs.yml + Slack
```

### Other changes
- **`prepare-release.yml`**: Updated the PR body template to explain the automated post-merge flow instead of listing manual release creation steps
- **`sdk-release` skill**: Updated to document the automated pipeline; checklist now marks post-merge steps as _(Automated)_

### Safety consideration

The safety guardrail shifts entirely to the **merge decision** — once the PR is merged, the full release pipeline fires automatically. The skill doc reflects this by emphasizing human approval at the merge step.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f309626c-3d02-46f4-8fd6-ed058c575307)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:04e850d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-04e850d-python \
  ghcr.io/openhands/agent-server:04e850d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:04e850d-golang-amd64
ghcr.io/openhands/agent-server:04e850d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:04e850d-golang-arm64
ghcr.io/openhands/agent-server:04e850d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:04e850d-java-amd64
ghcr.io/openhands/agent-server:04e850d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:04e850d-java-arm64
ghcr.io/openhands/agent-server:04e850d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:04e850d-python-amd64
ghcr.io/openhands/agent-server:04e850d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:04e850d-python-arm64
ghcr.io/openhands/agent-server:04e850d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:04e850d-golang
ghcr.io/openhands/agent-server:04e850d-java
ghcr.io/openhands/agent-server:04e850d-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `04e850d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `04e850d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->