### PR TITLE
perf: batch ConversationState autosaves inside context manager

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -218,6 +218,8 @@ class ConversationState(OpenHandsModel):
     _lock: FIFOLock = PrivateAttr(
         default_factory=FIFOLock
     )  # FIFO lock for thread safety
+    _save_depth: int = PrivateAttr(default=0)  # context-manager nesting depth
+    _dirty: bool = PrivateAttr(default=False)  # pending unsaved field changes
 
     @property
     def events(self) -> EventLog:
@@ -419,11 +421,16 @@ class ConversationState(OpenHandsModel):
             return
 
         if old is _sentinel or old != value:
-            try:
-                self._save_base_state(fs)
-            except Exception as e:
-                logger.exception("Auto-persist base_state failed", exc_info=True)
-                raise e
+            # Inside a context-manager block, defer the save until __exit__
+            # so that multiple field mutations produce a single I/O write.
+            if getattr(self, "_save_depth", 0) > 0:
+                self._dirty = True
+            else:
+                try:
+                    self._save_base_state(fs)
+                except Exception as e:
+                    logger.exception("Auto-persist base_state failed", exc_info=True)
+                    raise e
 
             # Call state change callback if set
             callback = getattr(self, "_on_state_change", None)
@@ -538,13 +545,27 @@ class ConversationState(OpenHandsModel):
         self._lock.release()
 
     def __enter__(self: Self) -> Self:
-        """Context manager entry."""
+        """Context manager entry.
+
+        Field mutations inside the ``with`` block are batched: the state
+        is persisted at most once, on exit, instead of on every assignment.
+        """
         self._lock.acquire()
+        self._save_depth += 1
         return self
 
     def __exit__(self, exc_type: Any, exc_val: Any, exc_tb: Any) -> None:
-        """Context manager exit."""
-        self._lock.release()
+        """Context manager exit — flushes any deferred save."""
+        try:
+            self._save_depth -= 1
+            if self._save_depth == 0 and self._dirty:
+                fs = getattr(self, "_fs", None)
+                autosave_enabled = getattr(self, "_autosave_enabled", False)
+                if autosave_enabled and fs is not None:
+                    self._save_base_state(fs)
+                self._dirty = False
+        finally:
+            self._lock.release()
 
     def locked(self) -> bool:
         """

--- a/tests/sdk/conversation/local/test_state_serialization.py
+++ b/tests/sdk/conversation/local/test_state_serialization.py
@@ -20,6 +20,7 @@ from openhands.sdk.conversation.types import (
     ConversationTokenCallbackType,
 )
 from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
+from openhands.sdk.io import InMemoryFileStore
 from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.llm.llm_registry import RegistryEvent
 from openhands.sdk.security.confirmation_policy import AlwaysConfirm
@@ -1340,8 +1341,6 @@ def test_context_manager_batches_saves() -> None:
         persistence_dir="/tmp/test/.state",
         agent=agent,
     )
-
-    from openhands.sdk.io import InMemoryFileStore
 
     fs = InMemoryFileStore()
     state._fs = fs

--- a/tests/sdk/conversation/local/test_state_serialization.py
+++ b/tests/sdk/conversation/local/test_state_serialization.py
@@ -1328,6 +1328,48 @@ def test_v1_11_5_cli_default_conversation_resumes_when_runtime_adds_delegate(
     )
 
 
+def test_context_manager_batches_saves() -> None:
+    """Multiple field mutations inside `with state:` produce a single save."""
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("k"), usage_id="test-llm")
+    agent = Agent(llm=llm)
+    workspace = LocalWorkspace(working_dir="/tmp/test")
+
+    state = ConversationState(
+        id=uuid.uuid4(),
+        workspace=workspace,
+        persistence_dir="/tmp/test/.state",
+        agent=agent,
+    )
+
+    from openhands.sdk.io import InMemoryFileStore
+
+    fs = InMemoryFileStore()
+    state._fs = fs
+    state._autosave_enabled = True
+
+    save_count = 0
+    _original = state._save_base_state
+
+    def _counting_save(f):
+        nonlocal save_count
+        save_count += 1
+        _original(f)
+
+    state._save_base_state = _counting_save  # type: ignore[method-assign]
+
+    # Three mutations inside one context-manager block → exactly 1 save
+    with state:
+        state.execution_status = ConversationExecutionStatus.RUNNING
+        state.max_iterations = 999
+        state.stuck_detection = False
+
+    assert save_count == 1
+
+    # Mutation outside a context-manager block → immediate save
+    state.max_iterations = 42
+    assert save_count == 2
+
+
 def test_v1_17_0_conversation_with_mcp_config_restores(tmp_path: Path) -> None:
     """Test resuming a legacy conversation that persisted agent.mcp_config."""
     fixture_path = (


### PR DESCRIPTION
## Summary

`ConversationState.__setattr__` triggered a **full JSON serialization + synchronous file write** on every public-field mutation. During a single agent step, multiple fields are updated (`execution_status`, `stats`, `max_iterations`, etc.), producing 2–4 redundant writes per step — each serializing the entire state including large nested objects like `agent`, `stats`, and `workspace`.

## Fix

Extend the existing `with state:` context-manager protocol (currently just a FIFO lock) to also batch saves:

| Region | Behavior |
|---|---|
| Inside `with state:` | Mutations set `_dirty = True`; **one** save on `__exit__` |
| Outside `with state:` | Immediate save per mutation (backward compat) |

Implementation:
- `__enter__` increments `_save_depth`
- `__setattr__` checks `_save_depth > 0` → sets `_dirty` instead of saving
- `__exit__` decrements `_save_depth`; when it reaches 0 and `_dirty`, flush one save, then release lock
- **State-change callbacks still fire eagerly** on each mutation (WebSocket clients see intermediate updates)
- Nesting-safe via depth counter

### I/O reduction per step

| Before | After |
|---|---|
| 2–4 `model_dump_json()` + `open()/write()` per step | 1 per `with` block |
| 3 saves on conversation resume | 1 save on resume |

## Verification

- All 550 tests pass (477 conversation + 73 event service)
- All pre-commit hooks pass (ruff, pyright, etc.)
- Added `test_context_manager_batches_saves` — proves 3 mutations → 1 save inside `with`, and immediate save outside

Fixes #3145

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:792d603-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-792d603-python \
  ghcr.io/openhands/agent-server:792d603-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:792d603-golang-amd64
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-golang-amd64
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-golang-amd64
ghcr.io/openhands/agent-server:792d603-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:792d603-golang-arm64
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-golang-arm64
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-golang-arm64
ghcr.io/openhands/agent-server:792d603-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:792d603-java-amd64
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-java-amd64
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-java-amd64
ghcr.io/openhands/agent-server:792d603-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:792d603-java-arm64
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-java-arm64
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-java-arm64
ghcr.io/openhands/agent-server:792d603-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:792d603-python-amd64
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-python-amd64
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-python-amd64
ghcr.io/openhands/agent-server:792d603-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:792d603-python-arm64
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-python-arm64
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-python-arm64
ghcr.io/openhands/agent-server:792d603-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:792d603-golang
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-golang
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-golang
ghcr.io/openhands/agent-server:792d603-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:792d603-java
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-java
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-java
ghcr.io/openhands/agent-server:792d603-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:792d603-python
ghcr.io/openhands/agent-server:792d6038a1addd9cc982929322a6c5d71fe45311-python
ghcr.io/openhands/agent-server:fix-3145-state-autosave-debounce-python
ghcr.io/openhands/agent-server:792d603-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `792d603-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `792d603-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->