### PR TITLE
fix(sdk): update default critic route

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/impl/api/client.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/client.py
@@ -71,6 +71,10 @@ class LabelProbMap(BaseModel):
 # ============================================================
 
 
+DEFAULT_CRITIC_SERVER_URL = "https://llm-proxy.app.all-hands.dev/vllm"
+DEFAULT_CRITIC_MODEL_NAME = "critic"
+
+
 class CriticClient(BaseModel):
     """
     Core inference client for the Critic classification service.
@@ -91,7 +95,7 @@ class CriticClient(BaseModel):
 
     # --- connection / model config ---
     server_url: str = Field(
-        default="https://all-hands-ai--critic-qwen3-4b-serve.modal.run",
+        default=DEFAULT_CRITIC_SERVER_URL,
         description="Base URL of the vLLM classification service",
     )
     # validate_secret() normalizes empty, whitespace-only, and redacted inputs
@@ -101,7 +105,7 @@ class CriticClient(BaseModel):
         ..., description="API key for authenticating with the vLLM service"
     )
     model_name: str = Field(
-        default="critic-qwen3-4b", description="Name of the model to use"
+        default=DEFAULT_CRITIC_MODEL_NAME, description="Name of the model to use"
     )
     tokenizer_name: str = Field(
         default="Qwen/Qwen3-4B-Instruct-2507",

--- a/tests/sdk/critic/test_critic_client.py
+++ b/tests/sdk/critic/test_critic_client.py
@@ -5,8 +5,22 @@ from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent
 from openhands.sdk.critic.impl.api import APIBasedCritic
-from openhands.sdk.critic.impl.api.client import CriticClient
+from openhands.sdk.critic.impl.api.client import (
+    DEFAULT_CRITIC_MODEL_NAME,
+    DEFAULT_CRITIC_SERVER_URL,
+    CriticClient,
+)
 from openhands.sdk.utils.cipher import Cipher
+
+
+def test_critic_client_uses_current_default_route():
+    """Default critic route should target the hosted proxy pass-through."""
+    client = CriticClient(api_key="test_api_key_123")
+
+    assert DEFAULT_CRITIC_SERVER_URL == "https://llm-proxy.app.all-hands.dev/vllm"
+    assert DEFAULT_CRITIC_MODEL_NAME == "critic"
+    assert client.server_url == DEFAULT_CRITIC_SERVER_URL
+    assert client.model_name == DEFAULT_CRITIC_MODEL_NAME
 
 
 def test_critic_client_with_str_api_key():


### PR DESCRIPTION
## Summary
- update APIBasedCritic default server URL to the production LiteLLM `/vllm` pass-through
- update the default critic model name to the LiteLLM `critic` alias
- add coverage that locks the SDK defaults to the production proxy route

## Validation
- `uv run pytest tests/sdk/critic/test_critic_client.py -q`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/critic/impl/api/client.py tests/sdk/critic/test_critic_client.py`
- Verified production infra maps model alias `critic` to the hosted critic backend and exposes it through the `/vllm` pass-through path.
- Sanity checked the proxy path shape: unauthenticated `https://llm-proxy.app.all-hands.dev/vllm/classify` reaches proxy auth, while bare `/classify` is not served.

## Eval Validation
- Eval monitor: https://openhands-eval-monitor.vercel.app/?date=2026-05-04&text=25335478724
- Eval result: run-eval-1 completed successfully on SDK commit `0040a4964f613519a197f679d2c43403675f681a` with 1/1 resolved, 0 unresolved, 0 errors, and 0 empty patches.
- Human review done: eval looks good and is acceptable for this routing fix.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0040a49-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0040a49-python \
  ghcr.io/openhands/agent-server:0040a49-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0040a49-golang-amd64
ghcr.io/openhands/agent-server:0040a49-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0040a49-golang-arm64
ghcr.io/openhands/agent-server:0040a49-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0040a49-java-amd64
ghcr.io/openhands/agent-server:0040a49-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0040a49-java-arm64
ghcr.io/openhands/agent-server:0040a49-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0040a49-python-amd64
ghcr.io/openhands/agent-server:0040a49-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0040a49-python-arm64
ghcr.io/openhands/agent-server:0040a49-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0040a49-golang
ghcr.io/openhands/agent-server:0040a49-java
ghcr.io/openhands/agent-server:0040a49-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0040a49-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0040a49-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
