### PR TITLE
fix(visualizer): cap cache hit rate at 100% for ACP token usage

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
@@ -397,7 +397,12 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
         # Cache hit rate (prompt + cache)
         prompt = usage.prompt_tokens or 0
         cache_read = usage.cache_read_tokens or 0
-        cache_rate = f"{(cache_read / prompt * 100):.2f}%" if prompt > 0 else "N/A"
+        # litellm/OpenAI convention: prompt_tokens includes cached reads, so
+        # prompt is the right denominator. ACP (claude-agent-acp) reports
+        # input_tokens excluding cached reads, in which case the two are
+        # disjoint and the total is prompt + cache_read.
+        denom = prompt + cache_read if cache_read > prompt else prompt
+        cache_rate = f"{(cache_read / denom * 100):.2f}%" if denom > 0 else "N/A"
         reasoning_tokens = usage.reasoning_tokens or 0
 
         # Cost

--- a/tests/sdk/conversation/test_visualizer.py
+++ b/tests/sdk/conversation/test_visualizer.py
@@ -2,13 +2,16 @@
 
 import io
 import json
+import re
 import sys
 from collections.abc import Sequence
 from typing import IO, TYPE_CHECKING, Self, cast
+from unittest.mock import MagicMock
 
 from pydantic import Field
 from rich.text import Text
 
+from openhands.sdk.conversation.conversation_stats import ConversationStats
 from openhands.sdk.conversation.visualizer import (
     DefaultConversationVisualizer,
 )
@@ -30,6 +33,7 @@ from openhands.sdk.llm import (
     MessageToolCall,
     TextContent,
 )
+from openhands.sdk.llm.utils.metrics import Metrics
 from openhands.sdk.tool import Action, Observation, ToolDefinition, ToolExecutor
 
 
@@ -468,6 +472,38 @@ def test_metrics_formatting():
     assert "20.00%" in subtitle  # Cache hit rate
     assert "200" in subtitle  # Reasoning tokens
     assert "0.0234" in subtitle  # Cost
+
+
+def test_metrics_subtitle_caps_cache_rate_when_cache_exceeds_prompt():
+    """Regression for #3044: ACP reports input_tokens excluding cached reads,
+    so cache_read_tokens can exceed prompt_tokens. The rendered cache hit
+    rate must stay within [0, 100]%."""
+    stats = ConversationStats()
+    metrics = Metrics(model_name="test-model")
+    # Numbers reproduced from the issue: 13 input + ~117,654 cached previously
+    # rendered as "cache hit 905030.77%".
+    metrics.add_token_usage(
+        prompt_tokens=13,
+        completion_tokens=568,
+        cache_read_tokens=117_654,
+        cache_write_tokens=0,
+        reasoning_tokens=0,
+        context_window=200_000,
+        response_id="acp_response",
+    )
+    stats.usage_to_metrics["acp_usage"] = metrics
+
+    visualizer = DefaultConversationVisualizer()
+    mock_state = MagicMock()
+    mock_state.stats = stats
+    visualizer.initialize(mock_state)
+
+    subtitle = visualizer._format_metrics_subtitle()
+    assert subtitle is not None
+    match = re.search(r"cache hit ([\d.]+)%", subtitle)
+    assert match, subtitle
+    rate = float(match.group(1))
+    assert 0.0 <= rate <= 100.0, f"cache hit rate {rate} outside [0, 100]"
 
 
 def test_metrics_abbreviation_formatting():


### PR DESCRIPTION

- [x] A human has tested these changes.


## Summary

- Fixes #3044: visualizer no longer renders cache hit rates above 100% for ACP runs.                                                                                                                               
- Detects the two reporting conventions and picks the right denominator: prompt when cache_read is a subset (litellm/OpenAI), prompt + cache_read when they are disjoint (claude-agent-acp).

## Issue Number
Closes #3044

## Tests
- Adds a regression test using the exact numbers from the issue (prompt_tokens=13, cache_read_tokens=117_654), fails before the fix with cache hit 905030.77%, passes after.  

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bdf4f74-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bdf4f74-python \
  ghcr.io/openhands/agent-server:bdf4f74-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bdf4f74-golang-amd64
ghcr.io/openhands/agent-server:bdf4f74-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bdf4f74-golang-arm64
ghcr.io/openhands/agent-server:bdf4f74-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bdf4f74-java-amd64
ghcr.io/openhands/agent-server:bdf4f74-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bdf4f74-java-arm64
ghcr.io/openhands/agent-server:bdf4f74-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bdf4f74-python-amd64
ghcr.io/openhands/agent-server:bdf4f74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bdf4f74-python-arm64
ghcr.io/openhands/agent-server:bdf4f74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bdf4f74-golang
ghcr.io/openhands/agent-server:bdf4f74-java
ghcr.io/openhands/agent-server:bdf4f74-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bdf4f74-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bdf4f74-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->