### PR TITLE
ci: dispatch PyPI release after creating GitHub release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -18,6 +18,7 @@ jobs:
             startsWith(github.event.pull_request.head.ref, 'rel-')
         runs-on: ubuntu-24.04
         permissions:
+            actions: write
             contents: write
         steps:
             - name: Extract version from branch name
@@ -81,6 +82,18 @@ jobs:
                   echo "✅ Release v${VERSION} created!"
                   echo "🔗 https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"
 
+            - name: Dispatch PyPI release workflow
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh workflow run pypi-release.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref "v${VERSION}"
+
+                  echo "🚀 Dispatched pypi-release.yml for v${VERSION}"
+
             - name: Summary
               env:
                   VERSION: ${{ steps.version.outputs.version }}
@@ -90,4 +103,4 @@ jobs:
                   echo "- **Tag**: v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
                   echo "- **Release**: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
                   echo "" >> "$GITHUB_STEP_SUMMARY"
-                  echo "The \`pypi-release.yml\` workflow will now publish packages to PyPI." >> "$GITHUB_STEP_SUMMARY"
+                  echo "The \`pypi-release.yml\` workflow was dispatched to publish packages to PyPI." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Grant the release-creation job `actions: write` so it can dispatch workflows.
- Dispatch `pypi-release.yml` explicitly after creating a GitHub release.
- Update the job summary to report that the PyPI release workflow was dispatched.

## Root Cause
The auto-created GitHub release uses the repository `GITHUB_TOKEN`, so the resulting `release.published` event does not create another workflow run. Dispatching `pypi-release.yml` directly uses the supported `workflow_dispatch` path.

## Validation
- `uv run pre-commit run --files .github/workflows/create-release.yml`
- Manually dispatched `pypi-release.yml` for `v1.20.0`: https://github.com/OpenHands/software-agent-sdk/actions/runs/25391325228

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f7548bd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f7548bd-python \
  ghcr.io/openhands/agent-server:f7548bd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f7548bd-golang-amd64
ghcr.io/openhands/agent-server:f7548bd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f7548bd-golang-arm64
ghcr.io/openhands/agent-server:f7548bd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f7548bd-java-amd64
ghcr.io/openhands/agent-server:f7548bd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f7548bd-java-arm64
ghcr.io/openhands/agent-server:f7548bd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f7548bd-python-amd64
ghcr.io/openhands/agent-server:f7548bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f7548bd-python-arm64
ghcr.io/openhands/agent-server:f7548bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f7548bd-golang
ghcr.io/openhands/agent-server:f7548bd-java
ghcr.io/openhands/agent-server:f7548bd-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f7548bd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f7548bd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->