### PR TITLE
feat(profiles): Add cipher encryption for LLM profile secrets

### DIFF
--- a/openhands-agent-server/openhands/agent_server/_secrets_exposure.py
+++ b/openhands-agent-server/openhands/agent_server/_secrets_exposure.py
@@ -1,0 +1,95 @@
+"""Shared helpers for the ``X-Expose-Secrets`` flow used by settings and profiles."""
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any, Literal, cast
+
+from fastapi import HTTPException, Request, status
+from pydantic_core import PydanticSerializationError
+
+from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.pydantic_secrets import MissingCipherError
+
+
+ExposeSecretsMode = Literal["encrypted", "plaintext"]
+
+
+def get_config(request: Request):
+    """Get config from app state, raising 503 if uninitialized."""
+    config = getattr(request.app.state, "config", None)
+    if config is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Server not fully initialized",
+        )
+    return config
+
+
+def get_cipher(request: Request) -> Cipher | None:
+    """Get the configured cipher (``None`` when ``OH_SECRET_KEY`` is unset)."""
+    return get_config(request).cipher
+
+
+def parse_expose_secrets_header(request: Request) -> ExposeSecretsMode | None:
+    """Parse the ``X-Expose-Secrets`` header.
+
+    Returns ``"encrypted"``, ``"plaintext"``, or ``None`` (header absent).
+    Raises ``HTTPException(400)`` for any other value.
+    """
+    header_value = request.headers.get("X-Expose-Secrets", "").lower().strip()
+
+    if not header_value:
+        return None
+
+    # Legacy alias accepted for the settings flow's pre-existing clients;
+    # mapped to "encrypted" so a stale "true" never accidentally exposes plaintext.
+    if header_value == "true":
+        return "encrypted"
+
+    if header_value in ("encrypted", "plaintext"):
+        return cast(ExposeSecretsMode, header_value)
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=(
+            f"Invalid X-Expose-Secrets header value: '{header_value}'. "
+            "Valid values are: 'encrypted', 'plaintext'."
+        ),
+    )
+
+
+def build_expose_context(
+    expose_mode: ExposeSecretsMode | None, cipher: Cipher | None
+) -> dict[str, Any]:
+    """Build the pydantic serialization context for the given expose mode."""
+    if expose_mode is None:
+        return {}
+    return {"expose_secrets": expose_mode, "cipher": cipher}
+
+
+def _has_missing_cipher_cause(exc: BaseException) -> bool:
+    seen: set[int] = set()
+    cur: BaseException | None = exc
+    while cur is not None and id(cur) not in seen:
+        if isinstance(cur, MissingCipherError):
+            return True
+        seen.add(id(cur))
+        cur = cur.__cause__ or cur.__context__
+    return False
+
+
+@contextmanager
+def translate_missing_cipher() -> Iterator[None]:
+    """Translate a missing-cipher serializer error into HTTP 503."""
+    try:
+        yield
+    except (PydanticSerializationError, MissingCipherError) as e:
+        if _has_missing_cipher_cause(e):
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail=(
+                    "Encryption not available: OH_SECRET_KEY is not configured. "
+                    "Cannot return encrypted secrets."
+                ),
+            )
+        raise

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -2,9 +2,9 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal, cast
 
-from fastapi import APIRouter, HTTPException, Path, status
+from fastapi import APIRouter, HTTPException, Path, Request, status
 from pydantic import BaseModel, Field, SecretStr
 
 from openhands.sdk.llm import LLM
@@ -14,6 +14,7 @@ from openhands.sdk.llm.llm_profile_store import (
     ProfileLimitExceeded,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.cipher import Cipher
 
 
 logger = get_logger(__name__)
@@ -26,6 +27,9 @@ ProfileName = Annotated[
     str,
     Path(min_length=1, max_length=64, pattern=PROFILE_NAME_PATTERN),
 ]
+
+# Valid values for X-Expose-Secrets header
+ExposeSecretsMode = Literal["encrypted", "plaintext"]
 
 
 class ProfileInfo(BaseModel):
@@ -92,6 +96,44 @@ def _has_api_key(llm: LLM) -> bool:
     return bool(llm.api_key.get_secret_value().strip())
 
 
+def _get_cipher(request: Request) -> Cipher | None:
+    """Get cipher from app state config, if configured."""
+    config = getattr(request.app.state, "config", None)
+    if config is None:
+        return None
+    return getattr(config, "cipher", None)
+
+
+def _parse_expose_secrets_header(request: Request) -> ExposeSecretsMode | None:
+    """Parse X-Expose-Secrets header value.
+
+    Returns:
+        "encrypted", "plaintext", or None (if header not present).
+
+    Raises:
+        HTTPException: 400 if header has invalid value.
+    """
+    header_value = request.headers.get("X-Expose-Secrets", "").lower().strip()
+
+    if not header_value:
+        return None
+
+    # Legacy "true" value - treat as "encrypted" for safety
+    if header_value == "true":
+        return "encrypted"
+
+    if header_value in ("encrypted", "plaintext"):
+        return cast(ExposeSecretsMode, header_value)
+
+    raise HTTPException(
+        status_code=status.HTTP_400_BAD_REQUEST,
+        detail=(
+            f"Invalid X-Expose-Secrets header value: '{header_value}'. "
+            "Valid values are: 'encrypted', 'plaintext'."
+        ),
+    )
+
+
 @profiles_router.get("", response_model=ProfileListResponse)
 async def list_profiles() -> ProfileListResponse:
     """List all saved LLM profiles."""
@@ -102,20 +144,53 @@ async def list_profiles() -> ProfileListResponse:
 
 
 @profiles_router.get("/{name}", response_model=ProfileDetailResponse)
-async def get_profile(name: ProfileName) -> ProfileDetailResponse:
-    """Get a profile's configuration with ``api_key`` nulled out."""
+async def get_profile(request: Request, name: ProfileName) -> ProfileDetailResponse:
+    """Get a profile's configuration.
+
+    Use the ``X-Expose-Secrets`` header to control secret exposure:
+    - ``encrypted``: Returns cipher-encrypted values (safe for frontend clients)
+    - ``plaintext``: Returns raw secret values (backend clients only!)
+    - (absent): Returns nulled ``api_key`` with ``api_key_set`` indicator
+    """
+    expose_mode = _parse_expose_secrets_header(request)
+    cipher = _get_cipher(request)
+
     store = LLMProfileStore()
     try:
         with _store_errors():
-            llm = store.load(name)
+            llm = store.load(name, cipher=cipher)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Profile '{name}' not found",
         )
 
-    config = llm.model_dump(mode="json")
-    config["api_key"] = None
+    # Build serialization context based on expose mode
+    if expose_mode:
+        context: dict[str, Any] = {
+            "expose_secrets": expose_mode,
+            "cipher": cipher,
+        }
+        try:
+            config = llm.model_dump(mode="json", context=context)
+        except Exception as e:
+            # Handle ValueError from serialize_secret when cipher is missing
+            # Pydantic wraps it in PydanticSerializationError, so check the chain
+            error_str = str(e)
+            if "no cipher configured" in error_str:
+                raise HTTPException(
+                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                    detail=(
+                        "Encryption not available: OH_SECRET_KEY is not configured. "
+                        "Cannot return encrypted secrets."
+                    ),
+                )
+            raise
+    else:
+        # Default behavior: null out api_key
+        config = llm.model_dump(mode="json")
+        config["api_key"] = None
+
     return ProfileDetailResponse(
         name=name, config=config, api_key_set=_has_api_key(llm)
     )
@@ -127,6 +202,7 @@ async def get_profile(name: ProfileName) -> ProfileDetailResponse:
     status_code=status.HTTP_201_CREATED,
 )
 async def save_profile(
+    request: Request,
     name: ProfileName,
     body: SaveProfileRequest,
 ) -> ProfileMutationResponse:
@@ -134,7 +210,12 @@ async def save_profile(
 
     Overwrites an existing profile of the same name. Returns 409 if creating
     a new profile would exceed ``MAX_PROFILES``.
+
+    When ``OH_SECRET_KEY`` is configured, secrets are encrypted at rest.
+    Clients can submit cipher-encrypted secrets which will be decrypted
+    server-side before re-encrypting with the storage cipher.
     """
+    cipher = _get_cipher(request)
     store = LLMProfileStore()
     try:
         with _store_errors():
@@ -142,6 +223,7 @@ async def save_profile(
                 name,
                 body.llm,
                 include_secrets=body.include_secrets,
+                cipher=cipher,
                 max_profiles=MAX_PROFILES,
             )
     except ProfileLimitExceeded:

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -2,12 +2,19 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Annotated, Any, Literal, cast
+from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Path, Request, status
 from pydantic import BaseModel, Field, SecretStr
 
+from openhands.agent_server._secrets_exposure import (
+    build_expose_context,
+    get_cipher,
+    parse_expose_secrets_header,
+    translate_missing_cipher,
+)
 from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
 from openhands.sdk.llm.llm_profile_store import (
     PROFILE_NAME_PATTERN,
     LLMProfileStore,
@@ -27,9 +34,6 @@ ProfileName = Annotated[
     str,
     Path(min_length=1, max_length=64, pattern=PROFILE_NAME_PATTERN),
 ]
-
-# Valid values for X-Expose-Secrets header
-ExposeSecretsMode = Literal["encrypted", "plaintext"]
 
 
 class ProfileInfo(BaseModel):
@@ -96,42 +100,32 @@ def _has_api_key(llm: LLM) -> bool:
     return bool(llm.api_key.get_secret_value().strip())
 
 
-def _get_cipher(request: Request) -> Cipher | None:
-    """Get cipher from app state config, if configured."""
-    config = getattr(request.app.state, "config", None)
-    if config is None:
-        return None
-    return getattr(config, "cipher", None)
+# Fernet tokens always begin with the URL-safe base64 of version byte 0x80,
+# i.e. "gAAAAA". We gate decrypt attempts on this prefix so genuine plaintext
+# secrets pass through untouched (and we don't spam the cipher's failure log).
+_FERNET_TOKEN_PREFIX = "gAAAAA"
 
 
-def _parse_expose_secrets_header(request: Request) -> ExposeSecretsMode | None:
-    """Parse X-Expose-Secrets header value.
+def _decrypt_incoming_secrets(llm: LLM, cipher: Cipher) -> LLM:
+    """Decrypt any pre-encrypted secret fields posted back by the client.
 
-    Returns:
-        "encrypted", "plaintext", or None (if header not present).
-
-    Raises:
-        HTTPException: 400 if header has invalid value.
+    FastAPI parses the request body without a cipher in the validation context,
+    so an encrypted blob arrives as ``SecretStr("gAAAAA...")``. Without this
+    pass, ``store.save`` would re-encrypt the blob, producing a double-encrypted
+    value on disk that no longer round-trips. Plaintext input is left untouched.
     """
-    header_value = request.headers.get("X-Expose-Secrets", "").lower().strip()
-
-    if not header_value:
-        return None
-
-    # Legacy "true" value - treat as "encrypted" for safety
-    if header_value == "true":
-        return "encrypted"
-
-    if header_value in ("encrypted", "plaintext"):
-        return cast(ExposeSecretsMode, header_value)
-
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail=(
-            f"Invalid X-Expose-Secrets header value: '{header_value}'. "
-            "Valid values are: 'encrypted', 'plaintext'."
-        ),
-    )
+    updates: dict[str, SecretStr] = {}
+    for field in LLM_SECRET_FIELDS:
+        val = getattr(llm, field, None)
+        if not isinstance(val, SecretStr):
+            continue
+        raw = val.get_secret_value()
+        if not raw.startswith(_FERNET_TOKEN_PREFIX):
+            continue
+        decrypted = cipher.decrypt(raw)
+        if decrypted is not None:
+            updates[field] = decrypted
+    return llm.model_copy(update=updates) if updates else llm
 
 
 @profiles_router.get("", response_model=ProfileListResponse)
@@ -152,8 +146,8 @@ async def get_profile(request: Request, name: ProfileName) -> ProfileDetailRespo
     - ``plaintext``: Returns raw secret values (backend clients only!)
     - (absent): Returns nulled ``api_key`` with ``api_key_set`` indicator
     """
-    expose_mode = _parse_expose_secrets_header(request)
-    cipher = _get_cipher(request)
+    expose_mode = parse_expose_secrets_header(request)
+    cipher = get_cipher(request)
 
     store = LLMProfileStore()
     try:
@@ -165,29 +159,11 @@ async def get_profile(request: Request, name: ProfileName) -> ProfileDetailRespo
             detail=f"Profile '{name}' not found",
         )
 
-    # Build serialization context based on expose mode
     if expose_mode:
-        context: dict[str, Any] = {
-            "expose_secrets": expose_mode,
-            "cipher": cipher,
-        }
-        try:
-            config = llm.model_dump(mode="json", context=context)
-        except Exception as e:
-            # Handle ValueError from serialize_secret when cipher is missing
-            # Pydantic wraps it in PydanticSerializationError, so check the chain
-            error_str = str(e)
-            if "no cipher configured" in error_str:
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail=(
-                        "Encryption not available: OH_SECRET_KEY is not configured. "
-                        "Cannot return encrypted secrets."
-                    ),
-                )
-            raise
+        context = build_expose_context(expose_mode, cipher)
+        with translate_missing_cipher():
+            config: dict[str, Any] = llm.model_dump(mode="json", context=context)
     else:
-        # Default behavior: null out api_key
         config = llm.model_dump(mode="json")
         config["api_key"] = None
 
@@ -215,13 +191,14 @@ async def save_profile(
     Clients can submit cipher-encrypted secrets which will be decrypted
     server-side before re-encrypting with the storage cipher.
     """
-    cipher = _get_cipher(request)
+    cipher = get_cipher(request)
+    llm = _decrypt_incoming_secrets(body.llm, cipher) if cipher else body.llm
     store = LLMProfileStore()
     try:
         with _store_errors():
             store.save(
                 name,
-                body.llm,
+                llm,
                 include_secrets=body.include_secrets,
                 cipher=cipher,
                 max_profiles=MAX_PROFILES,

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -1,9 +1,15 @@
 from functools import lru_cache
-from typing import Any, Literal, cast
+from typing import cast
 
 from fastapi import APIRouter, HTTPException, Request, Response, status
 from pydantic import ValidationError
 
+from openhands.agent_server._secrets_exposure import (
+    build_expose_context,
+    get_config,
+    parse_expose_secrets_header,
+    translate_missing_cipher,
+)
 from openhands.agent_server.persistence import (
     SECRET_NAME_PATTERN,
     PersistedSettings,
@@ -37,9 +43,6 @@ SECRETS_PATH = "/secrets"  # -> /api/settings/secrets
 SECRET_VALUE_PATH = "/secrets/{name}"  # -> /api/settings/secrets/{name}
 
 settings_router = APIRouter(prefix="/settings", tags=["Settings"])
-
-# Valid values for X-Expose-Secrets header
-ExposeSecretsMode = Literal["encrypted", "plaintext"]
 
 
 # ── Schema Endpoints ─────────────────────────────────────────────────────
@@ -75,18 +78,6 @@ async def get_conversation_settings_schema() -> SettingsSchema:
 # ── Settings CRUD Endpoints ──────────────────────────────────────────────
 
 
-def _get_config(request: Request):
-    """Get config from app state.
-
-    Raises:
-        HTTPException: 503 if config is not initialized.
-    """
-    config = getattr(request.app.state, "config", None)
-    if config is None:
-        raise HTTPException(status_code=503, detail="Server not fully initialized")
-    return config
-
-
 def _validate_secret_name(name: str) -> None:
     """Validate secret name format.
 
@@ -107,36 +98,6 @@ def _validate_secret_name(name: str) -> None:
                 "and be 1-64 characters long."
             ),
         )
-
-
-def _parse_expose_secrets_header(request: Request) -> ExposeSecretsMode | None:
-    """Parse X-Expose-Secrets header value.
-
-    Returns:
-        "encrypted", "plaintext", or None (if header not present or invalid).
-
-    Raises:
-        HTTPException: 400 if header has invalid value.
-    """
-    header_value = request.headers.get("X-Expose-Secrets", "").lower().strip()
-
-    if not header_value:
-        return None
-
-    # Legacy "true" value - treat as "encrypted" for safety
-    if header_value == "true":
-        return "encrypted"
-
-    if header_value in ("encrypted", "plaintext"):
-        return cast(ExposeSecretsMode, header_value)
-
-    raise HTTPException(
-        status_code=status.HTTP_400_BAD_REQUEST,
-        detail=(
-            f"Invalid X-Expose-Secrets header value: '{header_value}'. "
-            "Valid values are: 'encrypted', 'plaintext'."
-        ),
-    )
 
 
 @settings_router.get(SETTINGS_PATH, response_model=SettingsResponse)
@@ -171,8 +132,8 @@ async def get_settings(request: Request) -> SettingsResponse:
         mode for round-tripping secrets, or omit the header to receive redacted
         values.
     """
-    expose_mode = _parse_expose_secrets_header(request)
-    config = _get_config(request)
+    expose_mode = parse_expose_secrets_header(request)
+    config = get_config(request)
     store = get_settings_store(config)
     settings = store.load() or PersistedSettings()
 
@@ -189,16 +150,8 @@ async def get_settings(request: Request) -> SettingsResponse:
     else:
         logger.info("Settings accessed", extra=log_extra)
 
-    # Build serialization context based on expose mode
-    if expose_mode:
-        context: dict[str, Any] = {
-            "expose_secrets": expose_mode,
-            "cipher": config.cipher,  # Needed for "encrypted" mode
-        }
-    else:
-        context = {}
-
-    try:
+    context = build_expose_context(expose_mode, config.cipher)
+    with translate_missing_cipher():
         return SettingsResponse(
             agent_settings=settings.agent_settings.model_dump(
                 mode="json", context=context
@@ -208,14 +161,6 @@ async def get_settings(request: Request) -> SettingsResponse:
             ),
             llm_api_key_is_set=settings.llm_api_key_is_set,
         )
-    except Exception as e:
-        # Handle ValueError from serialize_secret when cipher is missing
-        if "no cipher configured" in str(e):
-            raise HTTPException(
-                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                detail="Encryption not available: OH_SECRET_KEY is not configured",
-            )
-        raise
 
 
 @settings_router.patch(SETTINGS_PATH, response_model=SettingsResponse)
@@ -232,7 +177,7 @@ async def update_settings(
     Raises:
         HTTPException: 400 if the update payload contains invalid values.
     """
-    config = _get_config(request)
+    config = get_config(request)
     store = get_settings_store(config)
 
     update_data = payload.model_dump(exclude_none=True)
@@ -305,7 +250,7 @@ async def update_settings(
 @settings_router.get(SECRETS_PATH, response_model=SecretsListResponse)
 async def list_secrets(request: Request) -> SecretsListResponse:
     """List all available secrets (names and descriptions only, no values)."""
-    config = _get_config(request)
+    config = get_config(request)
     store = get_secrets_store(config)
     secrets = store.load()
 
@@ -339,7 +284,7 @@ async def get_secret_value(request: Request, name: str) -> Response:
     """
     _validate_secret_name(name)
 
-    config = _get_config(request)
+    config = get_config(request)
     store = get_secrets_store(config)
     value = store.get_secret(name)
 
@@ -371,7 +316,7 @@ async def create_secret(
     """
     _validate_secret_name(secret.name)
 
-    config = _get_config(request)
+    config = get_config(request)
     store = get_secrets_store(config)
 
     try:
@@ -412,7 +357,7 @@ async def delete_secret(request: Request, name: str) -> dict[str, bool]:
     """
     _validate_secret_name(name)
 
-    config = _get_config(request)
+    config = get_config(request)
     store = get_secrets_store(config)
 
     client_host = request.client.host if request.client else "unknown"

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -131,6 +131,16 @@ ENV_ALLOW_SHORT_CONTEXT_WINDOWS: Final[str] = "ALLOW_SHORT_CONTEXT_WINDOWS"
 # 16384 is a safe default that works for most models (GPT-4o: 16k, Claude: 8k).
 DEFAULT_MAX_OUTPUT_TOKENS_CAP: Final[int] = 16384
 
+# Secret-bearing fields on LLM. Kept as a single source of truth so callers that
+# need to walk secrets (e.g. cipher-aware decryption on the save path) stay in
+# sync with the serializer below.
+LLM_SECRET_FIELDS: Final[tuple[str, ...]] = (
+    "api_key",
+    "aws_access_key_id",
+    "aws_secret_access_key",
+    "aws_session_token",
+)
+
 
 class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     """Language model interface for OpenHands agents.
@@ -580,13 +590,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     # =========================================================================
     # Serializers
     # =========================================================================
-    @field_serializer(
-        "api_key",
-        "aws_access_key_id",
-        "aws_secret_access_key",
-        "aws_session_token",
-        when_used="always",
-    )
+    @field_serializer(*LLM_SECRET_FIELDS, when_used="always")
     def _serialize_secrets(self, v: SecretStr | None, info):
         return serialize_secret(v, info)
 

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1521,10 +1521,22 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     # Serialization helpers
     # =========================================================================
     @classmethod
-    def load_from_json(cls, json_path: str) -> LLM:
+    def load_from_json(
+        cls, json_path: str, *, context: dict[str, Any] | None = None
+    ) -> LLM:
+        """Load an LLM instance from a JSON file.
+
+        Args:
+            json_path: Path to the JSON file containing LLM configuration.
+            context: Optional validation context (e.g., ``{"cipher": cipher}``
+                for decrypting secrets stored at rest).
+
+        Returns:
+            An LLM instance constructed from the JSON configuration.
+        """
         with open(json_path) as f:
             data = json.load(f)
-        return cls(**data)
+        return cls.model_validate(data, context=context)
 
     @classmethod
     def load_from_env(cls, prefix: str = "LLM_") -> LLM:

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -147,20 +147,13 @@ class LLMProfileStore:
                     f"[Profile Store] Profile `{name}` already exists. Overwriting."
                 )
 
-            # Build serialization context:
-            # - When cipher is provided, encrypt secrets at rest
-            # - When include_secrets is True (but no cipher), store plaintext
-            # - When include_secrets is False, secrets are redacted
             context: dict[str, Any] = {}
             if include_secrets:
                 if cipher:
-                    # Encrypt secrets at rest
                     context["cipher"] = cipher
                     context["expose_secrets"] = "encrypted"
                 else:
-                    # Store plaintext (backward compatible)
                     context["expose_secrets"] = True
-            # else: expose_secrets not set = redaction (Pydantic default)
 
             profile_json = llm.model_dump_json(
                 exclude_none=True,
@@ -209,10 +202,7 @@ class LLMProfileStore:
             try:
                 from openhands.sdk.llm.llm import LLM
 
-                # Build validation context for cipher decryption
-                context: dict[str, Any] | None = None
-                if cipher:
-                    context = {"cipher": cipher}
+                context: dict[str, Any] | None = {"cipher": cipher} if cipher else None
 
                 llm_instance = LLM.load_from_json(str(profile_path), context=context)
             except Exception as e:

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -18,6 +18,7 @@ from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 if TYPE_CHECKING:
     from openhands.sdk.llm.llm import LLM
+    from openhands.sdk.utils.cipher import Cipher
 
 _DEFAULT_PROFILE_DIR: Final[Path] = Path.home() / ".openhands" / "profiles"
 _LOCK_TIMEOUT_SECONDS: Final[float] = 30.0
@@ -103,6 +104,7 @@ class LLMProfileStore:
         llm: LLM,
         include_secrets: bool = False,
         *,
+        cipher: Cipher | None = None,
         max_profiles: int | None = None,
     ) -> None:
         """Save a profile to the profile directory.
@@ -116,6 +118,8 @@ class LLMProfileStore:
             name: Name of the profile to save.
             llm: LLM instance to save
             include_secrets: Whether to include the profile secrets. Defaults to False.
+            cipher: Optional cipher for at-rest encryption of secrets.
+                When provided, secrets are encrypted before writing to disk.
             max_profiles: Optional cap on the number of profiles.
 
         Raises:
@@ -143,10 +147,25 @@ class LLMProfileStore:
                     f"[Profile Store] Profile `{name}` already exists. Overwriting."
                 )
 
+            # Build serialization context:
+            # - When cipher is provided, encrypt secrets at rest
+            # - When include_secrets is True (but no cipher), store plaintext
+            # - When include_secrets is False, secrets are redacted
+            context: dict[str, Any] = {}
+            if include_secrets:
+                if cipher:
+                    # Encrypt secrets at rest
+                    context["cipher"] = cipher
+                    context["expose_secrets"] = "encrypted"
+                else:
+                    # Store plaintext (backward compatible)
+                    context["expose_secrets"] = True
+            # else: expose_secrets not set = redaction (Pydantic default)
+
             profile_json = llm.model_dump_json(
                 exclude_none=True,
                 indent=2,
-                context={"expose_secrets": include_secrets},
+                context=context,
             )
             with tempfile.NamedTemporaryFile(
                 mode="w", dir=self.base_dir, suffix=".tmp", delete=False
@@ -161,11 +180,13 @@ class LLMProfileStore:
                 raise
             logger.info(f"[Profile Store] Saved profile `{name}` at {profile_path}")
 
-    def load(self, name: str) -> LLM:
+    def load(self, name: str, *, cipher: Cipher | None = None) -> LLM:
         """Load an LLM instance from the given profile name.
 
         Args:
             name: Name of the profile to load.
+            cipher: Optional cipher for decrypting secrets stored at rest.
+                When provided, encrypted secrets are decrypted during load.
 
         Returns:
             An LLM instance constructed from the profile configuration.
@@ -188,7 +209,12 @@ class LLMProfileStore:
             try:
                 from openhands.sdk.llm.llm import LLM
 
-                llm_instance = LLM.load_from_json(str(profile_path))
+                # Build validation context for cipher decryption
+                context: dict[str, Any] | None = None
+                if cipher:
+                    context = {"cipher": cipher}
+
+                llm_instance = LLM.load_from_json(str(profile_path), context=context)
             except Exception as e:
                 # Re-raise as ValueError for clearer error handling
                 raise ValueError(f"Failed to load profile `{name}`: {e}") from e

--- a/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
+++ b/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
@@ -14,6 +14,10 @@ ExposeSecretsMode = Literal["encrypted", "plaintext"] | bool
 _logger = logging.getLogger(__name__)
 
 
+class MissingCipherError(ValueError):
+    """Raised by ``serialize_secret`` when encryption is requested without a cipher."""
+
+
 def is_redacted_secret(v: str | SecretStr | None) -> bool:
     if v is None:
         return False
@@ -52,7 +56,7 @@ def serialize_secret(v: SecretStr | None, info):
     if expose_mode == "encrypted" or cipher:
         if not cipher:
             # Encrypted mode explicitly requested but no cipher available
-            raise ValueError(
+            raise MissingCipherError(
                 "Cannot encrypt secret: no cipher configured. "
                 "Set OH_SECRET_KEY environment variable."
             )

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -25,8 +25,9 @@ def temp_profiles_dir():
 
 @pytest.fixture
 def client(temp_profiles_dir):
-    """Create test client with isolated profiles directory."""
-    config = Config(static_files_path=None, session_api_keys=[])
+    """Create test client with isolated profiles directory and NO cipher."""
+    # Explicitly disable cipher by setting secret_key to None
+    config = Config(static_files_path=None, session_api_keys=[], secret_key=None)
     app = create_app(config)
 
     # Patch LLMProfileStore to use temp directory
@@ -431,7 +432,7 @@ def test_get_profile_timeout_returns_503(client, store, monkeypatch):
     """Get endpoint surfaces TimeoutError as 503."""
     store.save("present", LLM(model="gpt-4o"))
 
-    def boom(self, name):
+    def boom(self, name, *, cipher=None):
         raise TimeoutError("locked")
 
     monkeypatch.setattr(LLMProfileStore, "load", boom)
@@ -519,7 +520,7 @@ def test_get_profile_corrupted_returns_400(client, temp_profiles_dir):
 def test_save_profile_timeout_returns_503(client, monkeypatch):
     """Save endpoint surfaces TimeoutError as 503."""
 
-    def boom(self, name, llm, include_secrets=False, *, max_profiles=None):
+    def boom(self, name, llm, include_secrets=False, *, cipher=None, max_profiles=None):
         raise TimeoutError("locked")
 
     monkeypatch.setattr(LLMProfileStore, "save", boom)
@@ -601,3 +602,207 @@ def test_get_profile_does_not_expose_api_key(client, store):
     assert body["api_key_set"] is True
     # And the secret string itself never appears in the response
     assert "sk-very-secret" not in response.text
+
+
+# ── Cipher Encryption Tests ────────────────────────────────────────────────
+
+
+@pytest.fixture
+def secret_key():
+    """Generate a secret key for cipher encryption."""
+    from base64 import urlsafe_b64encode
+
+    return urlsafe_b64encode(b"a" * 32).decode("ascii")
+
+
+@pytest.fixture
+def client_with_cipher(temp_profiles_dir, secret_key):
+    """Create test client with cipher configured."""
+    from pydantic import SecretStr
+
+    config = Config(
+        static_files_path=None,
+        session_api_keys=[],
+        secret_key=SecretStr(secret_key),
+    )
+    app = create_app(config)
+
+    with patch(
+        "openhands.agent_server.profiles_router.LLMProfileStore",
+        lambda: LLMProfileStore(base_dir=temp_profiles_dir),
+    ):
+        yield TestClient(app)
+
+
+@pytest.fixture
+def cipher(secret_key):
+    """Create a cipher instance for testing."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    return Cipher(secret_key)
+
+
+def test_get_profile_invalid_expose_secrets_header_returns_400(client_with_cipher):
+    """GET with invalid X-Expose-Secrets header returns 400."""
+    response = client_with_cipher.get(
+        "/api/profiles/any", headers={"X-Expose-Secrets": "invalid-value"}
+    )
+    assert response.status_code == 400
+    assert "Invalid X-Expose-Secrets" in response.json()["detail"]
+
+
+def test_get_profile_with_plaintext_header_exposes_secrets(
+    client_with_cipher, store, cipher
+):
+    """GET with X-Expose-Secrets: plaintext returns raw secrets."""
+    llm = LLM(model="gpt-4o", api_key="sk-test-secret-key")
+    store.save("with-secret", llm, include_secrets=True, cipher=cipher)
+
+    response = client_with_cipher.get(
+        "/api/profiles/with-secret", headers={"X-Expose-Secrets": "plaintext"}
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    # Secret should be exposed
+    assert body["config"]["api_key"] == "sk-test-secret-key"
+
+
+def test_get_profile_with_encrypted_header_encrypts_secrets(
+    client_with_cipher, store, cipher
+):
+    """GET with X-Expose-Secrets: encrypted returns cipher-encrypted secrets."""
+    llm = LLM(model="gpt-4o", api_key="sk-test-secret-key")
+    store.save("with-secret", llm, include_secrets=True, cipher=cipher)
+
+    response = client_with_cipher.get(
+        "/api/profiles/with-secret", headers={"X-Expose-Secrets": "encrypted"}
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    api_key = body["config"]["api_key"]
+    # Should be encrypted (not plaintext, not None)
+    assert api_key != "sk-test-secret-key"
+    assert api_key is not None
+    # Should be decryptable
+    decrypted = cipher.decrypt(api_key)
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == "sk-test-secret-key"
+
+
+def test_get_profile_with_true_header_treats_as_encrypted(
+    client_with_cipher, store, cipher
+):
+    """GET with X-Expose-Secrets: true treats as encrypted (safety)."""
+    llm = LLM(model="gpt-4o", api_key="sk-test-secret-key")
+    store.save("with-secret", llm, include_secrets=True, cipher=cipher)
+
+    response = client_with_cipher.get(
+        "/api/profiles/with-secret", headers={"X-Expose-Secrets": "true"}
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    api_key = body["config"]["api_key"]
+    # Should be encrypted (not plaintext)
+    assert api_key != "sk-test-secret-key"
+    # Should be decryptable
+    decrypted = cipher.decrypt(api_key)
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == "sk-test-secret-key"
+
+
+def test_save_profile_with_cipher_encrypts_at_rest(
+    client_with_cipher, temp_profiles_dir, cipher
+):
+    """POST with cipher configured encrypts secrets at rest."""
+    import json
+
+    response = client_with_cipher.post(
+        "/api/profiles/encrypted-profile",
+        json={
+            "llm": {"model": "gpt-4o", "api_key": "sk-test-secret"},
+            "include_secrets": True,
+        },
+    )
+
+    assert response.status_code == 201
+
+    # Read raw file to verify encryption
+    profile_path = temp_profiles_dir / "encrypted-profile.json"
+    data = json.loads(profile_path.read_text())
+    # api_key should be encrypted, not plaintext
+    assert data["api_key"] != "sk-test-secret"
+    # Should be decryptable
+    decrypted = cipher.decrypt(data["api_key"])
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == "sk-test-secret"
+
+
+def test_encrypted_roundtrip_workflow(client_with_cipher, store, cipher):
+    """Client can GET encrypted, modify, and re-submit encrypted secrets."""
+    # 1. Save profile with secret
+    llm = LLM(model="gpt-4o", api_key="sk-original-secret")
+    store.save("roundtrip", llm, include_secrets=True, cipher=cipher)
+
+    # 2. GET with encrypted mode
+    get_response = client_with_cipher.get(
+        "/api/profiles/roundtrip", headers={"X-Expose-Secrets": "encrypted"}
+    )
+    assert get_response.status_code == 200
+    encrypted_api_key = get_response.json()["config"]["api_key"]
+
+    # 3. Re-submit with the encrypted api_key (should work)
+    update_response = client_with_cipher.post(
+        "/api/profiles/roundtrip",
+        json={
+            "llm": {"model": "gpt-4o-mini", "api_key": encrypted_api_key},
+            "include_secrets": True,
+        },
+    )
+    assert update_response.status_code == 201
+
+    # 4. Verify the secret was re-encrypted correctly
+    get_final = client_with_cipher.get(
+        "/api/profiles/roundtrip", headers={"X-Expose-Secrets": "plaintext"}
+    )
+    # Note: The encrypted value is re-encrypted, so it decrypts to the original
+    # (This tests that encrypted blobs can be submitted and round-tripped)
+    assert get_final.status_code == 200
+
+
+def test_get_profile_encrypted_without_cipher_returns_503(client, store):
+    """GET with X-Expose-Secrets: encrypted without cipher configured returns 503."""
+    llm = LLM(model="gpt-4o", api_key="sk-test-secret")
+    store.save("no-cipher", llm, include_secrets=True)
+
+    response = client.get(
+        "/api/profiles/no-cipher", headers={"X-Expose-Secrets": "encrypted"}
+    )
+
+    assert response.status_code == 503
+    body = response.json()
+    # 503 errors use "exception" field to avoid leaking internal details
+    error_text = body.get("detail", "") + body.get("exception", "")
+    assert "OH_SECRET_KEY" in error_text
+
+
+def test_save_without_cipher_stores_plaintext_for_backward_compat(client, store):
+    """POST without cipher configured stores plaintext (backward compatible)."""
+    import json
+
+    response = client.post(
+        "/api/profiles/plaintext-profile",
+        json={
+            "llm": {"model": "gpt-4o", "api_key": "sk-plain-secret"},
+            "include_secrets": True,
+        },
+    )
+
+    assert response.status_code == 201
+
+    # Read raw file - should be plaintext
+    profile_path = store.base_dir / "plaintext-profile.json"
+    data = json.loads(profile_path.read_text())
+    assert data["api_key"] == "sk-plain-secret"

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -742,18 +742,15 @@ def test_save_profile_with_cipher_encrypts_at_rest(
 
 def test_encrypted_roundtrip_workflow(client_with_cipher, store, cipher):
     """Client can GET encrypted, modify, and re-submit encrypted secrets."""
-    # 1. Save profile with secret
     llm = LLM(model="gpt-4o", api_key="sk-original-secret")
     store.save("roundtrip", llm, include_secrets=True, cipher=cipher)
 
-    # 2. GET with encrypted mode
     get_response = client_with_cipher.get(
         "/api/profiles/roundtrip", headers={"X-Expose-Secrets": "encrypted"}
     )
     assert get_response.status_code == 200
     encrypted_api_key = get_response.json()["config"]["api_key"]
 
-    # 3. Re-submit with the encrypted api_key (should work)
     update_response = client_with_cipher.post(
         "/api/profiles/roundtrip",
         json={
@@ -763,13 +760,36 @@ def test_encrypted_roundtrip_workflow(client_with_cipher, store, cipher):
     )
     assert update_response.status_code == 201
 
-    # 4. Verify the secret was re-encrypted correctly
     get_final = client_with_cipher.get(
         "/api/profiles/roundtrip", headers={"X-Expose-Secrets": "plaintext"}
     )
-    # Note: The encrypted value is re-encrypted, so it decrypts to the original
-    # (This tests that encrypted blobs can be submitted and round-tripped)
     assert get_final.status_code == 200
+    body = get_final.json()
+    assert body["config"]["api_key"] == "sk-original-secret"
+    assert body["config"]["model"] == "gpt-4o-mini"
+
+
+def test_save_plaintext_secret_with_cipher_encrypts_at_rest(
+    client_with_cipher, temp_profiles_dir, cipher
+):
+    """First-save path: plaintext input + cipher configured → encrypted on disk."""
+    import json
+
+    response = client_with_cipher.post(
+        "/api/profiles/first-save",
+        json={
+            "llm": {"model": "gpt-4o", "api_key": "sk-plaintext-input"},
+            "include_secrets": True,
+        },
+    )
+    assert response.status_code == 201
+
+    profile_path = temp_profiles_dir / "first-save.json"
+    data = json.loads(profile_path.read_text())
+    assert data["api_key"] != "sk-plaintext-input"
+    decrypted = cipher.decrypt(data["api_key"])
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == "sk-plaintext-input"
 
 
 def test_get_profile_encrypted_without_cipher_returns_503(client, store):


### PR DESCRIPTION
## Summary                                                                                                                                                                            
Brings the LLM profiles API to parity with the settings flow on secret handling (closes #3154), and along the way deduplicates the X-Expose-Secrets plumbing so both routers share one implementation.        
                                                                                                                                                                                     
Profile secret handling — three behaviors, matching settings:                                                                                                                      
   
- At-rest encryption. When OH_SECRET_KEY is configured, LLMProfileStore.save encrypts secret-bearing fields (api_key, AWS keys) via serialize_secret(cipher=…) before writing to   
  disk. With no key set, profiles continue to store plaintext (backward-compatible with PR #3129).
- X-Expose-Secrets header on GET /api/profiles/{name}. encrypted returns Fernet-encrypted values for safe FE round-trip; plaintext returns raw values for backend clients;         
  absent/default returns the existing nulled-api_key shape.                                                                                                                          
- Encrypted round-trip on POST /api/profiles/{name}. The save endpoint detects incoming Fernet-prefixed (gAAAAA…) blobs and decrypts them with the configured cipher before
  re-encryption at rest, so a GET encrypted → POST cycle preserves the original plaintext instead of double-encrypting it. Plaintext input passes through untouched (Fernet prefix is
   the gate).                
                                                                                                                                                                                     
Shared _secrets_exposure module for settings_router and profiles_router:                                                                                                           
   
- parse_expose_secrets_header — single parser, single 400 error message, single legacy "true" → "encrypted" alias.                                                                 
- build_expose_context — one place that builds the pydantic serialization context.
- translate_missing_cipher — context manager that catches PydanticSerializationError and walks the cause chain for the new MissingCipherError(ValueError). Replaces the            
  substring-match on "no cipher configured" in both routers with a typed check, so changes to the error message no longer silently degrade to a 500.                                 
- get_config / get_cipher — one access pattern for both routers; profiles previously had its own defensive variant.                                                                
                                                                                                                                                                                     
Other touch-ups:                                                                                                                                                                   
                                                                                                                                                                                     
- New LLM_SECRET_FIELDS constant in openhands.sdk.llm.llm so the field-list used by the serializer and the new decrypt helper stays in sync.                                       
- LLM.load_from_json now accepts a context= kwarg, used by the store to thread the cipher into validate_secret on load.
                                                                                                                                                                                     
## Test plan                  
                                                                                                                                                                                     
  - uv run pytest tests/agent_server/test_profiles_router.py tests/agent_server/test_settings_router.py tests/sdk/utils/test_pydantic_secrets.py — 121/121 passing locally.          
  - uv run pytest tests/sdk/llm — 730/730 passing locally (covers LLM_SECRET_FIELDS extraction).
  - uv run pre-commit run --files <changed> — clean (ruff, pyright, dependency rules).                                                                                               
  - New tests cover the three behaviors directly: invalid header → 400, plaintext header → raw secret, encrypted header → cipher-encrypted, missing cipher + encrypted header → 503, 
  encrypted round-trip preserves plaintext through GET encrypted → POST → GET plaintext, plaintext POST with cipher configured encrypts at rest, plaintext POST without cipher stores
   plaintext (back-compat).                                                                                                                                                          
  - Manual: OH_SECRET_KEY=…  server, POST an encrypted blob obtained from GET encrypted, GET plaintext returns the original value. 


Closes #3154


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3eed4a2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3eed4a2-python \
  ghcr.io/openhands/agent-server:3eed4a2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3eed4a2-golang-amd64
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-golang-amd64
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-golang-amd64
ghcr.io/openhands/agent-server:3eed4a2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3eed4a2-golang-arm64
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-golang-arm64
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-golang-arm64
ghcr.io/openhands/agent-server:3eed4a2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3eed4a2-java-amd64
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-java-amd64
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-java-amd64
ghcr.io/openhands/agent-server:3eed4a2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3eed4a2-java-arm64
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-java-arm64
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-java-arm64
ghcr.io/openhands/agent-server:3eed4a2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3eed4a2-python-amd64
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-python-amd64
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-python-amd64
ghcr.io/openhands/agent-server:3eed4a2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3eed4a2-python-arm64
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-python-arm64
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-python-arm64
ghcr.io/openhands/agent-server:3eed4a2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3eed4a2-golang
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-golang
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-golang
ghcr.io/openhands/agent-server:3eed4a2-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3eed4a2-java
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-java
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-java
ghcr.io/openhands/agent-server:3eed4a2-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3eed4a2-python
ghcr.io/openhands/agent-server:3eed4a25fe3ed1b2620b97adccbbfe968baa4fe5-python
ghcr.io/openhands/agent-server:feat-profiles-cipher-encryption-python
ghcr.io/openhands/agent-server:3eed4a2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3eed4a2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3eed4a2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->