### PR TITLE
fix(agent-server): bound WebhookSubscriber queue under failed retries

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -88,6 +88,17 @@ class WebhookSpec(BaseModel):
     )
     retry_delay: int = Field(default=5, ge=0, description="The delay between retries")
 
+    # Backpressure parameters
+    max_queue_size: int = Field(
+        default=1000,
+        ge=1,
+        description=(
+            "Upper bound on the number of events buffered for delivery. When the "
+            "downstream is failing and events are re-queued for retry, the oldest "
+            "events are dropped past this bound to prevent unbounded memory growth."
+        ),
+    )
+
 
 class Config(BaseModel):
     """

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1195,8 +1195,15 @@ class WebhookSubscriber(Subscriber):
                         f"Failed to post events to webhook {events_url} "
                         f"after {self.spec.num_retries + 1} attempts"
                     )
-                    # Re-queue events for potential retry later
                     self.queue.extend(events_to_post)
+                    overflow = len(self.queue) - self.spec.max_queue_size
+                    if overflow > 0:
+                        del self.queue[:overflow]
+                        logger.warning(
+                            f"Webhook queue exceeded max_queue_size="
+                            f"{self.spec.max_queue_size}; dropped {overflow} "
+                            f"oldest event(s) for {events_url}."
+                        )
 
     def _cancel_flush_timer(self):
         """Cancel the current flush timer if it exists."""

--- a/tests/agent_server/stress/test_slow_webhook.py
+++ b/tests/agent_server/stress/test_slow_webhook.py
@@ -295,6 +295,7 @@ async def failing_webhook_service(tmp_path: Path, always_fail_webhook_url: str):
                 flush_delay=0.5,
                 num_retries=0,
                 retry_delay=0,
+                max_queue_size=100,
             )
         ],
     )
@@ -302,14 +303,6 @@ async def failing_webhook_service(tmp_path: Path, always_fail_webhook_url: str):
         yield service
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "conversation_service.py:1059 extends failed batches back onto "
-        "self.queue without bound; sustained downstream failure → OOM. "
-        "Tracked in https://github.com/OpenHands/software-agent-sdk/issues/3122."
-    ),
-)
 async def test_webhook_queue_bounded_under_sustained_downstream_failure(
     failing_webhook_service, tmp_path
 ):

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -504,6 +504,53 @@ class TestWebhookSubscriberPostEvents:
         assert subscriber.queue == original_events
 
     @pytest.mark.asyncio
+    async def test_post_events_drops_oldest_when_requeue_exceeds_max_queue_size(
+        self, mock_event_service, sample_conversation_id
+    ):
+        """Failed re-queue trims oldest events past max_queue_size."""
+        # Tight bound so we can construct overflow easily.
+        spec = WebhookSpec(
+            base_url="https://example.com",
+            event_buffer_size=1,
+            flush_delay=0.1,
+            num_retries=0,
+            retry_delay=0,
+            max_queue_size=3,
+        )
+        subscriber = WebhookSubscriber(
+            conversation_id=sample_conversation_id,
+            service=mock_event_service,
+            spec=spec,
+        )
+
+        # Build 5 distinct, identifiable events.
+        events = []
+        for i in range(5):
+            ev = MessageEvent(
+                source="user",
+                llm_message=Message(role="user", content=[TextContent(text=f"e{i}")]),
+            )
+            events.append(ev)
+
+        # Pre-load queue beyond bound so re-extend after failure must trim.
+        subscriber.queue = events.copy()
+
+        async def mock_request(*args, **kwargs):
+            raise httpx.HTTPStatusError(
+                "Server Error", request=MagicMock(), response=MagicMock()
+            )
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.request = mock_request
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+            await subscriber._post_events()
+
+        # Bound is honored, and the *oldest* events are the ones dropped.
+        assert len(subscriber.queue) == spec.max_queue_size
+        assert subscriber.queue == events[-spec.max_queue_size :]
+
+    @pytest.mark.asyncio
     @patch("httpx.AsyncClient")
     async def test_post_events_handles_events_without_model_dump(
         self,


### PR DESCRIPTION
- [ ] A human has tested these changes.

## Summary

- Adds WebhookSpec.max_queue_size (default 1000) and trims oldest events when re-queuing a failed batch would exceed the bound — prevents the OOM path documented in #3122.
- Removes the xfail marker from test_webhook_queue_bounded_under_sustained_downstream_failure and tightens its fixture to max_queue_size=100 so the bound is exercised within the test's 500-event window.
- Adds a unit test asserting the failed re-queue drops the oldest events (drop-oldest, not drop-newest).

## Issue Number
Closes #3122

## How to Test

- uv run pytest tests/agent_server/test_webhook_subscriber.py — 37 pass, 1 pre-existing xfail
- uv run pytest tests/agent_server/stress/test_slow_webhook.py -m stress — both stress tests pass
- uv run pre-commit run --files <changed> — ruff/pycodestyle/pyright all pass

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:868490b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-868490b-python \
  ghcr.io/openhands/agent-server:868490b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:868490b-golang-amd64
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-golang-amd64
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-golang-amd64
ghcr.io/openhands/agent-server:868490b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:868490b-golang-arm64
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-golang-arm64
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-golang-arm64
ghcr.io/openhands/agent-server:868490b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:868490b-java-amd64
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-java-amd64
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-java-amd64
ghcr.io/openhands/agent-server:868490b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:868490b-java-arm64
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-java-arm64
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-java-arm64
ghcr.io/openhands/agent-server:868490b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:868490b-python-amd64
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-python-amd64
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-python-amd64
ghcr.io/openhands/agent-server:868490b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:868490b-python-arm64
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-python-arm64
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-python-arm64
ghcr.io/openhands/agent-server:868490b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:868490b-golang
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-golang
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-golang
ghcr.io/openhands/agent-server:868490b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:868490b-java
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-java
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-java
ghcr.io/openhands/agent-server:868490b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:868490b-python
ghcr.io/openhands/agent-server:868490b380cd24a94447c15a171f37ef8c83a9d7-python
ghcr.io/openhands/agent-server:3122-agent-server-webhooksubscriberqueue-grows-unbounded-under-sustained-downstream-failure-python
ghcr.io/openhands/agent-server:868490b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `868490b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `868490b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->