### PR TITLE
fix: always close tool executors on conversation close

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -993,23 +993,23 @@ class LocalConversation(BaseConversation):
             self.agent.close()
         except Exception as e:
             logger.warning(f"Error closing agent: {e}")
-        if self.delete_on_close:
+        # Always close tool executors — they hold runtime resources
+        # (subprocesses, connections, etc.) that must be released regardless
+        # of whether the conversation data is preserved (delete_on_close).
+        try:
+            tools_map = self.agent.tools_map
+        except (AttributeError, RuntimeError):
+            # Agent not initialized or partially constructed
+            return
+        for tool in tools_map.values():
             try:
-                tools_map = self.agent.tools_map
-            except (AttributeError, RuntimeError):
-                # Agent not initialized or partially constructed
-                return
-            for tool in tools_map.values():
-                try:
-                    executable_tool = tool.as_executable()
-                    executable_tool.executor.close()
-                except NotImplementedError:
-                    # Tool has no executor, skip it without erroring
-                    continue
-                except Exception as e:
-                    logger.warning(
-                        f"Error closing executor for tool '{tool.name}': {e}"
-                    )
+                executable_tool = tool.as_executable()
+                executable_tool.executor.close()
+            except NotImplementedError:
+                # Tool has no executor, skip it without erroring
+                continue
+            except Exception as e:
+                logger.warning(f"Error closing executor for tool '{tool.name}': {e}")
 
     def ask_agent(self, question: str) -> str:
         """Ask the agent a simple, stateless question and get a direct LLM response.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1,4 +1,5 @@
 import atexit
+import contextlib
 import copy
 import uuid
 from collections.abc import Mapping
@@ -997,20 +998,17 @@ class LocalConversation(BaseConversation):
         # Always close tool executors — they hold runtime resources
         # (subprocesses, connections, etc.) that must be released regardless
         # of whether the conversation data is preserved (delete_on_close).
-        try:
-            tools_map = self.agent.tools_map
-        except (AttributeError, RuntimeError):
-            # Agent not initialized or partially constructed
-            return
-        for tool in tools_map.values():
-            try:
-                executable_tool = tool.as_executable()
-                executable_tool.executor.close()
-            except NotImplementedError:
-                # Tool has no executor, skip it without erroring
-                continue
-            except Exception as e:
-                logger.warning(f"Error closing executor for tool '{tool.name}': {e}")
+        with contextlib.suppress(AttributeError, RuntimeError):
+            # Agent not initialized or partially constructed → skip
+            for tool in self.agent.tools_map.values():
+                with contextlib.suppress(NotImplementedError):
+                    try:
+                        executable_tool = tool.as_executable()
+                        executable_tool.executor.close()
+                    except Exception as e:
+                        logger.warning(
+                            f"Error closing executor for tool '{tool.name}': {e}"
+                        )
 
     def ask_agent(self, question: str) -> str:
         """Ask the agent a simple, stateless question and get a direct LLM response.

--- a/tests/tools/terminal/test_conversation_cleanup.py
+++ b/tests/tools/terminal/test_conversation_cleanup.py
@@ -34,7 +34,6 @@ def test_conversation_close_calls_executor_close(mock_llm):
             llm=mock_llm,
             tools=[Tool(name="test_terminal")],
         )
-        # delete_on_close=True is required to trigger executor cleanup
         conversation = Conversation(
             agent=agent, workspace=temp_dir, delete_on_close=True
         )
@@ -46,6 +45,34 @@ def test_conversation_close_calls_executor_close(mock_llm):
         conversation.close()
 
         # Verify that the executor's close method was called
+        terminal_executor.close.assert_called_once()
+
+
+def test_conversation_close_calls_executor_close_without_delete(mock_llm):
+    """Executors are closed even when delete_on_close=False."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        terminal_executor = TerminalExecutor(
+            working_dir=temp_dir, terminal_type="subprocess"
+        )
+        terminal_executor.close = Mock()
+
+        def _make_tool(conv_state, **params):
+            tools = TerminalTool.create(conv_state)
+            tool = tools[0]
+            return [tool.model_copy(update={"executor": terminal_executor})]
+
+        register_tool("test_terminal", _make_tool)
+
+        agent = Agent(
+            llm=mock_llm,
+            tools=[Tool(name="test_terminal")],
+        )
+        conversation = Conversation(
+            agent=agent, workspace=temp_dir, delete_on_close=False
+        )
+        conversation._ensure_agent_ready()
+        conversation.close()
+
         terminal_executor.close.assert_called_once()
 
 
@@ -70,7 +97,6 @@ def test_conversation_del_calls_close(mock_llm):
             llm=mock_llm,
             tools=[Tool(name="test_terminal")],
         )
-        # delete_on_close=True is required to trigger executor cleanup
         conversation = Conversation(
             agent=agent, workspace=temp_dir, delete_on_close=True
         )


### PR DESCRIPTION
## Summary

Tool executor cleanup in `LocalConversation.close()` was gated behind `if self.delete_on_close`. When `delete_on_close=False` — used by the agent-server during conversation forks — tool executors (terminal sessions, browser processes, MCP connections, task managers) were never released, causing resource leaks.

## Root cause

`local_conversation.py:996` — the executor cleanup loop was inside an `if self.delete_on_close:` block. The `delete_on_close` flag controls whether *persisted data* should be removed, but runtime resources (subprocesses, connections) must always be released.

## Fix

Moved the executor cleanup loop outside the `if self.delete_on_close:` guard. Executors are now always closed when a conversation closes, regardless of whether conversation data is preserved.

## Test

Added `test_conversation_close_calls_executor_close_without_delete` — verifies that `executor.close()` is called even when `delete_on_close=False`. All 7 existing cleanup tests continue to pass.

Fixes #3149

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ac3adfc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ac3adfc-python \
  ghcr.io/openhands/agent-server:ac3adfc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ac3adfc-golang-amd64
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-golang-amd64
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-golang-amd64
ghcr.io/openhands/agent-server:ac3adfc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ac3adfc-golang-arm64
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-golang-arm64
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-golang-arm64
ghcr.io/openhands/agent-server:ac3adfc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ac3adfc-java-amd64
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-java-amd64
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-java-amd64
ghcr.io/openhands/agent-server:ac3adfc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ac3adfc-java-arm64
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-java-arm64
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-java-arm64
ghcr.io/openhands/agent-server:ac3adfc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ac3adfc-python-amd64
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-python-amd64
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-python-amd64
ghcr.io/openhands/agent-server:ac3adfc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ac3adfc-python-arm64
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-python-arm64
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-python-arm64
ghcr.io/openhands/agent-server:ac3adfc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ac3adfc-golang
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-golang
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-golang
ghcr.io/openhands/agent-server:ac3adfc-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ac3adfc-java
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-java
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-java
ghcr.io/openhands/agent-server:ac3adfc-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ac3adfc-python
ghcr.io/openhands/agent-server:ac3adfc996b081fefee658ac5bccc8d7682f0817-python
ghcr.io/openhands/agent-server:fix-3149-tool-executor-close-on-conversation-close-python
ghcr.io/openhands/agent-server:ac3adfc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ac3adfc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ac3adfc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->