### PR TITLE
Use native Python zipfile for trajectory downloads

### DIFF
--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -1,4 +1,6 @@
+import asyncio
 import os
+import zipfile
 from pathlib import Path
 from typing import Annotated
 from uuid import UUID
@@ -15,10 +17,8 @@ from fastapi.responses import FileResponse
 from pydantic import BaseModel
 from starlette.background import BackgroundTask
 
-from openhands.agent_server.bash_service import get_default_bash_event_service
 from openhands.agent_server.config import get_default_config
-from openhands.agent_server.conversation_service import get_default_conversation_service
-from openhands.agent_server.models import ExecuteBashRequest, Success
+from openhands.agent_server.models import Success
 from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.sdk.logger import get_logger
 
@@ -39,9 +39,6 @@ class HomeResponse(BaseModel):
 
 logger = get_logger(__name__)
 file_router = APIRouter(prefix="/file", tags=["Files"])
-config = get_default_config()
-conversation_service = get_default_conversation_service()
-bash_event_service = get_default_bash_event_service()
 
 
 async def _upload_file(path: str, file: UploadFile) -> Success:
@@ -113,6 +110,18 @@ async def _download_file(path: str) -> FileResponse:
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to download file: {str(e)}",
         )
+
+
+def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
+    """Create a zip archive for source_dir using only Python stdlib APIs."""
+    try:
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as archive:
+            archive.write(source_dir, source_dir.name)
+            for path in sorted(source_dir.rglob("*")):
+                archive.write(path, path.relative_to(source_dir.parent))
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
 
 
 @file_router.post("/upload")
@@ -227,14 +236,18 @@ async def search_subdirs(
 async def download_trajectory(
     conversation_id: UUID,
 ) -> FileResponse:
-    """Download a file from the workspace."""
+    """Download a zip archive of a conversation trajectory."""
     config = get_default_config()
     temp_file = config.conversations_path / f"{conversation_id.hex}.zip"
     conversation_dir = config.conversations_path / conversation_id.hex
-    _, task = await bash_event_service.start_bash_command(
-        ExecuteBashRequest(command=f"zip -r {temp_file} {conversation_dir}")
-    )
-    await task
+
+    if not conversation_dir.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Conversation not found",
+        )
+
+    await asyncio.to_thread(_create_zip_from_directory, conversation_dir, temp_file)
     return FileResponse(
         path=temp_file,
         filename=temp_file.name,

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -1,11 +1,15 @@
 """Tests for file_router.py endpoints."""
 
 import io
+import zipfile
 from pathlib import Path
+from types import SimpleNamespace
+from uuid import uuid4
 
 import pytest
 from fastapi.testclient import TestClient
 
+from openhands.agent_server import file_router as file_router_module
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 
@@ -224,6 +228,44 @@ def test_upload_file_with_special_characters_in_path(client, tmp_path):
     assert response.status_code == 200
     assert target_path.exists()
     assert target_path.read_bytes() == file_content
+
+
+def test_download_trajectory_uses_python_zipfile(client, monkeypatch, tmp_path):
+    """Trajectory downloads should not depend on an OS-level zip command."""
+    conversations_path = tmp_path / "conversations"
+    conversation_id = uuid4()
+    conversation_dir = conversations_path / conversation_id.hex
+    nested_dir = conversation_dir / "nested"
+    nested_dir.mkdir(parents=True)
+    (conversation_dir / "meta.json").write_text("{}")
+    (nested_dir / "event.json").write_text('{"id": "event-1"}')
+
+    monkeypatch.setattr(
+        "openhands.agent_server.file_router.get_default_config",
+        lambda: Config(session_api_keys=[], conversations_path=conversations_path),
+    )
+
+    async def fail_if_shell_zip_is_used(*_args, **_kwargs):
+        raise AssertionError("download_trajectory must not shell out to zip")
+
+    monkeypatch.setattr(
+        file_router_module,
+        "bash_event_service",
+        SimpleNamespace(start_bash_command=fail_if_shell_zip_is_used),
+        raising=False,
+    )
+
+    response = client.get(f"/api/file/download-trajectory/{conversation_id}")
+
+    assert response.status_code == 200
+    assert response.headers["content-type"] == "application/octet-stream"
+    with zipfile.ZipFile(io.BytesIO(response.content)) as archive:
+        assert archive.read(f"{conversation_id.hex}/meta.json") == b"{}"
+        assert archive.read(f"{conversation_id.hex}/nested/event.json") == (
+            b'{"id": "event-1"}'
+        )
+
+    assert not (conversations_path / f"{conversation_id.hex}.zip").exists()
 
 
 def test_download_file_with_special_characters_in_path(client, tmp_path):


### PR DESCRIPTION
## Summary
- Replaces the `download-trajectory` endpoint's shell-based `zip -r` call with Python's stdlib `zipfile` implementation.
- Offloads archive creation to a worker thread so the async route does not block the event loop while zipping.
- Returns a 404 when the requested conversation directory is missing.
- Adds regression coverage that patches the old shell zip path to fail, verifies the endpoint still returns a valid archive, checks nested trajectory files are included, and confirms the temporary zip is cleaned up.

This addresses the Windows failure mode discussed in OpenHands/agent-canvas#2322, where the server may not have a `zip` executable available.

## Verification
- `uv run pytest tests/agent_server/test_file_router.py -k download_trajectory -q` (failed before the fix, passes after)
- `uv run pytest tests/agent_server/test_file_router.py -q`
- `uv run ruff format --check openhands-agent-server/openhands/agent_server/file_router.py tests/agent_server/test_file_router.py`
- `uv run ruff check openhands-agent-server/openhands/agent_server/file_router.py tests/agent_server/test_file_router.py`
- `uv run pyright openhands-agent-server/openhands/agent_server/file_router.py tests/agent_server/test_file_router.py`

---
This PR was created by an AI agent (OpenHands) on behalf of the user.

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1d853e05-b52f-47d6-b61a-3a6ff8a21d1e)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8f1f74b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8f1f74b-python \
  ghcr.io/openhands/agent-server:8f1f74b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8f1f74b-golang-amd64
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-golang-amd64
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-golang-amd64
ghcr.io/openhands/agent-server:8f1f74b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8f1f74b-golang-arm64
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-golang-arm64
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-golang-arm64
ghcr.io/openhands/agent-server:8f1f74b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8f1f74b-java-amd64
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-java-amd64
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-java-amd64
ghcr.io/openhands/agent-server:8f1f74b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8f1f74b-java-arm64
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-java-arm64
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-java-arm64
ghcr.io/openhands/agent-server:8f1f74b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8f1f74b-python-amd64
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-python-amd64
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-python-amd64
ghcr.io/openhands/agent-server:8f1f74b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8f1f74b-python-arm64
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-python-arm64
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-python-arm64
ghcr.io/openhands/agent-server:8f1f74b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8f1f74b-golang
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-golang
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-golang
ghcr.io/openhands/agent-server:8f1f74b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8f1f74b-java
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-java
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-java
ghcr.io/openhands/agent-server:8f1f74b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8f1f74b-python
ghcr.io/openhands/agent-server:8f1f74bb2de556f1cbabcce8e6be259a330b87e2-python
ghcr.io/openhands/agent-server:fix-native-trajectory-zip-python
ghcr.io/openhands/agent-server:8f1f74b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8f1f74b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8f1f74b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->