### PR TITLE
fix(tools): recover pooled terminal reset after tmux exit

### DIFF
--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -487,6 +487,13 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
                     f"Terminal pane replaced (reset) working_dir: {self._working_dir}"
                 )
 
+                if not action.command.strip():
+                    return TerminalObservation.from_text(
+                        text=reset_text,
+                        command="[RESET]",
+                        exit_code=0,
+                    )
+
             session = self._wrap_session(handle.terminal)
             self._prepare_pooled_session(session)
 

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -3,6 +3,8 @@ import threading
 import time
 from typing import TYPE_CHECKING, Literal
 
+from libtmux.exc import LibTmuxException
+
 from openhands.sdk.llm import TextContent
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool import ToolExecutor
@@ -35,6 +37,10 @@ logger = get_logger(__name__)
 # Environment variable names must be alphanumeric + underscores, starting with
 # a letter or underscore. This guards against shell injection via key names.
 _ENV_VAR_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def _is_tmux_server_unavailable(exc: Exception) -> bool:
+    return isinstance(exc, LibTmuxException) and "no server running" in str(exc)
 
 
 class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
@@ -71,6 +77,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         self._username = username
         self._no_change_timeout_seconds = no_change_timeout_seconds
         self._terminal_type = terminal_type
+        self._max_panes = max_panes
         self.full_output_save_dir: str | None = full_output_save_dir
 
         # Pool mode: use TmuxPanePool for parallel execution
@@ -165,6 +172,60 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
                 session._closed = True
                 # Also mark the terminal so the pooled close() is a no-op
                 terminal._closed = True
+
+    def _discard_all_pooled_sessions(self) -> None:
+        """Mark cached pooled sessions closed before dropping references."""
+        with self._sessions_lock:
+            for session in self._sessions.values():
+                session._closed = True
+                session.terminal._closed = True
+            self._sessions.clear()
+
+    def _reset_pooled_pool(self) -> TerminalObservation:
+        """Recreate the pooled tmux session from scratch."""
+        assert self._pool is not None
+        self._discard_all_pooled_sessions()
+        self._pool.close()
+        self._pool = TmuxPanePool(
+            self._working_dir,
+            self._username,
+            max_panes=self._max_panes,
+        )
+        self._pool.initialize()
+
+        logger.info(
+            "Terminal pane pool reset successfully with working_dir: %s",
+            self._working_dir,
+        )
+        return TerminalObservation.from_text(
+            text=self._RESET_TEXT,
+            command="[RESET]",
+            exit_code=0,
+        )
+
+    def _compose_reset_observation(
+        self,
+        reset_result: TerminalObservation,
+        action: TerminalAction,
+        conversation: "LocalConversation | None",
+    ) -> TerminalObservation:
+        if not action.command.strip():
+            return self._mask_observation(reset_result, conversation)
+
+        command_action = TerminalAction(
+            command=action.command,
+            timeout=action.timeout,
+            is_input=False,
+        )
+        observation = self._execute_pooled(command_action, conversation)
+        return observation.model_copy(
+            update={
+                "content": [
+                    TextContent(text=f"{reset_result.text}\n\n{observation.text}")
+                ],
+                "command": f"[RESET] {action.command}",
+            }
+        )
 
     @staticmethod
     def _prepare_pooled_session(session: TerminalSession) -> None:
@@ -321,6 +382,8 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
 
     def reset(self) -> TerminalObservation:
         """Public reset – delegates to the appropriate backend."""
+        if self._pool is not None:
+            return self._reset_pooled_pool()
         return self._reset_single_session()
 
     def _reset_single_session(self) -> TerminalObservation:
@@ -411,23 +474,18 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         managed by the pool's context manager so there is exactly one
         checkout and one checkin per call.
         """
-        with self._pool.pane() as handle:  # type: ignore[union-attr]
+        assert self._pool is not None
+
+        with self._pool.pane() as handle:
             reset_text: str | None = None
 
             if action.reset or handle.terminal._closed:
                 self._discard_session(handle.terminal)
-                handle.terminal = self._pool.replace(handle.terminal)  # type: ignore[union-attr]
+                handle.terminal = self._pool.replace(handle.terminal)
                 reset_text = self._RESET_TEXT
                 logger.info(
                     f"Terminal pane replaced (reset) working_dir: {self._working_dir}"
                 )
-
-                if not action.command.strip():
-                    return TerminalObservation.from_text(
-                        text=reset_text,
-                        command="[RESET]",
-                        exit_code=0,
-                    )
 
             session = self._wrap_session(handle.terminal)
             self._prepare_pooled_session(session)
@@ -465,7 +523,31 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
             raise ValueError("Cannot use reset=True with is_input=True")
 
         if self._pool is not None:
-            return self._execute_pooled(action, conversation)
+            try:
+                return self._execute_pooled(action, conversation)
+            except Exception as exc:
+                if not _is_tmux_server_unavailable(exc):
+                    raise
+                logger.warning(
+                    "Tmux server became unavailable; recreating terminal pane pool",
+                    exc_info=True,
+                )
+                reset_result = self._reset_pooled_pool()
+                if action.reset:
+                    return self._compose_reset_observation(
+                        reset_result,
+                        action,
+                        conversation,
+                    )
+                return TerminalObservation.from_text(
+                    text=(
+                        "Terminal session became unavailable and has been reset. "
+                        "Please rerun the command if needed."
+                    ),
+                    command=action.command,
+                    exit_code=-1,
+                    is_error=True,
+                )
         else:
             return self._execute_single_session(action, conversation)
 

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
@@ -33,6 +33,13 @@ logger = get_logger(__name__)
 DEFAULT_MAX_PANES: Final[int] = 4
 
 
+def _safe_pane_id(terminal: PooledTmuxTerminal) -> str:
+    try:
+        return str(terminal.pane.pane_id)
+    except Exception:
+        return "<unavailable>"
+
+
 class PooledTmuxTerminal(TmuxTerminal):
     """A TmuxTerminal variant used inside a pane pool.
 
@@ -197,7 +204,9 @@ class TmuxPanePool:
         terminal._initialized = True
         terminal.clear_screen()
 
-        logger.debug(f"Created pooled pane #{len(self._all_panes)}: {active_pane}")
+        logger.debug(
+            f"Created pooled pane #{len(self._all_panes)}: {active_pane.pane_id}"
+        )
         return terminal
 
     def checkout(self, timeout: float | None = None) -> PooledTmuxTerminal:
@@ -226,13 +235,13 @@ class TmuxPanePool:
         with self._lock:
             if self._available:
                 terminal = self._available.popleft()
-                logger.debug(f"Checked out existing pane: {terminal.pane}")
+                logger.debug(f"Checked out existing pane: {_safe_pane_id(terminal)}")
                 return terminal
 
             # Create a new pane (still under max_panes thanks to semaphore)
             terminal = self._create_pane()
             self._all_panes.append(terminal)
-            logger.debug(f"Checked out new pane: {terminal.pane}")
+            logger.debug(f"Checked out new pane: {_safe_pane_id(terminal)}")
             return terminal
 
     def checkin(self, terminal: PooledTmuxTerminal) -> None:
@@ -245,7 +254,7 @@ class TmuxPanePool:
                 self._available.append(terminal)
 
         self._semaphore.release()
-        logger.debug(f"Checked in pane: {terminal.pane}")
+        logger.debug(f"Checked in pane: {_safe_pane_id(terminal)}")
 
     def replace(self, old_terminal: PooledTmuxTerminal) -> PooledTmuxTerminal:
         """Replace a checked-out pane with a fresh one.
@@ -268,8 +277,8 @@ class TmuxPanePool:
                 self._available.remove(old_terminal)
 
         # Capture IDs before killing (repr would fail after kill).
-        old_pane_id = old_terminal.pane.pane_id
-        new_pane_id = new_terminal.pane.pane_id
+        old_pane_id = _safe_pane_id(old_terminal)
+        new_pane_id = _safe_pane_id(new_terminal)
 
         # Only destroy the old terminal's window — NOT terminal.close()
         # which would kill the entire shared tmux session.

--- a/tests/tools/terminal/test_pool_integration.py
+++ b/tests/tools/terminal/test_pool_integration.py
@@ -109,3 +109,79 @@ class TestConcurrentExecution:
         assert elapsed < serial_time, (
             f"Expected parallel execution under {serial_time}s, took {elapsed:.1f}s"
         )
+
+
+def test_explicit_reset_recovers_after_tmux_server_exits(tmp_path, monkeypatch):
+    """A killed tmux server should not make reset=True unusable."""
+    tmux_tmpdir = tmp_path / "tmux"
+    tmux_tmpdir.mkdir()
+    monkeypatch.setenv("TMUX_TMPDIR", str(tmux_tmpdir))
+
+    executor = TerminalExecutor(
+        working_dir=str(tmp_path),
+        terminal_type="tmux",
+        max_panes=1,
+    )
+    try:
+        timed_out = executor(
+            TerminalAction(
+                command="tmux -L openhands kill-server; sleep 10",
+                timeout=1,
+            )
+        )
+        assert timed_out.exit_code == -1
+        assert timed_out.metadata is not None
+        assert "timed out after 1" in timed_out.metadata.suffix
+
+        recovered = executor(
+            TerminalAction(command="echo recovered", reset=True, timeout=5)
+        )
+        assert recovered.exit_code == 0
+        assert "Terminal session has been reset" in recovered.text
+        assert "recovered" in recovered.text
+    finally:
+        executor.close()
+
+
+def test_explicit_reset_does_not_interrupt_other_pooled_panes(
+    tmp_path,
+    monkeypatch,
+):
+    """A normal reset should replace one pane, not the whole pool."""
+    tmux_tmpdir = tmp_path / "tmux-normal-reset"
+    tmux_tmpdir.mkdir()
+    monkeypatch.setenv("TMUX_TMPDIR", str(tmux_tmpdir))
+
+    executor = TerminalExecutor(
+        working_dir=str(tmp_path),
+        terminal_type="tmux",
+        max_panes=2,
+    )
+    errors: list[Exception] = []
+    results: list[str] = []
+
+    def run_long_command() -> None:
+        try:
+            obs = executor(
+                TerminalAction(command="sleep 2 && echo still_running", timeout=5)
+            )
+            results.append(obs.text)
+        except Exception as exc:
+            errors.append(exc)
+
+    thread = threading.Thread(target=run_long_command)
+    thread.start()
+    time.sleep(0.5)
+    try:
+        reset = executor(
+            TerminalAction(command="echo reset_done", reset=True, timeout=5)
+        )
+        thread.join(timeout=6)
+
+        assert reset.exit_code == 0
+        assert "reset_done" in reset.text
+        assert not thread.is_alive()
+        assert not errors
+        assert results == ["still_running"]
+    finally:
+        executor.close()


### PR DESCRIPTION
## Summary
- Reproduce the tmux-backed terminal failure where the shared tmux server disappears and `reset=true` could not recover.
- Recreate the pooled tmux session from scratch for explicit resets instead of touching stale pane handles.
- Avoid libtmux pane repr lookups in pool logging after the tmux server is gone.

## Testing
- `uv run pytest tests/tools/terminal/test_pool_integration.py -q`
- `uv run pre-commit run --files openhands-tools/openhands/tools/terminal/impl.py openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py tests/tools/terminal/test_pool_integration.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7c7ab74-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7c7ab74-python \
  ghcr.io/openhands/agent-server:7c7ab74-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7c7ab74-golang-amd64
ghcr.io/openhands/agent-server:7c7ab74-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7c7ab74-golang-arm64
ghcr.io/openhands/agent-server:7c7ab74-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7c7ab74-java-amd64
ghcr.io/openhands/agent-server:7c7ab74-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7c7ab74-java-arm64
ghcr.io/openhands/agent-server:7c7ab74-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7c7ab74-python-amd64
ghcr.io/openhands/agent-server:7c7ab74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7c7ab74-python-arm64
ghcr.io/openhands/agent-server:7c7ab74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7c7ab74-golang
ghcr.io/openhands/agent-server:7c7ab74-java
ghcr.io/openhands/agent-server:7c7ab74-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7c7ab74-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7c7ab74-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->