### PR TITLE
fix(sdk): abort run loop on repeated Stop-hook denials without progress

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -98,7 +98,6 @@ class LocalConversation(BaseConversation):
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
         max_iteration_per_run: int = 500,
-        max_consecutive_stop_denials: int = 5,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
             StuckDetectionThresholds | Mapping[str, int] | None
@@ -110,6 +109,7 @@ class LocalConversation(BaseConversation):
         delete_on_close: bool = True,
         cipher: Cipher | None = None,
         tags: dict[str, str] | None = None,
+        max_consecutive_stop_denials: int = 5,
         **_: object,
     ):
         """Initialize the conversation.
@@ -800,19 +800,20 @@ class LocalConversation(BaseConversation):
                             )
                             if not should_stop:
                                 logger.info("Stop hook denied agent stopping")
-                                if consecutive_stop_denials > 0 and any(
-                                    isinstance(self._state.events[i], ActionEvent)
-                                    for i in range(
-                                        events_count_at_last_deny,
-                                        len(self._state.events),
-                                    )
-                                ):
-                                    consecutive_stop_denials = 0
+                                if consecutive_stop_denials > 0:
+                                    recent_events = self._state.events[
+                                        events_count_at_last_deny:
+                                    ]
+                                    if any(
+                                        isinstance(e, ActionEvent)
+                                        for e in recent_events
+                                    ):
+                                        consecutive_stop_denials = 0
                                 consecutive_stop_denials += 1
 
                                 if (
                                     consecutive_stop_denials
-                                    > self.max_consecutive_stop_denials
+                                    >= self.max_consecutive_stop_denials
                                 ):
                                     error_msg = (
                                         f"Stop hook denied {consecutive_stop_denials}"

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -75,6 +75,7 @@ class LocalConversation(BaseConversation):
     _on_event: ConversationCallbackType
     _on_token: ConversationTokenCallbackType | None
     max_iteration_per_run: int
+    max_consecutive_stop_denials: int
     _stuck_detector: StuckDetector | None
     llm_registry: LLMRegistry
     _cleanup_initiated: bool
@@ -97,6 +98,7 @@ class LocalConversation(BaseConversation):
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
         max_iteration_per_run: int = 500,
+        max_consecutive_stop_denials: int = 5,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
             StuckDetectionThresholds | Mapping[str, int] | None
@@ -132,6 +134,8 @@ class LocalConversation(BaseConversation):
             hook_config: Optional hook configuration to auto-wire session hooks.
                 If plugins are loaded, their hooks are combined with this config.
             max_iteration_per_run: Maximum number of iterations per run
+            max_consecutive_stop_denials: Abort the run loop after this many
+                consecutive Stop-hook denials with no ActionEvent in between.
             visualizer: Visualization configuration. Can be:
                        - ConversationVisualizerBase subclass: Class to instantiate
                          (default: ConversationVisualizer)
@@ -244,6 +248,7 @@ class LocalConversation(BaseConversation):
         )
 
         self.max_iteration_per_run = max_iteration_per_run
+        self.max_consecutive_stop_denials = max_consecutive_stop_denials
 
         # Initialize stuck detector
         if stuck_detection:
@@ -375,6 +380,7 @@ class LocalConversation(BaseConversation):
                 persistence_dir=fork_persistence,
                 conversation_id=fork_id,
                 max_iteration_per_run=self.max_iteration_per_run,
+                max_consecutive_stop_denials=self.max_consecutive_stop_denials,
                 stuck_detection=self._stuck_detector is not None,
                 visualizer=type(self._visualizer) if self._visualizer else None,
                 delete_on_close=self.delete_on_close,
@@ -768,6 +774,8 @@ class LocalConversation(BaseConversation):
                 self._state.execution_status = ConversationExecutionStatus.RUNNING
 
         iteration = 0
+        consecutive_stop_denials = 0
+        events_count_at_last_deny = 0
         try:
             while True:
                 logger.debug(f"Conversation run iteration {iteration}")
@@ -792,6 +800,39 @@ class LocalConversation(BaseConversation):
                             )
                             if not should_stop:
                                 logger.info("Stop hook denied agent stopping")
+                                if consecutive_stop_denials > 0 and any(
+                                    isinstance(self._state.events[i], ActionEvent)
+                                    for i in range(
+                                        events_count_at_last_deny,
+                                        len(self._state.events),
+                                    )
+                                ):
+                                    consecutive_stop_denials = 0
+                                consecutive_stop_denials += 1
+
+                                if (
+                                    consecutive_stop_denials
+                                    > self.max_consecutive_stop_denials
+                                ):
+                                    error_msg = (
+                                        f"Stop hook denied {consecutive_stop_denials}"
+                                        f" times without progress (limit "
+                                        f"{self.max_consecutive_stop_denials}). "
+                                        f"Last feedback: {feedback or '(none)'}"
+                                    )
+                                    logger.error(error_msg)
+                                    self._state.execution_status = (
+                                        ConversationExecutionStatus.ERROR
+                                    )
+                                    self._on_event(
+                                        ConversationErrorEvent(
+                                            source="environment",
+                                            code="StopHookLoopDetected",
+                                            detail=error_msg,
+                                        )
+                                    )
+                                    break
+
                                 if feedback:
                                     prefixed = f"[Stop hook feedback] {feedback}"
                                     feedback_msg = MessageEvent(
@@ -802,6 +843,7 @@ class LocalConversation(BaseConversation):
                                         ),
                                     )
                                     self._on_event(feedback_msg)
+                                events_count_at_last_deny = len(self._state.events)
                                 self._state.execution_status = (
                                     ConversationExecutionStatus.RUNNING
                                 )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -748,6 +748,50 @@ class LocalConversation(BaseConversation):
             )
             self._on_event(user_msg_event)
 
+    def _handle_stop_denial(
+        self,
+        consecutive_stop_denials: int,
+        events_count_at_last_deny: int,
+        feedback: str | None,
+    ) -> tuple[bool, int, int]:
+        if consecutive_stop_denials > 0:
+            recent_events = self._state.events[events_count_at_last_deny:]
+            if any(isinstance(e, ActionEvent) for e in recent_events):
+                consecutive_stop_denials = 0
+        consecutive_stop_denials += 1
+
+        if consecutive_stop_denials >= self.max_consecutive_stop_denials:
+            error_msg = (
+                f"Stop hook denied {consecutive_stop_denials}"
+                f" times without progress (limit "
+                f"{self.max_consecutive_stop_denials}). "
+                f"Last feedback: {feedback or '(none)'}"
+            )
+            logger.error(error_msg)
+            self._state.execution_status = ConversationExecutionStatus.ERROR
+            self._on_event(
+                ConversationErrorEvent(
+                    source="environment",
+                    code="StopHookLoopDetected",
+                    detail=error_msg,
+                )
+            )
+            return True, consecutive_stop_denials, events_count_at_last_deny
+
+        if feedback:
+            prefixed = f"[Stop hook feedback] {feedback}"
+            feedback_msg = MessageEvent(
+                source="environment",
+                llm_message=Message(
+                    role="user",
+                    content=[TextContent(text=prefixed)],
+                ),
+            )
+            self._on_event(feedback_msg)
+        events_count_at_last_deny = len(self._state.events)
+        self._state.execution_status = ConversationExecutionStatus.RUNNING
+        return False, consecutive_stop_denials, events_count_at_last_deny
+
     @observe(name="conversation.run")
     def run(self) -> None:
         """Runs the conversation until the agent finishes.
@@ -800,54 +844,17 @@ class LocalConversation(BaseConversation):
                             )
                             if not should_stop:
                                 logger.info("Stop hook denied agent stopping")
-                                if consecutive_stop_denials > 0:
-                                    recent_events = self._state.events[
-                                        events_count_at_last_deny:
-                                    ]
-                                    if any(
-                                        isinstance(e, ActionEvent)
-                                        for e in recent_events
-                                    ):
-                                        consecutive_stop_denials = 0
-                                consecutive_stop_denials += 1
-
-                                if (
-                                    consecutive_stop_denials
-                                    >= self.max_consecutive_stop_denials
-                                ):
-                                    error_msg = (
-                                        f"Stop hook denied {consecutive_stop_denials}"
-                                        f" times without progress (limit "
-                                        f"{self.max_consecutive_stop_denials}). "
-                                        f"Last feedback: {feedback or '(none)'}"
-                                    )
-                                    logger.error(error_msg)
-                                    self._state.execution_status = (
-                                        ConversationExecutionStatus.ERROR
-                                    )
-                                    self._on_event(
-                                        ConversationErrorEvent(
-                                            source="environment",
-                                            code="StopHookLoopDetected",
-                                            detail=error_msg,
-                                        )
-                                    )
-                                    break
-
-                                if feedback:
-                                    prefixed = f"[Stop hook feedback] {feedback}"
-                                    feedback_msg = MessageEvent(
-                                        source="environment",
-                                        llm_message=Message(
-                                            role="user",
-                                            content=[TextContent(text=prefixed)],
-                                        ),
-                                    )
-                                    self._on_event(feedback_msg)
-                                events_count_at_last_deny = len(self._state.events)
-                                self._state.execution_status = (
-                                    ConversationExecutionStatus.RUNNING
+                                (
+                                    should_break,
+                                    consecutive_stop_denials,
+                                    events_count_at_last_deny,
+                                ) = self._handle_stop_denial(
+                                    consecutive_stop_denials,
+                                    events_count_at_last_deny,
+                                    feedback,
                                 )
+                                if should_break:
+                                    break
                                 continue
                         # No hooks or hooks allowed stopping
                         break

--- a/tests/sdk/hooks/test_integration.py
+++ b/tests/sdk/hooks/test_integration.py
@@ -912,6 +912,138 @@ class TestStopHookConversationIntegration:
         ]
         assert len(feedback_messages) == 1, "Feedback message should be injected once"
 
+    def test_consecutive_stop_hook_denials_abort_with_error(self, tmp_path):
+        from unittest.mock import patch
+
+        from pydantic import SecretStr
+
+        from openhands.sdk.agent import Agent
+        from openhands.sdk.conversation import LocalConversation
+        from openhands.sdk.conversation.state import ConversationExecutionStatus
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.llm import LLM
+
+        command = _json_command({"decision": "deny", "reason": "always denying"}, 2)
+        hook_config = HookConfig.from_dict(
+            {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": command}]}]}}
+        )
+        llm = LLM(model="test-model", api_key=SecretStr("test-key"))
+        agent = Agent(llm=llm, tools=[])
+
+        events_captured: list = []
+
+        def mock_step(self, conversation, on_event, on_token=None):
+            conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+        max_denials = 3
+        with patch.object(Agent, "step", mock_step):
+            conversation = LocalConversation(
+                agent=agent,
+                workspace=tmp_path,
+                hook_config=hook_config,
+                callbacks=[events_captured.append],
+                visualizer=None,
+                max_iteration_per_run=100,
+                max_consecutive_stop_denials=max_denials,
+            )
+            conversation.send_message("Hello")
+            conversation.run()
+            conversation.close()
+
+        assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+        error_events = [
+            e for e in events_captured if isinstance(e, ConversationErrorEvent)
+        ]
+        assert len(error_events) == 1
+        assert error_events[0].code == "StopHookLoopDetected"
+        assert "always denying" in error_events[0].detail
+
+        deny_events = [
+            e
+            for e in events_captured
+            if isinstance(e, HookExecutionEvent)
+            and e.hook_event_type == "Stop"
+            and e.blocked
+        ]
+        assert len(deny_events) == max_denials + 1
+
+    def test_stop_hook_deny_streak_resets_on_action_progress(self, tmp_path):
+        from unittest.mock import patch
+
+        from pydantic import SecretStr
+
+        from openhands.sdk.agent import Agent
+        from openhands.sdk.conversation import LocalConversation
+        from openhands.sdk.conversation.state import ConversationExecutionStatus
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.llm import LLM
+        from openhands.sdk.llm.message import MessageToolCall
+
+        # Streak limit 2; hook denies 4 times then allows. An ActionEvent
+        # between denials 2 and 3 must reset the streak so we don't abort.
+        stop_count_file = tmp_path / "stop_count"
+        stop_count_file.write_text("0")
+        command = python_command(
+            "import json, sys; "
+            "from pathlib import Path; "
+            f"path = Path({str(stop_count_file)!r}); "
+            "count = int(path.read_text()); "
+            "path.write_text(str(count + 1)); "
+            "denied = count < 4; "
+            "payload = ({'decision': 'deny', 'reason': 'nope'} "
+            "if denied else {'decision': 'allow'}); "
+            "print(json.dumps(payload)); "
+            "sys.exit(2 if denied else 0)"
+        )
+        hook_config = HookConfig.from_dict(
+            {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": command}]}]}}
+        )
+        llm = LLM(model="test-model", api_key=SecretStr("test-key"))
+        agent = Agent(llm=llm, tools=[])
+
+        events_captured: list = []
+        step_count = 0
+
+        def mock_step(self, conversation, on_event, on_token=None):
+            nonlocal step_count
+            step_count += 1
+            if step_count == 3:
+                on_event(
+                    ActionEvent(
+                        source="agent",
+                        tool_name="noop",
+                        tool_call_id="call-1",
+                        tool_call=MessageToolCall(
+                            id="call-1",
+                            name="noop",
+                            arguments="{}",
+                            origin="completion",
+                        ),
+                        thought=[TextContent(text="progress")],
+                        llm_response_id="resp-1",
+                    )
+                )
+            conversation.state.execution_status = ConversationExecutionStatus.FINISHED
+
+        with patch.object(Agent, "step", mock_step):
+            conversation = LocalConversation(
+                agent=agent,
+                workspace=tmp_path,
+                hook_config=hook_config,
+                callbacks=[events_captured.append],
+                visualizer=None,
+                max_iteration_per_run=100,
+                max_consecutive_stop_denials=2,
+            )
+            conversation.send_message("Hello")
+            conversation.run()
+            conversation.close()
+
+        assert not [e for e in events_captured if isinstance(e, ConversationErrorEvent)]
+        assert (
+            conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+        )
+
 
 class TestHookExecutionEventEmission:
     """Tests for HookExecutionEvent emission during hook execution."""

--- a/tests/sdk/hooks/test_integration.py
+++ b/tests/sdk/hooks/test_integration.py
@@ -1,16 +1,26 @@
 """Integration tests for hooks blocking in Agent and Conversation."""
 
-import pytest
+from unittest.mock import patch
 
-from openhands.sdk.conversation.state import ConversationState
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import LocalConversation
+from openhands.sdk.conversation.state import (
+    ConversationExecutionStatus,
+    ConversationState,
+)
 from openhands.sdk.event import ActionEvent, HookExecutionEvent, MessageEvent
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.hooks.config import HookConfig
 from openhands.sdk.hooks.conversation_hooks import (
     HookEventProcessor,
     create_hook_callback,
 )
 from openhands.sdk.hooks.manager import HookManager
-from openhands.sdk.llm import Message, TextContent
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.llm.message import MessageToolCall
 from tests.command_utils import python_command
 
 
@@ -913,16 +923,6 @@ class TestStopHookConversationIntegration:
         assert len(feedback_messages) == 1, "Feedback message should be injected once"
 
     def test_consecutive_stop_hook_denials_abort_with_error(self, tmp_path):
-        from unittest.mock import patch
-
-        from pydantic import SecretStr
-
-        from openhands.sdk.agent import Agent
-        from openhands.sdk.conversation import LocalConversation
-        from openhands.sdk.conversation.state import ConversationExecutionStatus
-        from openhands.sdk.event.conversation_error import ConversationErrorEvent
-        from openhands.sdk.llm import LLM
-
         command = _json_command({"decision": "deny", "reason": "always denying"}, 2)
         hook_config = HookConfig.from_dict(
             {"hooks": {"Stop": [{"hooks": [{"type": "command", "command": command}]}]}}
@@ -968,17 +968,6 @@ class TestStopHookConversationIntegration:
         assert len(deny_events) == max_denials + 1
 
     def test_stop_hook_deny_streak_resets_on_action_progress(self, tmp_path):
-        from unittest.mock import patch
-
-        from pydantic import SecretStr
-
-        from openhands.sdk.agent import Agent
-        from openhands.sdk.conversation import LocalConversation
-        from openhands.sdk.conversation.state import ConversationExecutionStatus
-        from openhands.sdk.event.conversation_error import ConversationErrorEvent
-        from openhands.sdk.llm import LLM
-        from openhands.sdk.llm.message import MessageToolCall
-
         # Streak limit 2; hook denies 4 times then allows. An ActionEvent
         # between denials 2 and 3 must reset the streak so we don't abort.
         stop_count_file = tmp_path / "stop_count"

--- a/tests/sdk/hooks/test_integration.py
+++ b/tests/sdk/hooks/test_integration.py
@@ -965,10 +965,10 @@ class TestStopHookConversationIntegration:
             and e.hook_event_type == "Stop"
             and e.blocked
         ]
-        assert len(deny_events) == max_denials + 1
+        assert len(deny_events) == max_denials
 
     def test_stop_hook_deny_streak_resets_on_action_progress(self, tmp_path):
-        # Streak limit 2; hook denies 4 times then allows. An ActionEvent
+        # Streak limit 3; hook denies 4 times then allows. An ActionEvent
         # between denials 2 and 3 must reset the streak so we don't abort.
         stop_count_file = tmp_path / "stop_count"
         stop_count_file.write_text("0")
@@ -1022,7 +1022,7 @@ class TestStopHookConversationIntegration:
                 callbacks=[events_captured.append],
                 visualizer=None,
                 max_iteration_per_run=100,
-                max_consecutive_stop_denials=2,
+                max_consecutive_stop_denials=3,
             )
             conversation.send_message("Hello")
             conversation.run()


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

https://openhands-ai.slack.com/archives/C06R25BT5B2/p1778340691700839

## Summary

- Adds max_consecutive_stop_denials (default 5) to LocalConversation. When a Stop hook denies repeatedly with no ActionEvent between denials, the run loop now aborts with a ConversationErrorEvent(code="StopHookLoopDetected") and
  ERROR status instead of looping until max_iteration_per_run (default 500) is exhausted.
- The streak counter resets whenever the agent emits an ActionEvent between two denials, so legitimate iterative work keeps running.

Surfaced from a trajectory where a misconfigured `.openhands/hooks/on_stop.sh` (running npm run lint against an env missing dev deps) returned decision: deny on every Stop event. The agent recognized the hook was broken and emitted
text-only "I'm done" turns, but each one re-triggered the Stop hook — 56 cycles before the user manually paused, and nothing tool-actionable for the agent to do. Without this guard the loop would have run to the 500-iteration cap.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore






<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:780f5d1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-780f5d1-python \
  ghcr.io/openhands/agent-server:780f5d1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:780f5d1-golang-amd64
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-hooks-golang-amd64
ghcr.io/openhands/agent-server:780f5d1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:780f5d1-golang-arm64
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-hooks-golang-arm64
ghcr.io/openhands/agent-server:780f5d1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:780f5d1-java-amd64
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-hooks-java-amd64
ghcr.io/openhands/agent-server:780f5d1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:780f5d1-java-arm64
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-hooks-java-arm64
ghcr.io/openhands/agent-server:780f5d1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:780f5d1-python-amd64
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-hooks-python-amd64
ghcr.io/openhands/agent-server:780f5d1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:780f5d1-python-arm64
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-hooks-python-arm64
ghcr.io/openhands/agent-server:780f5d1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:780f5d1-golang
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-golang
ghcr.io/openhands/agent-server:vasco-fix-hooks-golang
ghcr.io/openhands/agent-server:780f5d1-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:780f5d1-java
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-java
ghcr.io/openhands/agent-server:vasco-fix-hooks-java
ghcr.io/openhands/agent-server:780f5d1-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:780f5d1-python
ghcr.io/openhands/agent-server:780f5d157578be5a4754b2b65cd2fe58acce63f5-python
ghcr.io/openhands/agent-server:vasco-fix-hooks-python
ghcr.io/openhands/agent-server:780f5d1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `780f5d1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `780f5d1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->