### PR TITLE
Prepare AgentSettings removal helpers

### DIFF
--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -23,10 +23,10 @@ from pydantic import (
 )
 
 from openhands.sdk.settings import (
-    AgentSettings,
     AgentSettingsConfig,
     ConversationSettings,
     default_agent_settings,
+    validate_agent_settings,
 )
 from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secret
 
@@ -139,7 +139,7 @@ class PersistedSettings(BaseModel):
                     agent_update,
                 )
                 try:
-                    new_agent = AgentSettings.from_persisted(agent_merged)
+                    new_agent = validate_agent_settings(agent_merged)
                 except Exception as e:
                     # Use 'from None' to break exception chain - the original
                     # exception may contain secret values in Pydantic errors
@@ -218,7 +218,7 @@ class PersistedSettings(BaseModel):
         ensuring forward compatibility when loading settings files saved with
         older schema versions.
 
-        Agent settings are normalized through ``AgentSettings.from_persisted``
+        Agent settings are normalized through ``validate_agent_settings``
         so the same migration entry point is used for settings files and direct
         SDK callers. The validation context is forwarded so cipher-based secret
         decryption still works during the nested settings validation.
@@ -229,7 +229,7 @@ class PersistedSettings(BaseModel):
         agent_settings = data.get("agent_settings")
         if isinstance(agent_settings, dict):
             coerced = _coerce_dict_secrets(agent_settings)
-            data["agent_settings"] = AgentSettings.from_persisted(
+            data["agent_settings"] = validate_agent_settings(
                 coerced,
                 context=info.context,
             )

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1316,12 +1316,21 @@ def validate_agent_settings(
     *,
     context: Mapping[str, Any] | None = None,
 ) -> OpenHandsAgentSettings | LLMAgentSettings | ACPAgentSettings:
-    """Validate ``data`` as an :data:`AgentSettingsConfig` discriminated union.
+    """Load and validate an agent-settings payload.
 
-    This is the drop-in replacement for the old
-    ``AgentSettings.model_validate(...)`` classmethod.
+    Persisted payloads are migrated to the current schema version before
+    validation, including legacy ``agent_kind: "llm"`` payloads from before the
+    ``OpenHandsAgentSettings`` rename.
     """
-    return _AGENT_SETTINGS_ADAPTER.validate_python(data, context=context)
+    if isinstance(data, OpenHandsAgentSettings | ACPAgentSettings):
+        return data
+    payload = _apply_persisted_migrations(
+        data,
+        current_version=AGENT_SETTINGS_SCHEMA_VERSION,
+        migrations=_AGENT_SETTINGS_MIGRATIONS,
+        payload_name="AgentSettings",
+    )
+    return _AGENT_SETTINGS_ADAPTER.validate_python(payload, context=context)
 
 
 class AgentSettings(LLMAgentSettings):
@@ -1363,13 +1372,7 @@ class AgentSettings(LLMAgentSettings):
         context: Mapping[str, Any] | None = None,
     ) -> OpenHandsAgentSettings | LLMAgentSettings | ACPAgentSettings:
         """Load persisted agent settings, applying any schema migrations."""
-        payload = _apply_persisted_migrations(
-            data,
-            current_version=AGENT_SETTINGS_SCHEMA_VERSION,
-            migrations=_AGENT_SETTINGS_MIGRATIONS,
-            payload_name="AgentSettings",
-        )
-        return validate_agent_settings(payload, context=context)
+        return validate_agent_settings(data, context=context)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         from openhands.sdk.utils.deprecation import warn_deprecated
@@ -1409,7 +1412,7 @@ def create_agent_from_settings(
 
 
 def export_agent_settings_schema() -> SettingsSchema:
-    """Export a combined schema for the :data:`AgentSettings` union.
+    """Export a combined schema for the :data:`AgentSettingsConfig` union.
 
     Walks both variants, tags each non-shared section with its variant,
     and returns a single :class:`SettingsSchema`. The discriminator

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -332,7 +332,7 @@ def test_validate_agent_settings_dispatches_on_agent_kind() -> None:
         {"agent_kind": "llm", "llm": {"model": "legacy-model"}}
     )
     assert isinstance(legacy_llm, OpenHandsAgentSettings)
-    assert legacy_llm.agent_kind == "llm"
+    assert legacy_llm.agent_kind == "openhands"
     assert legacy_llm.llm.model == "legacy-model"
 
     acp = validate_agent_settings(
@@ -346,8 +346,8 @@ def test_validate_agent_settings_dispatches_on_agent_kind() -> None:
     assert acp.acp_command == ["npx", "-y", "claude-agent-acp"]
 
 
-def test_agent_settings_from_persisted_migrates_v0_llm_payload() -> None:
-    settings = AgentSettings.from_persisted({"llm": {"model": "test-model"}})
+def test_validate_agent_settings_migrates_v0_llm_payload() -> None:
+    settings = validate_agent_settings({"llm": {"model": "test-model"}})
 
     assert isinstance(settings, OpenHandsAgentSettings)
     assert settings.schema_version == 3
@@ -355,8 +355,8 @@ def test_agent_settings_from_persisted_migrates_v0_llm_payload() -> None:
     assert settings.llm.model == "test-model"
 
 
-def test_agent_settings_from_persisted_dispatches_current_acp_payload() -> None:
-    settings = AgentSettings.from_persisted(
+def test_validate_agent_settings_dispatches_current_acp_payload() -> None:
+    settings = validate_agent_settings(
         {
             "schema_version": 1,
             "agent_kind": "acp",
@@ -371,10 +371,10 @@ def test_agent_settings_from_persisted_dispatches_current_acp_payload() -> None:
     assert settings.acp_command == ["npx", "-y", "claude-agent-acp"]
 
 
-def test_agent_settings_from_persisted_canonicalizes_legacy_llm_kind() -> None:
+def test_validate_agent_settings_canonicalizes_legacy_llm_kind() -> None:
     """v1 payloads with the deprecated ``agent_kind: 'llm'`` are migrated to
     the canonical ``'openhands'`` discriminator on read."""
-    settings = AgentSettings.from_persisted(
+    settings = validate_agent_settings(
         {
             "schema_version": 1,
             "agent_kind": "llm",
@@ -388,8 +388,8 @@ def test_agent_settings_from_persisted_canonicalizes_legacy_llm_kind() -> None:
     assert settings.llm.model == "legacy-model"
 
 
-def test_agent_settings_from_persisted_drops_legacy_verification_fields() -> None:
-    settings = AgentSettings.from_persisted(
+def test_validate_agent_settings_drops_legacy_verification_fields() -> None:
+    settings = validate_agent_settings(
         {
             "schema_version": 2,
             "agent_kind": "openhands",
@@ -409,9 +409,9 @@ def test_agent_settings_from_persisted_drops_legacy_verification_fields() -> Non
     assert "security_analyzer" not in verification
 
 
-def test_agent_settings_from_persisted_rejects_newer_schema_version() -> None:
+def test_validate_agent_settings_rejects_newer_schema_version() -> None:
     with pytest.raises(ValueError, match="newer than supported version 3"):
-        AgentSettings.from_persisted({"schema_version": 4, "llm": {"model": "m"}})
+        validate_agent_settings({"schema_version": 4, "llm": {"model": "m"}})
 
 
 def test_conversation_settings_from_persisted_migrates_v0_payload() -> None:
@@ -834,7 +834,7 @@ def test_acp_agent_settings_acp_env_encrypts_with_cipher() -> None:
     restored = ACPAgentSettings.model_validate(dumped, context={"cipher": cipher})
     assert restored.acp_env == {"OPENAI_API_KEY": "sk-real-secret"}
 
-    restored_from_persisted = AgentSettings.from_persisted(
+    restored_from_persisted = validate_agent_settings(
         dumped, context={"cipher": cipher}
     )
     assert isinstance(restored_from_persisted, ACPAgentSettings)


### PR DESCRIPTION
## Summary
- keep the deprecated `AgentSettings` public export while main remains at v1.22.x, so the API breakage policy stays satisfied until the scheduled removal release
- move persisted settings loading through `validate_agent_settings()` and canonical helpers in agent-server persistence paths
- make `validate_agent_settings()` apply persisted settings migrations directly while preserving validation context for encrypted secrets
- keep compatibility guardrails for the legacy alias while focusing migration tests on the canonical `validate_agent_settings()` entry point

The actual `AgentSettings` public export removal must wait for a version bump to v1.23.0 or later, because its scheduled removal is v1.23.0.

## Testing
- `uv run pytest tests/sdk/test_settings.py -k 'agent_settings or llm_agent_settings or validate_agent_settings or acp_agent_settings_acp_env_encrypts_with_cipher' -q`
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/persistence/models.py openhands-sdk/openhands/sdk/settings/model.py tests/sdk/test_settings.py`

This PR was updated by an AI agent (OpenHands) on behalf of the user.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:455fdd6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-455fdd6-python \
  ghcr.io/openhands/agent-server:455fdd6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:455fdd6-golang-amd64
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-golang-amd64
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-golang-amd64
ghcr.io/openhands/agent-server:455fdd6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:455fdd6-golang-arm64
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-golang-arm64
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-golang-arm64
ghcr.io/openhands/agent-server:455fdd6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:455fdd6-java-amd64
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-java-amd64
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-java-amd64
ghcr.io/openhands/agent-server:455fdd6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:455fdd6-java-arm64
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-java-arm64
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-java-arm64
ghcr.io/openhands/agent-server:455fdd6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:455fdd6-python-amd64
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-python-amd64
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-python-amd64
ghcr.io/openhands/agent-server:455fdd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:455fdd6-python-arm64
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-python-arm64
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-python-arm64
ghcr.io/openhands/agent-server:455fdd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:455fdd6-golang
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-golang
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-golang
ghcr.io/openhands/agent-server:455fdd6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:455fdd6-java
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-java
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-java
ghcr.io/openhands/agent-server:455fdd6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:455fdd6-python
ghcr.io/openhands/agent-server:455fdd6541b28053f2d483e01de68490dbf42c66-python
ghcr.io/openhands/agent-server:remove-legacy-agent-settings-python
ghcr.io/openhands/agent-server:455fdd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `455fdd6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `455fdd6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->