### PR TITLE
fix: handle mcpServers format in get_mcp_config and add expose_secrets

### DIFF
--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -682,9 +682,15 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
     def get_mcp_config(self) -> dict[str, Any]:
         """Fetch MCP configuration from the user's SaaS account.
 
-        Calls ``GET /api/v1/users/me`` to retrieve the user's MCP configuration
-        and transforms it into the format expected by the SDK Agent and
+        Calls ``GET /api/v1/users/me?expose_secrets=true`` to retrieve the
+        user's MCP configuration in the format expected by the SDK Agent and
         ``fastmcp.mcp_config.MCPConfig``.
+
+        The API returns ``mcp_config`` in the standard ``fastmcp.MCPConfig``
+        format with a ``mcpServers`` dict. This method passes that through
+        directly. For backward compatibility, it also supports transforming
+        the legacy format (``sse_servers``, ``shttp_servers``, ``stdio_servers``
+        arrays) if encountered.
 
         Returns:
             A dictionary with ``mcpServers`` key containing server configurations
@@ -711,6 +717,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         resp = self._send_api_request(
             "GET",
             f"{self.cloud_api_url}/api/v1/users/me",
+            params={"expose_secrets": "true"},
             headers={"X-Session-API-Key": self._session_api_key or ""},
         )
         data = resp.json()
@@ -719,6 +726,11 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         if not mcp_config_data:
             return {}
 
+        # Standard format: API returns mcpServers dict directly (fastmcp.MCPConfig)
+        if "mcpServers" in mcp_config_data:
+            return mcp_config_data
+
+        # Legacy format: transform sse_servers/shttp_servers/stdio_servers arrays
         mcp_servers: dict[str, dict[str, Any]] = {}
 
         # Transform SSE servers → RemoteMCPServer format

--- a/tests/workspace/test_cloud_workspace_sdk_settings.py
+++ b/tests/workspace/test_cloud_workspace_sdk_settings.py
@@ -209,8 +209,52 @@ class TestGetMcpConfig:
 
         assert mcp_config == {}
 
+    def test_get_mcp_config_passthrough_mcpservers_format(self, mock_workspace):
+        """get_mcp_config passes through mcpServers format from API directly.
+
+        This is the standard fastmcp.MCPConfig format returned by the API since
+        April 2025. The method should recognize this format and return it as-is.
+        """
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "mcp_config": {
+                "mcpServers": {
+                    "hubspot": {
+                        "url": "https://mcp.example.com/hubspot",
+                        "transport": "streamable-http",
+                        "headers": {"Authorization": "Bearer secret-key"},
+                    },
+                    "slack": {
+                        "url": "https://mcp.example.com/slack",
+                        "transport": "sse",
+                    },
+                }
+            }
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            mock_workspace, "_send_api_request", return_value=mock_response
+        ) as mock_req:
+            mcp_config = mock_workspace.get_mcp_config()
+
+        # Verify expose_secrets is passed
+        mock_req.assert_called_once_with(
+            "GET",
+            f"{CLOUD_URL}/api/v1/users/me",
+            params={"expose_secrets": "true"},
+            headers={"X-Session-API-Key": SESSION_KEY},
+        )
+
+        # Should pass through the mcpServers format directly
+        assert "mcpServers" in mcp_config
+        assert len(mcp_config["mcpServers"]) == 2
+        assert mcp_config["mcpServers"]["hubspot"]["url"] == "https://mcp.example.com/hubspot"
+        assert mcp_config["mcpServers"]["hubspot"]["headers"]["Authorization"] == "Bearer secret-key"
+        assert mcp_config["mcpServers"]["slack"]["transport"] == "sse"
+
     def test_get_mcp_config_transforms_sse_servers(self, mock_workspace):
-        """get_mcp_config correctly transforms SSE servers."""
+        """get_mcp_config correctly transforms legacy SSE servers format."""
         mock_response = MagicMock()
         mock_response.json.return_value = {
             "mcp_config": {
@@ -232,6 +276,7 @@ class TestGetMcpConfig:
         mock_req.assert_called_once_with(
             "GET",
             f"{CLOUD_URL}/api/v1/users/me",
+            params={"expose_secrets": "true"},
             headers={"X-Session-API-Key": SESSION_KEY},
         )
 

--- a/tests/workspace/test_cloud_workspace_sdk_settings.py
+++ b/tests/workspace/test_cloud_workspace_sdk_settings.py
@@ -249,8 +249,14 @@ class TestGetMcpConfig:
         # Should pass through the mcpServers format directly
         assert "mcpServers" in mcp_config
         assert len(mcp_config["mcpServers"]) == 2
-        assert mcp_config["mcpServers"]["hubspot"]["url"] == "https://mcp.example.com/hubspot"
-        assert mcp_config["mcpServers"]["hubspot"]["headers"]["Authorization"] == "Bearer secret-key"
+        assert (
+            mcp_config["mcpServers"]["hubspot"]["url"]
+            == "https://mcp.example.com/hubspot"
+        )
+        assert (
+            mcp_config["mcpServers"]["hubspot"]["headers"]["Authorization"]
+            == "Bearer secret-key"
+        )
         assert mcp_config["mcpServers"]["slack"]["transport"] == "sse"
 
     def test_get_mcp_config_transforms_sse_servers(self, mock_workspace):


### PR DESCRIPTION
## Summary

Fix `get_mcp_config()` to work with automation-triggered conversations by addressing two issues:

1. **Add `expose_secrets=true` parameter** to the API call, matching `get_llm()` behavior. Without this, credentials are masked and MCP authentication fails.

2. **Passthrough `mcpServers` format directly** when the API returns it. The API was updated in April 2025 to return the standard `fastmcp.MCPConfig` format with a `mcpServers` dict, but `get_mcp_config()` was still expecting the legacy `sse_servers`/`shttp_servers`/`stdio_servers` arrays.

## Root Cause

This was a regression introduced when the settings schema was unified to use `fastmcp.MCPConfig`:

| Date | Change |
|------|--------|
| Mar 27 | `get_mcp_config()` added to SDK, expecting legacy format |
| Apr 15 | **BREAKING**: Settings refactored — `mcp_config` changed from `openhands.core.config.mcp_config.MCPConfig` to `fastmcp.MCPConfig` (which uses `mcpServers` dict format) |

The SDK's transformation code found no `sse_servers`/`shttp_servers` arrays (since the API now returns `mcpServers`), so it returned an empty config.

## Changes

- **`workspace.py`**: 
  - Add `params={"expose_secrets": "true"}` to the API call
  - Check for `mcpServers` key and passthrough directly if present
  - Keep legacy transformation as fallback for backward compatibility
  - Updated docstring to document both formats

- **Tests**: 
  - Added `test_get_mcp_config_passthrough_mcpservers_format` to verify the new format is passed through correctly
  - Updated existing test to verify `expose_secrets` parameter is included

## Testing

The new test verifies:
- The `expose_secrets=true` parameter is passed to the API
- The `mcpServers` format from the API is returned as-is (no transformation)
- Credentials in headers are preserved

Fixes OpenHands/automation#93

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e56a07a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e56a07a-python \
  ghcr.io/openhands/agent-server:e56a07a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e56a07a-golang-amd64
ghcr.io/openhands/agent-server:e56a07a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e56a07a-golang-arm64
ghcr.io/openhands/agent-server:e56a07a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e56a07a-java-amd64
ghcr.io/openhands/agent-server:e56a07a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e56a07a-java-arm64
ghcr.io/openhands/agent-server:e56a07a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e56a07a-python-amd64
ghcr.io/openhands/agent-server:e56a07a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e56a07a-python-arm64
ghcr.io/openhands/agent-server:e56a07a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e56a07a-golang
ghcr.io/openhands/agent-server:e56a07a-java
ghcr.io/openhands/agent-server:e56a07a-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e56a07a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e56a07a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->