### PR TITLE
feat: return dynamic favorites + roots from /api/file/home

### DIFF
--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -33,8 +33,15 @@ class SubdirectoryPage(BaseModel):
     next_page_id: str | None = None
 
 
+class FileBrowserEntry(BaseModel):
+    label: str
+    path: str
+
+
 class HomeResponse(BaseModel):
     home: str
+    favorites: list[FileBrowserEntry] = []
+    locations: list[FileBrowserEntry] = []
 
 
 logger = get_logger(__name__)
@@ -141,13 +148,66 @@ async def download_file_query(
     return await _download_file(path)
 
 
+def _list_home_favorites(home: Path, limit: int = 50) -> list[FileBrowserEntry]:
+    """Top-level visible directories inside the user's home, alphabetised.
+
+    Hidden entries (names starting with '.') and symlinks are skipped so the
+    list matches what ``search_subdirs`` returns for the same path.
+    """
+    entries: list[FileBrowserEntry] = []
+    try:
+        with os.scandir(home) as scanner:
+            for entry in scanner:
+                if entry.name.startswith("."):
+                    continue
+                try:
+                    if not entry.is_dir(follow_symlinks=False):
+                        continue
+                except OSError:
+                    continue
+                entries.append(
+                    FileBrowserEntry(label=entry.name, path=str(home / entry.name))
+                )
+    except (PermissionError, FileNotFoundError):
+        return []
+    entries.sort(key=lambda e: e.label.lower())
+    return entries[:limit]
+
+
+def _list_root_locations() -> list[FileBrowserEntry]:
+    """Filesystem roots: present drives on Windows, '/' on POSIX."""
+    if os.name == "nt":
+        from string import ascii_uppercase
+
+        roots: list[FileBrowserEntry] = []
+        for letter in ascii_uppercase:
+            candidate = Path(f"{letter}:\\")
+            try:
+                if candidate.exists():
+                    roots.append(
+                        FileBrowserEntry(label=f"{letter}:", path=str(candidate))
+                    )
+            except OSError:
+                continue
+        return roots
+    return [FileBrowserEntry(label="/", path="/")]
+
+
 @file_router.get("/home")
 async def get_home_directory() -> HomeResponse:
-    """Return the agent-server user's home directory.
+    """Return the agent-server user's home directory and dynamic sidebar lists.
 
-    Used by the GUI to start a folder-browser at a sensible default location.
+    ``favorites`` is the set of visible top-level directories actually present
+    in the user's home (so it reflects the real environment instead of a
+    hardcoded list of names that may not exist). ``locations`` is the set of
+    filesystem roots — '/' on POSIX or available drive letters on Windows.
     """
-    return HomeResponse(home=str(Path.home()))
+    home = Path.home()
+    return HomeResponse(
+        home=str(home),
+        favorites=_list_home_favorites(home),
+        locations=_list_root_locations(),
+    )
 
 
 @file_router.get("/search_subdirs")

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -396,6 +396,32 @@ def test_get_home_returns_user_home(client):
     assert response.json()["home"] == str(Path.home())
 
 
+def test_get_home_returns_dynamic_favorites_and_locations(
+    client, tmp_path, monkeypatch
+):
+    # Arrange: pretend the user's home is tmp_path, populated with a mix of
+    # visible dirs, a hidden dir, and a file. Favorites should include only
+    # the visible dirs, alphabetised. Locations should report the POSIX root.
+    monkeypatch.setenv("HOME", str(tmp_path))
+    (tmp_path / "projects").mkdir()
+    (tmp_path / "Documents").mkdir()
+    (tmp_path / ".cache").mkdir()
+    (tmp_path / "readme.txt").write_text("ignored")
+
+    # Act
+    response = client.get("/api/file/home")
+
+    # Assert
+    assert response.status_code == 200
+    body = response.json()
+    assert body["home"] == str(tmp_path)
+    assert body["favorites"] == [
+        {"label": "Documents", "path": str(tmp_path / "Documents")},
+        {"label": "projects", "path": str(tmp_path / "projects")},
+    ]
+    assert body["locations"] == [{"label": "/", "path": "/"}]
+
+
 @pytest.mark.xfail(
     strict=True,
     reason=(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Description

`GET /api/file/home` currently returns only `{"home": "<Path.home()>"}`. Downstream consumers (agent-canvas's Add Workspace modal) work around the limited shape by string-concatenating predefined names — `${home}/Desktop`, `${home}/Documents`, `${home}/Downloads` — which:

- 404s inside the dev Docker image because those subdirectories don't exist (`/home/openhands` has no `Documents`, `Desktop`, `Downloads`).
- Builds invalid paths on Windows (where `Path.home()` is `C:\Users\…` and `/` concatenation produces nonsense).
- Doesn't reflect the user's real environment (XDG-overridden folders, custom top-level dirs, etc.).

The cleanest fix is to move the responsibility into the agent server: the process already knows its OS and filesystem, so let it return what's actually there.

Extend `HomeResponse` with two fields:

- `favorites`: visible top-level directories of `Path.home()`, alphabetized, hidden entries (`.cache`, `.config`, …) and symlinks excluded. Capped at 50 entries to bound pathological homes.
- `locations`: filesystem roots — `[{label:"/", path:"/"}]` on POSIX, the set of present drive letters on Windows.

Both fields default to empty arrays so older clients keep working without change.

## Acceptance criteria

- `GET /api/file/home` returns `home`, `favorites`, `locations` (in that order) and the existing `home` value is unchanged.
- `favorites` contains only entries that satisfy `is_dir()` and don't start with `.`, sorted case-insensitively by name, capped at 50.
- `locations` returns `[{label:"/", path:"/"}]` on POSIX and one entry per existing drive letter on Windows.
- `HomeResponse` is backwards-compatible: existing clients deserializing the response continue to work; the new fields are additive with defaults.
- A regression test exercises the new shape (visible dir, hidden dir, file, and roots) without depending on the developer's real `$HOME`.

## Out of scope

- Persistence / favorites personalization per user.
- Anything in `/api/file/search_subdirs` (already filters hidden + symlinks the same way; no change needed).
- Removing the existing hardcoded sidebar in agent-canvas (tracked in the GUI ticket).

## Summary

<!-- 1-3 bullets describing what changed. -->
- Extend `HomeResponse` with `favorites` (visible top-level dirs of `Path.home()`) and `locations` (filesystem roots).
- Add `_list_home_favorites` and `_list_root_locations` helpers using the same hidden-entry / symlink rules as `search_subdirs`.
- Update `GET /api/file/home` to populate the new fields. Default values keep older clients working unchanged.

## Why

`/api/file/home` only returned `{home: Path.home()}`. The downstream GUI (`agent-canvas` Add Workspace modal) worked around the limited shape by hardcoding `${home}/Desktop|Documents|Downloads`. That breaks in three ways:

1. **Dev Docker image:** the container only has `/home/openhands` — none of the three guessed subdirs exist, so every click 404'd.
2. **Windows:** `Path.home()` is `C:\Users\…` and forward-slash concatenation produces invalid paths.
3. **Real users:** people have arbitrary top-level dirs (custom project roots, XDG-overridden locations) that the hardcoded list misses.

The agent server already knows its OS and filesystem, so it can answer these questions correctly. Moving the responsibility upstream removes the guesswork from every current and future consumer of the endpoint.

## API shape

```jsonc id="gxjlwm"
// Before
GET /api/file/home →
{ "home": "/Users/me" }

// After
GET /api/file/home →
{
  "home": "/Users/me",
  "favorites": [
    { "label": "Documents", "path": "/Users/me/Documents" },
    { "label": "projects",  "path": "/Users/me/projects" }
  ],
  "locations": [
    { "label": "/", "path": "/" }
  ]
}
```

### `favorites`

- Visible top-level directories under `Path.home()`.
- Entries whose names start with `.` are skipped.
- Symlinks are skipped (matches `search_subdirs`).
- Sorted case-insensitively by name, capped at 50.

### `locations`

- POSIX: `[{label:"/", path:"/"}]`.
- Windows: one entry per drive letter that `exists()` (e.g. `C:`, `D:`).

Both fields default to empty arrays in the Pydantic model, so older clients that deserialize `HomeResponse` without these keys continue to work.

## Changes

| File                                                           | Change                                                                                                                                                                                      |
| -------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `openhands-agent-server/openhands/agent_server/file_router.py` | New `FileBrowserEntry` model; `HomeResponse` extended with `favorites` + `locations`; new `_list_home_favorites` / `_list_root_locations` helpers; `get_home_directory` now populates them. |
| `tests/agent_server/test_file_router.py`                       | New regression test: monkeypatches `$HOME` to a temp dir, seeds visible/hidden/file entries, asserts favorites are filtered + sorted and locations contain the POSIX root.                  |

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. `PROJECT_PATH=/path/to/projects npm run dev` (Docker-backed dev mode).
2. Open `http://localhost:3001` → click **Add Workspace**.
3. Click any of the **FAVORITES** entries (Desktop / Documents / Downloads).

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/26501cda-3beb-4341-a41e-405f197e0fe3

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

- **Backwards compatibility:** the new fields are additive with default values. Clients that only consumed `home` keep working. New clients (agent-canvas's Add Workspace fix) start using `favorites` / `locations` once they upgrade.
- **Privacy:** `favorites` lists top-level directory names under the user's home. This is no broader than what `search_subdirs` already returns for the same path, and stays behind the existing `/api/file/*` auth.
- **Performance:** scanning at most 50 entries with `os.scandir` is negligible; the endpoint already does an `os.scandir` for `search_subdirs`.
- **No client coupling:** the GUI still works if it doesn't read the new fields, and works if it does. Pair this release with the agent-canvas PR to get the dynamic sidebar UX.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:30ea5cb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-30ea5cb-python \
  ghcr.io/openhands/agent-server:30ea5cb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:30ea5cb-golang-amd64
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-1676-golang-amd64
ghcr.io/openhands/agent-server:30ea5cb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:30ea5cb-golang-arm64
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-1676-golang-arm64
ghcr.io/openhands/agent-server:30ea5cb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:30ea5cb-java-amd64
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-1676-java-amd64
ghcr.io/openhands/agent-server:30ea5cb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:30ea5cb-java-arm64
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-1676-java-arm64
ghcr.io/openhands/agent-server:30ea5cb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:30ea5cb-python-amd64
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-1676-python-amd64
ghcr.io/openhands/agent-server:30ea5cb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:30ea5cb-python-arm64
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-1676-python-arm64
ghcr.io/openhands/agent-server:30ea5cb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:30ea5cb-golang
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-golang
ghcr.io/openhands/agent-server:hieptl-app-1676-golang
ghcr.io/openhands/agent-server:30ea5cb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:30ea5cb-java
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-java
ghcr.io/openhands/agent-server:hieptl-app-1676-java
ghcr.io/openhands/agent-server:30ea5cb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:30ea5cb-python
ghcr.io/openhands/agent-server:30ea5cba480ec6bedeb158fc11551d566bddeb7a-python
ghcr.io/openhands/agent-server:hieptl-app-1676-python
ghcr.io/openhands/agent-server:30ea5cb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `30ea5cb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `30ea5cb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->