### PR TITLE
Add explicit DeepSeek V4 model support to eval configs

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -231,6 +231,16 @@ MODELS = {
         "display_name": "DeepSeek V3.2 Reasoner",
         "llm_config": {"model": "litellm_proxy/deepseek/deepseek-reasoner"},
     },
+    "deepseek-v4-pro": {
+        "id": "deepseek-v4-pro",
+        "display_name": "DeepSeek V4 Pro",
+        "llm_config": {"model": "litellm_proxy/deepseek/deepseek-v4-pro"},
+    },
+    "deepseek-v4-flash": {
+        "id": "deepseek-v4-flash",
+        "display_name": "DeepSeek V4 Flash",
+        "llm_config": {"model": "litellm_proxy/deepseek/deepseek-v4-flash"},
+    },
     "qwen-3-coder": {
         "id": "qwen-3-coder",
         "display_name": "Qwen 3 Coder",

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -50,7 +50,7 @@ on:
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
     # Default models for scheduled/label-triggered runs (subset of models from resolve_model_config.py)
-    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v3.2-reasoner,kimi-k2-thinking,gemini-3.1-pro
+    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v4-pro,kimi-k2-thinking,gemini-3.1-pro
 
 jobs:
     setup-matrix:

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -641,3 +641,21 @@ def test_gpt_5_5_config():
     assert model["display_name"] == "GPT-5.5"
     assert model["llm_config"]["model"] == "litellm_proxy/openai/gpt-5.5"
     assert model["llm_config"]["reasoning_effort"] == "high"
+
+
+def test_deepseek_v4_pro_config():
+    """Test that deepseek-v4-pro has correct configuration."""
+    model = MODELS["deepseek-v4-pro"]
+
+    assert model["id"] == "deepseek-v4-pro"
+    assert model["display_name"] == "DeepSeek V4 Pro"
+    assert model["llm_config"]["model"] == "litellm_proxy/deepseek/deepseek-v4-pro"
+
+
+def test_deepseek_v4_flash_config():
+    """Test that deepseek-v4-flash has correct configuration."""
+    model = MODELS["deepseek-v4-flash"]
+
+    assert model["id"] == "deepseek-v4-flash"
+    assert model["display_name"] == "DeepSeek V4 Flash"
+    assert model["llm_config"]["model"] == "litellm_proxy/deepseek/deepseek-v4-flash"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: be concise and specific. Do not check the box below. -->

- [x] A human has tested these changes.

---

## Why

DeepSeek V4 (`deepseek-v4-pro`, `deepseek-v4-flash`) was officially released on 2026-04-24. The legacy aliases (`deepseek-chat`, `deepseek-reasoner`) are scheduled for deprecation on 2026-07-24. The eval configs should use explicit V4 model IDs.

## Summary

- Added `deepseek-v4-pro` and `deepseek-v4-flash` model entries to `resolve_model_config.py`
- Updated `DEFAULT_MODEL_IDS` in `integration-runner.yml` to use `deepseek-v4-pro` instead of `deepseek-v3.2-reasoner`
- Kept `deepseek-v3.2-reasoner` entry for backward compatibility until legacy alias deprecation

## Issue Number

Closes #2947

## How to Test

All 32 existing tests pass:
```
uv run python -m pytest tests/cross/test_resolve_model_config.py -v
```
The Pydantic validation test (`test_all_models_valid_with_pydantic`) and `test_find_all_models` automatically cover the new entries. Full eval comparison will happen when integration tests run with the new default.

## Video/Screenshots

N/A — config-only change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `deepseek-v3.2-reasoner` entry is intentionally kept so existing workflows or manual dispatches referencing it continue to work until the upstream alias is removed (2026-07-24).