### PR TITLE
Add gpt-5.5 to verified models

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -1,4 +1,5 @@
 VERIFIED_OPENAI_MODELS = [
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.2",
     "gpt-5.2-codex",
@@ -95,6 +96,7 @@ VERIFIED_OPENHANDS_MODELS = [
     "claude-opus-4-7",
     "claude-sonnet-4-5",
     "claude-sonnet-4-6",
+    "gpt-5.5",
     "gpt-5.4",
     "gpt-5.2",
     "gpt-5.2-codex",


### PR DESCRIPTION
Add `gpt-5.5` to `VERIFIED_OPENAI_MODELS` and `VERIFIED_OPENHANDS_MODELS` in `verified_models.py`.

The model already has configuration entries in `resolve_model_config.py`, tests in `test_resolve_model_config.py`, and references in `model_prompt_spec.py`, but was missing from the verified models lists.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8602b537-cc51-4e65-91cd-3162de44394d)