### PR TITLE
perf: centralize lease renewal into one background task

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -948,8 +948,9 @@ class ConversationService:
         """Single background task that renews leases for all active conversations.
 
         Replaces N per-conversation renewal tasks with one centralized loop,
-        reducing asyncio task overhead and spreading file-lock acquisitions
-        into a single sequential pass.
+        reducing asyncio task overhead.  Each renewal involves synchronous
+        file I/O (FileLock + read + write), so individual calls are offloaded
+        via ``asyncio.to_thread`` to avoid blocking the event loop.
         """
         try:
             while True:
@@ -958,7 +959,7 @@ class ConversationService:
                 if event_services is None:
                     return
                 for event_service in list(event_services.values()):
-                    event_service.renew_lease()
+                    await asyncio.to_thread(event_service.renew_lease)
         except asyncio.CancelledError:
             raise
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import logging
+from contextlib import suppress
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -11,7 +12,10 @@ from pydantic import BaseModel
 
 from openhands.agent_server.config import Config, WebhookSpec
 from openhands.agent_server.conversation_lease import ConversationLeaseHeldError
-from openhands.agent_server.event_service import EventService
+from openhands.agent_server.event_service import (
+    LEASE_RENEW_INTERVAL_SECONDS,
+    EventService,
+)
 from openhands.agent_server.models import (
     ACPConversationInfo,
     ACPConversationPage,
@@ -165,6 +169,7 @@ class ConversationService:
     _conversation_webhook_subscribers: list["ConversationWebhookSubscriber"] = field(
         default_factory=list, init=False
     )
+    _lease_renewal_task: asyncio.Task | None = field(default=None, init=False)
 
     async def get_conversation(self, conversation_id: UUID) -> ConversationInfo | None:
         if self._event_services is None:
@@ -816,9 +821,35 @@ class ConversationService:
             for webhook_spec in self.webhook_specs
         ]
 
+        self._lease_renewal_task = asyncio.create_task(self._renew_all_leases_loop())
+
         return self
 
+    async def _renew_all_leases_loop(self) -> None:
+        """Single background task that renews leases for all active conversations.
+
+        Replaces N per-conversation renewal tasks with one centralized loop,
+        reducing asyncio task overhead and spreading file-lock acquisitions
+        into a single sequential pass.
+        """
+        try:
+            while True:
+                await asyncio.sleep(LEASE_RENEW_INTERVAL_SECONDS)
+                event_services = self._event_services
+                if event_services is None:
+                    return
+                for event_service in list(event_services.values()):
+                    event_service.renew_lease()
+        except asyncio.CancelledError:
+            raise
+
     async def __aexit__(self, exc_type, exc_value, traceback):
+        if self._lease_renewal_task is not None:
+            self._lease_renewal_task.cancel()
+            with suppress(asyncio.CancelledError):
+                await self._lease_renewal_task
+            self._lease_renewal_task = None
+
         event_services = self._event_services
         if event_services is None:
             return
@@ -853,6 +884,9 @@ class ConversationService:
             cipher=self.cipher,
             owner_instance_id=self.owner_instance_id,
         )
+        # Lease renewal is handled by the centralized
+        # _renew_all_leases_loop task on ConversationService.
+        event_service._external_lease_renewal = True
         # Create subscribers...
         await event_service.subscribe_to_events(_EventSubscriber(service=event_service))
         if stored.autotitle and stored.title is None:

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -66,6 +66,7 @@ class EventService:
     _lease: ConversationLease | None = field(default=None, init=False)
     _lease_generation: int | None = field(default=None, init=False)
     _lease_task: asyncio.Task | None = field(default=None, init=False)
+    _external_lease_renewal: bool = field(default=False, init=False)
 
     @property
     def conversation_dir(self):
@@ -96,15 +97,16 @@ class EventService:
             return nullcontext()
         return self._lease.guarded_write(self._lease_generation)
 
-    async def _renew_lease_loop(self) -> None:
+    def renew_lease(self) -> None:
+        """Renew this service's conversation lease.
+
+        Called by a centralized renewal loop (when ``_external_lease_renewal``
+        is True) or by the per-service ``_renew_lease_loop`` background task.
+        """
         if self._lease is None or self._lease_generation is None:
             return
         try:
-            while True:
-                await asyncio.sleep(LEASE_RENEW_INTERVAL_SECONDS)
-                self._lease.renew(self._lease_generation)
-        except asyncio.CancelledError:
-            raise
+            self._lease.renew(self._lease_generation)
         except ConversationOwnershipLostError:
             logger.warning(
                 "Conversation lease lost while renewing: %s",
@@ -115,6 +117,16 @@ class EventService:
                 "Failed to renew conversation lease for %s",
                 self.stored.id,
             )
+
+    async def _renew_lease_loop(self) -> None:
+        if self._lease is None or self._lease_generation is None:
+            return
+        try:
+            while True:
+                await asyncio.sleep(LEASE_RENEW_INTERVAL_SECONDS)
+                self.renew_lease()
+        except asyncio.CancelledError:
+            raise
 
     def get_conversation(self):
         if not self._conversation:
@@ -620,7 +632,8 @@ class EventService:
         conversation.set_security_analyzer(self.stored.security_analyzer)
         self._conversation = conversation
         self._conversation._state.set_write_guard(self._write_guard)
-        self._lease_task = asyncio.create_task(self._renew_lease_loop())
+        if not self._external_lease_renewal:
+            self._lease_task = asyncio.create_task(self._renew_lease_loop())
 
         # Register state change callback to automatically publish updates
         self._conversation._state.set_on_state_change(self._conversation._on_event)

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -273,6 +273,52 @@ async def test_event_services_use_centralized_lease_renewal(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_centralized_lease_renewal_invokes_renew(tmp_path):
+    """The centralized loop calls renew_lease() on every active service."""
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+    with patch(
+        "openhands.agent_server.conversation_service.LEASE_RENEW_INTERVAL_SECONDS",
+        0.05,
+    ):
+        async with ConversationService(conversations_dir=conversations_dir) as svc:
+            info1, _ = await svc.start_conversation(request)
+            info2, _ = await svc.start_conversation(request)
+            assert svc._event_services is not None
+            es1 = svc._event_services[info1.id]
+            es2 = svc._event_services[info2.id]
+
+            renew_calls: dict[str, int] = {"es1": 0, "es2": 0}
+            original_renew1 = es1.renew_lease
+            original_renew2 = es2.renew_lease
+
+            def counting_renew1():
+                renew_calls["es1"] += 1
+                original_renew1()
+
+            def counting_renew2():
+                renew_calls["es2"] += 1
+                original_renew2()
+
+            es1.renew_lease = counting_renew1  # type: ignore[method-assign]
+            es2.renew_lease = counting_renew2  # type: ignore[method-assign]
+
+            # Wait for at least 2 renewal cycles
+            await asyncio.sleep(0.15)
+
+            assert renew_calls["es1"] >= 1, "renew_lease not called on es1"
+            assert renew_calls["es2"] >= 1, "renew_lease not called on es2"
+
+
+@pytest.mark.asyncio
 async def test_event_services_share_dedicated_run_executor(tmp_path):
     """Event services created by ConversationService should share a single
     dedicated thread pool for conversation.run() calls."""

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -219,6 +219,37 @@ async def test_stale_owner_cannot_append_after_lease_takeover(tmp_path):
                 primary_state.execution_status = ConversationExecutionStatus.ERROR
 
 
+@pytest.mark.asyncio
+async def test_event_services_use_centralized_lease_renewal(tmp_path):
+    """Event services created by ConversationService should not spawn
+    their own lease renewal tasks — renewal is handled centrally."""
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+    async with ConversationService(conversations_dir=conversations_dir) as svc:
+        info, _ = await svc.start_conversation(request)
+        assert svc._event_services is not None
+        es = svc._event_services[info.id]
+
+        # Per-service renewal task should NOT be created
+        assert es._lease_task is None
+        assert es._external_lease_renewal is True
+
+        # Centralized task should exist
+        assert svc._lease_renewal_task is not None
+        assert not svc._lease_renewal_task.done()
+
+    # After __aexit__, centralized task should be cleaned up
+    assert svc._lease_renewal_task is None
+
+
 class TestConversationServiceSearchConversations:
     """Test cases for ConversationService.search_conversations method."""
 


### PR DESCRIPTION
## Summary

Each `EventService` spawned its own asyncio task to renew its file-based lease every 15 seconds (`FileLock` acquire + JSON read + JSON write). With N active conversations, this produced **N independent tasks** and ~N/15 lock-contended file operations per second. At 500 conversations: ~33 lease file operations/sec, continuous.

## Fix

Replace N per-service renewal tasks with **one centralized loop** in `ConversationService`:

| Component | Change |
|---|---|
| `event_service.py` | Added `renew_lease()` public method (extracted error handling from loop); added `_external_lease_renewal` flag — when True, `start()` skips creating per-service `_lease_task` |
| `conversation_service.py` | Sets `_external_lease_renewal=True` on each managed service; creates one `_renew_all_leases_loop` task in `__aenter__()`; cancels it in `__aexit__()` |

### Backward compatibility
- Standalone `EventService` (without `ConversationService`) still spawns its own renewal task (`_external_lease_renewal` defaults to `False`)
- Lease semantics unchanged — same TTL (45s), same renewal interval (15s), same file format

### I/O reduction

| Before | After |
|---|---|
| N asyncio tasks (one per conversation) | 1 asyncio task |
| N scattered file-lock acquisitions per interval | 1 sequential pass per interval |
| At 500 conversations: ~33 ops/sec continuous | Same total I/O but no task overhead, no scattered contention |

## Verification

- All 873 agent-server tests pass (including 1 new test)
- All pre-commit hooks pass (ruff, pyright, etc.)
- Added `test_event_services_use_centralized_lease_renewal` — verifies `_lease_task` is None, `_external_lease_renewal` is True, centralized task exists and is cleaned up

Fixes #3144

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:eb6f19a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-eb6f19a-python \
  ghcr.io/openhands/agent-server:eb6f19a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:eb6f19a-golang-amd64
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-golang-amd64
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-golang-amd64
ghcr.io/openhands/agent-server:eb6f19a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:eb6f19a-golang-arm64
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-golang-arm64
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-golang-arm64
ghcr.io/openhands/agent-server:eb6f19a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:eb6f19a-java-amd64
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-java-amd64
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-java-amd64
ghcr.io/openhands/agent-server:eb6f19a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:eb6f19a-java-arm64
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-java-arm64
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-java-arm64
ghcr.io/openhands/agent-server:eb6f19a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:eb6f19a-python-amd64
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-python-amd64
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-python-amd64
ghcr.io/openhands/agent-server:eb6f19a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:eb6f19a-python-arm64
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-python-arm64
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-python-arm64
ghcr.io/openhands/agent-server:eb6f19a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:eb6f19a-golang
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-golang
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-golang
ghcr.io/openhands/agent-server:eb6f19a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:eb6f19a-java
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-java
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-java
ghcr.io/openhands/agent-server:eb6f19a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:eb6f19a-python
ghcr.io/openhands/agent-server:eb6f19a35097180261d9d260e77eb79bb62eafb4-python
ghcr.io/openhands/agent-server:fix-3144-lease-renewal-batching-python
ghcr.io/openhands/agent-server:eb6f19a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `eb6f19a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `eb6f19a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->