### PR TITLE
fix(settings): accept None for agent_context when switching agent_kind

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -693,6 +693,12 @@ class OpenHandsAgentSettings(BaseModel):
         default_factory=AgentContext,
         description="Context for the agent (skills, secrets, message suffixes).",
     )
+
+    @field_validator("agent_context", mode="before")
+    @classmethod
+    def _agent_context_none_to_default(cls, v: object) -> object:
+        return AgentContext() if v is None else v
+
     condenser: CondenserSettings = Field(
         default_factory=CondenserSettings,
         description="Condenser settings for the agent.",


### PR DESCRIPTION
## Summary

Switching from ACP back to the OpenHands agent throws a 500 \"Something went wrong storing settings\" because stored ACP settings can contain `agent_context: null`.

**Root cause:** When a user first switches *to* ACP, `deep_merge` preserves all fields from the existing OpenHands settings dump — including `agent_context`, which is only a field on `OpenHandsAgentSettings`. Depending on the stored value this lands as `null` in the persisted blob. On the return trip to OpenHands, `deep_merge` leaves that `null` in place (it only removes `None` from the *updates*, not the *base*), and Pydantic rejects it because `agent_context: AgentContext` is non-optional.

**Fix:** A `before` validator on `agent_context` coerces `None` → `AgentContext()`, the same value the `default_factory` would have produced. The field semantics are unchanged for all other inputs.

## Test plan

- [x] Existing `tests/sdk/test_settings.py` (37 tests) all pass
- [x] Manually reproduced the failure with the exact stored settings shape and confirmed the validator resolves it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c856e58-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c856e58-python \
  ghcr.io/openhands/agent-server:c856e58-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c856e58-golang-amd64
ghcr.io/openhands/agent-server:c856e58-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c856e58-golang-arm64
ghcr.io/openhands/agent-server:c856e58-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c856e58-java-amd64
ghcr.io/openhands/agent-server:c856e58-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c856e58-java-arm64
ghcr.io/openhands/agent-server:c856e58-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c856e58-python-amd64
ghcr.io/openhands/agent-server:c856e58-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c856e58-python-arm64
ghcr.io/openhands/agent-server:c856e58-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c856e58-golang
ghcr.io/openhands/agent-server:c856e58-java
ghcr.io/openhands/agent-server:c856e58-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c856e58-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c856e58-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->