### PR TITLE
feat(profiles): LLM profile management API

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -35,6 +35,7 @@ from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
 from openhands.agent_server.llm_router import llm_router
 from openhands.agent_server.middleware import LocalhostCORSMiddleware
+from openhands.agent_server.profiles_router import profiles_router
 from openhands.agent_server.server_details_router import (
     get_server_info,
     mark_initialization_complete,
@@ -280,6 +281,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
     api_router.include_router(settings_router)
+    api_router.include_router(profiles_router)
     api_router.include_router(cloud_proxy_router)
     app.include_router(api_router)
     app.include_router(sockets_router)

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -11,6 +11,7 @@ from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import (
     PROFILE_NAME_PATTERN,
     LLMProfileStore,
+    ProfileLimitExceeded,
 )
 from openhands.sdk.logger import get_logger
 
@@ -135,19 +136,22 @@ async def save_profile(
     a new profile would exceed ``MAX_PROFILES``.
     """
     store = LLMProfileStore()
-    filename = f"{name}.json"
-
-    with _store_errors():
-        existing = store.list()
-        if filename not in existing and len(existing) >= MAX_PROFILES:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=(
-                    f"Profile limit reached ({MAX_PROFILES}). "
-                    "Delete a profile before saving a new one."
-                ),
+    try:
+        with _store_errors():
+            store.save(
+                name,
+                body.llm,
+                include_secrets=body.include_secrets,
+                max_profiles=MAX_PROFILES,
             )
-        store.save(name, body.llm, include_secrets=body.include_secrets)
+    except ProfileLimitExceeded:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                f"Profile limit reached ({MAX_PROFILES}). "
+                "Delete a profile before saving a new one."
+            ),
+        )
 
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' saved")
 

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -1,0 +1,338 @@
+"""LLM Profiles router for agent-server.
+
+Provides HTTP endpoints for managing named LLM configurations (profiles).
+Profiles are stored as JSON files via LLMProfileStore.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Annotated, Any, Final
+
+from fastapi import APIRouter, HTTPException, Path, Request, status
+from pydantic import BaseModel, Field, SecretStr
+
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+profiles_router = APIRouter(prefix="/profiles", tags=["Profiles"])
+
+# Profile name constraints: alphanumerics + . _ - only, 1-64 chars.
+# Blocks empty names, path-traversal fragments, and special characters.
+_NAME_PATTERN: Final[str] = r"^[A-Za-z0-9._-]{1,64}$"
+_NAME_REGEX: Final[re.Pattern[str]] = re.compile(_NAME_PATTERN)
+
+# Maximum number of profiles per user (soft cap)
+MAX_PROFILES: Final[int] = 50
+
+ProfileName = Annotated[
+    str,
+    Path(min_length=1, max_length=64, pattern=_NAME_PATTERN),
+]
+
+
+# ── Response/Request Models ────────────────────────────────────────────────
+
+
+class ProfileInfo(BaseModel):
+    """Profile summary for list endpoint."""
+
+    name: str
+    model: str | None = None
+    base_url: str | None = None
+    api_key_set: bool = False
+
+
+class ProfileListResponse(BaseModel):
+    """Response body for listing profiles."""
+
+    profiles: list[ProfileInfo]
+
+
+class ProfileDetailResponse(BaseModel):
+    """Response body for fetching a single profile.
+
+    ``config.api_key`` is always nulled; use ``api_key_set`` to check if set.
+    """
+
+    name: str
+    config: dict[str, Any]
+    api_key_set: bool = False
+
+
+class ProfileMutationResponse(BaseModel):
+    """Response body for save/delete/rename operations."""
+
+    name: str
+    message: str
+
+
+class SaveProfileRequest(BaseModel):
+    """Request body for saving a profile."""
+
+    llm: LLM
+    include_secrets: bool = Field(
+        default=True,
+        description="Whether to persist the API key with the profile.",
+    )
+
+
+class RenameProfileRequest(BaseModel):
+    """Request body for renaming a profile."""
+
+    new_name: str = Field(
+        ...,
+        min_length=1,
+        max_length=64,
+        pattern=_NAME_PATTERN,
+    )
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _get_profile_store(_request: Request) -> LLMProfileStore:
+    """Get or create profile store.
+
+    Uses default directory (~/.openhands/profiles).
+    The request argument is kept for future extensibility (e.g., per-user stores).
+    """
+    return LLMProfileStore()
+
+
+def _has_api_key(llm: LLM) -> bool:
+    """Check if LLM has a non-empty API key configured."""
+    if llm.api_key is None:
+        return False
+    secret_value = (
+        llm.api_key.get_secret_value()
+        if isinstance(llm.api_key, SecretStr)
+        else str(llm.api_key)
+    )
+    return bool(secret_value and secret_value.strip())
+
+
+def _clean_name(filename: str) -> str:
+    """Remove .json extension from filename."""
+    return filename.removesuffix(".json")
+
+
+# ── Endpoints ──────────────────────────────────────────────────────────────
+
+
+@profiles_router.get("", response_model=ProfileListResponse)
+async def list_profiles(request: Request) -> ProfileListResponse:
+    """List all saved LLM profiles.
+
+    Returns profile names with basic model info. API keys are never exposed.
+    """
+    store = _get_profile_store(request)
+
+    try:
+        filenames = store.list()
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    profiles: list[ProfileInfo] = []
+    for filename in filenames:
+        name = _clean_name(filename)
+        try:
+            llm = store.load(name)
+            profiles.append(
+                ProfileInfo(
+                    name=name,
+                    model=llm.model,
+                    base_url=llm.base_url,
+                    api_key_set=_has_api_key(llm),
+                )
+            )
+        except (FileNotFoundError, ValueError) as e:
+            # Skip corrupted profiles but log warning
+            logger.warning(f"Skipping corrupted profile '{name}': {e}")
+            continue
+
+    logger.info(f"Listed {len(profiles)} profile(s)")
+    return ProfileListResponse(profiles=profiles)
+
+
+@profiles_router.get("/{name}", response_model=ProfileDetailResponse)
+async def get_profile(request: Request, name: ProfileName) -> ProfileDetailResponse:
+    """Get a specific profile's configuration.
+
+    Returns the full LLM config with ``api_key`` nulled out.
+    """
+    store = _get_profile_store(request)
+
+    try:
+        llm = store.load(name)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Profile '{name}' not found",
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Profile '{name}' is corrupted: {e}",
+        )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    api_key_set = _has_api_key(llm)
+    config = llm.model_dump(mode="json")
+    config["api_key"] = None  # Never expose in response
+
+    logger.info(f"Retrieved profile '{name}'")
+    return ProfileDetailResponse(name=name, config=config, api_key_set=api_key_set)
+
+
+@profiles_router.post(
+    "/{name}",
+    response_model=ProfileMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def save_profile(
+    request: Request,
+    name: ProfileName,
+    body: SaveProfileRequest,
+) -> ProfileMutationResponse:
+    """Save an LLM configuration as a named profile.
+
+    Overwrites if profile with same name exists. Returns 409 if creating
+    a new profile would exceed the profile limit.
+    """
+    store = _get_profile_store(request)
+
+    # Check profile limit for new profiles
+    try:
+        existing = store.list()
+        clean_existing = [_clean_name(f) for f in existing]
+        if name not in clean_existing and len(existing) >= MAX_PROFILES:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=f"Profile limit reached ({MAX_PROFILES}). "
+                "Delete a profile before saving a new one.",
+            )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    try:
+        store.save(name, body.llm, include_secrets=body.include_secrets)
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
+
+    logger.info(f"Saved profile '{name}'")
+    return ProfileMutationResponse(name=name, message=f"Profile '{name}' saved")
+
+
+@profiles_router.delete("/{name}", response_model=ProfileMutationResponse)
+async def delete_profile(
+    request: Request, name: ProfileName
+) -> ProfileMutationResponse:
+    """Delete a saved profile.
+
+    Idempotent: returns success even if profile didn't exist.
+    """
+    store = _get_profile_store(request)
+
+    try:
+        store.delete(name)
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    logger.info(f"Deleted profile '{name}'")
+    return ProfileMutationResponse(name=name, message=f"Profile '{name}' deleted")
+
+
+@profiles_router.post("/{name}/rename", response_model=ProfileMutationResponse)
+async def rename_profile(
+    request: Request,
+    name: ProfileName,
+    body: RenameProfileRequest,
+) -> ProfileMutationResponse:
+    """Rename a saved profile.
+
+    Preserves the stored LLM config including api_key.
+    Returns 409 if new_name is already in use.
+    """
+    if name == body.new_name:
+        return ProfileMutationResponse(
+            name=name,
+            message=f"Profile '{name}' unchanged (same name)",
+        )
+
+    store = _get_profile_store(request)
+
+    # Check if new name already exists
+    try:
+        existing = [_clean_name(f) for f in store.list()]
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    if body.new_name in existing:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Profile '{body.new_name}' already exists",
+        )
+
+    # Load existing profile
+    try:
+        llm = store.load(name)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Profile '{name}' not found",
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Profile '{name}' is corrupted: {e}",
+        )
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    # Save with new name (preserving secrets) then delete old
+    try:
+        store.save(body.new_name, llm, include_secrets=True)
+        store.delete(name)
+    except TimeoutError:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Profile store is busy. Please retry.",
+        )
+
+    logger.info(f"Renamed profile '{name}' to '{body.new_name}'")
+    return ProfileMutationResponse(
+        name=body.new_name,
+        message=f"Profile '{name}' renamed to '{body.new_name}'",
+    )

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -1,19 +1,17 @@
-"""LLM Profiles router for agent-server.
+"""HTTP endpoints for managing named LLM configurations (profiles)."""
 
-Provides HTTP endpoints for managing named LLM configurations (profiles).
-Profiles are stored as JSON files via LLMProfileStore.
-"""
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Annotated, Any
 
-from __future__ import annotations
-
-import re
-from typing import Annotated, Any, Final
-
-from fastapi import APIRouter, HTTPException, Path, Request, status
+from fastapi import APIRouter, HTTPException, Path, status
 from pydantic import BaseModel, Field, SecretStr
 
 from openhands.sdk.llm import LLM
-from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.llm.llm_profile_store import (
+    PROFILE_NAME_PATTERN,
+    LLMProfileStore,
+)
 from openhands.sdk.logger import get_logger
 
 
@@ -21,26 +19,15 @@ logger = get_logger(__name__)
 
 profiles_router = APIRouter(prefix="/profiles", tags=["Profiles"])
 
-# Profile name constraints: alphanumerics + . _ - only, 1-64 chars.
-# Blocks empty names, path-traversal fragments, and special characters.
-_NAME_PATTERN: Final[str] = r"^[A-Za-z0-9._-]{1,64}$"
-_NAME_REGEX: Final[re.Pattern[str]] = re.compile(_NAME_PATTERN)
-
-# Maximum number of profiles per user (soft cap)
-MAX_PROFILES: Final[int] = 50
+MAX_PROFILES = 50
 
 ProfileName = Annotated[
     str,
-    Path(min_length=1, max_length=64, pattern=_NAME_PATTERN),
+    Path(min_length=1, max_length=64, pattern=PROFILE_NAME_PATTERN),
 ]
 
 
-# ── Response/Request Models ────────────────────────────────────────────────
-
-
 class ProfileInfo(BaseModel):
-    """Profile summary for list endpoint."""
-
     name: str
     model: str | None = None
     base_url: str | None = None
@@ -48,16 +35,11 @@ class ProfileInfo(BaseModel):
 
 
 class ProfileListResponse(BaseModel):
-    """Response body for listing profiles."""
-
     profiles: list[ProfileInfo]
 
 
 class ProfileDetailResponse(BaseModel):
-    """Response body for fetching a single profile.
-
-    ``config.api_key`` is always nulled; use ``api_key_set`` to check if set.
-    """
+    """``config.api_key`` is always nulled; use ``api_key_set`` instead."""
 
     name: str
     config: dict[str, Any]
@@ -65,15 +47,11 @@ class ProfileDetailResponse(BaseModel):
 
 
 class ProfileMutationResponse(BaseModel):
-    """Response body for save/delete/rename operations."""
-
     name: str
     message: str
 
 
 class SaveProfileRequest(BaseModel):
-    """Request body for saving a profile."""
-
     llm: LLM
     include_secrets: bool = Field(
         default=True,
@@ -82,155 +60,19 @@ class SaveProfileRequest(BaseModel):
 
 
 class RenameProfileRequest(BaseModel):
-    """Request body for renaming a profile."""
-
     new_name: str = Field(
         ...,
         min_length=1,
         max_length=64,
-        pattern=_NAME_PATTERN,
+        pattern=PROFILE_NAME_PATTERN,
     )
 
 
-# ── Helpers ────────────────────────────────────────────────────────────────
-
-
-def _get_profile_store(_request: Request) -> LLMProfileStore:
-    """Get or create profile store.
-
-    Uses default directory (~/.openhands/profiles).
-    The request argument is kept for future extensibility (e.g., per-user stores).
-    """
-    return LLMProfileStore()
-
-
-def _has_api_key(llm: LLM) -> bool:
-    """Check if LLM has a non-empty API key configured."""
-    if llm.api_key is None:
-        return False
-    secret_value = (
-        llm.api_key.get_secret_value()
-        if isinstance(llm.api_key, SecretStr)
-        else str(llm.api_key)
-    )
-    return bool(secret_value and secret_value.strip())
-
-
-def _clean_name(filename: str) -> str:
-    """Remove .json extension from filename."""
-    return filename.removesuffix(".json")
-
-
-# ── Endpoints ──────────────────────────────────────────────────────────────
-
-
-@profiles_router.get("", response_model=ProfileListResponse)
-async def list_profiles(request: Request) -> ProfileListResponse:
-    """List all saved LLM profiles.
-
-    Returns profile names with basic model info. API keys are never exposed.
-    """
-    store = _get_profile_store(request)
-
+@contextmanager
+def _store_errors() -> Iterator[None]:
+    """Map ``LLMProfileStore`` errors to HTTP responses."""
     try:
-        filenames = store.list()
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
-        )
-
-    profiles: list[ProfileInfo] = []
-    for filename in filenames:
-        name = _clean_name(filename)
-        try:
-            llm = store.load(name)
-            profiles.append(
-                ProfileInfo(
-                    name=name,
-                    model=llm.model,
-                    base_url=llm.base_url,
-                    api_key_set=_has_api_key(llm),
-                )
-            )
-        except (FileNotFoundError, ValueError) as e:
-            # Skip corrupted profiles but log warning
-            logger.warning(f"Skipping corrupted profile '{name}': {e}")
-            continue
-
-    logger.info(f"Listed {len(profiles)} profile(s)")
-    return ProfileListResponse(profiles=profiles)
-
-
-@profiles_router.get("/{name}", response_model=ProfileDetailResponse)
-async def get_profile(request: Request, name: ProfileName) -> ProfileDetailResponse:
-    """Get a specific profile's configuration.
-
-    Returns the full LLM config with ``api_key`` nulled out.
-    """
-    store = _get_profile_store(request)
-
-    try:
-        llm = store.load(name)
-    except FileNotFoundError:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail=f"Profile '{name}' not found",
-        )
-    except ValueError as e:
-        raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Profile '{name}' is corrupted: {e}",
-        )
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
-        )
-
-    api_key_set = _has_api_key(llm)
-    config = llm.model_dump(mode="json")
-    config["api_key"] = None  # Never expose in response
-
-    logger.info(f"Retrieved profile '{name}'")
-    return ProfileDetailResponse(name=name, config=config, api_key_set=api_key_set)
-
-
-@profiles_router.post(
-    "/{name}",
-    response_model=ProfileMutationResponse,
-    status_code=status.HTTP_201_CREATED,
-)
-async def save_profile(
-    request: Request,
-    name: ProfileName,
-    body: SaveProfileRequest,
-) -> ProfileMutationResponse:
-    """Save an LLM configuration as a named profile.
-
-    Overwrites if profile with same name exists. Returns 409 if creating
-    a new profile would exceed the profile limit.
-    """
-    store = _get_profile_store(request)
-
-    # Check profile limit for new profiles
-    try:
-        existing = store.list()
-        clean_existing = [_clean_name(f) for f in existing]
-        if name not in clean_existing and len(existing) >= MAX_PROFILES:
-            raise HTTPException(
-                status_code=status.HTTP_409_CONFLICT,
-                detail=f"Profile limit reached ({MAX_PROFILES}). "
-                "Delete a profile before saving a new one.",
-            )
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
-        )
-
-    try:
-        store.save(name, body.llm, include_secrets=body.include_secrets)
+        yield
     except TimeoutError:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
@@ -242,42 +84,92 @@ async def save_profile(
             detail=str(e),
         )
 
-    logger.info(f"Saved profile '{name}'")
+
+def _has_api_key(llm: LLM) -> bool:
+    if not isinstance(llm.api_key, SecretStr):
+        return False
+    return bool(llm.api_key.get_secret_value().strip())
+
+
+@profiles_router.get("", response_model=ProfileListResponse)
+async def list_profiles() -> ProfileListResponse:
+    """List all saved LLM profiles."""
+    store = LLMProfileStore()
+    with _store_errors():
+        summaries = store.list_summaries()
+    return ProfileListResponse(profiles=[ProfileInfo(**s) for s in summaries])
+
+
+@profiles_router.get("/{name}", response_model=ProfileDetailResponse)
+async def get_profile(name: ProfileName) -> ProfileDetailResponse:
+    """Get a profile's configuration with ``api_key`` nulled out."""
+    store = LLMProfileStore()
+    try:
+        with _store_errors():
+            llm = store.load(name)
+    except FileNotFoundError:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Profile '{name}' not found",
+        )
+
+    config = llm.model_dump(mode="json")
+    config["api_key"] = None
+    return ProfileDetailResponse(
+        name=name, config=config, api_key_set=_has_api_key(llm)
+    )
+
+
+@profiles_router.post(
+    "/{name}",
+    response_model=ProfileMutationResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def save_profile(
+    name: ProfileName,
+    body: SaveProfileRequest,
+) -> ProfileMutationResponse:
+    """Save an LLM configuration as a named profile.
+
+    Overwrites an existing profile of the same name. Returns 409 if creating
+    a new profile would exceed ``MAX_PROFILES``.
+    """
+    store = LLMProfileStore()
+    filename = f"{name}.json"
+
+    with _store_errors():
+        existing = store.list()
+        if filename not in existing and len(existing) >= MAX_PROFILES:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=(
+                    f"Profile limit reached ({MAX_PROFILES}). "
+                    "Delete a profile before saving a new one."
+                ),
+            )
+        store.save(name, body.llm, include_secrets=body.include_secrets)
+
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' saved")
 
 
 @profiles_router.delete("/{name}", response_model=ProfileMutationResponse)
-async def delete_profile(
-    request: Request, name: ProfileName
-) -> ProfileMutationResponse:
-    """Delete a saved profile.
-
-    Idempotent: returns success even if profile didn't exist.
-    """
-    store = _get_profile_store(request)
-
-    try:
+async def delete_profile(name: ProfileName) -> ProfileMutationResponse:
+    """Delete a saved profile (idempotent)."""
+    store = LLMProfileStore()
+    with _store_errors():
         store.delete(name)
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
-        )
-
-    logger.info(f"Deleted profile '{name}'")
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' deleted")
 
 
 @profiles_router.post("/{name}/rename", response_model=ProfileMutationResponse)
 async def rename_profile(
-    request: Request,
     name: ProfileName,
     body: RenameProfileRequest,
 ) -> ProfileMutationResponse:
-    """Rename a saved profile.
+    """Rename a saved profile atomically.
 
-    Preserves the stored LLM config including api_key.
-    Returns 409 if new_name is already in use.
+    Returns 404 if the source does not exist, or 409 if ``new_name`` already
+    exists.
     """
     if name == body.new_name:
         return ProfileMutationResponse(
@@ -285,53 +177,21 @@ async def rename_profile(
             message=f"Profile '{name}' unchanged (same name)",
         )
 
-    store = _get_profile_store(request)
-
-    # Check if new name already exists
+    store = LLMProfileStore()
     try:
-        existing = [_clean_name(f) for f in store.list()]
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
-        )
-
-    if body.new_name in existing:
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail=f"Profile '{body.new_name}' already exists",
-        )
-
-    # Load existing profile
-    try:
-        llm = store.load(name)
+        with _store_errors():
+            store.rename(name, body.new_name)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Profile '{name}' not found",
         )
-    except ValueError as e:
+    except FileExistsError:
         raise HTTPException(
-            status_code=status.HTTP_400_BAD_REQUEST,
-            detail=f"Profile '{name}' is corrupted: {e}",
-        )
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Profile '{body.new_name}' already exists",
         )
 
-    # Save with new name (preserving secrets) then delete old
-    try:
-        store.save(body.new_name, llm, include_secrets=True)
-        store.delete(name)
-    except TimeoutError:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Profile store is busy. Please retry.",
-        )
-
-    logger.info(f"Renamed profile '{name}' to '{body.new_name}'")
     return ProfileMutationResponse(
         name=body.new_name,
         message=f"Profile '{name}' renamed to '{body.new_name}'",

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -153,6 +153,7 @@ async def save_profile(
             ),
         )
 
+    logger.info(f"Saved profile '{name}' (include_secrets={body.include_secrets})")
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' saved")
 
 
@@ -162,6 +163,7 @@ async def delete_profile(name: ProfileName) -> ProfileMutationResponse:
     store = LLMProfileStore()
     with _store_errors():
         store.delete(name)
+    logger.info(f"Deleted profile '{name}'")
     return ProfileMutationResponse(name=name, message=f"Profile '{name}' deleted")
 
 
@@ -173,14 +175,8 @@ async def rename_profile(
     """Rename a saved profile atomically.
 
     Returns 404 if the source does not exist, or 409 if ``new_name`` already
-    exists.
+    exists. A same-name rename is a verified no-op (still 404s if missing).
     """
-    if name == body.new_name:
-        return ProfileMutationResponse(
-            name=name,
-            message=f"Profile '{name}' unchanged (same name)",
-        )
-
     store = LLMProfileStore()
     try:
         with _store_errors():
@@ -196,7 +192,9 @@ async def rename_profile(
             detail=f"Profile '{body.new_name}' already exists",
         )
 
-    return ProfileMutationResponse(
-        name=body.new_name,
-        message=f"Profile '{name}' renamed to '{body.new_name}'",
-    )
+    if name == body.new_name:
+        message = f"Profile '{name}' unchanged (same name)"
+    else:
+        message = f"Profile '{name}' renamed to '{body.new_name}'"
+    logger.info(message)
+    return ProfileMutationResponse(name=body.new_name, message=message)

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -31,6 +31,10 @@ PROFILE_NAME_REGEX: Final[re.Pattern[str]] = re.compile(PROFILE_NAME_PATTERN)
 logger = get_logger(__name__)
 
 
+class ProfileLimitExceeded(Exception):
+    """Raised when saving would exceed the configured profile limit."""
+
+
 class LLMProfileStore:
     """Standalone utility for persisting LLM configurations."""
 
@@ -93,22 +97,41 @@ class LLMProfileStore:
             )
         return self.base_dir / f"{clean_name}.json"
 
-    def save(self, name: str, llm: LLM, include_secrets: bool = False) -> None:
+    def save(
+        self,
+        name: str,
+        llm: LLM,
+        include_secrets: bool = False,
+        *,
+        max_profiles: int | None = None,
+    ) -> None:
         """Save a profile to the profile directory.
 
-        Note that if a profile name already exists, it will be overwritten.
+        Overwrites an existing profile of the same name. When ``max_profiles``
+        is set, raises ``ProfileLimitExceeded`` if creating a *new* profile
+        would exceed the limit. The check happens under the same lock as the
+        save, so it is race-free against other ``save`` calls in this process.
 
         Args:
             name: Name of the profile to save.
             llm: LLM instance to save
             include_secrets: Whether to include the profile secrets. Defaults to False.
+            max_profiles: Optional cap on the number of profiles.
 
         Raises:
+            ProfileLimitExceeded: If ``max_profiles`` would be exceeded.
             TimeoutError: If the lock cannot be acquired.
         """
         profile_path = self._get_profile_path(name)
 
         with self._acquire_lock():
+            if max_profiles is not None and not profile_path.exists():
+                count = sum(1 for _ in self.base_dir.glob("*.json"))
+                if count >= max_profiles:
+                    raise ProfileLimitExceeded(
+                        f"Profile limit reached ({max_profiles})."
+                    )
+
             if profile_path.exists():
                 logger.info(
                     f"[Profile Store] Profile `{name}` already exists. Overwriting."
@@ -208,17 +231,28 @@ class LLMProfileStore:
         """List profile metadata without instantiating LLM objects.
 
         Reads JSON directly to avoid ``LLM._set_env_side_effects`` mutating
-        ``os.environ``. Corrupted profiles are skipped with a warning.
+        ``os.environ``. Files with invalid names, corrupted JSON, or non-dict
+        top-level values are skipped with a warning.
         """
         summaries: list[dict[str, Any]] = []
         with self._acquire_lock():
             for path in sorted(self.base_dir.glob("*.json")):
                 name = path.stem
+                if not PROFILE_NAME_REGEX.match(name):
+                    logger.warning(
+                        f"[Profile Store] Skipping profile with invalid name {name!r}"
+                    )
+                    continue
                 try:
                     data = json.loads(path.read_text())
                 except (OSError, json.JSONDecodeError) as e:
                     logger.warning(
                         f"[Profile Store] Skipping corrupted profile {name!r}: {e}"
+                    )
+                    continue
+                if not isinstance(data, dict):
+                    logger.warning(
+                        f"[Profile Store] Skipping non-dict profile {name!r}"
                     )
                     continue
                 api_key = data.get("api_key")

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -1,12 +1,19 @@
+# Required: ``LLMProfileStore.list()`` shadows the builtin in the class body,
+# so annotations like ``list[dict[str, Any]]`` would fail without deferral.
+from __future__ import annotations
+
+import json
+import re
 import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Final
+from typing import TYPE_CHECKING, Any, Final
 
 from filelock import FileLock, Timeout
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 
 if TYPE_CHECKING:
@@ -14,6 +21,12 @@ if TYPE_CHECKING:
 
 _DEFAULT_PROFILE_DIR: Final[Path] = Path.home() / ".openhands" / "profiles"
 _LOCK_TIMEOUT_SECONDS: Final[float] = 30.0
+
+# Profile names: 1-64 chars, must start with alphanumeric, then alphanumerics
+# or '.', '_', '-'. Blocks empty names, path separators, leading dots
+# (hidden files / path traversal), and shell-special characters.
+PROFILE_NAME_PATTERN: Final[str] = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+PROFILE_NAME_REGEX: Final[re.Pattern[str]] = re.compile(PROFILE_NAME_PATTERN)
 
 logger = get_logger(__name__)
 
@@ -66,29 +79,21 @@ class LLMProfileStore:
         """Get the full path for a profile name.
 
         Args:
-            name: Profile name (must be a simple filename without path separators)
+            name: Profile name (must match ``PROFILE_NAME_PATTERN``).
 
         Raises:
-            ValueError: If name contains path separators or is invalid
+            ValueError: If name does not match the allowed pattern.
         """
-        # Remove .json extension if present for consistent handling
         clean_name = name.removesuffix(".json")
-
-        # Validate: no path separators, not empty, no hidden files
-        if (
-            not clean_name
-            or "/" in clean_name
-            or "\\" in clean_name
-            or clean_name.startswith(".")
-        ):
+        if not PROFILE_NAME_REGEX.match(clean_name):
             raise ValueError(
                 f"Invalid profile name: {name!r}. "
-                "Profile names must be simple filenames without path separators."
+                "Profile names must be 1-64 characters, start with a letter "
+                "or digit, and contain only letters, digits, '.', '_', or '-'."
             )
-
         return self.base_dir / f"{clean_name}.json"
 
-    def save(self, name: str, llm: "LLM", include_secrets: bool = False) -> None:
+    def save(self, name: str, llm: LLM, include_secrets: bool = False) -> None:
         """Save a profile to the profile directory.
 
         Note that if a profile name already exists, it will be overwritten.
@@ -123,7 +128,7 @@ class LLMProfileStore:
             Path.replace(tmp_path, profile_path)
             logger.info(f"[Profile Store] Saved profile `{name}` at {profile_path}")
 
-    def load(self, name: str) -> "LLM":
+    def load(self, name: str) -> LLM:
         """Load an LLM instance from the given profile name.
 
         Args:
@@ -178,3 +183,56 @@ class LLMProfileStore:
 
             profile_path.unlink()
             logger.info(f"[Profile Store] Deleted profile `{name}`")
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        """Atomically rename a profile.
+
+        Raises FileNotFoundError if ``old_name`` is missing, FileExistsError
+        if ``new_name`` is taken.
+        """
+        old_path = self._get_profile_path(old_name)
+        new_path = self._get_profile_path(new_name)
+
+        if old_path == new_path:
+            return
+
+        with self._acquire_lock():
+            if not old_path.exists():
+                raise FileNotFoundError(f"Profile `{old_name}` not found")
+            if new_path.exists():
+                raise FileExistsError(f"Profile `{new_name}` already exists")
+            old_path.rename(new_path)
+            logger.info(f"[Profile Store] Renamed profile `{old_name}` to `{new_name}`")
+
+    def list_summaries(self) -> list[dict[str, Any]]:
+        """List profile metadata without instantiating LLM objects.
+
+        Reads JSON directly to avoid ``LLM._set_env_side_effects`` mutating
+        ``os.environ``. Corrupted profiles are skipped with a warning.
+        """
+        summaries: list[dict[str, Any]] = []
+        with self._acquire_lock():
+            for path in sorted(self.base_dir.glob("*.json")):
+                name = path.stem
+                try:
+                    data = json.loads(path.read_text())
+                except (OSError, json.JSONDecodeError) as e:
+                    logger.warning(
+                        f"[Profile Store] Skipping corrupted profile {name!r}: {e}"
+                    )
+                    continue
+                api_key = data.get("api_key")
+                api_key_set = (
+                    isinstance(api_key, str)
+                    and bool(api_key.strip())
+                    and api_key != REDACTED_SECRET_VALUE
+                )
+                summaries.append(
+                    {
+                        "name": name,
+                        "model": data.get("model"),
+                        "base_url": data.get("base_url"),
+                        "api_key_set": api_key_set,
+                    }
+                )
+        return summaries

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -126,7 +126,13 @@ class LLMProfileStore:
 
         with self._acquire_lock():
             if max_profiles is not None and not profile_path.exists():
-                count = sum(1 for _ in self.base_dir.glob("*.json"))
+                # Only count files visible via list_summaries (valid names),
+                # so stray invalid files don't consume slots.
+                count = sum(
+                    1
+                    for p in self.base_dir.glob("*.json")
+                    if PROFILE_NAME_REGEX.match(p.stem)
+                )
                 if count >= max_profiles:
                     raise ProfileLimitExceeded(
                         f"Profile limit reached ({max_profiles})."
@@ -148,7 +154,11 @@ class LLMProfileStore:
                 tmp.write(profile_json)
                 tmp_path = Path(tmp.name)
 
-            Path.replace(tmp_path, profile_path)
+            try:
+                Path.replace(tmp_path, profile_path)
+            except Exception:
+                tmp_path.unlink(missing_ok=True)
+                raise
             logger.info(f"[Profile Store] Saved profile `{name}` at {profile_path}")
 
     def load(self, name: str) -> LLM:
@@ -211,17 +221,17 @@ class LLMProfileStore:
         """Atomically rename a profile.
 
         Raises FileNotFoundError if ``old_name`` is missing, FileExistsError
-        if ``new_name`` is taken.
+        if ``new_name`` is taken. When the names resolve to the same path,
+        the call is a no-op but still verifies the profile exists.
         """
         old_path = self._get_profile_path(old_name)
         new_path = self._get_profile_path(new_name)
 
-        if old_path == new_path:
-            return
-
         with self._acquire_lock():
             if not old_path.exists():
                 raise FileNotFoundError(f"Profile `{old_name}` not found")
+            if old_path == new_path:
+                return
             if new_path.exists():
                 raise FileExistsError(f"Profile `{new_name}` already exists")
             old_path.rename(new_path)

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -304,6 +304,15 @@ def test_rename_profile_same_name(client, store):
     assert "unchanged" in response.json()["message"].lower()
 
 
+def test_rename_profile_same_name_missing_returns_404(client):
+    """Same-name rename of a missing profile must return 404, not 200."""
+    response = client.post(
+        "/api/profiles/ghost/rename",
+        json={"new_name": "ghost"},
+    )
+    assert response.status_code == 404
+
+
 def test_rename_profile_invalid_new_name(client, store):
     """POST /api/profiles/{name}/rename returns 422 for invalid new_name."""
     llm = LLM(model="gpt-4o")
@@ -546,6 +555,38 @@ def test_delete_profile_timeout_returns_503(client, store, monkeypatch):
 
     response = client.delete("/api/profiles/present")
     assert response.status_code == 503
+
+
+def test_whitespace_api_key_reports_not_set(client, store):
+    """A profile with a whitespace-only api_key reports api_key_set=False."""
+    # Save with a real key, then poke whitespace into the on-disk file.
+    store.save("ws", LLM(model="gpt-4o", api_key="placeholder"), include_secrets=True)
+    profile_path = store.base_dir / "ws.json"
+    profile_path.write_text('{"model": "gpt-4o", "api_key": "   "}')
+
+    response = client.get("/api/profiles")
+    profile = next(p for p in response.json()["profiles"] if p["name"] == "ws")
+    assert profile["api_key_set"] is False
+
+    detail = client.get("/api/profiles/ws").json()
+    assert detail["api_key_set"] is False
+
+
+def test_save_at_limit_does_not_write_partial_state(client, store, monkeypatch):
+    """When the limit is hit, no profile file (or .tmp leftover) should appear."""
+    monkeypatch.setattr(profiles_router_module, "MAX_PROFILES", 1)
+
+    store.save("first", LLM(model="gpt-4o"))
+    files_before = sorted(p.name for p in store.base_dir.iterdir())
+
+    response = client.post(
+        "/api/profiles/second",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 409
+
+    files_after = sorted(p.name for p in store.base_dir.iterdir())
+    assert files_after == files_before  # no new file, no .tmp leftover
 
 
 def test_get_profile_does_not_expose_api_key(client, store):

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1,0 +1,349 @@
+"""Tests for profiles_router endpoints."""
+
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+
+
+@pytest.fixture
+def temp_profiles_dir():
+    """Create a temporary directory for profiles."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        profiles_dir = Path(tmpdir) / "profiles"
+        profiles_dir.mkdir(parents=True, exist_ok=True)
+        yield profiles_dir
+
+
+@pytest.fixture
+def client(temp_profiles_dir):
+    """Create test client with isolated profiles directory."""
+    config = Config(static_files_path=None, session_api_keys=[])
+    app = create_app(config)
+
+    # Patch LLMProfileStore to use temp directory
+    with patch(
+        "openhands.agent_server.profiles_router.LLMProfileStore",
+        lambda: LLMProfileStore(base_dir=temp_profiles_dir),
+    ):
+        yield TestClient(app)
+
+
+@pytest.fixture
+def store(temp_profiles_dir):
+    """Create a profile store using the temp directory."""
+    return LLMProfileStore(base_dir=temp_profiles_dir)
+
+
+# ── List Profiles ──────────────────────────────────────────────────────────
+
+
+def test_list_profiles_empty(client):
+    """GET /api/profiles returns empty list when no profiles exist."""
+    response = client.get("/api/profiles")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["profiles"] == []
+
+
+def test_list_profiles_returns_saved_profiles(client, store):
+    """GET /api/profiles returns all saved profiles with model info."""
+    # Save some profiles directly via store
+    llm1 = LLM(model="gpt-4o")
+    llm2 = LLM(model="claude-3-opus", api_key="sk-test-key")
+    store.save("profile-a", llm1)
+    store.save("profile-b", llm2, include_secrets=True)
+
+    response = client.get("/api/profiles")
+
+    assert response.status_code == 200
+    body = response.json()
+    profiles = body["profiles"]
+    assert len(profiles) == 2
+
+    names = {p["name"] for p in profiles}
+    assert names == {"profile-a", "profile-b"}
+
+    # Check profile details
+    profile_a = next(p for p in profiles if p["name"] == "profile-a")
+    assert profile_a["model"] == "gpt-4o"
+    assert profile_a["api_key_set"] is False
+
+    profile_b = next(p for p in profiles if p["name"] == "profile-b")
+    assert profile_b["model"] == "claude-3-opus"
+    assert profile_b["api_key_set"] is True
+
+
+# ── Get Profile ────────────────────────────────────────────────────────────
+
+
+def test_get_profile_returns_config(client, store):
+    """GET /api/profiles/{name} returns profile config with api_key nulled."""
+    llm = LLM(model="gpt-4o", api_key="sk-secret-key", temperature=0.7)
+    store.save("my-profile", llm, include_secrets=True)
+
+    response = client.get("/api/profiles/my-profile")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "my-profile"
+    assert body["config"]["model"] == "gpt-4o"
+    assert body["config"]["temperature"] == 0.7
+    assert body["config"]["api_key"] is None  # Never exposed
+    assert body["api_key_set"] is True
+
+
+def test_get_profile_not_found(client):
+    """GET /api/profiles/{name} returns 404 for non-existent profile."""
+    response = client.get("/api/profiles/nonexistent")
+
+    assert response.status_code == 404
+    assert "not found" in response.json()["detail"].lower()
+
+
+def test_get_profile_invalid_name(client):
+    """GET /api/profiles/{name} rejects invalid profile names."""
+    # Path traversal attempt - may be 404 (decoded and treated as not found)
+    # or 422 (validation error) depending on how the path is parsed
+    response = client.get("/api/profiles/..%2Fetc%2Fpasswd")
+    assert response.status_code in (404, 422)
+
+    # Hidden file attempt
+    response = client.get("/api/profiles/.hidden")
+    assert response.status_code in (400, 404, 422)
+
+
+# ── Save Profile ───────────────────────────────────────────────────────────
+
+
+def test_save_profile_creates_new(client, store):
+    """POST /api/profiles/{name} creates a new profile."""
+    response = client.post(
+        "/api/profiles/new-profile",
+        json={
+            "llm": {"model": "gpt-4o", "api_key": "sk-test-key"},
+            "include_secrets": True,
+        },
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["name"] == "new-profile"
+    assert "saved" in body["message"].lower()
+
+    # Verify profile was saved
+    loaded = store.load("new-profile")
+    assert loaded.model == "gpt-4o"
+
+
+def test_save_profile_overwrites_existing(client, store):
+    """POST /api/profiles/{name} overwrites existing profile."""
+    # Save initial profile
+    llm1 = LLM(model="gpt-4o")
+    store.save("existing", llm1)
+
+    # Overwrite with new config
+    response = client.post(
+        "/api/profiles/existing",
+        json={"llm": {"model": "claude-3-opus"}},
+    )
+
+    assert response.status_code == 201
+
+    # Verify overwritten
+    loaded = store.load("existing")
+    assert loaded.model == "claude-3-opus"
+
+
+def test_save_profile_without_secrets(client, store):
+    """POST /api/profiles/{name} with include_secrets=False omits api_key."""
+    response = client.post(
+        "/api/profiles/no-secrets",
+        json={
+            "llm": {"model": "gpt-4o", "api_key": "sk-should-not-save"},
+            "include_secrets": False,
+        },
+    )
+
+    assert response.status_code == 201
+
+    # Verify api_key was not saved
+    loaded = store.load("no-secrets")
+    assert loaded.api_key is None or loaded.api_key.get_secret_value() == ""
+
+
+def test_save_profile_invalid_name(client):
+    """POST /api/profiles/{name} returns 422 for invalid names."""
+    response = client.post(
+        "/api/profiles/invalid/name",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    # Should fail at path validation or be treated as different route
+    assert response.status_code in (404, 422)
+
+
+# ── Delete Profile ─────────────────────────────────────────────────────────
+
+
+def test_delete_profile_removes_existing(client, store):
+    """DELETE /api/profiles/{name} removes the profile."""
+    llm = LLM(model="gpt-4o")
+    store.save("to-delete", llm)
+
+    response = client.delete("/api/profiles/to-delete")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "to-delete"
+    assert "deleted" in body["message"].lower()
+
+    # Verify deleted
+    with pytest.raises(FileNotFoundError):
+        store.load("to-delete")
+
+
+def test_delete_profile_idempotent(client):
+    """DELETE /api/profiles/{name} succeeds even for non-existent profile."""
+    response = client.delete("/api/profiles/nonexistent")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "nonexistent"
+
+
+# ── Rename Profile ─────────────────────────────────────────────────────────
+
+
+def test_rename_profile_success(client, store):
+    """POST /api/profiles/{name}/rename renames the profile."""
+    llm = LLM(model="gpt-4o", api_key="sk-secret")
+    store.save("old-name", llm, include_secrets=True)
+
+    response = client.post(
+        "/api/profiles/old-name/rename",
+        json={"new_name": "new-name"},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "new-name"
+    assert "renamed" in body["message"].lower()
+
+    # Verify old gone, new exists with same config
+    with pytest.raises(FileNotFoundError):
+        store.load("old-name")
+
+    loaded = store.load("new-name")
+    assert loaded.model == "gpt-4o"
+
+
+def test_rename_profile_preserves_secrets(client, store):
+    """POST /api/profiles/{name}/rename preserves api_key."""
+    llm = LLM(model="gpt-4o", api_key="sk-secret-preserve")
+    store.save("with-secret", llm, include_secrets=True)
+
+    response = client.post(
+        "/api/profiles/with-secret/rename",
+        json={"new_name": "renamed-secret"},
+    )
+
+    assert response.status_code == 200
+
+    # Verify secret preserved
+    loaded = store.load("renamed-secret")
+    assert loaded.api_key is not None
+    assert loaded.api_key.get_secret_value() == "sk-secret-preserve"
+
+
+def test_rename_profile_not_found(client):
+    """POST /api/profiles/{name}/rename returns 404 for non-existent profile."""
+    response = client.post(
+        "/api/profiles/nonexistent/rename",
+        json={"new_name": "new-name"},
+    )
+
+    assert response.status_code == 404
+
+
+def test_rename_profile_conflict(client, store):
+    """POST /api/profiles/{name}/rename returns 409 if new_name exists."""
+    llm1 = LLM(model="gpt-4o")
+    llm2 = LLM(model="claude-3-opus")
+    store.save("source", llm1)
+    store.save("target", llm2)
+
+    response = client.post(
+        "/api/profiles/source/rename",
+        json={"new_name": "target"},
+    )
+
+    assert response.status_code == 409
+    assert "already exists" in response.json()["detail"].lower()
+
+
+def test_rename_profile_same_name(client, store):
+    """POST /api/profiles/{name}/rename with same name is a no-op."""
+    llm = LLM(model="gpt-4o")
+    store.save("same-name", llm)
+
+    response = client.post(
+        "/api/profiles/same-name/rename",
+        json={"new_name": "same-name"},
+    )
+
+    assert response.status_code == 200
+    assert "unchanged" in response.json()["message"].lower()
+
+
+def test_rename_profile_invalid_new_name(client, store):
+    """POST /api/profiles/{name}/rename returns 422 for invalid new_name."""
+    llm = LLM(model="gpt-4o")
+    store.save("valid-name", llm)
+
+    response = client.post(
+        "/api/profiles/valid-name/rename",
+        json={"new_name": "../etc/passwd"},
+    )
+
+    assert response.status_code == 422
+
+
+# ── Profile Name Validation ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        "simple",
+        "with-dash",
+        "with_underscore",
+        "with.dot",
+        "MixedCase123",
+        "a" * 64,  # Max length
+    ],
+)
+def test_valid_profile_names(client, name):
+    """Valid profile names are accepted."""
+    response = client.post(
+        f"/api/profiles/{name}",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 201
+
+
+def test_invalid_profile_name_too_long(client):
+    """Profile name that is too long is rejected."""
+    name = "a" * 65  # Exceeds 64 char limit
+    response = client.post(
+        f"/api/profiles/{name}",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 422

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 import pytest
 from fastapi.testclient import TestClient
 
+from openhands.agent_server import profiles_router as profiles_router_module
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.sdk.llm import LLM
@@ -347,3 +348,202 @@ def test_invalid_profile_name_too_long(client):
         json={"llm": {"model": "gpt-4o"}},
     )
     assert response.status_code == 422
+
+
+@pytest.mark.parametrize("name", [".leading-dot", "-leading-dash", "_leading_under"])
+def test_invalid_profile_name_leading_non_alnum(client, name):
+    """Profile names must start with an alphanumeric character."""
+    response = client.post(
+        f"/api/profiles/{name}",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.parametrize("name", ["name@symbol", "name$dollar", "name space"])
+def test_invalid_profile_name_special_chars(client, name):
+    """Profile names with disallowed characters are rejected."""
+    response = client.post(
+        f"/api/profiles/{name}",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 422
+
+
+# ── Profile Limit ──────────────────────────────────────────────────────────
+
+
+def test_save_profile_at_limit_returns_409(client, store, monkeypatch):
+    """POST /api/profiles/{name} returns 409 when MAX_PROFILES is reached."""
+    monkeypatch.setattr(profiles_router_module, "MAX_PROFILES", 2)
+
+    store.save("first", LLM(model="gpt-4o"))
+    store.save("second", LLM(model="gpt-4o"))
+
+    response = client.post(
+        "/api/profiles/third",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 409
+    assert "limit" in response.json()["detail"].lower()
+
+
+def test_save_profile_at_limit_overwrite_allowed(client, store, monkeypatch):
+    """Overwriting an existing profile is allowed even at the limit."""
+    monkeypatch.setattr(profiles_router_module, "MAX_PROFILES", 2)
+
+    store.save("first", LLM(model="gpt-4o"))
+    store.save("second", LLM(model="gpt-4o"))
+
+    response = client.post(
+        "/api/profiles/first",
+        json={"llm": {"model": "claude-3-opus"}},
+    )
+    assert response.status_code == 201
+    assert store.load("first").model == "claude-3-opus"
+
+
+# ── Store Errors → HTTP ────────────────────────────────────────────────────
+
+
+def test_list_profiles_timeout_returns_503(client, monkeypatch):
+    """List endpoint surfaces TimeoutError as 503."""
+
+    def boom(self):
+        raise TimeoutError("locked")
+
+    monkeypatch.setattr(LLMProfileStore, "list_summaries", boom)
+
+    response = client.get("/api/profiles")
+    assert response.status_code == 503
+
+
+def test_get_profile_timeout_returns_503(client, store, monkeypatch):
+    """Get endpoint surfaces TimeoutError as 503."""
+    store.save("present", LLM(model="gpt-4o"))
+
+    def boom(self, name):
+        raise TimeoutError("locked")
+
+    monkeypatch.setattr(LLMProfileStore, "load", boom)
+
+    response = client.get("/api/profiles/present")
+    assert response.status_code == 503
+
+
+def test_delete_profile_invalid_internal_name_returns_400(client, store, monkeypatch):
+    """If the store raises ValueError, delete responds 400 instead of 500."""
+
+    def boom(self, name):
+        raise ValueError("Invalid profile name: 'x'.")
+
+    monkeypatch.setattr(LLMProfileStore, "delete", boom)
+
+    response = client.delete("/api/profiles/some-name")
+    assert response.status_code == 400
+
+
+def test_list_profiles_skips_corrupted(client, temp_profiles_dir):
+    """Corrupted profile files are skipped, not returned."""
+    (temp_profiles_dir / "good.json").write_text('{"model": "gpt-4o"}')
+    (temp_profiles_dir / "bad.json").write_text("{ not valid json")
+
+    response = client.get("/api/profiles")
+    assert response.status_code == 200
+
+    names = {p["name"] for p in response.json()["profiles"]}
+    assert names == {"good"}
+
+
+def test_list_profiles_api_key_set_for_redacted(client, store):
+    """A profile saved without secrets reports api_key_set=False."""
+    llm = LLM(model="gpt-4o", api_key="sk-secret-not-saved")
+    store.save("redacted", llm, include_secrets=False)
+
+    response = client.get("/api/profiles")
+    assert response.status_code == 200
+
+    profile = next(p for p in response.json()["profiles"] if p["name"] == "redacted")
+    assert profile["api_key_set"] is False
+
+
+# ── Malformed Bodies ───────────────────────────────────────────────────────
+
+
+def test_save_profile_missing_llm_field(client):
+    """Save without the required 'llm' field returns 422."""
+    response = client.post("/api/profiles/missing", json={})
+    assert response.status_code == 422
+
+
+def test_save_profile_wrong_type_for_llm(client):
+    """Save with 'llm' as a non-dict returns 422."""
+    response = client.post(
+        "/api/profiles/bad-llm",
+        json={"llm": "not-an-object"},
+    )
+    assert response.status_code == 422
+
+
+def test_rename_profile_missing_new_name(client, store):
+    """Rename without the required 'new_name' field returns 422."""
+    store.save("source", LLM(model="gpt-4o"))
+    response = client.post("/api/profiles/source/rename", json={})
+    assert response.status_code == 422
+
+
+def test_rename_profile_empty_new_name(client, store):
+    """Rename with empty 'new_name' returns 422."""
+    store.save("source", LLM(model="gpt-4o"))
+    response = client.post("/api/profiles/source/rename", json={"new_name": ""})
+    assert response.status_code == 422
+
+
+def test_get_profile_corrupted_returns_400(client, temp_profiles_dir):
+    """A corrupted profile JSON returns 400 from the load endpoint."""
+    (temp_profiles_dir / "broken.json").write_text("{ not valid json")
+    response = client.get("/api/profiles/broken")
+    assert response.status_code == 400
+    assert "broken" in response.json()["detail"].lower()
+
+
+def test_save_profile_timeout_returns_503(client, monkeypatch):
+    """Save endpoint surfaces TimeoutError as 503."""
+
+    def boom(self):
+        raise TimeoutError("locked")
+
+    monkeypatch.setattr(LLMProfileStore, "list", boom)
+
+    response = client.post(
+        "/api/profiles/anything",
+        json={"llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 503
+
+
+def test_rename_profile_timeout_returns_503(client, store, monkeypatch):
+    """Rename endpoint surfaces TimeoutError as 503."""
+    store.save("src", LLM(model="gpt-4o"))
+
+    def boom(self, old, new):
+        raise TimeoutError("locked")
+
+    monkeypatch.setattr(LLMProfileStore, "rename", boom)
+
+    response = client.post("/api/profiles/src/rename", json={"new_name": "dst"})
+    assert response.status_code == 503
+
+
+def test_get_profile_does_not_expose_api_key(client, store):
+    """Even when api_key is saved, GET response nulls it out."""
+    llm = LLM(model="gpt-4o", api_key="sk-very-secret")
+    store.save("secret-profile", llm, include_secrets=True)
+
+    response = client.get("/api/profiles/secret-profile")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["config"]["api_key"] is None
+    assert body["api_key_set"] is True
+    # And the secret string itself never appears in the response
+    assert "sk-very-secret" not in response.text

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -510,10 +510,10 @@ def test_get_profile_corrupted_returns_400(client, temp_profiles_dir):
 def test_save_profile_timeout_returns_503(client, monkeypatch):
     """Save endpoint surfaces TimeoutError as 503."""
 
-    def boom(self):
+    def boom(self, name, llm, include_secrets=False, *, max_profiles=None):
         raise TimeoutError("locked")
 
-    monkeypatch.setattr(LLMProfileStore, "list", boom)
+    monkeypatch.setattr(LLMProfileStore, "save", boom)
 
     response = client.post(
         "/api/profiles/anything",
@@ -532,6 +532,19 @@ def test_rename_profile_timeout_returns_503(client, store, monkeypatch):
     monkeypatch.setattr(LLMProfileStore, "rename", boom)
 
     response = client.post("/api/profiles/src/rename", json={"new_name": "dst"})
+    assert response.status_code == 503
+
+
+def test_delete_profile_timeout_returns_503(client, store, monkeypatch):
+    """Delete endpoint surfaces TimeoutError as 503."""
+    store.save("present", LLM(model="gpt-4o"))
+
+    def boom(self, name):
+        raise TimeoutError("locked")
+
+    monkeypatch.setattr(LLMProfileStore, "delete", boom)
+
+    response = client.delete("/api/profiles/present")
     assert response.status_code == 503
 
 

--- a/tests/sdk/llm/test_llm_profile_store.py
+++ b/tests/sdk/llm/test_llm_profile_store.py
@@ -445,6 +445,12 @@ def test_rename_same_name_is_noop(
     assert profile_store.list() == ["same.json"]
 
 
+def test_rename_same_name_missing_raises(profile_store: LLMProfileStore) -> None:
+    """Same-name rename still verifies the profile exists."""
+    with pytest.raises(FileNotFoundError, match="ghost"):
+        profile_store.rename("ghost", "ghost")
+
+
 def test_rename_invalid_name_raises(
     profile_store: LLMProfileStore, sample_llm: LLM
 ) -> None:
@@ -559,6 +565,38 @@ def test_save_with_max_profiles_allows_under_limit(
     profile_store.save("a", sample_llm, max_profiles=5)
     profile_store.save("b", sample_llm, max_profiles=5)
     assert len(profile_store.list()) == 2
+
+
+def test_save_cleans_up_tmp_on_replace_failure(
+    profile_store: LLMProfileStore,
+    sample_llm: LLM,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If Path.replace fails, no .tmp file should be left behind."""
+
+    def boom(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "replace", boom)
+
+    with pytest.raises(OSError, match="disk full"):
+        profile_store.save("doomed", sample_llm)
+
+    leftovers = list(profile_store.base_dir.glob("*.tmp"))
+    assert leftovers == []
+
+
+def test_save_with_max_profiles_ignores_invalid_filenames(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    """Stray .json files with invalid names must not consume limit slots."""
+    profile_store.save("real", sample_llm)
+    (profile_store.base_dir / ".hidden.json").write_text('{"model": "x"}')
+    (profile_store.base_dir / "bad@name.json").write_text('{"model": "x"}')
+
+    # Only 'real' counts, so saving up to the limit of 2 should succeed.
+    profile_store.save("another", sample_llm, max_profiles=2)
+    assert "another.json" in profile_store.list()
 
 
 def test_list_summaries_does_not_mutate_env(

--- a/tests/sdk/llm/test_llm_profile_store.py
+++ b/tests/sdk/llm/test_llm_profile_store.py
@@ -1,5 +1,6 @@
 import concurrent.futures
 import json
+import re
 import threading
 from pathlib import Path
 
@@ -119,12 +120,26 @@ def test_save_creates_file(profile_store: LLMProfileStore, sample_llm: LLM) -> N
 
 @pytest.mark.parametrize(
     "name",
-    ["", ".json", ".", "..", "my/profile", "my//profile"],
+    [
+        "",
+        ".json",
+        ".",
+        "..",
+        "my/profile",
+        "my//profile",
+        ".leading-dot",
+        "-leading-dash",
+        "_leading_under",
+        "name with space",
+        "name@symbol",
+        "name$dollar",
+        "a" * 65,
+    ],
 )
 def test_save_with_invalid_profile_name(
     name: str, profile_store: LLMProfileStore, sample_llm: LLM
 ) -> None:
-    with pytest.raises(ValueError, match=f"Invalid profile name: {name!r}. "):
+    with pytest.raises(ValueError, match=re.escape(f"Invalid profile name: {name!r}.")):
         profile_store.save(name, sample_llm)
 
 
@@ -375,6 +390,137 @@ def test_full_workflow(profile_store: LLMProfileStore) -> None:
     # Delete
     profile_store.delete("workflow_profile")
     assert "workflow_profile.json" not in profile_store.list()
+
+
+# ── Rename ────────────────────────────────────────────────────────────────
+
+
+def test_rename_moves_file(profile_store: LLMProfileStore, sample_llm: LLM) -> None:
+    profile_store.save("old", sample_llm)
+    profile_store.rename("old", "new")
+
+    assert (profile_store.base_dir / "new.json").exists()
+    assert not (profile_store.base_dir / "old.json").exists()
+    assert profile_store.load("new").model == sample_llm.model
+
+
+def test_rename_preserves_secrets(
+    profile_store: LLMProfileStore, sample_llm_with_secrets: LLM
+) -> None:
+    profile_store.save("old", sample_llm_with_secrets, include_secrets=True)
+    profile_store.rename("old", "new")
+
+    loaded = profile_store.load("new")
+    assert isinstance(loaded.api_key, SecretStr)
+    assert loaded.api_key.get_secret_value() == "secret-api-key-12345"
+
+
+def test_rename_source_missing_raises(profile_store: LLMProfileStore) -> None:
+    with pytest.raises(FileNotFoundError, match="missing"):
+        profile_store.rename("missing", "anywhere")
+
+
+def test_rename_target_exists_raises(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("old", sample_llm)
+    profile_store.save("taken", sample_llm)
+
+    with pytest.raises(FileExistsError, match="taken"):
+        profile_store.rename("old", "taken")
+
+    # Both files still present (no partial state)
+    assert (profile_store.base_dir / "old.json").exists()
+    assert (profile_store.base_dir / "taken.json").exists()
+
+
+def test_rename_same_name_is_noop(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("same", sample_llm)
+    profile_store.rename("same", "same")
+    assert profile_store.list() == ["same.json"]
+
+
+def test_rename_invalid_name_raises(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("ok", sample_llm)
+    with pytest.raises(ValueError, match="Invalid profile name"):
+        profile_store.rename("ok", "../escape")
+    with pytest.raises(ValueError, match="Invalid profile name"):
+        profile_store.rename(".hidden", "ok2")
+
+
+# ── list_summaries ────────────────────────────────────────────────────────
+
+
+def test_list_summaries_empty(profile_store: LLMProfileStore) -> None:
+    assert profile_store.list_summaries() == []
+
+
+def test_list_summaries_returns_metadata(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("a", sample_llm)
+    profile_store.save("b", sample_llm)
+
+    summaries = profile_store.list_summaries()
+    assert len(summaries) == 2
+    by_name = {s["name"]: s for s in summaries}
+    assert by_name["a"]["model"] == sample_llm.model
+    assert by_name["a"]["api_key_set"] is False
+
+
+def test_list_summaries_api_key_set_with_secrets(
+    profile_store: LLMProfileStore, sample_llm_with_secrets: LLM
+) -> None:
+    profile_store.save("with_key", sample_llm_with_secrets, include_secrets=True)
+
+    [summary] = profile_store.list_summaries()
+    assert summary["api_key_set"] is True
+
+
+def test_list_summaries_api_key_redacted_means_not_set(
+    profile_store: LLMProfileStore, sample_llm_with_secrets: LLM
+) -> None:
+    """A profile saved without secrets stores '**********' on disk; not 'set'."""
+    profile_store.save("no_key", sample_llm_with_secrets, include_secrets=False)
+
+    [summary] = profile_store.list_summaries()
+    assert summary["api_key_set"] is False
+
+
+def test_list_summaries_skips_corrupted(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("good", sample_llm)
+    (profile_store.base_dir / "bad.json").write_text("{ not valid json")
+
+    summaries = profile_store.list_summaries()
+    assert [s["name"] for s in summaries] == ["good"]
+
+
+def test_list_summaries_does_not_mutate_env(
+    profile_store: LLMProfileStore, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Listing summaries must not run LLM validators (which set env vars)."""
+    llm = LLM(
+        usage_id="t",
+        model="bedrock/test",
+        aws_access_key_id="from-profile",
+    )
+    profile_store.save("aws", llm, include_secrets=True)
+
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    profile_store.list_summaries()
+
+    import os
+
+    assert os.environ.get("AWS_ACCESS_KEY_ID") is None
+
+
+# ── Misc ──────────────────────────────────────────────────────────────────
 
 
 def test_multiple_profiles(profile_store: LLMProfileStore) -> None:

--- a/tests/sdk/llm/test_llm_profile_store.py
+++ b/tests/sdk/llm/test_llm_profile_store.py
@@ -8,7 +8,10 @@ import pytest
 from pydantic import SecretStr
 
 from openhands.sdk.llm import LLM
-from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.llm.llm_profile_store import (
+    LLMProfileStore,
+    ProfileLimitExceeded,
+)
 
 
 @pytest.fixture
@@ -469,6 +472,7 @@ def test_list_summaries_returns_metadata(
     assert len(summaries) == 2
     by_name = {s["name"]: s for s in summaries}
     assert by_name["a"]["model"] == sample_llm.model
+    assert by_name["a"]["base_url"] == sample_llm.base_url
     assert by_name["a"]["api_key_set"] is False
 
 
@@ -499,6 +503,62 @@ def test_list_summaries_skips_corrupted(
 
     summaries = profile_store.list_summaries()
     assert [s["name"] for s in summaries] == ["good"]
+
+
+def test_list_summaries_skips_non_dict(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    """A JSON file whose top-level value isn't an object is skipped, not raised."""
+    profile_store.save("good", sample_llm)
+    (profile_store.base_dir / "list.json").write_text("[1, 2, 3]")
+    (profile_store.base_dir / "string.json").write_text('"plain"')
+
+    summaries = profile_store.list_summaries()
+    assert [s["name"] for s in summaries] == ["good"]
+
+
+def test_list_summaries_skips_invalid_filename(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    """Files with names not matching PROFILE_NAME_REGEX are skipped."""
+    profile_store.save("good", sample_llm)
+    (profile_store.base_dir / ".hidden.json").write_text('{"model": "x"}')
+    (profile_store.base_dir / "bad@name.json").write_text('{"model": "x"}')
+
+    summaries = profile_store.list_summaries()
+    assert [s["name"] for s in summaries] == ["good"]
+
+
+# ── Save with max_profiles ─────────────────────────────────────────────────
+
+
+def test_save_with_max_profiles_blocks_over_limit(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("a", sample_llm)
+    profile_store.save("b", sample_llm)
+
+    with pytest.raises(ProfileLimitExceeded, match="2"):
+        profile_store.save("c", sample_llm, max_profiles=2)
+
+
+def test_save_with_max_profiles_allows_overwrite(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    """Overwriting an existing profile is allowed even when at the limit."""
+    profile_store.save("a", sample_llm)
+    profile_store.save("b", sample_llm)
+
+    profile_store.save("a", sample_llm, max_profiles=2)
+    assert len(profile_store.list()) == 2
+
+
+def test_save_with_max_profiles_allows_under_limit(
+    profile_store: LLMProfileStore, sample_llm: LLM
+) -> None:
+    profile_store.save("a", sample_llm, max_profiles=5)
+    profile_store.save("b", sample_llm, max_profiles=5)
+    assert len(profile_store.list()) == 2
 
 
 def test_list_summaries_does_not_mutate_env(


### PR DESCRIPTION
## Why             
     
  Users need a way to save, list, retrieve, rename, and delete named LLM configurations from the agent-server (e.g., to switch models mid-conversation or maintain per-task LLM presets). The SDK already had LLMProfileStore for on-disk
   persistence, but no HTTP surface — so the frontend and remote clients couldn't manage profiles. This PR adds that surface, hardens the store against name-validation drift and os.environ mutation, and ships full test coverage.     
   
## Summary                                                                                                                                                                                                                                
                  
  - New /api/profiles endpoints in openhands-agent-server: GET / (list), GET /{name} (detail with api_key nulled), POST /{name} (save with optional include_secrets), DELETE /{name} (idempotent), POST /{name}/rename. Returns 409 at a 
  50-profile soft cap, 503 on store-lock timeouts, 404/409 on rename source/target conflicts.
  - LLMProfileStore additions: PROFILE_NAME_PATTERN (^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$) as the single source of truth for name validation, atomic rename() (single-lock move), and list_summaries() that reads JSON directly so listing  
  profiles never instantiates LLM objects (avoiding silent AWS_*/OR_* env mutation from LLM._set_env_side_effects).                                                                                                                      
  - Router hardening: shared regex with the store, single _store_errors context manager translating TimeoutError/ValueError to HTTP, atomic rename surfaces 404 before 409, api_key is always nulled in detail responses and never echoed
   back in the body.                                                                                                                                                                                                                     
  - 95 new tests across tests/agent_server/test_profiles_router.py and tests/sdk/llm/test_llm_profile_store.py covering happy paths, the profile cap, store timeouts (503), corrupted-profile listing/get (400), redacted-key reporting,
  malformed bodies, special-char/leading-non-alnum names, full rename matrix, and an explicit list_summaries env-isolation guarantee.                                                                                                    
                  

## How to Test

  - make pre-commit (passes: ruff, pyright, dependency rules).                                                                                                                                                                           
  - python -m pytest tests/agent_server/test_profiles_router.py tests/sdk/llm/test_llm_profile_store.py -q → 95 passing.
  - Manual smoke against a running agent-server:                                                                                                                                                                                         
    - POST /api/profiles/work {"llm": {"model": "gpt-4o", "api_key": "sk-…"}, "include_secrets": true} → 201.                                                                                                                            
    - GET /api/profiles → entry with api_key_set: true, no secret material in the response.                                                                                                                                              
    - GET /api/profiles/work → config.api_key is null.                                                                                                                                                                                   
    - POST /api/profiles/work/rename {"new_name": "play"} → 200; calling it again with a missing source → 404 (not 409).                                                                                                                 
    - POST /api/profiles/.hidden → 422 (regex rejects leading dot).                                                                                                                                                                      
    - With a profile containing aws_access_key_id, hitting GET /api/profiles does not modify os.environ["AWS_ACCESS_KEY_ID"].                                                                                                            
    - Save 50 profiles, then POST /api/profiles/<new> → 409 "Profile limit reached".       



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:af4cf76-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-af4cf76-python \
  ghcr.io/openhands/agent-server:af4cf76-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:af4cf76-golang-amd64
ghcr.io/openhands/agent-server:af4cf76-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:af4cf76-golang-arm64
ghcr.io/openhands/agent-server:af4cf76-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:af4cf76-java-amd64
ghcr.io/openhands/agent-server:af4cf76-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:af4cf76-java-arm64
ghcr.io/openhands/agent-server:af4cf76-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:af4cf76-python-amd64
ghcr.io/openhands/agent-server:af4cf76-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:af4cf76-python-arm64
ghcr.io/openhands/agent-server:af4cf76-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:af4cf76-golang
ghcr.io/openhands/agent-server:af4cf76-java
ghcr.io/openhands/agent-server:af4cf76-python
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `af4cf76-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `af4cf76-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->