### PR TITLE
fix(agent-server): run bash cleanup traps on timeout via process-group SIGTERM

### DIFF
--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -1,6 +1,8 @@
 import asyncio
 import glob
 import json
+import os
+import signal
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
@@ -178,6 +180,22 @@ class BashEventService:
 
         return BashEventPage(items=page_events, next_page_id=next_page_id)
 
+    def _signal_process_group(
+        self,
+        process: asyncio.subprocess.Process,
+        sig: signal.Signals,
+        command: str,
+    ) -> None:
+        try:
+            os.killpg(os.getpgid(process.pid), sig)
+        except ProcessLookupError:
+            pass
+        except OSError as e:
+            logger.debug(
+                f"Failed to send {sig.name} to process group for command "
+                f"'{command}': {e}"
+            )
+
     async def start_bash_command(
         self, request: ExecuteBashRequest
     ) -> tuple[BashCommand, asyncio.Task]:
@@ -194,7 +212,9 @@ class BashEventService:
     async def _execute_bash_command(self, command: BashCommand) -> None:
         """Execute the bash event and create an observation event."""
         try:
-            # Create subprocess
+            # Create subprocess in a new session so we can signal the whole
+            # process group on teardown (the shell's children, e.g. sleep, must
+            # die before the shell can run user-installed traps).
             process = await asyncio.create_subprocess_shell(
                 command.command,
                 cwd=command.cwd,
@@ -202,6 +222,7 @@ class BashEventService:
                 stderr=asyncio.subprocess.PIPE,
                 shell=True,
                 env=sanitized_env(),
+                start_new_session=True,
             )
 
             # Track output order and buffers
@@ -272,14 +293,13 @@ class BashEventService:
                 )
                 exit_code = process.returncode
             except TimeoutError:
-                # Kill the process if it times out
-                process.kill()
+                # Send SIGTERM to the whole process group so user-installed
+                # cleanup traps can run, then escalate to SIGKILL if needed.
+                self._signal_process_group(process, signal.SIGTERM, command.command)
                 try:
-                    # Give the process a short time to die gracefully
                     await asyncio.wait_for(process.wait(), timeout=1.0)
                 except TimeoutError:
-                    # If it still won't die, terminate it more forcefully
-                    process.terminate()
+                    self._signal_process_group(process, signal.SIGKILL, command.command)
                     try:
                         await asyncio.wait_for(process.wait(), timeout=1.0)
                     except TimeoutError:

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -44,15 +44,6 @@ async def client(bash_service: BashEventService) -> AsyncIterator[httpx.AsyncCli
         yield ac
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "bash_service.py:276 sends SIGKILL before SIGTERM, so cleanup "
-        "traps never run. Fix: terminate() → wait → kill() (see "
-        "vscode_service.py:78-84). "
-        "Tracked in https://github.com/OpenHands/software-agent-sdk/issues/3120."
-    ),
-)
 @pytest.mark.timeout(30)
 async def test_bash_timeout_runs_sigterm_trap(
     client: httpx.AsyncClient,


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

When a bash command exceeds its timeout, the agent-server sent SIGKILL before SIGTERM, so user-installed traps (trap 'cleanup' EXIT, etc.) never ran — leaving stale PID files, temp dirs, and connections behind.                     
   
  Just swapping the order isn't enough: asyncio.create_subprocess_shell runs the command under a shell, and process.terminate() only signals the shell. While the shell is blocked waiting on a foreground child (e.g. sleep), it cannot 
  dispatch its trap until the child exits. Signaling only the shell leaves the trap pending forever, then SIGKILL on the shell still bypasses it.
                                                                                                                                                                                                                                         
  Fix: spawn the command in its own session (start_new_session=True) and signal the whole process group via os.killpg — SIGTERM first, escalating to SIGKILL after a 1s grace period. The shell's children die, the shell unblocks, and  
  the trap runs. This matches the pattern already used in openhands-sdk/.../hooks/executor.py and openhands-tools/.../subprocess_terminal.py.
                                         

## Issue Number
Closes #3120.

## How to Test
- tests/agent_server/test_bash_service.py::test_bash_timeout_runs_sigterm_trap now passes (xfail removed)
  - tests/agent_server/stress/test_long_running_command.py::test_bash_timeout_kills_process_cleanly still passes — no zombie descendants after timeout-kill                                                                              
  - tests/agent_server/stress/test_long_running_command.py::test_long_running_bash_does_not_block_event_loop still passes                                  
  - pre-commit clean (ruff, pyright, dep rules)             

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4679f60-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4679f60-python \
  ghcr.io/openhands/agent-server:4679f60-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4679f60-golang-amd64
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-golang-amd64
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-golang-amd64
ghcr.io/openhands/agent-server:4679f60-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4679f60-golang-arm64
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-golang-arm64
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-golang-arm64
ghcr.io/openhands/agent-server:4679f60-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4679f60-java-amd64
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-java-amd64
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-java-amd64
ghcr.io/openhands/agent-server:4679f60-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4679f60-java-arm64
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-java-arm64
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-java-arm64
ghcr.io/openhands/agent-server:4679f60-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4679f60-python-amd64
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-python-amd64
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-python-amd64
ghcr.io/openhands/agent-server:4679f60-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4679f60-python-arm64
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-python-arm64
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-python-arm64
ghcr.io/openhands/agent-server:4679f60-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4679f60-golang
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-golang
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-golang
ghcr.io/openhands/agent-server:4679f60-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4679f60-java
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-java
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-java
ghcr.io/openhands/agent-server:4679f60-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4679f60-python
ghcr.io/openhands/agent-server:4679f600027de58844b62dcdc1d64bd3b69eac41-python
ghcr.io/openhands/agent-server:3120-agent-server-bash-cleanup-traps-dont-run-because-sigkill-precedes-sigterm-python
ghcr.io/openhands/agent-server:4679f60-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4679f60-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4679f60-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->