### PR TITLE
perf: bound InMemoryFileStore with LRU eviction

### DIFF
--- a/openhands-sdk/openhands/sdk/io/memory.py
+++ b/openhands-sdk/openhands/sdk/io/memory.py
@@ -5,23 +5,34 @@ from collections.abc import Iterator
 from contextlib import contextmanager
 
 from openhands.sdk.io.base import FileStore
+from openhands.sdk.io.cache import MemoryLRUCache
 from openhands.sdk.logger import get_logger
 
 
 logger = get_logger(__name__)
 
+_DEFAULT_MAX_SIZE = 500
+_DEFAULT_MAX_MEMORY = 20 * 1024 * 1024  # 20 MB
+
 
 class InMemoryFileStore(FileStore):
-    files: dict[str, str]
+    files: MemoryLRUCache
     _instance_id: str
     _lock: threading.Lock
 
-    def __init__(self, files: dict[str, str] | None = None) -> None:
-        self.files = {}
+    def __init__(
+        self,
+        files: dict[str, str] | None = None,
+        *,
+        max_size: int = _DEFAULT_MAX_SIZE,
+        max_memory: int = _DEFAULT_MAX_MEMORY,
+    ) -> None:
+        self.files = MemoryLRUCache(max_memory=max_memory, max_size=max_size)
         self._instance_id = uuid.uuid4().hex
         self._lock = threading.Lock()
         if files is not None:
-            self.files = files
+            for path, contents in files.items():
+                self.files[path] = contents
 
     def write(self, path: str, contents: str | bytes) -> None:
         if isinstance(contents, bytes):

--- a/openhands-sdk/openhands/sdk/io/memory.py
+++ b/openhands-sdk/openhands/sdk/io/memory.py
@@ -12,7 +12,7 @@ from openhands.sdk.logger import get_logger
 
 logger = get_logger(__name__)
 
-_DEFAULT_MAX_SIZE: Final = 500
+_DEFAULT_MAX_SIZE: Final = 100_000
 _DEFAULT_MAX_MEMORY: Final = 20 * 1024 * 1024  # 20 MB
 
 

--- a/openhands-sdk/openhands/sdk/io/memory.py
+++ b/openhands-sdk/openhands/sdk/io/memory.py
@@ -3,6 +3,7 @@ import threading
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from typing import Final
 
 from openhands.sdk.io.base import FileStore
 from openhands.sdk.io.cache import MemoryLRUCache
@@ -11,8 +12,8 @@ from openhands.sdk.logger import get_logger
 
 logger = get_logger(__name__)
 
-_DEFAULT_MAX_SIZE = 500
-_DEFAULT_MAX_MEMORY = 20 * 1024 * 1024  # 20 MB
+_DEFAULT_MAX_SIZE: Final = 500
+_DEFAULT_MAX_MEMORY: Final = 20 * 1024 * 1024  # 20 MB
 
 
 class InMemoryFileStore(FileStore):


### PR DESCRIPTION
## Summary

`InMemoryFileStore` used a plain `dict[str, str]` as its backing store with no size limit. When used as the non-persistent fallback (no `persistence_dir`), the dict grew monotonically — every event written stayed in memory forever.

## Fix

Replace the backing `dict` with `MemoryLRUCache` — the same dual-limit LRU cache already used internally by `LocalFileStore`. When either the entry-count or memory-size limit is exceeded, the least-recently-used entries are evicted.

**Defaults** (matching `LocalFileStore`):
- `max_size=500` entries
- `max_memory=20MB`

Both limits are configurable via keyword-only `max_size`/`max_memory` constructor params. The existing `files=` dict argument is preserved for backward compatibility.

### Key design choice

Unlike `LocalFileStore` where eviction just clears the cache (data persists on disk), `InMemoryFileStore` eviction means data loss. This is acceptable because:
1. `InMemoryFileStore` is only used when `persistence_dir` is not set — the data is already ephemeral
2. The 500-entry / 20MB defaults are generous for typical SDK usage
3. Users who need more can pass larger limits

## Verification

- All 494 tests in `tests/sdk/io/` + `tests/sdk/conversation/` pass
- All pre-commit hooks pass (ruff, pyright, etc.)
- Single file changed: `openhands-sdk/openhands/sdk/io/memory.py` (+15, -4)

Fixes #3146

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5803a9f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5803a9f-python \
  ghcr.io/openhands/agent-server:5803a9f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5803a9f-golang-amd64
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-golang-amd64
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-golang-amd64
ghcr.io/openhands/agent-server:5803a9f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5803a9f-golang-arm64
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-golang-arm64
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-golang-arm64
ghcr.io/openhands/agent-server:5803a9f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5803a9f-java-amd64
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-java-amd64
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-java-amd64
ghcr.io/openhands/agent-server:5803a9f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5803a9f-java-arm64
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-java-arm64
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-java-arm64
ghcr.io/openhands/agent-server:5803a9f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5803a9f-python-amd64
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-python-amd64
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-python-amd64
ghcr.io/openhands/agent-server:5803a9f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5803a9f-python-arm64
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-python-arm64
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-python-arm64
ghcr.io/openhands/agent-server:5803a9f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5803a9f-golang
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-golang
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-golang
ghcr.io/openhands/agent-server:5803a9f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5803a9f-java
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-java
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-java
ghcr.io/openhands/agent-server:5803a9f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5803a9f-python
ghcr.io/openhands/agent-server:5803a9ffcc2dc6ce95a4c0b76934e5e4a0d73695-python
ghcr.io/openhands/agent-server:fix-3146-inmemory-filestore-bounded-cache-python
ghcr.io/openhands/agent-server:5803a9f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5803a9f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5803a9f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->