### PR TITLE
ci: read integration test default models from checked-out branch

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -43,6 +43,17 @@ if sigalrm := getattr(signal, "SIGALRM", None):
 # Keep this list in sync with SDK LLM config parameters that are SDK-internal.
 SDK_ONLY_PARAMS = {"disable_vision"}
 
+# Default model IDs for scheduled/label-triggered integration test runs.
+# This list is the single source of truth; the integration-runner workflow
+# reads it from the checked-out branch via `resolve_model_config.py`, so
+# changes on release branches take effect even though `pull_request_target`
+# evaluates workflow-level env vars from the default branch.
+DEFAULT_INTEGRATION_MODEL_IDS = [
+    "claude-sonnet-4-6",
+    "deepseek-v4-flash",
+    "kimi-k2.6",
+    "gemini-3.1-pro",
+]
 
 # Model configurations dictionary
 MODELS = {

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -49,8 +49,6 @@ on:
 
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
-    # Default models for scheduled/label-triggered runs (subset of models from resolve_model_config.py)
-    DEFAULT_MODEL_IDS: claude-sonnet-4-6,deepseek-v4-flash,kimi-k2.6,gemini-3.1-pro
 
 jobs:
     setup-matrix:
@@ -75,27 +73,26 @@ jobs:
               id: resolve-models
               env:
                   MODEL_IDS_INPUT: ${{ github.event.inputs.model_ids || '' }}
-                  DEFAULT_MODEL_IDS: ${{ env.DEFAULT_MODEL_IDS }}
               run: |
-                  # Use input model_ids if provided, otherwise use defaults
-                  if [ -z "$MODEL_IDS_INPUT" ]; then
-                    MODEL_IDS="$DEFAULT_MODEL_IDS"
-                    echo "No model_ids specified, using defaults: $MODEL_IDS"
-                  else
-                    MODEL_IDS="$MODEL_IDS_INPUT"
-                    echo "Using specified model_ids: $MODEL_IDS"
-                  fi
-
-                  # Resolve model configs using resolve_model_config.py
-                  # Transform output to matrix format for integration tests
-                  MATRIX=$(python3 << EOF
+                  # Resolve model configs using resolve_model_config.py from the
+                  # checked-out branch.  DEFAULT_INTEGRATION_MODEL_IDS lives in
+                  # that file so release branches can update the default set
+                  # without waiting for main to be updated (pull_request_target
+                  # evaluates workflow-level env from the default branch).
+                  MATRIX=$(python3 << 'EOF'
                   import json
+                  import os
                   import sys
                   sys.path.insert(0, '.github/run-eval')
-                  from resolve_model_config import MODELS
+                  from resolve_model_config import DEFAULT_INTEGRATION_MODEL_IDS, MODELS
 
-                  model_ids = "$MODEL_IDS".split(",")
-                  model_ids = [m.strip() for m in model_ids if m.strip()]
+                  model_ids_input = os.environ.get("MODEL_IDS_INPUT", "").strip()
+                  if model_ids_input:
+                      model_ids = [m.strip() for m in model_ids_input.split(",") if m.strip()]
+                      print(f"Using specified model_ids: {','.join(model_ids)}", file=sys.stderr)
+                  else:
+                      model_ids = list(DEFAULT_INTEGRATION_MODEL_IDS)
+                      print(f"No model_ids specified, using defaults: {','.join(model_ids)}", file=sys.stderr)
 
                   matrix = []
                   for model_id in model_ids:
@@ -104,7 +101,6 @@ jobs:
                           print(f"Error: Model ID '{model_id}' not found. Available: {available}", file=sys.stderr)
                           sys.exit(1)
                       model = MODELS[model_id]
-                      # Create run-suffix from model id (replace special chars with underscore)
                       run_suffix = model_id.replace("-", "_").replace(".", "_") + "_run"
                       matrix.append({
                           "id": model_id,

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -14,6 +14,7 @@ from pydantic import BaseModel, field_validator, model_validator
 run_eval_path = Path(__file__).parent.parent.parent / ".github" / "run-eval"
 sys.path.append(str(run_eval_path))
 from resolve_model_config import (  # noqa: E402  # type: ignore[import-not-found]
+    DEFAULT_INTEGRATION_MODEL_IDS,
     MODELS,
     check_model,
     find_models_by_id,
@@ -659,3 +660,12 @@ def test_deepseek_v4_flash_config():
     assert model["id"] == "deepseek-v4-flash"
     assert model["display_name"] == "DeepSeek V4 Flash"
     assert model["llm_config"]["model"] == "litellm_proxy/deepseek/deepseek-v4-flash"
+
+
+def test_default_integration_model_ids_all_exist():
+    """Every ID in DEFAULT_INTEGRATION_MODEL_IDS must exist in MODELS."""
+    for model_id in DEFAULT_INTEGRATION_MODEL_IDS:
+        assert model_id in MODELS, (
+            f"DEFAULT_INTEGRATION_MODEL_IDS contains '{model_id}' "
+            f"which is not in MODELS"
+        )


### PR DESCRIPTION
## Problem

The `integration-runner.yml` workflow uses `pull_request_target`, which always evaluates workflow-level `env:` vars from the **default branch** (main). When a release branch updates the default model list before those changes are merged to main, the integration tests still run with the old model set.

This is what happened with the v1.21.0 release PR #3103: the `integration-test` label was applied before the model update PR #3102 was merged to main, so CI ran against `kimi-k2-thinking` and `deepseek-v3.2-reasoner` instead of the intended `kimi-k2.6` and `deepseek-v4-flash`.

## Fix

Move the default model list from a workflow-level `env:` var (`DEFAULT_MODEL_IDS`) into a Python constant (`DEFAULT_INTEGRATION_MODEL_IDS`) in `.github/run-eval/resolve_model_config.py`.

Since the `setup-matrix` step already checks out the PR branch before running `resolve_model_config.py`, the Python constant is always read from the **correct branch** — regardless of what main contains.

## Changes

| File | Change |
|---|---|
| `.github/run-eval/resolve_model_config.py` | Add `DEFAULT_INTEGRATION_MODEL_IDS` list |
| `.github/workflows/integration-runner.yml` | Remove `DEFAULT_MODEL_IDS` env var; read defaults from Python |
| `tests/cross/test_resolve_model_config.py` | Add test that all default IDs exist in `MODELS` |

## How to update default models going forward

Edit the `DEFAULT_INTEGRATION_MODEL_IDS` list in `.github/run-eval/resolve_model_config.py`. Changes take effect immediately on any branch — no need to wait for main to be updated.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/cc62fa38-b4cd-4ce2-a6ad-3ee9b6b04802)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d220ba0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d220ba0-python \
  ghcr.io/openhands/agent-server:d220ba0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d220ba0-golang-amd64
ghcr.io/openhands/agent-server:d220ba0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d220ba0-golang-arm64
ghcr.io/openhands/agent-server:d220ba0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d220ba0-java-amd64
ghcr.io/openhands/agent-server:d220ba0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d220ba0-java-arm64
ghcr.io/openhands/agent-server:d220ba0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d220ba0-python-amd64
ghcr.io/openhands/agent-server:d220ba0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d220ba0-python-arm64
ghcr.io/openhands/agent-server:d220ba0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d220ba0-golang
ghcr.io/openhands/agent-server:d220ba0-java
ghcr.io/openhands/agent-server:d220ba0-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d220ba0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d220ba0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->