### PR TITLE
fix(sdk): mark iterative refinement as critical setting

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -169,6 +169,7 @@ class VerificationSettings(BaseModel):
         json_schema_extra={
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
                 label="Enable iterative refinement",
+                prominence=SettingProminence.CRITICAL,
                 depends_on=("critic_enabled",),
             ).model_dump()
         },

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -110,6 +110,10 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
         "finish_and_message",
         "all_actions",
     ]
+    assert (
+        v_fields["verification.enable_iterative_refinement"].prominence
+        is SettingProminence.CRITICAL
+    )
 
 
 def test_acp_agent_settings_export_schema_has_acp_section() -> None:


### PR DESCRIPTION
## Summary

- Mark `verification.enable_iterative_refinement` as a critical SDK setting so clients render it in Basic settings next to `Enable Critic` once its dependency is enabled.
- Add a schema export assertion covering the prominence.

## Context

This replaces the frontend-only workaround that was reverted from OpenHands/OpenHands#14133. The frontend can now pick up the intended Basic visibility directly from the SDK schema after the SDK is bumped in OpenHands.

## Validation

- `make build`
- `uv run pytest tests/sdk/test_settings.py -k "agent_settings_export_schema or iterative_refinement"`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/settings/model.py tests/sdk/test_settings.py`

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6560d50-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6560d50-python \
  ghcr.io/openhands/agent-server:6560d50-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6560d50-golang-amd64
ghcr.io/openhands/agent-server:6560d50-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6560d50-golang-arm64
ghcr.io/openhands/agent-server:6560d50-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6560d50-java-amd64
ghcr.io/openhands/agent-server:6560d50-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6560d50-java-arm64
ghcr.io/openhands/agent-server:6560d50-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6560d50-python-amd64
ghcr.io/openhands/agent-server:6560d50-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6560d50-python-arm64
ghcr.io/openhands/agent-server:6560d50-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6560d50-golang
ghcr.io/openhands/agent-server:6560d50-java
ghcr.io/openhands/agent-server:6560d50-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6560d50-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6560d50-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->