### PR TITLE
feat(agent-server): cookie auth for workspace static server (cross-domain friendly)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
 
+from openhands.agent_server.auth_router import auth_router
 from openhands.agent_server.bash_router import bash_router
 from openhands.agent_server.cloud_proxy_router import cloud_proxy_router
 from openhands.agent_server.config import (
@@ -26,7 +27,10 @@ from openhands.agent_server.conversation_router_acp import conversation_router_a
 from openhands.agent_server.conversation_service import (
     get_default_conversation_service,
 )
-from openhands.agent_server.dependencies import create_session_api_key_dependency
+from openhands.agent_server.dependencies import (
+    create_session_api_key_dependency,
+    create_workspace_session_dependency,
+)
 from openhands.agent_server.desktop_router import desktop_router
 from openhands.agent_server.desktop_service import get_desktop_service
 from openhands.agent_server.event_router import event_router
@@ -264,6 +268,9 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     """
     app.include_router(server_details_router)
 
+    # Header-only auth: applied to every /api/* route EXCEPT the workspace
+    # static-file routes (handled separately below). Cookies are NOT honored
+    # here so that we don't expand the CSRF surface across the whole API.
     dependencies = []
     if config.session_api_keys:
         dependencies.append(Depends(create_session_api_key_dependency(config)))
@@ -272,7 +279,6 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(event_router)
     api_router.include_router(conversation_router)
     api_router.include_router(conversation_router_acp)
-    api_router.include_router(workspace_router)
     api_router.include_router(tool_router)
     api_router.include_router(bash_router)
     api_router.include_router(git_router)
@@ -285,7 +291,25 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(settings_router)
     api_router.include_router(profiles_router)
     api_router.include_router(cloud_proxy_router)
+    # /api/auth/* mints workspace cookies and requires the header to bootstrap,
+    # so it lives under the header-only auth group.
+    api_router.include_router(auth_router)
     app.include_router(api_router)
+
+    # Workspace static-file routes get their own auth group that accepts
+    # EITHER the X-Session-API-Key header OR the workspace session cookie.
+    # The cookie is required so that <iframe src> / <img src> embeds of
+    # workspace artifacts work — browsers cannot attach custom headers to
+    # those requests.
+    workspace_dependencies = []
+    if config.session_api_keys:
+        workspace_dependencies.append(
+            Depends(create_workspace_session_dependency(config))
+        )
+    workspace_api_router = APIRouter(prefix="/api", dependencies=workspace_dependencies)
+    workspace_api_router.include_router(workspace_router)
+    app.include_router(workspace_api_router)
+
     app.include_router(sockets_router)
 
 

--- a/openhands-agent-server/openhands/agent_server/auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/auth_router.py
@@ -1,0 +1,158 @@
+"""Workspace static-server cookie auth endpoints.
+
+Browsers cannot attach custom headers to ``<iframe src>``, ``<img src>`` or
+top-level navigation requests, so the workspace static file server cannot
+be authenticated by the ``X-Session-API-Key`` header alone when the canvas
+frontend wants to embed workspace artifacts (HTML reports, plots, PDFs).
+
+These endpoints let a client that already has a valid session API key
+exchange it for a short-lived cookie which the browser will automatically
+attach to every workspace request — including cross-site iframes, thanks
+to ``SameSite=None; Secure; Partitioned``.
+
+The cookie is honored by ``workspace_router`` ONLY. Every other API route
+continues to require the ``X-Session-API-Key`` header. This is deliberate:
+keeping cookies off the rest of the API removes the CSRF surface that
+cookie auth would otherwise add.
+"""
+
+from fastapi import APIRouter, Request, Response, status
+
+from openhands.agent_server.dependencies import WORKSPACE_SESSION_COOKIE_NAME
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+auth_router = APIRouter(prefix="/auth", tags=["Auth"])
+
+# Cookie lifetime in seconds. Short enough that a stolen cookie isn't a
+# long-lived credential; long enough that a user previewing artifacts in
+# canvas isn't constantly re-authing. The cookie auto-renews on every call
+# to POST /api/auth/workspace-session, which the canvas frontend can do on
+# load.
+_COOKIE_MAX_AGE_SECONDS = 60 * 60 * 8  # 8 hours
+
+# Path scope: only sent on workspace-router URLs. Other /api/* endpoints
+# never see the cookie.
+_COOKIE_PATH = "/api/conversations"
+
+
+def _request_is_https(request: Request) -> bool:
+    """Detect HTTPS, honoring ``X-Forwarded-Proto`` set by trusted proxies.
+
+    We can't rely on ``request.url.scheme`` alone because the agent server
+    is typically behind nginx which terminates TLS and forwards plain HTTP.
+    Nginx (and the canvas ingress) set ``X-Forwarded-Proto`` accordingly.
+    """
+    forwarded = request.headers.get("x-forwarded-proto", "").lower()
+    if forwarded:
+        return forwarded.split(",")[0].strip() == "https"
+    return request.url.scheme == "https"
+
+
+def _set_workspace_cookie(
+    response: Response, *, value: str, secure: bool, max_age: int
+) -> None:
+    """Issue the workspace session cookie.
+
+    Cross-site iframe support requires ``SameSite=None; Secure``. Modern
+    Chrome additionally requires ``Partitioned`` (CHIPS) for cookies set
+    in third-party contexts; without it, the cookie may be silently
+    dropped under third-party-cookie phase-out.
+
+    We always set ``SameSite=None`` so the same cookie works for both
+    same-site and cross-site iframes, and we always set ``HttpOnly`` so
+    JS in workspace HTML can't read it.
+    """
+    response.set_cookie(
+        key=WORKSPACE_SESSION_COOKIE_NAME,
+        value=value,
+        max_age=max_age,
+        path=_COOKIE_PATH,
+        secure=secure,
+        httponly=True,
+        samesite="none",
+    )
+    # Starlette plumbs ``partitioned`` through to ``http.cookies.Morsel``,
+    # which only recognized the attribute starting in Python 3.14. We need
+    # the flag on 3.12/3.13 too, so patch the ``Set-Cookie`` header in
+    # place. Only meaningful when Secure is set — browsers ignore
+    # Partitioned on non-Secure cookies.
+    if secure:
+        _append_partitioned_to_last_set_cookie(response)
+
+
+def _append_partitioned_to_last_set_cookie(response: Response) -> None:
+    """Append ``; Partitioned`` to the most recent Set-Cookie header.
+
+    ``MutableHeaders`` doesn't expose an "edit by name" helper for
+    duplicate-allowed headers, and we need to be careful not to clobber
+    any other Set-Cookie headers a parent middleware might have queued.
+    """
+    raw = response.raw_headers
+    for idx in range(len(raw) - 1, -1, -1):
+        name, value = raw[idx]
+        if name.lower() == b"set-cookie" and value.startswith(
+            WORKSPACE_SESSION_COOKIE_NAME.encode("latin-1") + b"="
+        ):
+            if b"partitioned" not in value.lower():
+                raw[idx] = (name, value + b"; Partitioned")
+            return
+
+
+@auth_router.post(
+    "/workspace-session",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={
+        204: {"description": "Cookie set"},
+        401: {"description": "Missing or invalid X-Session-API-Key header"},
+    },
+)
+async def create_workspace_session(request: Request, response: Response) -> Response:
+    """Mint a workspace-scoped session cookie.
+
+    Caller must already be authenticated by the ``X-Session-API-Key``
+    header (enforced by the parent router's dependency). The cookie value
+    is the validated session API key itself; it is HttpOnly so JS in
+    workspace HTML cannot read it back.
+    """
+    session_api_key = request.headers.get("x-session-api-key", "")
+    secure = _request_is_https(request)
+    _set_workspace_cookie(
+        response,
+        value=session_api_key,
+        secure=secure,
+        max_age=_COOKIE_MAX_AGE_SECONDS,
+    )
+    if not secure:
+        # SameSite=None requires Secure in modern browsers, so a non-HTTPS
+        # cookie will be rejected by Chrome/Firefox. Loudly warn so dev
+        # users investigating "my iframe is 401" can find the cause.
+        logger.warning(
+            "Issuing workspace-session cookie over a non-HTTPS connection; "
+            "browsers will reject SameSite=None cookies without Secure. "
+            "Run the agent server behind a TLS-terminating proxy that sets "
+            "X-Forwarded-Proto=https for cross-site iframe support."
+        )
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response
+
+
+@auth_router.delete(
+    "/workspace-session",
+    status_code=status.HTTP_204_NO_CONTENT,
+    responses={204: {"description": "Cookie cleared"}},
+)
+async def delete_workspace_session(request: Request, response: Response) -> Response:
+    """Clear the workspace session cookie.
+
+    Browsers identify cookies by ``(name, domain, path)``; the deletion
+    cookie must therefore share the original cookie's attributes. We
+    overwrite with an empty value and ``max_age=0`` so the browser drops
+    it immediately.
+    """
+    secure = _request_is_https(request)
+    _set_workspace_cookie(response, value="", secure=secure, max_age=0)
+    response.status_code = status.HTTP_204_NO_CONTENT
+    return response

--- a/openhands-agent-server/openhands/agent_server/dependencies.py
+++ b/openhands-agent-server/openhands/agent_server/dependencies.py
@@ -1,14 +1,23 @@
 from uuid import UUID
 
 from fastapi import Depends, HTTPException, Request, status
-from fastapi.security import APIKeyHeader
+from fastapi.security import APIKeyCookie, APIKeyHeader
 
 from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.event_service import EventService
 
 
+# Cookie name used to authenticate the workspace static-file routes.
+# Intentionally distinct from the header name: the cookie is ONLY honored
+# by the workspace router (so iframes / <img> can load workspace files),
+# and is rejected by every other API endpoint.
+WORKSPACE_SESSION_COOKIE_NAME = "oh_workspace_session_key"
+
 _SESSION_API_KEY_HEADER = APIKeyHeader(name="X-Session-API-Key", auto_error=False)
+_WORKSPACE_SESSION_COOKIE = APIKeyCookie(
+    name=WORKSPACE_SESSION_COOKIE_NAME, auto_error=False
+)
 
 
 def create_session_api_key_dependency(config: Config):
@@ -24,6 +33,32 @@ def create_session_api_key_dependency(config: Config):
             raise HTTPException(status.HTTP_401_UNAUTHORIZED)
 
     return check_session_api_key
+
+
+def create_workspace_session_dependency(config: Config):
+    """Auth dependency for the workspace static-file routes.
+
+    Accepts EITHER the standard ``X-Session-API-Key`` header OR the
+    ``oh_workspace_session_key`` cookie (minted by
+    ``POST /api/auth/workspace-session``).
+    The cookie is required because browsers cannot attach custom headers to
+    ``<iframe src>`` or ``<img src>`` requests, which is how the canvas
+    frontend embeds workspace artifacts. The cookie is deliberately scoped
+    to this router only; no other endpoint honors it.
+    """
+
+    def check_workspace_session(
+        header_key: str | None = Depends(_SESSION_API_KEY_HEADER),
+        cookie_key: str | None = Depends(_WORKSPACE_SESSION_COOKIE),
+    ):
+        if not config.session_api_keys:
+            return
+        for candidate in (header_key, cookie_key):
+            if candidate and candidate in config.session_api_keys:
+                return
+        raise HTTPException(status.HTTP_401_UNAUTHORIZED)
+
+    return check_workspace_session
 
 
 def get_conversation_service(request: Request):

--- a/tests/agent_server/test_workspace_cookie_auth.py
+++ b/tests/agent_server/test_workspace_cookie_auth.py
@@ -1,0 +1,230 @@
+"""End-to-end tests for the workspace cookie auth flow.
+
+Exercises the full ``create_app(Config(session_api_keys=...))`` wiring so
+we cover both the new ``/api/auth/workspace-session`` endpoints and the
+cookie-or-header dependency that gates the workspace static-file routes.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import UUID, uuid4
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.dependencies import (
+    WORKSPACE_SESSION_COOKIE_NAME,
+    get_conversation_service,
+)
+from openhands.agent_server.event_service import EventService
+from openhands.sdk.workspace import LocalWorkspace
+
+
+SESSION_KEY = "test-key-abc"
+
+
+@pytest.fixture
+def client_factory(tmp_path):
+    """Build a TestClient with auth configured and one workspace served."""
+
+    def _build(*, conversation_id: UUID, workspace_dir=None) -> TestClient:
+        ws = workspace_dir if workspace_dir is not None else tmp_path
+
+        event_service = AsyncMock(spec=EventService)
+        event_service.stored = SimpleNamespace(
+            workspace=LocalWorkspace(working_dir=str(ws))
+        )
+        conversation_service = AsyncMock(spec=ConversationService)
+
+        async def _get_event_service(cid: UUID):
+            if cid == conversation_id:
+                return event_service
+            return None
+
+        conversation_service.get_event_service.side_effect = _get_event_service
+
+        app = create_app(Config(session_api_keys=[SESSION_KEY]))
+        # Override the lifespan-managed conversation service with our mock.
+        app.dependency_overrides[get_conversation_service] = (
+            lambda: conversation_service
+        )
+        return TestClient(app, raise_server_exceptions=False)
+
+    return _build
+
+
+@pytest.fixture
+def workspace_with_index(tmp_path):
+    (tmp_path / "index.html").write_text("<title>hello</title>")
+    return tmp_path
+
+
+def _workspace_url(cid: UUID, path: str = "index.html") -> str:
+    return f"/api/conversations/{cid}/workspace/{path}"
+
+
+# ---- baseline header behavior (regression coverage) -----------------------
+
+
+def test_workspace_rejects_request_without_credentials(
+    client_factory, workspace_with_index
+):
+    cid = uuid4()
+    client = client_factory(conversation_id=cid, workspace_dir=workspace_with_index)
+
+    assert client.get(_workspace_url(cid)).status_code == 401
+
+
+def test_workspace_accepts_valid_header(client_factory, workspace_with_index):
+    cid = uuid4()
+    client = client_factory(conversation_id=cid, workspace_dir=workspace_with_index)
+
+    resp = client.get(
+        _workspace_url(cid),
+        headers={"X-Session-API-Key": SESSION_KEY},
+    )
+    assert resp.status_code == 200
+    assert resp.text == "<title>hello</title>"
+
+
+def test_workspace_rejects_invalid_header(client_factory, workspace_with_index):
+    cid = uuid4()
+    client = client_factory(conversation_id=cid, workspace_dir=workspace_with_index)
+
+    resp = client.get(
+        _workspace_url(cid),
+        headers={"X-Session-API-Key": "not-the-key"},
+    )
+    assert resp.status_code == 401
+
+
+# ---- POST /api/auth/workspace-session -------------------------------------
+
+
+def test_mint_session_requires_header(client_factory, workspace_with_index):
+    client = client_factory(conversation_id=uuid4())
+
+    resp = client.post("/api/auth/workspace-session")
+    assert resp.status_code == 401
+    assert "set-cookie" not in {k.lower() for k in resp.headers}
+
+
+def test_mint_session_rejects_bad_header(client_factory):
+    client = client_factory(conversation_id=uuid4())
+
+    resp = client.post(
+        "/api/auth/workspace-session",
+        headers={"X-Session-API-Key": "wrong"},
+    )
+    assert resp.status_code == 401
+
+
+def test_mint_session_returns_cookie_attrs_over_https(client_factory):
+    client = client_factory(conversation_id=uuid4())
+
+    resp = client.post(
+        "/api/auth/workspace-session",
+        headers={
+            "X-Session-API-Key": SESSION_KEY,
+            "X-Forwarded-Proto": "https",
+        },
+    )
+    assert resp.status_code == 204
+
+    set_cookie = resp.headers["set-cookie"]
+    assert set_cookie.startswith(f"{WORKSPACE_SESSION_COOKIE_NAME}={SESSION_KEY}")
+    # Cross-site iframe requirements:
+    assert "SameSite=none" in set_cookie
+    assert "Secure" in set_cookie
+    assert "Partitioned" in set_cookie
+    # Defensive defaults:
+    assert "HttpOnly" in set_cookie
+    assert "Path=/api/conversations" in set_cookie
+
+
+def test_mint_session_over_plain_http_drops_secure_and_partitioned(client_factory):
+    """On non-HTTPS we still set the cookie (handy for local dev), but we
+    must NOT mark it Secure/Partitioned — those would be rejected by the
+    browser anyway. SameSite=None is preserved to keep behavior uniform."""
+    client = client_factory(conversation_id=uuid4())
+
+    resp = client.post(
+        "/api/auth/workspace-session",
+        headers={"X-Session-API-Key": SESSION_KEY},  # no X-Forwarded-Proto
+    )
+    assert resp.status_code == 204
+
+    set_cookie = resp.headers["set-cookie"]
+    assert "SameSite=none" in set_cookie
+    assert "Secure" not in set_cookie
+    assert "Partitioned" not in set_cookie
+
+
+# ---- Cookie auth on workspace router --------------------------------------
+
+
+def test_workspace_accepts_valid_cookie(client_factory, workspace_with_index):
+    cid = uuid4()
+    client = client_factory(conversation_id=cid, workspace_dir=workspace_with_index)
+
+    mint = client.post(
+        "/api/auth/workspace-session",
+        headers={"X-Session-API-Key": SESSION_KEY},
+    )
+    assert mint.status_code == 204
+    assert WORKSPACE_SESSION_COOKIE_NAME in mint.cookies
+
+    # Now fetch with ONLY the cookie -- no X-Session-API-Key header.
+    resp = client.get(_workspace_url(cid))
+    assert resp.status_code == 200
+    assert resp.text == "<title>hello</title>"
+
+
+def test_workspace_rejects_bogus_cookie(client_factory, workspace_with_index):
+    cid = uuid4()
+    client = client_factory(conversation_id=cid, workspace_dir=workspace_with_index)
+
+    client.cookies.set(WORKSPACE_SESSION_COOKIE_NAME, "definitely-wrong")
+    resp = client.get(_workspace_url(cid))
+    assert resp.status_code == 401
+
+
+# ---- Cookie is rejected by non-workspace endpoints ------------------------
+
+
+def test_cookie_does_not_authenticate_other_api_endpoints(client_factory):
+    """The cookie must only be honored by the workspace router. The rest of
+    the API continues to require the X-Session-API-Key header so we don't
+    add a CSRF surface to state-changing endpoints."""
+    client = client_factory(conversation_id=uuid4())
+
+    mint = client.post(
+        "/api/auth/workspace-session",
+        headers={"X-Session-API-Key": SESSION_KEY},
+    )
+    assert mint.status_code == 204
+
+    # /api/conversations is gated by the header-only dependency.
+    resp = client.get("/api/conversations")
+    assert resp.status_code == 401
+
+
+# ---- DELETE clears the cookie ---------------------------------------------
+
+
+def test_delete_session_clears_cookie(client_factory):
+    client = client_factory(conversation_id=uuid4())
+
+    resp = client.delete(
+        "/api/auth/workspace-session",
+        headers={"X-Session-API-Key": SESSION_KEY},
+    )
+    assert resp.status_code == 204
+    # Cookie cleared via Max-Age=0 with matching attributes.
+    set_cookie = resp.headers["set-cookie"]
+    assert f'{WORKSPACE_SESSION_COOKIE_NAME}=""' in set_cookie
+    assert "Max-Age=0" in set_cookie
+    assert "Path=/api/conversations" in set_cookie


### PR DESCRIPTION
## Why

#3192 added `GET /api/conversations/{cid}/workspace/{path}` as a plain static file server. It inherits the `X-Session-API-Key` header check from the global `/api` auth dependency, but **browsers cannot attach custom headers to `<iframe src>`, `<img src>`, or top-level navigation requests** — and that's exactly how canvas's `file-content-viewer` embeds workspace HTML / PDFs / images:

```tsx
<iframe src={staticUrl} ... />     // HTML, PDF
<img    src={staticUrl} ... />     // images
```

Result: as soon as the agent server is run with `OH_SESSION_API_KEYS_0` configured (i.e., in real deployments — not just local dev), every iframe / image preview 401s. The canvas helper at `src/utils/workspace-file-url.ts` literally calls this out in a comment:

> The route inherits the agent server's session-API-key auth dependency, but `auto_error=False` means it returns 401 only when the server is configured with session keys. **On unauthenticated dev servers** the URL can be used directly as e.g. an `<iframe src>` with no extra headers.

In other words, the previous design works *only* when auth is disabled. This PR fixes that without weakening auth and without expanding the CSRF surface elsewhere in the API.

## What changes

A tiny new auth surface, scoped only to the workspace static-file route:

```
POST   /api/auth/workspace-session    # mint cookie (must present X-Session-API-Key header)
DELETE /api/auth/workspace-session    # clear cookie
```

The cookie (`oh_workspace_session_key`) is:

| Attribute   | Value                          | Why |
|-------------|--------------------------------|-----|
| HttpOnly    | yes                            | JS in workspace HTML can't exfiltrate it |
| SameSite    | None                           | sent on cross-site iframes embedding `…/workspace/…` |
| Secure      | when `X-Forwarded-Proto=https` | required for SameSite=None |
| Partitioned | when Secure                    | CHIPS — survives 3p-cookie phase-out in Chrome |
| Path        | `/api/conversations`           | not sent to any other URL space |

Only `workspace_router` honors the cookie. Every other `/api/*` route keeps the header-only check (`create_session_api_key_dependency`), so we do **not** add CSRF risk to any state-changing endpoint.

### Implementation

- `dependencies.py`: new `create_workspace_session_dependency(config)` factory that accepts header OR cookie. Cookie name exported as `WORKSPACE_SESSION_COOKIE_NAME`.
- `auth_router.py` (new): `POST`/`DELETE /auth/workspace-session`. Detects HTTPS via `X-Forwarded-Proto` (falling back to `request.url.scheme`) and sets `Secure`/`Partitioned` accordingly. The `Partitioned` attribute is patched onto the `Set-Cookie` header in place because the Starlette flag relies on `http.cookies.Morsel` Partitioned support which only exists on Python 3.14+.
- `api.py`: workspace_router moves out of the header-only `/api` router and into a sibling `/api` router whose only dependency is the cookie-or-header check. `auth_router` lives under the header-only group so minting requires a real header.

### Cross-domain support

The cookie is explicitly designed for the case where the canvas frontend and the agent server live on different domains (e.g. `canvas.example.com` + `agent-{id}.example.com`):

- Canvas does `fetch("https://agent-server/api/auth/workspace-session", { method: "POST", headers: { "X-Session-API-Key": … }, credentials: "include" })`. CORS is already configured with `allow_credentials=True` via `LocalhostCORSMiddleware`, so this works once the canvas origin is in `allow_cors_origins`.
- The agent server responds `Set-Cookie: …; SameSite=None; Secure; Partitioned; HttpOnly`.
- Subsequent `<iframe src="https://agent-server/api/conversations/{cid}/workspace/index.html">` embeds attach the cookie automatically.

For the same-origin case (canvas's current local deployment) this also works — `SameSite=None; Secure` is strictly more permissive than `Lax`.

## Test coverage

`tests/agent_server/test_workspace_cookie_auth.py` (11 cases) exercises the full `create_app(Config(session_api_keys=[…]))` wiring:

- Workspace route: rejects missing creds, accepts valid header, rejects bad header *(regression coverage for #3192)*
- Mint endpoint: rejects missing/bad header, returns proper `Set-Cookie` over HTTPS (Secure + Partitioned + SameSite=None + HttpOnly + Path), drops Secure/Partitioned over plain HTTP
- Cookie auth: workspace route accepts valid cookie with no header, rejects bogus cookie
- Isolation: the cookie does **not** authenticate other `/api/*` endpoints (verified against `/api/conversations`)
- Logout: `DELETE` returns `Max-Age=0` deletion cookie with matching attributes

Full test sweep on auth-adjacent suites: 98/98 passing (workspace_router, workspace_cookie_auth, api_authentication, dependencies, api, websocket_first_message_auth). Ruff lint + format clean, pyright clean.

## Frontend follow-up

Canvas's `buildWorkspaceFileUrl` / `file-content-viewer` will need a one-time `POST /api/auth/workspace-session` (with `credentials: "include"`) before rendering any iframe/img — happy to land that in a sibling PR.

---

_This PR was created by an AI agent (OpenHands) on behalf of the maintainer._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:750c9f7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-750c9f7-python \
  ghcr.io/openhands/agent-server:750c9f7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:750c9f7-golang-amd64
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-golang-amd64
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-golang-amd64
ghcr.io/openhands/agent-server:750c9f7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:750c9f7-golang-arm64
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-golang-arm64
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-golang-arm64
ghcr.io/openhands/agent-server:750c9f7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:750c9f7-java-amd64
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-java-amd64
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-java-amd64
ghcr.io/openhands/agent-server:750c9f7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:750c9f7-java-arm64
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-java-arm64
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-java-arm64
ghcr.io/openhands/agent-server:750c9f7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:750c9f7-python-amd64
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-python-amd64
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-python-amd64
ghcr.io/openhands/agent-server:750c9f7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:750c9f7-python-arm64
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-python-arm64
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-python-arm64
ghcr.io/openhands/agent-server:750c9f7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:750c9f7-golang
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-golang
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-golang
ghcr.io/openhands/agent-server:750c9f7-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:750c9f7-java
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-java
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-java
ghcr.io/openhands/agent-server:750c9f7-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:750c9f7-python
ghcr.io/openhands/agent-server:750c9f72a83c391a029e98b22cddf7369b9282e0-python
ghcr.io/openhands/agent-server:fix-workspace-cookie-auth-python
ghcr.io/openhands/agent-server:750c9f7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `750c9f7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `750c9f7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->