### PR TITLE
fix(agent-server): close MCP clients reliably on conversation teardown

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -789,6 +789,23 @@ class EventService:
                 await self._lease_task
             self._lease_task = None
 
+        # Drain in-flight run before teardown so MCP close doesn't race
+        # with a tool call mid-step.
+        if self._run_task is not None and not self._run_task.done():
+            if self._conversation is not None:
+                loop = asyncio.get_running_loop()
+                try:
+                    await loop.run_in_executor(None, self._conversation.pause)
+                except Exception:
+                    logger.warning(
+                        "Failed to pause conversation during close", exc_info=True
+                    )
+            try:
+                await asyncio.wait_for(self._run_task, timeout=10.0)
+            except Exception as exc:
+                logger.warning("Run task did not exit cleanly during close: %s", exc)
+            self._run_task = None
+
         await self._pub_sub.close()
         if self._conversation:
             loop = asyncio.get_running_loop()

--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -110,6 +110,9 @@ class MCPToolExecutor(ToolExecutor):
                 tool_name=self.tool_name,
             )
 
+    def close(self) -> None:
+        self.client.sync_close()
+
 
 _mcp_dynamic_action_type: dict[str, type[Schema]] = {}
 

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1935,3 +1935,88 @@ class TestEventServiceClose:
         await event_service.close()  # second call — _conversation is already None
 
         conversation.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_pauses_before_closing_conversation(self, event_service):
+        """close() must pause an in-flight run before calling conversation.close().
+        If close() ran first, the still-active run loop would race with executor
+        teardown — closing MCP clients while a tool call is in flight."""
+        conversation = MagicMock(spec=Conversation)
+        call_order: list[str] = []
+
+        def record_pause():
+            call_order.append("pause")
+
+        def record_close():
+            call_order.append("close")
+
+        conversation.pause = record_pause
+        conversation.close = record_close
+        event_service._conversation = conversation
+
+        # Task is in-flight when close() inspects it, finishes during the await.
+        async def fake_run():
+            await asyncio.sleep(0.05)
+
+        event_service._run_task = asyncio.create_task(fake_run())
+
+        await event_service.close()
+
+        assert call_order == ["pause", "close"], (
+            f"Expected pause before close, got {call_order}"
+        )
+        assert event_service._run_task is None
+
+    @pytest.mark.asyncio
+    async def test_close_skips_pause_when_no_run_task(self, event_service):
+        """close() must not call pause() when no run task is in flight."""
+        conversation = MagicMock(spec=Conversation)
+        conversation.pause = MagicMock()
+        conversation.close = MagicMock()
+        event_service._conversation = conversation
+        event_service._run_task = None
+
+        await event_service.close()
+
+        conversation.pause.assert_not_called()
+        conversation.close.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_close_proceeds_on_run_task_timeout(self, event_service, caplog):
+        """If the run task does not finish within the timeout, close() logs
+        and still proceeds. Server shutdown must not block on a hanging
+        agent.step(): cancel-on-timeout only cancels the asyncio wrapper, not
+        the underlying worker thread, so we accept that case as best-effort.
+        Pause must still be attempted so the common case (step finishes
+        promptly) stays clean."""
+        conversation = MagicMock(spec=Conversation)
+        conversation.pause = MagicMock()
+        conversation.close = MagicMock()
+        event_service._conversation = conversation
+
+        async def hanging_run():
+            await asyncio.sleep(60)
+
+        hanging_task = asyncio.create_task(hanging_run())
+        event_service._run_task = hanging_task
+
+        try:
+            with (
+                caplog.at_level("WARNING"),
+                patch(
+                    "openhands.agent_server.event_service.asyncio.wait_for",
+                    AsyncMock(side_effect=asyncio.TimeoutError),
+                ),
+            ):
+                await event_service.close()
+        finally:
+            hanging_task.cancel()
+            try:
+                await hanging_task
+            except (asyncio.CancelledError, BaseException):
+                pass
+
+        conversation.pause.assert_called_once()
+        assert "did not exit cleanly" in caplog.text
+        assert event_service._run_task is None
+        conversation.close.assert_called_once()

--- a/tests/sdk/mcp/test_mcp_tool.py
+++ b/tests/sdk/mcp/test_mcp_tool.py
@@ -238,6 +238,13 @@ class TestMCPToolExecutor:
         assert "timed out" in observation.text
         assert f"{self.executor.timeout} seconds" in observation.text
 
+    def test_close_calls_client_sync_close(self):
+        """close() must invoke MCPClient.sync_close() to tear down the
+        stdio subprocess. Without this, MCP clients survive conversation
+        deletion and accumulate over a long-running server."""
+        self.executor.close()
+        self.mock_client.sync_close.assert_called_once()
+
 
 class TestMCPTool:
     """Test MCPTool functionality."""


### PR DESCRIPTION
- [x] A human has tested these changes.


## Summary
- MCPToolExecutor.close() was inheriting the no-op ToolExecutor.close(), so the per-tool close loop in LocalConversation.close() never reached MCPClient.sync_close(). Long-lived agent-servers accumulated stdio subprocesses across  conversation creation/deletion. Implemented as a thin forward to client.sync_close() (idempotent on the client side, safe across the multiple tools that share one client per mcp_config).
- EventService.close() did not pause/await _run_task before teardown. With the above fix, executor close could now race with a tool call mid-step. Added a pause + wait_for(_run_task, timeout=10s) step before pub_sub/conversation close. Pause is logged-and-continue on failure; the timeout is best-effort because thread-pool tasks aren't interruptible — a hung agent.step() falls back to today's behavior with a logged warning rather than blocking shutdown.    
   
Resolves claims 2 and 3 from #2603. Claim 1 (the missing await on EventService.close()) was already fixed in #2734. Claim 4 (one MCP client per conversation, no dedupe) is the architectural piece called out in the issue and will be
   a separate design proposal.

## Issue Number
#2603

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc3ca3e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc3ca3e-python \
  ghcr.io/openhands/agent-server:dc3ca3e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc3ca3e-golang-amd64
ghcr.io/openhands/agent-server:dc3ca3e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc3ca3e-golang-arm64
ghcr.io/openhands/agent-server:dc3ca3e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc3ca3e-java-amd64
ghcr.io/openhands/agent-server:dc3ca3e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc3ca3e-java-arm64
ghcr.io/openhands/agent-server:dc3ca3e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc3ca3e-python-amd64
ghcr.io/openhands/agent-server:dc3ca3e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dc3ca3e-python-arm64
ghcr.io/openhands/agent-server:dc3ca3e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dc3ca3e-golang
ghcr.io/openhands/agent-server:dc3ca3e-java
ghcr.io/openhands/agent-server:dc3ca3e-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc3ca3e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc3ca3e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->