### PR TITLE
fix(release): dispatch server.yml to build versioned Docker images on release

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -94,6 +94,21 @@ jobs:
 
                   echo "🚀 Dispatched pypi-release.yml for v${VERSION}"
 
+            - name: Dispatch Agent Server image build
+              # server.yml builds versioned Docker images (e.g. 1.21.0-python) when
+              # triggered on a tag ref. Tags created by GITHUB_TOKEN don't trigger
+              # workflow runs automatically, so we dispatch it explicitly here.
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh workflow run server.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref "v${VERSION}"
+
+                  echo "🐳 Dispatched server.yml image build for v${VERSION}"
+
             - name: Summary
               env:
                   VERSION: ${{ steps.version.outputs.version }}
@@ -104,3 +119,4 @@ jobs:
                   echo "- **Release**: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
                   echo "" >> "$GITHUB_STEP_SUMMARY"
                   echo "The \`pypi-release.yml\` workflow was dispatched to publish packages to PyPI." >> "$GITHUB_STEP_SUMMARY"
+                  echo "The \`server.yml\` workflow was dispatched to build versioned Docker images." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary

Fixes #3207.

Tags created by `GITHUB_TOKEN` do not trigger other workflow runs (GitHub Actions prevents this to avoid infinite loops). When `create-release.yml` creates the `v1.21.0` git tag, `server.yml` is silently never triggered, so versioned Docker images like `ghcr.io/openhands/agent-server:1.21.0-python` are never built.

This adds an explicit `workflow_dispatch` of `server.yml` on the release tag immediately after the release is created. `workflow_dispatch` events triggered by `GITHUB_TOKEN` are allowed, and `server.yml` already has the logic to produce versioned tags when `github.ref` starts with `refs/tags/`.

## Changes

- Add "Dispatch Agent Server image build" step in `create-release.yml` that dispatches `server.yml` on `v${VERSION}` after creating the release
- Update the Summary step to mention the image build dispatch

## Test plan

- [ ] Merge a release PR and confirm `server.yml` is dispatched on the release tag
- [ ] Confirm `ghcr.io/openhands/agent-server:<version>-python` (and `-java`, `-golang`) appear in GHCR after the run completes
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7946f1b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7946f1b-python \
  ghcr.io/openhands/agent-server:7946f1b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7946f1b-golang-amd64
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-golang-amd64
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-golang-amd64
ghcr.io/openhands/agent-server:7946f1b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7946f1b-golang-arm64
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-golang-arm64
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-golang-arm64
ghcr.io/openhands/agent-server:7946f1b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7946f1b-java-amd64
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-java-amd64
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-java-amd64
ghcr.io/openhands/agent-server:7946f1b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7946f1b-java-arm64
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-java-arm64
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-java-arm64
ghcr.io/openhands/agent-server:7946f1b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7946f1b-python-amd64
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-python-amd64
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-python-amd64
ghcr.io/openhands/agent-server:7946f1b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7946f1b-python-arm64
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-python-arm64
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-python-arm64
ghcr.io/openhands/agent-server:7946f1b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7946f1b-golang
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-golang
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-golang
ghcr.io/openhands/agent-server:7946f1b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7946f1b-java
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-java
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-java
ghcr.io/openhands/agent-server:7946f1b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7946f1b-python
ghcr.io/openhands/agent-server:7946f1bd24a61c291b12ee9e824dc795d7354c03-python
ghcr.io/openhands/agent-server:fix-dispatch-server-workflow-on-release-python
ghcr.io/openhands/agent-server:7946f1b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7946f1b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7946f1b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->