### PR TITLE
fix(agent-server): suppress noisy traceback when sending events to a …

### DIFF
--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -26,6 +26,7 @@ from fastapi import (
     WebSocket,
     WebSocketDisconnect,
 )
+from starlette.websockets import WebSocketState
 
 from openhands.agent_server.bash_service import get_default_bash_event_service
 from openhands.agent_server.config import Config, get_default_config
@@ -413,9 +414,17 @@ async def bash_events_socket(
 
 
 async def _send_event(event: Event, websocket: WebSocket):
+    if not _is_websocket_connected(websocket):
+        # Client already disconnected; the pub/sub callback was racing with
+        # cleanup. Avoid noisy tracebacks from starlette refusing to send.
+        logger.debug("skip_sending_event_socket_disconnected: %r", event)
+        return
     try:
         dumped = event.model_dump(mode="json")
         await websocket.send_json(dumped)
+    except (RuntimeError, WebSocketDisconnect) as e:
+        # Expected race: client disconnected between our state check and send.
+        logger.debug("error_sending_event_disconnected: %r (%s)", event, e)
     except Exception:
         logger.exception("error_sending_event: %r", event, stack_info=True)
 
@@ -432,6 +441,26 @@ async def _safe_close_websocket(
         logger.debug("WebSocket close failed (may already be closed)")
 
 
+def _is_websocket_connected(websocket: WebSocket) -> bool:
+    """Best-effort check that the websocket is still in the CONNECTED state.
+
+    Starlette raises ``RuntimeError('Cannot call "send" once a close message
+    has been sent.')`` if we try to send on a socket whose ``application_state``
+    is ``DISCONNECTED``. Pre-checking avoids noisy tracebacks when a pub/sub
+    callback fires after the peer has gone away.
+
+    Returns ``True`` when the state is unknown (e.g. tests using ``MagicMock``)
+    so callers still attempt the send and get the original behaviour.
+    """
+    app_state = getattr(websocket, "application_state", None)
+    client_state = getattr(websocket, "client_state", None)
+    if app_state is WebSocketState.DISCONNECTED:
+        return False
+    if client_state is WebSocketState.DISCONNECTED:
+        return False
+    return True
+
+
 @dataclass
 class _WebSocketSubscriber(Subscriber):
     """WebSocket subscriber for conversation events."""
@@ -443,9 +472,14 @@ class _WebSocketSubscriber(Subscriber):
 
 
 async def _send_bash_event(event: BashEventBase, websocket: WebSocket):
+    if not _is_websocket_connected(websocket):
+        logger.debug("skip_sending_bash_event_socket_disconnected: %r", event)
+        return
     try:
         dumped = event.model_dump(mode="json")
         await websocket.send_json(dumped)
+    except (RuntimeError, WebSocketDisconnect) as e:
+        logger.debug("error_sending_bash_event_disconnected: %r (%s)", event, e)
     except Exception:
         logger.exception("error_sending_bash_event: %r", event, stack_info=True)
 

--- a/tests/agent_server/test_event_router_websocket.py
+++ b/tests/agent_server/test_event_router_websocket.py
@@ -81,6 +81,55 @@ async def test_websocket_subscriber_call_exception(mock_websocket):
 
 
 @pytest.mark.asyncio
+async def test_websocket_subscriber_skips_send_when_disconnected(mock_websocket):
+    """Regression: pub/sub callbacks must not attempt send() on a closed socket.
+
+    Starlette raises ``RuntimeError: Cannot call "send" once a close message
+    has been sent.`` if we send after disconnect. The subscriber should detect
+    the DISCONNECTED state and skip silently.
+    """
+    from starlette.websockets import WebSocketState
+
+    mock_websocket.application_state = WebSocketState.DISCONNECTED
+    subscriber = _WebSocketSubscriber(websocket=mock_websocket)
+    event = MessageEvent(
+        id="test_event",
+        source="user",
+        llm_message=Message(role="user", content=[TextContent(text="test")]),
+    )
+
+    await subscriber(event)
+
+    mock_websocket.send_json.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_websocket_subscriber_send_runtime_error_not_logged_as_exception(
+    mock_websocket,
+):
+    """Regression: a RuntimeError from send (race between disconnect and send)
+    should be logged at debug level, not as a full traceback via
+    ``logger.exception``.
+    """
+    mock_websocket.send_json.side_effect = RuntimeError(
+        'Cannot call "send" once a close message has been sent.'
+    )
+    subscriber = _WebSocketSubscriber(websocket=mock_websocket)
+    event = MessageEvent(
+        id="test_event",
+        source="user",
+        llm_message=Message(role="user", content=[TextContent(text="test")]),
+    )
+
+    with patch("openhands.agent_server.sockets.logger") as mock_logger:
+        await subscriber(event)
+
+    mock_websocket.send_json.assert_called_once()
+    mock_logger.exception.assert_not_called()
+    mock_logger.debug.assert_called()
+
+
+@pytest.mark.asyncio
 async def test_websocket_disconnect_breaks_loop(
     mock_websocket, mock_event_service, sample_conversation_id
 ):


### PR DESCRIPTION
…disconnected websocket

The pub/sub callback in the events / bash-events websocket endpoints can fire after the peer has gone away. Starlette then raises 'RuntimeError: Cannot call "send" once a close message has been sent.' which we were logging via logger.exception, producing a full traceback on every disconnect race.

Pre-check WebSocketState.DISCONNECTED in _send_event / _send_bash_event and downgrade RuntimeError / WebSocketDisconnect from send() to a debug-level log. Other unexpected exceptions still log a full traceback.

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:95f115f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-95f115f-python \
  ghcr.io/openhands/agent-server:95f115f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:95f115f-golang-amd64
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-golang-amd64
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-golang-amd64
ghcr.io/openhands/agent-server:95f115f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:95f115f-golang-arm64
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-golang-arm64
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-golang-arm64
ghcr.io/openhands/agent-server:95f115f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:95f115f-java-amd64
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-java-amd64
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-java-amd64
ghcr.io/openhands/agent-server:95f115f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:95f115f-java-arm64
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-java-arm64
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-java-arm64
ghcr.io/openhands/agent-server:95f115f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:95f115f-python-amd64
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-python-amd64
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-python-amd64
ghcr.io/openhands/agent-server:95f115f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:95f115f-python-arm64
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-python-arm64
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-python-arm64
ghcr.io/openhands/agent-server:95f115f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:95f115f-golang
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-golang
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-golang
ghcr.io/openhands/agent-server:95f115f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:95f115f-java
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-java
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-java
ghcr.io/openhands/agent-server:95f115f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:95f115f-python
ghcr.io/openhands/agent-server:95f115f38f5e5f69f0f707e2d5f384ee66f2bd24-python
ghcr.io/openhands/agent-server:openhands-fix-websocket-send-after-disconnect-python
ghcr.io/openhands/agent-server:95f115f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `95f115f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `95f115f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->