### PR TITLE
fix(agent-server): decrypt cipher-encrypted profiles on conversation switch

### DIFF
--- a/openhands-agent-server/openhands/agent_server/_secrets_exposure.py
+++ b/openhands-agent-server/openhands/agent_server/_secrets_exposure.py
@@ -5,8 +5,11 @@ from contextlib import contextmanager
 from typing import Any, Literal, cast
 
 from fastapi import HTTPException, Request, status
+from pydantic import SecretStr
 from pydantic_core import PydanticSerializationError
 
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.utils.pydantic_secrets import MissingCipherError
 
@@ -76,6 +79,36 @@ def _has_missing_cipher_cause(exc: BaseException) -> bool:
         seen.add(id(cur))
         cur = cur.__cause__ or cur.__context__
     return False
+
+
+# Fernet tokens always begin with the URL-safe base64 of version byte 0x80,
+# i.e. "gAAAAA". We gate decrypt attempts on this prefix so genuine plaintext
+# secrets pass through untouched (and we don't spam the cipher's failure log).
+_FERNET_TOKEN_PREFIX = "gAAAAA"
+
+
+def decrypt_incoming_llm_secrets(llm: LLM, cipher: Cipher) -> LLM:
+    """Decrypt any pre-encrypted LLM secret fields posted back by the client.
+
+    FastAPI parses the request body without a cipher in the validation context,
+    so an encrypted blob arrives as ``SecretStr("gAAAAA...")``. Without this
+    pass, downstream code (e.g. profile save, ``conversation.switch_llm``) sees
+    the encrypted ciphertext as the API key and would either re-encrypt it or
+    forward it to the model provider verbatim. Plaintext input is left
+    untouched.
+    """
+    updates: dict[str, SecretStr] = {}
+    for field in LLM_SECRET_FIELDS:
+        val = getattr(llm, field, None)
+        if not isinstance(val, SecretStr):
+            continue
+        raw = val.get_secret_value()
+        if not raw.startswith(_FERNET_TOKEN_PREFIX):
+            continue
+        decrypted = cipher.decrypt(raw)
+        if decrypted is not None:
+            updates[field] = decrypted
+    return llm.model_copy(update=updates) if updates else llm
 
 
 @contextmanager

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -3,9 +3,22 @@
 from typing import Annotated
 from uuid import UUID
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
+from fastapi import (
+    APIRouter,
+    Body,
+    Depends,
+    HTTPException,
+    Query,
+    Request,
+    Response,
+    status,
+)
 from pydantic import SecretStr
 
+from openhands.agent_server._secrets_exposure import (
+    decrypt_incoming_llm_secrets,
+    get_cipher,
+)
 from openhands.agent_server.conversation_service import (
     ConversationContractMismatchError,
     ConversationService,
@@ -324,6 +337,7 @@ async def switch_conversation_profile(
     responses={404: {"description": "Conversation not found"}},
 )
 async def switch_conversation_llm(
+    request: Request,
     conversation_id: UUID,
     llm: LLM = Body(..., embed=True),  # noqa: B008
     conversation_service: ConversationService = Depends(get_conversation_service),
@@ -337,6 +351,9 @@ async def switch_conversation_llm(
     if event_service is None:
         raise HTTPException(status.HTTP_404_NOT_FOUND)
     conversation = event_service.get_conversation()
+    cipher = get_cipher(request)
+    if cipher is not None:
+        llm = decrypt_incoming_llm_secrets(llm, cipher)
     conversation.switch_llm(llm)
     return Success()
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -968,7 +968,7 @@ class AutoTitleSubscriber(Subscriber):
             from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 
             profile_store = LLMProfileStore()
-            return profile_store.load(profile_name)
+            return profile_store.load(profile_name, cipher=self.service.cipher)
         except (FileNotFoundError, ValueError) as e:
             logger.warning(
                 f"Failed to load title LLM profile '{profile_name}': {e}. "

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -9,19 +9,18 @@ from pydantic import BaseModel, Field, SecretStr
 
 from openhands.agent_server._secrets_exposure import (
     build_expose_context,
+    decrypt_incoming_llm_secrets,
     get_cipher,
     parse_expose_secrets_header,
     translate_missing_cipher,
 )
 from openhands.sdk.llm import LLM
-from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
 from openhands.sdk.llm.llm_profile_store import (
     PROFILE_NAME_PATTERN,
     LLMProfileStore,
     ProfileLimitExceeded,
 )
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils.cipher import Cipher
 
 
 logger = get_logger(__name__)
@@ -100,34 +99,6 @@ def _has_api_key(llm: LLM) -> bool:
     return bool(llm.api_key.get_secret_value().strip())
 
 
-# Fernet tokens always begin with the URL-safe base64 of version byte 0x80,
-# i.e. "gAAAAA". We gate decrypt attempts on this prefix so genuine plaintext
-# secrets pass through untouched (and we don't spam the cipher's failure log).
-_FERNET_TOKEN_PREFIX = "gAAAAA"
-
-
-def _decrypt_incoming_secrets(llm: LLM, cipher: Cipher) -> LLM:
-    """Decrypt any pre-encrypted secret fields posted back by the client.
-
-    FastAPI parses the request body without a cipher in the validation context,
-    so an encrypted blob arrives as ``SecretStr("gAAAAA...")``. Without this
-    pass, ``store.save`` would re-encrypt the blob, producing a double-encrypted
-    value on disk that no longer round-trips. Plaintext input is left untouched.
-    """
-    updates: dict[str, SecretStr] = {}
-    for field in LLM_SECRET_FIELDS:
-        val = getattr(llm, field, None)
-        if not isinstance(val, SecretStr):
-            continue
-        raw = val.get_secret_value()
-        if not raw.startswith(_FERNET_TOKEN_PREFIX):
-            continue
-        decrypted = cipher.decrypt(raw)
-        if decrypted is not None:
-            updates[field] = decrypted
-    return llm.model_copy(update=updates) if updates else llm
-
-
 @profiles_router.get("", response_model=ProfileListResponse)
 async def list_profiles() -> ProfileListResponse:
     """List all saved LLM profiles."""
@@ -192,7 +163,7 @@ async def save_profile(
     server-side before re-encrypting with the storage cipher.
     """
     cipher = get_cipher(request)
-    llm = _decrypt_incoming_secrets(body.llm, cipher) if cipher else body.llm
+    llm = decrypt_incoming_llm_secrets(body.llm, cipher) if cipher else body.llm
     store = LLMProfileStore()
     try:
         with _store_errors():

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -265,6 +265,7 @@ class LocalConversation(BaseConversation):
         # This ensures plugins are loaded before agent initialization
         self.llm_registry = LLMRegistry()
         self._profile_store = LLMProfileStore()
+        self._cipher = cipher
 
         # Initialize secrets if provided
         if secrets:
@@ -671,7 +672,7 @@ class LocalConversation(BaseConversation):
         try:
             cached = self.llm_registry.get(usage_id)
         except KeyError:
-            loaded = self._profile_store.load(profile_name)
+            loaded = self._profile_store.load(profile_name, cipher=self._cipher)
             cached = loaded.model_copy(update={"usage_id": usage_id})
         self.switch_llm(cached)
 

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -8,6 +8,7 @@ from fastapi import FastAPI
 from fastapi.testclient import TestClient
 from pydantic import SecretStr
 
+from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_router import conversation_router
 from openhands.agent_server.conversation_service import (
     ConversationContractMismatchError,
@@ -34,6 +35,11 @@ def client():
     """Create a test client for the FastAPI app without authentication."""
     app = FastAPI()
     app.include_router(conversation_router, prefix="/api")
+    # switch_llm reads request.app.state.config to get the optional cipher;
+    # populate it with a no-cipher config so unrelated tests don't 503.
+    app.state.config = Config(
+        static_files_path=None, session_api_keys=[], secret_key=None
+    )
     return TestClient(app)
 
 
@@ -1634,6 +1640,104 @@ def test_switch_conversation_llm_success(
         assert isinstance(forwarded_llm, LLM)
         assert forwarded_llm.model == "openai/gpt-4o"
         assert forwarded_llm.usage_id == "caller-supplied-id"
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_switch_conversation_llm_decrypts_encrypted_api_key(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """When the server has a cipher and the client posts an encrypted api_key
+    (the natural FE flow: GET profile with X-Expose-Secrets: encrypted, then
+    forward into switch_llm), the router decrypts before applying. Regression
+    for #3164.
+    """
+    from base64 import urlsafe_b64encode
+
+    from openhands.sdk.utils.cipher import Cipher
+
+    secret_key = urlsafe_b64encode(b"a" * 32).decode("ascii")
+    cipher = Cipher(secret_key)
+    encrypted_api_key = cipher.encrypt(SecretStr("plaintext-api-key"))
+    assert encrypted_api_key is not None
+
+    # Install a cipher-enabled config on the test app for this test.
+    client.app.state.config = Config(
+        static_files_path=None,
+        session_api_keys=[],
+        secret_key=SecretStr(secret_key),
+    )
+
+    mock_conversation = MagicMock()
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.get_conversation.return_value = mock_conversation
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_llm",
+            json={
+                "llm": {
+                    "model": "openai/gpt-4o",
+                    "api_key": encrypted_api_key,
+                    "usage_id": "caller-supplied-id",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        forwarded_llm = mock_conversation.switch_llm.call_args.args[0]
+        assert isinstance(forwarded_llm, LLM)
+        assert isinstance(forwarded_llm.api_key, SecretStr)
+        assert forwarded_llm.api_key.get_secret_value() == "plaintext-api-key"
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_switch_conversation_llm_plaintext_with_cipher_passes_through(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """A plaintext api_key must pass through untouched even when the server
+    has a cipher configured (no Fernet prefix → no decrypt attempted).
+    Regression guard for #3164: backward-compat for app-servers that supply
+    plaintext keys.
+    """
+    from base64 import urlsafe_b64encode
+
+    secret_key = urlsafe_b64encode(b"a" * 32).decode("ascii")
+    client.app.state.config = Config(
+        static_files_path=None,
+        session_api_keys=[],
+        secret_key=SecretStr(secret_key),
+    )
+
+    mock_conversation = MagicMock()
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.get_conversation.return_value = mock_conversation
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/switch_llm",
+            json={
+                "llm": {
+                    "model": "openai/gpt-4o",
+                    "api_key": "sk-plaintext",
+                    "usage_id": "caller-supplied-id",
+                }
+            },
+        )
+
+        assert response.status_code == 200
+        forwarded_llm = mock_conversation.switch_llm.call_args.args[0]
+        assert isinstance(forwarded_llm.api_key, SecretStr)
+        assert forwarded_llm.api_key.get_secret_value() == "sk-plaintext"
     finally:
         client.app.dependency_overrides.clear()
 

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2000,7 +2000,9 @@ class TestAutoTitle:
             await self._drain_title_task(lambda: service.stored.title is not None)
 
             MockStore.assert_called_once_with()
-            mock_store_instance.load.assert_called_once_with("cheap-model")
+            mock_store_instance.load.assert_called_once_with(
+                "cheap-model", cipher=service.cipher
+            )
             # Profile-loaded LLM wins over agent.llm
             assert mock_generate_title.called
             assert mock_generate_title.call_args.args[1] is mock_llm
@@ -2180,6 +2182,89 @@ class TestAutoTitle:
         )
         assert service.stored.title == "✨ Generated"
         service.save_meta.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_autotitle_decrypts_cipher_encrypted_title_profile(self, tmp_path):
+        """Regression for #3164: a cipher-encrypted title-LLM profile must be
+        decrypted on load so the title LLM sees the plaintext API key, not
+        Fernet ciphertext.
+        """
+        from litellm.types.utils import (
+            Choices,
+            Message as LiteLLMMessage,
+            ModelResponse,
+            Usage,
+        )
+
+        from openhands.sdk.llm import LLMResponse, MetricsSnapshot
+        from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+        from openhands.sdk.utils.cipher import Cipher
+
+        cipher = Cipher("title-cipher-test-key")
+
+        profile_dir = tmp_path / "profiles"
+        LLMProfileStore(base_dir=profile_dir).save(
+            "title-encrypted",
+            LLM(
+                usage_id="title-llm",
+                model="claude-haiku-4-5",
+                api_key=SecretStr("plaintext-title-key"),
+            ),
+            include_secrets=True,
+            cipher=cipher,
+        )
+
+        service = self._make_service(title_llm_profile="title-encrypted")
+        # Inject the cipher; AutoTitleSubscriber reads it via service.cipher.
+        service.cipher = cipher
+
+        seen_keys: list[str] = []
+
+        def fake_completion(self_llm, _messages, **_kwargs):
+            seen_keys.append(
+                self_llm.api_key.get_secret_value() if self_llm.api_key else ""
+            )
+            msg = LiteLLMMessage(content="✨ Generated", role="assistant")
+            choice = Choices(finish_reason="stop", index=0, message=msg)
+            raw = ModelResponse(
+                id="resp-1",
+                choices=[choice],
+                created=0,
+                model=self_llm.model,
+                object="chat.completion",
+                usage=Usage(prompt_tokens=1, completion_tokens=1, total_tokens=2),
+            )
+            return LLMResponse(
+                message=Message.from_llm_chat_message(choice["message"]),
+                metrics=MetricsSnapshot(
+                    model_name=self_llm.model,
+                    accumulated_cost=0.0,
+                    max_budget_per_task=None,
+                    accumulated_token_usage=None,
+                ),
+                raw_response=raw,
+            )
+
+        with (
+            patch(
+                "openhands.sdk.llm.llm_profile_store._DEFAULT_PROFILE_DIR", profile_dir
+            ),
+            patch(
+                "openhands.sdk.llm.llm.LLM.completion",
+                autospec=True,
+                side_effect=fake_completion,
+            ),
+        ):
+            subscriber = AutoTitleSubscriber(service=service)
+            await subscriber(self._user_message_event("Fix the login bug"))
+            for _ in range(50):
+                await asyncio.sleep(0.02)
+                if service.stored.title is not None:
+                    break
+
+        assert seen_keys == ["plaintext-title-key"], (
+            f"Expected title LLM to receive decrypted key, got: {seen_keys}"
+        )
 
 
 class TestACPActivityHeartbeatWiring:

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -1,12 +1,14 @@
 from pathlib import Path
 
 import pytest
+from pydantic import SecretStr
 
 from openhands.sdk import LLM, LocalConversation
 from openhands.sdk.agent import Agent
 from openhands.sdk.llm import llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.testing import TestLLM
+from openhands.sdk.utils.cipher import Cipher
 
 
 def _make_llm(model: str, usage_id: str) -> LLM:
@@ -191,6 +193,44 @@ def test_switch_llm_does_not_consult_store(empty_profile_store, monkeypatch):
     conv.switch_llm(_make_llm("inline-model", "x"))
 
     assert calls == [], f"profile store was consulted: {calls}"
+
+
+def test_switch_profile_decrypts_with_cipher(tmp_path, monkeypatch):
+    """A profile saved with cipher-encrypted secrets must decrypt on switch
+    so the agent's LLM ends up with the plaintext API key, not a Fernet
+    token (regression for #3164).
+    """
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    monkeypatch.setattr(llm_profile_store, "_DEFAULT_PROFILE_DIR", profile_dir)
+
+    cipher = Cipher("test-key-for-switch-profile")
+    store = LLMProfileStore(base_dir=profile_dir)
+    store.save(
+        "encrypted",
+        LLM(
+            model="gpt-4o",
+            usage_id="encrypted",
+            api_key=SecretStr("plaintext-secret"),
+        ),
+        include_secrets=True,
+        cipher=cipher,
+    )
+
+    conv = LocalConversation(
+        agent=Agent(
+            llm=_make_llm("default-model", "test-llm"),
+            tools=[],
+        ),
+        workspace=Path.cwd(),
+        cipher=cipher,
+    )
+
+    conv.switch_profile("encrypted")
+
+    api_key = conv.agent.llm.api_key
+    assert isinstance(api_key, SecretStr)
+    assert api_key.get_secret_value() == "plaintext-secret"
 
 
 def test_switch_profile_delegates_to_switch_llm(profile_store, monkeypatch):


### PR DESCRIPTION
## Summary                                                                                                                                                                            
                  
  Fixes #3164. After #3161 enabled cipher encryption for LLM profile secrets at rest, the three places that wire a profile (or external LLM) into a live conversation never threaded 
  the cipher through, so encrypted API keys reached the model provider as Fernet ciphertext and authentication failed.
                                                                                                                                                                                     
  - LocalConversation now stores the cipher passed to its constructor and forwards it on switch_profile → LLMProfileStore.load(name, cipher=…).                                      
  - POST /conversations/{id}/switch_llm now reads the request cipher and runs the same decrypt_incoming_llm_secrets pass that save_profile uses, so the FE flow GET /profiles/X
  (encrypted) → forward into switch_llm round-trips correctly. Plaintext keys still pass through untouched (Fernet prefix gate).                                                     
  - AutoTitleSubscriber._load_title_llm now passes service.cipher when loading the title-LLM profile.
  - The _decrypt_incoming_secrets helper has been lifted from profiles_router into agent_server/_secrets_exposure.py and shared by both routers.                                     
                                                                                                                                                                                     
## Test plan                                                                                                                                                                          
                                                                                                                                                                                     
  - New: SDK test_switch_profile_decrypts_with_cipher — encrypted on-disk profile decrypts through LocalConversation.switch_profile.                                                 
  - New: router test_switch_conversation_llm_decrypts_encrypted_api_key — encrypted blob posted to /switch_llm is decrypted before reaching conversation.switch_llm.
  - New: router test_switch_conversation_llm_plaintext_with_cipher_passes_through — plaintext keys remain untouched when a cipher is configured (backward compat).                   
  - New: service test_autotitle_decrypts_cipher_encrypted_title_profile — end-to-end encrypted title-LLM profile reaches LLM.completion with the plaintext key.                      
  - Existing tests/agent_server/test_conversation_router.py, test_profiles_router.py, test_conversation_service.py, tests/sdk/conversation/test_switch_model.py all pass. 
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:48ed525-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-48ed525-python \
  ghcr.io/openhands/agent-server:48ed525-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:48ed525-golang-amd64
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-golang-amd64
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-golang-amd64
ghcr.io/openhands/agent-server:48ed525-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:48ed525-golang-arm64
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-golang-arm64
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-golang-arm64
ghcr.io/openhands/agent-server:48ed525-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:48ed525-java-amd64
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-java-amd64
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-java-amd64
ghcr.io/openhands/agent-server:48ed525-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:48ed525-java-arm64
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-java-arm64
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-java-arm64
ghcr.io/openhands/agent-server:48ed525-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:48ed525-python-amd64
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-python-amd64
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-python-amd64
ghcr.io/openhands/agent-server:48ed525-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:48ed525-python-arm64
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-python-arm64
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-python-arm64
ghcr.io/openhands/agent-server:48ed525-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:48ed525-golang
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-golang
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-golang
ghcr.io/openhands/agent-server:48ed525-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:48ed525-java
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-java
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-java
ghcr.io/openhands/agent-server:48ed525-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:48ed525-python
ghcr.io/openhands/agent-server:48ed525bc1c379e6d578c87a9307c8581b6fd270-python
ghcr.io/openhands/agent-server:3164-agent-server-cipher-encrypted-llm-profiles-cant-be-used-by-conversations-switch-profileswitch-llm-dont-decrypt-python
ghcr.io/openhands/agent-server:48ed525-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `48ed525-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `48ed525-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->