### PR TITLE
fix(agent-server): mark workspace-session cookie Secure on HTTPS and loopback

### DIFF
--- a/openhands-agent-server/openhands/agent_server/auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/auth_router.py
@@ -19,10 +19,7 @@ cookie auth would otherwise add.
 from fastapi import APIRouter, Request, Response, status
 
 from openhands.agent_server.dependencies import WORKSPACE_SESSION_COOKIE_NAME
-from openhands.sdk.logger import get_logger
 
-
-logger = get_logger(__name__)
 
 auth_router = APIRouter(prefix="/auth", tags=["Auth"])
 
@@ -37,18 +34,36 @@ _COOKIE_MAX_AGE_SECONDS = 60 * 60 * 8  # 8 hours
 # never see the cookie.
 _COOKIE_PATH = "/api/conversations"
 
+# Hostnames the browser treats as "secure contexts" even over plain HTTP, so
+# we can issue ``Secure`` cookies against them in local development without
+# requiring TLS. Matches the platform-secure-contexts list in the WHATWG
+# Secure Contexts spec.
+_LOOPBACK_HOSTS = frozenset({"localhost", "127.0.0.1", "::1"})
 
-def _request_is_https(request: Request) -> bool:
-    """Detect HTTPS, honoring ``X-Forwarded-Proto`` set by trusted proxies.
 
-    We can't rely on ``request.url.scheme`` alone because the agent server
-    is typically behind nginx which terminates TLS and forwards plain HTTP.
-    Nginx (and the canvas ingress) set ``X-Forwarded-Proto`` accordingly.
+def _request_is_secure_context(request: Request) -> bool:
+    """Whether the request originated from a context where the browser
+    will accept ``Secure`` cookies.
+
+    That's true for:
+      - HTTPS (honoring ``X-Forwarded-Proto`` set by trusted proxies that
+        terminate TLS in front of us), and
+      - Plain HTTP against loopback hostnames, which browsers (per the
+        Secure Contexts spec) treat as secure.
     """
-    forwarded = request.headers.get("x-forwarded-proto", "").lower()
-    if forwarded:
-        return forwarded.split(",")[0].strip() == "https"
-    return request.url.scheme == "https"
+    forwarded_proto = request.headers.get("x-forwarded-proto", "").lower()
+    scheme = forwarded_proto.split(",")[0].strip() or request.url.scheme
+    if scheme == "https":
+        return True
+
+    forwarded_host = request.headers.get("x-forwarded-host", "")
+    host = forwarded_host.split(",")[0].strip() or request.url.hostname or ""
+    # Strip an optional ``:port`` suffix; IPv6 hosts are bracketed.
+    if host.startswith("["):
+        host = host.partition("]")[0].lstrip("[")
+    else:
+        host = host.split(":")[0]
+    return host.lower() in _LOOPBACK_HOSTS
 
 
 def _set_workspace_cookie(
@@ -62,8 +77,11 @@ def _set_workspace_cookie(
     dropped under third-party-cookie phase-out.
 
     We always set ``SameSite=None`` so the same cookie works for both
-    same-site and cross-site iframes, and we always set ``HttpOnly`` so
-    JS in workspace HTML can't read it.
+    same-site and cross-site iframes, and always set ``HttpOnly`` so JS
+    in workspace HTML can't read it back. ``Secure`` is set whenever
+    the request comes from a secure context (HTTPS or loopback) — the
+    only contexts where a ``SameSite=None`` cookie will actually be
+    stored by the browser.
     """
     response.set_cookie(
         key=WORKSPACE_SESSION_COOKIE_NAME,
@@ -118,23 +136,12 @@ async def create_workspace_session(request: Request, response: Response) -> Resp
     workspace HTML cannot read it back.
     """
     session_api_key = request.headers.get("x-session-api-key", "")
-    secure = _request_is_https(request)
     _set_workspace_cookie(
         response,
         value=session_api_key,
-        secure=secure,
+        secure=_request_is_secure_context(request),
         max_age=_COOKIE_MAX_AGE_SECONDS,
     )
-    if not secure:
-        # SameSite=None requires Secure in modern browsers, so a non-HTTPS
-        # cookie will be rejected by Chrome/Firefox. Loudly warn so dev
-        # users investigating "my iframe is 401" can find the cause.
-        logger.warning(
-            "Issuing workspace-session cookie over a non-HTTPS connection; "
-            "browsers will reject SameSite=None cookies without Secure. "
-            "Run the agent server behind a TLS-terminating proxy that sets "
-            "X-Forwarded-Proto=https for cross-site iframe support."
-        )
     response.status_code = status.HTTP_204_NO_CONTENT
     return response
 
@@ -152,7 +159,11 @@ async def delete_workspace_session(request: Request, response: Response) -> Resp
     overwrite with an empty value and ``max_age=0`` so the browser drops
     it immediately.
     """
-    secure = _request_is_https(request)
-    _set_workspace_cookie(response, value="", secure=secure, max_age=0)
+    _set_workspace_cookie(
+        response,
+        value="",
+        secure=_request_is_secure_context(request),
+        max_age=0,
+    )
     response.status_code = status.HTTP_204_NO_CONTENT
     return response

--- a/tests/agent_server/test_workspace_cookie_auth.py
+++ b/tests/agent_server/test_workspace_cookie_auth.py
@@ -123,6 +123,8 @@ def test_mint_session_rejects_bad_header(client_factory):
 
 
 def test_mint_session_returns_cookie_attrs_over_https(client_factory):
+    """Behind a TLS-terminating proxy that sets X-Forwarded-Proto=https,
+    we issue the full cross-site iframe cookie attribute set."""
     client = client_factory(conversation_id=uuid4())
 
     resp = client.post(
@@ -130,6 +132,7 @@ def test_mint_session_returns_cookie_attrs_over_https(client_factory):
         headers={
             "X-Session-API-Key": SESSION_KEY,
             "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "agent.example.com",
         },
     )
     assert resp.status_code == 204
@@ -145,15 +148,47 @@ def test_mint_session_returns_cookie_attrs_over_https(client_factory):
     assert "Path=/api/conversations" in set_cookie
 
 
-def test_mint_session_over_plain_http_drops_secure_and_partitioned(client_factory):
-    """On non-HTTPS we still set the cookie (handy for local dev), but we
-    must NOT mark it Secure/Partitioned — those would be rejected by the
-    browser anyway. SameSite=None is preserved to keep behavior uniform."""
+@pytest.mark.parametrize(
+    "host_header",
+    [
+        "localhost",
+        "localhost:8000",
+        "127.0.0.1",
+        "127.0.0.1:8000",
+    ],
+)
+def test_mint_session_marks_cookie_secure_on_loopback(client_factory, host_header):
+    """Browsers (per the Secure Contexts spec) accept ``Secure`` cookies
+    on plain-HTTP loopback origins. Issuing Secure here lets local dev
+    against ``http://localhost`` actually receive the cookie, which a
+    ``SameSite=None`` non-Secure cookie would not."""
     client = client_factory(conversation_id=uuid4())
 
     resp = client.post(
         "/api/auth/workspace-session",
-        headers={"X-Session-API-Key": SESSION_KEY},  # no X-Forwarded-Proto
+        headers={"X-Session-API-Key": SESSION_KEY, "Host": host_header},
+    )
+    assert resp.status_code == 204
+
+    set_cookie = resp.headers["set-cookie"]
+    assert "Secure" in set_cookie
+    assert "Partitioned" in set_cookie
+
+
+def test_mint_session_over_remote_plain_http_drops_secure(client_factory):
+    """On non-HTTPS to a non-loopback host we don't claim Secure — the
+    browser would reject a Secure cookie over plain HTTP anyway. The
+    cookie won't actually work for cross-site embedding in that case
+    (SameSite=None requires Secure), but emitting a Secure attribute we
+    can't honor would just make the failure mode less obvious."""
+    client = client_factory(conversation_id=uuid4())
+
+    resp = client.post(
+        "/api/auth/workspace-session",
+        headers={
+            "X-Session-API-Key": SESSION_KEY,
+            "Host": "agent.example.com",
+        },
     )
     assert resp.status_code == 204
 


### PR DESCRIPTION
The workspace-session cookie is issued with `SameSite=None` so it works in cross-site iframes embedding workspace artifacts. Modern browsers refuse to store a `SameSite=None` cookie without `Secure`, so the previous logic of only marking the cookie `Secure` when `X-Forwarded-Proto` was `https` silently produced a non-functional cookie when developing against `http://localhost`.

This PR marks the cookie `Secure` (and `Partitioned`) whenever the request comes from a *secure context* per the WHATWG spec, which means:

- HTTPS (honoring `X-Forwarded-Proto` set by nginx/ingress that terminates TLS in front of the agent server), or
- A loopback host — `localhost`, `127.0.0.1`, `::1` — over plain HTTP. Browsers treat these as secure contexts and will store `Secure` cookies on them.

Loopback detection prefers `X-Forwarded-Host` and falls back to the request URL; it strips an optional `:port` suffix and IPv6 brackets.

For non-loopback plain HTTP we still leave `Secure` off — the browser would reject a `Secure` cookie over plain HTTP, so claiming it would just hide the misconfiguration. The cookie won't work for cross-site embedding in that case (since `SameSite=None` requires `Secure`), but that's an existing deployment constraint, not something we want to paper over.

Tests cover all three cases: HTTPS → `Secure` + `Partitioned`; `localhost` / `127.0.0.1` (with and without ports) → `Secure` + `Partitioned`; non-loopback plain HTTP → neither.

---
_This PR was opened by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:06133cf-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-06133cf-python \
  ghcr.io/openhands/agent-server:06133cf-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:06133cf-golang-amd64
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-golang-amd64
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-golang-amd64
ghcr.io/openhands/agent-server:06133cf-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:06133cf-golang-arm64
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-golang-arm64
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-golang-arm64
ghcr.io/openhands/agent-server:06133cf-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:06133cf-java-amd64
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-java-amd64
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-java-amd64
ghcr.io/openhands/agent-server:06133cf-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:06133cf-java-arm64
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-java-arm64
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-java-arm64
ghcr.io/openhands/agent-server:06133cf-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:06133cf-python-amd64
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-python-amd64
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-python-amd64
ghcr.io/openhands/agent-server:06133cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:06133cf-python-arm64
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-python-arm64
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-python-arm64
ghcr.io/openhands/agent-server:06133cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:06133cf-golang
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-golang
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-golang
ghcr.io/openhands/agent-server:06133cf-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:06133cf-java
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-java
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-java
ghcr.io/openhands/agent-server:06133cf-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:06133cf-python
ghcr.io/openhands/agent-server:06133cf46bf5caf5465682d9db009be1c63b3ae1-python
ghcr.io/openhands/agent-server:fix-workspace-session-cookie-secure-python
ghcr.io/openhands/agent-server:06133cf-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `06133cf-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `06133cf-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->