### PR TITLE
Recover terminal pool after tmux server exit

### DIFF
--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -1,7 +1,10 @@
 import re
 import threading
 import time
+from contextlib import suppress
 from typing import TYPE_CHECKING, Literal
+
+from libtmux.exc import LibTmuxException, TmuxObjectDoesNotExist
 
 from openhands.sdk.llm import TextContent
 from openhands.sdk.logger import get_logger
@@ -29,6 +32,24 @@ from openhands.tools.terminal.terminal.tmux_pane_pool import (
     TmuxPanePool,
 )
 
+
+_TMUX_POOL_RECOVERY_MESSAGE = (
+    "The terminal session was reset because the underlying tmux server/session "
+    "disappeared while running the previous command. This often happens when a "
+    "command terminates the persistent shell, for example by ending with a "
+    "top-level `exit` such as `exit $code`, or otherwise kills tmux. OpenHands "
+    "rebuilt the terminal pool, but the interrupted command's result is not "
+    "reliable and was not retried. Avoid top-level `exit` in future terminal "
+    'commands; use a non-shell-exiting status check like `test "$code" -eq 0` '
+    "or conditional shell logic instead. Please rerun any needed command."
+)
+
+_TMUX_RECOVERABLE_ERROR_MARKERS = (
+    "no server running",
+    "can't find session",
+    "could not find window_id",
+    "could not find pane_id",
+)
 
 logger = get_logger(__name__)
 
@@ -71,6 +92,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         self._username = username
         self._no_change_timeout_seconds = no_change_timeout_seconds
         self._terminal_type = terminal_type
+        self._max_panes = max_panes
         self.full_output_save_dir: str | None = full_output_save_dir
 
         # Pool mode: use TmuxPanePool for parallel execution
@@ -78,17 +100,12 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         self._session: TerminalSession | None = None
         self._sessions: dict[int, TerminalSession] = {}
         self._sessions_lock = threading.Lock()
+        self._pool_recovery_lock = threading.Lock()
 
         use_pool = terminal_type in (None, "tmux") and _is_tmux_available()
 
         if use_pool:
-            self._pool = TmuxPanePool(working_dir, username, max_panes=max_panes)
-            self._pool.initialize()
-            logger.info(
-                f"TerminalExecutor initialized (pool mode) "
-                f"working_dir: {working_dir}, username: {username}, "
-                f"max_panes: {max_panes}"
-            )
+            self._initialize_pool()
         else:
             self._session = create_terminal_session(
                 work_dir=working_dir,
@@ -110,6 +127,50 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
     def is_pooled(self) -> bool:
         """Whether this executor is using the tmux pane pool for concurrency."""
         return self._pool is not None
+
+    def _initialize_pool(self) -> None:
+        self._pool = TmuxPanePool(
+            self._working_dir,
+            self._username,
+            max_panes=self._max_panes,
+        )
+        self._pool.initialize()
+        logger.info(
+            f"TerminalExecutor initialized (pool mode) "
+            f"working_dir: {self._working_dir}, username: {self._username}, "
+            f"max_panes: {self._max_panes}"
+        )
+
+    @staticmethod
+    def _is_recoverable_tmux_pool_error(error: Exception) -> bool:
+        recoverable_types = (LibTmuxException, TmuxObjectDoesNotExist)
+        if not isinstance(error, recoverable_types):
+            return False
+        message = " ".join(str(arg) for arg in error.args).lower()
+        return any(marker in message for marker in _TMUX_RECOVERABLE_ERROR_MARKERS)
+
+    def _recover_tmux_pool(self, failed_pool: TmuxPanePool) -> None:
+        with self._pool_recovery_lock:
+            if self._pool is not failed_pool:
+                return
+
+            with suppress(Exception):
+                failed_pool.close()
+            with self._sessions_lock:
+                self._sessions.clear()
+            self._initialize_pool()
+
+    @staticmethod
+    def _tmux_pool_recovery_observation(
+        action: TerminalAction,
+        error: Exception,
+    ) -> TerminalObservation:
+        return TerminalObservation.from_text(
+            text=(f"{_TMUX_POOL_RECOVERY_MESSAGE}\n\nOriginal tmux error: {error}"),
+            is_error=True,
+            command=action.command or "[RESET]",
+            exit_code=-1,
+        )
 
     @property
     def working_dir(self) -> str:
@@ -411,50 +472,63 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         managed by the pool's context manager so there is exactly one
         checkout and one checkin per call.
         """
-        with self._pool.pane() as handle:  # type: ignore[union-attr]
-            reset_text: str | None = None
+        pool = self._pool
+        assert pool is not None
+        try:
+            with pool.pane() as handle:
+                reset_text: str | None = None
 
-            if action.reset or handle.terminal._closed:
-                self._discard_session(handle.terminal)
-                handle.terminal = self._pool.replace(handle.terminal)  # type: ignore[union-attr]
-                reset_text = self._RESET_TEXT
-                logger.info(
-                    f"Terminal pane replaced (reset) working_dir: {self._working_dir}"
-                )
-
-                if not action.command.strip():
-                    return TerminalObservation.from_text(
-                        text=reset_text,
-                        command="[RESET]",
-                        exit_code=0,
+                if action.reset or handle.terminal._closed:
+                    self._discard_session(handle.terminal)
+                    handle.terminal = pool.replace(handle.terminal)
+                    reset_text = self._RESET_TEXT
+                    logger.info(
+                        "Terminal pane replaced (reset) "
+                        f"working_dir: {self._working_dir}"
                     )
 
-            session = self._wrap_session(handle.terminal)
-            self._prepare_pooled_session(session)
+                    if not action.command.strip():
+                        return TerminalObservation.from_text(
+                            text=reset_text,
+                            command="[RESET]",
+                            exit_code=0,
+                        )
 
-            cmd_action = (
-                action
-                if reset_text is None
-                else TerminalAction(
-                    command=action.command,
-                    timeout=action.timeout,
-                    is_input=False,
+                session = self._wrap_session(handle.terminal)
+                self._prepare_pooled_session(session)
+
+                cmd_action = (
+                    action
+                    if reset_text is None
+                    else TerminalAction(
+                        command=action.command,
+                        timeout=action.timeout,
+                        is_input=False,
+                    )
                 )
+                self._export_envs(cmd_action, conversation, session=session)
+                observation = session.execute(cmd_action)
+
+                if reset_text is not None:
+                    observation = observation.model_copy(
+                        update={
+                            "content": [
+                                TextContent(text=f"{reset_text}\n\n{observation.text}")
+                            ],
+                            "command": f"[RESET] {action.command}",
+                        }
+                    )
+
+                return self._mask_observation(observation, conversation)
+        except Exception as error:
+            if not self._is_recoverable_tmux_pool_error(error):
+                raise
+            logger.warning(
+                "Recovering terminal pane pool after tmux server/session disappeared",
+                exc_info=True,
             )
-            self._export_envs(cmd_action, conversation, session=session)
-            observation = session.execute(cmd_action)
-
-            if reset_text is not None:
-                observation = observation.model_copy(
-                    update={
-                        "content": [
-                            TextContent(text=f"{reset_text}\n\n{observation.text}")
-                        ],
-                        "command": f"[RESET] {action.command}",
-                    }
-                )
-
-            return self._mask_observation(observation, conversation)
+            self._recover_tmux_pool(pool)
+            return self._tmux_pool_recovery_observation(action, error)
 
     def __call__(
         self,

--- a/tests/tools/terminal/test_pool_integration.py
+++ b/tests/tools/terminal/test_pool_integration.py
@@ -109,3 +109,33 @@ class TestConcurrentExecution:
         assert elapsed < serial_time, (
             f"Expected parallel execution under {serial_time}s, took {elapsed:.1f}s"
         )
+
+
+class TestTmuxPoolRecovery:
+    def test_shell_exit_returns_actionable_error_and_rebuilds_pool(self, pool_executor):
+        obs = pool_executor(TerminalAction(command="exit 7", timeout=1.0))
+
+        assert obs.is_error
+        assert obs.exit_code == -1
+        assert "rebuilt the terminal pool" in obs.text
+        assert "top-level `exit`" in obs.text
+        assert "Original tmux error:" in obs.text
+
+        after = pool_executor(TerminalAction(command="echo after_rebuild", timeout=5.0))
+
+        assert not after.is_error
+        assert after.exit_code == 0
+        assert "after_rebuild" in after.text
+
+    def test_reset_after_shell_exit_uses_rebuilt_pool(self, pool_executor):
+        obs = pool_executor(TerminalAction(command="exit 0", timeout=1.0))
+        assert obs.is_error
+
+        reset_obs = pool_executor(
+            TerminalAction(command="pwd", reset=True, timeout=5.0)
+        )
+
+        assert not reset_obs.is_error
+        assert reset_obs.exit_code == 0
+        assert "Terminal session has been reset" in reset_obs.text
+        assert pool_executor.working_dir in reset_obs.text


### PR DESCRIPTION
## Summary
- rebuild the pooled tmux terminal when libtmux reports a missing tmux server/session/window/pane
- return an actionable `is_error=True` terminal observation explaining that the terminal was rebuilt and warning agents/users to avoid top-level `exit`
- add integration coverage for shell `exit` recovery, subsequent terminal calls, and `reset=True` after recovery

Fixes #3036.

## Testing
- `uv run pre-commit run --files openhands-tools/openhands/tools/terminal/impl.py tests/tools/terminal/test_pool_integration.py`
- `uv run pytest tests/tools/terminal/test_pool_integration.py -q`

## Live verification against `origin/main` and this PR branch

I reran the same two-step SDK + real LLM scenario in a separate `origin/main` worktree at `3afdd0f` and confirmed the original issue reproduces there:

```text
=== step 1: user message ===
Use the terminal tool exactly once to run this exact command: exit 7. Then finish.
EVENT 2: ACTION terminal: command='exit 7' is_input=False timeout=None reset=False kind='TerminalAction'
ERROR ... Unexpected error in tool 'terminal': Could not find window_id=@51 for list-windows ('-a',)
EVENT 3: AgentErrorEvent source=agent

=== step 2: user message ===
Use the terminal tool exactly once to run this exact command: echo "i'm still alive". Then finish.
EVENT 7: ACTION terminal: command='echo "i\'m still alive"' is_input=False timeout=None reset=False kind='TerminalAction'
ERROR ... Unexpected error in tool 'terminal': Could not find window_id=@51 for list-windows ('-a',)
EVENT 8: AgentErrorEvent source=agent
```

That shows `exit 7` breaks the pooled tmux terminal on main, and the follow-up `echo "i'm still alive"` hits the same stale tmux window error instead of running.

I reran the same script on this PR branch and confirmed recovery works end-to-end:

```text
=== step 1: user message ===
EVENT 2: ACTION terminal: command='exit 7' is_input=False timeout=None reset=False kind='TerminalAction'
EVENT 3: OBSERVATION TerminalObservation is_error=True
  command='exit 7' exit_code=-1
    The terminal session was reset because the underlying tmux server/session disappeared while running the previous command...
    OpenHands rebuilt the terminal pool...
    Avoid top-level `exit` in future terminal commands...
    Original tmux error: Could not find window_id=@53 for list-windows ('-a',)

=== step 2: user message ===
EVENT 7: ACTION terminal: command='echo "i\'m still alive"' is_input=False timeout=None reset=False kind='TerminalAction'
EVENT 8: OBSERVATION TerminalObservation is_error=False
  command='echo "i\'m still alive"' exit_code=0
    i'm still alive

=== final status ===
ConversationExecutionStatus.FINISHED
```

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f1b7fb25-6506-4376-b787-e5505e0b2962)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:362f665-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-362f665-python \
  ghcr.io/openhands/agent-server:362f665-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:362f665-golang-amd64
ghcr.io/openhands/agent-server:362f665-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:362f665-golang-arm64
ghcr.io/openhands/agent-server:362f665-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:362f665-java-amd64
ghcr.io/openhands/agent-server:362f665-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:362f665-java-arm64
ghcr.io/openhands/agent-server:362f665-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:362f665-python-amd64
ghcr.io/openhands/agent-server:362f665-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:362f665-python-arm64
ghcr.io/openhands/agent-server:362f665-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:362f665-golang
ghcr.io/openhands/agent-server:362f665-java
ghcr.io/openhands/agent-server:362f665-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `362f665-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `362f665-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->