### PR TITLE
docs(hooks): clarify exit-code semantics (only exit 2 blocks)

### DIFF
--- a/examples/01_standalone_sdk/33_hooks/README.md
+++ b/examples/01_standalone_sdk/33_hooks/README.md
@@ -52,5 +52,5 @@ hook contract):
   logged, but the operation still proceeds.
 
 > **Note:** Only exit code `2` blocks. Exit code `1` (the conventional Unix
-> failure code) is treated as a non-blocking error, just like in Claude Code.
-> A hook that is meant to enforce a policy must exit with `2`.
+> failure code) is treated as a non-blocking error. A hook that is meant to
+> enforce a policy must exit with `2`.

--- a/examples/01_standalone_sdk/33_hooks/README.md
+++ b/examples/01_standalone_sdk/33_hooks/README.md
@@ -37,3 +37,20 @@ python 33_hooks.py
 | Stop | When agent tries to finish | Yes (exit 2) |
 | SessionStart | When conversation starts | No |
 | SessionEnd | When conversation ends | No |
+
+## Exit Codes
+
+Hook scripts signal their result via the exit code (matching the Claude Code
+hook contract):
+
+- **`0` — success.** The operation proceeds. `stdout` is parsed as JSON for
+  structured output (`decision`, `reason`, `additionalContext`).
+- **`2` — block.** The operation is denied. For `Stop` hooks, this prevents
+  the agent from finishing and the agent continues running. `stderr` /
+  `reason` is surfaced as feedback.
+- **Any other non-zero exit code — non-blocking error.** The error is
+  logged, but the operation still proceeds.
+
+> **Note:** Only exit code `2` blocks. Exit code `1` (the conventional Unix
+> failure code) is treated as a non-blocking error, just like in Claude Code.
+> A hook that is meant to enforce a policy must exit with `2`.

--- a/openhands-sdk/openhands/sdk/hooks/executor.py
+++ b/openhands-sdk/openhands/sdk/hooks/executor.py
@@ -17,7 +17,16 @@ from openhands.sdk.utils import sanitized_env
 class HookResult(BaseModel):
     """Result from executing a hook.
 
-    Exit code 0 = success, exit code 2 = block operation.
+    Exit-code semantics (matching Claude Code's hook contract):
+
+    - **Exit 0**: success. ``stdout`` is parsed as JSON for structured output
+      (``decision``, ``reason``, ``additionalContext``, ``continue``).
+    - **Exit 2**: blocking error. The operation is denied / the agent is
+      prevented from stopping. ``stderr`` should explain why.
+    - **Any other non-zero exit code**: non-blocking error. ``success`` is set
+      to ``False`` and the error is logged, but the operation still proceeds.
+      In particular, exit code ``1`` does **not** block — only ``2`` does.
+      Hooks intended to enforce a policy must exit with ``2``.
     """
 
     success: bool = True


### PR DESCRIPTION
## Context

A user noticed that hook scripts in this repo only block on exit code `2`, and asked whether (1) that is consistent with Claude Code, and (2) whether it is documented clearly everywhere people learn about hooks.

### (1) Consistency: ✅ already consistent — no behavior change needed

`HookExecutor` does:

```python
success = (returncode == 0)
blocked = (returncode == 2)
```

This matches Claude Code's documented hook contract exactly:

> **Exit 0** means success... **Exit 2** means a blocking error... **Any other exit code** is a non-blocking error for most hook events.
>
> Warning: For most hook events, only exit code 2 blocks the action. Claude Code treats exit code 1 as a non-blocking error and proceeds with the action, even though 1 is the conventional Unix failure code.

For the `Stop` hook specifically, both Claude Code and our SDK behave the same way: exit 2 → don't stop, agent continues. ✅

### (2) Documentation: needed improvement

Places people learn about hooks:

| Location | Before |
|---|---|
| `OpenHands/docs` → `openhands/usage/customization/hooks.mdx` | ✅ Already had explicit "Exit codes" section |
| `OpenHands/docs` → `sdk/guides/hooks.mdx` | ⚠️ Only "Yes (exit 2)" in a table — covered in a companion docs PR |
| `examples/01_standalone_sdk/33_hooks/README.md` | ⚠️ Only "Yes (exit 2)" in a table |
| `openhands-sdk/openhands/sdk/hooks/executor.py` `HookResult` docstring | ⚠️ One-liner: "Exit code 0 = success, exit code 2 = block operation." |

The risk in the under-documented places is exactly the gotcha Claude Code calls out with a Warning: a developer assumes "non-zero exit = block" (the Unix convention), writes a hook that exits `1` to enforce a policy, and is surprised when the operation proceeds anyway.

## Changes

- **`openhands-sdk/openhands/sdk/hooks/executor.py`**: expand the `HookResult` docstring to document all three exit-code categories (0 success / 2 block / other non-blocking) and explicitly note that `1` does not block.
- **`examples/01_standalone_sdk/33_hooks/README.md`**: add an "Exit Codes" section right after the Hook Types table so example users see the full contract, not just the "Yes (exit 2)" hint.

A companion PR in `OpenHands/docs` adds the same "Exit Codes" section to `sdk/guides/hooks.mdx`.

## Testing

- `uv run pre-commit run --files <changed files>` — passed
- `uv run pytest tests/sdk/hooks/` — all 82 tests pass

No code/behavior change; documentation only.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/af4e7a4a-54e0-4215-a85b-96e14b91fa11)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2f6c247-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2f6c247-python \
  ghcr.io/openhands/agent-server:2f6c247-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2f6c247-golang-amd64
ghcr.io/openhands/agent-server:2f6c247-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2f6c247-golang-arm64
ghcr.io/openhands/agent-server:2f6c247-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2f6c247-java-amd64
ghcr.io/openhands/agent-server:2f6c247-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2f6c247-java-arm64
ghcr.io/openhands/agent-server:2f6c247-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2f6c247-python-amd64
ghcr.io/openhands/agent-server:2f6c247-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2f6c247-python-arm64
ghcr.io/openhands/agent-server:2f6c247-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2f6c247-golang
ghcr.io/openhands/agent-server:2f6c247-java
ghcr.io/openhands/agent-server:2f6c247-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2f6c247-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2f6c247-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->