### PR TITLE
Revert Kimi K2.6 to public moonshot endpoint

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -77,7 +77,7 @@ MODELS = {
         "id": "kimi-k2.6",
         "display_name": "Kimi K2.6",
         "llm_config": {
-            "model": "litellm_proxy/accounts/graham-openhands/deployments/mghcd1dc",
+            "model": "litellm_proxy/moonshot/kimi-k2.6",
             "temperature": 1.0,
         },
     },

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -629,10 +629,7 @@ def test_kimi_k2_6_config():
 
     assert model["id"] == "kimi-k2.6"
     assert model["display_name"] == "Kimi K2.6"
-    assert (
-        model["llm_config"]["model"]
-        == "litellm_proxy/accounts/graham-openhands/deployments/mghcd1dc"
-    )
+    assert model["llm_config"]["model"] == "litellm_proxy/moonshot/kimi-k2.6"
     assert model["llm_config"]["temperature"] == 1.0
 
 


### PR DESCRIPTION
## Summary

Now that the private-endpoint runs for Kimi K2.6 are complete, switch the eval
config back from the private litellm proxy deployment to the public endpoint:

- `litellm_proxy/accounts/graham-openhands/deployments/mghcd1dc` →
  `litellm_proxy/moonshot/kimi-k2.6`

Also updates the corresponding test in
`tests/cross/test_resolve_model_config.py::test_kimi_k2_6_config` to assert the
public endpoint.

Fixes #3080

## Testing

- `uv run pytest tests/cross/test_resolve_model_config.py::test_kimi_k2_6_config -v` ✅
- `uv run pre-commit run --files .github/run-eval/resolve_model_config.py tests/cross/test_resolve_model_config.py` ✅

---

_This PR was created by an AI agent (OpenHands) on behalf of the maintainers._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d9a2c77c-988a-42f0-b1cf-caf96ed04f1a)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d493249-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d493249-python \
  ghcr.io/openhands/agent-server:d493249-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d493249-golang-amd64
ghcr.io/openhands/agent-server:d493249-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d493249-golang-arm64
ghcr.io/openhands/agent-server:d493249-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d493249-java-amd64
ghcr.io/openhands/agent-server:d493249-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d493249-java-arm64
ghcr.io/openhands/agent-server:d493249-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d493249-python-amd64
ghcr.io/openhands/agent-server:d493249-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d493249-python-arm64
ghcr.io/openhands/agent-server:d493249-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d493249-golang
ghcr.io/openhands/agent-server:d493249-java
ghcr.io/openhands/agent-server:d493249-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d493249-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d493249-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->