### PR TITLE
feat(sdk): make security_risk tool parameter optional, default to UNKNOWN

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -67,7 +67,6 @@ from openhands.sdk.observability.laminar import (
     should_enable_observability,
 )
 from openhands.sdk.observability.utils import extract_action_name
-from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.tool import (
     Action,
     Observation,
@@ -648,11 +647,9 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
     def _extract_security_risk(
         self,
         arguments: dict,
-        tool_name: str,
         read_only_tool: bool,
         security_analyzer: analyzer.SecurityAnalyzerBase | None = None,
     ) -> risk.SecurityRisk:
-        requires_sr = isinstance(security_analyzer, LLMSecurityAnalyzer)
         raw = arguments.pop("security_risk", None)
 
         # Default risk value for action event
@@ -660,23 +657,14 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         if read_only_tool:
             return risk.SecurityRisk.UNKNOWN
 
-        # Raises exception if failed to pass risk field when expected
-        # Exception will be sent back to agent as error event
-        # Strong models like GPT-5 can correct itself by retrying
-        if requires_sr and raw is None:
-            raise ValueError(
-                f"Failed to provide security_risk field in tool '{tool_name}'"
-            )
-
         # When no security analyzer is configured, ignore any security_risk field
         # from LLM and return UNKNOWN. This ensures that security_risk is only
         # evaluated when a security analyzer is explicitly set.
         if security_analyzer is None:
             return risk.SecurityRisk.UNKNOWN
 
-        # When using non-LLM security analyzer without security risk field
-        # safely ignore missing security risk fields
-        if not requires_sr and raw is None:
+        # security_risk is optional: if the LLM omits it, default to UNKNOWN.
+        if raw is None:
             return risk.SecurityRisk.UNKNOWN
 
         # Raises exception if invalid risk enum passed by LLM
@@ -827,7 +815,6 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             )
             security_risk = self._extract_security_risk(
                 arguments,
-                tool.name,
                 tool.annotations.readOnlyHint if tool.annotations else False,
                 security_analyzer,
             )

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -569,8 +569,7 @@ def create_action_type_with_risk(action_type: type[Schema]) -> type[Schema]:
             (action_type,),
             {
                 "security_risk": Field(
-                    # We do NOT add default value to make it an required field
-                    # default=risk.SecurityRisk.UNKNOWN
+                    default=risk.SecurityRisk.UNKNOWN,
                     description="The LLM's assessment of the safety risk of this action.",  # noqa:E501
                 ),
                 "__annotations__": {"security_risk": risk.SecurityRisk},

--- a/tests/sdk/agent/test_extract_security_risk.py
+++ b/tests/sdk/agent/test_extract_security_risk.py
@@ -73,13 +73,12 @@ def agent_without_analyzer(mock_llm):
         ("agent_without_analyzer", "MEDIUM", SecurityRisk.UNKNOWN, False),
         ("agent_without_analyzer", "HIGH", SecurityRisk.UNKNOWN, False),
         ("agent_without_analyzer", "UNKNOWN", SecurityRisk.UNKNOWN, False),
-        # Case 4: LLM analyzer set, security risk not passed, ValueError raised
-        ("agent_with_llm_analyzer", None, None, True),
-        # Case 5: analyzer is not set, security risk is not passed, UNKNOWN returned
+        # Case 4: security risk not passed -> defaults to UNKNOWN regardless of analyzer
+        ("agent_with_llm_analyzer", None, SecurityRisk.UNKNOWN, False),
         ("agent_with_non_llm_analyzer", None, SecurityRisk.UNKNOWN, False),
         ("agent_without_analyzer", None, SecurityRisk.UNKNOWN, False),
-        # Case 6: invalid security risk value passed
-        # - With LLM analyzer: ValueError raised for validation
+        # Case 5: invalid security risk value passed
+        # - With LLM analyzer: ValueError raised for invalid enum
         # - With non-LLM analyzer: ValueError raised for invalid enum
         # - Without analyzer: ignored, returns UNKNOWN (no validation attempted)
         ("agent_with_llm_analyzer", "INVALID", None, True),
@@ -99,15 +98,11 @@ def test_extract_security_risk(
     if security_risk_value is not None:
         arguments["security_risk"] = security_risk_value
 
-    tool_name = "test_tool"
-
     if should_raise:
         with pytest.raises(ValueError):
-            agent._extract_security_risk(arguments, tool_name, False, security_analyzer)
+            agent._extract_security_risk(arguments, False, security_analyzer)
     else:
-        result = agent._extract_security_risk(
-            arguments, tool_name, False, security_analyzer
-        )
+        result = agent._extract_security_risk(arguments, False, security_analyzer)
         assert result == expected_result
 
         # Verify that security_risk was popped from arguments
@@ -131,7 +126,7 @@ def test_extract_security_risk_arguments_mutation():
     arguments = {"param1": "value1", "security_risk": "LOW", "param2": "value2"}
     original_args = arguments.copy()
 
-    result = agent._extract_security_risk(arguments, "test_tool", False, None)
+    result = agent._extract_security_risk(arguments, False, None)
 
     # Verify result is UNKNOWN when no analyzer is set (security_risk is ignored)
     assert result == SecurityRisk.UNKNOWN
@@ -157,7 +152,7 @@ def test_extract_security_risk_with_empty_arguments():
     )
 
     arguments = {}
-    result = agent._extract_security_risk(arguments, "test_tool", False, None)
+    result = agent._extract_security_risk(arguments, False, None)
 
     # Should return UNKNOWN when no analyzer and no security_risk
     assert result == SecurityRisk.UNKNOWN
@@ -177,9 +172,7 @@ def test_extract_security_risk_with_read_only_tool():
 
     # Test with readOnlyHint=True - should return UNKNOWN regardless of security_risk
     arguments = {"param1": "value1", "security_risk": "HIGH"}
-    result = agent._extract_security_risk(
-        arguments, "test_tool", True, LLMSecurityAnalyzer()
-    )
+    result = agent._extract_security_risk(arguments, True, LLMSecurityAnalyzer())
 
     # Should return UNKNOWN when read_only_tool is True
     assert result == SecurityRisk.UNKNOWN

--- a/tests/sdk/agent/test_tool_validation_error_message.py
+++ b/tests/sdk/agent/test_tool_validation_error_message.py
@@ -83,9 +83,13 @@ def test_validation_error_shows_keys_not_values():
     )
     agent = Agent(llm=llm, tools=[Tool(name="ValidationTestTool")])
 
-    # Create tool call with large arguments but missing security_risk field
+    # Create tool call with large arguments and an invalid security_risk to
+    # trigger a validation error in the same code path.
     large_value = "x" * 1000
-    tool_args = f'{{"command": "view", "path": "/test", "old_str": "{large_value}"}}'
+    tool_args = (
+        f'{{"command": "view", "path": "/test", "old_str": "{large_value}", '
+        f'"security_risk": "INVALID"}}'
+    )
 
     def mock_llm_response(messages, **kwargs):
         return ModelResponse(

--- a/tests/sdk/agent/test_tool_validation_error_message.py
+++ b/tests/sdk/agent/test_tool_validation_error_message.py
@@ -15,9 +15,12 @@ from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
-from openhands.sdk.event import AgentErrorEvent
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import ActionEvent, AgentErrorEvent, ObservationEvent
 from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.security.confirmation_policy import ConfirmRisky
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
+from openhands.sdk.security.risk import SecurityRisk
 from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
 from openhands.sdk.tool.tool import ToolDefinition
 
@@ -201,3 +204,122 @@ def test_unparseable_json_error_message():
     error_msg = error_events[0].error
     assert "validation_test_tool" in error_msg
     assert "unparseable JSON" in error_msg
+
+
+def _mock_llm_response_factory(tool_args: str):
+    """Return a mock LLM callable that emits one tool call with the given args."""
+
+    def mock_llm_response(messages, **kwargs):
+        return ModelResponse(
+            id="mock-1",
+            choices=[
+                Choices(
+                    index=0,
+                    message=LiteLLMMessage(
+                        role="assistant",
+                        content="I'll use the tool.",
+                        tool_calls=[
+                            ChatCompletionMessageToolCall(
+                                id="call_1",
+                                type="function",
+                                function=Function(
+                                    name="validation_test_tool",
+                                    arguments=tool_args,
+                                ),
+                            )
+                        ],
+                    ),
+                    finish_reason="tool_calls",
+                )
+            ],
+            created=0,
+            model="test-model",
+            object="chat.completion",
+        )
+
+    return mock_llm_response
+
+
+def test_tool_call_without_security_risk_succeeds():
+    """Omitting security_risk should not raise; the action gets UNKNOWN risk."""
+    llm = LLM(
+        usage_id="test-llm",
+        model="test-model",
+        api_key=SecretStr("test-key"),
+        base_url="http://test",
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="ValidationTestTool")])
+
+    # Two valid args, NO security_risk field
+    tool_args = '{"command": "view", "path": "/test"}'
+
+    collected_events = []
+    conversation = Conversation(agent=agent, callbacks=[collected_events.append])
+    conversation.set_security_analyzer(LLMSecurityAnalyzer())
+
+    with patch(
+        "openhands.sdk.llm.llm.litellm_completion",
+        side_effect=_mock_llm_response_factory(tool_args),
+    ):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="Do something")])
+        )
+        agent.step(conversation, on_event=collected_events.append)
+
+    # No error events should be emitted
+    error_events = [e for e in collected_events if isinstance(e, AgentErrorEvent)]
+    assert error_events == [], (
+        f"Expected no errors when security_risk is omitted, got: {error_events}"
+    )
+
+    # An ActionEvent with UNKNOWN risk should have been emitted
+    action_events = [e for e in collected_events if isinstance(e, ActionEvent)]
+    assert len(action_events) == 1
+    assert action_events[0].security_risk == SecurityRisk.UNKNOWN
+
+
+def test_omitted_security_risk_still_requires_confirmation():
+    """With LLMSecurityAnalyzer + ConfirmRisky, UNKNOWN risk must not auto-proceed."""
+    llm = LLM(
+        usage_id="test-llm",
+        model="test-model",
+        api_key=SecretStr("test-key"),
+        base_url="http://test",
+    )
+    agent = Agent(llm=llm, tools=[Tool(name="ValidationTestTool")])
+
+    # Two valid args, NO security_risk field
+    tool_args = '{"command": "view", "path": "/test"}'
+
+    collected_events = []
+    conversation = Conversation(agent=agent, callbacks=[collected_events.append])
+    conversation.set_security_analyzer(LLMSecurityAnalyzer())
+    conversation.set_confirmation_policy(ConfirmRisky(confirm_unknown=True))
+
+    with patch(
+        "openhands.sdk.llm.llm.litellm_completion",
+        side_effect=_mock_llm_response_factory(tool_args),
+    ):
+        conversation.send_message(
+            Message(role="user", content=[TextContent(text="Do something")])
+        )
+        agent.step(conversation, on_event=collected_events.append)
+
+    # The action should be pending confirmation, not auto-executed
+    assert (
+        conversation.state.execution_status
+        == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
+    )
+
+    # An ActionEvent should exist with UNKNOWN risk
+    action_events = [e for e in collected_events if isinstance(e, ActionEvent)]
+    assert len(action_events) == 1
+    assert action_events[0].security_risk == SecurityRisk.UNKNOWN
+
+    # No observation should have been produced (action was not executed)
+    observation_events = [
+        e for e in collected_events if isinstance(e, ObservationEvent)
+    ]
+    assert observation_events == [], (
+        "Action should not have been executed while waiting for confirmation"
+    )

--- a/tests/sdk/agent/test_tool_validation_error_message.py
+++ b/tests/sdk/agent/test_tool_validation_error_message.py
@@ -294,7 +294,9 @@ def test_omitted_security_risk_still_requires_confirmation():
     collected_events = []
     conversation = Conversation(agent=agent, callbacks=[collected_events.append])
     conversation.set_security_analyzer(LLMSecurityAnalyzer())
-    conversation.set_confirmation_policy(ConfirmRisky(confirm_unknown=True))
+    # confirm_unknown defaults to True, so the default ConfirmRisky policy
+    # will require confirmation for UNKNOWN-risk actions.
+    conversation.set_confirmation_policy(ConfirmRisky())
 
     with patch(
         "openhands.sdk.llm.llm.litellm_completion",

--- a/tests/sdk/mcp/test_mcp_security_risk.py
+++ b/tests/sdk/mcp/test_mcp_security_risk.py
@@ -87,10 +87,11 @@ def test_mcp_tool_to_openai_with_security_risk():
         f"Unexpected 'data' field in properties. Properties: {props_list}"
     )
 
-    # Both fields should be required
+    # Tool's own parameters remain required; security_risk is optional and defaults
+    # to UNKNOWN when not provided by the LLM.
     assert "url" in required, f"Expected 'url' in required, but got: {required}"
-    assert "security_risk" in required, (
-        f"Expected 'security_risk' in required, but got: {required}"
+    assert "security_risk" not in required, (
+        f"Expected 'security_risk' NOT in required, but got: {required}"
     )
 
 

--- a/tests/sdk/tool/test_tool_definition.py
+++ b/tests/sdk/tool/test_tool_definition.py
@@ -629,17 +629,17 @@ class TestTool:
         writable_no_risk_params = writable_no_risk_function["parameters"]
         assert "security_risk" not in writable_no_risk_params["properties"]
 
-    def test_security_risk_is_required_field_in_schema(self):
-        """Test that _create_action_type_with_risk always makes security_risk a required field."""  # noqa: E501
+    def test_security_risk_is_optional_field_in_schema(self):
+        """Test that _create_action_type_with_risk makes security_risk an optional field defaulting to UNKNOWN."""  # noqa: E501
         from openhands.sdk.tool.tool import create_action_type_with_risk
 
         # Test with a simple action type
         action_type_with_risk = create_action_type_with_risk(ToolMockAction)
 
-        # Get the schema and check that security_risk is in required fields
+        # security_risk should appear in properties but NOT in required
         schema = action_type_with_risk.to_mcp_schema()
         assert "security_risk" in schema["properties"]
-        assert "security_risk" in schema["required"]
+        assert "security_risk" not in schema.get("required", [])
 
         # Test via to_openai_tool method
         tool = MockTestTool(
@@ -653,11 +653,8 @@ class TestTool:
         assert "parameters" in function_chunk
         function_params = function_chunk["parameters"]
 
-        # Verify security_risk is present in properties
         assert "security_risk" in function_params["properties"]
-
-        # Verify security_risk is in the required fields list
-        assert "security_risk" in function_params["required"]
+        assert "security_risk" not in function_params.get("required", [])
 
         # Test with a tool that has annotations but is not read-only
         writable_annotations = ToolAnnotations(
@@ -679,9 +676,8 @@ class TestTool:
         assert "parameters" in writable_function_chunk
         writable_function_params = writable_function_chunk["parameters"]
 
-        # Verify security_risk is present and required
         assert "security_risk" in writable_function_params["properties"]
-        assert "security_risk" in writable_function_params["required"]
+        assert "security_risk" not in writable_function_params.get("required", [])
 
     def test_security_risk_precedes_content_params_in_schema(self):
         """Test that security_risk appears before content parameters in the schema.


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

See slack discussion: https://openhands-ai.slack.com/archives/C06R25BT5B2/p1778172944886569

## Summary

- security_risk is now an optional field on tool action schemas with a default of SecurityRisk.UNKNOWN, instead of a required field.                                                                                                   
- Agent._extract_security_risk no longer raises when the LLM omits security_risk while an LLMSecurityAnalyzer is set — it returns UNKNOWN.
- Cleaned up dead code: removed the requires_sr branch, the unused LLMSecurityAnalyzer import, and the tool_name parameter from _extract_security_risk (only referenced by the removed error message). 

## Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1b45249-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1b45249-python \
  ghcr.io/openhands/agent-server:1b45249-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1b45249-golang-amd64
ghcr.io/openhands/agent-server:1b45249-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1b45249-golang-arm64
ghcr.io/openhands/agent-server:1b45249-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1b45249-java-amd64
ghcr.io/openhands/agent-server:1b45249-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1b45249-java-arm64
ghcr.io/openhands/agent-server:1b45249-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1b45249-python-amd64
ghcr.io/openhands/agent-server:1b45249-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1b45249-python-arm64
ghcr.io/openhands/agent-server:1b45249-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1b45249-golang
ghcr.io/openhands/agent-server:1b45249-java
ghcr.io/openhands/agent-server:1b45249-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1b45249-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1b45249-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->