### PR TITLE
fix(remote_conversation): weakref in run_complete_callback breaks circular reference

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -5,6 +5,7 @@ import os
 import threading
 import time
 import uuid
+import weakref
 from collections.abc import Mapping
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, SupportsIndex, overload
@@ -811,15 +812,24 @@ class RemoteConversation(BaseConversation):
             # No visualization (visualizer is None)
             self._visualizer = None
 
-        # Add a callback that signals when run completes via WebSocket
-        # This ensures we wait for all events to be delivered before run() returns
+        # Add a callback that signals when run completes via WebSocket.
+        # This ensures we wait for all events to be delivered before run() returns.
+        # Use a weakref to avoid creating a cycle:
+        #   RemoteConversation → _ws_client → callback → self
+        # Without weakref, CPython's reference counter cannot free the conversation
+        # when it goes out of scope; it must wait for the cyclic GC instead.
+        self_ref: weakref.ref[RemoteConversation] = weakref.ref(self)
+
         def run_complete_callback(event: Event) -> None:
+            conv = self_ref()
+            if conv is None:
+                return
             if isinstance(event, ConversationStateUpdateEvent):
                 if event.key == "execution_status":
                     try:
                         status = ConversationExecutionStatus(event.value)
                         if status.is_terminal():
-                            self._terminal_status_queue.put(event.value)
+                            conv._terminal_status_queue.put(event.value)
                     except ValueError:
                         pass  # Unknown status value, ignore
 


### PR DESCRIPTION
## Summary

- Replace the direct `self` capture in `run_complete_callback` with `weakref.ref(self)`, eliminating the circular reference in `RemoteConversation`

## Why

`run_complete_callback` is a closure defined inside `RemoteConversation.__init__` that captures `self` via `self._terminal_status_queue`. It is stored in `composed_callback`, which is passed to `WebSocketCallbackClient`. This creates a cycle:

```
RemoteConversation → _ws_client (WebSocketCallbackClient)
                   → callback (composed_callback)
                   → run_complete_callback → self (RemoteConversation)
```

Because of this cycle CPython's reference counter cannot free the `RemoteConversation` when all external references drop — it must wait for the cyclic GC, which only runs on a threshold.

In eval workloads with many concurrent instances this causes significant memory accumulation. ACP agents (acp-codex, acp-claude) make it severe because they have no condenser, so `_cached_events` grows large (100+ tool calls, MB-sized `raw_output`).

**Observed failure**: swebenchmultimodal with `acp-codex` OOMed the eval-container (12Gi limit) at ~40/68 instances across 5 consecutive runs. See OpenHands/evaluation#540.

## Fix

Replace `self` with `weakref.ref(self)` in the closure. The callback now holds only a weak reference, so there is no cycle — CPython's reference counter can immediately reclaim the conversation and its `_cached_events` when it goes out of scope.

```python
self_ref: weakref.ref[RemoteConversation] = weakref.ref(self)

def run_complete_callback(event: Event) -> None:
    conv = self_ref()
    if conv is None:
        return
    ...
```

The `conv is None` guard handles the (unlikely) case where the callback fires after the conversation is already collected.

## Companion PR

OpenHands/benchmarks (fix/gc-collect-after-instance) adds `gc.collect()` in the eval orchestrator as a belt-and-suspenders safety net.

## Test plan

- [ ] Existing unit tests pass
- [ ] Manual: run swebenchmultimodal with acp-codex and verify no OOMKill

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:feff8c9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-feff8c9-python \
  ghcr.io/openhands/agent-server:feff8c9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:feff8c9-golang-amd64
ghcr.io/openhands/agent-server:feff8c9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:feff8c9-golang-arm64
ghcr.io/openhands/agent-server:feff8c9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:feff8c9-java-amd64
ghcr.io/openhands/agent-server:feff8c9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:feff8c9-java-arm64
ghcr.io/openhands/agent-server:feff8c9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:feff8c9-python-amd64
ghcr.io/openhands/agent-server:feff8c9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:feff8c9-python-arm64
ghcr.io/openhands/agent-server:feff8c9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:feff8c9-golang
ghcr.io/openhands/agent-server:feff8c9-java
ghcr.io/openhands/agent-server:feff8c9-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `feff8c9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `feff8c9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->