### PR TITLE
fix: eliminate TOCTOU race in EventService.send_message

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -378,26 +378,11 @@ class EventService:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._conversation.send_message, message)
         if run:
-            run = (
-                await self._get_execution_status()
-                != ConversationExecutionStatus.RUNNING
-            )
-        if run:
-            conversation = self._conversation
-
-            async def _run_with_error_handling():
-                try:
-                    await loop.run_in_executor(None, conversation.run)
-                except Exception:
-                    logger.exception("Error during conversation run from send_message")
-
-            # Fire-and-forget: This task is intentionally not tracked because
-            # send_message() is designed to return immediately after queuing the
-            # message. The conversation run happens in the background and any
-            # errors are logged. Unlike the run() method which is explicitly
-            # awaited, this pattern allows clients to send messages without
-            # blocking on the full conversation execution.
-            loop.create_task(_run_with_error_handling())
+            try:
+                await self.run()
+            except ValueError:
+                # Already running or inactive — message was sent, skip run.
+                pass
 
     async def subscribe_to_events(self, subscriber: Subscriber[Event]) -> UUID:
         subscriber_id = self._pub_sub.subscribe(subscriber)

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -381,11 +381,9 @@ class EventService:
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._conversation.send_message, message)
         if run:
-            try:
+            # Already running or inactive — message was sent, skip run.
+            with suppress(ValueError):
                 await self.run()
-            except ValueError:
-                # Already running or inactive — message was sent, skip run.
-                pass
 
     async def subscribe_to_events(self, subscriber: Subscriber[Event]) -> UUID:
         subscriber_id = self._pub_sub.subscribe(subscriber)

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -2,6 +2,7 @@ import asyncio
 import shutil
 import threading
 import time
+from contextlib import suppress
 from datetime import UTC, datetime
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -688,6 +689,8 @@ class TestEventServiceSendMessage:
         conversation.run = MagicMock()
 
         event_service._conversation = conversation
+        # Simulate conversation already running to test the ValueError path
+        event_service._run_task = asyncio.create_task(asyncio.sleep(10))
         message = Message(role="user", content=[])
 
         # Call send_message with run=True — should silently skip run
@@ -698,6 +701,11 @@ class TestEventServiceSendMessage:
         # and raises ValueError (caught by send_message) — so
         # conversation.run is never invoked.
         conversation.run.assert_not_called()
+
+        # Clean up the simulated running task
+        event_service._run_task.cancel()
+        with suppress(asyncio.CancelledError):
+            await event_service._run_task
 
     @pytest.mark.asyncio
     async def test_send_message_with_run_true_agent_idle(self, event_service):

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -688,16 +688,15 @@ class TestEventServiceSendMessage:
         conversation.run = MagicMock()
 
         event_service._conversation = conversation
-        event_service._get_execution_status = AsyncMock(
-            return_value=ConversationExecutionStatus.RUNNING
-        )
         message = Message(role="user", content=[])
 
-        # Call send_message with run=True
+        # Call send_message with run=True — should silently skip run
         await event_service.send_message(message, run=True)
 
         conversation.send_message.assert_called_once_with(message)
-        event_service._get_execution_status.assert_awaited_once()
+        # run() delegates to self.run() which checks status under lock
+        # and raises ValueError (caught by send_message) — so
+        # conversation.run is never invoked.
         conversation.run.assert_not_called()
 
     @pytest.mark.asyncio
@@ -715,6 +714,7 @@ class TestEventServiceSendMessage:
         conversation.run = MagicMock()
 
         event_service._conversation = conversation
+        event_service._publish_state_update = AsyncMock()
         message = Message(role="user", content=[])
 
         # Call send_message with run=True
@@ -723,12 +723,9 @@ class TestEventServiceSendMessage:
         # Verify send_message was called
         conversation.send_message.assert_called_once_with(message)
 
-        # Wait for the background task to call run with a timeout
-        async def wait_for_run_called():
-            while not conversation.run.called:
-                await asyncio.sleep(0.001)
-
-        await asyncio.wait_for(wait_for_run_called(), timeout=1.0)
+        # send_message delegates to self.run() which creates a background task
+        assert event_service._run_task is not None
+        await event_service._run_task
 
         # Verify run was called since agent was idle
         conversation.run.assert_called_once()
@@ -748,6 +745,7 @@ class TestEventServiceSendMessage:
         conversation.run = MagicMock(side_effect=RuntimeError("Test error"))
 
         event_service._conversation = conversation
+        event_service._publish_state_update = AsyncMock()
         message = Message(role="user", content=[])
 
         # Patch the logger to verify exception logging
@@ -755,16 +753,14 @@ class TestEventServiceSendMessage:
             # Call send_message with run=True
             await event_service.send_message(message, run=True)
 
-            # Wait for the background task to complete with a timeout
-            async def wait_for_exception_logged():
-                while not mock_logger.exception.called:
-                    await asyncio.sleep(0.001)
-
-            await asyncio.wait_for(wait_for_exception_logged(), timeout=1.0)
+            # Wait for the background task to complete
+            assert event_service._run_task is not None
+            await event_service._run_task
 
             # Verify the exception was logged via logger.exception()
+            # (logged by run()'s _run_and_publish handler)
             mock_logger.exception.assert_called_once_with(
-                "Error during conversation run from send_message"
+                "Error during conversation run"
             )
 
         # Verify send_message was still called


### PR DESCRIPTION
## Summary

`send_message(run=True)` had a time-of-check/time-of-use race condition: it checked `execution_status != RUNNING` then created an untracked fire-and-forget task — all without holding `_run_lock`. Two concurrent `send_message` calls could both see the conversation as non-running and start parallel `conversation.run()` executions.

## Root cause

`event_service.py:380-400` — the status check and task dispatch were outside any lock. The existing `run()` method already solved this correctly with `async with self._run_lock:`, but `send_message` had its own independent, unprotected code path.

## Fix

Replace the inline check-and-dispatch with delegation to `self.run()`, catching `ValueError` when the conversation is already running. This:

- **Fixes the race**: `run()` wraps check + dispatch in `_run_lock`
- **Tracks the task**: `run()` assigns to `_run_task`, enabling the double-guard (`execution_status` + `_run_task.done()`)
- **Adds proper cleanup**: `run()`'s `finally` block waits for pending callbacks and publishes state updates — the old fire-and-forget skipped this
- **Reduces code**: 19 insertions, 38 deletions — eliminates duplicated dispatch logic

The change is 5 lines of production code (net -19 lines).

## Verification

- All 73 `test_event_service.py` tests pass
- All pre-commit hooks pass (ruff, pyright, etc.)
- Updated 3 tests to match the delegation pattern

Fixes #3147

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b5fad88-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b5fad88-python \
  ghcr.io/openhands/agent-server:b5fad88-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b5fad88-golang-amd64
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-golang-amd64
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-golang-amd64
ghcr.io/openhands/agent-server:b5fad88-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b5fad88-golang-arm64
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-golang-arm64
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-golang-arm64
ghcr.io/openhands/agent-server:b5fad88-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b5fad88-java-amd64
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-java-amd64
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-java-amd64
ghcr.io/openhands/agent-server:b5fad88-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b5fad88-java-arm64
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-java-arm64
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-java-arm64
ghcr.io/openhands/agent-server:b5fad88-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b5fad88-python-amd64
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-python-amd64
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-python-amd64
ghcr.io/openhands/agent-server:b5fad88-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b5fad88-python-arm64
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-python-arm64
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-python-arm64
ghcr.io/openhands/agent-server:b5fad88-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b5fad88-golang
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-golang
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-golang
ghcr.io/openhands/agent-server:b5fad88-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b5fad88-java
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-java
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-java
ghcr.io/openhands/agent-server:b5fad88-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b5fad88-python
ghcr.io/openhands/agent-server:b5fad88128cf44ca71f89d25fbad0dffe9caf891-python
ghcr.io/openhands/agent-server:fix-3147-send-message-toctou-race-python
ghcr.io/openhands/agent-server:b5fad88-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b5fad88-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b5fad88-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->