### PR TITLE
Add usable_tools to server_info

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,8 @@ When reviewing code, provide constructive feedback:
 
 - Remote workspace git operations should call `/api/git/changes` and `/api/git/diff` via the `path` query parameter with slash-normalized strings; building those URLs with `pathlib.Path` leaks host-platform separators and breaks Windows paths. The grep tool now prefers `rg`, then system `grep`, then Python; both the real grep executor and the SDK's terminal-command compatibility fallback should keep that order. For grep parity, the Python fallback should hide dotfiles by default but still let explicit `include` globs surface files like `.env`, matching ripgrep. For glob parity, any symlink-preservation regression test should force the Python fallback path, because ripgrep availability changes whether the fallback implementation runs at all.
 - Keep path helpers split by purpose: `is_absolute_path_source()` is for cross-platform source/wire syntax detection, while local filesystem writes/validation (for example, the file editor) should use host-native absolute-path semantics so POSIX does not silently accept Windows drive paths as creatable files.
+- Tool availability filtering belongs in `openhands-sdk/openhands/sdk/tool/registry.py` via `list_usable_tools()`, which preserves registration order and defaults tools to usable unless they expose an `is_usable()` callable. Environment-specific checks like Chromium detection should live on the concrete tool class (`BrowserToolSet.is_usable()`), while agent-server surfaces such as `/server_info` should consume the registry helper rather than re-implement per-tool filtering.
+
 
 
 

--- a/examples/01_standalone_sdk/02_custom_tools.py
+++ b/examples/01_standalone_sdk/02_custom_tools.py
@@ -169,24 +169,29 @@ llm = LLM(
 cwd = os.getcwd()
 
 
-def _make_bash_and_grep_tools(conv_state) -> list[ToolDefinition]:
-    """Create terminal and custom grep tools sharing one executor."""
+class BashAndGrepToolSet(ToolDefinition[Action, Observation]):
+    """Create terminal and grep tools sharing one terminal executor."""
 
-    terminal_executor = TerminalExecutor(working_dir=conv_state.workspace.working_dir)
-    # terminal_tool = terminal_tool.set_executor(executor=terminal_executor)
-    terminal_tool = TerminalTool.create(conv_state, executor=terminal_executor)[0]
+    @classmethod
+    def create(cls, conv_state, **params) -> Sequence[ToolDefinition]:
+        terminal_executor = TerminalExecutor(
+            working_dir=conv_state.workspace.working_dir
+        )
+        terminal_tool = TerminalTool.create(
+            conv_state, executor=terminal_executor, **params
+        )[0]
+        grep_tool = GrepTool.create(
+            conv_state,
+            terminal_executor=terminal_executor,
+        )[0]
+        return [terminal_tool, grep_tool]
 
-    # Use the GrepTool.create() method with shared terminal_executor
-    grep_tool = GrepTool.create(conv_state, terminal_executor=terminal_executor)[0]
 
-    return [terminal_tool, grep_tool]
-
-
-register_tool("BashAndGrepToolSet", _make_bash_and_grep_tools)
+register_tool(BashAndGrepToolSet.name, BashAndGrepToolSet)
 
 tools = [
     Tool(name=FileEditorTool.name),
-    Tool(name="BashAndGrepToolSet"),
+    Tool(name=BashAndGrepToolSet.name),
 ]
 
 # Agent

--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -46,7 +46,7 @@ class ServerInfo(BaseModel):
         default_factory=lambda: os.environ.get("OPENHANDS_BUILD_GIT_REF", "unknown")
     )
     python_version: str = Field(default_factory=lambda: sys.version)
-    available_tools: list[str] = Field(default_factory=lambda: list_usable_tools())
+    usable_tools: list[str] = Field(default_factory=lambda: list_usable_tools())
 
     docs: str = "/docs"
     redoc: str = "/redoc"

--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -7,11 +7,14 @@ from importlib.metadata import version
 from fastapi import APIRouter, Response
 from pydantic import BaseModel, Field
 
+from openhands.sdk.tool.registry import list_registered_tools
+
 
 server_details_router = APIRouter(prefix="", tags=["Server Details"])
 _start_time = time.time()
 _last_event_time = time.time()
 _initialization_complete = asyncio.Event()
+_BROWSER_TOOL_SET_NAME = "browser_tool_set"
 
 
 def _package_version(dist_name: str) -> str:
@@ -19,6 +22,24 @@ def _package_version(dist_name: str) -> str:
         return version(dist_name)
     except Exception:
         return "unknown"
+
+
+def _browser_tool_available() -> bool:
+    try:
+        from openhands.tools.browser_use.impl import BrowserToolExecutor
+
+        return BrowserToolExecutor.check_chromium_available() is not None
+    except Exception:
+        return False
+
+
+def _list_available_tools() -> list[str]:
+    tools = list_registered_tools()
+    if _BROWSER_TOOL_SET_NAME not in tools:
+        return tools
+    if _browser_tool_available():
+        return tools
+    return [tool for tool in tools if tool != _BROWSER_TOOL_SET_NAME]
 
 
 class ServerInfo(BaseModel):
@@ -44,6 +65,7 @@ class ServerInfo(BaseModel):
         default_factory=lambda: os.environ.get("OPENHANDS_BUILD_GIT_REF", "unknown")
     )
     python_version: str = Field(default_factory=lambda: sys.version)
+    available_tools: list[str] = Field(default_factory=_list_available_tools)
 
     docs: str = "/docs"
     redoc: str = "/redoc"

--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -7,14 +7,13 @@ from importlib.metadata import version
 from fastapi import APIRouter, Response
 from pydantic import BaseModel, Field
 
-from openhands.sdk.tool.registry import list_registered_tools
+from openhands.sdk.tool.registry import list_usable_tools
 
 
 server_details_router = APIRouter(prefix="", tags=["Server Details"])
 _start_time = time.time()
 _last_event_time = time.time()
 _initialization_complete = asyncio.Event()
-_BROWSER_TOOL_SET_NAME = "browser_tool_set"
 
 
 def _package_version(dist_name: str) -> str:
@@ -22,24 +21,6 @@ def _package_version(dist_name: str) -> str:
         return version(dist_name)
     except Exception:
         return "unknown"
-
-
-def _browser_tool_available() -> bool:
-    try:
-        from openhands.tools.browser_use.impl import BrowserToolExecutor
-
-        return BrowserToolExecutor.check_chromium_available() is not None
-    except Exception:
-        return False
-
-
-def _list_available_tools() -> list[str]:
-    tools = list_registered_tools()
-    if _BROWSER_TOOL_SET_NAME not in tools:
-        return tools
-    if _browser_tool_available():
-        return tools
-    return [tool for tool in tools if tool != _BROWSER_TOOL_SET_NAME]
 
 
 class ServerInfo(BaseModel):
@@ -65,7 +46,7 @@ class ServerInfo(BaseModel):
         default_factory=lambda: os.environ.get("OPENHANDS_BUILD_GIT_REF", "unknown")
     )
     python_version: str = Field(default_factory=lambda: sys.version)
-    available_tools: list[str] = Field(default_factory=_list_available_tools)
+    available_tools: list[str] = Field(default_factory=lambda: list_usable_tools())
 
     docs: str = "/docs"
     redoc: str = "/redoc"

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -119,17 +119,29 @@ def _resolver_from_subclass(_name: str, cls: type[ToolDefinition]) -> Resolver:
     return _resolve
 
 
+def _call_tool_usable_hook(cls: type[ToolDefinition]) -> bool:
+    for base in cls.__mro__:
+        if base is ToolDefinition:
+            break
+        if "is_usable" in base.__dict__:
+            return cls.is_usable()
+        if "is_available" in base.__dict__:
+            return cls.is_available()
+    return cls.is_usable()
+
+
 def _availability_from_instance(tool: ToolDefinition) -> AvailabilityChecker:
-    return lambda: tool.__class__.is_available()
+    return lambda: _call_tool_usable_hook(tool.__class__)
 
 
 def _availability_from_subclass(cls: type[ToolDefinition]) -> AvailabilityChecker:
-    return lambda: cls.is_available()
+    return lambda: _call_tool_usable_hook(cls)
 
 
 def _availability_from_callable(
     _factory: Callable[..., Sequence[ToolDefinition]],
 ) -> AvailabilityChecker:
+    # Callable factories are deprecated and have no usability hook.
     return lambda: True
 
 

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -16,7 +16,7 @@ logger = get_logger(__name__)
 
 # A resolver produces ToolDefinition instances for given params.
 Resolver = Callable[[dict[str, Any], "ConversationState"], Sequence[ToolDefinition]]
-AvailabilityChecker = Callable[[], bool]
+UsabilityChecker = Callable[[], bool]
 """A resolver produces ToolDefinition instances for given params.
 
 Args:
@@ -31,7 +31,7 @@ Returns: A sequence of ToolDefinition instances. Most of the time this will be a
 
 _LOCK = RLock()
 _REG: dict[str, Resolver] = {}
-_AVAILABILITY_REG: dict[str, AvailabilityChecker] = {}
+_USABILITY_REG: dict[str, UsabilityChecker] = {}
 _MODULE_QUALNAMES: dict[str, str] = {}  # Maps tool name to module qualname
 
 
@@ -119,38 +119,27 @@ def _resolver_from_subclass(_name: str, cls: type[ToolDefinition]) -> Resolver:
     return _resolve
 
 
-def _call_tool_usable_hook(cls: type[ToolDefinition]) -> bool:
-    for base in cls.__mro__:
-        if base is ToolDefinition:
-            break
-        if "is_usable" in base.__dict__:
-            return cls.is_usable()
-        if "is_available" in base.__dict__:
-            return cls.is_available()
-    return cls.is_usable()
+def _usability_from_instance(tool: ToolDefinition) -> UsabilityChecker:
+    return lambda: tool.__class__.is_usable()
 
 
-def _availability_from_instance(tool: ToolDefinition) -> AvailabilityChecker:
-    return lambda: _call_tool_usable_hook(tool.__class__)
+def _usability_from_subclass(cls: type[ToolDefinition]) -> UsabilityChecker:
+    return lambda: cls.is_usable()
 
 
-def _availability_from_subclass(cls: type[ToolDefinition]) -> AvailabilityChecker:
-    return lambda: _call_tool_usable_hook(cls)
-
-
-def _availability_from_callable(
+def _usability_from_callable(
     _factory: Callable[..., Sequence[ToolDefinition]],
-) -> AvailabilityChecker:
+) -> UsabilityChecker:
     # Callable factories are deprecated and have no usability hook.
     return lambda: True
 
 
-def _check_tool_available(name: str, checker: AvailabilityChecker) -> bool:
+def _check_tool_usable(name: str, checker: UsabilityChecker) -> bool:
     try:
         return checker()
     except Exception:
         logger.warning(
-            "Failed to determine availability for tool '%s'", name, exc_info=True
+            "Failed to determine usability for tool '%s'", name, exc_info=True
         )
         return False
 
@@ -166,10 +155,10 @@ def register_tool(
 
     if isinstance(factory, ToolDefinition):
         resolver = _resolver_from_instance(name, factory)
-        availability_checker = _availability_from_instance(factory)
+        usability_checker = _usability_from_instance(factory)
     elif isinstance(factory, type) and issubclass(factory, ToolDefinition):
         resolver = _resolver_from_subclass(name, factory)
-        availability_checker = _availability_from_subclass(factory)
+        usability_checker = _usability_from_subclass(factory)
     elif callable(factory):
         warn_deprecated(
             "register_tool(callable_factory)",
@@ -182,7 +171,7 @@ def register_tool(
             stacklevel=2,
         )
         resolver = _resolver_from_callable(name, factory)
-        availability_checker = _availability_from_callable(factory)
+        usability_checker = _usability_from_callable(factory)
     else:
         raise TypeError(
             "register_tool(...) only accepts: (1) a ToolDefinition instance with "
@@ -204,7 +193,7 @@ def register_tool(
         if name in _REG:
             logger.warning(f"Duplicate tool name registerd {name}")
         _REG[name] = resolver
-        _AVAILABILITY_REG[name] = availability_checker
+        _USABILITY_REG[name] = usability_checker
         if module_qualname:
             _MODULE_QUALNAMES[name] = module_qualname
 
@@ -229,12 +218,12 @@ def list_registered_tools() -> list[str]:
 def list_usable_tools() -> list[str]:
     with _LOCK:
         tool_names = list(_REG.keys())
-        availability_checkers = dict(_AVAILABILITY_REG)
+        usability_checkers = dict(_USABILITY_REG)
 
     return [
         name
         for name in tool_names
-        if _check_tool_available(name, availability_checkers.get(name, lambda: True))
+        if _check_tool_usable(name, usability_checkers.get(name, lambda: True))
     ]
 
 

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -1,11 +1,12 @@
 import inspect
 from collections.abc import Callable, Sequence
 from threading import RLock
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool.spec import Tool
 from openhands.sdk.tool.tool import ToolDefinition
+from openhands.sdk.utils.deprecation import warn_deprecated
 
 
 if TYPE_CHECKING:
@@ -15,7 +16,7 @@ logger = get_logger(__name__)
 
 # A resolver produces ToolDefinition instances for given params.
 Resolver = Callable[[dict[str, Any], "ConversationState"], Sequence[ToolDefinition]]
-UsabilityChecker = Callable[[], bool]
+AvailabilityChecker = Callable[[], bool]
 """A resolver produces ToolDefinition instances for given params.
 
 Args:
@@ -30,7 +31,7 @@ Returns: A sequence of ToolDefinition instances. Most of the time this will be a
 
 _LOCK = RLock()
 _REG: dict[str, Resolver] = {}
-_USABILITY_REG: dict[str, UsabilityChecker] = {}
+_AVAILABILITY_REG: dict[str, AvailabilityChecker] = {}
 _MODULE_QUALNAMES: dict[str, str] = {}  # Maps tool name to module qualname
 
 
@@ -118,50 +119,26 @@ def _resolver_from_subclass(_name: str, cls: type[ToolDefinition]) -> Resolver:
     return _resolve
 
 
-def _build_usability_checker(
-    checker: Any,
-    *,
-    owner_description: str,
-) -> UsabilityChecker:
-    if checker is None:
-        return lambda: True
-    if not callable(checker):
-        raise TypeError(
-            "register_tool(...) "
-            f"{owner_description} may define is_usable only as a callable"
-        )
-    return cast(UsabilityChecker, checker)
+def _availability_from_instance(tool: ToolDefinition) -> AvailabilityChecker:
+    return lambda: tool.__class__.is_available()
 
 
-def _usability_from_instance(tool: ToolDefinition) -> UsabilityChecker:
-    return lambda: _build_usability_checker(
-        getattr(tool.__class__, "is_usable", None),
-        owner_description="ToolDefinition instances",
-    )()
+def _availability_from_subclass(cls: type[ToolDefinition]) -> AvailabilityChecker:
+    return lambda: cls.is_available()
 
 
-def _usability_from_subclass(cls: type[ToolDefinition]) -> UsabilityChecker:
-    return lambda: _build_usability_checker(
-        getattr(cls, "is_usable", None),
-        owner_description="ToolDefinition subclasses",
-    )()
+def _availability_from_callable(
+    _factory: Callable[..., Sequence[ToolDefinition]],
+) -> AvailabilityChecker:
+    return lambda: True
 
 
-def _usability_from_callable(
-    factory: Callable[..., Sequence[ToolDefinition]],
-) -> UsabilityChecker:
-    return lambda: _build_usability_checker(
-        getattr(factory, "is_usable", None),
-        owner_description="callable factories",
-    )()
-
-
-def _check_tool_usable(name: str, checker: UsabilityChecker) -> bool:
+def _check_tool_available(name: str, checker: AvailabilityChecker) -> bool:
     try:
         return checker()
     except Exception:
         logger.warning(
-            "Failed to determine usability for tool '%s'", name, exc_info=True
+            "Failed to determine availability for tool '%s'", name, exc_info=True
         )
         return False
 
@@ -177,13 +154,23 @@ def register_tool(
 
     if isinstance(factory, ToolDefinition):
         resolver = _resolver_from_instance(name, factory)
-        usability_checker = _usability_from_instance(factory)
+        availability_checker = _availability_from_instance(factory)
     elif isinstance(factory, type) and issubclass(factory, ToolDefinition):
         resolver = _resolver_from_subclass(name, factory)
-        usability_checker = _usability_from_subclass(factory)
+        availability_checker = _availability_from_subclass(factory)
     elif callable(factory):
+        warn_deprecated(
+            "register_tool(callable_factory)",
+            deprecated_in="1.19.1",
+            removed_in="1.24.0",
+            details=(
+                "Register a ToolDefinition subclass with create(...) or a "
+                "ToolDefinition instance instead."
+            ),
+            stacklevel=2,
+        )
         resolver = _resolver_from_callable(name, factory)
-        usability_checker = _usability_from_callable(factory)
+        availability_checker = _availability_from_callable(factory)
     else:
         raise TypeError(
             "register_tool(...) only accepts: (1) a ToolDefinition instance with "
@@ -205,7 +192,7 @@ def register_tool(
         if name in _REG:
             logger.warning(f"Duplicate tool name registerd {name}")
         _REG[name] = resolver
-        _USABILITY_REG[name] = usability_checker
+        _AVAILABILITY_REG[name] = availability_checker
         if module_qualname:
             _MODULE_QUALNAMES[name] = module_qualname
 
@@ -230,12 +217,12 @@ def list_registered_tools() -> list[str]:
 def list_usable_tools() -> list[str]:
     with _LOCK:
         tool_names = list(_REG.keys())
-        usability_checkers = dict(_USABILITY_REG)
+        availability_checkers = dict(_AVAILABILITY_REG)
 
     return [
         name
         for name in tool_names
-        if _check_tool_usable(name, usability_checkers.get(name, lambda: True))
+        if _check_tool_available(name, availability_checkers.get(name, lambda: True))
     ]
 
 

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -1,7 +1,7 @@
 import inspect
 from collections.abc import Callable, Sequence
 from threading import RLock
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool.spec import Tool
@@ -15,6 +15,7 @@ logger = get_logger(__name__)
 
 # A resolver produces ToolDefinition instances for given params.
 Resolver = Callable[[dict[str, Any], "ConversationState"], Sequence[ToolDefinition]]
+UsabilityChecker = Callable[[], bool]
 """A resolver produces ToolDefinition instances for given params.
 
 Args:
@@ -29,6 +30,7 @@ Returns: A sequence of ToolDefinition instances. Most of the time this will be a
 
 _LOCK = RLock()
 _REG: dict[str, Resolver] = {}
+_USABILITY_REG: dict[str, UsabilityChecker] = {}
 _MODULE_QUALNAMES: dict[str, str] = {}  # Maps tool name to module qualname
 
 
@@ -116,6 +118,54 @@ def _resolver_from_subclass(_name: str, cls: type[ToolDefinition]) -> Resolver:
     return _resolve
 
 
+def _build_usability_checker(
+    checker: Any,
+    *,
+    owner_description: str,
+) -> UsabilityChecker:
+    if checker is None:
+        return lambda: True
+    if not callable(checker):
+        raise TypeError(
+            "register_tool(...) "
+            f"{owner_description} may define is_usable only as a callable"
+        )
+    return cast(UsabilityChecker, checker)
+
+
+def _usability_from_instance(tool: ToolDefinition) -> UsabilityChecker:
+    return lambda: _build_usability_checker(
+        getattr(tool.__class__, "is_usable", None),
+        owner_description="ToolDefinition instances",
+    )()
+
+
+def _usability_from_subclass(cls: type[ToolDefinition]) -> UsabilityChecker:
+    return lambda: _build_usability_checker(
+        getattr(cls, "is_usable", None),
+        owner_description="ToolDefinition subclasses",
+    )()
+
+
+def _usability_from_callable(
+    factory: Callable[..., Sequence[ToolDefinition]],
+) -> UsabilityChecker:
+    return lambda: _build_usability_checker(
+        getattr(factory, "is_usable", None),
+        owner_description="callable factories",
+    )()
+
+
+def _check_tool_usable(name: str, checker: UsabilityChecker) -> bool:
+    try:
+        return checker()
+    except Exception:
+        logger.warning(
+            "Failed to determine usability for tool '%s'", name, exc_info=True
+        )
+        return False
+
+
 def register_tool(
     name: str,
     factory: ToolDefinition
@@ -127,10 +177,13 @@ def register_tool(
 
     if isinstance(factory, ToolDefinition):
         resolver = _resolver_from_instance(name, factory)
+        usability_checker = _usability_from_instance(factory)
     elif isinstance(factory, type) and issubclass(factory, ToolDefinition):
         resolver = _resolver_from_subclass(name, factory)
+        usability_checker = _usability_from_subclass(factory)
     elif callable(factory):
         resolver = _resolver_from_callable(name, factory)
+        usability_checker = _usability_from_callable(factory)
     else:
         raise TypeError(
             "register_tool(...) only accepts: (1) a ToolDefinition instance with "
@@ -152,6 +205,7 @@ def register_tool(
         if name in _REG:
             logger.warning(f"Duplicate tool name registerd {name}")
         _REG[name] = resolver
+        _USABILITY_REG[name] = usability_checker
         if module_qualname:
             _MODULE_QUALNAMES[name] = module_qualname
 
@@ -171,6 +225,18 @@ def resolve_tool(
 def list_registered_tools() -> list[str]:
     with _LOCK:
         return list(_REG.keys())
+
+
+def list_usable_tools() -> list[str]:
+    with _LOCK:
+        tool_names = list(_REG.keys())
+        usability_checkers = dict(_USABILITY_REG)
+
+    return [
+        name
+        for name in tool_names
+        if _check_tool_usable(name, usability_checkers.get(name, lambda: True))
+    ]
 
 
 def get_tool_module_qualnames() -> dict[str, str]:

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -245,11 +245,6 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         return True
 
     @classmethod
-    def is_available(cls) -> bool:
-        """Backward-compatible alias for ``is_usable()``."""
-        return cls.is_usable()
-
-    @classmethod
     @abstractmethod
     def create(cls, *args, **kwargs) -> Sequence[Self]:
         """Create a sequence of Tool instances.

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -240,9 +240,14 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
     )
 
     @classmethod
-    def is_available(cls) -> bool:
+    def is_usable(cls) -> bool:
         """Return whether the tool can be used in the current environment."""
         return True
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """Backward-compatible alias for ``is_usable()``."""
+        return cls.is_usable()
 
     @classmethod
     @abstractmethod

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -240,6 +240,11 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
     )
 
     @classmethod
+    def is_available(cls) -> bool:
+        """Return whether the tool can be used in the current environment."""
+        return True
+
+    @classmethod
     @abstractmethod
     def create(cls, *args, **kwargs) -> Sequence[Self]:
         """Create a sequence of Tool instances.

--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -789,6 +789,12 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
     _shared_executor_lock: ClassVar[threading.Lock] = threading.Lock()
 
     @classmethod
+    def is_usable(cls) -> bool:
+        from openhands.tools.browser_use.impl import BrowserToolExecutor
+
+        return BrowserToolExecutor.check_chromium_available() is not None
+
+    @classmethod
     def create(
         cls,
         conv_state: "ConversationState",

--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -789,7 +789,7 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
     _shared_executor_lock: ClassVar[threading.Lock] = threading.Lock()
 
     @classmethod
-    def is_usable(cls) -> bool:
+    def is_available(cls) -> bool:
         from openhands.tools.browser_use.impl import BrowserToolExecutor
 
         return BrowserToolExecutor.check_chromium_available() is not None

--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -789,7 +789,7 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
     _shared_executor_lock: ClassVar[threading.Lock] = threading.Lock()
 
     @classmethod
-    def is_available(cls) -> bool:
+    def is_usable(cls) -> bool:
         from openhands.tools.browser_use.impl import BrowserToolExecutor
 
         return BrowserToolExecutor.check_chromium_available() is not None

--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -273,6 +273,7 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
     _action_timeout_seconds: float
 
     @staticmethod
+    @functools.cache
     def check_chromium_available() -> str | None:
         """Check if a Chromium/Chrome binary is available.
 

--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -272,7 +272,8 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
     _cleanup_initiated: bool
     _action_timeout_seconds: float
 
-    def check_chromium_available(self) -> str | None:
+    @staticmethod
+    def check_chromium_available() -> str | None:
         """Check if a Chromium/Chrome binary is available.
 
         Returns:

--- a/tests/agent_server/test_server_details_router.py
+++ b/tests/agent_server/test_server_details_router.py
@@ -61,4 +61,4 @@ def test_server_info_reports_usable_tools(client, monkeypatch: pytest.MonkeyPatc
     response = client.get("/server_info")
 
     assert response.status_code == 200
-    assert response.json()["available_tools"] == ["terminal", "file_editor"]
+    assert response.json()["usable_tools"] == ["terminal", "file_editor"]

--- a/tests/agent_server/test_server_details_router.py
+++ b/tests/agent_server/test_server_details_router.py
@@ -48,3 +48,39 @@ def test_ready_resets_after_new_event(client):
     sdr._initialization_complete = asyncio.Event()
     response = client.get("/ready")
     assert response.status_code == 503
+
+
+def test_server_info_filters_browser_tool_when_unavailable(
+    client, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        sdr,
+        "list_registered_tools",
+        lambda: ["terminal", "file_editor", "browser_tool_set"],
+    )
+    monkeypatch.setattr(sdr, "_browser_tool_available", lambda: False)
+
+    response = client.get("/server_info")
+
+    assert response.status_code == 200
+    assert response.json()["available_tools"] == ["terminal", "file_editor"]
+
+
+def test_server_info_keeps_browser_tool_when_available(
+    client, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.setattr(
+        sdr,
+        "list_registered_tools",
+        lambda: ["terminal", "file_editor", "browser_tool_set"],
+    )
+    monkeypatch.setattr(sdr, "_browser_tool_available", lambda: True)
+
+    response = client.get("/server_info")
+
+    assert response.status_code == 200
+    assert response.json()["available_tools"] == [
+        "terminal",
+        "file_editor",
+        "browser_tool_set",
+    ]

--- a/tests/agent_server/test_server_details_router.py
+++ b/tests/agent_server/test_server_details_router.py
@@ -50,37 +50,15 @@ def test_ready_resets_after_new_event(client):
     assert response.status_code == 503
 
 
-def test_server_info_filters_browser_tool_when_unavailable(
-    client, monkeypatch: pytest.MonkeyPatch
-):
+def test_server_info_reports_usable_tools(client, monkeypatch: pytest.MonkeyPatch):
+    """/server_info should expose the registry-filtered usable tool list."""
     monkeypatch.setattr(
         sdr,
-        "list_registered_tools",
-        lambda: ["terminal", "file_editor", "browser_tool_set"],
+        "list_usable_tools",
+        lambda: ["terminal", "file_editor"],
     )
-    monkeypatch.setattr(sdr, "_browser_tool_available", lambda: False)
 
     response = client.get("/server_info")
 
     assert response.status_code == 200
     assert response.json()["available_tools"] == ["terminal", "file_editor"]
-
-
-def test_server_info_keeps_browser_tool_when_available(
-    client, monkeypatch: pytest.MonkeyPatch
-):
-    monkeypatch.setattr(
-        sdr,
-        "list_registered_tools",
-        lambda: ["terminal", "file_editor", "browser_tool_set"],
-    )
-    monkeypatch.setattr(sdr, "_browser_tool_available", lambda: True)
-
-    response = client.get("/server_info")
-
-    assert response.status_code == 200
-    assert response.json()["available_tools"] == [
-        "terminal",
-        "file_editor",
-        "browser_tool_set",
-    ]

--- a/tests/cross/test_automatic_registration.py
+++ b/tests/cross/test_automatic_registration.py
@@ -47,6 +47,31 @@ def test_browser_tool_automatic_registration():
     assert "browser_tool_set" in registered_tools
 
 
+def test_browser_tool_usable_listing_respects_chromium_availability(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """Usable tools should follow the browser tool's Chromium availability."""
+    import openhands.tools.browser_use.definition  # noqa: F401
+    from openhands.sdk.tool.registry import list_usable_tools
+    from openhands.tools.browser_use.definition import BrowserToolSet
+
+    assert "browser_tool_set" in list_registered_tools()
+
+    monkeypatch.setattr(
+        BrowserToolSet,
+        "is_usable",
+        classmethod(lambda cls: False),
+    )
+    assert "browser_tool_set" not in list_usable_tools()
+
+    monkeypatch.setattr(
+        BrowserToolSet,
+        "is_usable",
+        classmethod(lambda cls: True),
+    )
+    assert "browser_tool_set" in list_usable_tools()
+
+
 def test_grep_tool_automatic_registration():
     """Test that GrepTool is automatically registered when imported."""
     # Import the module to trigger registration

--- a/tests/cross/test_automatic_registration.py
+++ b/tests/cross/test_automatic_registration.py
@@ -59,14 +59,14 @@ def test_browser_tool_usable_listing_respects_chromium_availability(
 
     monkeypatch.setattr(
         BrowserToolSet,
-        "is_usable",
+        "is_available",
         classmethod(lambda cls: False),
     )
     assert "browser_tool_set" not in list_usable_tools()
 
     monkeypatch.setattr(
         BrowserToolSet,
-        "is_usable",
+        "is_available",
         classmethod(lambda cls: True),
     )
     assert "browser_tool_set" in list_usable_tools()

--- a/tests/cross/test_automatic_registration.py
+++ b/tests/cross/test_automatic_registration.py
@@ -59,14 +59,14 @@ def test_browser_tool_usable_listing_respects_chromium_availability(
 
     monkeypatch.setattr(
         BrowserToolSet,
-        "is_available",
+        "is_usable",
         classmethod(lambda cls: False),
     )
     assert "browser_tool_set" not in list_usable_tools()
 
     monkeypatch.setattr(
         BrowserToolSet,
-        "is_available",
+        "is_usable",
         classmethod(lambda cls: True),
     )
     assert "browser_tool_set" in list_usable_tools()

--- a/tests/cross/test_registry_qualnames.py
+++ b/tests/cross/test_registry_qualnames.py
@@ -1,5 +1,8 @@
 """Tests for tool registry module qualname tracking."""
 
+import pytest
+from deprecation import DeprecatedWarning
+
 from openhands.sdk.tool.registry import (
     get_tool_module_qualnames,
     list_registered_tools,
@@ -29,7 +32,8 @@ def test_get_tool_module_qualnames_with_callable():
         return []
 
     # Register the callable
-    register_tool("test_callable", test_factory)
+    with pytest.warns(DeprecatedWarning, match=r"register_tool\(callable_factory\)"):
+        register_tool("test_callable", test_factory)
 
     # Get the module qualnames
     qualnames = get_tool_module_qualnames()

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -1497,6 +1497,16 @@ def test_agent_final_response_endpoint(server_env, monkeypatch: pytest.MonkeyPat
     conv.close()
 
 
+def test_server_info_exposes_available_tools(server_env):
+    with httpx.Client(base_url=server_env["host"]) as client:
+        response = client.get("/server_info", timeout=10.0)
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert isinstance(payload.get("available_tools"), list)
+    assert "terminal" in payload["available_tools"]
+
+
 def test_remote_state_exposes_invoked_skills(
     server_env,
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -1497,14 +1497,14 @@ def test_agent_final_response_endpoint(server_env, monkeypatch: pytest.MonkeyPat
     conv.close()
 
 
-def test_server_info_exposes_available_tools(server_env):
+def test_server_info_exposes_usable_tools(server_env):
     with httpx.Client(base_url=server_env["host"]) as client:
         response = client.get("/server_info", timeout=10.0)
 
     assert response.status_code == 200
     payload = response.json()
-    assert isinstance(payload.get("available_tools"), list)
-    assert "terminal" in payload["available_tools"]
+    assert isinstance(payload.get("usable_tools"), list)
+    assert "terminal" in payload["usable_tools"]
 
 
 def test_remote_state_exposes_invoked_skills(

--- a/tests/sdk/tool/test_registry.py
+++ b/tests/sdk/tool/test_registry.py
@@ -2,12 +2,13 @@ from collections.abc import Sequence
 from unittest.mock import MagicMock
 
 import pytest
+from deprecation import DeprecatedWarning
 
 from openhands.sdk import register_tool
 from openhands.sdk.conversation.state import ConversationState
 from openhands.sdk.llm.message import ImageContent, TextContent
 from openhands.sdk.tool import ToolDefinition
-from openhands.sdk.tool.registry import resolve_tool
+from openhands.sdk.tool.registry import list_usable_tools, resolve_tool
 from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.tool.spec import Tool
 from openhands.sdk.tool.tool import ToolExecutor
@@ -88,11 +89,14 @@ def _hello_tool_factory(conv_state=None, **params) -> list[ToolDefinition]:
 
 
 def test_register_and_resolve_callable_factory():
-    register_tool("say_hello", _hello_tool_factory)
+    with pytest.warns(DeprecatedWarning, match=r"register_tool\(callable_factory\)"):
+        register_tool("say_hello", _hello_tool_factory)
+
     tools = resolve_tool(Tool(name="say_hello"), _create_mock_conv_state())
     assert len(tools) == 1
     assert isinstance(tools[0], ToolDefinition)
     assert tools[0].name == "__simple_hello"
+    assert "say_hello" in list_usable_tools()
 
 
 def test_register_tool_instance_rejects_params():

--- a/tests/sdk/tool/test_registry.py
+++ b/tests/sdk/tool/test_registry.py
@@ -90,12 +90,6 @@ class _UnavailableHelloTool(_SimpleHelloTool):
         return False
 
 
-class _LegacyUnavailableHelloTool(_SimpleHelloTool):
-    @classmethod
-    def is_available(cls) -> bool:
-        return False
-
-
 def _hello_tool_factory(conv_state=None, **params) -> list[ToolDefinition]:
     return list(_SimpleHelloTool.create(conv_state, **params))
 
@@ -115,12 +109,6 @@ def test_register_tool_type_respects_is_usable():
     register_tool("say_hello_unusable", _UnavailableHelloTool)
 
     assert "say_hello_unusable" not in list_usable_tools()
-
-
-def test_register_tool_type_supports_legacy_is_available():
-    register_tool("say_hello_legacy_unavailable", _LegacyUnavailableHelloTool)
-
-    assert "say_hello_legacy_unavailable" not in list_usable_tools()
 
 
 def test_register_tool_instance_rejects_params():

--- a/tests/sdk/tool/test_registry.py
+++ b/tests/sdk/tool/test_registry.py
@@ -84,6 +84,18 @@ class _SimpleHelloTool(ToolDefinition[_HelloAction, _HelloObservation]):
         ]
 
 
+class _UnavailableHelloTool(_SimpleHelloTool):
+    @classmethod
+    def is_usable(cls) -> bool:
+        return False
+
+
+class _LegacyUnavailableHelloTool(_SimpleHelloTool):
+    @classmethod
+    def is_available(cls) -> bool:
+        return False
+
+
 def _hello_tool_factory(conv_state=None, **params) -> list[ToolDefinition]:
     return list(_SimpleHelloTool.create(conv_state, **params))
 
@@ -97,6 +109,18 @@ def test_register_and_resolve_callable_factory():
     assert isinstance(tools[0], ToolDefinition)
     assert tools[0].name == "__simple_hello"
     assert "say_hello" in list_usable_tools()
+
+
+def test_register_tool_type_respects_is_usable():
+    register_tool("say_hello_unusable", _UnavailableHelloTool)
+
+    assert "say_hello_unusable" not in list_usable_tools()
+
+
+def test_register_tool_type_supports_legacy_is_available():
+    register_tool("say_hello_legacy_unavailable", _LegacyUnavailableHelloTool)
+
+    assert "say_hello_legacy_unavailable" not in list_usable_tools()
 
 
 def test_register_tool_instance_rejects_params():

--- a/tests/tools/browser_use/test_chromium_detection.py
+++ b/tests/tools/browser_use/test_chromium_detection.py
@@ -9,6 +9,13 @@ import pytest
 from openhands.tools.browser_use.impl import BrowserToolExecutor, _install_chromium
 
 
+@pytest.fixture(autouse=True)
+def clear_chromium_detection_cache():
+    BrowserToolExecutor.check_chromium_available.cache_clear()
+    yield
+    BrowserToolExecutor.check_chromium_available.cache_clear()
+
+
 class TestChromiumDetection:
     """Test Chromium detection functionality."""
 
@@ -21,6 +28,18 @@ class TestChromiumDetection:
         ):
             result = executor.check_chromium_available()
             assert result == "/usr/bin/chromium"
+
+    def test_check_chromium_available_is_cached(self):
+        """Test that Chromium detection is memoized across repeated calls."""
+        executor = BrowserToolExecutor.__new__(BrowserToolExecutor)
+        with (
+            patch.object(Path, "exists", return_value=False),
+            patch("shutil.which", return_value="/usr/bin/chromium") as mock_which,
+        ):
+            assert executor.check_chromium_available() == "/usr/bin/chromium"
+            assert executor.check_chromium_available() == "/usr/bin/chromium"
+
+        assert mock_which.call_count == 1
 
     def test_check_chromium_available_multiple_binaries(self):
         """Test that first available binary is returned."""


### PR DESCRIPTION
## Summary
- add an additive `usable_tools` field to `/server_info`
- omit `browser_tool_set` from that list when Chromium is not available
- cover the new metadata with router and live-server tests
- deprecate callable tool factories

## Verification
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/server_details_router.py openhands-tools/openhands/tools/browser_use/impl.py tests/agent_server/test_server_details_router.py tests/cross/test_remote_conversation_live_server.py`
- `uv run pytest tests/agent_server/test_server_details_router.py tests/tools/browser_use/test_chromium_detection.py tests/cross/test_remote_conversation_live_server.py -k "server_info or chromium_available or usable_tools"`

_This PR was created by an AI agent (OpenHands) on behalf of the user._






<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1ac7e09-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1ac7e09-python \
  ghcr.io/openhands/agent-server:1ac7e09-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1ac7e09-golang-amd64
ghcr.io/openhands/agent-server:1ac7e09-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1ac7e09-golang-arm64
ghcr.io/openhands/agent-server:1ac7e09-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1ac7e09-java-amd64
ghcr.io/openhands/agent-server:1ac7e09-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1ac7e09-java-arm64
ghcr.io/openhands/agent-server:1ac7e09-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1ac7e09-python-amd64
ghcr.io/openhands/agent-server:1ac7e09-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1ac7e09-python-arm64
ghcr.io/openhands/agent-server:1ac7e09-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1ac7e09-golang
ghcr.io/openhands/agent-server:1ac7e09-java
ghcr.io/openhands/agent-server:1ac7e09-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1ac7e09-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1ac7e09-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->