### PR TITLE
fix(sdk): add v1->v2 settings migration that canonicalizes agent_kind

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -293,7 +293,7 @@ def _default_llm_settings() -> LLM:
 
 _RequestT = TypeVar("_RequestT")
 
-AGENT_SETTINGS_SCHEMA_VERSION = 1
+AGENT_SETTINGS_SCHEMA_VERSION = 2
 CONVERSATION_SETTINGS_SCHEMA_VERSION = 1
 
 PersistedSettingsMigrator = Callable[[dict[str, Any]], dict[str, Any]]
@@ -367,6 +367,26 @@ def _migrate_agent_settings_v0_to_v1(payload: dict[str, Any]) -> dict[str, Any]:
     return migrated
 
 
+def _migrate_agent_settings_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
+    """Canonicalize the deprecated ``agent_kind: 'llm'`` discriminator to
+    ``'openhands'``.
+
+    Before the v1.19.0 ``LLMAgentSettings`` → ``OpenHandsAgentSettings`` rename,
+    persisted payloads carried ``agent_kind: 'llm'``. The two classes are
+    field-compatible (``LLMAgentSettings`` is a subclass of
+    ``OpenHandsAgentSettings`` that only narrows the discriminator literal),
+    and ``LLMAgentSettings`` is scheduled for removal in v1.22.0. Rewriting
+    the discriminator on read lets callers that explicitly validate as
+    ``OpenHandsAgentSettings`` (the canonical class) accept legacy data
+    without losing any fields.
+    """
+    migrated = dict(payload)
+    migrated["schema_version"] = 2
+    if migrated.get("agent_kind") == "llm":
+        migrated["agent_kind"] = "openhands"
+    return migrated
+
+
 def _migrate_conversation_settings_v0_to_v1(
     payload: dict[str, Any],
 ) -> dict[str, Any]:
@@ -377,6 +397,7 @@ def _migrate_conversation_settings_v0_to_v1(
 
 _AGENT_SETTINGS_MIGRATIONS: dict[int, PersistedSettingsMigrator] = {
     0: _migrate_agent_settings_v0_to_v1,
+    1: _migrate_agent_settings_v1_to_v2,
 }
 _CONVERSATION_SETTINGS_MIGRATIONS: dict[int, PersistedSettingsMigrator] = {
     0: _migrate_conversation_settings_v0_to_v1,

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -330,7 +330,7 @@ def test_agent_settings_from_persisted_migrates_v0_llm_payload() -> None:
     settings = AgentSettings.from_persisted({"llm": {"model": "test-model"}})
 
     assert isinstance(settings, OpenHandsAgentSettings)
-    assert settings.schema_version == 1
+    assert settings.schema_version == 2
     assert settings.agent_kind == "openhands"
     assert settings.llm.model == "test-model"
 
@@ -346,13 +346,31 @@ def test_agent_settings_from_persisted_dispatches_current_acp_payload() -> None:
     )
 
     assert isinstance(settings, ACPAgentSettings)
-    assert settings.schema_version == 1
+    # v1 → v2 is a no-op for ACP payloads, but the schema_version is bumped.
+    assert settings.schema_version == 2
     assert settings.acp_command == ["npx", "-y", "claude-agent-acp"]
 
 
+def test_agent_settings_from_persisted_canonicalizes_legacy_llm_kind() -> None:
+    """v1 payloads with the deprecated ``agent_kind: 'llm'`` are migrated to
+    the canonical ``'openhands'`` discriminator on read."""
+    settings = AgentSettings.from_persisted(
+        {
+            "schema_version": 1,
+            "agent_kind": "llm",
+            "llm": {"model": "legacy-model"},
+        }
+    )
+
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert settings.schema_version == 2
+    assert settings.agent_kind == "openhands"
+    assert settings.llm.model == "legacy-model"
+
+
 def test_agent_settings_from_persisted_rejects_newer_schema_version() -> None:
-    with pytest.raises(ValueError, match="newer than supported version 1"):
-        AgentSettings.from_persisted({"schema_version": 2, "llm": {"model": "m"}})
+    with pytest.raises(ValueError, match="newer than supported version 2"):
+        AgentSettings.from_persisted({"schema_version": 3, "llm": {"model": "m"}})
 
 
 def test_conversation_settings_from_persisted_migrates_v0_payload() -> None:


### PR DESCRIPTION
## Why

Production incident: new cloud users could sign up but were 500'd on every action. Root cause as identified by the on-call team:

> `enterprise/server/routes/org_models.py` — both `OrgResponse.from_org` and `OrgDefaultsSettingsResponse.from_org` validate persisted `org.agent_settings` using the SDK's deprecated `AgentSettings` class, which inherits from `LLMAgentSettings` and enforces `agent_kind: Literal["llm"]`. Stored data now carries the canonical `agent_kind: "openhands"`, so Pydantic raises a literal_error and the route 500s.

Background: when the `LLMAgentSettings` → `OpenHandsAgentSettings` rename landed in v1.19.0, the canonical discriminator value flipped from `"llm"` to `"openhands"`, but the persisted-settings `schema_version` was **not** bumped and **no migration** was registered. The cloud's `from_org` call sites already go through `AgentSettings.from_persisted(...)`, which runs the migration framework — they just hit no migration that would normalize the discriminator, so the legacy/canonical mismatch leaks through to validation.

A point hot-fix already shipped on the cloud side ([OpenHands/OpenHands#14263](https://github.com/OpenHands/OpenHands/pull/14263)) that force-sets `agent_kind = 'openhands'` in `OrgStore.get_agent_settings_from_org`. That becomes redundant once this migration ships.

## How migrations work in the SDK

The framework already exists in `openhands-sdk/openhands/sdk/settings/model.py`:

- Both `AgentSettings` and `ConversationSettings` carry a `schema_version: int` field, with the current value pinned by module-level constants `AGENT_SETTINGS_SCHEMA_VERSION` / `CONVERSATION_SETTINGS_SCHEMA_VERSION`.
- A persistence-only `from_persisted(data)` classmethod runs `_apply_persisted_migrations(...)`, which reads `schema_version` (defaulting to `0`), then walks a registered `{old_version: migrator_callable}` dict until it reaches the current version. Each migrator is `(dict) -> dict` and **must** advance `schema_version` strictly.
- After migration, the discriminated-union validator (`validate_agent_settings`) routes the payload to the correct concrete class.

Until this PR there was exactly one migration: `v0 -> v1` (added the `agent_kind` field). The v1.19.0 rename should have come with a `v1 -> v2` migration, but didn't. This PR adds it.

## Changes

- Bumped `AGENT_SETTINGS_SCHEMA_VERSION` 1 → 2.
- Registered `_migrate_agent_settings_v1_to_v2` that rewrites legacy `agent_kind: 'llm'` → `'openhands'`.
  - Safe because `LLMAgentSettings` is field-compatible with `OpenHandsAgentSettings` (it only narrows the discriminator literal).
  - Consistent with the existing deprecation: `LLMAgentSettings` is scheduled for removal in v1.22.0, so canonicalizing on read just hastens what was already going to happen.
  - After this migration, `AgentSettings.from_persisted(...)` consistently lands on the canonical `OpenHandsAgentSettings`/`ACPAgentSettings` variants regardless of how the data was originally persisted.
- Updated the existing migration tests for the new `current_version` (the `v0 → v1 → v2` chain bumps `schema_version == 2` on the v0-entry-point test, and the v1-entry-point ACP test now also lands on `schema_version == 2`).
- Updated the "rejects newer version" test from `schema_version=2` to `schema_version=3`.
- Added `test_agent_settings_from_persisted_canonicalizes_legacy_llm_kind` to exercise the new migration directly.

## How to test

```python
from openhands.sdk import AgentSettings, OpenHandsAgentSettings

legacy = AgentSettings.from_persisted(
    {"schema_version": 1, "agent_kind": "llm", "llm": {"model": "m"}}
)
assert isinstance(legacy, OpenHandsAgentSettings)
assert legacy.agent_kind == "openhands"
assert legacy.schema_version == 2
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Targeted at a v1.20.1 patch release.** The package version bump itself is handled by the `prepare-release.yml` workflow per `.github/workflows/README-RELEASE.md`, so this PR intentionally does not touch any `pyproject.toml` versions.
- **Cloud follow-up (separate PR, not blocking):** the [OpenHands/OpenHands#14263](https://github.com/OpenHands/OpenHands/pull/14263) hot-fix that hard-codes `agent_kind = 'openhands'` in `OrgStore.get_agent_settings_from_org` can be reverted once this SDK release is consumed — the migration handles that case correctly through `from_persisted`.
- **Process improvement:** the engineer who triaged the incident flagged that we don't have an automation that fails CI when a discriminator literal (or other persisted-shape contract) changes without a `schema_version` bump + matching migration. That's worth a follow-up — the existing `api-breakage` checker tracks public API surface, not persisted-shape semantics.

---

_This PR was created by an AI agent (OpenHands) on behalf of @robert-brennan during the incident response._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6c23aab-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6c23aab-python \
  ghcr.io/openhands/agent-server:6c23aab-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6c23aab-golang-amd64
ghcr.io/openhands/agent-server:6c23aab-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6c23aab-golang-arm64
ghcr.io/openhands/agent-server:6c23aab-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6c23aab-java-amd64
ghcr.io/openhands/agent-server:6c23aab-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6c23aab-java-arm64
ghcr.io/openhands/agent-server:6c23aab-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6c23aab-python-amd64
ghcr.io/openhands/agent-server:6c23aab-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6c23aab-python-arm64
ghcr.io/openhands/agent-server:6c23aab-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6c23aab-golang
ghcr.io/openhands/agent-server:6c23aab-java
ghcr.io/openhands/agent-server:6c23aab-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6c23aab-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6c23aab-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->