### PR TITLE
perf: dedicated thread pool for conversation execution

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -163,6 +163,15 @@ class Config(BaseModel):
         default=True,
         description="Whether to preload tools",
     )
+    max_concurrent_runs: int = Field(
+        default=10,
+        ge=1,
+        description=(
+            "Maximum number of conversations that can execute agent steps "
+            "concurrently.  Controls the size of the dedicated thread pool "
+            "used for conversation.run() calls."
+        ),
+    )
     secret_key: SecretStr | None = Field(
         default_factory=_default_secret_key,
         description=(

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import TYPE_CHECKING, cast
@@ -161,10 +162,12 @@ class ConversationService:
     session_api_key: str | None = field(default=None)
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
+    max_concurrent_runs: int = 10
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_webhook_subscribers: list["ConversationWebhookSubscriber"] = field(
         default_factory=list, init=False
     )
+    _run_executor: ThreadPoolExecutor | None = field(default=None, init=False)
 
     async def get_conversation(self, conversation_id: UUID) -> ConversationInfo | None:
         if self._event_services is None:
@@ -743,6 +746,10 @@ class ConversationService:
 
     async def __aenter__(self):
         self.conversations_dir.mkdir(parents=True, exist_ok=True)
+        self._run_executor = ThreadPoolExecutor(
+            max_workers=self.max_concurrent_runs,
+            thread_name_prefix="conversation-run",
+        )
         self._event_services = {}
         for conversation_dir in self.conversations_dir.iterdir():
             stored: StoredConversation | None = None
@@ -830,6 +837,9 @@ class ConversationService:
                 for event_service in event_services.values()
             ]
         )
+        if self._run_executor is not None:
+            self._run_executor.shutdown(wait=False)
+            self._run_executor = None
 
     @classmethod
     def get_instance(cls, config: Config) -> "ConversationService":
@@ -840,6 +850,7 @@ class ConversationService:
                 config.session_api_keys[0] if config.session_api_keys else None
             ),
             cipher=config.cipher,
+            max_concurrent_runs=config.max_concurrent_runs,
         )
 
     async def _start_event_service(self, stored: StoredConversation) -> EventService:
@@ -853,6 +864,7 @@ class ConversationService:
             cipher=self.cipher,
             owner_instance_id=self.owner_instance_id,
         )
+        event_service._run_executor = self._run_executor
         # Create subscribers...
         await event_service.subscribe_to_events(_EventSubscriber(service=event_service))
         if stored.autotitle and stored.title is None:

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,4 +1,5 @@
 import asyncio
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -66,6 +67,7 @@ class EventService:
     _lease: ConversationLease | None = field(default=None, init=False)
     _lease_generation: int | None = field(default=None, init=False)
     _lease_task: asyncio.Task | None = field(default=None, init=False)
+    _run_executor: ThreadPoolExecutor | None = field(default=None, init=False)
 
     @property
     def conversation_dir(self):
@@ -387,7 +389,7 @@ class EventService:
 
             async def _run_with_error_handling():
                 try:
-                    await loop.run_in_executor(None, conversation.run)
+                    await loop.run_in_executor(self._run_executor, conversation.run)
                 except Exception:
                     logger.exception("Error during conversation run from send_message")
 
@@ -703,7 +705,7 @@ class EventService:
 
             async def _run_and_publish():
                 try:
-                    await loop.run_in_executor(None, conversation.run)
+                    await loop.run_in_executor(self._run_executor, conversation.run)
                 except Exception:
                     logger.exception("Error during conversation run")
                 finally:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -219,6 +219,41 @@ async def test_stale_owner_cannot_append_after_lease_takeover(tmp_path):
                 primary_state.execution_status = ConversationExecutionStatus.ERROR
 
 
+@pytest.mark.asyncio
+async def test_event_services_share_dedicated_run_executor(tmp_path):
+    """Event services created by ConversationService should share a single
+    dedicated thread pool for conversation.run() calls."""
+    from concurrent.futures import ThreadPoolExecutor
+
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    request = StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+    async with ConversationService(
+        conversations_dir=conversations_dir, max_concurrent_runs=5
+    ) as svc:
+        info, _ = await svc.start_conversation(request)
+        assert svc._event_services is not None
+        es = svc._event_services[info.id]
+
+        # A dedicated executor should exist on the service
+        assert svc._run_executor is not None
+        assert isinstance(svc._run_executor, ThreadPoolExecutor)
+        assert svc._run_executor._max_workers == 5
+
+        # EventService should share the same executor instance
+        assert es._run_executor is svc._run_executor
+
+    # After __aexit__, executor should be shut down
+    assert svc._run_executor is None
+
+
 class TestConversationServiceSearchConversations:
     """Test cases for ConversationService.search_conversations method."""
 


### PR DESCRIPTION
## Summary

`EventService.run()` and the fire-and-forget run path in `send_message()` dispatch `conversation.run()` via `loop.run_in_executor(None, ...)`, which uses asyncio's **default shared executor** (capped at `min(32, cpu_count+4)` threads). All 22+ `run_in_executor` calls in `EventService` share this single pool. Long-running agent step loops can exhaust it, starving short I/O operations (event search, status checks, pause, etc.) and silently queuing new conversation runs with no visibility.

## Fix

Create a **dedicated `ThreadPoolExecutor`** for conversation execution, separate from the default pool used for short I/O operations:

| Component | Change |
|---|---|
| `config.py` | Added `max_concurrent_runs: int = 10` — configurable upper bound on simultaneous agent step threads |
| `conversation_service.py` | Creates shared `ThreadPoolExecutor(max_workers=max_concurrent_runs)` in `__aenter__()`; shuts it down in `__aexit__()`; passes to each `EventService` via `_run_executor`; reads config via `get_instance()` |
| `event_service.py` | Added `_run_executor: ThreadPoolExecutor | None` field; `run()` and `send_message()` dispatch `conversation.run` to `self._run_executor` instead of `None` |

### Isolation

| Operation | Executor |
|---|---|
| `conversation.run()` (long-running agent loop) | Dedicated pool (`max_concurrent_runs` threads) |
| `search_events`, `count_events`, `get_state`, `pause`, etc. (short I/O) | Default asyncio pool (unchanged) |

### Backward compatibility
- When `_run_executor` is `None` (standalone `EventService` without `ConversationService`), `run_in_executor(None, ...)` falls back to the default pool
- Default `max_concurrent_runs=10` is conservative; operators can tune via config

## Verification

- All 872 agent-server tests pass (including 1 new test)
- All pre-commit hooks pass (ruff, pyright, etc.)
- Added `test_event_services_share_dedicated_run_executor` — verifies executor creation, sharing, cleanup

Fixes #3143

_This PR was created by an AI agent (OpenHands) on behalf of @csmith49._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dbc55ce-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dbc55ce-python \
  ghcr.io/openhands/agent-server:dbc55ce-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dbc55ce-golang-amd64
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-golang-amd64
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-golang-amd64
ghcr.io/openhands/agent-server:dbc55ce-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dbc55ce-golang-arm64
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-golang-arm64
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-golang-arm64
ghcr.io/openhands/agent-server:dbc55ce-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dbc55ce-java-amd64
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-java-amd64
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-java-amd64
ghcr.io/openhands/agent-server:dbc55ce-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dbc55ce-java-arm64
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-java-arm64
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-java-arm64
ghcr.io/openhands/agent-server:dbc55ce-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dbc55ce-python-amd64
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-python-amd64
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-python-amd64
ghcr.io/openhands/agent-server:dbc55ce-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dbc55ce-python-arm64
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-python-arm64
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-python-arm64
ghcr.io/openhands/agent-server:dbc55ce-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dbc55ce-golang
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-golang
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-golang
ghcr.io/openhands/agent-server:dbc55ce-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:dbc55ce-java
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-java
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-java
ghcr.io/openhands/agent-server:dbc55ce-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:dbc55ce-python
ghcr.io/openhands/agent-server:dbc55cee7fc5edf61ee0b5262fc61ea450a24aae-python
ghcr.io/openhands/agent-server:fix-3143-dedicated-thread-pool-python
ghcr.io/openhands/agent-server:dbc55ce-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dbc55ce-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dbc55ce-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->