### PR TITLE
Fix Laminar root span exception handling

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -313,12 +313,23 @@ def _maybe_use_root_span(args: tuple[Any, ...]) -> Iterator[None]:
         yield
         return
     try:
-        with Laminar.use_span(root.span):
-            yield
+        span_context = Laminar.use_span(root.span)
+        span_context.__enter__()
     except Exception:
         # Never let an observability error break the wrapped function.
         logger.debug("use_span failed; calling without parent", exc_info=True)
         yield
+        return
+
+    exc_info = (None, None, None)
+    try:
+        yield
+    except BaseException:
+        exc_info = sys.exc_info()
+        raise
+    finally:
+        with contextlib.suppress(Exception):
+            span_context.__exit__(*exc_info)
 
 
 def _root_span_from_args(args: tuple[Any, ...]) -> RootSpan | None:

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -302,6 +302,39 @@ def test_observe_calls_use_span_with_owner_root_span_on_sync():
         os.environ.pop("LMNR_PROJECT_API_KEY", None)
 
 
+def test_observe_with_owner_root_span_preserves_wrapped_exceptions():
+    """Exceptions from wrapped functions must not be treated as use_span errors."""
+    os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+    try:
+        from lmnr import Laminar
+
+        from openhands.sdk.observability import laminar as lam
+
+        sentinel_span = MagicMock(name="root-span")
+        used_with: list = []
+
+        @contextlib_compat()
+        def fake_use_span(span, *args, **kwargs):
+            used_with.append(span)
+            yield span
+
+        with patch.object(Laminar, "use_span", side_effect=fake_use_span):
+            lam._observability_enabled = True
+            with patch("lmnr.observe", lambda **kw: (lambda f: f)):
+
+                @lam.observe(name="conversation.run")
+                def run(self) -> None:
+                    raise ValueError("boom")
+
+                owner = _DummyOwner(sentinel_span)
+                with pytest.raises(ValueError, match="boom"):
+                    run(owner)
+
+        assert used_with == [sentinel_span]
+    finally:
+        os.environ.pop("LMNR_PROJECT_API_KEY", None)
+
+
 def test_observe_calls_use_span_with_owner_root_span_on_async():
     """Async ``@observe``'d methods must re-attach the owner's root span."""
     os.environ["LMNR_PROJECT_API_KEY"] = "test-key"


### PR DESCRIPTION
## Summary
- Fix `_maybe_use_root_span` so exceptions raised by wrapped functions are not treated as `Laminar.use_span()` failures.
- Preserve the existing behavior that observability enter/exit failures do not break SDK execution.
- Add regression coverage for wrapped exception propagation.

## Validation
- `uv run pytest tests/sdk/conversation/local/test_run_exception_includes_conversation_id.py tests/sdk/observability/test_laminar.py -q`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/observability/laminar.py tests/sdk/observability/test_laminar.py`
- Direct LLM proxy check against `https://llm-proxy.app.all-hands.dev/chat/completions` with `prod/claude-sonnet-4-5-20250929`: returned `status 200` and `content ok`.
- Live Laminar smoke test with `LMNR_PROJECT_API_KEY`, `LMNR_BASE_URL=https://api.lmnr.ai`, and `LMNR_FORCE_HTTP=true`: verified an observed synthetic `ValueError` propagates unchanged, root span flush succeeds, and no exporter auth error is reported.
- Queried Laminar via `LaminarClient.sql.query(...)` and confirmed the synthetic smoke trace was logged with the expected shape:
  - trace id `476bc9e3-20aa-f70e-ba5f-fd6d32fa28d1`
  - session id `openhands-laminar-smoke-54267a7f-2cb9-4152-8fcd-695459c3aca3`
  - root span `openhands-sdk-laminar-smoke-root`, child span `openhands-sdk-laminar-smoke-child`
  - both spans had `status=error` and recorded the expected `ValueError` exception event.
- OpenHands example validation: ran `examples/01_standalone_sdk/27_observability_laminar.py` with observability enabled, `LLM_BASE_URL=https://llm-proxy.app.all-hands.dev`, `LLM_MODEL=openai/prod/claude-sonnet-4-5-20250929`, and `LMNR_BASE_URL=https://api.lmnr.ai`; the conversation completed, `Laminar.flush()` returned `True`, and the log contained no `Failed to export` or `401` export errors.
- Queried Laminar for the OpenHands example trace and confirmed the expected production trace shape:
  - conversation/session id `f8d49d81-d303-4dc1-883c-55e920b2cfd4`
  - trace id `28ec7808-5a3c-7433-7726-ca7f4fc325a7`
  - top span `conversation`, `status=success`
  - child spans included `conversation.send_message`, `conversation.run`, `agent.step`, `litellm.completion`, and `TerminalAction`
  - LLM spans were typed as `LLM` with model/token/cost metadata, and tool spans were typed as `TOOL`.

_This pull request was updated by an AI agent (OpenHands) on behalf of the user._
