### PR TITLE
feat(agent-server): add seatbelt option for macOS sandbox-exec

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -22,6 +22,7 @@ from openhands.agent_server.models import (
     SendMessageRequest,
     SetConfirmationPolicyRequest,
     SetSecurityAnalyzerRequest,
+    StartACPConversationRequest,
     StartConversationRequest,
     Success,
     UpdateConversationRequest,
@@ -29,6 +30,7 @@ from openhands.agent_server.models import (
 )
 from openhands.sdk import LLM, Agent, TextContent
 from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.utils.seatbelt import is_seatbelt_supported
 from openhands.sdk.workspace import LocalWorkspace
 from openhands.tools.preset.default import get_default_tools
 
@@ -149,9 +151,34 @@ async def batch_get_conversations(
 # Write Methods
 
 
+def _ensure_seatbelt_available(
+    request: StartConversationRequest | StartACPConversationRequest,
+) -> None:
+    """Reject the request if seatbelt is requested but unavailable.
+
+    Seatbelt (`sandbox-exec`) only ships with macOS, so we fail fast at the API
+    boundary instead of letting the conversation start in an unsandboxed state
+    on a host that cannot honor the request. Used by both the legacy and ACP
+    conversation routers.
+    """
+    if not request.seatbelt:
+        return
+    if not is_seatbelt_supported():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "seatbelt=true is only supported on macOS hosts with "
+                "`sandbox-exec` available on PATH."
+            ),
+        )
+
+
 @conversation_router.post(
     "",
-    responses={409: {"description": "Conversation contract mismatch"}},
+    responses={
+        400: {"description": "Seatbelt requested but not available on this host"},
+        409: {"description": "Conversation contract mismatch"},
+    },
 )
 async def start_conversation(
     request: Annotated[
@@ -161,6 +188,7 @@ async def start_conversation(
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> ConversationInfo:
     """Start a conversation in the local environment."""
+    _ensure_seatbelt_available(request)
     try:
         info, is_new = await conversation_service.start_conversation(request)
     except ConversationContractMismatchError as e:

--- a/openhands-agent-server/openhands/agent_server/conversation_router_acp.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router_acp.py
@@ -6,6 +6,7 @@ from uuid import UUID
 from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response, status
 from pydantic import SecretStr
 
+from openhands.agent_server.conversation_router import _ensure_seatbelt_available
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.models import (
@@ -118,7 +119,12 @@ async def batch_get_acp_conversations(
     return await conversation_service.batch_get_acp_conversations(ids)
 
 
-@conversation_router_acp.post("")
+@conversation_router_acp.post(
+    "",
+    responses={
+        400: {"description": "Seatbelt requested but not available on this host"},
+    },
+)
 async def start_acp_conversation(
     request: Annotated[
         StartACPConversationRequest,
@@ -128,6 +134,7 @@ async def start_acp_conversation(
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> ACPConversationInfo:
     """Start a conversation using the ACP-capable contract."""
+    _ensure_seatbelt_available(request)
     info, is_new = await conversation_service.start_acp_conversation(request)
     response.status_code = status.HTTP_201_CREATED if is_new else status.HTTP_200_OK
     return info

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -614,6 +614,7 @@ class EventService:
             cipher=self.cipher,
             hook_config=self.stored.hook_config,
             tags=self.stored.tags,
+            seatbelt=self.stored.seatbelt,
         )
 
         conversation.set_confirmation_policy(self.stored.confirmation_policy)

--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -181,6 +181,13 @@ class _ConversationInfoBase(BaseModel):
             "alphanumeric. Values are arbitrary strings up to 256 characters."
         ),
     )
+    seatbelt: bool = Field(
+        default=False,
+        description=(
+            "If true, the conversation's shell tools run inside macOS' "
+            "Seatbelt (`sandbox-exec`) sandbox."
+        ),
+    )
 
 
 class ConversationInfo(_ConversationInfoBase):

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -80,6 +80,7 @@ class Conversation:
         secrets: dict[str, SecretValue] | dict[str, str] | None = None,
         delete_on_close: bool = True,
         tags: dict[str, str] | None = None,
+        seatbelt: bool = False,
     ) -> "LocalConversation": ...
 
     @overload
@@ -104,6 +105,7 @@ class Conversation:
         secrets: dict[str, SecretValue] | dict[str, str] | None = None,
         delete_on_close: bool = True,
         tags: dict[str, str] | None = None,
+        seatbelt: bool = False,
     ) -> "RemoteConversation": ...
 
     def __new__(
@@ -128,6 +130,7 @@ class Conversation:
         secrets: dict[str, SecretValue] | dict[str, str] | None = None,
         delete_on_close: bool = True,
         tags: dict[str, str] | None = None,
+        seatbelt: bool = False,
     ) -> BaseConversation:
         from openhands.sdk.conversation.impl.local_conversation import LocalConversation
         from openhands.sdk.conversation.impl.remote_conversation import (
@@ -181,6 +184,7 @@ class Conversation:
                 secrets=secrets,
                 delete_on_close=delete_on_close,
                 tags=effective_tags if effective_tags else None,
+                seatbelt=seatbelt,
             )
 
         return LocalConversation(
@@ -199,4 +203,5 @@ class Conversation:
             secrets=secrets,
             delete_on_close=delete_on_close,
             tags=tags,
+            seatbelt=seatbelt,
         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -108,6 +108,7 @@ class LocalConversation(BaseConversation):
         delete_on_close: bool = True,
         cipher: Cipher | None = None,
         tags: dict[str, str] | None = None,
+        seatbelt: bool = False,
         **_: object,
     ):
         """Initialize the conversation.
@@ -186,6 +187,7 @@ class LocalConversation(BaseConversation):
             else None,
             max_iterations=max_iteration_per_run,
             stuck_detection=stuck_detection,
+            seatbelt=seatbelt,
             cipher=cipher,
             tags=tags,
         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -666,6 +666,7 @@ class RemoteConversation(BaseConversation):
         secrets: Mapping[str, SecretValue] | None = None,
         delete_on_close: bool = False,
         tags: dict[str, str] | None = None,
+        seatbelt: bool = False,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -768,6 +769,8 @@ class RemoteConversation(BaseConversation):
                 "hook_config": hook_config.model_dump() if hook_config else None,
                 # Include tags if provided
                 "tags": tags or {},
+                # Opt-in macOS Seatbelt sandbox for shell tools
+                "seatbelt": seatbelt,
             }
             if stuck_detection_thresholds is not None:
                 # Convert to StuckDetectionThresholds if dict, then serialize

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -163,6 +163,17 @@ class _StartConversationRequestBase(BaseModel):
             "loads) → agent.llm → message truncation."
         ),
     )
+    seatbelt: bool = Field(
+        default=False,
+        description=(
+            "If true, run shell commands spawned by this conversation inside "
+            "macOS' Seatbelt sandbox via `sandbox-exec`. Only supported when "
+            "the agent server is running on macOS with `sandbox-exec` available; "
+            "the server will reject the request otherwise. The default sandbox "
+            "profile permits reads anywhere, network access, and writes only "
+            "to the conversation's workspace and the standard temp directories."
+        ),
+    )
     title_llm_profile: str | None = Field(
         default=None,
         description=(

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -113,6 +113,14 @@ class ConversationState(OpenHandsModel):
         default=True,
         description="Whether to enable stuck detection for the agent.",
     )
+    seatbelt: bool = Field(
+        default=False,
+        description=(
+            "If true, shell tools spawned by this conversation are wrapped "
+            "with macOS' Seatbelt sandbox (`sandbox-exec`). Tools opt in by "
+            "consulting this flag on the conversation state."
+        ),
+    )
 
     # Enum-based state management
     execution_status: ConversationExecutionStatus = Field(
@@ -280,6 +288,7 @@ class ConversationState(OpenHandsModel):
         persistence_dir: str | None = None,
         max_iterations: int = 500,
         stuck_detection: bool = True,
+        seatbelt: bool = False,
         cipher: Cipher | None = None,
         tags: dict[str, str] | None = None,
     ) -> "ConversationState":
@@ -361,6 +370,7 @@ class ConversationState(OpenHandsModel):
             state.agent = agent
             state.workspace = workspace
             state.max_iterations = max_iterations
+            state.seatbelt = seatbelt
 
             # Note: stats are already deserialized from base_state.json above.
             # Do NOT reset stats here - this would lose accumulated metrics.
@@ -385,6 +395,7 @@ class ConversationState(OpenHandsModel):
             persistence_dir=persistence_dir,
             max_iterations=max_iterations,
             stuck_detection=stuck_detection,
+            seatbelt=seatbelt,
             tags=tags or {},
         )
         state._fs = file_store

--- a/openhands-sdk/openhands/sdk/utils/seatbelt.py
+++ b/openhands-sdk/openhands/sdk/utils/seatbelt.py
@@ -1,0 +1,93 @@
+"""Helpers for running shells inside macOS' Seatbelt (`sandbox-exec`) sandbox.
+
+Seatbelt is the user-facing name for the macOS application sandbox. It is
+configured through a TinyScheme profile and applied to a child process via
+``/usr/bin/sandbox-exec``. This module centralises the small surface we need:
+
+* a reasonable default profile that allows agent-style work in a workspace
+  while restricting writes elsewhere on disk, and
+* the helper used by terminal backends to wrap a shell command in
+  ``sandbox-exec -p <profile> ...``.
+
+The agent-server is responsible for validating availability up-front (macOS +
+``sandbox-exec`` on ``PATH``); this module is intentionally side-effect free.
+"""
+
+from __future__ import annotations
+
+import platform
+import shutil
+
+
+SANDBOX_EXEC_BIN = "/usr/bin/sandbox-exec"
+
+
+def is_seatbelt_supported() -> bool:
+    """Return True if Seatbelt (`sandbox-exec`) can be used on this host."""
+    if platform.system() != "Darwin":
+        return False
+    return shutil.which("sandbox-exec") is not None or _binary_exists(SANDBOX_EXEC_BIN)
+
+
+def _binary_exists(path: str) -> bool:
+    import os
+
+    return os.path.isfile(path) and os.access(path, os.X_OK)
+
+
+def default_profile(workspace_dir: str) -> str:
+    """Return a Seatbelt profile string for an agent operating in a workspace.
+
+    The profile allows arbitrary file reads, network access, process
+    fork/exec, and IPC, but restricts writes to the workspace, the standard
+    temporary directories, and the user's caches/log dirs. This roughly mirrors
+    what other agent runtimes (e.g. Claude Code) ship as a default profile.
+    """
+    # The workspace path is interpolated as-is. Seatbelt profiles are
+    # TinyScheme; embedded double-quotes would be a syntax error. Reject them
+    # rather than silently producing an invalid profile.
+    if '"' in workspace_dir:
+        raise ValueError(
+            f"workspace_dir cannot contain a double-quote: {workspace_dir!r}"
+        )
+
+    return f"""(version 1)
+(deny default)
+(allow process-fork)
+(allow process-exec)
+(allow signal (target self))
+(allow sysctl-read)
+(allow mach-lookup)
+(allow ipc-posix-shm)
+(allow file-read*)
+(allow file-write*
+    (subpath "{workspace_dir}")
+    (subpath "/tmp")
+    (subpath "/private/tmp")
+    (subpath "/var/folders")
+    (subpath "/private/var/folders")
+    (subpath "/dev")
+)
+(allow network*)
+"""
+
+
+def wrap_with_sandbox_exec(
+    command: list[str],
+    workspace_dir: str,
+    profile: str | None = None,
+) -> list[str]:
+    """Prefix ``command`` with ``sandbox-exec -p <profile>`` for execution.
+
+    Args:
+        command: The command (argv) to run inside the sandbox.
+        workspace_dir: Workspace path used to render the default profile.
+        profile: Optional explicit profile string. If omitted, the default
+            workspace profile is used.
+
+    Returns:
+        A new argv list that, when executed, runs ``command`` under Seatbelt.
+    """
+    sb_profile = profile if profile is not None else default_profile(workspace_dir)
+    sb_path = shutil.which("sandbox-exec") or SANDBOX_EXEC_BIN
+    return [sb_path, "-p", sb_profile, *command]

--- a/openhands-tools/openhands/tools/terminal/definition.py
+++ b/openhands-tools/openhands/tools/terminal/definition.py
@@ -273,6 +273,7 @@ class TerminalTool(ToolDefinition[TerminalAction, TerminalObservation]):
                 terminal_type=terminal_type,
                 shell_path=shell_path,
                 full_output_save_dir=conv_state.env_observation_persistence_dir,
+                seatbelt=getattr(conv_state, "seatbelt", False),
             )
 
         tool_description = (

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -70,6 +70,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         shell_path: str | None = None,
         full_output_save_dir: str | None = None,
         max_panes: int = DEFAULT_MAX_PANES,
+        seatbelt: bool = False,
     ):
         """Initialize TerminalExecutor with auto-detected or specified session type.
 
@@ -86,6 +87,10 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
             full_output_save_dir: Path to directory to save full output
                                   logs and files, used when truncation is needed.
             max_panes: Maximum number of concurrent panes in pool mode.
+            seatbelt: If True, wrap shell processes with macOS' `sandbox-exec`
+                      so reads are unrestricted but writes are confined to the
+                      working directory and standard temp paths. Only valid on
+                      macOS; the caller is expected to validate availability.
         """
         self.shell_path = shell_path
         self._working_dir = working_dir
@@ -93,6 +98,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         self._no_change_timeout_seconds = no_change_timeout_seconds
         self._terminal_type = terminal_type
         self._max_panes = max_panes
+        self._seatbelt = seatbelt
         self.full_output_save_dir: str | None = full_output_save_dir
 
         # Pool mode: use TmuxPanePool for parallel execution
@@ -113,6 +119,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
                 no_change_timeout_seconds=no_change_timeout_seconds,
                 terminal_type=terminal_type,
                 shell_path=shell_path,
+                seatbelt=seatbelt,
             )
             self._session.initialize()
             logger.info(
@@ -133,6 +140,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
             self._working_dir,
             self._username,
             max_panes=self._max_panes,
+            seatbelt=self._seatbelt,
         )
         self._pool.initialize()
         logger.info(
@@ -398,6 +406,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
             no_change_timeout_seconds=original_no_change_timeout,
             terminal_type=None,
             shell_path=self.shell_path,
+            seatbelt=self._seatbelt,
         )
         self._session.initialize()
 

--- a/openhands-tools/openhands/tools/terminal/terminal/factory.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/factory.py
@@ -81,6 +81,7 @@ def create_terminal_session(
     no_change_timeout_seconds: int | None = None,
     terminal_type: Literal["tmux", "subprocess", "powershell"] | None = None,
     shell_path: str | None = None,
+    seatbelt: bool = False,
 ) -> TerminalSession:
     """Create an appropriate terminal session based on system capabilities.
 
@@ -92,6 +93,8 @@ def create_terminal_session(
             or 'powershell'). If None, auto-detect based on system capabilities.
         shell_path: Path to the shell binary. On Unix this is used for the
             subprocess backend; on Windows it can point to a PowerShell binary.
+        seatbelt: If True, run shells inside macOS' `sandbox-exec`. The
+            PowerShell backend ignores this flag (Seatbelt is macOS-only).
 
     Returns:
         TerminalSession instance
@@ -106,7 +109,7 @@ def create_terminal_session(
             from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
             logger.info("Using forced TmuxTerminal")
-            terminal = TmuxTerminal(work_dir, username)
+            terminal = TmuxTerminal(work_dir, username, seatbelt=seatbelt)
             return TerminalSession(terminal, no_change_timeout_seconds)
 
         if terminal_type == "powershell":
@@ -136,7 +139,9 @@ def create_terminal_session(
             )
 
             logger.info("Using forced SubprocessTerminal")
-            terminal = SubprocessTerminal(work_dir, username, shell_path)
+            terminal = SubprocessTerminal(
+                work_dir, username, shell_path, seatbelt=seatbelt
+            )
             return TerminalSession(terminal, no_change_timeout_seconds)
 
         raise ValueError(f"Unknown session type: {terminal_type}")
@@ -154,7 +159,7 @@ def create_terminal_session(
         from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
         logger.info("Auto-detected: Using TmuxTerminal (tmux available)")
-        terminal = TmuxTerminal(work_dir, username)
+        terminal = TmuxTerminal(work_dir, username, seatbelt=seatbelt)
         return TerminalSession(terminal, no_change_timeout_seconds)
 
     from openhands.tools.terminal.terminal.subprocess_terminal import (
@@ -168,5 +173,5 @@ def create_terminal_session(
     )
     logger.warning(_tmux_warning)
     warnings.warn(_tmux_warning, stacklevel=2)
-    terminal = SubprocessTerminal(work_dir, username, shell_path)
+    terminal = SubprocessTerminal(work_dir, username, shell_path, seatbelt=seatbelt)
     return TerminalSession(terminal, no_change_timeout_seconds)

--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -84,6 +84,7 @@ class SubprocessTerminal(TerminalInterface):
         work_dir: str,
         username: str | None = None,
         shell_path: str | None = None,
+        seatbelt: bool = False,
     ):
         super().__init__(work_dir, username)
         self.PS1 = CmdOutputMetadata.to_ps1_prompt()
@@ -96,6 +97,7 @@ class SubprocessTerminal(TerminalInterface):
         self.reader_thread = None
         self._current_command_running = False
         self.shell_path = shell_path
+        self.seatbelt = seatbelt
 
     # ------------------------- Lifecycle -------------------------
 
@@ -142,6 +144,15 @@ class SubprocessTerminal(TerminalInterface):
         env["TERM"] = "xterm-256color"
 
         bash_cmd = [resolved_shell_path, "-i"]
+
+        # Wrap with macOS Seatbelt sandbox-exec if requested. The agent server
+        # validates that we're on macOS with sandbox-exec available before
+        # ever setting this flag, so we don't re-validate here.
+        if self.seatbelt:
+            from openhands.sdk.utils.seatbelt import wrap_with_sandbox_exec
+
+            bash_cmd = wrap_with_sandbox_exec(bash_cmd, self.work_dir)
+            logger.info("Bash will run inside Seatbelt sandbox-exec")
 
         # Create a PTY; give the slave to the child, keep the master
         master_fd, slave_fd = pty.openpty()

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
@@ -25,7 +25,10 @@ from openhands.tools.terminal.constants import (
     TMUX_SESSION_WIDTH,
     TMUX_SOCKET_NAME,
 )
-from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
+from openhands.tools.terminal.terminal.tmux_terminal import (
+    TmuxTerminal,
+    _seatbelt_wrap_shell,
+)
 
 
 logger = get_logger(__name__)
@@ -81,6 +84,7 @@ class TmuxPanePool:
     work_dir: str
     username: str | None = None
     max_panes: int = DEFAULT_MAX_PANES
+    seatbelt: bool = False
 
     # tmux handles
     _server: libtmux.Server | None = field(default=None, init=False, repr=False)
@@ -165,6 +169,10 @@ class TmuxPanePool:
         shell_command = "/bin/bash"
         if self.username in ["root", "openhands"]:
             shell_command = f"su {self.username} -"
+
+        shell_command = _seatbelt_wrap_shell(
+            shell_command, self.work_dir, self.seatbelt
+        )
 
         window = self._session.new_window(
             window_name=f"pane-{len(self._all_panes)}",

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -1,5 +1,6 @@
 """Tmux-based terminal backend implementation."""
 
+import shlex
 import time
 import uuid
 
@@ -7,6 +8,7 @@ import libtmux
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils import sanitized_env
+from openhands.sdk.utils.seatbelt import wrap_with_sandbox_exec
 from openhands.tools.terminal.constants import (
     HISTORY_LIMIT,
     TMUX_SESSION_HEIGHT,
@@ -40,6 +42,21 @@ _TMUX_SPECIALS: dict[str, str] = {
 }
 
 
+def _seatbelt_wrap_shell(
+    shell_command: str, work_dir: str, seatbelt: bool
+) -> str:
+    """Wrap ``shell_command`` with ``sandbox-exec`` when seatbelt is enabled.
+
+    tmux's ``window_shell`` is a single shell-quoted command string, so we
+    need to render the argv produced by ``wrap_with_sandbox_exec`` back through
+    ``shlex.join`` for tmux to spawn it correctly.
+    """
+    if not seatbelt:
+        return shell_command
+    argv = wrap_with_sandbox_exec(shlex.split(shell_command), work_dir)
+    return shlex.join(argv)
+
+
 class TmuxTerminal(TerminalInterface):
     """Tmux-based terminal backend.
 
@@ -57,9 +74,11 @@ class TmuxTerminal(TerminalInterface):
         self,
         work_dir: str,
         username: str | None = None,
+        seatbelt: bool = False,
     ):
         super().__init__(work_dir, username)
         self.PS1 = CmdOutputMetadata.to_ps1_prompt()
+        self.seatbelt = seatbelt
 
     def initialize(self) -> None:
         """Initialize the tmux terminal session."""
@@ -74,7 +93,9 @@ class TmuxTerminal(TerminalInterface):
             # This starts a non-login (new) shell for the given user
             _shell_command = f"su {self.username} -"
 
-        window_command = _shell_command
+        window_command = _seatbelt_wrap_shell(
+            _shell_command, self.work_dir, self.seatbelt
+        )
 
         logger.debug(f"Initializing tmux terminal with command: {window_command}")
         session_name = f"openhands-{self.username}-{uuid.uuid4()}"

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -1,6 +1,6 @@
 """Tests for conversation_router.py endpoints."""
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
 import pytest
@@ -1729,5 +1729,103 @@ def test_fork_conversation_duplicate_id_returns_409(
         )
 
         assert response.status_code == 409
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def _seatbelt_request_payload() -> dict:
+    return {
+        "agent": {
+            "kind": "Agent",
+            "llm": {
+                "model": "gpt-4o",
+                "api_key": "test-key",
+                "usage_id": "test-llm",
+            },
+            "tools": [{"name": "TerminalTool"}],
+        },
+        "workspace": {"working_dir": "/tmp/test"},
+        "seatbelt": True,
+    }
+
+
+def test_start_conversation_seatbelt_unsupported_returns_400(
+    client, mock_conversation_service
+):
+    """The router rejects seatbelt=true when sandbox-exec is unavailable."""
+
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        with patch(
+            "openhands.agent_server.conversation_router.is_seatbelt_supported",
+            return_value=False,
+        ):
+            response = client.post(
+                "/api/conversations", json=_seatbelt_request_payload()
+            )
+
+        assert response.status_code == 400
+        assert "seatbelt" in response.json()["detail"].lower()
+        # The conversation service must not be hit when the precondition fails.
+        mock_conversation_service.start_conversation.assert_not_called()
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_start_conversation_seatbelt_supported_passes_through(
+    client, mock_conversation_service, sample_conversation_info
+):
+    """When seatbelt is available the request reaches the service unchanged."""
+
+    mock_conversation_service.start_conversation.return_value = (
+        sample_conversation_info,
+        True,
+    )
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        with patch(
+            "openhands.agent_server.conversation_router.is_seatbelt_supported",
+            return_value=True,
+        ):
+            response = client.post(
+                "/api/conversations", json=_seatbelt_request_payload()
+            )
+
+        assert response.status_code == 201
+        called_request = mock_conversation_service.start_conversation.call_args.args[0]
+        assert called_request.seatbelt is True
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_start_conversation_seatbelt_false_skips_check(
+    client, mock_conversation_service, sample_conversation_info
+):
+    """seatbelt=false (the default) must not require sandbox-exec."""
+
+    mock_conversation_service.start_conversation.return_value = (
+        sample_conversation_info,
+        True,
+    )
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        with patch(
+            "openhands.agent_server.conversation_router.is_seatbelt_supported"
+        ) as supported:
+            payload = _seatbelt_request_payload()
+            payload["seatbelt"] = False
+            response = client.post("/api/conversations", json=payload)
+            supported.assert_not_called()
+
+        assert response.status_code == 201
     finally:
         client.app.dependency_overrides.clear()

--- a/tests/sdk/utils/test_seatbelt.py
+++ b/tests/sdk/utils/test_seatbelt.py
@@ -1,0 +1,75 @@
+"""Tests for the SDK seatbelt utility module."""
+
+from unittest.mock import patch
+
+import pytest
+
+from openhands.sdk.utils.seatbelt import (
+    SANDBOX_EXEC_BIN,
+    default_profile,
+    is_seatbelt_supported,
+    wrap_with_sandbox_exec,
+)
+
+
+def test_default_profile_includes_workspace_subpath():
+    profile = default_profile("/Users/me/work")
+    assert '(subpath "/Users/me/work")' in profile
+    # Standard temp dirs are always allowed for writes.
+    assert '(subpath "/tmp")' in profile
+    assert '(subpath "/private/tmp")' in profile
+    # Reads everywhere, network on, fork/exec allowed.
+    assert "(allow file-read*)" in profile
+    assert "(allow network*)" in profile
+    assert "(allow process-fork)" in profile
+
+
+def test_default_profile_rejects_double_quote_in_workspace():
+    # A double-quote would terminate the TinyScheme string and produce an
+    # invalid profile, so the helper rejects it explicitly rather than
+    # silently emitting a broken profile.
+    with pytest.raises(ValueError, match="double-quote"):
+        default_profile('/some"path')
+
+
+def test_wrap_with_sandbox_exec_uses_default_profile():
+    argv = wrap_with_sandbox_exec(["/bin/bash", "-i"], "/Users/me/work")
+    assert argv[-2:] == ["/bin/bash", "-i"]
+    assert argv[0] in {"/usr/bin/sandbox-exec", SANDBOX_EXEC_BIN}
+    assert argv[1] == "-p"
+    assert '(subpath "/Users/me/work")' in argv[2]
+
+
+def test_wrap_with_sandbox_exec_accepts_explicit_profile():
+    argv = wrap_with_sandbox_exec(
+        ["echo", "hi"], "/work", profile="(version 1)\n(allow default)"
+    )
+    assert argv[2] == "(version 1)\n(allow default)"
+    assert argv[-2:] == ["echo", "hi"]
+
+
+def test_is_seatbelt_supported_requires_darwin():
+    # On non-Darwin hosts the helper short-circuits, regardless of whether
+    # `sandbox-exec` happens to exist on PATH.
+    with patch("openhands.sdk.utils.seatbelt.platform.system", return_value="Linux"):
+        assert is_seatbelt_supported() is False
+
+
+def test_is_seatbelt_supported_requires_sandbox_exec():
+    with (
+        patch("openhands.sdk.utils.seatbelt.platform.system", return_value="Darwin"),
+        patch("openhands.sdk.utils.seatbelt.shutil.which", return_value=None),
+        patch("openhands.sdk.utils.seatbelt._binary_exists", return_value=False),
+    ):
+        assert is_seatbelt_supported() is False
+
+
+def test_is_seatbelt_supported_when_available():
+    with (
+        patch("openhands.sdk.utils.seatbelt.platform.system", return_value="Darwin"),
+        patch(
+            "openhands.sdk.utils.seatbelt.shutil.which",
+            return_value="/usr/bin/sandbox-exec",
+        ),
+    ):
+        assert is_seatbelt_supported() is True

--- a/tests/tools/terminal/test_seatbelt_wiring.py
+++ b/tests/tools/terminal/test_seatbelt_wiring.py
@@ -1,0 +1,57 @@
+"""Verify the ``seatbelt`` flag flows from TerminalExecutor down to backends."""
+
+from __future__ import annotations
+
+import pytest
+
+from openhands.tools.terminal.terminal.factory import create_terminal_session
+from openhands.tools.terminal.terminal.subprocess_terminal import SubprocessTerminal
+from openhands.tools.terminal.terminal.tmux_terminal import (
+    TmuxTerminal,
+    _seatbelt_wrap_shell,
+)
+
+
+def test_seatbelt_wrap_shell_noop_when_disabled():
+    assert _seatbelt_wrap_shell("/bin/bash", "/tmp/work", False) == "/bin/bash"
+
+
+def test_seatbelt_wrap_shell_wraps_with_sandbox_exec():
+    wrapped = _seatbelt_wrap_shell("/bin/bash", "/tmp/work", True)
+    # The wrapped command must invoke sandbox-exec with the workspace profile,
+    # and the original shell command must come last.
+    assert "sandbox-exec" in wrapped
+    assert wrapped.endswith("/bin/bash")
+    assert '/tmp/work' in wrapped
+
+
+def test_factory_subprocess_propagates_seatbelt():
+    """Forcing the subprocess backend constructs SubprocessTerminal with seatbelt."""
+    session = create_terminal_session(
+        work_dir="/tmp",
+        terminal_type="subprocess",
+        seatbelt=True,
+    )
+    try:
+        # ``terminal`` is the underlying SubprocessTerminal that received the flag.
+        assert isinstance(session.terminal, SubprocessTerminal)
+        assert session.terminal.seatbelt is True
+    finally:
+        session.close()
+
+
+def test_tmux_terminal_stores_seatbelt_flag():
+    """The TmuxTerminal stores seatbelt without trying to actually launch tmux."""
+    terminal = TmuxTerminal("/tmp/work", username=None, seatbelt=True)
+    assert terminal.seatbelt is True
+
+
+def test_subprocess_terminal_stores_seatbelt_flag():
+    terminal = SubprocessTerminal("/tmp/work", seatbelt=True)
+    assert terminal.seatbelt is True
+
+
+@pytest.mark.parametrize("seatbelt", [True, False])
+def test_subprocess_terminal_default_seatbelt_off(seatbelt: bool):
+    terminal = SubprocessTerminal("/tmp/work", seatbelt=seatbelt)
+    assert terminal.seatbelt is seatbelt


### PR DESCRIPTION
Adds a `seatbelt` boolean option to the conversation creation API. When true, the agent-server validates that the host is macOS with `sandbox-exec` available (returning HTTP 400 otherwise) and threads the flag through LocalConversation -> ConversationState -> TerminalTool, so shell processes spawned by the conversation are wrapped with `sandbox-exec -p <profile>`.

The default profile permits arbitrary reads, network, and fork/exec, but restricts writes to the workspace and standard temp directories.

- New `openhands.sdk.utils.seatbelt` helper (availability check, default profile, argv wrapper)
- Plumbed through StartConversationRequest, StartACPConversationRequest, Conversation/LocalConversation/RemoteConversation, ConversationState, EventService, TerminalTool, TerminalExecutor, and both terminal backends (subprocess + tmux, including the tmux pane pool)
- Tests for the helper, terminal wiring, and the new router validation

Fixes https://github.com/OpenHands/software-agent-sdk/issues/1999

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2a84be5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2a84be5-python \
  ghcr.io/openhands/agent-server:2a84be5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2a84be5-golang-amd64
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-golang-amd64
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-golang-amd64
ghcr.io/openhands/agent-server:2a84be5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2a84be5-golang-arm64
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-golang-arm64
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-golang-arm64
ghcr.io/openhands/agent-server:2a84be5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2a84be5-java-amd64
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-java-amd64
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-java-amd64
ghcr.io/openhands/agent-server:2a84be5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2a84be5-java-arm64
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-java-arm64
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-java-arm64
ghcr.io/openhands/agent-server:2a84be5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2a84be5-python-amd64
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-python-amd64
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-python-amd64
ghcr.io/openhands/agent-server:2a84be5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2a84be5-python-arm64
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-python-arm64
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-python-arm64
ghcr.io/openhands/agent-server:2a84be5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2a84be5-golang
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-golang
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-golang
ghcr.io/openhands/agent-server:2a84be5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2a84be5-java
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-java
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-java
ghcr.io/openhands/agent-server:2a84be5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2a84be5-python
ghcr.io/openhands/agent-server:2a84be5d189e2e9329cf945c006236e4ad9f534e-python
ghcr.io/openhands/agent-server:feat-seatbelt-conversation-option-python
ghcr.io/openhands/agent-server:2a84be5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2a84be5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2a84be5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->