### PR TITLE
feat(acp): suppress conflicting env vars when CLAUDE_CONFIG_DIR is active

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -104,6 +104,20 @@ _RETRIABLE_SERVER_ERROR_CODES: frozenset[int] = frozenset({-32603})
 # used by the terminal tool and the default max_message_chars in LLM config.
 MAX_ACP_CONTENT_CHARS: int = 30_000
 
+# Env vars that must be removed from the subprocess environment when a
+# particular "dominant" env var is present.
+#
+# Rationale: some auth mechanisms are mutually exclusive and their env vars
+# conflict.  For example, CLAUDE_CONFIG_DIR activates Claude Code's OAuth
+# credential-file flow.  If ANTHROPIC_API_KEY or ANTHROPIC_BASE_URL are
+# also present they redirect requests to a different endpoint (e.g. a proxy)
+# that doesn't support OAuth bearer tokens, breaking authentication silently.
+# When CLAUDE_CONFIG_DIR is detected we strip the conflicting vars so the
+# subprocess can reach api.anthropic.com with its own OAuth token.
+_ENV_CONFLICT_MAP: dict[str, frozenset[str]] = {
+    "CLAUDE_CONFIG_DIR": frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"}),
+}
+
 # Limit for asyncio.StreamReader buffers used by the ACP subprocess pipes.
 # The default (64 KiB) is too small for session_update notifications that
 # carry large tool-call outputs (e.g. file contents, test results).  When
@@ -958,6 +972,14 @@ class ACPAgent(AgentBase):
                         env[name] = value
         # Strip CLAUDECODE so nested Claude Code instances don't refuse to start
         env.pop("CLAUDECODE", None)
+
+        # Strip env vars that conflict with an active auth mechanism.
+        # E.g. CLAUDE_CONFIG_DIR (OAuth credential file) conflicts with
+        # ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL (API-key + proxy auth).
+        for dominant, conflicts in _ENV_CONFLICT_MAP.items():
+            if dominant in env:
+                for conflict in conflicts:
+                    env.pop(conflict, None)
 
         command = self.acp_command[0]
         args = list(self.acp_command[1:]) + list(self.acp_args)

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -693,6 +693,11 @@ class OpenHandsAgentSettings(BaseModel):
         default_factory=AgentContext,
         description="Context for the agent (skills, secrets, message suffixes).",
     )
+
+    @field_validator("agent_context", mode="before")
+    @classmethod
+    def _agent_context_none_to_default(cls, v: object) -> object:
+        return AgentContext() if v is None else v
     condenser: CondenserSettings = Field(
         default_factory=CondenserSettings,
         description="Condenser settings for the agent.",

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -693,11 +693,6 @@ class OpenHandsAgentSettings(BaseModel):
         default_factory=AgentContext,
         description="Context for the agent (skills, secrets, message suffixes).",
     )
-
-    @field_validator("agent_context", mode="before")
-    @classmethod
-    def _agent_context_none_to_default(cls, v: object) -> object:
-        return AgentContext() if v is None else v
     condenser: CondenserSettings = Field(
         default_factory=CondenserSettings,
         description="Condenser settings for the agent.",

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -3686,9 +3686,7 @@ class TestACPEnvConflictSuppression:
                 )
             )
             if extra_os_env:
-                stack.enter_context(
-                    patch.dict("os.environ", extra_os_env, clear=False)
-                )
+                stack.enter_context(patch.dict("os.environ", extra_os_env, clear=False))
             agent._start_acp_server(state)
 
         return captured
@@ -3736,7 +3734,9 @@ class TestACPEnvConflictSuppression:
             acp_env={"CLAUDE_CONFIG_DIR": "/tmp/claude-creds"},
             agent_context=AgentContext(
                 secrets={
-                    "ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-secret")),
+                    "ANTHROPIC_API_KEY": StaticSecret(
+                        value=SecretStr("sk-from-secret")
+                    ),
                     "ANTHROPIC_BASE_URL": StaticSecret(
                         value=SecretStr("https://proxy.example.com")
                     ),

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -3604,3 +3604,157 @@ class TestACPSecretsEnvInjection:
         )
         env = self._run_start_capturing_env(agent, tmp_path)
         assert "EMPTY_SECRET" not in env
+
+
+class TestACPEnvConflictSuppression:
+    """CLAUDE_CONFIG_DIR OAuth auth must not coexist with API-key env vars.
+
+    When CLAUDE_CONFIG_DIR is present in the subprocess environment the agent
+    uses a credential file for OAuth.  If ANTHROPIC_API_KEY or
+    ANTHROPIC_BASE_URL are also present they redirect requests to a proxy that
+    does not support OAuth bearer tokens, breaking auth silently.
+
+    _start_acp_server must strip the conflicting vars regardless of where they
+    came from: acp_env, os.environ, or agent_context.secrets.
+    """
+
+    @staticmethod
+    def _make_conn():
+        conn = MagicMock()
+        init_response = MagicMock()
+        init_response.agent_info = MagicMock()
+        init_response.agent_info.name = "claude-agent-acp"
+        init_response.agent_info.version = "1.0"
+        init_response.auth_methods = []
+        conn.initialize = AsyncMock(return_value=init_response)
+        new_response = MagicMock()
+        new_response.session_id = "sess-conflict"
+        conn.new_session = AsyncMock(return_value=new_response)
+        conn.load_session = AsyncMock(return_value=MagicMock())
+        conn.set_session_mode = AsyncMock()
+        conn.set_session_model = AsyncMock()
+        conn.authenticate = AsyncMock()
+        conn.close = AsyncMock()
+        return conn
+
+    @staticmethod
+    def _run_start_capturing_env(agent, tmp_path, *, extra_os_env=None) -> dict:
+        from contextlib import ExitStack
+
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        captured: dict = {}
+        conn = TestACPEnvConflictSuppression._make_conn()
+
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+
+        async def _fake_create_subprocess_exec(*_args, env=None, **_kwargs):
+            captured.update(env or {})
+            return mock_process
+
+        async def _fake_filter(_src, _dst):
+            return None
+
+        state = _make_state(tmp_path)
+        agent._executor = AsyncExecutor()
+
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                    new=_fake_create_subprocess_exec,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                    return_value=conn,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                    new=_fake_filter,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.StreamReader",
+                    return_value=MagicMock(),
+                )
+            )
+            if extra_os_env:
+                stack.enter_context(
+                    patch.dict("os.environ", extra_os_env, clear=False)
+                )
+            agent._start_acp_server(state)
+
+        return captured
+
+    def test_claude_config_dir_suppresses_api_key_from_acp_env(self, tmp_path):
+        """ANTHROPIC_API_KEY from acp_env is stripped when CLAUDE_CONFIG_DIR present."""
+        agent = _make_agent(
+            acp_env={
+                "CLAUDE_CONFIG_DIR": "/tmp/claude-creds",
+                "ANTHROPIC_API_KEY": "sk-conflict",
+                "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            }
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        assert env["CLAUDE_CONFIG_DIR"] == "/tmp/claude-creds"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_BASE_URL" not in env
+
+    def test_claude_config_dir_suppresses_api_key_from_os_environ(self, tmp_path):
+        """ANTHROPIC_API_KEY leaking in from os.environ is stripped too."""
+        agent = _make_agent(
+            acp_env={"CLAUDE_CONFIG_DIR": "/tmp/claude-creds"},
+        )
+        env = self._run_start_capturing_env(
+            agent,
+            tmp_path,
+            extra_os_env={
+                "ANTHROPIC_API_KEY": "sk-leaked",
+                "ANTHROPIC_BASE_URL": "https://proxy.example.com",
+            },
+        )
+
+        assert "CLAUDE_CONFIG_DIR" in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_BASE_URL" not in env
+
+    def test_claude_config_dir_suppresses_api_key_from_secrets(self, tmp_path):
+        """ANTHROPIC_API_KEY injected via agent_context.secrets is stripped too."""
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(
+            acp_env={"CLAUDE_CONFIG_DIR": "/tmp/claude-creds"},
+            agent_context=AgentContext(
+                secrets={
+                    "ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-secret")),
+                    "ANTHROPIC_BASE_URL": StaticSecret(
+                        value=SecretStr("https://proxy.example.com")
+                    ),
+                }
+            ),
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        assert "CLAUDE_CONFIG_DIR" in env
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "ANTHROPIC_BASE_URL" not in env
+
+    def test_no_suppression_without_claude_config_dir(self, tmp_path):
+        """Without CLAUDE_CONFIG_DIR, ANTHROPIC_API_KEY passes through unchanged."""
+        agent = _make_agent(
+            acp_env={"ANTHROPIC_API_KEY": "sk-valid"},
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        assert env.get("ANTHROPIC_API_KEY") == "sk-valid"
+        assert "CLAUDE_CONFIG_DIR" not in env


### PR DESCRIPTION
## Why

When a user authenticates via \`claude auth login\` (Claude Max subscription), Claude Code reads OAuth credentials from \`CLAUDE_CONFIG_DIR\`. If \`ANTHROPIC_API_KEY\` or \`ANTHROPIC_BASE_URL\` are also present in the subprocess environment — from \`acp_env\`, the host \`os.environ\`, or injected secrets — the HTTP client gets redirected to an API-key proxy that doesn't speak OAuth bearer tokens. Authentication fails silently.

## What

Add \`_ENV_CONFLICT_MAP\` — a module-level table declaring which env vars to strip when a dominant auth var is present. \`_start_acp_server\` applies the map after the full environment is assembled, just before \`create_subprocess_exec\`:

```python
_ENV_CONFLICT_MAP: dict[str, frozenset[str]] = {
    "CLAUDE_CONFIG_DIR": frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"}),
}
```

The constant is open for future entries — e.g. a Codex OAuth credential file that conflicts with \`OPENAI_API_KEY\`.

## Tests

Four regression tests in \`TestACPEnvConflictSuppression\`:
- conflict var in \`acp_env\`
- conflict var leaked from \`os.environ\`
- conflict var injected via \`agent_context.secrets\`
- no suppression when \`CLAUDE_CONFIG_DIR\` is absent

## Related

OpenHands/OpenHands#14319 — the app-server PR that first surfaced this. A temporary shim there handles suppression until OpenHands pins to the SDK version that ships this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6678858-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6678858-python \
  ghcr.io/openhands/agent-server:6678858-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6678858-golang-amd64
ghcr.io/openhands/agent-server:6678858-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6678858-golang-arm64
ghcr.io/openhands/agent-server:6678858-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6678858-java-amd64
ghcr.io/openhands/agent-server:6678858-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6678858-java-arm64
ghcr.io/openhands/agent-server:6678858-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6678858-python-amd64
ghcr.io/openhands/agent-server:6678858-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6678858-python-arm64
ghcr.io/openhands/agent-server:6678858-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6678858-golang
ghcr.io/openhands/agent-server:6678858-java
ghcr.io/openhands/agent-server:6678858-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6678858-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6678858-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->