### PR TITLE
fix for unencrypted secrets

### DIFF
--- a/openhands-sdk/openhands/sdk/secret/secrets.py
+++ b/openhands-sdk/openhands/sdk/secret/secrets.py
@@ -7,7 +7,11 @@ from pydantic import Field, SecretStr, field_serializer, field_validator
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
-from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
+from openhands.sdk.utils.pydantic_secrets import (
+    is_redacted_secret,
+    serialize_secret,
+    validate_secret,
+)
 from openhands.sdk.utils.redact import is_secret_key
 
 
@@ -63,17 +67,33 @@ class LookupSecret(SecretSource):
     def _validate_secrets(cls, headers: dict[str, str], info):
         result = {}
         for key, value in headers.items():
-            if is_secret_key(key):
-                secret_value = validate_secret(SecretStr(value), info)
-                # Skip headers with redacted/empty secret values
-                if secret_value is None:
-                    logger.debug(
-                        f"Skipping redacted header '{key}' during deserialization"
-                    )
-                    continue
-                result[key] = secret_value.get_secret_value()
-            else:
+            if not is_secret_key(key):
                 result[key] = value
+                continue
+
+            # Drop empty / redacted header values up-front; they carry no
+            # usable auth material regardless of cipher state.
+            if not value or not value.strip() or is_redacted_secret(value):
+                logger.debug(f"Skipping redacted header '{key}' during deserialization")
+                continue
+
+            secret_value = validate_secret(SecretStr(value), info)
+            if secret_value is None:
+                # validate_secret only returns None for a non-empty input when
+                # a cipher was supplied in the validation context but
+                # decryption failed. That happens when callers (e.g. a frontend
+                # building a LookupSecret) send a plaintext auth header but
+                # the request is otherwise tagged as containing encrypted
+                # secrets. Preserve the original value rather than silently
+                # dropping the header — the caller's intent for headers is
+                # always plaintext authentication metadata.
+                logger.debug(
+                    f"Header '{key}' could not be decrypted; "
+                    "treating value as plaintext"
+                )
+                result[key] = value
+            else:
+                result[key] = secret_value.get_secret_value()
         return result
 
     @field_serializer("headers", when_used="always")

--- a/tests/sdk/conversation/test_secret_source.py
+++ b/tests/sdk/conversation/test_secret_source.py
@@ -169,6 +169,85 @@ def test_lookup_secret_redacts_token_and_cookie_headers():
     assert serialized["headers"]["Content-Type"] == "application/json"
 
 
+def test_lookup_secret_validate_with_cipher_preserves_plaintext_headers():
+    """Plaintext auth headers must survive validation when a cipher is in
+    the context.
+
+    Regression test: agent-canvas (and any other client that round-trips
+    encrypted agent secrets via ``secrets_encrypted=True``) sends a
+    ``LookupSecret`` whose ``headers`` carry a plaintext ``X-Session-API-Key``
+    used to authenticate the lazy lookup. The validator used to feed that
+    plaintext header through ``cipher.decrypt`` (because the header name
+    matches a secret pattern), which fails and used to drop the header
+    silently. The runtime ``httpx.get`` then made an unauthenticated request
+    to the agent-server and got a 401, so the secret value was never
+    available to the conversation.
+    """
+    cipher = Cipher(secret_key="some secret key")
+    plaintext_session_key = "plaintext-session-api-key-value"
+
+    serialized = {
+        "kind": "LookupSecret",
+        "url": "http://localhost:8000/api/settings/secrets/MY_TOKEN",
+        "headers": {
+            "X-Session-API-Key": plaintext_session_key,
+            "Content-Type": "application/json",
+        },
+    }
+
+    validated = LookupSecret.model_validate(serialized, context={"cipher": cipher})
+
+    # Plaintext auth header survives despite cipher being in context.
+    assert validated.headers["X-Session-API-Key"] == plaintext_session_key
+    # Non-secret headers are still pass-through.
+    assert validated.headers["Content-Type"] == "application/json"
+
+
+def test_lookup_secret_validate_with_cipher_decrypts_encrypted_headers():
+    """Round-trip encrypted headers with cipher should still decrypt.
+
+    Companion to the plaintext test above: when a header was actually
+    encrypted with the same cipher (e.g. loaded from at-rest storage),
+    validation must still decrypt it back to plaintext rather than treating
+    it as opaque ciphertext.
+    """
+    cipher = Cipher(secret_key="some secret key")
+    secret = LookupSecret(
+        url="https://my-oauth-service.com",
+        headers={"Authorization": "Bearer real-token"},
+    )
+
+    dumped = secret.model_dump(mode="json", context={"cipher": cipher})
+    # Sanity check: the header is encrypted on the wire.
+    assert dumped["headers"]["Authorization"] != "Bearer real-token"
+
+    validated = LookupSecret.model_validate(dumped, context={"cipher": cipher})
+    assert validated.headers["Authorization"] == "Bearer real-token"
+
+
+def test_lookup_secret_validate_with_cipher_drops_redacted_headers():
+    """Redacted headers must still be dropped, even when a cipher is set.
+
+    Confirms the plaintext-fallback fix doesn't accidentally resurrect
+    masked values like ``"**********"`` as if they were real auth material.
+    """
+    cipher = Cipher(secret_key="some secret key")
+    serialized = {
+        "kind": "LookupSecret",
+        "url": "https://my-oauth-service.com",
+        "headers": {
+            "Authorization": "**********",
+            "X-Access-Token": "",
+            "Content-Type": "application/json",
+        },
+    }
+
+    validated = LookupSecret.model_validate(serialized, context={"cipher": cipher})
+    assert "Authorization" not in validated.headers
+    assert "X-Access-Token" not in validated.headers
+    assert validated.headers["Content-Type"] == "application/json"
+
+
 def test_lookup_secret_author_header_not_redacted():
     """Test that legitimate 'Author' headers are NOT falsely redacted.
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6339cc6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6339cc6-python \
  ghcr.io/openhands/agent-server:6339cc6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6339cc6-golang-amd64
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-golang-amd64
ghcr.io/openhands/agent-server:rb-encryption-fix-golang-amd64
ghcr.io/openhands/agent-server:6339cc6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6339cc6-golang-arm64
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-golang-arm64
ghcr.io/openhands/agent-server:rb-encryption-fix-golang-arm64
ghcr.io/openhands/agent-server:6339cc6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6339cc6-java-amd64
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-java-amd64
ghcr.io/openhands/agent-server:rb-encryption-fix-java-amd64
ghcr.io/openhands/agent-server:6339cc6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6339cc6-java-arm64
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-java-arm64
ghcr.io/openhands/agent-server:rb-encryption-fix-java-arm64
ghcr.io/openhands/agent-server:6339cc6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6339cc6-python-amd64
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-python-amd64
ghcr.io/openhands/agent-server:rb-encryption-fix-python-amd64
ghcr.io/openhands/agent-server:6339cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6339cc6-python-arm64
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-python-arm64
ghcr.io/openhands/agent-server:rb-encryption-fix-python-arm64
ghcr.io/openhands/agent-server:6339cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6339cc6-golang
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-golang
ghcr.io/openhands/agent-server:rb-encryption-fix-golang
ghcr.io/openhands/agent-server:6339cc6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6339cc6-java
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-java
ghcr.io/openhands/agent-server:rb-encryption-fix-java
ghcr.io/openhands/agent-server:6339cc6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6339cc6-python
ghcr.io/openhands/agent-server:6339cc63b553eae64f686a1ce0676240f7eb86eb-python
ghcr.io/openhands/agent-server:rb-encryption-fix-python
ghcr.io/openhands/agent-server:6339cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6339cc6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6339cc6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->