### PR TITLE
fix(git): treat ref=HEAD with unresolved HEAD as empty tree

### DIFF
--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -105,9 +105,17 @@ def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | No
     """Get a valid git reference to compare against.
 
     If ``override`` is provided, it is resolved via ``git rev-parse --verify``
-    and returned (raising ``GitCommandError`` if it does not resolve). This
-    lets callers request, for example, ``HEAD`` to get ``git status``-style
-    diffs against the latest commit instead of against the remote branch.
+    and returned. This lets callers request, for example, ``HEAD`` to get
+    ``git status``-style diffs against the latest commit instead of against
+    the remote branch.
+
+    The ``"HEAD"`` override is treated specially: if it does not resolve
+    (no commits on the current branch — e.g. a freshly ``git init``'d
+    workspace, or an orphan branch in a repo that has commits elsewhere),
+    we fall back to the empty-tree hash so callers see untracked files as
+    additions instead of an opaque ``rev-parse --verify`` failure. Other
+    overrides that do not resolve still raise ``GitCommandError`` so a
+    typo'd branch/SHA is not silently swallowed.
 
     Otherwise, tries multiple strategies to find a valid reference:
     1. Current branch's origin (e.g., origin/main)
@@ -124,25 +132,43 @@ def get_valid_ref(repo_dir: str | Path, override: str | None = None) -> str | No
         Valid git reference hash, or None if no valid reference found
 
     Raises:
-        GitCommandError: If ``override`` is provided and does not resolve.
+        GitCommandError: If a non-``"HEAD"`` ``override`` is provided and
+            does not resolve.
     """
     if override is not None:
-        # ``HEAD`` doesn't resolve in a freshly-init'd repo with no commits.
-        # Treat it the same as the auto-detected path (empty tree) so the
-        # Changes tab on a brand-new workspace renders untracked files as
-        # added instead of erroring out.
-        if override == "HEAD" and not _repo_has_commits(repo_dir):
-            logger.debug(
-                "Override 'HEAD' requested but repo has no commits; "
-                "using empty tree reference"
+        try:
+            # Resolve explicit override and surface failure to the caller so
+            # the difference between "ref not found" and "no changes" stays
+            # visible.
+            return run_git_command(
+                [
+                    "git",
+                    "--no-pager",
+                    "rev-parse",
+                    "--verify",
+                    f"{override}^{{commit}}",
+                ],
+                repo_dir,
             )
-            return GIT_EMPTY_TREE_HASH
-        # Resolve explicit override and surface failure to the caller so the
-        # difference between "ref not found" and "no changes" stays visible.
-        return run_git_command(
-            ["git", "--no-pager", "rev-parse", "--verify", f"{override}^{{commit}}"],
-            repo_dir,
-        )
+        except GitCommandError:
+            # ``HEAD`` is the canonical "current branch tip"; if it doesn't
+            # resolve, the current branch has no commits yet. That happens for
+            # freshly ``git init``'d workspaces *and* for orphan branches in
+            # repos that have commits on other branches (so ``_repo_has_commits``
+            # alone can't catch the latter). Treat both as empty-tree compares
+            # so the Changes tab renders working-tree additions instead of
+            # bubbling up an opaque ``rev-parse --verify`` failure to the GUI.
+            #
+            # For non-``HEAD`` overrides (explicit branches/SHAs the caller
+            # asked for), keep the strict behavior so a typo doesn't silently
+            # become "no changes".
+            if override == "HEAD":
+                logger.debug(
+                    "Override 'HEAD' did not resolve in %s; using empty tree",
+                    repo_dir,
+                )
+                return GIT_EMPTY_TREE_HASH
+            raise
 
     refs_to_try = []
 

--- a/tests/agent_server/test_git_router.py
+++ b/tests/agent_server/test_git_router.py
@@ -179,6 +179,46 @@ async def test_git_changes_query_param_ref_head_on_empty_repo_returns_200(
 
 
 @pytest.mark.asyncio
+async def test_git_changes_query_param_ref_head_on_orphan_branch_returns_200(
+    client, tmp_path
+):
+    """End-to-end: ``?ref=HEAD`` on an orphan branch must return 200.
+
+    Real git repo (no mock) so the SDK fix is exercised through the router.
+    The repo has a commit on ``main``, but HEAD is currently pointing at an
+    unborn orphan branch — exactly the user-reported state that surfaced as
+    ``400 Bad Request: Git command failed: git --no-pager rev-parse --verify
+    'HEAD^{commit}'`` in the Changes tab. The earlier ``_repo_has_commits``
+    short-circuit doesn't catch this case (commits exist on main), so the
+    fix has to come from the ``rev-parse`` failure handler instead.
+    """
+    # Arrange: repo with one commit on main, then switch to an orphan branch.
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", *args], cwd=tmp_path, check=True, capture_output=True
+    )
+    run("init")
+    run("config", "user.email", "test@example.com")
+    run("config", "user.name", "Test")
+    (tmp_path / "committed.txt").write_text("on main")
+    run("add", ".")
+    run("commit", "-m", "on main")
+    run("checkout", "--orphan", "orphan")
+    run("rm", "-rf", "--cached", ".")
+    (tmp_path / "untracked.txt").write_text("new")
+
+    # Act
+    response = client.get(
+        "/api/git/changes",
+        params={"path": str(tmp_path), "ref": "HEAD"},
+    )
+
+    # Assert
+    assert response.status_code == 200
+    paths = {entry["path"] for entry in response.json()}
+    assert "untracked.txt" in paths
+
+
+@pytest.mark.asyncio
 async def test_git_changes_missing_path_param(client):
     """Test git changes endpoint returns 422 when path parameter is missing."""
     response = client.get("/api/git/changes")

--- a/tests/agent_server/test_git_router.py
+++ b/tests/agent_server/test_git_router.py
@@ -192,18 +192,24 @@ async def test_git_changes_query_param_ref_head_on_orphan_branch_returns_200(
     short-circuit doesn't catch this case (commits exist on main), so the
     fix has to come from the ``rev-parse`` failure handler instead.
     """
+
     # Arrange: repo with one commit on main, then switch to an orphan branch.
-    run = lambda *args: subprocess.run(  # noqa: E731
-        ["git", *args], cwd=tmp_path, check=True, capture_output=True
-    )
-    run("init")
-    run("config", "user.email", "test@example.com")
-    run("config", "user.name", "Test")
+    def run_git(*args: str) -> None:
+        subprocess.run(
+            ["git", *args],
+            cwd=tmp_path,
+            check=True,
+            capture_output=True,
+        )
+
+    run_git("init")
+    run_git("config", "user.email", "test@example.com")
+    run_git("config", "user.name", "Test")
     (tmp_path / "committed.txt").write_text("on main")
-    run("add", ".")
-    run("commit", "-m", "on main")
-    run("checkout", "--orphan", "orphan")
-    run("rm", "-rf", "--cached", ".")
+    run_git("add", ".")
+    run_git("commit", "-m", "on main")
+    run_git("checkout", "--orphan", "orphan")
+    run_git("rm", "-rf", "--cached", ".")
     (tmp_path / "untracked.txt").write_text("new")
 
     # Act

--- a/tests/sdk/git/test_git_changes.py
+++ b/tests/sdk/git/test_git_changes.py
@@ -478,6 +478,56 @@ def test_get_changes_in_repo_ref_head_on_empty_repo_returns_untracked_as_added()
         ]
 
 
+def test_get_changes_in_repo_ref_head_on_orphan_branch_returns_untracked_as_added():
+    """``ref='HEAD'`` on an orphan branch (HEAD unborn but other branches
+    have commits) must not raise.
+
+    The original empty-repo fix used ``_repo_has_commits`` to detect "no
+    commits anywhere" and skip the ``rev-parse --verify HEAD^{commit}``
+    step. That check returns ``True`` here (commits exist on ``main``),
+    so without an additional safety net the user sees the same
+    ``Git command failed: git --no-pager rev-parse --verify 'HEAD^{commit}'``
+    400 in the Changes tab.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+
+        # Land a commit on the default branch so the repo "has commits".
+        (Path(temp_dir) / "committed.txt").write_text("on main")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'on main'", temp_dir)
+
+        # Switch to an orphan branch: HEAD now points to refs/heads/orphan,
+        # which doesn't exist as a commit yet.
+        run_bash_command("git checkout --orphan orphan", temp_dir)
+        run_bash_command("git rm -rf --cached .", temp_dir)
+        (Path(temp_dir) / "untracked.txt").write_text("new")
+
+        # Act / Assert: must not raise GitCommandError; untracked file shows
+        # up as added (mirrors the empty-repo behavior).
+        changes = get_changes_in_repo(temp_dir, ref="HEAD")
+        paths = {str(c.path) for c in changes}
+        assert "untracked.txt" in paths
+
+
+def test_get_changes_in_repo_invalid_non_head_ref_still_raises_after_fix():
+    """The ``HEAD`` fallback must not swallow typos in other refs.
+
+    Regression guard for the new ``except GitCommandError`` in
+    ``get_valid_ref``: it only short-circuits when the *override* is
+    exactly ``"HEAD"``. Any other unresolved ref must still raise so a
+    typo (e.g. ``ref=mian``) doesn't silently render as "no changes".
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        setup_git_repo(temp_dir)
+        (Path(temp_dir) / "f.txt").write_text("hi")
+        run_bash_command("git add .", temp_dir)
+        run_bash_command("git commit -m 'init'", temp_dir)
+
+        with pytest.raises(GitCommandError):
+            get_changes_in_repo(temp_dir, ref="not-a-real-branch-name")
+
+
 def test_get_git_changes_propagates_ref():
     """``get_git_changes`` should pass the ref through to inner-repo lookups."""
     with tempfile.TemporaryDirectory() as temp_dir:


### PR DESCRIPTION
The empty-repo fallback in get_valid_ref relied on _repo_has_commits to decide whether to short-circuit ref="HEAD" to the empty tree. That check returns True for repos that have *any* commits anywhere — so an orphan branch (HEAD pointing to a ref with no commit, while other branches do have commits) still ran git rev-parse --verify HEAD^{commit} and failed with:

  HTTP 400 Bad Request
  {"detail":"Git command failed: git --no-pager rev-parse --verify
   'HEAD^{commit}'"}

surfacing in the agent-canvas Changes tab whenever a workspace was in that state.

Replace the pre-check with a tighter try/except around the rev-parse itself: when override == "HEAD" and rev-parse fails, fall back to GIT_EMPTY_TREE_HASH (empty repo *or* orphan branch — anything where HEAD has no commit yet). Non-"HEAD" overrides still raise so typo'd branches/SHAs aren't silently turned into "no changes".

This also drops the extra git rev-list --count call on the ref="HEAD" happy path.

Tests:
- New SDK regression: ref="HEAD" on an orphan branch returns untracked files as ADDED (mirrors existing empty-repo test).
- New SDK regression: non-"HEAD" unresolved ref still raises GitCommandError.
- New end-to-end router test: GET /api/git/changes?ref=HEAD on an orphan-branch repo returns 200 (was 400 before this fix).

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ca076f9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ca076f9-python \
  ghcr.io/openhands/agent-server:ca076f9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ca076f9-golang-amd64
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-golang-amd64
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-golang-amd64
ghcr.io/openhands/agent-server:ca076f9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ca076f9-golang-arm64
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-golang-arm64
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-golang-arm64
ghcr.io/openhands/agent-server:ca076f9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ca076f9-java-amd64
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-java-amd64
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-java-amd64
ghcr.io/openhands/agent-server:ca076f9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ca076f9-java-arm64
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-java-arm64
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-java-arm64
ghcr.io/openhands/agent-server:ca076f9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ca076f9-python-amd64
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-python-amd64
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-python-amd64
ghcr.io/openhands/agent-server:ca076f9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ca076f9-python-arm64
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-python-arm64
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-python-arm64
ghcr.io/openhands/agent-server:ca076f9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ca076f9-golang
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-golang
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-golang
ghcr.io/openhands/agent-server:ca076f9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ca076f9-java
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-java
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-java
ghcr.io/openhands/agent-server:ca076f9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ca076f9-python
ghcr.io/openhands/agent-server:ca076f9da9ad18169d6fce3438d7c06478057415-python
ghcr.io/openhands/agent-server:fix-git-changes-empty-repo-explicit-ref-python
ghcr.io/openhands/agent-server:ca076f9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ca076f9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ca076f9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->