### PR TITLE
Fix critic conversation info secret serialization

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/impl/api/client.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/client.py
@@ -13,9 +13,14 @@ from pydantic import (
     field_serializer,
     field_validator,
 )
+from pydantic.json_schema import SkipJsonSchema
 from tenacity import retry, retry_if_exception, stop_after_attempt, wait_exponential
 
-from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
+from openhands.sdk.utils.pydantic_secrets import (
+    is_redacted_secret,
+    serialize_secret,
+    validate_secret,
+)
 
 from .chat_template import ChatTemplateRenderer
 
@@ -89,7 +94,10 @@ class CriticClient(BaseModel):
         default="https://all-hands-ai--critic-qwen3-4b-serve.modal.run",
         description="Base URL of the vLLM classification service",
     )
-    api_key: str | SecretStr = Field(
+    # validate_secret() normalizes empty, whitespace-only, and redacted inputs
+    # to None. That value may serialize as null during response-model rebuilds,
+    # but it is not part of the public REST schema contract.
+    api_key: str | SecretStr | SkipJsonSchema[None] = Field(
         ..., description="API key for authenticating with the vLLM service"
     )
     model_name: str = Field(
@@ -159,16 +167,15 @@ class CriticClient(BaseModel):
     # ---------------------
     @field_validator("api_key", mode="before")
     @classmethod
-    def _validate_and_convert_api_key(cls, v: str | SecretStr, info) -> SecretStr:
+    def _validate_and_convert_api_key(
+        cls, v: str | SecretStr | None, info
+    ) -> SecretStr | None:
         """Validate api_key and decrypt it when needed."""
-        secret = validate_secret(v, info)
-        if secret is None:
-            raise ValueError("api_key must be non-empty")
-        return secret
+        return validate_secret(v, info)
 
     @field_serializer("api_key", when_used="always")
-    def _serialize_api_key(self, v: str | SecretStr, info):
-        secret = v if isinstance(v, SecretStr) else SecretStr(v)
+    def _serialize_api_key(self, v: str | SecretStr | None, info):
+        secret = v if v is None or isinstance(v, SecretStr) else SecretStr(v)
         return serialize_secret(secret, info)
 
     # ---------------------
@@ -236,6 +243,18 @@ class CriticClient(BaseModel):
     # ---------------------
     # Inference
     # ---------------------
+    def _get_api_key_value(self) -> str:
+        if self.api_key is None:
+            raise ValueError("api_key must be non-empty")
+        api_key_value = (
+            self.api_key.get_secret_value()
+            if isinstance(self.api_key, SecretStr)
+            else self.api_key
+        )
+        if not api_key_value.strip() or is_redacted_secret(api_key_value):
+            raise ValueError("api_key must be non-empty")
+        return api_key_value
+
     def classify_trace(
         self,
         messages: Sequence[dict],
@@ -259,11 +278,7 @@ class CriticClient(BaseModel):
             reraise=True,  # re-raise the last exception if all retries fail
         )
         def _post_with_retry():
-            api_key_value = (
-                self.api_key.get_secret_value()
-                if isinstance(self.api_key, SecretStr)
-                else self.api_key
-            )
+            api_key_value = self._get_api_key_value()
             resp = self._client.post(
                 f"{self.server_url}/classify",
                 headers={

--- a/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
+++ b/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
@@ -3,6 +3,17 @@ from pydantic import SecretStr
 from openhands.sdk.utils.cipher import Cipher
 
 
+REDACTED_SECRET_VALUE = "**********"
+
+
+def is_redacted_secret(v: str | SecretStr | None) -> bool:
+    if v is None:
+        return False
+    if isinstance(v, SecretStr):
+        return v.get_secret_value() == REDACTED_SECRET_VALUE
+    return v == REDACTED_SECRET_VALUE
+
+
 def serialize_secret(v: SecretStr | None, info):
     """
     Serialize secret fields with encryption or redaction.
@@ -49,7 +60,7 @@ def validate_secret(v: str | SecretStr | None, info) -> SecretStr | None:
         secret_value = v
 
     # If the secret is empty, whitespace-only or redacted - return None
-    if not secret_value or not secret_value.strip() or secret_value == "**********":
+    if not secret_value or not secret_value.strip() or is_redacted_secret(secret_value):
         return None
 
     # check if a cipher is supplied

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -38,6 +38,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.critic.impl.api import APIBasedCritic
 from openhands.sdk.event import ActionEvent, AgentErrorEvent, ObservationEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.event.llm_convertible import MessageEvent
@@ -264,6 +265,55 @@ class TestConversationServiceSearchConversations:
         assert result.items[0].id == conversation_id
         assert result.items[0].execution_status == ConversationExecutionStatus.IDLE
         assert result.next_page_id is None
+
+    @pytest.mark.asyncio
+    async def test_search_conversations_with_critic_redacts_api_key(
+        self, conversation_service
+    ):
+        """ConversationInfo should serialize critic secrets without rejecting them."""
+        agent = Agent(
+            llm=LLM(model="gpt-4o", api_key=SecretStr("llm-secret")),
+            tools=[],
+            critic=APIBasedCritic(
+                api_key=SecretStr("critic-secret"),
+                server_url="https://critic.example.com",
+                model_name="critic",
+            ),
+        )
+        stored_conv = StoredConversation(
+            id=uuid4(),
+            agent=agent,
+            workspace=LocalWorkspace(working_dir="workspace/project"),
+            confirmation_policy=NeverConfirm(),
+            initial_message=None,
+            metrics=None,
+            created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+            updated_at=datetime(2025, 1, 1, 12, 30, 0, tzinfo=UTC),
+        )
+
+        mock_service = AsyncMock(spec=EventService)
+        mock_service.stored = stored_conv
+        mock_service.get_state.return_value = ConversationState(
+            id=stored_conv.id,
+            agent=stored_conv.agent,
+            workspace=stored_conv.workspace,
+            execution_status=ConversationExecutionStatus.IDLE,
+            confirmation_policy=stored_conv.confirmation_policy,
+        )
+        conversation_service._event_services[stored_conv.id] = mock_service
+
+        result = await conversation_service.search_conversations()
+
+        info = result.items[0]
+        assert isinstance(info.agent.critic, APIBasedCritic)
+        assert info.agent.critic.api_key is None
+
+        payload = info.model_dump(mode="json")
+        assert payload["agent"]["llm"]["api_key"] is None
+        assert payload["agent"]["critic"]["api_key"] is None
+        assert "llm-secret" not in str(payload)
+        assert "critic-secret" not in str(payload)
+        assert "critic-secret" not in str(info)
 
     @pytest.mark.asyncio
     async def test_search_conversations_status_filter(self, conversation_service):

--- a/tests/sdk/critic/test_critic_client.py
+++ b/tests/sdk/critic/test_critic_client.py
@@ -1,7 +1,7 @@
 """Tests for CriticClient api_key handling."""
 
 import pytest
-from pydantic import SecretStr, ValidationError
+from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent
 from openhands.sdk.critic.impl.api import APIBasedCritic
@@ -27,27 +27,46 @@ def test_critic_client_with_secret_str_api_key():
 
 
 def test_critic_client_empty_string_api_key():
-    """Test that CriticClient rejects an empty string api_key."""
-    with pytest.raises(ValidationError, match="api_key must be non-empty"):
-        CriticClient(api_key="")
+    """Test that CriticClient normalizes an empty string api_key to None."""
+    client = CriticClient(api_key="")
+
+    assert client.api_key is None
 
 
 def test_critic_client_whitespace_only_api_key():
-    """Test that CriticClient rejects a whitespace-only api_key."""
-    with pytest.raises(ValidationError, match="api_key must be non-empty"):
-        CriticClient(api_key="   \t\n  ")
+    """Test that CriticClient normalizes a whitespace-only api_key to None."""
+    client = CriticClient(api_key="   \t\n  ")
+
+    assert client.api_key is None
 
 
 def test_critic_client_empty_secret_str_api_key():
-    """Test that CriticClient rejects an empty SecretStr api_key."""
-    with pytest.raises(ValidationError, match="api_key must be non-empty"):
-        CriticClient(api_key=SecretStr(""))
+    """Test that CriticClient normalizes an empty SecretStr api_key to None."""
+    client = CriticClient(api_key=SecretStr(""))
+
+    assert client.api_key is None
+
+
+def test_critic_client_normalizes_redacted_api_key_placeholder():
+    """Test that redacted critic api_key placeholders become None."""
+    client = CriticClient(api_key="**********")
+
+    assert client.api_key is None
+
+
+def test_critic_client_rejects_none_api_key_for_inference():
+    """Test that missing api_key cannot be used as a runtime credential."""
+    client = CriticClient(api_key="**********")
+
+    with pytest.raises(ValueError, match="api_key must be non-empty"):
+        client._get_api_key_value()
 
 
 def test_critic_client_whitespace_secret_str_api_key():
-    """Test that CriticClient rejects a whitespace-only SecretStr api_key."""
-    with pytest.raises(ValidationError, match="api_key must be non-empty"):
-        CriticClient(api_key=SecretStr("   \t\n  "))
+    """Test that CriticClient normalizes a whitespace-only SecretStr api_key."""
+    client = CriticClient(api_key=SecretStr("   \t\n  "))
+
+    assert client.api_key is None
 
 
 def test_critic_client_api_key_not_exposed_in_repr():


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

When a conversation has an `APIBasedCritic`, the agent-server can fail while composing a `ConversationInfo` response. The response builder uses `state.model_dump(mode="json")`, which redacts `SecretStr` fields to `**********`; the subsequent `ConversationInfo` validation rebuilds the nested `APIBasedCritic` and previously rejected that redacted `api_key`.

This showed up in a staging critic smoke test as a 500 from `POST /api/conversations` even though the critic evaluation itself completed and persisted a non-null `critic_result`.

## Summary

- Normalize empty, whitespace-only, and redacted secret values to `None` through the shared secret validator.
- Make `CriticClient.api_key` accept `None` at runtime so response-model rebuilds can represent a redacted critic key as `null` instead of failing validation.
- Keep the generated REST schema unchanged by excluding the runtime-only `None` arm from JSON schema generation.
- Keep runtime inference strict: `CriticClient` still refuses to call `/classify` when the API key is missing, empty, whitespace-only, or redacted.
- Add regression tests for the redacted/null round trip and for conversation search responses not containing raw LLM or critic secrets.

## Issue Number

N/A

## How to Test

Before this fix, the underlying response-model round trip failed with:

```bash
uv run --package openhands-sdk python - <<'PY'
from pydantic import SecretStr
from openhands.sdk.critic.impl.api import APIBasedCritic
critic = APIBasedCritic(api_key=SecretStr('real-key'))
APIBasedCritic.model_validate(critic.model_dump(mode='json'))
PY
```

The failure was `api_key must be non-empty` because the dumped value was redacted to `**********`.

Validation after the fix:

```bash
uv run pytest tests/sdk/critic/test_critic_client.py tests/agent_server/test_conversation_service.py
uv run pre-commit run --files openhands-sdk/openhands/sdk/critic/impl/api/client.py openhands-sdk/openhands/sdk/utils/pydantic_secrets.py tests/sdk/critic/test_critic_client.py tests/agent_server/test_conversation_service.py
uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py
```

Results:

- `77 passed, 15 warnings`
- pre-commit passed for the changed files
- REST API breakage check reported no breaking changes locally

## Video/Screenshots

N/A; backend bug fix.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This keeps the existing `ConversationInfo(**state.model_dump(mode="json"), ...)` path. The data model can now carry either a real critic API key or runtime `None` when the stored value was redacted/empty, while runtime inference still requires a real non-empty credential.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc092ba-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc092ba-python \
  ghcr.io/openhands/agent-server:dc092ba-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc092ba-golang-amd64
ghcr.io/openhands/agent-server:dc092ba-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc092ba-golang-arm64
ghcr.io/openhands/agent-server:dc092ba-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc092ba-java-amd64
ghcr.io/openhands/agent-server:dc092ba-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc092ba-java-arm64
ghcr.io/openhands/agent-server:dc092ba-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc092ba-python-amd64
ghcr.io/openhands/agent-server:dc092ba-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dc092ba-python-arm64
ghcr.io/openhands/agent-server:dc092ba-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dc092ba-golang
ghcr.io/openhands/agent-server:dc092ba-java
ghcr.io/openhands/agent-server:dc092ba-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc092ba-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc092ba-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->