### PR TITLE
Fix release workflow dispatch token

### DIFF
--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -18,6 +18,7 @@ jobs:
             !github.event.release.prerelease
         runs-on: ubuntu-24.04
         permissions:
+            actions: write
             contents: read
         outputs:
             version: ${{ steps.extract_version.outputs.version }}
@@ -79,7 +80,7 @@ jobs:
 
             - name: Dispatch version bump workflow
               env:
-                  GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
+                  GH_TOKEN: ${{ github.token }}
                   VERSION: ${{ steps.extract_version.outputs.version }}
               run: |
                   gh workflow run version-bump-prs.yml \


### PR DESCRIPTION
## Summary

- Grant the PyPI release workflow `actions: write` so it can dispatch the downstream version bump workflow.
- Use the workflow token for the dispatch step instead of the bot PAT.

## Root cause

The v1.21.0 publish job uploaded all packages successfully, then failed when `gh workflow run version-bump-prs.yml` returned HTTP 403 for `OPENHANDS_BOT_GITHUB_PAT_PUBLIC`.

## Validation

- `uv run pre-commit run --files .github/workflows/pypi-release.yml`

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:12d6818-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-12d6818-python \
  ghcr.io/openhands/agent-server:12d6818-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:12d6818-golang-amd64
ghcr.io/openhands/agent-server:12d6818-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:12d6818-golang-arm64
ghcr.io/openhands/agent-server:12d6818-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:12d6818-java-amd64
ghcr.io/openhands/agent-server:12d6818-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:12d6818-java-arm64
ghcr.io/openhands/agent-server:12d6818-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:12d6818-python-amd64
ghcr.io/openhands/agent-server:12d6818-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:12d6818-python-arm64
ghcr.io/openhands/agent-server:12d6818-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:12d6818-golang
ghcr.io/openhands/agent-server:12d6818-java
ghcr.io/openhands/agent-server:12d6818-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `12d6818-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `12d6818-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->