### PR TITLE
fix(agent-server): bound initial-state push in subscribe_to_events

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -42,6 +42,7 @@ from openhands.sdk.workspace import LocalWorkspace
 
 
 LEASE_RENEW_INTERVAL_SECONDS = 15.0
+INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
 
 
 logger = get_logger(__name__)
@@ -409,7 +410,15 @@ class EventService:
             state_update_event = await self._create_state_update_event()
 
             try:
-                await subscriber(state_update_event)
+                await asyncio.wait_for(
+                    subscriber(state_update_event),
+                    timeout=INITIAL_STATE_PUSH_TIMEOUT_SECONDS,
+                )
+            except TimeoutError:
+                logger.warning(
+                    f"Initial state push to subscriber {subscriber_id} timed "
+                    f"out after {INITIAL_STATE_PUSH_TIMEOUT_SECONDS}s."
+                )
             except Exception as e:
                 logger.error(
                     f"Error sending initial state to subscriber {subscriber_id}: {e}"

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -42,6 +42,8 @@ from openhands.sdk.workspace import LocalWorkspace
 
 
 LEASE_RENEW_INTERVAL_SECONDS = 15.0
+# Bounds initial-state push so subscribe_to_events does not stall on a
+# subscriber whose __call__ blocks (e.g. WS with a full TCP send buffer).
 INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
 
 
@@ -415,6 +417,9 @@ class EventService:
                     timeout=INITIAL_STATE_PUSH_TIMEOUT_SECONDS,
                 )
             except TimeoutError:
+                # Subscriber stays registered; only the initial-state push is
+                # dropped. Subsequent publishes go through pub_sub and may
+                # still block there if the subscriber remains wedged.
                 logger.warning(
                     f"Initial state push to subscriber {subscriber_id} timed "
                     f"out after {INITIAL_STATE_PUSH_TIMEOUT_SECONDS}s."

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -2051,15 +2051,6 @@ class _WedgedSubscriber:
         self.unblock.set()  # let PubSub.close() finish
 
 
-@pytest.mark.xfail(
-    strict=True,
-    reason=(
-        "event_service.py:412 awaits subscriber(state_update_event) "
-        "synchronously; a wedged WS client deadlocks the WS handler "
-        "(reachable from sockets.py:250). "
-        "Tracked in https://github.com/OpenHands/software-agent-sdk/issues/3118."
-    ),
-)
 @pytest.mark.timeout(15)
 async def test_subscribe_to_events_does_not_deadlock_on_wedged_subscriber(
     real_conversation_service, tmp_path


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

- Wraps the initial-state subscriber call at event_service.py:412 in asyncio.wait_for(...) with a 0.5s timeout, defined as a module constant INITIAL_STATE_PUSH_TIMEOUT_SECONDS matching the existing LEASE_RENEW_INTERVAL_SECONDS style.
- On timeout, logs a warning and returns the subscriber id — subscribe_to_events no longer deadlocks on a wedged WS client (TCP send buffer full) or any other subscriber whose __call__ blocks indefinitely.
- Drops the xfail marker on test_subscribe_to_events_does_not_deadlock_on_wedged_subscriber.

**Design choice**

Chose timeout over fan-out-as-background-task. A detached task would lose error propagation — init errors would land in an orphan task and never reach the caller. With wait_for, fast failures still propagate via the existing except
Exception branch; only the blocking case is short-circuited. This keeps the fix forward-compatible with #3121 (which wants subscriber init errors to surface to start_conversation).

**Out of scope**

The wedged subscriber stays registered after the timeout, so a subsequent pub_sub publication will still block on it (pub_sub.__call__ awaits subscribers sequentially). #3118 is specifically about subscribe_to_events deadlocking; the downstream pub_sub deadlock is a separate surface and not addressed here.


## Issue Number
Closes #3118

## How to Test
- uv run pytest tests/agent_server/test_event_service.py::test_subscribe_to_events_does_not_deadlock_on_wedged_subscriber — passes (previously xfail)
- uv run pytest tests/agent_server/test_event_service.py tests/agent_server/test_webhook_subscriber.py tests/agent_server/test_event_router_websocket.py tests/agent_server/test_conversation_service.py — 195 passed, 1 xfail (the
  unrelated #3121 marker), 1 pre-existing failure (TestAutoTitle::test_autotitle_sets_title_on_first_user_message, reproduces on baseline via git stash)
- uv run pre-commit run --files <changed> — ruff format, ruff lint, pycodestyle, pyright, import-rules, tool-registration all pass

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ce02843-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ce02843-python \
  ghcr.io/openhands/agent-server:ce02843-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ce02843-golang-amd64
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-golang-amd64
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-golang-amd64
ghcr.io/openhands/agent-server:ce02843-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ce02843-golang-arm64
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-golang-arm64
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-golang-arm64
ghcr.io/openhands/agent-server:ce02843-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ce02843-java-amd64
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-java-amd64
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-java-amd64
ghcr.io/openhands/agent-server:ce02843-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ce02843-java-arm64
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-java-arm64
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-java-arm64
ghcr.io/openhands/agent-server:ce02843-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ce02843-python-amd64
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-python-amd64
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-python-amd64
ghcr.io/openhands/agent-server:ce02843-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ce02843-python-arm64
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-python-arm64
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-python-arm64
ghcr.io/openhands/agent-server:ce02843-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ce02843-golang
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-golang
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-golang
ghcr.io/openhands/agent-server:ce02843-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ce02843-java
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-java
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-java
ghcr.io/openhands/agent-server:ce02843-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ce02843-python
ghcr.io/openhands/agent-server:ce0284392a451c0857ac86813a524e68ca8f027a-python
ghcr.io/openhands/agent-server:3118-agent-server-subscribe-to-events-deadlocks-on-a-wedged-ws-subscriber-python
ghcr.io/openhands/agent-server:ce02843-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ce02843-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ce02843-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->