### PR TITLE
handle lookup secrets that are local

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -130,6 +130,8 @@ When reviewing code, provide constructive feedback:
 - Tool availability filtering belongs in `openhands-sdk/openhands/sdk/tool/registry.py` via `list_usable_tools()`, which preserves registration order and defaults tools to usable unless they expose an `is_usable()` callable. Environment-specific checks like Chromium detection should live on the concrete tool class (`BrowserToolSet.is_usable()`), while agent-server surfaces such as `/server_info` should consume the registry helper rather than re-implement per-tool filtering.
 - Pydantic secret field helpers live in `openhands-sdk/openhands/sdk/utils/pydantic_secrets.py`. `serialize_secret()` handles serialization (cipher / `expose_secrets` / default Pydantic masking); `validate_secret()` handles deserialization (cipher decryption, redacted/empty → `None`); `is_redacted_secret()` checks for the sentinel; `REDACTED_SECRET_VALUE` is the canonical sentinel string. For `dict[str, str]` fields whose values are all secrets, wrap each value in `SecretStr` and call `serialize_secret` per value (see `LookupSecret._serialize_secrets` and `ACPAgent._serialize_acp_env`). Do not hand-roll redaction logic in field serializers.
 
+- `LookupSecret` normalizes hostless URLs against `OH_INTERNAL_SERVER_URL` (set by `openhands-agent-server.__main__` from the bound host/port, rewriting wildcard binds to loopback) and otherwise falls back to `http://127.0.0.1:8000`, so relative secret URLs can safely target the current agent-server instance.
+
 
 
 

--- a/openhands-agent-server/openhands/agent_server/__main__.py
+++ b/openhands-agent-server/openhands/agent_server/__main__.py
@@ -2,6 +2,7 @@ import argparse
 import atexit
 import faulthandler
 import importlib
+import os
 import signal
 import sys
 from types import FrameType
@@ -14,6 +15,18 @@ from openhands.sdk.logger import DEBUG, get_logger
 
 
 logger = get_logger(__name__)
+
+
+_INTERNAL_SERVER_URL_ENV = "OH_INTERNAL_SERVER_URL"
+
+
+def _get_internal_server_url(host: str, port: int) -> str:
+    resolved_host = host
+    if host in {"0.0.0.0", "::", "[::]"}:
+        resolved_host = "127.0.0.1"
+    elif ":" in host and not host.startswith("["):
+        resolved_host = f"[{host}]"
+    return f"http://{resolved_host}:{port}"
 
 
 def preload_modules(modules_arg: str | None) -> None:
@@ -156,6 +169,10 @@ def main() -> None:
 
     # Import user modules after early-exit checks
     preload_modules(args.import_modules)
+
+    os.environ[_INTERNAL_SERVER_URL_ENV] = _get_internal_server_url(
+        args.host, args.port
+    )
 
     print(f"Starting OpenHands Agent Server on {args.host}:{args.port}")
     print(f"API docs will be available at http://{args.host}:{args.port}/docs")

--- a/openhands-agent-server/openhands/agent_server/__main__.py
+++ b/openhands-agent-server/openhands/agent_server/__main__.py
@@ -21,6 +21,20 @@ _INTERNAL_SERVER_URL_ENV = "OH_INTERNAL_SERVER_URL"
 
 
 def _get_internal_server_url(host: str, port: int) -> str:
+    """Build the current agent-server URL for local secret lookups.
+
+    Wildcard binds are rewritten to loopback so in-process callers can connect
+    back to the current server instance, and IPv6 literals are bracketed to
+    produce a valid URL.
+
+    Examples:
+        >>> _get_internal_server_url("0.0.0.0", 8000)
+        'http://127.0.0.1:8000'
+        >>> _get_internal_server_url("::", 8000)
+        'http://127.0.0.1:8000'
+        >>> _get_internal_server_url("fe80::1", 8000)
+        'http://[fe80::1]:8000'
+    """
     resolved_host = host
     if host in {"0.0.0.0", "::", "[::]"}:
         resolved_host = "127.0.0.1"

--- a/openhands-sdk/openhands/sdk/secret/secrets.py
+++ b/openhands-sdk/openhands/sdk/secret/secrets.py
@@ -1,6 +1,8 @@
 """Secret sources and types for handling sensitive data."""
 
+import os
 from abc import ABC, abstractmethod
+from urllib.parse import urljoin, urlsplit
 
 import httpx
 from pydantic import Field, SecretStr, field_serializer, field_validator
@@ -12,6 +14,18 @@ from openhands.sdk.utils.redact import is_secret_key
 
 
 logger = get_logger(__name__)
+
+_INTERNAL_SERVER_URL_ENV = "OH_INTERNAL_SERVER_URL"
+_DEFAULT_INTERNAL_SERVER_URL = "http://127.0.0.1:8000"
+
+
+def _resolve_lookup_secret_url(url: str) -> str:
+    parsed = urlsplit(url)
+    if parsed.netloc or parsed.scheme:
+        return url
+
+    base_url = os.getenv(_INTERNAL_SERVER_URL_ENV, _DEFAULT_INTERNAL_SERVER_URL)
+    return urljoin(f"{base_url.rstrip('/')}/", url)
 
 
 class SecretSource(DiscriminatedUnionMixin, ABC):
@@ -52,6 +66,11 @@ class LookupSecret(SecretSource):
 
     url: str
     headers: dict[str, str] = Field(default_factory=dict)
+
+    @field_validator("url")
+    @classmethod
+    def _normalize_url(cls, url: str) -> str:
+        return _resolve_lookup_secret_url(url)
 
     def get_value(self) -> str:
         response = httpx.get(self.url, headers=self.headers, timeout=30.0)

--- a/openhands-sdk/openhands/sdk/secret/secrets.py
+++ b/openhands-sdk/openhands/sdk/secret/secrets.py
@@ -7,7 +7,11 @@ from pydantic import Field, SecretStr, field_serializer, field_validator
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
-from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
+from openhands.sdk.utils.pydantic_secrets import (
+    is_redacted_secret,
+    serialize_secret,
+    validate_secret,
+)
 from openhands.sdk.utils.redact import is_secret_key
 
 
@@ -63,17 +67,33 @@ class LookupSecret(SecretSource):
     def _validate_secrets(cls, headers: dict[str, str], info):
         result = {}
         for key, value in headers.items():
-            if is_secret_key(key):
-                secret_value = validate_secret(SecretStr(value), info)
-                # Skip headers with redacted/empty secret values
-                if secret_value is None:
-                    logger.debug(
-                        f"Skipping redacted header '{key}' during deserialization"
-                    )
-                    continue
-                result[key] = secret_value.get_secret_value()
-            else:
+            if not is_secret_key(key):
                 result[key] = value
+                continue
+
+            # Drop empty / redacted header values up-front; they carry no
+            # usable auth material regardless of cipher state.
+            if not value or not value.strip() or is_redacted_secret(value):
+                logger.debug(f"Skipping redacted header '{key}' during deserialization")
+                continue
+
+            secret_value = validate_secret(SecretStr(value), info)
+            if secret_value is None:
+                # validate_secret only returns None for a non-empty input when
+                # a cipher was supplied in the validation context but
+                # decryption failed. That happens when callers (e.g. a frontend
+                # building a LookupSecret) send a plaintext auth header but
+                # the request is otherwise tagged as containing encrypted
+                # secrets. Preserve the original value rather than silently
+                # dropping the header — the caller's intent for headers is
+                # always plaintext authentication metadata.
+                logger.debug(
+                    f"Header '{key}' could not be decrypted; "
+                    "treating value as plaintext"
+                )
+                result[key] = value
+            else:
+                result[key] = secret_value.get_secret_value()
         return result
 
     @field_serializer("headers", when_used="always")

--- a/tests/agent_server/test_preload_modules.py
+++ b/tests/agent_server/test_preload_modules.py
@@ -1,13 +1,14 @@
 """Tests for the --import-modules preloading helper."""
 
 import logging
+import os
 import sys
 import textwrap
 from unittest.mock import MagicMock, patch
 
 import pytest
 
-from openhands.agent_server.__main__ import preload_modules
+from openhands.agent_server.__main__ import _get_internal_server_url, preload_modules
 
 
 class TestPreloadModules:
@@ -111,6 +112,14 @@ class TestPreloadModules:
         )
 
 
+def test_get_internal_server_url_rewrites_wildcard_host():
+    assert _get_internal_server_url("0.0.0.0", 4321) == "http://127.0.0.1:4321"
+
+
+def test_get_internal_server_url_preserves_explicit_host():
+    assert _get_internal_server_url("localhost", 4321) == "http://localhost:4321"
+
+
 class TestMainCheckBrowserOrdering:
     """Verify --check-browser runs independently of --import-modules."""
 
@@ -141,3 +150,21 @@ class TestMainCheckBrowserOrdering:
             assert exc_info.value.code == 0
             # preload_modules must NOT have been called
             mock_preload.assert_not_called()
+
+    def test_main_sets_internal_server_url(self, monkeypatch):
+        monkeypatch.delenv("OH_INTERNAL_SERVER_URL", raising=False)
+
+        with (
+            patch("sys.argv", ["prog", "--host", "0.0.0.0", "--port", "4321"]),
+            patch("openhands.agent_server.__main__.preload_modules"),
+            patch("openhands.agent_server.__main__.LoggingServer") as mock_server_cls,
+        ):
+            mock_server_cls.return_value.run.side_effect = SystemExit(0)
+
+            from openhands.agent_server.__main__ import main
+
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+
+        assert exc_info.value.code == 0
+        assert os.environ["OH_INTERNAL_SERVER_URL"] == "http://127.0.0.1:4321"

--- a/tests/agent_server/test_preload_modules.py
+++ b/tests/agent_server/test_preload_modules.py
@@ -112,12 +112,17 @@ class TestPreloadModules:
         )
 
 
-def test_get_internal_server_url_rewrites_wildcard_host():
-    assert _get_internal_server_url("0.0.0.0", 4321) == "http://127.0.0.1:4321"
+@pytest.mark.parametrize("host", ["0.0.0.0", "::", "[::]"])
+def test_get_internal_server_url_rewrites_wildcard_host(host):
+    assert _get_internal_server_url(host, 4321) == "http://127.0.0.1:4321"
 
 
 def test_get_internal_server_url_preserves_explicit_host():
     assert _get_internal_server_url("localhost", 4321) == "http://localhost:4321"
+
+
+def test_get_internal_server_url_brackets_ipv6_host():
+    assert _get_internal_server_url("fe80::1", 4321) == "http://[fe80::1]:4321"
 
 
 class TestMainCheckBrowserOrdering:

--- a/tests/sdk/conversation/test_secret_source.py
+++ b/tests/sdk/conversation/test_secret_source.py
@@ -1,5 +1,7 @@
 """Tests for SecretSources class."""
 
+from unittest.mock import Mock, patch
+
 import pytest
 from pydantic import SecretStr
 
@@ -194,3 +196,30 @@ def test_lookup_secret_author_header_not_redacted():
 
     # But Authorization should be redacted
     assert serialized["headers"]["Authorization"] == "**********"
+
+
+def test_lookup_secret_relative_url_uses_current_server(monkeypatch):
+    monkeypatch.setenv("OH_INTERNAL_SERVER_URL", "http://127.0.0.1:4321")
+
+    secret = LookupSecret(url="/api/settings/secrets/OPENAI_API_KEY")
+
+    assert secret.url == "http://127.0.0.1:4321/api/settings/secrets/OPENAI_API_KEY"
+
+
+def test_lookup_secret_get_value_resolves_relative_url(monkeypatch):
+    monkeypatch.setenv("OH_INTERNAL_SERVER_URL", "http://127.0.0.1:4321")
+    response = Mock(text="resolved-secret")
+    response.raise_for_status = Mock()
+
+    with patch(
+        "openhands.sdk.secret.secrets.httpx.get", return_value=response
+    ) as mock_get:
+        secret = LookupSecret(url="api/settings/secrets/OPENAI_API_KEY")
+
+        assert secret.get_value() == "resolved-secret"
+
+    mock_get.assert_called_once_with(
+        "http://127.0.0.1:4321/api/settings/secrets/OPENAI_API_KEY",
+        headers={},
+        timeout=30.0,
+    )

--- a/tests/sdk/conversation/test_secret_source.py
+++ b/tests/sdk/conversation/test_secret_source.py
@@ -169,6 +169,85 @@ def test_lookup_secret_redacts_token_and_cookie_headers():
     assert serialized["headers"]["Content-Type"] == "application/json"
 
 
+def test_lookup_secret_validate_with_cipher_preserves_plaintext_headers():
+    """Plaintext auth headers must survive validation when a cipher is in
+    the context.
+
+    Regression test: agent-canvas (and any other client that round-trips
+    encrypted agent secrets via ``secrets_encrypted=True``) sends a
+    ``LookupSecret`` whose ``headers`` carry a plaintext ``X-Session-API-Key``
+    used to authenticate the lazy lookup. The validator used to feed that
+    plaintext header through ``cipher.decrypt`` (because the header name
+    matches a secret pattern), which fails and used to drop the header
+    silently. The runtime ``httpx.get`` then made an unauthenticated request
+    to the agent-server and got a 401, so the secret value was never
+    available to the conversation.
+    """
+    cipher = Cipher(secret_key="some secret key")
+    plaintext_session_key = "plaintext-session-api-key-value"
+
+    serialized = {
+        "kind": "LookupSecret",
+        "url": "http://localhost:8000/api/settings/secrets/MY_TOKEN",
+        "headers": {
+            "X-Session-API-Key": plaintext_session_key,
+            "Content-Type": "application/json",
+        },
+    }
+
+    validated = LookupSecret.model_validate(serialized, context={"cipher": cipher})
+
+    # Plaintext auth header survives despite cipher being in context.
+    assert validated.headers["X-Session-API-Key"] == plaintext_session_key
+    # Non-secret headers are still pass-through.
+    assert validated.headers["Content-Type"] == "application/json"
+
+
+def test_lookup_secret_validate_with_cipher_decrypts_encrypted_headers():
+    """Round-trip encrypted headers with cipher should still decrypt.
+
+    Companion to the plaintext test above: when a header was actually
+    encrypted with the same cipher (e.g. loaded from at-rest storage),
+    validation must still decrypt it back to plaintext rather than treating
+    it as opaque ciphertext.
+    """
+    cipher = Cipher(secret_key="some secret key")
+    secret = LookupSecret(
+        url="https://my-oauth-service.com",
+        headers={"Authorization": "Bearer real-token"},
+    )
+
+    dumped = secret.model_dump(mode="json", context={"cipher": cipher})
+    # Sanity check: the header is encrypted on the wire.
+    assert dumped["headers"]["Authorization"] != "Bearer real-token"
+
+    validated = LookupSecret.model_validate(dumped, context={"cipher": cipher})
+    assert validated.headers["Authorization"] == "Bearer real-token"
+
+
+def test_lookup_secret_validate_with_cipher_drops_redacted_headers():
+    """Redacted headers must still be dropped, even when a cipher is set.
+
+    Confirms the plaintext-fallback fix doesn't accidentally resurrect
+    masked values like ``"**********"`` as if they were real auth material.
+    """
+    cipher = Cipher(secret_key="some secret key")
+    serialized = {
+        "kind": "LookupSecret",
+        "url": "https://my-oauth-service.com",
+        "headers": {
+            "Authorization": "**********",
+            "X-Access-Token": "",
+            "Content-Type": "application/json",
+        },
+    }
+
+    validated = LookupSecret.model_validate(serialized, context={"cipher": cipher})
+    assert "Authorization" not in validated.headers
+    assert "X-Access-Token" not in validated.headers
+    assert validated.headers["Content-Type"] == "application/json"
+
+
 def test_lookup_secret_author_header_not_redacted():
     """Test that legitimate 'Author' headers are NOT falsely redacted.
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

Confirmed working with some minor changes to the frontend (for relative URLs)

---

## Why

`LookupSecret` values created from local agent-server UIs can be relative paths, so the SDK needs to resolve them against the current server instance.

We also hit a real auth bug: when validation ran with a cipher in context, plaintext `X-Session-API-Key` headers could be dropped, which turned secret lookups into unauthenticated 401s.

## Summary

- Resolve relative `LookupSecret.url` values against `OH_INTERNAL_SERVER_URL` with a loopback fallback for local agent-server use.
- Preserve plaintext auth headers during cipher-backed validation while still decrypting actually encrypted header values.
- Set `OH_INTERNAL_SERVER_URL` during agent-server startup and cover wildcard / IPv6 URL shaping in tests.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

1. Run the focused regression tests:

```bash
uv run pytest tests/sdk/conversation/test_secret_source.py tests/agent_server/test_preload_modules.py
```

Observed result:

```text
29 passed, 5 warnings in 0.90s
```

2. Relative URL resolution + live `get_value()` request against a real local HTTP server:

```bash
OPENHANDS_SUPPRESS_BANNER=1 uv run python - <<'PY' 2>/dev/null
import os
import threading
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
from pydantic import SecretStr

from openhands.sdk.secret import LookupSecret
from openhands.sdk.utils.cipher import Cipher

seen = {}

class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        seen['path'] = self.path
        seen['session_key'] = self.headers.get('X-Session-API-Key')
        seen['authorization'] = self.headers.get('Authorization')
        if self.headers.get('X-Session-API-Key') != 'test-session-key':
            self.send_response(401)
            self.end_headers()
            self.wfile.write(b'unauthorized')
            return
        self.send_response(200)
        self.end_headers()
        self.wfile.write(b'secret-value')

    def log_message(self, format, *args):
        return

server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
thread = threading.Thread(target=server.serve_forever, daemon=True)
thread.start()

try:
    base_url = f'http://127.0.0.1:{server.server_port}'
    os.environ['OH_INTERNAL_SERVER_URL'] = base_url
    cipher = Cipher(secret_key='some secret key')
    serialized = {
        'kind': 'LookupSecret',
        'url': '/api/settings/secrets/MY_TOKEN',
        'headers': {
            'X-Session-API-Key': 'test-session-key',
            'Authorization': cipher.encrypt(SecretStr('Bearer upstream-token')),
        },
    }
    secret = LookupSecret.model_validate(serialized, context={'cipher': cipher})
    print(f'resolved_url={secret.url}')
    print(f'get_value={secret.get_value()}')
    print(f'seen_path={seen["path"]}')
    print(f'seen_session_key={seen["session_key"]}')
    print(f'seen_authorization={seen["authorization"]}')
finally:
    server.shutdown()
    server.server_close()
PY
```

Observed output:

```text
resolved_url=http://127.0.0.1:33507/api/settings/secrets/MY_TOKEN
get_value=secret-value
seen_path=/api/settings/secrets/MY_TOKEN
seen_session_key=test-session-key
seen_authorization=Bearer upstream-token
```

3. Before/after auth-header behavior using the pre-fix implementation from `origin/main` versus this branch:

```bash
OPENHANDS_SUPPRESS_BANNER=1 uv run python - <<'PY' 2>/dev/null
import importlib.util
import subprocess
import tempfile
import threading
from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
from pathlib import Path

from pydantic import SecretStr

from openhands.sdk.secret import LookupSecret as CurrentLookupSecret
from openhands.sdk.utils.cipher import Cipher

seen = {}

class Handler(BaseHTTPRequestHandler):
    def do_GET(self):
        seen['session_key'] = self.headers.get('X-Session-API-Key')
        seen['authorization'] = self.headers.get('Authorization')
        if self.headers.get('X-Session-API-Key') != 'test-session-key':
            self.send_response(401)
            self.end_headers()
            self.wfile.write(b'unauthorized')
            return
        self.send_response(200)
        self.end_headers()
        self.wfile.write(b'secret-value')

    def log_message(self, format, *args):
        return

server = ThreadingHTTPServer(('127.0.0.1', 0), Handler)
thread = threading.Thread(target=server.serve_forever, daemon=True)
thread.start()

try:
    with tempfile.TemporaryDirectory() as tmpdir:
        before_path = Path(tmpdir) / 'secrets_before.py'
        before_path.write_text(
            subprocess.check_output(
                [
                    'git',
                    'show',
                    'origin/main:openhands-sdk/openhands/sdk/secret/secrets.py',
                ],
                text=True,
            )
        )
        spec = importlib.util.spec_from_file_location('secrets_before', before_path)
        before_module = importlib.util.module_from_spec(spec)
        assert spec.loader is not None
        spec.loader.exec_module(before_module)

        base_url = f'http://127.0.0.1:{server.server_port}'
        cipher = Cipher(secret_key='some secret key')
        encrypted_auth = cipher.encrypt(SecretStr('Bearer upstream-token'))
        serialized = {
            'kind': 'LookupSecret',
            'url': f'{base_url}/api/settings/secrets/MY_TOKEN',
            'headers': {
                'X-Session-API-Key': 'test-session-key',
                'Authorization': encrypted_auth,
            },
        }

        before_secret = before_module.LookupSecret.model_validate(
            serialized,
            context={'cipher': cipher},
        )
        print(f'before_headers={before_secret.headers}')
        try:
            before_secret.get_value()
        except Exception as exc:
            print(f'before_result={type(exc).__name__}: {exc}')
            print(f'before_seen_session_key={seen["session_key"]}')

        seen.clear()

        after_secret = CurrentLookupSecret.model_validate(
            serialized,
            context={'cipher': cipher},
        )
        print(f'after_headers={after_secret.headers}')
        print(f'after_result={after_secret.get_value()}')
        print(f'after_seen_session_key={seen["session_key"]}')
        print(f'after_seen_authorization={seen["authorization"]}')
finally:
    server.shutdown()
    server.server_close()
PY
```

Observed output:

```text
before_headers={'Authorization': 'Bearer upstream-token'}
before_result=HTTPStatusError: Client error '401 Unauthorized' for url 'http://127.0.0.1:41003/api/settings/secrets/MY_TOKEN'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401
before_seen_session_key=None
after_headers={'X-Session-API-Key': 'test-session-key', 'Authorization': 'Bearer upstream-token'}
after_result=secret-value
after_seen_session_key=test-session-key
after_seen_authorization=Bearer upstream-token
```

## Video/Screenshots

<img width="987" height="479" alt="Screenshot 2026-05-09 at 2 54 01 PM" src="https://github.com/user-attachments/assets/7fe7690a-a12e-4ac6-82e2-de709006c567" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Added explicit IPv6 wildcard / literal coverage for `_get_internal_server_url()` and documented the helper with examples while addressing the review feedback.

_This PR description was updated by an AI agent (OpenHands) on behalf of the user._


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bb59c98-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bb59c98-python \
  ghcr.io/openhands/agent-server:bb59c98-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bb59c98-golang-amd64
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-golang-amd64
ghcr.io/openhands/agent-server:local-lookup-secret-golang-amd64
ghcr.io/openhands/agent-server:bb59c98-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bb59c98-golang-arm64
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-golang-arm64
ghcr.io/openhands/agent-server:local-lookup-secret-golang-arm64
ghcr.io/openhands/agent-server:bb59c98-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bb59c98-java-amd64
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-java-amd64
ghcr.io/openhands/agent-server:local-lookup-secret-java-amd64
ghcr.io/openhands/agent-server:bb59c98-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bb59c98-java-arm64
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-java-arm64
ghcr.io/openhands/agent-server:local-lookup-secret-java-arm64
ghcr.io/openhands/agent-server:bb59c98-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bb59c98-python-amd64
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-python-amd64
ghcr.io/openhands/agent-server:local-lookup-secret-python-amd64
ghcr.io/openhands/agent-server:bb59c98-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bb59c98-python-arm64
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-python-arm64
ghcr.io/openhands/agent-server:local-lookup-secret-python-arm64
ghcr.io/openhands/agent-server:bb59c98-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bb59c98-golang
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-golang
ghcr.io/openhands/agent-server:local-lookup-secret-golang
ghcr.io/openhands/agent-server:bb59c98-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:bb59c98-java
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-java
ghcr.io/openhands/agent-server:local-lookup-secret-java
ghcr.io/openhands/agent-server:bb59c98-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:bb59c98-python
ghcr.io/openhands/agent-server:bb59c98da4135f63a41fc1ef12673b997bc5e1df-python
ghcr.io/openhands/agent-server:local-lookup-secret-python
ghcr.io/openhands/agent-server:bb59c98-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bb59c98-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bb59c98-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->