### PR TITLE
Remove VERIFIED_TRINITY_MODELS; keep trinity-large-thinking as OpenHands-only

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -90,10 +90,6 @@ VERIFIED_QWEN_MODELS = [
     "qwen3-coder-480b",
 ]
 
-VERIFIED_TRINITY_MODELS = [
-    "trinity-large-thinking",
-]
-
 VERIFIED_OPENHANDS_MODELS = [
     "claude-opus-4-5",
     "claude-opus-4-5-20251101",
@@ -145,5 +141,4 @@ VERIFIED_MODELS = {
     "glm": VERIFIED_GLM_MODELS,
     "nvidia": VERIFIED_NVIDIA_MODELS,
     "qwen": VERIFIED_QWEN_MODELS,
-    "trinity": VERIFIED_TRINITY_MODELS,
 }

--- a/tests/sdk/llm/test_model_list.py
+++ b/tests/sdk/llm/test_model_list.py
@@ -86,14 +86,37 @@ def test_list_bedrock_models_with_boto3(monkeypatch):
 def test_openhands_models_all_have_provider_list():
     """Every model in VERIFIED_OPENHANDS_MODELS must also appear in at least one
     provider-specific list so that the UI can display it under its actual provider.
+
+    Exception: models that are only available through the OpenHands provider
+    (e.g. ``trinity-large-thinking``) are not exposed under any other provider.
     """
+    openhands_only_models = {"trinity-large-thinking"}
+
     provider_models = set()
     for provider, models in VERIFIED_MODELS.items():
         if provider == "openhands":
             continue
         provider_models.update(models)
 
-    missing = [m for m in VERIFIED_OPENHANDS_MODELS if m not in provider_models]
+    missing = [
+        m
+        for m in VERIFIED_OPENHANDS_MODELS
+        if m not in provider_models and m not in openhands_only_models
+    ]
     assert not missing, (
         f"Models in VERIFIED_OPENHANDS_MODELS missing from any provider list: {missing}"
     )
+
+
+def test_trinity_model_is_openhands_only():
+    """trinity-large-thinking should be available only via the OpenHands provider
+    and must not be listed under any other provider.
+    """
+    assert "trinity-large-thinking" in VERIFIED_OPENHANDS_MODELS
+    assert "trinity" not in VERIFIED_MODELS
+    for provider, models in VERIFIED_MODELS.items():
+        if provider == "openhands":
+            continue
+        assert "trinity-large-thinking" not in models, (
+            f"trinity-large-thinking should not be in provider list {provider!r}"
+        )


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Per #3071, `trinity-large-thinking` should only be available through the OpenHands provider, not as its own standalone `trinity` provider. The `VERIFIED_TRINITY_MODELS` list and its entry in `VERIFIED_MODELS` exposed it as if it were a separate provider, which is incorrect.

## Summary

- Removed `VERIFIED_TRINITY_MODELS` from `openhands-sdk/openhands/sdk/llm/utils/verified_models.py`.
- Removed the `"trinity": VERIFIED_TRINITY_MODELS` entry from the `VERIFIED_MODELS` dict.
- Kept `trinity-large-thinking` in `VERIFIED_OPENHANDS_MODELS` so it remains available via the OpenHands provider.
- Updated `tests/sdk/llm/test_model_list.py` to allow OpenHands-only models (i.e. `trinity-large-thinking`) to skip the "every OpenHands model must be in some other provider list" invariant, and added a regression test that pins trinity as OpenHands-only.

## Issue Number

Fixes #3071

## How to Test

Run the relevant unit tests:

```bash
uv run pytest tests/sdk/llm/test_model_list.py tests/agent_server/test_llm_router.py -q
```

Both files pass (15 passed locally). Pre-commit also runs cleanly on the changed files:

```bash
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/llm/utils/verified_models.py \
  tests/sdk/llm/test_model_list.py
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a minimal change: it does not modify any other provider lists and does not remove `trinity-large-thinking` from the OpenHands list, matching the request in the issue. Downstream consumers that read `VERIFIED_MODELS` will simply no longer see a `trinity` provider key.

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6bdde3ab-7794-4515-b107-031e06c7cbcc)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:abdefb7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-abdefb7-python \
  ghcr.io/openhands/agent-server:abdefb7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:abdefb7-golang-amd64
ghcr.io/openhands/agent-server:abdefb7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:abdefb7-golang-arm64
ghcr.io/openhands/agent-server:abdefb7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:abdefb7-java-amd64
ghcr.io/openhands/agent-server:abdefb7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:abdefb7-java-arm64
ghcr.io/openhands/agent-server:abdefb7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:abdefb7-python-amd64
ghcr.io/openhands/agent-server:abdefb7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:abdefb7-python-arm64
ghcr.io/openhands/agent-server:abdefb7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:abdefb7-golang
ghcr.io/openhands/agent-server:abdefb7-java
ghcr.io/openhands/agent-server:abdefb7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `abdefb7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `abdefb7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->