### PR TITLE
fix: cap per-conversation WebSocket subscriber count

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -30,7 +30,8 @@ class BashEventService:
 
     bash_events_dir: Path = field()
     _pub_sub: PubSub[BashEventBase] = field(
-        default_factory=lambda: PubSub[BashEventBase](), init=False
+        default_factory=lambda: PubSub[BashEventBase](max_subscribers=50),
+        init=False,
     )
 
     def _ensure_bash_events_dir(self) -> None:

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -59,7 +59,9 @@ class EventService:
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     _conversation: LocalConversation | None = field(default=None, init=False)
-    _pub_sub: PubSub[Event] = field(default_factory=lambda: PubSub[Event](), init=False)
+    _pub_sub: PubSub[Event] = field(
+        default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
+    )
     _run_task: asyncio.Task | None = field(default=None, init=False)
     _run_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
     _callback_wrapper: AsyncCallbackWrapper | None = field(default=None, init=False)

--- a/openhands-agent-server/openhands/agent_server/pub_sub.py
+++ b/openhands-agent-server/openhands/agent_server/pub_sub.py
@@ -21,6 +21,10 @@ class Subscriber[T](ABC):
         """Clean up this subscriber"""
 
 
+class MaxSubscribersError(Exception):
+    """Raised when a PubSub instance has reached its subscriber limit."""
+
+
 @dataclass
 class PubSub[T]:
     """A subscription service that extends ConversationCallbackType functionality.
@@ -30,6 +34,7 @@ class PubSub[T]:
     """
 
     _subscribers: dict[UUID, Subscriber[T]] = field(default_factory=dict)
+    max_subscribers: int | None = None
 
     def subscribe(self, subscriber: Subscriber[T]) -> UUID:
         """Subscribe a subscriber and return its UUID for later unsubscription.
@@ -37,7 +42,16 @@ class PubSub[T]:
             subscriber: The callback function to register
         Returns:
             UUID: UUID that can be used to unsubscribe this callback
+        Raises:
+            MaxSubscribersError: If the subscriber limit has been reached.
         """
+        if (
+            self.max_subscribers is not None
+            and len(self._subscribers) >= self.max_subscribers
+        ):
+            raise MaxSubscribersError(
+                f"Subscriber limit reached ({self.max_subscribers})"
+            )
         subscriber_id = uuid4()
         self._subscribers[subscriber_id] = subscriber
         logger.debug(f"Subscribed subscriber with ID: {subscriber_id}")

--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -39,7 +39,7 @@ from openhands.agent_server.models import (
     ExecuteBashRequest,
     ServerErrorEvent,
 )
-from openhands.agent_server.pub_sub import Subscriber
+from openhands.agent_server.pub_sub import MaxSubscribersError, Subscriber
 from openhands.sdk import Event, Message
 from openhands.sdk.utils.paging import page_iterator
 
@@ -247,9 +247,16 @@ async def events_socket(
         await websocket.close(code=4004, reason="Conversation not found")
         return
 
-    subscriber_id = await event_service.subscribe_to_events(
-        _WebSocketSubscriber(websocket)
-    )
+    try:
+        subscriber_id = await event_service.subscribe_to_events(
+            _WebSocketSubscriber(websocket)
+        )
+    except MaxSubscribersError:
+        logger.warning(f"Subscriber limit reached for conversation {conversation_id}")
+        await websocket.close(
+            code=1013, reason="Too many connections for this conversation"
+        )
+        return
 
     # Determine effective resend mode (handle deprecated resend_all)
     effective_mode = resend_mode
@@ -359,9 +366,14 @@ async def bash_events_socket(
         return
 
     logger.info("Bash Websocket Connected")
-    subscriber_id = await bash_event_service.subscribe_to_events(
-        _BashWebSocketSubscriber(websocket)
-    )
+    try:
+        subscriber_id = await bash_event_service.subscribe_to_events(
+            _BashWebSocketSubscriber(websocket)
+        )
+    except MaxSubscribersError:
+        logger.warning("Subscriber limit reached for bash events")
+        await websocket.close(code=1013, reason="Too many bash event connections")
+        return
 
     # Determine effective resend mode (handle deprecated resend_all)
     effective_mode = resend_mode

--- a/tests/agent_server/test_pub_sub.py
+++ b/tests/agent_server/test_pub_sub.py
@@ -810,3 +810,53 @@ class TestPubSubIntegration:
             assert subscriber.close_called is True
 
         assert len(pubsub._subscribers) == 0
+
+
+class TestPubSubMaxSubscribers:
+    """Tests for the max_subscribers limit using the real PubSub class."""
+
+    async def test_subscribe_rejected_at_limit(self):
+        from openhands.agent_server.pub_sub import (
+            MaxSubscribersError,
+            PubSub,
+            Subscriber,
+        )
+
+        class _Sub(Subscriber[str]):
+            async def __call__(self, event: str) -> None:
+                pass
+
+        pubsub: PubSub[str] = PubSub(max_subscribers=2)
+        pubsub.subscribe(_Sub())
+        pubsub.subscribe(_Sub())
+
+        with pytest.raises(MaxSubscribersError):
+            pubsub.subscribe(_Sub())
+
+    async def test_subscribe_allowed_after_unsubscribe(self):
+        from openhands.agent_server.pub_sub import PubSub, Subscriber
+
+        class _Sub(Subscriber[str]):
+            async def __call__(self, event: str) -> None:
+                pass
+
+        pubsub: PubSub[str] = PubSub(max_subscribers=2)
+        id_a = pubsub.subscribe(_Sub())
+        pubsub.subscribe(_Sub())
+        pubsub.unsubscribe(id_a)
+
+        # Slot freed — should succeed
+        pubsub.subscribe(_Sub())
+        assert len(pubsub._subscribers) == 2
+
+    async def test_no_limit_when_none(self):
+        from openhands.agent_server.pub_sub import PubSub, Subscriber
+
+        class _Sub(Subscriber[str]):
+            async def __call__(self, event: str) -> None:
+                pass
+
+        pubsub: PubSub[str] = PubSub(max_subscribers=None)
+        for _ in range(100):
+            pubsub.subscribe(_Sub())
+        assert len(pubsub._subscribers) == 100


### PR DESCRIPTION
## Summary

`PubSub` accepted unlimited subscribers. A malicious or buggy client could open hundreds of WebSocket connections to a single conversation, exhausting server memory and multiplying fan-out cost for every published event.

## Fix

Add an optional `max_subscribers` parameter to `PubSub`. When the limit is reached, `subscribe()` raises `MaxSubscribersError`.

| Component | Change |
|---|---|
| `pub_sub.py` | Added `max_subscribers: int \| None` field and `MaxSubscribersError` exception |
| `event_service.py` | Default `max_subscribers=50` for conversation event PubSub |
| `bash_service.py` | Default `max_subscribers=50` for bash event PubSub |
| `sockets.py` | Both WS handlers catch `MaxSubscribersError` → close with WS 1013 (Try Again Later) |

The limit of 50 allows ~47 WebSocket connections per conversation (after 2–3 internal subscribers: EventSubscriber, AutoTitleSubscriber, WebhookSubscribers). This is very generous for legitimate use while preventing resource exhaustion.

`PubSub(max_subscribers=None)` preserves the old unbounded behavior for backward compat.

## Verification

- All 875 agent-server tests pass (including 3 new max_subscribers tests)
- All pre-commit hooks pass (ruff, pyright, etc.)
- 5 files changed, +88/-9

Fixes #3152

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:63eee5b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-63eee5b-python \
  ghcr.io/openhands/agent-server:63eee5b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:63eee5b-golang-amd64
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-golang-amd64
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-golang-amd64
ghcr.io/openhands/agent-server:63eee5b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:63eee5b-golang-arm64
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-golang-arm64
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-golang-arm64
ghcr.io/openhands/agent-server:63eee5b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:63eee5b-java-amd64
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-java-amd64
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-java-amd64
ghcr.io/openhands/agent-server:63eee5b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:63eee5b-java-arm64
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-java-arm64
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-java-arm64
ghcr.io/openhands/agent-server:63eee5b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:63eee5b-python-amd64
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-python-amd64
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-python-amd64
ghcr.io/openhands/agent-server:63eee5b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:63eee5b-python-arm64
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-python-arm64
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-python-arm64
ghcr.io/openhands/agent-server:63eee5b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:63eee5b-golang
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-golang
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-golang
ghcr.io/openhands/agent-server:63eee5b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:63eee5b-java
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-java
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-java
ghcr.io/openhands/agent-server:63eee5b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:63eee5b-python
ghcr.io/openhands/agent-server:63eee5b83e9e36ec20b04aee18cb17964c2d4f41-python
ghcr.io/openhands/agent-server:fix-3152-bounded-websocket-connections-python
ghcr.io/openhands/agent-server:63eee5b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `63eee5b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `63eee5b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->