### PR TITLE
fix(release): remaining Docker image fixes — merge-manifests gate, v-prefix stripping, release-binaries dispatch

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -94,6 +94,34 @@ jobs:
 
                   echo "🚀 Dispatched pypi-release.yml for v${VERSION}"
 
+            # Events created by GITHUB_TOKEN don't trigger other workflows,
+            # so the tag push above won't trigger server.yml or
+            # release-binaries.yml automatically. Dispatch them explicitly.
+            - name: Dispatch Agent Server Docker build
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh workflow run server.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref "v${VERSION}"
+
+                  echo "🐳 Dispatched server.yml for v${VERSION}"
+
+            - name: Dispatch release binaries workflow
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  VERSION: ${{ steps.version.outputs.version }}
+              run: |
+                  gh workflow run release-binaries.yml \
+                    --repo "${{ github.repository }}" \
+                    --ref "v${VERSION}" \
+                    -f release_tag="v${VERSION}"
+
+                  echo "📦 Dispatched release-binaries.yml for v${VERSION}"
+
             - name: Summary
               env:
                   VERSION: ${{ steps.version.outputs.version }}
@@ -103,4 +131,7 @@ jobs:
                   echo "- **Tag**: v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
                   echo "- **Release**: https://github.com/${{ github.repository }}/releases/tag/v${VERSION}" >> "$GITHUB_STEP_SUMMARY"
                   echo "" >> "$GITHUB_STEP_SUMMARY"
-                  echo "The \`pypi-release.yml\` workflow was dispatched to publish packages to PyPI." >> "$GITHUB_STEP_SUMMARY"
+                  echo "Dispatched workflows:" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- \`pypi-release.yml\` — publish packages to PyPI" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- \`server.yml\` — build and push Docker images" >> "$GITHUB_STEP_SUMMARY"
+                  echo "- \`release-binaries.yml\` — build and attach release binaries" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -335,6 +335,7 @@ jobs:
         needs: build-and-push-image
         if: >
             github.event_name == 'push' ||
+            github.event_name == 'workflow_dispatch' ||
             (github.event_name == 'pull_request' &&
              !github.event.pull_request.head.repo.fork)
         runs-on: ubuntu-24.04

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -473,7 +473,11 @@ class BuildOptions(BaseModel):
     @property
     def release_tag_source(self) -> str | None:
         if self.git_ref.startswith("refs/tags/"):
-            return self.git_ref.removeprefix("refs/tags/")
+            tag = self.git_ref.removeprefix("refs/tags/")
+            # Strip the conventional "v" prefix so versioned Docker tags use
+            # bare semver (e.g. 1.21.0-python), matching the sdk_version
+            # fallback and the format that downstream consumers expect.
+            return tag.removeprefix("v")
         if self.sdk_version and self.sdk_version != "unknown":
             return self.sdk_version
         return None

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -474,10 +474,12 @@ class BuildOptions(BaseModel):
     def release_tag_source(self) -> str | None:
         if self.git_ref.startswith("refs/tags/"):
             tag = self.git_ref.removeprefix("refs/tags/")
-            # Strip the conventional "v" prefix so versioned Docker tags use
-            # bare semver (e.g. 1.21.0-python), matching the sdk_version
-            # fallback and the format that downstream consumers expect.
-            return tag.removeprefix("v")
+            # For semver release tags (v1.2.3), use the SDK package version
+            # which follows PEP 440 (bare semver, no "v" prefix).
+            if _SEMVER_RELEASE_RE.fullmatch(tag) and self.sdk_version != "unknown":
+                return self.sdk_version
+            # Non-semver tags (e.g. build-docker) are used as-is.
+            return tag
         if self.sdk_version and self.sdk_version != "unknown":
             return self.sdk_version
         return None

--- a/openhands-agent-server/openhands/agent_server/docker/build.py
+++ b/openhands-agent-server/openhands/agent_server/docker/build.py
@@ -476,8 +476,11 @@ class BuildOptions(BaseModel):
             tag = self.git_ref.removeprefix("refs/tags/")
             # For semver release tags (v1.2.3), use the SDK package version
             # which follows PEP 440 (bare semver, no "v" prefix).
-            if _SEMVER_RELEASE_RE.fullmatch(tag) and self.sdk_version != "unknown":
-                return self.sdk_version
+            if _SEMVER_RELEASE_RE.fullmatch(tag):
+                if self.sdk_version != "unknown":
+                    return self.sdk_version
+                # Defensive: strip "v" if sdk_version is unavailable.
+                return tag.removeprefix("v")
             # Non-semver tags (e.g. build-docker) are used as-is.
             return tag
         if self.sdk_version and self.sdk_version != "unknown":

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -372,6 +372,20 @@ def test_versioned_tags_use_sdk_version_for_semver_git_tags():
     assert opts.versioned_tags == ["1-python", "1.2-python", "1.2.3-python"]
 
 
+def test_versioned_tags_semver_git_tag_strips_v_when_sdk_version_unknown():
+    """Semver git tags still produce bare semver even if sdk_version is unknown."""
+    from openhands.agent_server.docker.build import BuildOptions
+
+    opts = BuildOptions(
+        custom_tags="python",
+        git_ref="refs/tags/v1.2.3",
+        sdk_version="unknown",
+        include_versioned_tag=True,
+    )
+
+    assert opts.versioned_tags == ["1-python", "1.2-python", "1.2.3-python"]
+
+
 def test_versioned_tags_fallback_to_sdk_version_aliases():
     """Test versioned_tags fall back to the SDK version when no git tag exists."""
     from openhands.agent_server.docker.build import BuildOptions

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -357,19 +357,18 @@ def test_release_tag_aliases_sanitize_non_semver_tags():
     assert _release_tag_aliases("release/v1.2.3+build") == ["release-v1.2.3-build"]
 
 
-def test_versioned_tags_use_git_tag_semver_aliases():
-    """Test versioned_tags derived from a git tag strip the v prefix."""
+def test_versioned_tags_use_sdk_version_for_semver_git_tags():
+    """Semver git tags (v1.2.3) defer to sdk_version (PEP 440, no 'v')."""
     from openhands.agent_server.docker.build import BuildOptions
 
     opts = BuildOptions(
         custom_tags="python",
         git_ref="refs/tags/v1.2.3",
-        sdk_version="9.9.9",
+        sdk_version="1.2.3",
         include_versioned_tag=True,
     )
 
-    # The "v" prefix is stripped so Docker tags use bare semver,
-    # matching the sdk_version fallback and downstream expectations.
+    # Docker tags use bare semver from sdk_version, not the git tag.
     assert opts.versioned_tags == ["1-python", "1.2-python", "1.2.3-python"]
 
 
@@ -448,6 +447,7 @@ def test_all_tags_includes_versioned_tags():
     opts = BuildOptions(
         custom_tags="python,java",
         git_ref="refs/tags/v1.2.0",
+        sdk_version="1.2.0",
         git_sha="abc1234567890",
         include_versioned_tag=True,
         include_base_tag=False,
@@ -493,6 +493,7 @@ def test_all_tags_with_arch_suffix():
     opts = BuildOptions(
         custom_tags="python",
         git_ref="refs/tags/v1.2.0",
+        sdk_version="1.2.0",
         git_sha="abc1234567890",
         arch="amd64",
         include_versioned_tag=True,

--- a/tests/agent_server/test_docker_build.py
+++ b/tests/agent_server/test_docker_build.py
@@ -358,7 +358,7 @@ def test_release_tag_aliases_sanitize_non_semver_tags():
 
 
 def test_versioned_tags_use_git_tag_semver_aliases():
-    """Test versioned_tags derived from a git tag include semver aliases."""
+    """Test versioned_tags derived from a git tag strip the v prefix."""
     from openhands.agent_server.docker.build import BuildOptions
 
     opts = BuildOptions(
@@ -368,7 +368,9 @@ def test_versioned_tags_use_git_tag_semver_aliases():
         include_versioned_tag=True,
     )
 
-    assert opts.versioned_tags == ["v1-python", "v1.2-python", "v1.2.3-python"]
+    # The "v" prefix is stripped so Docker tags use bare semver,
+    # matching the sdk_version fallback and downstream expectations.
+    assert opts.versioned_tags == ["1-python", "1.2-python", "1.2.3-python"]
 
 
 def test_versioned_tags_fallback_to_sdk_version_aliases():
@@ -440,7 +442,7 @@ def test_all_tags_include_short_long_sha_and_branch():
 
 
 def test_all_tags_includes_versioned_tags():
-    """Test that all_tags includes semver aliases when enabled for a tag build."""
+    """Test that all_tags includes bare semver aliases when enabled for a tag build."""
     from openhands.agent_server.docker.build import BuildOptions
 
     opts = BuildOptions(
@@ -455,11 +457,12 @@ def test_all_tags_includes_versioned_tags():
 
     assert "ghcr.io/openhands/agent-server:abc1234-python" in all_tags
     assert "ghcr.io/openhands/agent-server:abc1234567890-python" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1-python" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1.2-python" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1.2.0-python" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1.2.0-java" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1-java" in all_tags
+    # Versioned tags use bare semver (no "v" prefix)
+    assert "ghcr.io/openhands/agent-server:1-python" in all_tags
+    assert "ghcr.io/openhands/agent-server:1.2-python" in all_tags
+    assert "ghcr.io/openhands/agent-server:1.2.0-python" in all_tags
+    assert "ghcr.io/openhands/agent-server:1.2.0-java" in all_tags
+    assert "ghcr.io/openhands/agent-server:1-java" in all_tags
 
 
 def test_all_tags_excludes_versioned_tags_when_disabled():
@@ -498,9 +501,10 @@ def test_all_tags_with_arch_suffix():
 
     all_tags = opts.all_tags
 
-    assert "ghcr.io/openhands/agent-server:v1-python-amd64" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1.2-python-amd64" in all_tags
-    assert "ghcr.io/openhands/agent-server:v1.2.0-python-amd64" in all_tags
+    # Versioned tags use bare semver (no "v" prefix)
+    assert "ghcr.io/openhands/agent-server:1-python-amd64" in all_tags
+    assert "ghcr.io/openhands/agent-server:1.2-python-amd64" in all_tags
+    assert "ghcr.io/openhands/agent-server:1.2.0-python-amd64" in all_tags
     assert "ghcr.io/openhands/agent-server:abc1234567890-python-amd64" in all_tags
 
 


### PR DESCRIPTION
## Context

PR #3209 fixed the primary issue: `server.yml` was not being dispatched from `create-release.yml` because `GITHUB_TOKEN`-created events don't propagate. This PR addresses the **remaining issues** that would still prevent the dispatched workflow from producing correct, pullable Docker images.

## Problem

Even with #3209 merged, three issues remain:

1. **`merge-manifests` job skips on `workflow_dispatch`** — The job condition only allows `push` and `pull_request` events, so the dispatched `server.yml` run builds per-arch images but never creates the multi-arch manifest. `docker pull ghcr.io/openhands/agent-server:1.21.0-python` still fails.

2. **Versioned Docker tags have a `v` prefix** — The `release_tag_source` property extracts the version from the git ref (`refs/tags/v1.21.0` → `v1.21.0`), producing tags like `v1.21.0-python`. But consumers expect `1.21.0-python` (no prefix). The old code used `sdk_version` (the PEP 440 package version, always bare semver) — the refactoring that introduced `release_tag_source` accidentally switched the source from the package version to the raw git tag.

3. **`release-binaries.yml` is also not dispatched** — Same `GITHUB_TOKEN` limitation: the `release: published` event doesn't propagate, so binary artifacts aren't attached to releases.

## Evidence: every existing agent-server image uses bare semver (no `v` prefix)

Queried the GHCR OCI registry directly (`/v2/openhands/agent-server/tags/list`, all 115,789 tags):

| Check | Result |
|---|---|
| Tags matching `v<semver>-<variant>` (e.g. `v1.19.1-python`) | **0** — never existed |
| Tags matching `<semver>-<variant>` (e.g. `1.19.1-python`) | **308** — every release from `1.0.0` through `1.19.1` |
| Tags for 1.20+ (any format) | **0** — confirms nothing was published after the regression |

```
$ # Sample from GHCR tag listing (all 308 bare-semver release tags)
1.0.0-python-amd64
1.0.0-python-arm64
...
1.18.1-python
1.18.1-python-amd64
1.18.1-python-arm64
1.19.0-python
1.19.0-python-amd64
1.19.0-python-arm64
1.19.1-python        # ← last working release
1.19.1-python-amd64
1.19.1-python-arm64
                     # ← nothing after this (1.20.0+ missing)
```

Without the fix, the dispatched `server.yml` would produce `v1.22.0-python` — a format that has never existed in the registry and that the deploy system won't find.

## Changes

### 1. `server.yml` — add `workflow_dispatch` to `merge-manifests` condition
```yaml
# Before (skips dispatched runs):
if: github.event_name == 'push' || (pull_request && ...)

# After:
if: github.event_name == 'push' || github.event_name == 'workflow_dispatch' || (pull_request && ...)
```

### 2. `build.py` — prefer `sdk_version` for semver release tags
For semver git tags (like `v1.2.3`), `release_tag_source` now uses `sdk_version` (the PEP 440 package version, always bare semver) instead of extracting from the git ref. Non-semver tags (like `build-docker`) pass through unchanged.

```python
# Before: extracts from git ref → "v1.21.0" → v1.21.0-python
return self.git_ref.removeprefix("refs/tags/")

# After: for semver tags, uses sdk_version → "1.21.0" → 1.21.0-python
if _SEMVER_RELEASE_RE.fullmatch(tag) and self.sdk_version != "unknown":
    return self.sdk_version
return tag  # non-semver tags pass through as-is
```

### 3. `create-release.yml` — dispatch `release-binaries.yml`
Adds explicit `gh workflow run release-binaries.yml` step (same pattern as the existing pypi-release and server.yml dispatches).

## Testing

- All 38 tests in `tests/agent_server/test_docker_build.py` pass ✅
- Pre-commit checks pass ✅

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:552ff46-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-552ff46-python \
  ghcr.io/openhands/agent-server:552ff46-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:552ff46-golang-amd64
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-golang-amd64
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-golang-amd64
ghcr.io/openhands/agent-server:552ff46-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:552ff46-golang-arm64
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-golang-arm64
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-golang-arm64
ghcr.io/openhands/agent-server:552ff46-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:552ff46-java-amd64
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-java-amd64
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-java-amd64
ghcr.io/openhands/agent-server:552ff46-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:552ff46-java-arm64
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-java-arm64
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-java-arm64
ghcr.io/openhands/agent-server:552ff46-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:552ff46-python-amd64
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-python-amd64
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-python-amd64
ghcr.io/openhands/agent-server:552ff46-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:552ff46-python-arm64
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-python-arm64
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-python-arm64
ghcr.io/openhands/agent-server:552ff46-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:552ff46-golang
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-golang
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-golang
ghcr.io/openhands/agent-server:552ff46-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:552ff46-java
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-java
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-java
ghcr.io/openhands/agent-server:552ff46-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:552ff46-python
ghcr.io/openhands/agent-server:552ff46de13545644509cdb9d3f1833f843ec446-python
ghcr.io/openhands/agent-server:fix-release-docker-image-tagging-python
ghcr.io/openhands/agent-server:552ff46-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `552ff46-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `552ff46-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->