### PR TITLE
fix(pyinstaller): bundle binaryornot data files in agent-server binary

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -68,6 +68,7 @@ a = Analysis(
         *collect_data_files("fastmcp"),
         *collect_data_files("mcp"),
         *collect_data_files("fakeredis"),  # Required for commands.json used by fakeredis ACL
+        *collect_data_files("binaryornot"),  # Required for binary file detection data
         *get_fakeredis_data(),  # Ensure fakeredis/model/ directory structure exists
 
         # OpenHands SDK prompt templates (adjusted for shallow namespace layout)


### PR DESCRIPTION
## Summary

- `binaryornot` ships a `magic.db` data file that PyInstaller doesn't auto-discover via static analysis
- Without it the binary crashes on startup: `ModuleNotFoundError: No module named 'binaryornot.data'`
- Adding `collect_data_files("binaryornot")` to the `.spec` datas list fixes the crash

## Test plan

- [ ] Build the agent-server image locally and verify the container starts without the `binaryornot.data` error
- [ ] Start a new conversation — agent-server container should reach `RUNNING` state

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:739d1c2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-739d1c2-python \
  ghcr.io/openhands/agent-server:739d1c2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:739d1c2-golang-amd64
ghcr.io/openhands/agent-server:739d1c2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:739d1c2-golang-arm64
ghcr.io/openhands/agent-server:739d1c2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:739d1c2-java-amd64
ghcr.io/openhands/agent-server:739d1c2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:739d1c2-java-arm64
ghcr.io/openhands/agent-server:739d1c2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:739d1c2-python-amd64
ghcr.io/openhands/agent-server:739d1c2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:739d1c2-python-arm64
ghcr.io/openhands/agent-server:739d1c2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:739d1c2-golang
ghcr.io/openhands/agent-server:739d1c2-java
ghcr.io/openhands/agent-server:739d1c2-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `739d1c2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `739d1c2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->