### PR TITLE
feat(workspace): Add completion callback support to RemoteWorkspace

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -68,11 +68,6 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     """
 
     _client: httpx.Client | None = PrivateAttr(default=None)
-
-    # Callback state (read from env vars via _init_callback_settings)
-    _automation_callback_url: str | None = PrivateAttr(default=None)
-    _automation_callback_api_key: str | None = PrivateAttr(default=None)
-    _automation_run_id: str | None = PrivateAttr(default=None)
     _conversation_id: str | None = PrivateAttr(default=None)
 
     def reset_client(self) -> None:
@@ -277,28 +272,18 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         """
         return self._conversation_id
 
-    def _init_callback_settings(self) -> None:
-        """Read automation callback settings from environment variables.
-
-        Called by subclasses in model_post_init() to initialize callback settings.
-        Reads:
-          - ``AUTOMATION_CALLBACK_URL`` — URL to POST completion status to
-          - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
-          - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
-        """
-        self._automation_callback_url = os.environ.get("AUTOMATION_CALLBACK_URL")
-        self._automation_callback_api_key = os.environ.get(
-            "AUTOMATION_CALLBACK_API_KEY"
-        )
-        self._automation_run_id = os.environ.get("AUTOMATION_RUN_ID")
-
     def _send_completion_callback(
         self, exc_type: type | None, exc_val: BaseException | None
     ) -> None:
         """POST completion status to the automation service (best-effort).
 
         Call this from ``__exit__`` before ``cleanup()``. Does nothing when
-        ``AUTOMATION_CALLBACK_URL`` env var was not set.
+        ``AUTOMATION_CALLBACK_URL`` env var is not set.
+
+        Reads configuration from environment variables:
+          - ``AUTOMATION_CALLBACK_URL`` — URL to POST completion status to
+          - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
+          - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
 
         Includes ``conversation_id`` in the payload if one was registered via
         ``register_conversation()``.
@@ -307,18 +292,17 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             exc_type: Exception type if an exception was raised, None otherwise
             exc_val: Exception value if an exception was raised, None otherwise
         """
-        try:
-            callback_url = self._automation_callback_url
-        except AttributeError:
-            return
-
+        callback_url = os.environ.get("AUTOMATION_CALLBACK_URL")
         if not callback_url:
             return
 
+        callback_api_key = os.environ.get("AUTOMATION_CALLBACK_API_KEY")
+        run_id = os.environ.get("AUTOMATION_RUN_ID")
+
         status = "COMPLETED" if exc_type is None else "FAILED"
         payload: dict[str, Any] = {"status": status}
-        if self._automation_run_id:
-            payload["run_id"] = self._automation_run_id
+        if run_id:
+            payload["run_id"] = run_id
         if exc_val is not None:
             payload["error"] = str(exc_val)
 
@@ -328,8 +312,8 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
 
         try:
             headers: dict[str, str] = {}
-            if self._automation_callback_api_key:
-                headers["Authorization"] = f"Bearer {self._automation_callback_api_key}"
+            if callback_api_key:
+                headers["Authorization"] = f"Bearer {callback_api_key}"
             with httpx.Client(timeout=10.0) as cb_client:
                 resp = cb_client.post(callback_url, json=payload, headers=headers)
                 logger.info(f"Completion callback sent ({status}): {resp.status_code}")

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -320,6 +320,18 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         except Exception as e:
             logger.warning(f"Completion callback failed: {e}")
 
+    def __exit__(
+        self, exc_type: type | None, exc_val: BaseException | None, exc_tb: Any
+    ) -> None:
+        """Exit the workspace context, send completion callback, and cleanup.
+
+        Sends a completion callback (if configured via env vars) before calling
+        the parent cleanup. Subclasses that override ``__exit__`` should call
+        ``super().__exit__(...)`` to ensure the callback is sent.
+        """
+        self._send_completion_callback(exc_type, exc_val)
+        super().__exit__(exc_type, exc_val, exc_tb)
+
     # ── Settings Methods ──────────────────────────────────────────────────
     # These methods fetch configuration from the agent-server's persisted
     # settings endpoints. Subclasses like OpenHandsCloudWorkspace may override

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -1,3 +1,4 @@
+import os
 from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -51,6 +52,11 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     OpenHands agent server. This is the recommended approach for production deployments
     as it provides better isolation and security.
 
+    Supports optional completion callbacks on exit via environment variables:
+      - ``AUTOMATION_CALLBACK_URL`` — URL to POST completion status to
+      - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
+      - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
+
     Example:
         >>> workspace = RemoteWorkspace(
         ...     host="https://agent-server.example.com",
@@ -62,6 +68,12 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
     """
 
     _client: httpx.Client | None = PrivateAttr(default=None)
+
+    # Callback state (read from env vars via _init_callback_settings)
+    _automation_callback_url: str | None = PrivateAttr(default=None)
+    _automation_callback_api_key: str | None = PrivateAttr(default=None)
+    _automation_run_id: str | None = PrivateAttr(default=None)
+    _conversation_id: str | None = PrivateAttr(default=None)
 
     def reset_client(self) -> None:
         """Reset the HTTP client to force re-initialization.
@@ -247,14 +259,14 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         """Register a conversation ID with this workspace.
 
         Called by RemoteConversation after creation to associate the conversation
-        with the workspace. Subclasses can override to track conversation IDs
-        for callbacks or other purposes.
+        with the workspace. The conversation ID is included in the completion
+        callback sent to the automation service.
 
         Args:
             conversation_id: The conversation ID to register
         """
-        # Default implementation is a no-op
-        pass
+        self._conversation_id = conversation_id
+        logger.debug(f"Registered conversation: {conversation_id}")
 
     @property
     def conversation_id(self) -> str | None:
@@ -263,7 +275,66 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         Returns:
             The conversation ID if one has been registered, None otherwise.
         """
-        return None
+        return self._conversation_id
+
+    def _init_callback_settings(self) -> None:
+        """Read automation callback settings from environment variables.
+
+        Called by subclasses in model_post_init() to initialize callback settings.
+        Reads:
+          - ``AUTOMATION_CALLBACK_URL`` — URL to POST completion status to
+          - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
+          - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
+        """
+        self._automation_callback_url = os.environ.get("AUTOMATION_CALLBACK_URL")
+        self._automation_callback_api_key = os.environ.get(
+            "AUTOMATION_CALLBACK_API_KEY"
+        )
+        self._automation_run_id = os.environ.get("AUTOMATION_RUN_ID")
+
+    def _send_completion_callback(
+        self, exc_type: type | None, exc_val: BaseException | None
+    ) -> None:
+        """POST completion status to the automation service (best-effort).
+
+        Call this from ``__exit__`` before ``cleanup()``. Does nothing when
+        ``AUTOMATION_CALLBACK_URL`` env var was not set.
+
+        Includes ``conversation_id`` in the payload if one was registered via
+        ``register_conversation()``.
+
+        Args:
+            exc_type: Exception type if an exception was raised, None otherwise
+            exc_val: Exception value if an exception was raised, None otherwise
+        """
+        try:
+            callback_url = self._automation_callback_url
+        except AttributeError:
+            return
+
+        if not callback_url:
+            return
+
+        status = "COMPLETED" if exc_type is None else "FAILED"
+        payload: dict[str, Any] = {"status": status}
+        if self._automation_run_id:
+            payload["run_id"] = self._automation_run_id
+        if exc_val is not None:
+            payload["error"] = str(exc_val)
+
+        # Include conversation_id if one was registered
+        if self._conversation_id is not None:
+            payload["conversation_id"] = self._conversation_id
+
+        try:
+            headers: dict[str, str] = {}
+            if self._automation_callback_api_key:
+                headers["Authorization"] = f"Bearer {self._automation_callback_api_key}"
+            with httpx.Client(timeout=10.0) as cb_client:
+                resp = cb_client.post(callback_url, json=payload, headers=headers)
+                logger.info(f"Completion callback sent ({status}): {resp.status_code}")
+        except Exception as e:
+            logger.warning(f"Completion callback failed: {e}")
 
     # ── Settings Methods ──────────────────────────────────────────────────
     # These methods fetch configuration from the agent-server's persisted

--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -422,5 +422,5 @@ class APIRemoteWorkspace(RemoteWorkspace):
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        self._send_completion_callback(exc_type, exc_val)
+        super().__exit__(exc_type, exc_val, exc_tb)
         self.cleanup()

--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -131,6 +131,9 @@ class APIRemoteWorkspace(RemoteWorkspace):
 
         self.runtime_api_url = self.runtime_api_url.rstrip("/")
 
+        # Initialize callback settings from env vars
+        self._init_callback_settings()
+
         try:
             self._start_or_attach_to_runtime()
             super().model_post_init(context)
@@ -422,4 +425,5 @@ class APIRemoteWorkspace(RemoteWorkspace):
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
+        self._send_completion_callback(exc_type, exc_val)
         self.cleanup()

--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -131,9 +131,6 @@ class APIRemoteWorkspace(RemoteWorkspace):
 
         self.runtime_api_url = self.runtime_api_url.rstrip("/")
 
-        # Initialize callback settings from env vars
-        self._init_callback_settings()
-
         try:
             self._start_or_attach_to_runtime()
             super().model_post_init(context)

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -951,3 +951,186 @@ def test_load_skills_from_agent_server_with_project_dirs():
         # Should have loaded global skills + 2 project dirs = 3 calls
         assert mock_post.call_count == 3
         assert len(skills) >= 1  # At least the global skill
+
+
+# --- Completion callback tests ---
+
+
+def test_register_conversation_stores_id():
+    """Test register_conversation stores the conversation ID."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    workspace.register_conversation("conv-123")
+
+    assert workspace._conversation_id == "conv-123"
+    assert workspace.conversation_id == "conv-123"
+
+
+def test_conversation_id_property_returns_none_initially():
+    """Test conversation_id property returns None when not registered."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+
+    assert workspace.conversation_id is None
+
+
+def test_init_callback_settings_reads_env_vars(monkeypatch):
+    """Test _init_callback_settings reads from environment variables."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_CALLBACK_API_KEY", "test-api-key")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
+
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._init_callback_settings()
+
+    assert workspace._automation_callback_url == "https://svc.test/complete"
+    assert workspace._automation_callback_api_key == "test-api-key"
+    assert workspace._automation_run_id == "run-42"
+
+
+def test_send_completion_callback_on_success(monkeypatch):
+    """Test _send_completion_callback POSTs COMPLETED status."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = "https://svc.test/complete"
+    workspace._automation_callback_api_key = "test-api-key"
+    workspace._automation_run_id = "run-42"
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        workspace._send_completion_callback(None, None)
+
+        mock_client.post.assert_called_once()
+        (url,) = mock_client.post.call_args.args
+        payload = mock_client.post.call_args.kwargs["json"]
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert url == "https://svc.test/complete"
+        assert payload["status"] == "COMPLETED"
+        assert payload["run_id"] == "run-42"
+        assert "error" not in payload
+        assert headers["Authorization"] == "Bearer test-api-key"
+
+
+def test_send_completion_callback_on_failure(monkeypatch):
+    """Test _send_completion_callback POSTs FAILED status with error."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = "https://svc.test/complete"
+    workspace._automation_run_id = "run-99"
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        exc = RuntimeError("script crashed")
+        workspace._send_completion_callback(RuntimeError, exc)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "FAILED"
+        assert payload["run_id"] == "run-99"
+        assert "script crashed" in payload["error"]
+
+
+def test_send_completion_callback_no_op_without_url():
+    """Test _send_completion_callback does nothing when URL not set."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = None
+
+    with patch("httpx.Client") as MockClient:
+        workspace._send_completion_callback(None, None)
+        MockClient.assert_not_called()
+
+
+def test_send_completion_callback_swallows_errors(monkeypatch):
+    """Test _send_completion_callback doesn't raise on HTTP errors."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = "https://svc.test/complete"
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.side_effect = httpx.ConnectError("refused")
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        # Should not raise
+        workspace._send_completion_callback(None, None)
+
+
+def test_send_completion_callback_without_api_key():
+    """Test _send_completion_callback sends without Authorization when no key."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = "https://svc.test/complete"
+    workspace._automation_callback_api_key = None
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        workspace._send_completion_callback(None, None)
+
+        headers = mock_client.post.call_args.kwargs["headers"]
+        assert "Authorization" not in headers
+
+
+def test_send_completion_callback_includes_conversation_id():
+    """Test _send_completion_callback includes conversation_id when registered."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = "https://svc.test/complete"
+    workspace._automation_run_id = "run-42"
+    workspace.register_conversation("conv-xyz")
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        workspace._send_completion_callback(None, None)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "COMPLETED"
+        assert payload["run_id"] == "run-42"
+        assert payload["conversation_id"] == "conv-xyz"
+
+
+def test_send_completion_callback_omits_conversation_id_when_not_registered():
+    """Test _send_completion_callback omits conversation_id when not registered."""
+    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
+    workspace._automation_callback_url = "https://svc.test/complete"
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        workspace._send_completion_callback(None, None)
+
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert "conversation_id" not in payload

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -973,26 +973,13 @@ def test_conversation_id_property_returns_none_initially():
     assert workspace.conversation_id is None
 
 
-def test_init_callback_settings_reads_env_vars(monkeypatch):
-    """Test _init_callback_settings reads from environment variables."""
+def test_send_completion_callback_on_success(monkeypatch):
+    """Test _send_completion_callback POSTs COMPLETED status."""
     monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
     monkeypatch.setenv("AUTOMATION_CALLBACK_API_KEY", "test-api-key")
     monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
 
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._init_callback_settings()
-
-    assert workspace._automation_callback_url == "https://svc.test/complete"
-    assert workspace._automation_callback_api_key == "test-api-key"
-    assert workspace._automation_run_id == "run-42"
-
-
-def test_send_completion_callback_on_success(monkeypatch):
-    """Test _send_completion_callback POSTs COMPLETED status."""
-    workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = "https://svc.test/complete"
-    workspace._automation_callback_api_key = "test-api-key"
-    workspace._automation_run_id = "run-42"
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -1019,9 +1006,10 @@ def test_send_completion_callback_on_success(monkeypatch):
 
 def test_send_completion_callback_on_failure(monkeypatch):
     """Test _send_completion_callback POSTs FAILED status with error."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-99")
+
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = "https://svc.test/complete"
-    workspace._automation_run_id = "run-99"
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -1042,10 +1030,11 @@ def test_send_completion_callback_on_failure(monkeypatch):
         assert "script crashed" in payload["error"]
 
 
-def test_send_completion_callback_no_op_without_url():
+def test_send_completion_callback_no_op_without_url(monkeypatch):
     """Test _send_completion_callback does nothing when URL not set."""
+    monkeypatch.delenv("AUTOMATION_CALLBACK_URL", raising=False)
+
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = None
 
     with patch("httpx.Client") as MockClient:
         workspace._send_completion_callback(None, None)
@@ -1054,8 +1043,9 @@ def test_send_completion_callback_no_op_without_url():
 
 def test_send_completion_callback_swallows_errors(monkeypatch):
     """Test _send_completion_callback doesn't raise on HTTP errors."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = "https://svc.test/complete"
 
     with patch("httpx.Client") as MockClient:
         mock_client = MagicMock()
@@ -1068,11 +1058,12 @@ def test_send_completion_callback_swallows_errors(monkeypatch):
         workspace._send_completion_callback(None, None)
 
 
-def test_send_completion_callback_without_api_key():
+def test_send_completion_callback_without_api_key(monkeypatch):
     """Test _send_completion_callback sends without Authorization when no key."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.delenv("AUTOMATION_CALLBACK_API_KEY", raising=False)
+
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = "https://svc.test/complete"
-    workspace._automation_callback_api_key = None
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200
@@ -1090,11 +1081,12 @@ def test_send_completion_callback_without_api_key():
         assert "Authorization" not in headers
 
 
-def test_send_completion_callback_includes_conversation_id():
+def test_send_completion_callback_includes_conversation_id(monkeypatch):
     """Test _send_completion_callback includes conversation_id when registered."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
+
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = "https://svc.test/complete"
-    workspace._automation_run_id = "run-42"
     workspace.register_conversation("conv-xyz")
 
     mock_resp = MagicMock()
@@ -1115,10 +1107,13 @@ def test_send_completion_callback_includes_conversation_id():
         assert payload["conversation_id"] == "conv-xyz"
 
 
-def test_send_completion_callback_omits_conversation_id_when_not_registered():
+def test_send_completion_callback_omits_conversation_id_when_not_registered(
+    monkeypatch,
+):
     """Test _send_completion_callback omits conversation_id when not registered."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+
     workspace = RemoteWorkspace(host="http://localhost:8000", working_dir="/workspace")
-    workspace._automation_callback_url = "https://svc.test/complete"
 
     mock_resp = MagicMock()
     mock_resp.status_code = 200

--- a/tests/workspace/test_api_remote_workspace.py
+++ b/tests/workspace/test_api_remote_workspace.py
@@ -306,19 +306,6 @@ def _make_workspace():
         return ws
 
 
-def test_api_remote_workspace_inits_callback_settings(monkeypatch):
-    """Test that APIRemoteWorkspace calls _init_callback_settings during init."""
-    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
-    monkeypatch.setenv("AUTOMATION_CALLBACK_API_KEY", "test-api-key")
-    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
-
-    ws = _make_workspace()
-
-    assert ws._automation_callback_url == "https://svc.test/complete"
-    assert ws._automation_callback_api_key == "test-api-key"
-    assert ws._automation_run_id == "run-42"
-
-
 def test_api_remote_workspace_exit_sends_callback(monkeypatch):
     """Test that APIRemoteWorkspace.__exit__ sends completion callback."""
     monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")

--- a/tests/workspace/test_api_remote_workspace.py
+++ b/tests/workspace/test_api_remote_workspace.py
@@ -287,3 +287,56 @@ def test_start_runtime_logs_environment_keys_without_values(caplog):
 
             workspace._runtime_id = None
             workspace.cleanup()
+
+
+# --- Callback integration tests ---
+
+
+def _make_workspace():
+    """Create a workspace without starting runtime for callback tests."""
+    from openhands.workspace import APIRemoteWorkspace
+
+    with patch.object(APIRemoteWorkspace, "_start_or_attach_to_runtime"):
+        ws = APIRemoteWorkspace(
+            runtime_api_url="https://example.com",
+            runtime_api_key="test-key",
+            server_image="test-image",
+        )
+        ws._runtime_id = None  # Prevent cleanup from making API calls
+        return ws
+
+
+def test_api_remote_workspace_inits_callback_settings(monkeypatch):
+    """Test that APIRemoteWorkspace calls _init_callback_settings during init."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_CALLBACK_API_KEY", "test-api-key")
+    monkeypatch.setenv("AUTOMATION_RUN_ID", "run-42")
+
+    ws = _make_workspace()
+
+    assert ws._automation_callback_url == "https://svc.test/complete"
+    assert ws._automation_callback_api_key == "test-api-key"
+    assert ws._automation_run_id == "run-42"
+
+
+def test_api_remote_workspace_exit_sends_callback(monkeypatch):
+    """Test that APIRemoteWorkspace.__exit__ sends completion callback."""
+    monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
+    monkeypatch.setenv("AUTOMATION_CALLBACK_API_KEY", "test-api-key")
+    ws = _make_workspace()
+
+    mock_resp = MagicMock()
+    mock_resp.status_code = 200
+
+    with patch("httpx.Client") as MockClient:
+        mock_client = MagicMock()
+        mock_client.post.return_value = mock_resp
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        MockClient.return_value = mock_client
+
+        ws.__exit__(None, None, None)
+
+        mock_client.post.assert_called_once()
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["status"] == "COMPLETED"


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

OpenHands Cloud workspace (`OpenHandsCloudWorkspace`) supports sending completion callbacks on exit for automations via `AUTOMATION_CALLBACK_URL`. This adds similar functionality to the `RemoteWorkspace` base class so all remote workspace implementations can send completion callbacks when configured via environment variables.

## Summary

- Add completion callback support to `RemoteWorkspace` base class via `_init_callback_settings()` and `_send_completion_callback()` methods
- Update `register_conversation()` to store the conversation ID (was a no-op)
- Update `APIRemoteWorkspace` to call the callback methods during init and exit

## Issue Number

N/A - User request

## How to Test

```bash
uv run pytest tests/sdk/workspace/remote/test_remote_workspace.py -v -k callback
uv run pytest tests/workspace/test_api_remote_workspace.py -v -k callback
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Environment variables:
- `AUTOMATION_CALLBACK_URL` — URL to POST completion status to
- `AUTOMATION_CALLBACK_API_KEY` — Bearer token for callback auth (optional)
- `AUTOMATION_RUN_ID` — Run ID to include in callback payload (optional)

_This PR was created by an AI agent (OpenHands) on behalf of the user._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:87af8d7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-87af8d7-python \
  ghcr.io/openhands/agent-server:87af8d7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:87af8d7-golang-amd64
ghcr.io/openhands/agent-server:87af8d7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:87af8d7-golang-arm64
ghcr.io/openhands/agent-server:87af8d7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:87af8d7-java-amd64
ghcr.io/openhands/agent-server:87af8d7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:87af8d7-java-arm64
ghcr.io/openhands/agent-server:87af8d7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:87af8d7-python-amd64
ghcr.io/openhands/agent-server:87af8d7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:87af8d7-python-arm64
ghcr.io/openhands/agent-server:87af8d7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:87af8d7-golang
ghcr.io/openhands/agent-server:87af8d7-java
ghcr.io/openhands/agent-server:87af8d7-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `87af8d7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `87af8d7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->