### PR TITLE
feat(settings): encrypt MCP env / headers with cipher at rest

### DIFF
--- a/openhands-agent-server/openhands/agent_server/_secrets_exposure.py
+++ b/openhands-agent-server/openhands/agent_server/_secrets_exposure.py
@@ -10,7 +10,7 @@ from pydantic_core import PydanticSerializationError
 
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm import LLM_SECRET_FIELDS
-from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
 from openhands.sdk.utils.pydantic_secrets import MissingCipherError
 
 
@@ -81,12 +81,6 @@ def _has_missing_cipher_cause(exc: BaseException) -> bool:
     return False
 
 
-# Fernet tokens always begin with the URL-safe base64 of version byte 0x80,
-# i.e. "gAAAAA". We gate decrypt attempts on this prefix so genuine plaintext
-# secrets pass through untouched (and we don't spam the cipher's failure log).
-_FERNET_TOKEN_PREFIX = "gAAAAA"
-
-
 def decrypt_incoming_llm_secrets(llm: LLM, cipher: Cipher) -> LLM:
     """Decrypt any pre-encrypted LLM secret fields posted back by the client.
 
@@ -103,7 +97,7 @@ def decrypt_incoming_llm_secrets(llm: LLM, cipher: Cipher) -> LLM:
         if not isinstance(val, SecretStr):
             continue
         raw = val.get_secret_value()
-        if not raw.startswith(_FERNET_TOKEN_PREFIX):
+        if not raw.startswith(FERNET_TOKEN_PREFIX):
             continue
         decrypted = cipher.decrypt(raw)
         if decrypted is not None:

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1,12 +1,21 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Callable, Mapping
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, get_args, get_origin
+from typing import (
+    TYPE_CHECKING,
+    Annotated,
+    Any,
+    Literal,
+    TypeVar,
+    cast,
+    get_args,
+    get_origin,
+)
 from uuid import UUID
 
-from cryptography.fernet import InvalidToken
 from fastmcp.mcp_config import MCPConfig
 from pydantic import (
     BaseModel,
@@ -30,8 +39,12 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.plugin import PluginSource
 from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.tool import Tool
-from openhands.sdk.utils.cipher import Cipher
-from openhands.sdk.utils.pydantic_secrets import MissingCipherError, serialize_secret
+from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
+from openhands.sdk.utils.pydantic_secrets import (
+    MissingCipherError,
+    resolve_expose_mode,
+    serialize_secret,
+)
 from openhands.sdk.utils.redact import sanitize_dict
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -59,11 +72,9 @@ def _walk_mcp_secret_values(
     config: dict[str, Any],
     transform: Callable[[str], str],
 ) -> dict[str, Any]:
-    """Apply ``transform`` to every string value inside ``env`` / ``headers``
-    dicts of each MCP server in ``config`` (a dumped ``MCPConfig`` dict).
-
-    Mutates and returns ``config``.
-    """
+    """Return a copy of ``config`` with ``transform`` applied to every string
+    value inside each MCP server's ``env`` / ``headers``. Does not mutate input."""
+    config = copy.deepcopy(config)
     servers = config.get("mcpServers")
     if not isinstance(servers, dict):
         return config
@@ -81,31 +92,24 @@ def _walk_mcp_secret_values(
     return config
 
 
-# Fernet tokens always begin with the URL-safe base64 of version byte 0x80,
-# i.e. "gAAAAA". Gate decryption attempts on this prefix so genuine plaintext
-# values (legacy on-disk data from before per-value MCP encryption) pass
-# through untouched — and we don't spam the cipher's failure log.
-_FERNET_TOKEN_PREFIX = "gAAAAA"
-
-
 def _decrypt_mcp_value_or_keep(cipher: Cipher, value: str) -> str:
     """Decrypt ``value`` with ``cipher``; return the original string if the
     value isn't a Fernet token (legacy plaintext) or fails to decrypt
     (cipher mismatch / corruption — logged once).
     """
-    if not value.startswith(_FERNET_TOKEN_PREFIX):
+    if not value.startswith(FERNET_TOKEN_PREFIX):
         # Not encrypted (legacy plaintext) — passes through quietly so the
         # next save can re-encrypt it.
         return value
-    try:
-        return cipher._get_fernet().decrypt(value.encode()).decode()
-    except InvalidToken:
+    decrypted = cipher.try_decrypt_str(value)
+    if decrypted is None:
         logger.warning(
             "MCP env/headers value looks encrypted but could not be "
             "decrypted (cipher mismatch or corruption); leaving the "
             "ciphertext in place."
         )
         return value
+    return decrypted
 
 
 SettingsValueType = Literal[
@@ -861,30 +865,23 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             return {}
         dumped = value.model_dump(exclude_none=True, exclude_defaults=True)
         ctx = info.context or {}
-        expose_mode = ctx.get("expose_secrets")
-        cipher: Cipher | None = ctx.get("cipher")
+        mode = resolve_expose_mode(ctx)
 
-        # Plaintext: caller explicitly asked for raw values (backend trusted
-        # path; e.g. ``X-Expose-Secrets: plaintext``).
-        if expose_mode == "plaintext" or expose_mode is True:
+        if mode == "plaintext":
             return dumped
 
-        # Encrypted: encrypt every ``env`` / ``headers`` value with the
-        # cipher. Triggered by either an explicit
-        # ``expose_secrets="encrypted"`` request (frontend-safe round trip)
-        # or the presence of a ``cipher`` (the on-disk persistence path —
-        # ``FileSettingsStore.save`` passes only ``{"cipher": cipher}``).
-        if expose_mode == "encrypted" or cipher is not None:
+        if mode == "encrypted":
+            cipher: Cipher | None = ctx.get("cipher")
             if cipher is None:
                 raise MissingCipherError(
                     "Cannot encrypt MCP env/headers: no cipher configured. "
                     "Set OH_SECRET_KEY environment variable."
                 )
+            # cipher.encrypt returns None only for None input; SecretStr(v) never is.
             return _walk_mcp_secret_values(
-                dumped, lambda v: cipher.encrypt(SecretStr(v)) or ""
+                dumped, lambda v: cast(str, cipher.encrypt(SecretStr(v)))
             )
 
-        # Default REST response: redact ``env`` / ``headers`` values.
         return sanitize_dict(dumped)
 
     def create_agent(self) -> Agent:

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Annotated, Any, Literal, TypeVar, get_args, get_origin
 from uuid import UUID
 
+from cryptography.fernet import InvalidToken
 from fastmcp.mcp_config import MCPConfig
 from pydantic import (
     BaseModel,
@@ -15,6 +16,7 @@ from pydantic import (
     SerializationInfo,
     Tag,
     TypeAdapter,
+    ValidationInfo,
     field_serializer,
     field_validator,
 )
@@ -24,10 +26,12 @@ from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.conversation.request import SendMessageRequest
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
+from openhands.sdk.logger import get_logger
 from openhands.sdk.plugin import PluginSource
 from openhands.sdk.subagent.schema import AgentDefinition
 from openhands.sdk.tool import Tool
-from openhands.sdk.utils.pydantic_secrets import serialize_secret
+from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.pydantic_secrets import MissingCipherError, serialize_secret
 from openhands.sdk.utils.redact import sanitize_dict
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -46,6 +50,62 @@ if TYPE_CHECKING:
     from openhands.sdk.agent.base import AgentBase
     from openhands.sdk.context.condenser import LLMSummarizingCondenser
     from openhands.sdk.critic.base import CriticBase
+
+
+logger = get_logger(__name__)
+
+
+def _walk_mcp_secret_values(
+    config: dict[str, Any],
+    transform: Callable[[str], str],
+) -> dict[str, Any]:
+    """Apply ``transform`` to every string value inside ``env`` / ``headers``
+    dicts of each MCP server in ``config`` (a dumped ``MCPConfig`` dict).
+
+    Mutates and returns ``config``.
+    """
+    servers = config.get("mcpServers")
+    if not isinstance(servers, dict):
+        return config
+    for server in servers.values():
+        if not isinstance(server, dict):
+            continue
+        for key in ("env", "headers"):
+            mapping = server.get(key)
+            if not isinstance(mapping, dict):
+                continue
+            server[key] = {
+                k: (transform(v) if isinstance(v, str) else v)
+                for k, v in mapping.items()
+            }
+    return config
+
+
+# Fernet tokens always begin with the URL-safe base64 of version byte 0x80,
+# i.e. "gAAAAA". Gate decryption attempts on this prefix so genuine plaintext
+# values (legacy on-disk data from before per-value MCP encryption) pass
+# through untouched — and we don't spam the cipher's failure log.
+_FERNET_TOKEN_PREFIX = "gAAAAA"
+
+
+def _decrypt_mcp_value_or_keep(cipher: Cipher, value: str) -> str:
+    """Decrypt ``value`` with ``cipher``; return the original string if the
+    value isn't a Fernet token (legacy plaintext) or fails to decrypt
+    (cipher mismatch / corruption — logged once).
+    """
+    if not value.startswith(_FERNET_TOKEN_PREFIX):
+        # Not encrypted (legacy plaintext) — passes through quietly so the
+        # next save can re-encrypt it.
+        return value
+    try:
+        return cipher._get_fernet().decrypt(value.encode()).decode()
+    except InvalidToken:
+        logger.warning(
+            "MCP env/headers value looks encrypted but could not be "
+            "decrypted (cipher mismatch or corruption); leaving the "
+            "ciphertext in place."
+        )
+        return value
 
 
 SettingsValueType = Literal[
@@ -773,6 +833,26 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             return None
         return value
 
+    @field_validator("mcp_config", mode="before")
+    @classmethod
+    def _decrypt_mcp_secret_values(cls, value: Any, info: ValidationInfo) -> Any:
+        """Decrypt MCP ``env`` / ``headers`` values when a cipher is in
+        context (the on-disk load path). Mirrors ``_serialize_mcp_config``'s
+        per-value encryption.
+
+        Values that aren't valid Fernet tokens are passed through as
+        plaintext (e.g. when migrating from a build that wrote env/headers
+        unencrypted to disk).
+        """
+        if not isinstance(value, dict):
+            return value
+        cipher: Cipher | None = info.context.get("cipher") if info.context else None
+        if cipher is None:
+            return value
+        return _walk_mcp_secret_values(
+            value, lambda v: _decrypt_mcp_value_or_keep(cipher, v)
+        )
+
     @field_serializer("mcp_config")
     def _serialize_mcp_config(
         self, value: MCPConfig | None, info: SerializationInfo
@@ -780,16 +860,31 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         if value is None:
             return {}
         dumped = value.model_dump(exclude_none=True, exclude_defaults=True)
-        # Pass through real env / headers when the caller has signalled trust:
-        # either ``expose_secrets`` (REST plaintext / encrypted modes) or a
-        # ``cipher`` (on-disk persistence path — the storage layer applies its
-        # own access controls and SecretStr fields are encrypted via
-        # ``serialize_secret``). Without one of those signals, fall back to
-        # redacting ``env`` / ``headers`` for the default REST response.
         ctx = info.context or {}
-        if ctx.get("expose_secrets") or ctx.get("cipher") is not None:
+        expose_mode = ctx.get("expose_secrets")
+        cipher: Cipher | None = ctx.get("cipher")
+
+        # Plaintext: caller explicitly asked for raw values (backend trusted
+        # path; e.g. ``X-Expose-Secrets: plaintext``).
+        if expose_mode == "plaintext" or expose_mode is True:
             return dumped
-        # ``sanitize_dict`` redacts ``env`` / ``headers`` (REDACT_ALL_VALUES_KEYS).
+
+        # Encrypted: encrypt every ``env`` / ``headers`` value with the
+        # cipher. Triggered by either an explicit
+        # ``expose_secrets="encrypted"`` request (frontend-safe round trip)
+        # or the presence of a ``cipher`` (the on-disk persistence path —
+        # ``FileSettingsStore.save`` passes only ``{"cipher": cipher}``).
+        if expose_mode == "encrypted" or cipher is not None:
+            if cipher is None:
+                raise MissingCipherError(
+                    "Cannot encrypt MCP env/headers: no cipher configured. "
+                    "Set OH_SECRET_KEY environment variable."
+                )
+            return _walk_mcp_secret_values(
+                dumped, lambda v: cipher.encrypt(SecretStr(v)) or ""
+            )
+
+        # Default REST response: redact ``env`` / ``headers`` values.
         return sanitize_dict(dumped)
 
     def create_agent(self) -> Agent:

--- a/openhands-sdk/openhands/sdk/utils/cipher.py
+++ b/openhands-sdk/openhands/sdk/utils/cipher.py
@@ -8,9 +8,15 @@ SECURITY WARNINGS:
 
 import hashlib
 from base64 import b64encode
+from typing import Final
 
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
 from pydantic import SecretStr
+
+
+# Fernet token prefix used to distinguish ciphertext from legacy plaintext.
+# Do not shorten: a 5-char prefix collides with realistic base64 plaintext.
+FERNET_TOKEN_PREFIX: Final[str] = "gAAAAA"
 
 
 class Cipher:
@@ -55,6 +61,13 @@ class Cipher:
                 "This may occur when loading conversations encrypted with a different "
                 "key or when upgrading from older versions."
             )
+            return None
+
+    def try_decrypt_str(self, value: str) -> str | None:
+        """Decrypt to a string, or ``None`` on InvalidToken (no logging)."""
+        try:
+            return self._get_fernet().decrypt(value.encode()).decode()
+        except InvalidToken:
             return None
 
     def _get_fernet(self):

--- a/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
+++ b/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
@@ -1,5 +1,6 @@
 import logging
-from typing import Literal
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from pydantic import SecretStr
 
@@ -11,11 +12,29 @@ REDACTED_SECRET_VALUE = "**********"
 # Type for expose_secrets context value
 ExposeSecretsMode = Literal["encrypted", "plaintext"] | bool
 
+ResolvedExposeMode = Literal["plaintext", "encrypted", "redact"]
+
 _logger = logging.getLogger(__name__)
 
 
 class MissingCipherError(ValueError):
     """Raised by ``serialize_secret`` when encryption is requested without a cipher."""
+
+
+def resolve_expose_mode(context: Mapping[str, Any] | None) -> ResolvedExposeMode:
+    """Resolve a Pydantic context to plaintext / encrypted / redact.
+
+    Cipher presence implies ``"encrypted"`` (storage-path opt-in) unless
+    ``expose_secrets`` overrides.
+    """
+    if not context:
+        return "redact"
+    expose_mode = context.get("expose_secrets")
+    if expose_mode == "plaintext" or expose_mode is True:
+        return "plaintext"
+    if expose_mode == "encrypted" or context.get("cipher") is not None:
+        return "encrypted"
+    return "redact"
 
 
 def is_redacted_secret(v: str | SecretStr | None) -> bool:
@@ -43,26 +62,20 @@ def serialize_secret(v: SecretStr | None, info):
     if v is None:
         return None
 
-    expose_mode = info.context.get("expose_secrets") if info.context else None
-    cipher: Cipher | None = info.context.get("cipher") if info.context else None
+    mode = resolve_expose_mode(info.context)
 
-    # Handle plaintext mode first - no encryption needed
-    if expose_mode == "plaintext" or expose_mode is True:
+    if mode == "plaintext":
         return v.get_secret_value()
 
-    # Handle encrypted mode (explicit or implicit via cipher presence)
-    # When cipher is present without explicit expose_mode, default to encryption
-    # This provides backward compatibility for storage operations
-    if expose_mode == "encrypted" or cipher:
-        if not cipher:
-            # Encrypted mode explicitly requested but no cipher available
+    if mode == "encrypted":
+        cipher: Cipher | None = info.context.get("cipher") if info.context else None
+        if cipher is None:
             raise MissingCipherError(
                 "Cannot encrypt secret: no cipher configured. "
                 "Set OH_SECRET_KEY environment variable."
             )
         return cipher.encrypt(v)
 
-    # Default: let Pydantic handle masking (redaction)
     return v
 
 

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -1,3 +1,4 @@
+import json
 import os
 import tempfile
 from base64 import urlsafe_b64encode
@@ -241,18 +242,15 @@ def test_patch_settings_updates_llm_config(client_with_settings):
     assert body["llm_api_key_is_set"] is True
 
 
-def test_patch_settings_persists_mcp_env_vars_verbatim(
+def test_patch_settings_encrypts_mcp_env_and_headers_on_disk(
     client_with_settings, temp_persistence_dir
 ):
-    """PATCH /api/settings must NOT replace MCP env / headers with ``"<redacted>"``
-    on disk.
+    """PATCH /api/settings must encrypt MCP ``env`` / ``headers`` values at
+    rest with the configured cipher — the same way other secret fields are
+    persisted — and never write them as ``"<redacted>"`` or plaintext.
 
-    Regression for the bug where saving MCP settings caused env / header
-    values to be written to ``settings.json`` as the literal string
-    ``"<redacted>"`` — irreversibly losing the user's credentials. The
-    storage path passes a ``cipher`` (and no ``expose_secrets``) in the
-    serialization context, which the MCP serializer was previously
-    treating the same as an untrusted REST default.
+    Reading them back via ``X-Expose-Secrets: plaintext`` must round-trip
+    to the original values (decrypted on load).
     """
     response = client_with_settings.patch(
         "/api/settings",
@@ -276,14 +274,23 @@ def test_patch_settings_persists_mcp_env_vars_verbatim(
     )
     assert response.status_code == 200, response.text
 
-    # Inspect the on-disk settings.json: env / headers must be the values the
-    # client sent, not ``<redacted>``.
-    on_disk = (temp_persistence_dir / "settings.json").read_text()
-    assert "<redacted>" not in on_disk
-    assert "ghp-router-secret" in on_disk
-    assert "tok-router-secret" in on_disk
+    # Inspect the on-disk settings.json: plaintext must NOT appear, the
+    # values must be Fernet ciphertext.
+    on_disk_path = temp_persistence_dir / "settings.json"
+    on_disk_text = on_disk_path.read_text()
+    assert "<redacted>" not in on_disk_text
+    assert "ghp-router-secret" not in on_disk_text
+    assert "tok-router-secret" not in on_disk_text
 
-    # GET with plaintext returns the same round-tripped values.
+    on_disk = json.loads(on_disk_text)
+    servers_on_disk = on_disk["agent_settings"]["mcp_config"]["mcpServers"]
+    assert servers_on_disk["github"]["env"]["GITHUB_TOKEN"].startswith("gAAAA")
+    assert servers_on_disk["remote"]["headers"]["Authorization"].startswith("gAAAA")
+    # Non-secret structure must remain readable.
+    assert servers_on_disk["github"]["command"] == "uvx"
+    assert servers_on_disk["remote"]["url"] == "https://example.com/mcp"
+
+    # GET with plaintext decrypts and returns the original round-tripped values.
     response = client_with_settings.get(
         "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
     )

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -817,9 +817,7 @@ def test_openhands_agent_settings_mcp_config_redacts_env_and_headers() -> None:
     assert leaky["headers"]["Authorization"] == "Bearer tok-mcp-secret"
 
 
-def test_openhands_agent_settings_mcp_config_encrypts_env_and_headers_with_cipher() -> (  # noqa: E501
-    None
-):
+def test_mcp_config_encrypts_env_and_headers_with_cipher() -> None:
     """When a cipher is in the serialization context (the on-disk persistence
     path), MCP ``env`` / ``headers`` values must be encrypted per-value with
     that cipher — the same way other secret fields are persisted.

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1,3 +1,4 @@
+import json
 import warnings
 
 import pytest
@@ -816,14 +817,15 @@ def test_openhands_agent_settings_mcp_config_redacts_env_and_headers() -> None:
     assert leaky["headers"]["Authorization"] == "Bearer tok-mcp-secret"
 
 
-def test_openhands_agent_settings_mcp_config_passes_through_with_cipher() -> None:
-    """Regression: when a cipher is in the serialization context (the on-disk
-    persistence path), MCP ``env`` / ``headers`` values must round-trip
-    verbatim instead of being overwritten with the literal ``"<redacted>"``.
+def test_openhands_agent_settings_mcp_config_encrypts_env_and_headers_with_cipher() -> (  # noqa: E501
+    None
+):
+    """When a cipher is in the serialization context (the on-disk persistence
+    path), MCP ``env`` / ``headers`` values must be encrypted per-value with
+    that cipher — the same way other secret fields are persisted.
 
-    Previously the field serializer only checked ``expose_secrets``, so saving
-    settings via ``FileSettingsStore`` (which passes ``{"cipher": cipher}``)
-    irreversibly destroyed every user's MCP credentials.
+    Round-tripping through ``model_validate`` with the same cipher must
+    recover the original plaintext values.
     """
     from openhands.sdk.utils.cipher import Cipher
 
@@ -848,9 +850,135 @@ def test_openhands_agent_settings_mcp_config_passes_through_with_cipher() -> Non
     dumped = settings.model_dump(mode="json", context={"cipher": cipher})
 
     servers = dumped["mcp_config"]["mcpServers"]
-    assert servers["github"]["env"]["GITHUB_TOKEN"] == "ghp-mcp-secret"
-    assert servers["fetch"]["headers"]["Authorization"] == "Bearer tok-mcp-secret"
-    assert "<redacted>" not in str(dumped)
+    enc_token = servers["github"]["env"]["GITHUB_TOKEN"]
+    enc_auth = servers["fetch"]["headers"]["Authorization"]
+
+    # Plaintext values must NOT appear on disk.
+    serialized = json.dumps(dumped)
+    assert "ghp-mcp-secret" not in serialized
+    assert "tok-mcp-secret" not in serialized
+    assert "<redacted>" not in serialized
+
+    # Values must be Fernet ciphertext (base64; starts with "gAAAA").
+    assert enc_token.startswith("gAAAA")
+    assert enc_auth.startswith("gAAAA")
+    # Non-secret structure must remain plaintext.
+    assert servers["github"]["command"] == "uvx"
+    assert servers["github"]["args"] == ["mcp-server-github"]
+    assert servers["fetch"]["url"] == "https://example.com/mcp"
+
+    # Round-trip: decrypt with the same cipher recovers the originals.
+    restored = OpenHandsAgentSettings.model_validate(dumped, context={"cipher": cipher})
+    assert restored.mcp_config is not None
+    restored_dump = restored.mcp_config.model_dump(exclude_none=True)
+    assert (
+        restored_dump["mcpServers"]["github"]["env"]["GITHUB_TOKEN"] == "ghp-mcp-secret"
+    )
+    assert (
+        restored_dump["mcpServers"]["fetch"]["headers"]["Authorization"]
+        == "Bearer tok-mcp-secret"
+    )
+
+
+def test_openhands_agent_settings_mcp_config_decrypt_legacy_plaintext_on_disk() -> None:
+    """Loading a settings file that pre-dates per-value encryption (env /
+    headers stored as plaintext) must NOT drop those values: each value that
+    isn't a valid Fernet token is passed through unchanged so the next save
+    can re-encrypt it.
+    """
+    from openhands.sdk.utils.cipher import Cipher
+
+    cipher = Cipher(secret_key="test-encryption-key")
+    legacy_payload = {
+        "mcp_config": {
+            "mcpServers": {
+                "github": {
+                    "command": "uvx",
+                    "args": ["mcp-server-github"],
+                    # plaintext, as the previous (pre-encryption) build wrote
+                    "env": {"GITHUB_TOKEN": "ghp-legacy-plaintext"},
+                }
+            }
+        }
+    }
+
+    restored = OpenHandsAgentSettings.model_validate(
+        legacy_payload, context={"cipher": cipher}
+    )
+    assert restored.mcp_config is not None
+    assert (
+        restored.mcp_config.model_dump(exclude_none=True)["mcpServers"]["github"][
+            "env"
+        ]["GITHUB_TOKEN"]
+        == "ghp-legacy-plaintext"
+    )
+
+
+def test_openhands_agent_settings_mcp_config_expose_encrypted_requires_cipher() -> None:
+    """``expose_secrets="encrypted"`` without a cipher must raise — mirroring
+    the contract used for individual ``SecretStr`` fields via
+    :func:`serialize_secret`. Pydantic wraps the inner
+    ``MissingCipherError`` in a ``PydanticSerializationError``; the
+    agent-server's ``translate_missing_cipher`` walks the cause chain to
+    surface a 503.
+    """
+    from pydantic_core import PydanticSerializationError
+
+    from openhands.sdk.utils.pydantic_secrets import MissingCipherError
+
+    settings = OpenHandsAgentSettings(
+        mcp_config=MCPConfig.model_validate(
+            {
+                "mcpServers": {
+                    "github": {
+                        "command": "uvx",
+                        "args": ["mcp-server-github"],
+                        "env": {"GITHUB_TOKEN": "ghp-secret"},
+                    }
+                }
+            }
+        )
+    )
+    with pytest.raises(PydanticSerializationError) as exc_info:
+        settings.model_dump(mode="json", context={"expose_secrets": "encrypted"})
+    cause: BaseException | None = exc_info.value
+    while cause is not None:
+        if isinstance(cause, MissingCipherError):
+            break
+        cause = cause.__cause__ or cause.__context__
+    assert isinstance(cause, MissingCipherError)
+
+
+def test_openhands_agent_settings_mcp_config_expose_plaintext_passes_through() -> None:
+    """``expose_secrets="plaintext"`` must return raw env / headers values
+    even when a cipher is also in the context (e.g. an admin GET with
+    explicit plaintext exposure).
+    """
+    from openhands.sdk.utils.cipher import Cipher
+
+    settings = OpenHandsAgentSettings(
+        mcp_config=MCPConfig.model_validate(
+            {
+                "mcpServers": {
+                    "github": {
+                        "command": "uvx",
+                        "args": ["mcp-server-github"],
+                        "env": {"GITHUB_TOKEN": "ghp-secret"},
+                    }
+                }
+            }
+        )
+    )
+    cipher = Cipher(secret_key="test-encryption-key")
+
+    dumped = settings.model_dump(
+        mode="json",
+        context={"cipher": cipher, "expose_secrets": "plaintext"},
+    )
+    assert (
+        dumped["mcp_config"]["mcpServers"]["github"]["env"]["GITHUB_TOKEN"]
+        == "ghp-secret"
+    )
 
 
 def test_openhands_agent_settings_create_agent_keeps_real_mcp_secrets() -> None:


### PR DESCRIPTION
Stacks on top of #PARENT (`fix/mcp-settings-redacted-on-disk`).

Per-value encrypts every string in MCP server `env` / `headers` when persisting `OpenHandsAgentSettings` — the same way other secret fields are encrypted via the cipher context. Other parts of `mcp_config` (server names, urls, commands, args) remain plaintext.

Until now the on-disk persistence path passed only `{"cipher": cipher}` in the serialization context, and the `mcp_config` field serializer simply trusted that signal and wrote env / headers verbatim — leaving user MCP credentials in plaintext on disk despite a cipher being configured. This change brings them under the same at-rest protection as `SecretStr` fields persisted via `serialize_secret`.

## Behavior

`_serialize_mcp_config` now branches on context:
- `expose_secrets=plaintext` / `True`: raw values (backend trusted path).
- `expose_secrets=encrypted` or `cipher` present: Fernet-encrypt every `env` / `headers` value. Raises `MissingCipherError` when encrypted-mode is requested without a cipher, mirroring `serialize_secret`.
- default: redact via `sanitize_dict` (REST default unchanged).

A new `_decrypt_mcp_secret_values` field validator decrypts values on load when a cipher is in context. Values that don't start with the Fernet `"gAAAAA"` prefix are treated as legacy plaintext and passed through unchanged, so settings written by the previous build (which stored `env` / `headers` unencrypted) migrate cleanly on the next save.

## Tests

- `tests/sdk/test_settings.py`:
  - Replaced the previous "passes through with cipher" test with a stronger one asserting Fernet ciphertext on the dump (`gAAAA…`), no plaintext / `<redacted>`, and that round-tripping through `model_validate(..., context={"cipher": cipher})` recovers the originals.
  - Added a legacy-plaintext-on-disk migration test (values without the Fernet prefix pass through on load).
  - Added an `expose_secrets="encrypted"` without cipher test asserting `MissingCipherError` in the cause chain (Pydantic wraps it in `PydanticSerializationError`).
  - Added an `expose_secrets="plaintext"` test (overrides cipher even when both are present).
- `tests/agent_server/test_settings_router.py`: updated to assert on-disk `settings.json` contains Fernet ciphertext (not plaintext) and that `GET /api/settings` with `X-Expose-Secrets: plaintext` round-trips to the original values.

Local verification:
- `pytest tests/sdk/test_settings.py tests/agent_server/test_settings_router.py` → 87 passed.
- `pytest tests/sdk/conversation/test_mcp_secrets_serialization_leak.py tests/sdk/conversation/local/test_state_serialization.py tests/workspace/test_cloud_workspace_sdk_settings.py` → 57 passed.
- `ruff check` and `pyright` clean on touched files.

---

_This PR was opened by an AI agent (OpenHands) on behalf of the repo owner._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5142d1e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5142d1e-python \
  ghcr.io/openhands/agent-server:5142d1e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5142d1e-golang-amd64
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-golang-amd64
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-golang-amd64
ghcr.io/openhands/agent-server:5142d1e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5142d1e-golang-arm64
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-golang-arm64
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-golang-arm64
ghcr.io/openhands/agent-server:5142d1e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5142d1e-java-amd64
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-java-amd64
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-java-amd64
ghcr.io/openhands/agent-server:5142d1e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5142d1e-java-arm64
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-java-arm64
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-java-arm64
ghcr.io/openhands/agent-server:5142d1e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5142d1e-python-amd64
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-python-amd64
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-python-amd64
ghcr.io/openhands/agent-server:5142d1e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5142d1e-python-arm64
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-python-arm64
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-python-arm64
ghcr.io/openhands/agent-server:5142d1e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5142d1e-golang
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-golang
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-golang
ghcr.io/openhands/agent-server:5142d1e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5142d1e-java
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-java
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-java
ghcr.io/openhands/agent-server:5142d1e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5142d1e-python
ghcr.io/openhands/agent-server:5142d1e8cb87ac06302f7ec195a7a69420600c5b-python
ghcr.io/openhands/agent-server:feat-encrypt-mcp-headers-env-python
ghcr.io/openhands/agent-server:5142d1e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5142d1e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5142d1e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->