### PR TITLE
fix(agent-server): propagate subscriber init errors

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -993,28 +993,32 @@ class ConversationService:
             cipher=self.cipher,
             owner_instance_id=self.owner_instance_id,
         )
-        # Create subscribers...
-        await event_service.subscribe_to_events(_EventSubscriber(service=event_service))
-        if stored.autotitle and stored.title is None:
-            await event_service.subscribe_to_events(
-                AutoTitleSubscriber(service=event_service)
-            )
-        asyncio.gather(
-            *[
-                event_service.subscribe_to_events(
-                    WebhookSubscriber(
-                        conversation_id=stored.id,
-                        service=event_service,
-                        spec=webhook_spec,
-                        session_api_key=self.session_api_key,
-                    )
-                )
-                for webhook_spec in self.webhook_specs
-            ]
-        )
 
         try:
             await event_service.start()
+            # Register subscribers after start() so subscribe_to_events runs
+            # its initial-state push synchronously and any failure surfaces to
+            # the caller instead of being silently logged on a later publish.
+            await event_service.subscribe_to_events(
+                _EventSubscriber(service=event_service)
+            )
+            if stored.autotitle and stored.title is None:
+                await event_service.subscribe_to_events(
+                    AutoTitleSubscriber(service=event_service)
+                )
+            await asyncio.gather(
+                *[
+                    event_service.subscribe_to_events(
+                        WebhookSubscriber(
+                            conversation_id=stored.id,
+                            service=event_service,
+                            spec=webhook_spec,
+                            session_api_key=self.session_api_key,
+                        )
+                    )
+                    for webhook_spec in self.webhook_specs
+                ]
+            )
             # Save metadata immediately after successful start to ensure persistence
             # even if the system is not shut down gracefully
             await event_service.save_meta()

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -424,10 +424,7 @@ class EventService:
                     f"Initial state push to subscriber {subscriber_id} timed "
                     f"out after {INITIAL_STATE_PUSH_TIMEOUT_SECONDS}s."
                 )
-            except Exception as e:
-                logger.error(
-                    f"Error sending initial state to subscriber {subscriber_id}: {e}"
-                )
+            # Non-timeout errors propagate to caller (e.g. webhook failures).
 
         return subscriber_id
 

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -1304,19 +1304,6 @@ class TestWebhookSubscriberTimerBehavior:
         subscriber._post_events.assert_called_once()
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "Subscribe-time errors from a subscriber's initial __call__ never "
-        "reach the start_conversation caller. Two swallow sites in series: "
-        "event_service.py:411-416 wraps the initial state sync in "
-        "try/except + logger.error (no re-raise), and "
-        "conversation_service.py:862 fires asyncio.gather() on the webhook "
-        "subscribes without awaiting. Both must be fixed for init errors "
-        "to surface. "
-        "Tracked in https://github.com/OpenHands/software-agent-sdk/issues/3121."
-    ),
-)
 @pytest.mark.timeout(30)
 async def test_webhook_subscribe_errors_surface(tmp_path, monkeypatch):
     persist = tmp_path / "persist"


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

- Removes the try/except + logger.error wrap around the initial-state push in EventService.subscribe_to_events (event_service.py:411-416) so failures from a new subscriber's first __call__ propagate to the caller.
- awaits the previously fire-and-forget asyncio.gather(...) of WebhookSubscriber registrations in ConversationService._start_event_service.
- Moves all subscriber registration to after event_service.start(). Required because at the prior call site _conversation was still None, so subscribe_to_events's initial-state branch was skipped — the broken __call__ only fired
  later via pub_sub, which swallows by design for inter-subscriber isolation. Registering after start() exercises the propagating path uniformly.
- Drops the xfail marker on test_webhook_subscribe_errors_surface (was tracking this issue).

**Behavior change to flag**
A subscriber failing during initial state push now causes start_conversation to raise instead of logging silently. event_service.close() runs as part of cleanup, so save_meta() no longer persists half-started conversations. This is the loud-fail behavior the issue calls for, but operators relying on "start always succeeds even if a webhook is broken" will see a difference.

## Issue Number
Closes #3121

## How to Test
- uv run pytest tests/agent_server/test_webhook_subscriber.py::test_webhook_subscribe_errors_surface — passes (previously xfail)
- uv run pytest tests/agent_server/test_webhook_subscriber.py tests/agent_server/test_event_service.py tests/agent_server/test_conversation_service.py tests/agent_server/test_conversation_router.py 
  tests/agent_server/test_conversation_tags.py tests/agent_server/test_conversation_service_plugin.py — 249 passed, 1 unrelated pre-existing failure (TestAutoTitle::test_autotitle_sets_title_on_first_user_message, reproduces on
  baseline)
- uv run pre-commit run --files <changed> — ruff format, ruff lint, pycodestyle, pyright, import-rules, tool-registration all pass

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2fec5b0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2fec5b0-python \
  ghcr.io/openhands/agent-server:2fec5b0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2fec5b0-golang-amd64
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-golang-amd64
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-golang-amd64
ghcr.io/openhands/agent-server:2fec5b0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2fec5b0-golang-arm64
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-golang-arm64
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-golang-arm64
ghcr.io/openhands/agent-server:2fec5b0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2fec5b0-java-amd64
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-java-amd64
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-java-amd64
ghcr.io/openhands/agent-server:2fec5b0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2fec5b0-java-arm64
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-java-arm64
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-java-arm64
ghcr.io/openhands/agent-server:2fec5b0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2fec5b0-python-amd64
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-python-amd64
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-python-amd64
ghcr.io/openhands/agent-server:2fec5b0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2fec5b0-python-arm64
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-python-arm64
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-python-arm64
ghcr.io/openhands/agent-server:2fec5b0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2fec5b0-golang
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-golang
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-golang
ghcr.io/openhands/agent-server:2fec5b0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2fec5b0-java
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-java
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-java
ghcr.io/openhands/agent-server:2fec5b0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2fec5b0-python
ghcr.io/openhands/agent-server:2fec5b0c689afc20855a2daf2481ecf4b11b56f1-python
ghcr.io/openhands/agent-server:3121-agent-server-subscriber-init-errors-are-silently-swallowed-two-sites-python
ghcr.io/openhands/agent-server:2fec5b0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2fec5b0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2fec5b0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->