### PR TITLE
feat: make OpenVSCode root configurable with PATH fallback

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -155,6 +155,15 @@ class Config(BaseModel):
             "For example, '/{runtime_id}/vscode' when using path-based routing."
         ),
     )
+    vscode_server_root: str = Field(
+        default="/openhands/.openvscode-server",
+        description=(
+            "Filesystem root of the OpenVSCode Server install. "
+            "Override with OH_VSCODE_SERVER_ROOT for non-Docker local dev. "
+            "When the binary is missing at this root, the service falls back "
+            "to discovering 'openvscode-server' on PATH."
+        ),
+    )
     enable_vnc: bool = Field(
         default=False,
         description="Whether to enable VNC desktop functionality",

--- a/openhands-agent-server/openhands/agent_server/vscode_service.py
+++ b/openhands-agent-server/openhands/agent_server/vscode_service.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import os
+import shutil
 from pathlib import Path
 
 from openhands.sdk.logger import get_logger
@@ -19,6 +20,7 @@ class VSCodeService:
         port: int = 8001,
         connection_token: str | None = None,
         server_base_path: str | None = None,
+        openvscode_server_root: str | None = None,
     ):
         """Initialize VSCode service.
 
@@ -28,13 +30,19 @@ class VSCodeService:
             create_workspace: Whether to create the workspace directory if it doesn't
                 exist
             server_base_path: Base path for the server (used in path-based routing)
+            openvscode_server_root: Filesystem root of the OpenVSCode Server install.
+                When the binary is missing at this root, falls back to discovering
+                'openvscode-server' on PATH.
         """
         self.port: int = port
         self.connection_token: str | None = connection_token
         self.server_base_path: str | None = server_base_path
         self.process: asyncio.subprocess.Process | None = None
-        self.openvscode_server_root: Path = Path("/openhands/.openvscode-server")
+        self.openvscode_server_root: Path = Path(
+            openvscode_server_root or "/openhands/.openvscode-server"
+        )
         self.extensions_dir: Path = self.openvscode_server_root / "extensions"
+        self._resolved_binary: Path | None = None
 
     async def start(self) -> bool:
         """Start the VSCode server.
@@ -120,11 +128,25 @@ class VSCodeService:
     def _check_vscode_available(self) -> bool:
         """Check if VSCode server binary is available.
 
+        Probes the configured root first; falls back to PATH discovery so local
+        dev installs (e.g. via brew) work without the Docker layout. Root takes
+        precedence so a stray system install can't silently override the
+        configured one.
+
         Returns:
             True if available, False otherwise
         """
         vscode_binary = self.openvscode_server_root / "bin" / "openvscode-server"
-        return vscode_binary.exists() and vscode_binary.is_file()
+        if vscode_binary.exists() and vscode_binary.is_file():
+            self._resolved_binary = vscode_binary
+            return True
+
+        path_binary = shutil.which("openvscode-server")
+        if path_binary:
+            self._resolved_binary = Path(path_binary)
+            return True
+
+        return False
 
     async def _is_port_available(self) -> bool:
         """Check if the specified port is available.
@@ -155,8 +177,11 @@ class VSCodeService:
             if self.server_base_path
             else ""
         )
+        binary_path = self._resolved_binary or (
+            self.openvscode_server_root / "bin" / "openvscode-server"
+        )
         cmd = (
-            f"exec {self.openvscode_server_root}/bin/openvscode-server "
+            f"exec {binary_path} "
             f"--host 0.0.0.0 "
             f"--connection-token {self.connection_token} "
             f"--port {self.port} "
@@ -241,5 +266,6 @@ def get_vscode_service() -> VSCodeService | None:
                 port=config.vscode_port,
                 connection_token=connection_token,
                 server_base_path=config.vscode_base_path,
+                openvscode_server_root=config.vscode_server_root,
             )
     return _vscode_service

--- a/tests/agent_server/test_vscode_service.py
+++ b/tests/agent_server/test_vscode_service.py
@@ -1,6 +1,7 @@
 """Tests for VSCode service."""
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -338,6 +339,7 @@ def test_get_vscode_service_enabled(tmp_path):
         mock_config.return_value.enable_vscode = True
         mock_config.return_value.vscode_port = 8001
         mock_config.return_value.vscode_base_path = None
+        mock_config.return_value.vscode_server_root = "/openhands/.openvscode-server"
         mock_config.return_value.session_api_keys = []
 
         service = get_vscode_service()
@@ -367,6 +369,7 @@ def test_get_vscode_service_singleton():
         mock_config.return_value.enable_vscode = True
         mock_config.return_value.vscode_port = 8001
         mock_config.return_value.vscode_base_path = None
+        mock_config.return_value.vscode_server_root = "/openhands/.openvscode-server"
         mock_config.return_value.session_api_keys = []
 
         service1 = get_vscode_service()
@@ -385,6 +388,7 @@ def test_get_vscode_service_with_custom_port():
         mock_config.return_value.enable_vscode = True
         mock_config.return_value.vscode_port = 9001
         mock_config.return_value.vscode_base_path = None
+        mock_config.return_value.vscode_server_root = "/openhands/.openvscode-server"
         mock_config.return_value.session_api_keys = []
 
         service = get_vscode_service()
@@ -402,6 +406,7 @@ def test_get_vscode_service_with_base_path():
         mock_config.return_value.enable_vscode = True
         mock_config.return_value.vscode_port = 8001
         mock_config.return_value.vscode_base_path = "/runtime-123/vscode"
+        mock_config.return_value.vscode_server_root = "/openhands/.openvscode-server"
         mock_config.return_value.session_api_keys = []
 
         service = get_vscode_service()
@@ -449,3 +454,126 @@ def test_vscode_base_path_configuration():
     with patch.dict(os.environ, {"OH_VSCODE_BASE_PATH": "/runtime-abc/vscode"}):
         config = from_env(Config, "OH")
         assert config.vscode_base_path == "/runtime-abc/vscode"
+
+
+# Tests for configurable openvscode_server_root + PATH discovery fallback
+
+
+def test_check_vscode_available_uses_shutil_which_fallback(tmp_path):
+    """Falls back to PATH when the configured root has no binary.
+
+    Local dev installs (e.g. brew, manual download on PATH) should be picked up
+    even when the Docker layout at /openhands/.openvscode-server is absent.
+    """
+    # Arrange: configured root has no binary; a real binary exists elsewhere
+    fake_binary = tmp_path / "openvscode-server"
+    fake_binary.write_text("#!/bin/bash\necho mock")
+    fake_binary.chmod(0o755)
+    service = VSCodeService(openvscode_server_root=str(tmp_path / "nonexistent"))
+
+    # Act
+    with patch(
+        "openhands.agent_server.vscode_service.shutil.which",
+        return_value=str(fake_binary),
+    ):
+        available = service._check_vscode_available()
+
+    # Assert
+    assert available is True
+    assert service._resolved_binary == fake_binary
+
+
+def test_check_vscode_available_root_takes_precedence_over_path(
+    mock_openvscode_binary, tmp_path
+):
+    """Configured root wins over PATH so a stray system install can't override.
+
+    Locks in the precedence decision: configured root first, PATH only as fallback.
+    """
+    # Arrange: both root binary and shutil.which would resolve
+    service = VSCodeService()
+    service.openvscode_server_root = mock_openvscode_binary
+    service.extensions_dir = mock_openvscode_binary / "extensions"
+    path_binary = tmp_path / "path-openvscode-server"
+    path_binary.write_text("#!/bin/bash\necho path")
+    path_binary.chmod(0o755)
+
+    # Act
+    with patch(
+        "openhands.agent_server.vscode_service.shutil.which",
+        return_value=str(path_binary),
+    ):
+        available = service._check_vscode_available()
+
+    # Assert
+    assert available is True
+    assert service._resolved_binary == (
+        mock_openvscode_binary / "bin" / "openvscode-server"
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_vscode_process_uses_resolved_binary(tmp_path):
+    """Process command must invoke the discovered binary, not a hardcoded path.
+
+    Regression guard: when the binary is found via PATH fallback, the spawned
+    process must exec that binary rather than the (possibly missing) Docker path.
+    """
+    # Arrange
+    service = VSCodeService(connection_token="test-token")
+    discovered = tmp_path / "custom-openvscode-server"
+    service._resolved_binary = discovered
+
+    mock_process = AsyncMock()
+    mock_process.stdout = AsyncMock()
+
+    # Act
+    with (
+        patch(
+            "asyncio.create_subprocess_shell", return_value=mock_process
+        ) as mock_create,
+        patch.object(service, "_wait_for_startup"),
+    ):
+        await service._start_vscode_process()
+
+    # Assert
+    cmd = mock_create.call_args[0][0]
+    assert str(discovered) in cmd
+    assert "/openhands/.openvscode-server/bin/openvscode-server" not in cmd
+
+
+def test_get_vscode_service_passes_server_root_from_config():
+    """get_vscode_service forwards vscode_server_root from config to the service."""
+    # Arrange
+    with (
+        patch("openhands.agent_server.config.get_default_config") as mock_config,
+        patch("openhands.agent_server.vscode_service._vscode_service", None),
+    ):
+        mock_config.return_value.enable_vscode = True
+        mock_config.return_value.vscode_port = 8001
+        mock_config.return_value.vscode_base_path = None
+        mock_config.return_value.vscode_server_root = "/custom/root"
+        mock_config.return_value.session_api_keys = []
+
+        # Act
+        service = get_vscode_service()
+
+        # Assert
+        assert isinstance(service, VSCodeService)
+        assert service.openvscode_server_root == Path("/custom/root")
+
+
+def test_vscode_server_root_configuration():
+    """vscode_server_root has a Docker default and is overridable via env var."""
+    import os
+
+    from openhands.agent_server.config import Config, from_env
+
+    # Default preserves Docker layout
+    config = Config()
+    assert config.vscode_server_root == "/openhands/.openvscode-server"
+
+    # Env var override for non-Docker local dev
+    with patch.dict(os.environ, {"OH_VSCODE_SERVER_ROOT": "/opt/openvscode"}):
+        config = from_env(Config, "OH")
+        assert config.vscode_server_root == "/opt/openvscode"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

The agent-server hardcoded `/openhands/.openvscode-server`, which only exists inside the agent-server Docker image. On a non-Docker host the binary check fails, `start()` short-circuits, `connection_token` stays `None`, and `/api/vscode/url` returns `{"url": null}`. Downstream this breaks the Code tab in any GUI that runs the agent-server locally.

## Summary

<!-- 1-3 bullets describing what changed. -->
- Add `Config.vscode_server_root` (`OH_VSCODE_SERVER_ROOT`) so the OpenVSCode Server install location is no longer hardcoded.
- In `VSCodeService._check_vscode_available`, fall back to `shutil.which("openvscode-server")` when the binary is missing at the configured root. Root takes precedence over PATH.
- Track the discovered binary in `_resolved_binary` so `_start_vscode_process` execs the actual found path instead of rebuilding the Docker-default path string.
- Wire `get_vscode_service` to pass `vscode_server_root` from config.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Please run the agent-server-gui locally using the agent server changes in this branch so we can review and validate them.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="791" alt="app-1555" src="https://github.com/user-attachments/assets/4c410632-8f4a-4681-8cd0-7bb1fd273cca" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c5e8908-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c5e8908-python \
  ghcr.io/openhands/agent-server:c5e8908-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c5e8908-golang-amd64
ghcr.io/openhands/agent-server:c5e8908-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c5e8908-golang-arm64
ghcr.io/openhands/agent-server:c5e8908-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c5e8908-java-amd64
ghcr.io/openhands/agent-server:c5e8908-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c5e8908-java-arm64
ghcr.io/openhands/agent-server:c5e8908-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c5e8908-python-amd64
ghcr.io/openhands/agent-server:c5e8908-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c5e8908-python-arm64
ghcr.io/openhands/agent-server:c5e8908-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c5e8908-golang
ghcr.io/openhands/agent-server:c5e8908-java
ghcr.io/openhands/agent-server:c5e8908-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c5e8908-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c5e8908-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->