### PR TITLE
fix(agent-server): don't dump tracebacks for raised HTTPExceptions

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -465,7 +465,15 @@ def _add_exception_handlers(api: FastAPI) -> None:
                 request.url.path,
                 exc.detail,
             )
-        # Log 5xx errors at error level with full traceback (server errors)
+        # Log 5xx errors at error level. HTTPException is intentionally
+        # raised flow control — the route picked this status and detail
+        # on purpose — so a stack trace adds no information beyond
+        # `exc.detail` and makes routine upstream blips (e.g. a 502 from
+        # /api/cloud-proxy when the cloud is unreachable) look
+        # indistinguishable from a process crash. Unhandled exceptions
+        # still get a full traceback via _unhandled_exception_handler
+        # above. Include the traceback only when DEBUG is on, as an
+        # opt-in debugging aid.
         elif exc.status_code >= 500:
             logger.error(
                 "HTTPException %d on %s %s: %s",
@@ -473,7 +481,7 @@ def _add_exception_handlers(api: FastAPI) -> None:
                 request.method,
                 request.url.path,
                 exc.detail,
-                exc_info=(type(exc), exc, exc.__traceback__),
+                exc_info=(type(exc), exc, exc.__traceback__) if DEBUG else None,
             )
             content = {
                 "detail": "Internal Server Error",

--- a/tests/agent_server/test_api.py
+++ b/tests/agent_server/test_api.py
@@ -540,3 +540,112 @@ def test_get_root_path_parametrized(web_url, expected_root_path):
     """Parametrized test for _get_root_path with various URL patterns."""
     config = Config(web_url=web_url)
     assert _get_root_path(config) == expected_root_path
+
+
+class TestHttpExceptionLogging:
+    """5xx HTTPExceptions are intentionally-raised flow control.
+
+    They should be logged as a single ERROR line without a full stack
+    trace; only genuinely unhandled exceptions should get a traceback.
+    Otherwise routine upstream blips (e.g. a 502 from /api/cloud-proxy
+    when the cloud is unreachable) look indistinguishable from a process
+    crash in the logs.
+    """
+
+    def _build_app_with_failing_route(self, status_code: int):
+        from fastapi import HTTPException as FastAPIHTTPException
+
+        config = Config(static_files_path=None)
+        app = create_app(config)
+
+        @app.get(f"/__test__/raise_{status_code}")
+        def _raise():
+            raise FastAPIHTTPException(
+                status_code=status_code, detail="boom from upstream"
+            )
+
+        return app
+
+    def test_5xx_http_exception_logged_without_traceback_by_default(self, caplog):
+        import logging
+
+        app = self._build_app_with_failing_route(502)
+        client = TestClient(app)
+
+        with caplog.at_level(logging.ERROR, logger="openhands.agent_server.api"):
+            response = client.get("/__test__/raise_502")
+
+        assert response.status_code == 502
+        # Client still sees the same sanitized 5xx envelope.
+        assert response.json()["detail"] == "Internal Server Error"
+
+        api_error_records = [
+            r
+            for r in caplog.records
+            if r.name == "openhands.agent_server.api" and r.levelno == logging.ERROR
+        ]
+        assert len(api_error_records) == 1, (
+            "Expected exactly one ERROR log line for a 5xx HTTPException, "
+            f"got: {[r.getMessage() for r in api_error_records]}"
+        )
+        record = api_error_records[0]
+        # The whole point of the fix: no stack trace attached for an
+        # intentionally-raised HTTPException.
+        assert record.exc_info is None, (
+            "5xx HTTPException should not log a traceback by default; "
+            f"got exc_info={record.exc_info!r}"
+        )
+        # Message must still carry status, method, path, and detail so
+        # the log is useful for monitoring.
+        message = record.getMessage()
+        assert "502" in message
+        assert "GET" in message
+        assert "/__test__/raise_502" in message
+        assert "boom from upstream" in message
+
+    def test_5xx_http_exception_includes_traceback_when_debug_enabled(
+        self, caplog, monkeypatch
+    ):
+        import logging
+
+        # DEBUG is read at module import time in api.py, so monkeypatch
+        # the bound name on the module rather than mutating the env.
+        monkeypatch.setattr("openhands.agent_server.api.DEBUG", True)
+
+        app = self._build_app_with_failing_route(503)
+        client = TestClient(app)
+
+        with caplog.at_level(logging.ERROR, logger="openhands.agent_server.api"):
+            response = client.get("/__test__/raise_503")
+
+        assert response.status_code == 503
+        api_error_records = [
+            r
+            for r in caplog.records
+            if r.name == "openhands.agent_server.api" and r.levelno == logging.ERROR
+        ]
+        assert len(api_error_records) == 1
+        # In DEBUG mode the traceback is preserved as an opt-in debugging aid.
+        assert api_error_records[0].exc_info is not None
+
+    def test_4xx_http_exception_logged_at_info_without_traceback(self, caplog):
+        import logging
+
+        app = self._build_app_with_failing_route(404)
+        client = TestClient(app)
+
+        with caplog.at_level(logging.INFO, logger="openhands.agent_server.api"):
+            response = client.get("/__test__/raise_404")
+
+        assert response.status_code == 404
+        # 4xx path returns the raw detail (not the sanitized 5xx envelope).
+        assert response.json() == {"detail": "boom from upstream"}
+
+        api_records = [
+            r for r in caplog.records if r.name == "openhands.agent_server.api"
+        ]
+        # No ERROR-level noise for a routine 4xx.
+        assert not any(r.levelno >= logging.ERROR for r in api_records)
+        info_records = [r for r in api_records if r.levelno == logging.INFO]
+        assert info_records, "Expected an INFO log line for a 4xx HTTPException"
+        assert all(r.exc_info is None for r in info_records)


### PR DESCRIPTION
## What

The 5xx branch of `_http_exception_handler` in
`openhands-agent-server/openhands/agent_server/api.py` was logging a
full traceback for every `HTTPException` with status ≥ 500. This patch
drops the `exc_info` from that log line by default, and preserves it
under `DEBUG` as an opt-in debugging aid.

Behavior unchanged for clients: same status code, same response body.
Genuinely unhandled exceptions still get a full traceback via
`_unhandled_exception_handler` immediately above.

## Why

`HTTPException` is *intentionally-raised flow control* — the route
picked the status and detail on purpose. A stack trace adds no
information beyond `exc.detail` and makes routine upstream blips look
indistinguishable from a process crash.

Reported symptom: agent-server "crashed" with a multi-page traceback.
What actually happened was a transient `ConnectTimeout` from
`/api/cloud-proxy` to `app.all-hands.dev` (for the GUI's cloud-health
probe at `GET /api/keys/current`). `cloud_proxy_router` already
correctly handled it with a one-line `WARNING` and `raise
HTTPException(502, ...)`, but the generic 5xx handler then re-logged
the same event as `ERROR` with a 60+ line stack trace. Server kept
serving requests fine — the log just looked terrifying.

Before:
```
WARNING  Cloud proxy upstream error for https://app.all-hands.dev/api/keys/current: ConnectTimeout
ERROR    HTTPException 502 on POST /api/cloud-proxy: Upstream error: ConnectTimeout
  <~60 lines of httpx/httpcore/anyio frames>
INFO     POST /api/cloud-proxy HTTP/1.1" 502
```

After:
```
WARNING  Cloud proxy upstream error for https://app.all-hands.dev/api/keys/current: ConnectTimeout
ERROR    HTTPException 502 on POST /api/cloud-proxy: Upstream error: ConnectTimeout
INFO     POST /api/cloud-proxy HTTP/1.1" 502
```

## Tests

New `TestHttpExceptionLogging` class in `tests/agent_server/test_api.py`:

- `test_5xx_http_exception_logged_without_traceback_by_default` — raises a 502 from a test route, asserts a single ERROR record is logged with `exc_info is None`, asserts the status/method/path/detail are still in the message, asserts the client still gets the sanitized 502 envelope.
- `test_5xx_http_exception_includes_traceback_when_debug_enabled` — monkeypatches `api.DEBUG = True`, raises a 503, asserts `exc_info is not None`.
- `test_4xx_http_exception_logged_at_info_without_traceback` — regression guard for the 4xx branch (unchanged but covered).

All 56 tests in `test_api.py` + `test_cloud_proxy_router.py` pass; lint/format clean.

---
_This PR was opened by an AI agent (OpenHands) on behalf of @rbren._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7c62a8e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7c62a8e-python \
  ghcr.io/openhands/agent-server:7c62a8e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7c62a8e-golang-amd64
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-golang-amd64
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-golang-amd64
ghcr.io/openhands/agent-server:7c62a8e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7c62a8e-golang-arm64
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-golang-arm64
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-golang-arm64
ghcr.io/openhands/agent-server:7c62a8e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7c62a8e-java-amd64
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-java-amd64
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-java-amd64
ghcr.io/openhands/agent-server:7c62a8e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7c62a8e-java-arm64
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-java-arm64
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-java-arm64
ghcr.io/openhands/agent-server:7c62a8e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7c62a8e-python-amd64
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-python-amd64
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-python-amd64
ghcr.io/openhands/agent-server:7c62a8e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7c62a8e-python-arm64
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-python-arm64
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-python-arm64
ghcr.io/openhands/agent-server:7c62a8e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7c62a8e-golang
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-golang
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-golang
ghcr.io/openhands/agent-server:7c62a8e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7c62a8e-java
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-java
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-java
ghcr.io/openhands/agent-server:7c62a8e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7c62a8e-python
ghcr.io/openhands/agent-server:7c62a8e32c9aef24cfc6e91ecc22fd28c6730674-python
ghcr.io/openhands/agent-server:fix-agent-server-quiet-5xx-http-exception-traceback-python
ghcr.io/openhands/agent-server:7c62a8e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7c62a8e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7c62a8e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->