### PR TITLE
Add programbench to run-eval benchmark choices

### DIFF
--- a/.agents/skills/manage-evals/SKILL.md
+++ b/.agents/skills/manage-evals/SKILL.md
@@ -69,6 +69,7 @@ done
 | `commit0` | Commit0 — commit generation tasks |
 | `swebenchmultimodal` | SWE-bench Multimodal — tasks with images |
 | `terminalbench` | TerminalBench — terminal interaction tasks |
+| `programbench` | ProgramBench — program-repair tasks against gold-standard test binaries |
 
 ### Trigger Options
 

--- a/.agents/skills/manage-evals/SKILL.md
+++ b/.agents/skills/manage-evals/SKILL.md
@@ -130,7 +130,7 @@ Each line is a run path. Match by benchmark and model to find the run.
 ### Step 2: Identify the Run Path Components
 
 A run path has three components:
-- **benchmark**: `swebench`, `gaia`, `swtbench`, `commit0`, `swebenchmultimodal`, `terminalbench`
+- **benchmark**: `swebench`, `gaia`, `swtbench`, `commit0`, `swebenchmultimodal`, `terminalbench`, `programbench`
 - **model_slug**: Derived from model name with `/:@.` replaced by `-` (e.g., `litellm_proxy-claude-sonnet-4-5-20250929`)
 - **run_id**: The GitHub Actions workflow run ID from the `OpenHands/evaluation` repo
 

--- a/.agents/skills/manage-evals/references/eval-infrastructure.md
+++ b/.agents/skills/manage-evals/references/eval-infrastructure.md
@@ -42,7 +42,7 @@ and served via CDN at `https://results.eval.all-hands.dev/`.
 {benchmark}/{model_slug}/{github_run_id}/
 ```
 
-- **benchmark**: `swebench`, `gaia`, `swtbench`, `commit0`, `swebenchmultimodal`, `terminalbench`
+- **benchmark**: `swebench`, `gaia`, `swtbench`, `commit0`, `swebenchmultimodal`, `terminalbench`, `programbench`
 - **model_slug**: Model name with `/:@.` replaced by `-`
   - Example: `litellm_proxy/claude-sonnet-4-5-20250929` → `litellm_proxy-claude-sonnet-4-5-20250929`
 - **github_run_id**: The GitHub Actions run ID from the `OpenHands/evaluation` repo

--- a/.agents/skills/manage-evals/scripts/manage_evals.py
+++ b/.agents/skills/manage-evals/scripts/manage_evals.py
@@ -42,6 +42,7 @@ BENCHMARKS = [
     "commit0",
     "swebenchmultimodal",
     "terminalbench",
+    "programbench",
 ]
 TOOL_PRESETS = ["default", "gemini", "gpt5", "planning"]
 AGENT_TYPES = ["default", "acp-claude", "acp-codex"]

--- a/.agents/skills/run-eval.md
+++ b/.agents/skills/run-eval.md
@@ -31,7 +31,7 @@ curl -X POST \
 ```
 
 **Key parameters:**
-- `benchmark`: `swebench`, `swebenchmultimodal`, `gaia`, `swtbench`, `commit0`, `multiswebench`, `terminalbench`
+- `benchmark`: `swebench`, `swebenchmultimodal`, `gaia`, `swtbench`, `commit0`, `multiswebench`, `terminalbench`, `programbench`
 - `eval_limit`: Any positive integer (e.g., `1`, `10`, `50`, `200`)
 - `model_ids`: See `.github/run-eval/resolve_model_config.py` for available models
 - `benchmarks_branch`: Use feature branch from the benchmarks repo to test benchmark changes before merging

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -21,6 +21,7 @@ on:
                     - commit0
                     - swebenchmultimodal
                     - terminalbench
+                    - programbench
             sdk_ref:
                 description: SDK commit/ref to evaluate (must be a semantic version like v1.0.0 unless 'Allow unreleased branches' is checked)
                 required: true


### PR DESCRIPTION
_This PR was created by an AI agent (OpenHands) on behalf of the user._

## Summary

Adds `programbench` to the SDK's per-PR / per-release evaluation entrypoint so it can be dispatched the same way every other benchmark (`swebench`, `gaia`, `swtbench`, `commit0`, `swebenchmultimodal`, `terminalbench`) is — from the SDK repo, against a chosen SDK ref/commit, with parallel inference workers running on k8s in the evaluation repo's `evaluation-jobs` namespace.

This PR is now stacked on top of OpenHands/software-agent-sdk#3191, which contains the standalone `RemoteConversation` FINISHED/stop-hook race fix discovered during ProgramBench testing. With that split, this PR contains only the ProgramBench workflow/docs changes.

## Companion PRs

- OpenHands/benchmarks#703 — merged; adds the ProgramBench benchmark package and reusable image-check workflow.
- OpenHands/evaluation#544 — merged; adds eval-job orchestration for ProgramBench.
- OpenHands/software-agent-sdk#3191 — base PR for the RemoteConversation race fix.

## Changes

- `.github/workflows/run-eval.yml` — add `programbench` to the `workflow_dispatch.inputs.benchmark.options` list.
- `.agents/skills/manage-evals/SKILL.md` — add `programbench` to the benchmark table.
- `.agents/skills/manage-evals/references/eval-infrastructure.md` — document `programbench` in the benchmark enumeration.
- `.agents/skills/run-eval.md` — document `programbench` as a supported `benchmark` parameter.

## Verification

- `uv run python - <<'PY' ... yaml.safe_load(open('.github/workflows/run-eval.yml')) ... PY` — `run-eval.yml valid YAML`

End-to-end ProgramBench CI evidence from the companion evaluation workflow-dispatch runs:

- Parent eval job: https://github.com/OpenHands/evaluation/actions/runs/25552125670 — success; jobs included `Verify ProgramBench Images`, `Run Inference`, `Wait For Infer Output`, and `Run Eval Harness` for `benchmark=programbench`, `eval_limit=1` (`cmatrix`).
- Downstream inference phase: https://github.com/OpenHands/evaluation/actions/runs/25552168816 — success.
- Downstream eval harness phase: https://github.com/OpenHands/evaluation/actions/runs/25552772174 — success.

After the base PR lands, `programbench` will be dispatchable end-to-end via:

```bash
gh workflow run run-eval.yml \
  --repo OpenHands/software-agent-sdk \
  -f sdk_ref=v1.20.1 \
  -f benchmark=programbench \
  -f eval_limit=5 \
  -f model_ids=litellm_proxy/anthropic/claude-sonnet-4-5-20250929
```

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:564c97c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-564c97c-python \
  ghcr.io/openhands/agent-server:564c97c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:564c97c-golang-amd64
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-golang-amd64
ghcr.io/openhands/agent-server:feat-programbench-golang-amd64
ghcr.io/openhands/agent-server:564c97c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:564c97c-golang-arm64
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-golang-arm64
ghcr.io/openhands/agent-server:feat-programbench-golang-arm64
ghcr.io/openhands/agent-server:564c97c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:564c97c-java-amd64
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-java-amd64
ghcr.io/openhands/agent-server:feat-programbench-java-amd64
ghcr.io/openhands/agent-server:564c97c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:564c97c-java-arm64
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-java-arm64
ghcr.io/openhands/agent-server:feat-programbench-java-arm64
ghcr.io/openhands/agent-server:564c97c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:564c97c-python-amd64
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-python-amd64
ghcr.io/openhands/agent-server:feat-programbench-python-amd64
ghcr.io/openhands/agent-server:564c97c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:564c97c-python-arm64
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-python-arm64
ghcr.io/openhands/agent-server:feat-programbench-python-arm64
ghcr.io/openhands/agent-server:564c97c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:564c97c-golang
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-golang
ghcr.io/openhands/agent-server:feat-programbench-golang
ghcr.io/openhands/agent-server:564c97c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:564c97c-java
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-java
ghcr.io/openhands/agent-server:feat-programbench-java
ghcr.io/openhands/agent-server:564c97c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:564c97c-python
ghcr.io/openhands/agent-server:564c97cc36c03b59ba2c077626f82e4ee2a467f9-python
ghcr.io/openhands/agent-server:feat-programbench-python
ghcr.io/openhands/agent-server:564c97c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `564c97c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `564c97c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->