### PR TITLE
Add optional ref query param to /api/git/{changes,diff}

### DIFF
--- a/openhands-agent-server/openhands/agent_server/git_router.py
+++ b/openhands-agent-server/openhands/agent_server/git_router.py
@@ -1,6 +1,7 @@
 """Git router for OpenHands SDK."""
 
 import asyncio
+import functools
 import logging
 from pathlib import Path
 
@@ -17,12 +18,21 @@ git_router = APIRouter(prefix="/git", tags=["Git"])
 logger = logging.getLogger(__name__)
 
 
-async def _get_git_changes(path: str) -> list[GitChange]:
+_REF_QUERY_DESCRIPTION = (
+    "Optional git ref to diff against (e.g. 'HEAD' for git status-style "
+    "changes, or a commit hash). When omitted, the upstream/default branch "
+    "is auto-detected."
+)
+
+
+async def _get_git_changes(path: str, ref: str | None) -> list[GitChange]:
     """Internal helper to get git changes for a given path."""
     update_last_execution_time()
     loop = asyncio.get_running_loop()
     try:
-        return await loop.run_in_executor(None, get_git_changes, Path(path))
+        return await loop.run_in_executor(
+            None, functools.partial(get_git_changes, Path(path), ref=ref)
+        )
     except GitRepositoryError:
         # A non-repo workspace has no git changes to report; respond with an
         # empty list so the Changes tab can render normally instead of 500ing.
@@ -30,12 +40,14 @@ async def _get_git_changes(path: str) -> list[GitChange]:
         return []
 
 
-async def _get_git_diff(path: str) -> GitDiff:
+async def _get_git_diff(path: str, ref: str | None) -> GitDiff:
     """Internal helper to get git diff for a given path."""
     update_last_execution_time()
     loop = asyncio.get_running_loop()
     try:
-        return await loop.run_in_executor(None, get_git_diff, Path(path))
+        return await loop.run_in_executor(
+            None, functools.partial(get_git_diff, Path(path), ref=ref)
+        )
     except GitRepositoryError:
         # Only collapse the not-a-repo case to an empty diff; file-level
         # GitPathError (missing/oversize/outside-repo) stays a 500 so
@@ -47,14 +59,16 @@ async def _get_git_diff(path: str) -> GitDiff:
 @git_router.get("/changes")
 async def git_changes_query(
     path: str = Query(..., description="The git repository path"),
+    ref: str | None = Query(None, description=_REF_QUERY_DESCRIPTION),
 ) -> list[GitChange]:
     """Get git changes using query parameter (preferred method)."""
-    return await _get_git_changes(path)
+    return await _get_git_changes(path, ref)
 
 
 @git_router.get("/diff")
 async def git_diff_query(
     path: str = Query(..., description="The file path to get diff for"),
+    ref: str | None = Query(None, description=_REF_QUERY_DESCRIPTION),
 ) -> GitDiff:
     """Get git diff using query parameter (preferred method)."""
-    return await _get_git_diff(path)
+    return await _get_git_diff(path, ref)

--- a/openhands-sdk/openhands/sdk/git/git_changes.py
+++ b/openhands-sdk/openhands/sdk/git/git_changes.py
@@ -34,26 +34,33 @@ def _map_git_status_to_enum(status: str) -> GitChangeStatus:
     return status_mapping[status]
 
 
-def get_changes_in_repo(repo_dir: str | Path) -> list[GitChange]:
-    """Get git changes in a repository relative to the origin default branch.
+def get_changes_in_repo(
+    repo_dir: str | Path, ref: str | None = None
+) -> list[GitChange]:
+    """Get git changes in a repository relative to a reference.
 
-    This is different from `git status` as it compares against the remote branch
-    rather than the staging area.
+    By default, compares against the auto-detected remote branch. Pass
+    ``ref="HEAD"`` to get ``git status``-style diffs (working tree + index
+    vs the latest commit) instead.
 
     Args:
         repo_dir: Path to the git repository
+        ref: Optional explicit ref to compare against (e.g. ``"HEAD"`` or a
+            commit hash). When ``None``, behaves as before and compares
+            against the upstream/default branch.
 
     Returns:
         List of GitChange objects representing the changes
 
     Raises:
         GitRepositoryError: If the directory is not a valid git repository
-        GitCommandError: If git commands fail
+        GitCommandError: If git commands fail (including when ``ref`` is
+            provided but does not resolve in the repository).
     """
     # Validate the repository first
     validated_repo = validate_git_repository(repo_dir)
 
-    ref = get_valid_ref(validated_repo)
+    ref = get_valid_ref(validated_repo, override=ref)
     if not ref:
         logger.warning(f"No valid git reference found for {validated_repo}")
         return []
@@ -195,14 +202,14 @@ def get_changes_in_repo(repo_dir: str | Path) -> list[GitChange]:
     return changes
 
 
-def get_git_changes(cwd: str | Path) -> list[GitChange]:
+def get_git_changes(cwd: str | Path, ref: str | None = None) -> list[GitChange]:
     git_dirs = {
         os.path.dirname(f)[2:]
         for f in glob.glob("./*/.git", root_dir=cwd, recursive=True)
     }
 
     # First try the workspace directory
-    changes = get_changes_in_repo(cwd)
+    changes = get_changes_in_repo(cwd, ref=ref)
 
     # Filter out any changes which are in one of the git directories
     changes = [
@@ -219,7 +226,7 @@ def get_git_changes(cwd: str | Path) -> list[GitChange]:
 
     # Add changes from git directories
     for git_dir in git_dirs:
-        git_dir_changes = get_changes_in_repo(str(Path(cwd, git_dir)))
+        git_dir_changes = get_changes_in_repo(str(Path(cwd, git_dir)), ref=ref)
         for change in git_dir_changes:
             # Create a new GitChange with the updated path
             updated_change = GitChange(

--- a/openhands-sdk/openhands/sdk/git/git_diff.py
+++ b/openhands-sdk/openhands/sdk/git/git_diff.py
@@ -50,11 +50,14 @@ def get_closest_git_repo(path: Path) -> Path | None:
         current_path = parent
 
 
-def get_git_diff(relative_file_path: str | Path) -> GitDiff:
+def get_git_diff(relative_file_path: str | Path, ref: str | None = None) -> GitDiff:
     """Get git diff for a single file.
 
     Args:
         relative_file_path: Path to the file relative to current working directory
+        ref: Optional explicit ref to compare against (e.g. ``"HEAD"`` or a
+            commit hash). When ``None``, compares against the auto-detected
+            upstream/default branch as before.
 
     Returns:
         GitDiff object containing diff information
@@ -62,7 +65,8 @@ def get_git_diff(relative_file_path: str | Path) -> GitDiff:
     Raises:
         GitPathError: If file is too large or doesn't exist
         GitRepositoryError: If not in a git repository
-        GitCommandError: If git commands fail
+        GitCommandError: If git commands fail (including when ``ref`` is
+            provided but does not resolve in the repository).
     """
     path = Path(os.getcwd(), relative_file_path).resolve()
 
@@ -89,7 +93,7 @@ def get_git_diff(relative_file_path: str | Path) -> GitDiff:
     # Validate the git repository
     validated_repo = validate_git_repository(closest_git_repo)
 
-    current_rev = get_valid_ref(validated_repo)
+    current_rev = get_valid_ref(validated_repo, override=ref)
     if not current_rev:
         logger.warning(f"No valid git reference found for {validated_repo}")
         return GitDiff(modified="", original="")

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -101,10 +101,15 @@ def _repo_has_commits(repo_dir: str | Path) -> bool:
         return False
 
 
-def get_valid_ref(repo_dir: str | Path) -> str | None:
+def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | None:
     """Get a valid git reference to compare against.
 
-    Tries multiple strategies to find a valid reference:
+    If ``override`` is provided, it is resolved via ``git rev-parse --verify``
+    and returned (raising ``GitCommandError`` if it does not resolve). This
+    lets callers request, for example, ``HEAD`` to get ``git status``-style
+    diffs against the latest commit instead of against the remote branch.
+
+    Otherwise, tries multiple strategies to find a valid reference:
     1. Current branch's origin (e.g., origin/main)
     2. Default branch (e.g., origin/main, origin/master)
     3. Merge base with default branch
@@ -112,10 +117,23 @@ def get_valid_ref(repo_dir: str | Path) -> str | None:
 
     Args:
         repo_dir: Path to the git repository
+        override: Optional explicit ref (e.g. ``"HEAD"`` or a commit hash) to
+            use instead of the auto-detected comparison ref.
 
     Returns:
         Valid git reference hash, or None if no valid reference found
+
+    Raises:
+        GitCommandError: If ``override`` is provided and does not resolve.
     """
+    if override is not None:
+        # Resolve explicit override and surface failure to the caller so the
+        # difference between "ref not found" and "no changes" stays visible.
+        return run_git_command(
+            ["git", "--no-pager", "rev-parse", "--verify", f"{override}^{{commit}}"],
+            repo_dir,
+        )
+
     refs_to_try = []
 
     # Check if repo has any commits first. Empty repos (created with git init)

--- a/tests/agent_server/test_git_router.py
+++ b/tests/agent_server/test_git_router.py
@@ -50,7 +50,7 @@ async def test_git_changes_query_param_success(client):
         assert response_data[2]["status"] == "DELETED"
         assert response_data[2]["path"] == "old_file.py"
 
-        mock_git_changes.assert_called_once_with(Path(test_path))
+        mock_git_changes.assert_called_once_with(Path(test_path), ref=None)
 
 
 @pytest.mark.asyncio
@@ -148,7 +148,7 @@ async def test_git_changes_query_param_absolute_path(client):
 
         assert response.status_code == 200
         assert len(response.json()) == 1
-        mock_git_changes.assert_called_once_with(Path(test_path))
+        mock_git_changes.assert_called_once_with(Path(test_path), ref=None)
 
 
 @pytest.mark.asyncio
@@ -170,7 +170,7 @@ async def test_git_diff_query_param_success(client):
 
         assert response_data["modified"] == expected_diff.modified
         assert response_data["original"] == expected_diff.original
-        mock_git_diff.assert_called_once_with(Path(test_path))
+        mock_git_diff.assert_called_once_with(Path(test_path), ref=None)
 
 
 @pytest.mark.asyncio
@@ -273,6 +273,51 @@ async def test_git_changes_with_complex_paths(client):
         assert response_data[0]["path"] == "src/deep/nested/file.py"
         assert response_data[1]["path"] == "file with spaces.txt"
         assert response_data[2]["path"] == "special-chars_file@123.py"
+
+
+@pytest.mark.asyncio
+async def test_git_changes_forwards_ref_query_param(client):
+    """The ``ref`` query param should be plumbed through to ``get_git_changes``."""
+    with patch("openhands.agent_server.git_router.get_git_changes") as mock_git_changes:
+        mock_git_changes.return_value = []
+
+        test_path = "src/test_repo"
+        response = client.get(
+            "/api/git/changes", params={"path": test_path, "ref": "HEAD"}
+        )
+
+        assert response.status_code == 200
+        mock_git_changes.assert_called_once_with(Path(test_path), ref="HEAD")
+
+
+@pytest.mark.asyncio
+async def test_git_diff_forwards_ref_query_param(client):
+    """The ``ref`` query param should be plumbed through to ``get_git_diff``."""
+    with patch("openhands.agent_server.git_router.get_git_diff") as mock_git_diff:
+        mock_git_diff.return_value = GitDiff(modified="m", original="o")
+
+        test_path = "src/test_file.py"
+        response = client.get(
+            "/api/git/diff",
+            params={"path": test_path, "ref": "abc1234"},
+        )
+
+        assert response.status_code == 200
+        mock_git_diff.assert_called_once_with(Path(test_path), ref="abc1234")
+
+
+def test_git_endpoints_expose_ref_query_param(client):
+    """OpenAPI schema should advertise the new optional ``ref`` query param."""
+    response = client.get("/openapi.json")
+    assert response.status_code == 200
+
+    paths = response.json()["paths"]
+    for endpoint in ("/api/git/changes", "/api/git/diff"):
+        params = paths[endpoint]["get"]["parameters"]
+        ref_param = next((p for p in params if p["name"] == "ref"), None)
+        assert ref_param is not None, f"ref param missing on {endpoint}"
+        assert ref_param["in"] == "query"
+        assert ref_param.get("required", False) is False
 
 
 def test_git_legacy_routes_are_removed_from_openapi(client):

--- a/tests/sdk/git/test_git_changes.py
+++ b/tests/sdk/git/test_git_changes.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 import pytest
 
+from openhands.sdk.git.exceptions import GitCommandError
 from openhands.sdk.git.git_changes import get_changes_in_repo, get_git_changes
 from openhands.sdk.git.models import GitChange, GitChangeStatus
 
@@ -362,3 +363,61 @@ def test_git_changes_with_binary_files():
 
         for change in changes:
             assert change.status == GitChangeStatus.ADDED
+
+
+def test_get_changes_in_repo_ref_head_shows_only_uncommitted():
+    """``ref='HEAD'`` should yield git status semantics: working tree vs HEAD."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+
+        # Commit a baseline file so HEAD exists.
+        (Path(temp_dir) / "committed.txt").write_text("baseline")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'initial'", temp_dir)
+
+        # Add an extra commit. Without ref='HEAD' this would still appear in
+        # the changeset (origin auto-detection + empty-tree fallback compares
+        # against the empty tree). With ref='HEAD' it must NOT appear.
+        (Path(temp_dir) / "second.txt").write_text("second commit")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'second'", temp_dir)
+
+        # Now create one untracked + one modified file vs HEAD.
+        (Path(temp_dir) / "committed.txt").write_text("baseline modified")
+        (Path(temp_dir) / "untracked.txt").write_text("new")
+
+        changes = get_changes_in_repo(temp_dir, ref="HEAD")
+
+        paths = {str(c.path) for c in changes}
+        # Files committed at HEAD must not appear; only working-tree changes.
+        assert "second.txt" not in paths
+        assert "committed.txt" in paths
+        assert "untracked.txt" in paths
+
+
+def test_get_changes_in_repo_invalid_ref_raises():
+    """An explicit ref that does not resolve should raise ``GitCommandError``."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        (Path(temp_dir) / "f.txt").write_text("hi")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'init'", temp_dir)
+
+        with pytest.raises(GitCommandError):
+            get_changes_in_repo(temp_dir, ref="definitely-not-a-real-ref")
+
+
+def test_get_git_changes_propagates_ref():
+    """``get_git_changes`` should pass the ref through to inner-repo lookups."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        (Path(temp_dir) / "a.txt").write_text("a")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'init'", temp_dir)
+
+        # Working-tree-only addition.
+        (Path(temp_dir) / "b.txt").write_text("b")
+
+        changes = get_git_changes(temp_dir, ref="HEAD")
+        paths = {str(c.path) for c in changes}
+        assert paths == {"b.txt"}

--- a/tests/sdk/git/test_git_diff.py
+++ b/tests/sdk/git/test_git_diff.py
@@ -284,3 +284,46 @@ def test_git_diff_large_file_error():
 
         with pytest.raises(GitPathError):
             run_in_directory(temp_dir, get_git_diff, "large_file.txt")
+
+
+def test_get_git_diff_ref_head_compares_against_latest_commit():
+    """``ref='HEAD'`` should diff against the latest commit, not the remote."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        target = Path(temp_dir) / "file.txt"
+
+        # First commit (this would be the empty-tree fallback's "original"
+        # in the default behavior).
+        target.write_text("v1\n")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'v1'", temp_dir)
+
+        # Second commit becomes HEAD.
+        target.write_text("v2\n")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'v2'", temp_dir)
+
+        # Working-tree edit (uncommitted).
+        target.write_text("v3\n")
+
+        diff = run_in_directory(temp_dir, get_git_diff, "file.txt", ref="HEAD")
+
+        assert isinstance(diff, GitDiff)
+        # original = HEAD's contents = v2 (NOT v1).
+        assert diff.original == "v2"
+        # modified = working-tree contents = v3.
+        assert diff.modified == "v3"
+
+
+def test_get_git_diff_invalid_ref_raises():
+    """An explicit ref that does not resolve should raise."""
+    from openhands.sdk.git.exceptions import GitCommandError
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        (Path(temp_dir) / "f.txt").write_text("hi")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'init'", temp_dir)
+
+        with pytest.raises(GitCommandError):
+            run_in_directory(temp_dir, get_git_diff, "f.txt", ref="not-a-real-ref")


### PR DESCRIPTION
Both endpoints currently auto-detect the comparison ref via get_valid_ref() (origin/<current_branch> -> origin/<default_branch> -> merge-base -> empty tree), which is the correct behaviour for diffing a feature branch against the remote. There is no way to ask for 'git status'-style diffs against the local HEAD, which a UI like agent-canvas's Changes tab needs.

This adds an optional 'ref' query parameter to both endpoints:

  GET /api/git/changes?path=<repo>&ref=HEAD
  GET /api/git/diff?path=<file>&ref=HEAD

When provided it is resolved via 'git rev-parse --verify <ref>^{commit}' and used directly as the comparison base, so 'ref=HEAD' yields working tree + index vs the latest commit (i.e. exactly what 'git status' / 'git diff HEAD' would show). Invalid refs surface a GitCommandError so callers can distinguish 'no changes' from 'ref not found'. When omitted, the existing auto-detection behaviour is preserved verbatim, so this is a purely additive, backwards-compatible change.

The ref is plumbed through get_valid_ref(override=...), get_changes_in_repo(ref=...), get_git_changes(ref=...) and get_git_diff(ref=...). New SDK-level tests exercise real temporary repos with multiple commits to confirm ref='HEAD' yields the git-status semantics (and that an invalid ref raises). Router tests verify the parameter is forwarded and that the OpenAPI schema advertises it as an optional query param.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0c65267-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0c65267-python \
  ghcr.io/openhands/agent-server:0c65267-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0c65267-golang-amd64
ghcr.io/openhands/agent-server:0c65267-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0c65267-golang-arm64
ghcr.io/openhands/agent-server:0c65267-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0c65267-java-amd64
ghcr.io/openhands/agent-server:0c65267-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0c65267-java-arm64
ghcr.io/openhands/agent-server:0c65267-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0c65267-python-amd64
ghcr.io/openhands/agent-server:0c65267-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0c65267-python-arm64
ghcr.io/openhands/agent-server:0c65267-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0c65267-golang
ghcr.io/openhands/agent-server:0c65267-java
ghcr.io/openhands/agent-server:0c65267-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0c65267-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0c65267-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->