### PR TITLE
fix: prevent O(n²) memory growth in ACP tool call streaming

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -282,18 +282,24 @@ def _serialize_tool_content(content: list[Any] | None) -> list[dict[str, Any]] |
     if not content:
         return None
     result = []
-    for c in content:
-        d = c.model_dump(mode="json") if hasattr(c, "model_dump") else c
+    for content_block in content:
+        block_dict = (
+            content_block.model_dump(mode="json")
+            if hasattr(content_block, "model_dump")
+            else content_block
+        )
         if (
-            isinstance(d, dict)
-            and d.get("type") == "text"
-            and isinstance(d.get("text"), str)
+            isinstance(block_dict, dict)
+            and block_dict.get("type") == "text"
+            and isinstance(block_dict.get("text"), str)
         ):
-            d = {
-                **d,
-                "text": maybe_truncate(d["text"], truncate_after=MAX_ACP_CONTENT_CHARS),
+            block_dict = {
+                **block_dict,
+                "text": maybe_truncate(
+                    block_dict["text"], truncate_after=MAX_ACP_CONTENT_CHARS
+                ),
             }
-        result.append(d)
+        result.append(block_dict)
     return result
 
 

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -59,6 +59,7 @@ from openhands.sdk.observability.laminar import maybe_init_laminar, observe
 from openhands.sdk.secret import SecretSource
 from openhands.sdk.tool import Tool  # noqa: TC002
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishObservation
+from openhands.sdk.utils import maybe_truncate
 
 
 logger = get_logger(__name__)
@@ -96,6 +97,10 @@ _RETRIABLE_CONNECTION_ERRORS = (OSError, ConnectionError, BrokenPipeError, EOFEr
 # -32603 = "Internal error" (JSON-RPC spec) — covers ACP server crashes,
 #          upstream model 500s, and transient infrastructure errors.
 _RETRIABLE_SERVER_ERROR_CODES: frozenset[int] = frozenset({-32603})
+
+# Maximum characters for ACP tool call content — matches MAX_CMD_OUTPUT_SIZE
+# used by the terminal tool and the default max_message_chars in LLM config.
+MAX_ACP_CONTENT_CHARS: int = 30_000
 
 # Limit for asyncio.StreamReader buffers used by the ACP subprocess pipes.
 # The default (64 KiB) is too small for session_update notifications that
@@ -276,9 +281,13 @@ def _serialize_tool_content(content: list[Any] | None) -> list[dict[str, Any]] |
     """Serialize ACP tool call content blocks to plain dicts for JSON storage."""
     if not content:
         return None
-    return [
-        c.model_dump(mode="json") if hasattr(c, "model_dump") else c for c in content
-    ]
+    result = []
+    for c in content:
+        d = c.model_dump(mode="json") if hasattr(c, "model_dump") else c
+        if isinstance(d, dict) and d.get("type") == "text" and isinstance(d.get("text"), str):
+            d = {**d, "text": maybe_truncate(d["text"], truncate_after=MAX_ACP_CONTENT_CHARS)}
+        result.append(d)
+    return result
 
 
 async def _filter_jsonrpc_lines(source: Any, dest: Any) -> None:
@@ -503,13 +512,16 @@ class _OpenHandsACPBridge:
         if self.on_event is None:
             return
         try:
+            raw_output = tc.get("raw_output")
+            if isinstance(raw_output, str):
+                raw_output = maybe_truncate(raw_output, truncate_after=MAX_ACP_CONTENT_CHARS)
             event = ACPToolCallEvent(
                 tool_call_id=tc["tool_call_id"],
                 title=tc["title"],
                 status=tc.get("status"),
                 tool_kind=tc.get("tool_kind"),
                 raw_input=tc.get("raw_input"),
-                raw_output=tc.get("raw_output"),
+                raw_output=raw_output,
                 content=tc.get("content"),
                 is_error=tc.get("status") == "failed",
             )

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -284,8 +284,15 @@ def _serialize_tool_content(content: list[Any] | None) -> list[dict[str, Any]] |
     result = []
     for c in content:
         d = c.model_dump(mode="json") if hasattr(c, "model_dump") else c
-        if isinstance(d, dict) and d.get("type") == "text" and isinstance(d.get("text"), str):
-            d = {**d, "text": maybe_truncate(d["text"], truncate_after=MAX_ACP_CONTENT_CHARS)}
+        if (
+            isinstance(d, dict)
+            and d.get("type") == "text"
+            and isinstance(d.get("text"), str)
+        ):
+            d = {
+                **d,
+                "text": maybe_truncate(d["text"], truncate_after=MAX_ACP_CONTENT_CHARS),
+            }
         result.append(d)
     return result
 
@@ -514,7 +521,9 @@ class _OpenHandsACPBridge:
         try:
             raw_output = tc.get("raw_output")
             if isinstance(raw_output, str):
-                raw_output = maybe_truncate(raw_output, truncate_after=MAX_ACP_CONTENT_CHARS)
+                raw_output = maybe_truncate(
+                    raw_output, truncate_after=MAX_ACP_CONTENT_CHARS
+                )
             event = ACPToolCallEvent(
                 tool_call_id=tc["tool_call_id"],
                 title=tc["title"],

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -37,6 +37,7 @@ from openhands.sdk.conversation.visualizer import (
     ConversationVisualizerBase,
     DefaultConversationVisualizer,
 )
+from openhands.sdk.event.acp_tool_call import ACPToolCallEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.event.conversation_state import (
@@ -259,6 +260,7 @@ class RemoteEventsList(EventsListBase):
         self._events_base_path = events_base_path
         self._cached_events: list[Event] = []
         self._cached_event_ids: set[str] = set()
+        self._acp_tool_call_id_to_event_id: dict[str, str] = {}
         self._lock = threading.RLock()
         # Initial fetch to sync existing events
         self._do_full_sync()
@@ -350,6 +352,25 @@ class RemoteEventsList(EventsListBase):
 
     def _add_event_unsafe(self, event: Event) -> None:
         """Add event to cache without acquiring lock (caller must hold lock)."""
+        # ACP streaming emits one ACPToolCallEvent per ToolCallProgress, each
+        # carrying the full cumulative stdout so far — O(n²) memory growth.
+        # Deduplicate by tool_call_id: replace the existing entry in-place so
+        # only the latest (most complete) snapshot is kept.
+        if isinstance(event, ACPToolCallEvent):
+            existing_id = self._acp_tool_call_id_to_event_id.get(event.tool_call_id)
+            if existing_id is not None:
+                for i, e in enumerate(self._cached_events):
+                    if e.id == existing_id:
+                        self._cached_events[i] = event
+                        self._cached_event_ids.discard(existing_id)
+                        self._cached_event_ids.add(event.id)
+                        self._acp_tool_call_id_to_event_id[event.tool_call_id] = event.id
+                        logger.debug(
+                            f"Replaced ACP tool call event {existing_id} -> {event.id} "
+                            f"(tool_call_id={event.tool_call_id})"
+                        )
+                        return
+
         # Use bisect with key function for O(log N) insertion
         # This ensures events are always ordered correctly even if
         # WebSocket delivers them out of order
@@ -358,6 +379,8 @@ class RemoteEventsList(EventsListBase):
         )
         self._cached_events.insert(insert_pos, event)
         self._cached_event_ids.add(event.id)
+        if isinstance(event, ACPToolCallEvent):
+            self._acp_tool_call_id_to_event_id[event.tool_call_id] = event.id
         logger.debug(f"Added event {event.id} to local cache at position {insert_pos}")
 
     def add_event(self, event: Event) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -372,6 +372,15 @@ class RemoteEventsList(EventsListBase):
                             f"(tool_call_id={event.tool_call_id})"
                         )
                         return
+                # Index pointed to an event that is no longer in _cached_events;
+                # clean up the stale entry so we don't carry it forward.
+                logger.warning(
+                    f"Stale ACP tool-call index entry: tool_call_id={event.tool_call_id} "
+                    f"pointed to event {existing_id} which is not in _cached_events. "
+                    "Removing stale entry and adding event normally."
+                )
+                self._cached_event_ids.discard(existing_id)
+                del self._acp_tool_call_id_to_event_id[event.tool_call_id]
 
         # Use bisect with key function for O(log N) insertion
         # This ensures events are always ordered correctly even if

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -375,9 +375,10 @@ class RemoteEventsList(EventsListBase):
                 # Index pointed to an event that is no longer in _cached_events;
                 # clean up the stale entry so we don't carry it forward.
                 logger.warning(
-                    f"Stale ACP tool-call index entry: tool_call_id={event.tool_call_id} "
-                    f"pointed to event {existing_id} which is not in _cached_events. "
-                    "Removing stale entry and adding event normally."
+                    "Stale ACP tool-call index entry: "
+                    f"tool_call_id={event.tool_call_id} "
+                    f"pointed to event {existing_id} "
+                    "not found in _cached_events; removing stale entry."
                 )
                 self._cached_event_ids.discard(existing_id)
                 del self._acp_tool_call_id_to_event_id[event.tool_call_id]

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -364,7 +364,9 @@ class RemoteEventsList(EventsListBase):
                         self._cached_events[i] = event
                         self._cached_event_ids.discard(existing_id)
                         self._cached_event_ids.add(event.id)
-                        self._acp_tool_call_id_to_event_id[event.tool_call_id] = event.id
+                        self._acp_tool_call_id_to_event_id[event.tool_call_id] = (
+                            event.id
+                        )
                         logger.debug(
                             f"Replaced ACP tool call event {existing_id} -> {event.id} "
                             f"(tool_call_id={event.tool_call_id})"

--- a/openhands-sdk/openhands/sdk/tests/test_acp_dedup_and_truncation.py
+++ b/openhands-sdk/openhands/sdk/tests/test_acp_dedup_and_truncation.py
@@ -1,0 +1,190 @@
+"""Regression tests for ACP tool call deduplication and content truncation.
+
+Covers:
+- RemoteEventsList._add_event_unsafe deduplicates ACPToolCallEvent by tool_call_id
+- _serialize_tool_content truncates text blocks to MAX_ACP_CONTENT_CHARS
+- _emit_tool_call_event (via _serialize_tool_content) preserves non-text blocks
+- Stale index entry is cleaned up and a warning is logged
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import unittest
+
+from unittest.mock import MagicMock, patch
+
+from openhands.sdk.agent.acp_agent import MAX_ACP_CONTENT_CHARS, _serialize_tool_content
+from openhands.sdk.conversation.impl.remote_conversation import RemoteEventsList
+from openhands.sdk.event.acp_tool_call import ACPToolCallEvent
+
+
+def _make_tool_call_event(tool_call_id: str, raw_output: str = "") -> ACPToolCallEvent:
+    return ACPToolCallEvent(
+        tool_call_id=tool_call_id,
+        title="test tool",
+        raw_output=raw_output,
+    )
+
+
+def _make_events_list() -> RemoteEventsList:
+    """Return a RemoteEventsList with _do_full_sync stubbed out."""
+    with patch.object(RemoteEventsList, "_do_full_sync"):
+        client = MagicMock()
+        return RemoteEventsList(client=client, conversation_id="conv-1")
+
+
+class TestACPToolCallDeduplication(unittest.TestCase):
+    def setUp(self) -> None:
+        self.events = _make_events_list()
+
+    def _add(self, event: ACPToolCallEvent) -> None:
+        with self.events._lock:
+            self.events._add_event_unsafe(event)
+
+    def test_first_event_is_added(self) -> None:
+        ev = _make_tool_call_event("tc-1", "output-1")
+        self._add(ev)
+        self.assertEqual(len(self.events._cached_events), 1)
+        self.assertIn(ev.id, self.events._cached_event_ids)
+
+    def test_subsequent_events_replace_not_append(self) -> None:
+        ev1 = _make_tool_call_event("tc-1", "output-1")
+        ev2 = _make_tool_call_event("tc-1", "output-1-updated")
+        ev3 = _make_tool_call_event("tc-1", "output-1-final")
+        self._add(ev1)
+        self._add(ev2)
+        self._add(ev3)
+
+        self.assertEqual(len(self.events._cached_events), 1)
+        last = self.events._cached_events[0]
+        assert isinstance(last, ACPToolCallEvent)
+        self.assertEqual(last.raw_output, "output-1-final")
+        self.assertNotIn(ev1.id, self.events._cached_event_ids)
+        self.assertNotIn(ev2.id, self.events._cached_event_ids)
+        self.assertIn(ev3.id, self.events._cached_event_ids)
+
+    def test_different_tool_call_ids_are_kept_separately(self) -> None:
+        ev_a = _make_tool_call_event("tc-a", "a-output")
+        ev_b = _make_tool_call_event("tc-b", "b-output")
+        self._add(ev_a)
+        self._add(ev_b)
+
+        self.assertEqual(len(self.events._cached_events), 2)
+        ids = {
+            e.tool_call_id
+            for e in self.events._cached_events
+            if isinstance(e, ACPToolCallEvent)
+        }
+        self.assertEqual(ids, {"tc-a", "tc-b"})
+
+    def test_index_stays_consistent_after_replacement(self) -> None:
+        ev1 = _make_tool_call_event("tc-1", "v1")
+        ev2 = _make_tool_call_event("tc-1", "v2")
+        self._add(ev1)
+        self._add(ev2)
+
+        self.assertEqual(self.events._acp_tool_call_id_to_event_id["tc-1"], ev2.id)
+
+    def test_stale_index_entry_is_cleaned_up_with_warning(self) -> None:
+        ev1 = _make_tool_call_event("tc-1", "v1")
+        self._add(ev1)
+
+        # Manually corrupt state: remove ev1 from _cached_events but leave index intact
+        self.events._cached_events.clear()
+        self.events._cached_event_ids.discard(ev1.id)
+
+        ev2 = _make_tool_call_event("tc-1", "v2")
+        with self.assertLogs("openhands.sdk", level=logging.WARNING) as log_ctx:
+            self._add(ev2)
+
+        self.assertTrue(
+            any("Stale" in line for line in log_ctx.output),
+            "Expected a stale-index warning to be logged",
+        )
+        # ev2 should be inserted normally after cleanup
+        self.assertEqual(len(self.events._cached_events), 1)
+        self.assertEqual(self.events._cached_events[0].id, ev2.id)
+        self.assertEqual(self.events._acp_tool_call_id_to_event_id["tc-1"], ev2.id)
+
+    def test_thread_safety_concurrent_updates(self) -> None:
+        """Multiple threads racing to update the same tool_call_id must not corrupt state."""
+        errors: list[Exception] = []
+
+        def updater(i: int) -> None:
+            try:
+                ev = _make_tool_call_event("tc-shared", f"output-{i}")
+                self._add(ev)
+            except Exception as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=updater, args=(i,)) for i in range(20)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(errors, [])
+        # Only one event per tool_call_id should survive
+        tc_events = [
+            e
+            for e in self.events._cached_events
+            if isinstance(e, ACPToolCallEvent) and e.tool_call_id == "tc-shared"
+        ]
+        self.assertEqual(len(tc_events), 1)
+
+
+class TestSerializeToolContentTruncation(unittest.TestCase):
+    def test_short_text_is_not_truncated(self) -> None:
+        content = [{"type": "text", "text": "short"}]
+        result = _serialize_tool_content(content)
+        assert result is not None
+        self.assertEqual(result[0]["text"], "short")
+
+    def test_long_text_is_truncated_to_max(self) -> None:
+        long_text = "x" * (MAX_ACP_CONTENT_CHARS + 5_000)
+        content = [{"type": "text", "text": long_text}]
+        result = _serialize_tool_content(content)
+        assert result is not None
+        self.assertLessEqual(len(result[0]["text"]), MAX_ACP_CONTENT_CHARS + 200)
+
+    def test_non_text_blocks_are_not_modified(self) -> None:
+        big_data = "y" * (MAX_ACP_CONTENT_CHARS + 1_000)
+        content = [{"type": "image_url", "url": big_data}]
+        result = _serialize_tool_content(content)
+        assert result is not None
+        self.assertEqual(result[0]["url"], big_data)
+
+    def test_none_content_returns_none(self) -> None:
+        self.assertIsNone(_serialize_tool_content(None))
+
+    def test_empty_content_returns_none(self) -> None:
+        self.assertIsNone(_serialize_tool_content([]))
+
+    def test_mixed_blocks_only_truncates_text(self) -> None:
+        long_text = "a" * (MAX_ACP_CONTENT_CHARS + 1_000)
+        big_url = "b" * (MAX_ACP_CONTENT_CHARS + 1_000)
+        content = [
+            {"type": "text", "text": long_text},
+            {"type": "image_url", "url": big_url},
+        ]
+        result = _serialize_tool_content(content)
+        assert result is not None
+        self.assertLessEqual(len(result[0]["text"]), MAX_ACP_CONTENT_CHARS + 200)
+        self.assertEqual(len(result[1]["url"]), MAX_ACP_CONTENT_CHARS + 1_000)
+
+    def test_pydantic_model_content_is_serialized(self) -> None:
+        """Content blocks that have model_dump() are serialized before truncation check."""
+
+        class FakeBlock:
+            def model_dump(self, **_kwargs: object) -> dict:
+                return {"type": "text", "text": "hello"}
+
+        result = _serialize_tool_content([FakeBlock()])
+        assert result is not None
+        self.assertEqual(result[0]["text"], "hello")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/openhands-sdk/openhands/sdk/tests/test_acp_dedup_and_truncation.py
+++ b/openhands-sdk/openhands/sdk/tests/test_acp_dedup_and_truncation.py
@@ -12,7 +12,6 @@ from __future__ import annotations
 import logging
 import threading
 import unittest
-
 from unittest.mock import MagicMock, patch
 
 from openhands.sdk.agent.acp_agent import MAX_ACP_CONTENT_CHARS, _serialize_tool_content
@@ -109,7 +108,7 @@ class TestACPToolCallDeduplication(unittest.TestCase):
         self.assertEqual(self.events._acp_tool_call_id_to_event_id["tc-1"], ev2.id)
 
     def test_thread_safety_concurrent_updates(self) -> None:
-        """Multiple threads racing to update the same tool_call_id must not corrupt state."""
+        """Concurrent updates to the same tool_call_id must not corrupt state."""
         errors: list[Exception] = []
 
         def updater(i: int) -> None:
@@ -175,7 +174,7 @@ class TestSerializeToolContentTruncation(unittest.TestCase):
         self.assertEqual(len(result[1]["url"]), MAX_ACP_CONTENT_CHARS + 1_000)
 
     def test_pydantic_model_content_is_serialized(self) -> None:
-        """Content blocks that have model_dump() are serialized before truncation check."""
+        """Blocks with model_dump() are serialized before the truncation check."""
 
         class FakeBlock:
             def model_dump(self, **_kwargs: object) -> dict:


### PR DESCRIPTION
## Problem

ACP agents (codex-acp, claude-agent-acp) stream tool call results as N `ToolCallProgress` events, each carrying the **full cumulative stdout** so far. `RemoteEventsList._cached_events` appends a new `ACPToolCallEvent` for every progress event — never replacing the old one.

This causes O(n²) memory growth:
- A single pytest command: 778 progress events × growing 0.7→1490 KB = **30.7 MB** stored
- npm builds in JS repos (5-20 min): estimated **hundreds of MB per tool call**
- 16 concurrent swebenchmultimodal instances → OOMKill at 10.8 Gi / 12 Gi limit

The default OpenHands agent avoids this by design: it stores one `ActionEvent`+`ObservationEvent` pair per tool call (final result only), truncated to `MAX_CMD_OUTPUT_SIZE=30_000` chars via `maybe_truncate`.

## Fix

### 1. Dedup `ACPToolCallEvent` by `tool_call_id` in `RemoteEventsList` (`remote_conversation.py`)

Add `_acp_tool_call_id_to_event_id` index and replace-in-place in `_add_event_unsafe` when a new event arrives for the same `tool_call_id`. Only the latest (most complete) snapshot is kept — identical to how the default agent sees only the final result.

**Memory reduction**: 437 MB → 40.5 MB (11x) for a typical swebenchmultimodal instance.

### 2. Truncate content to 30,000 chars in `acp_agent.py`

Apply `maybe_truncate(content, truncate_after=MAX_ACP_CONTENT_CHARS)` to:
- Text blocks in `_serialize_tool_content` (matches `TerminalObservation.to_llm_content`)
- `raw_output` strings in `_emit_tool_call_event`

`MAX_ACP_CONTENT_CHARS = 30_000` matches `MAX_CMD_OUTPUT_SIZE` from `openhands-tools` and `max_message_chars` default in LLM config.

**Combined reduction**: peak memory for 16 concurrent instances drops from ~1.28 GB → ~109 MB.

## Root cause confirmed via artifacts

Downloaded and analyzed output.jsonl from:
- `swebenchmultimodal` acp-codex run (OOMKilled at 65/68)
- `commit0` acp-codex run (succeeded, no OOM)
- `swtbench` acp-codex run (succeeded, one 355 MB outlier instance)

Data showed streaming duplication is the dominant memory consumer in all ACP runs.

Fixes https://github.com/OpenHands/evaluation/issues/540

## Validation

Validated on `swebenchmultimodal` with `acp-codex` + `gpt-5.5` (68 instances, dev set):
- **0 OOMKills** (previously OOMKilled at 65/68)
- **0 idle runtime kills** throughout the 64-minute run
- **35.3% resolve rate** (24/68 solveable instances)
- Run: https://github.com/OpenHands/evaluation/actions/runs/25233013876




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0d469a0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0d469a0-python \
  ghcr.io/openhands/agent-server:0d469a0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0d469a0-golang-amd64
ghcr.io/openhands/agent-server:0d469a0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0d469a0-golang-arm64
ghcr.io/openhands/agent-server:0d469a0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0d469a0-java-amd64
ghcr.io/openhands/agent-server:0d469a0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0d469a0-java-arm64
ghcr.io/openhands/agent-server:0d469a0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0d469a0-python-amd64
ghcr.io/openhands/agent-server:0d469a0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0d469a0-python-arm64
ghcr.io/openhands/agent-server:0d469a0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0d469a0-golang
ghcr.io/openhands/agent-server:0d469a0-java
ghcr.io/openhands/agent-server:0d469a0-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0d469a0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0d469a0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->