### PR TITLE
ci: replace kimi-k2-thinking with kimi-k2.6 in integration test defaults

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -50,7 +50,7 @@ on:
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
     # Default models for scheduled/label-triggered runs (subset of models from resolve_model_config.py)
-    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v3.2-reasoner,kimi-k2-thinking,gemini-3.1-pro
+    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v3.2-reasoner,kimi-k2.6,gemini-3.1-pro
 
 jobs:
     setup-matrix:

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -50,7 +50,7 @@ on:
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
     # Default models for scheduled/label-triggered runs (subset of models from resolve_model_config.py)
-    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v3.2-reasoner,kimi-k2.6,gemini-3.1-pro
+    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v4-flash,kimi-k2.6,gemini-3.1-pro
 
 jobs:
     setup-matrix:

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -72,7 +72,7 @@ Defined in `.github/workflows/integration-runner.yml`, this workflow runs integr
 2. **Manual Trigger**: Via workflow dispatch with a required reason
 3. **Scheduled Runs**: Daily at 10:30 PM UTC (cron: `30 22 * * *`)
 
-**Test Coverage:** Runs across 6 LLM models (Claude Sonnet 4.5, GPT-5.1 Codex Max, Deepseek, Kimi K2, Gemini 3.1 Pro, Devstral 2512)
+**Test Coverage:** Runs across 4 LLM models (Claude Sonnet 4.6, DeepSeek V3.2 Reasoner, Kimi K2.6, Gemini 3.1 Pro)
 
 ### Condenser Tests Workflow
 

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -72,7 +72,7 @@ Defined in `.github/workflows/integration-runner.yml`, this workflow runs integr
 2. **Manual Trigger**: Via workflow dispatch with a required reason
 3. **Scheduled Runs**: Daily at 10:30 PM UTC (cron: `30 22 * * *`)
 
-**Test Coverage:** Runs across 4 LLM models (Claude Sonnet 4.6, DeepSeek V3.2 Reasoner, Kimi K2.6, Gemini 3.1 Pro)
+**Test Coverage:** Runs across 4 LLM models (Claude Sonnet 4.6, DeepSeek V4 Flash, Kimi K2.6, Gemini 3.1 Pro)
 
 ### Condenser Tests Workflow
 


### PR DESCRIPTION
## Summary

Replace `kimi-k2-thinking` with `kimi-k2.6` in the default model set for integration tests.

## Changes

- **`.github/workflows/integration-runner.yml`**: Updated `DEFAULT_MODEL_IDS` to use `kimi-k2.6` instead of `kimi-k2-thinking`
- **`tests/integration/README.md`**: Updated the test coverage description to reflect the current default model list (Claude Sonnet 4.6, DeepSeek V3.2 Reasoner, Kimi K2.6, Gemini 3.1 Pro)

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cc62fa38-b4cd-4ce2-a6ad-3ee9b6b04802)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4524c9b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4524c9b-python \
  ghcr.io/openhands/agent-server:4524c9b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4524c9b-golang-amd64
ghcr.io/openhands/agent-server:4524c9b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4524c9b-golang-arm64
ghcr.io/openhands/agent-server:4524c9b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4524c9b-java-amd64
ghcr.io/openhands/agent-server:4524c9b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4524c9b-java-arm64
ghcr.io/openhands/agent-server:4524c9b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4524c9b-python-amd64
ghcr.io/openhands/agent-server:4524c9b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4524c9b-python-arm64
ghcr.io/openhands/agent-server:4524c9b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4524c9b-golang
ghcr.io/openhands/agent-server:4524c9b-java
ghcr.io/openhands/agent-server:4524c9b-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4524c9b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4524c9b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->