### PR TITLE
feat: add /api/cloud-proxy for cross-origin saas forwarding

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -16,6 +16,7 @@ from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
 
 from openhands.agent_server.bash_router import bash_router
+from openhands.agent_server.cloud_proxy_router import cloud_proxy_router
 from openhands.agent_server.config import (
     Config,
     get_default_config,
@@ -279,6 +280,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
     api_router.include_router(settings_router)
+    api_router.include_router(cloud_proxy_router)
     app.include_router(api_router)
     app.include_router(sockets_router)
 

--- a/openhands-agent-server/openhands/agent_server/cloud_proxy_router.py
+++ b/openhands-agent-server/openhands/agent_server/cloud_proxy_router.py
@@ -14,6 +14,7 @@ override via the ``OH_CLOUD_PROXY_ALLOWED_HOSTS`` environment variable
 
 from __future__ import annotations
 
+import ipaddress
 import os
 from typing import Any
 from urllib.parse import urlparse
@@ -64,6 +65,28 @@ def _allowed_hosts() -> tuple[str, ...]:
     return parsed or _DEFAULT_ALLOWED_HOSTS
 
 
+def _is_blocked_ip_literal(hostname: str) -> bool:
+    """Return True iff hostname is an IP literal in a non-routable range.
+
+    Defense in depth: even if an operator widens the allowlist, raw IP
+    literals pointing at loopback, RFC 1918 private space, link-local
+    (169.254.0.0/16, includes the AWS metadata service), or other
+    reserved blocks must never be reached through the proxy.
+    """
+    try:
+        ip = ipaddress.ip_address(hostname)
+    except ValueError:
+        return False
+    return (
+        ip.is_private
+        or ip.is_loopback
+        or ip.is_link_local
+        or ip.is_reserved
+        or ip.is_multicast
+        or ip.is_unspecified
+    )
+
+
 def _is_host_allowed(host_url: str) -> bool:
     parsed = urlparse(host_url)
     if parsed.scheme not in ("http", "https"):
@@ -74,6 +97,8 @@ def _is_host_allowed(host_url: str) -> bool:
     if hostname in _DENYLISTED_HOSTNAMES:
         # Block loopback to prevent the proxy from being used to reach
         # other local services on the operator's machine.
+        return False
+    if _is_blocked_ip_literal(hostname):
         return False
     for entry in _allowed_hosts():
         entry_lower = entry.lower()

--- a/openhands-agent-server/openhands/agent_server/cloud_proxy_router.py
+++ b/openhands-agent-server/openhands/agent_server/cloud_proxy_router.py
@@ -1,0 +1,201 @@
+"""Cloud proxy router.
+
+Forwards browser-originated requests to a configured cloud SaaS host so the
+GUI never has to make a cross-origin request. The browser talks to this
+local agent-server (same-origin in production, allowlisted localhost in
+dev) and this server makes the upstream call server-side, where CORS does
+not apply.
+
+Hosts are allowlisted to prevent the proxy from being abused as an SSRF
+relay. By default only `*.all-hands.dev` is permitted; the operator can
+override via the ``OH_CLOUD_PROXY_ALLOWED_HOSTS`` environment variable
+(comma-separated list of hostnames or suffixes).
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+from urllib.parse import urlparse
+
+import httpx
+from fastapi import APIRouter, HTTPException
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel, Field
+
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+cloud_proxy_router = APIRouter(prefix="/cloud-proxy", tags=["Cloud Proxy"])
+
+_DEFAULT_ALLOWED_HOSTS = ("all-hands.dev",)
+_DENYLISTED_HOSTNAMES = {"localhost", "127.0.0.1", "0.0.0.0", "::1"}
+
+
+class CloudProxyRequest(BaseModel):
+    """Envelope describing the upstream request to forward."""
+
+    host: str = Field(
+        description=(
+            "Cloud host base URL, e.g. 'https://app.all-hands.dev'. Must "
+            "match the configured allowlist."
+        )
+    )
+    method: str = Field(default="GET")
+    path: str = Field(description="Path on the cloud host, e.g. '/api/organizations'")
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description=(
+            "Headers to forward, including the Authorization bearer token "
+            "for the cloud backend."
+        ),
+    )
+    body: Any = None
+    timeout_seconds: float = Field(default=15.0, ge=1.0, le=60.0)
+
+
+def _allowed_hosts() -> tuple[str, ...]:
+    raw = os.environ.get("OH_CLOUD_PROXY_ALLOWED_HOSTS")
+    if not raw:
+        return _DEFAULT_ALLOWED_HOSTS
+    parsed = tuple(entry.strip().lower() for entry in raw.split(",") if entry.strip())
+    return parsed or _DEFAULT_ALLOWED_HOSTS
+
+
+def _is_host_allowed(host_url: str) -> bool:
+    parsed = urlparse(host_url)
+    if parsed.scheme not in ("http", "https"):
+        return False
+    hostname = (parsed.hostname or "").lower()
+    if not hostname:
+        return False
+    if hostname in _DENYLISTED_HOSTNAMES:
+        # Block loopback to prevent the proxy from being used to reach
+        # other local services on the operator's machine.
+        return False
+    for entry in _allowed_hosts():
+        entry_lower = entry.lower()
+        if hostname == entry_lower or hostname.endswith("." + entry_lower):
+            return True
+    return False
+
+
+# A small set of hop-by-hop / framing headers we should never forward.
+_STRIPPED_RESPONSE_HEADERS = {
+    "content-encoding",
+    "content-length",
+    "transfer-encoding",
+    "connection",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailers",
+    "upgrade",
+    # Don't leak upstream CORS state into the local response — irrelevant
+    # to the local-origin caller and confusing if it disagrees.
+    "access-control-allow-origin",
+    "access-control-allow-credentials",
+    "access-control-allow-headers",
+    "access-control-allow-methods",
+    "access-control-expose-headers",
+    "access-control-max-age",
+    # Don't propagate Set-Cookie into a different origin/agent-server.
+    "set-cookie",
+}
+
+
+def _filtered_response_headers(upstream: httpx.Response) -> dict[str, str]:
+    return {
+        key: value
+        for key, value in upstream.headers.items()
+        if key.lower() not in _STRIPPED_RESPONSE_HEADERS
+    }
+
+
+async def _forward_upstream(
+    method: str,
+    url: str,
+    headers: dict[str, str],
+    json_body: Any,
+    raw_body: bytes | None,
+    timeout_seconds: float,
+) -> httpx.Response:
+    """Make the upstream HTTP call.
+
+    Factored out so tests can mock it without touching the test harness's
+    own httpx clients.
+    """
+    async with httpx.AsyncClient(timeout=timeout_seconds) as client:
+        return await client.request(
+            method=method,
+            url=url,
+            headers=headers,
+            json=json_body,
+            content=raw_body,
+        )
+
+
+@cloud_proxy_router.post("")
+async def cloud_proxy(req: CloudProxyRequest) -> Response:
+    if not _is_host_allowed(req.host):
+        raise HTTPException(
+            status_code=403,
+            detail=f"Cloud proxy host not allowed: {req.host}",
+        )
+
+    upstream_url = f"{req.host.rstrip('/')}{req.path}"
+
+    # httpx supports passing dict/list as `json=` and bytes/str as `content=`.
+    json_body: Any = None
+    raw_body: bytes | None = None
+    if isinstance(req.body, (dict, list)):
+        json_body = req.body
+    elif isinstance(req.body, str):
+        raw_body = req.body.encode("utf-8")
+    elif req.body is not None:
+        # Coerce anything else through JSON so the upstream sees consistent
+        # content. Avoids accidental tuple/None ambiguity.
+        json_body = req.body
+
+    try:
+        upstream = await _forward_upstream(
+            method=req.method.upper(),
+            url=upstream_url,
+            headers=req.headers,
+            json_body=json_body,
+            raw_body=raw_body,
+            timeout_seconds=req.timeout_seconds,
+        )
+    except httpx.RequestError as exc:
+        logger.warning("Cloud proxy upstream error for %s: %s", upstream_url, exc)
+        raise HTTPException(status_code=502, detail=f"Upstream error: {exc}") from exc
+
+    media_type = upstream.headers.get("content-type", "application/octet-stream")
+    headers = _filtered_response_headers(upstream)
+
+    if "application/json" in media_type:
+        try:
+            payload = upstream.json()
+        except ValueError:
+            # Upstream lied about its content-type. Fall through to bytes.
+            return Response(
+                content=upstream.content,
+                status_code=upstream.status_code,
+                media_type=media_type,
+                headers=headers,
+            )
+        return JSONResponse(
+            content=payload,
+            status_code=upstream.status_code,
+            headers=headers,
+        )
+
+    return Response(
+        content=upstream.content,
+        status_code=upstream.status_code,
+        media_type=media_type,
+        headers=headers,
+    )

--- a/tests/agent_server/test_cloud_proxy_router.py
+++ b/tests/agent_server/test_cloud_proxy_router.py
@@ -1,0 +1,211 @@
+"""Tests for the cloud proxy router."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from openhands.agent_server.cloud_proxy_router import (
+    _is_host_allowed,
+    cloud_proxy_router,
+)
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(cloud_proxy_router, prefix="/api")
+    return app
+
+
+def _make_test_client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class TestHostAllowlist:
+    def test_allows_canonical_cloud_host(self):
+        assert _is_host_allowed("https://app.all-hands.dev")
+
+    def test_allows_subdomain_of_allowed_root(self):
+        assert _is_host_allowed("https://eu.all-hands.dev")
+
+    def test_rejects_loopback(self):
+        assert not _is_host_allowed("http://localhost:8000")
+        assert not _is_host_allowed("http://127.0.0.1")
+
+    def test_rejects_unrelated_host(self):
+        assert not _is_host_allowed("https://evil.example.com")
+
+    def test_rejects_non_http_scheme(self):
+        assert not _is_host_allowed("file:///etc/passwd")
+        assert not _is_host_allowed("ftp://app.all-hands.dev")
+
+    def test_env_var_overrides_default_allowlist(self, monkeypatch):
+        monkeypatch.setenv("OH_CLOUD_PROXY_ALLOWED_HOSTS", "example.com")
+        assert _is_host_allowed("https://example.com")
+        assert _is_host_allowed("https://api.example.com")
+        # Default allowlist is fully replaced — all-hands.dev no longer matches.
+        assert not _is_host_allowed("https://app.all-hands.dev")
+
+
+@pytest.mark.asyncio
+async def test_proxy_forwards_get_and_returns_upstream_json(monkeypatch):
+    app = _build_app()
+    upstream_payload = {
+        "items": [{"id": "org-1", "name": "Personal"}],
+        "current_org_id": "org-1",
+    }
+    captured: dict[str, object] = {}
+
+    async def fake_forward(method, url, headers, json_body, raw_body, timeout_seconds):
+        captured.update(
+            {
+                "method": method,
+                "url": url,
+                "headers": headers,
+                "json_body": json_body,
+                "raw_body": raw_body,
+                "timeout": timeout_seconds,
+            }
+        )
+        return httpx.Response(
+            status_code=200,
+            content=json.dumps(upstream_payload).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    monkeypatch.setattr(
+        "openhands.agent_server.cloud_proxy_router._forward_upstream",
+        fake_forward,
+    )
+
+    async with _make_test_client(app) as client:
+        response = await client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://app.all-hands.dev",
+                "method": "GET",
+                "path": "/api/organizations",
+                "headers": {"Authorization": "Bearer test-token"},
+            },
+        )
+
+    assert response.status_code == 200
+    assert response.json() == upstream_payload
+    assert captured["method"] == "GET"
+    assert captured["url"] == "https://app.all-hands.dev/api/organizations"
+    assert captured["headers"] == {"Authorization": "Bearer test-token"}
+
+
+@pytest.mark.asyncio
+async def test_proxy_propagates_upstream_error_status(monkeypatch):
+    app = _build_app()
+    error_body = {"detail": "invalid api key"}
+
+    async def fake_forward(*args, **kwargs):  # noqa: ARG001
+        return httpx.Response(
+            status_code=401,
+            content=json.dumps(error_body).encode(),
+            headers={"content-type": "application/json"},
+        )
+
+    monkeypatch.setattr(
+        "openhands.agent_server.cloud_proxy_router._forward_upstream",
+        fake_forward,
+    )
+
+    async with _make_test_client(app) as client:
+        response = await client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://app.all-hands.dev",
+                "method": "GET",
+                "path": "/api/organizations",
+                "headers": {"Authorization": "Bearer bad"},
+            },
+        )
+
+    assert response.status_code == 401
+    assert response.json() == error_body
+
+
+@pytest.mark.asyncio
+async def test_proxy_rejects_disallowed_host():
+    app = _build_app()
+    async with _make_test_client(app) as client:
+        response = await client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://evil.example.com",
+                "method": "GET",
+                "path": "/whatever",
+            },
+        )
+
+    assert response.status_code == 403
+    assert "not allowed" in response.json()["detail"].lower()
+
+
+@pytest.mark.asyncio
+async def test_proxy_returns_502_on_upstream_network_error(monkeypatch):
+    app = _build_app()
+
+    async def fake_forward(*args, **kwargs):  # noqa: ARG001
+        raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(
+        "openhands.agent_server.cloud_proxy_router._forward_upstream",
+        fake_forward,
+    )
+
+    async with _make_test_client(app) as client:
+        response = await client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://app.all-hands.dev",
+                "method": "GET",
+                "path": "/api/organizations",
+            },
+        )
+
+    assert response.status_code == 502
+
+
+@pytest.mark.asyncio
+async def test_proxy_strips_upstream_set_cookie_and_cors_headers(monkeypatch):
+    app = _build_app()
+
+    async def fake_forward(*args, **kwargs):  # noqa: ARG001
+        return httpx.Response(
+            status_code=200,
+            content=b'{"ok": true}',
+            headers={
+                "content-type": "application/json",
+                "set-cookie": "session=secret; HttpOnly",
+                "access-control-allow-origin": "*",
+            },
+        )
+
+    monkeypatch.setattr(
+        "openhands.agent_server.cloud_proxy_router._forward_upstream",
+        fake_forward,
+    )
+
+    async with _make_test_client(app) as client:
+        response = await client.post(
+            "/api/cloud-proxy",
+            json={
+                "host": "https://app.all-hands.dev",
+                "method": "GET",
+                "path": "/api/organizations",
+            },
+        )
+
+    assert response.status_code == 200
+    assert "set-cookie" not in {k.lower() for k in response.headers.keys()}
+    assert "access-control-allow-origin" not in {
+        k.lower() for k in response.headers.keys()
+    }

--- a/tests/agent_server/test_cloud_proxy_router.py
+++ b/tests/agent_server/test_cloud_proxy_router.py
@@ -36,6 +36,26 @@ class TestHostAllowlist:
         assert not _is_host_allowed("http://localhost:8000")
         assert not _is_host_allowed("http://127.0.0.1")
 
+    def test_rejects_private_ipv4_addresses(self):
+        assert not _is_host_allowed("http://10.0.0.1")
+        assert not _is_host_allowed("http://172.16.0.1")
+        assert not _is_host_allowed("http://192.168.1.1")
+
+    def test_rejects_link_local_addresses(self):
+        # 169.254.169.254 is the AWS / GCP / Azure instance metadata service.
+        assert not _is_host_allowed("http://169.254.169.254")
+
+    def test_rejects_private_ipv6_addresses(self):
+        assert not _is_host_allowed("http://[fc00::1]")
+        assert not _is_host_allowed("http://[fe80::1]")
+        assert not _is_host_allowed("http://[::1]")
+
+    def test_rejects_private_ip_even_when_allowlisted(self, monkeypatch):
+        # If an operator misconfigures the allowlist to include a private
+        # IP, the IP-literal denylist must still block it.
+        monkeypatch.setenv("OH_CLOUD_PROXY_ALLOWED_HOSTS", "10.0.0.1")
+        assert not _is_host_allowed("http://10.0.0.1")
+
     def test_rejects_unrelated_host(self):
         assert not _is_host_allowed("https://evil.example.com")
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

The agent-server is the natural host for terminating browser requests that need to reach the SaaS. It already runs same-origin (or allowlisted-origin) with the GUI and already enforces the session-key auth boundary. Forwarding through it gives:

- **Same-origin browser hop.** Browser → local agent-server, no CORS.
- **Server-side upstream call.** No browser CORS at the SaaS side either, because the request originates from the agent-server.
- **Token stays server-side after one inbound hop.** The cloud bearer token rides in the envelope body, gets attached to the upstream request server-side, and never leaves the user's machine via a cross-origin browser fetch.
- **One endpoint, two upstream families.** The same envelope (`host`, `method`, `path`, `headers`, `body`) works for the SaaS App API (`app.all-hands.dev/api/v1/...`, `Authorization: Bearer`) and for runtime sandboxes (`*.prod-runtime.all-hands.dev/api/...`, `X-Session-API-Key`).

## Summary

<!-- 1-3 bullets describing what changed. -->
### Context

Companion clients of the agent-server (notably `agent-server-gui`) need to make REST calls to OpenHands SaaS endpoints — `https://app.all-hands.dev/api/v1/...` for App-API resources, and `https://*.prod-runtime.all-hands.dev/api/...` for runtime sandboxes — on behalf of a user authenticated by API key.

Today those calls have no way to leave the browser:

- The SaaS App API allow-lists `https://app.all-hands.dev` as a CORS origin (and only that). A GUI hosted at any other origin (`localhost:3001` in dev, future first-party deployments, etc.) cannot fetch from it directly.
- Runtime sandboxes likewise allow-list a narrow set of origins.
- `Access-Control-Allow-Origin: *` plus `Authorization` is incompatible with the SaaS's cookie-based first-party UI auth (CSRF risk), so broadening CORS isn't an option.

The agent-server already runs on the user's machine alongside the GUI (or co-located with it in production). It's the natural place to terminate same-origin browser requests and forward them server-side.

### What this delivers

A new `cloud_proxy_router` mounted at `POST /api/cloud-proxy`. The endpoint accepts a JSON envelope describing the upstream request, forwards it via `httpx`, and returns the upstream response with status, JSON body, and content-type intact.

```jsonc
// Request body
{
  "host": "https://app.all-hands.dev",
  "method": "GET",
  "path": "/api/v1/conversation/abc123/events/search?limit=100",
  "headers": { "Authorization": "Bearer sk-…" },
  "body": null,
  "timeout_seconds": 15.0 // optional, 1.0 ≤ x ≤ 60.0
}
```

Same envelope works for runtime sandboxes — the caller sets `host` to `http://<id>.prod-runtime.all-hands.dev` and supplies an `X-Session-API-Key` header instead of `Authorization`.

### Security model

- **Host allowlist.** Default = `("all-hands.dev",)` (subdomain match via suffix). Configurable via the `OH_CLOUD_PROXY_ALLOWED_HOSTS` environment variable (comma-separated list).
- **Loopback denied.** `localhost`, `127.0.0.1`, `0.0.0.0`, `::1` are always rejected so the proxy can't be used to reach other services on the operator's machine (anti-SSRF).
- **HTTPS-or-HTTP scheme only.** `file://`, `ftp://`, etc. are rejected.
- **Header / cookie hygiene.** Hop-by-hop headers (`content-encoding`, `transfer-encoding`, …), `Set-Cookie`, and all `Access-Control-*` headers are stripped from the upstream response before returning it. Cloud session state can't leak into the proxy's local origin.
- The proxy itself is mounted under `/api`, which already enforces the local agent-server's session-key authentication. So an unauthenticated user can't invoke the proxy.

### Why this design

- **Envelope, not path-passthrough.** Letting the caller specify the upstream `host`, `method`, `path`, `headers`, and `body` keeps the proxy generic — one endpoint covers the SaaS App API, runtime sandboxes, and any future host on the allowlist.
- **`httpx.AsyncClient`** is already a transitive dependency of the agent-server (used by `conversation_service.py`), so no new third-party dependency.
- **Status / content-type passthrough.** The caller can react to upstream 4xx/5xx the same way it would to a direct fetch.
- **No auth performed by the proxy itself.** Auth headers ride in the envelope and are forwarded server-side. The proxy is a forwarder, not a token vault.

### Acceptance criteria

- [x] `POST /api/cloud-proxy` with a valid envelope forwards the upstream request and returns the upstream status, JSON body, and content-type.
- [x] Allowlist is enforced (default + env var override). Disallowed hosts return 403; loopback rejected; non-HTTP schemes rejected.
- [x] `httpx.RequestError` from the upstream → 502 with detail.
- [x] `Set-Cookie` and `Access-Control-*` headers are stripped from the response.
- [x] No regressions in the existing agent-server test suite.

### Files of note

- `openhands-agent-server/openhands/agent_server/cloud_proxy_router.py` — router, allowlist logic, upstream forwarder.
- `openhands-agent-server/openhands/agent_server/api.py` — registers the router under the existing `/api` prefix, inheriting the session-key auth dependency.
- `tests/agent_server/test_cloud_proxy_router.py` — 11 cases covering the allowlist (canonical host, subdomain match, loopback denial, scheme rejection, env-var override), upstream success, error propagation, host denial, network error → 502, and header stripping.

### Summary

- Adds `POST /api/cloud-proxy` to the agent-server: a generic forwarder for browser-originated requests to OpenHands SaaS hosts.
- Lets `agent-server-gui` (and any future companion client) call the SaaS App API and runtime sandboxes without exposing the cloud bearer token to a cross-origin browser fetch and without requiring CORS changes on the SaaS side.
- 11 unit tests covering happy path, allowlist, error propagation, and header stripping. No changes to existing routes.

### Why

The agent-server is the natural host for terminating browser requests that need to reach the SaaS. It already runs same-origin (or
allowlisted-origin) with the GUI and already enforces the session-key auth boundary. Forwarding through it gives:

- **Same-origin browser hop.** Browser → local agent-server, no CORS.
- **Server-side upstream call.** No browser CORS at the SaaS side either, because the request originates from the agent-server.
- **Token stays server-side after one inbound hop.** The cloud bearer token rides in the envelope body, gets attached to the upstream request server-side, and never leaves the user's machine via a cross-origin browser fetch.
- **One endpoint, two upstream families.** The same envelope (`host`, `method`, `path`, `headers`, `body`) works for the SaaS App API (`app.all-hands.dev/api/v1/...`, `Authorization: Bearer`) and for runtime sandboxes (`*.prod-runtime.all-hands.dev/api/...`, `X-Session-API-Key`).

### What changed

#### New router (`openhands/agent_server/cloud_proxy_router.py`)

```python
cloud_proxy_router = APIRouter(prefix="/cloud-proxy", tags=["Cloud Proxy"])

class CloudProxyRequest(BaseModel):
    host: str
    method: str = "GET"
    path: str
    headers: dict[str, str] = Field(default_factory=dict)
    body: Any = None
    timeout_seconds: float = Field(default=15.0, ge=1.0, le=60.0)

@cloud_proxy_router.post("")
async def cloud_proxy(req: CloudProxyRequest) -> Response:
    if not _is_host_allowed(req.host):
        raise HTTPException(status_code=403, detail=...)
    upstream = await _forward_upstream(...)
    return passthrough_response(upstream)
```

Highlights:

- **Allowlist** built from `OH_CLOUD_PROXY_ALLOWED_HOSTS` (env var, comma-separated), defaulting to `("all-hands.dev",)`. Subdomain matched via suffix, so `app.all-hands.dev` and any `*.prod-runtime.all-hands.dev` are both allowed.
- **Loopback denylist** (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) applied unconditionally so the proxy can't be turned into an open SSRF relay against other local services.
- **Scheme guard** rejects anything that isn't `http://` or `https://`.
- **`_forward_upstream`** is a tiny helper that wraps the actual `httpx.AsyncClient.request(...)` call. Factored out solely so tests can mock it cleanly without affecting the test harness's own `httpx` clients.
- **Response passthrough**: status code propagated, JSON body parsed and re-emitted as `JSONResponse` when content-type is JSON, otherwise returned as raw bytes with the upstream content-type. Hop-by-hop headers, `Set-Cookie`, and `Access-Control-*` are stripped.
- **Error mapping**: `httpx.RequestError` (network failures) → 502 with `Upstream error: <reason>`; pydantic validation errors → 422 via FastAPI's standard handler.

#### Wire-up (`openhands/agent_server/api.py`)

Two lines: an import and an `api_router.include_router(...)` call under the existing `/api` prefix. The proxy inherits the session-key auth dependency that already gates `/api/*` routes — an unauthenticated client can't invoke it.

#### Tests (`tests/agent_server/test_cloud_proxy_router.py`)

- `TestHostAllowlist` (6 cases): canonical host, subdomain suffix match, loopback denial, unrelated host denial, non-HTTP scheme rejection, env-var override fully replacing the default list.
- `test_proxy_forwards_get_and_returns_upstream_json`: end-to-end happy path, asserts both the recorded upstream call (method, URL, headers) and the passthrough response.
- `test_proxy_propagates_upstream_error_status`: 401 from upstream → 401 from proxy with body intact.
- `test_proxy_rejects_disallowed_host`: 403.
- `test_proxy_returns_502_on_upstream_network_error`: `ConnectError` → 502.
- `test_proxy_strips_upstream_set_cookie_and_cors_headers`: the scrubbing layer.

### Expected impact

- **Existing routes:** no changes. Proxy is mounted alongside them.
- **Performance:** one additional in-process JSON encode/decode + one outbound HTTP call per proxied request. Negligible compared to the network leg.
- **Operator config:** none required for the default `*.all-hands.dev` setup. Operators who want to point a companion GUI at a different SaaS deployment can set `OH_CLOUD_PROXY_ALLOWED_HOSTS=example.com,api.example.com`.
- **Companion clients:** `agent-server-gui` ships a corresponding client (`callCloudProxy`) in a sibling PR; the two together eliminate every cross-origin browser fetch the GUI would otherwise need.

### Out of scope

- Caching of upstream responses (could be a follow-up; today every call is a fresh hop).
- Streaming responses (the current implementation buffers; fine for the JSON-shaped APIs we use, would need work for SSE).
- Per-route rate-limiting (the proxy inherits whatever the agent-server itself has, which today is nothing).

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

- [x] `uv run pytest tests/agent_server/test_cloud_proxy_router.py` — 11/11 green.
- [x] `uv run pytest tests/agent_server/` — full agent-server suite passes; no regressions in adjacent routers.
- [x] Manual: `curl -X POST http://127.0.0.1:18000/api/cloud-proxy
    -H "Content-Type: application/json"
    -H "X-Session-API-Key: $OH_SECRET_KEY"
    -d '{"host":"https://app.all-hands.dev","method":"POST",
          "path":"/api/authenticate",
          "headers":{"Authorization":"Bearer $CLOUD_KEY"}}'`
      returns the SaaS authenticate response (200 with valid key,
      401 with bad key).
- [x] Manual: same with `host` = a runtime sandbox URL and `X-Session-API-Key` in headers — round-trips correctly.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2105eac-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2105eac-python \
  ghcr.io/openhands/agent-server:2105eac-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2105eac-golang-amd64
ghcr.io/openhands/agent-server:2105eac-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2105eac-golang-arm64
ghcr.io/openhands/agent-server:2105eac-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2105eac-java-amd64
ghcr.io/openhands/agent-server:2105eac-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2105eac-java-arm64
ghcr.io/openhands/agent-server:2105eac-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2105eac-python-amd64
ghcr.io/openhands/agent-server:2105eac-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2105eac-python-arm64
ghcr.io/openhands/agent-server:2105eac-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2105eac-golang
ghcr.io/openhands/agent-server:2105eac-java
ghcr.io/openhands/agent-server:2105eac-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2105eac-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2105eac-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->