### PR TITLE
fix(sdk): enforce skill allowed tools

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -93,6 +93,7 @@ class SkillInfo(BaseModel):
     description: str | None = None
     is_agentskills_format: bool = False
     disable_model_invocation: bool = False
+    allowed_tools: list[str] | None = None
 
 
 class SkillsResponse(BaseModel):
@@ -168,6 +169,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
             description=info.description,
             is_agentskills_format=info.is_agentskills_format,
             disable_model_invocation=info.disable_model_invocation,
+            allowed_tools=info.allowed_tools,
         )
         for info in (skill.to_skill_info() for skill in result.skills)
     ]

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -18,6 +18,10 @@ from openhands.sdk.agent.response_dispatch import (
     ResponseDispatchMixin,
     classify_response,
 )
+from openhands.sdk.agent.skill_tool_permissions import (
+    EffectiveTools,
+    effective_tools_for_state,
+)
 from openhands.sdk.agent.utils import (
     fix_malformed_tool_arguments,
     make_llm_completion,
@@ -461,8 +465,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         batch.emit(on_event)
         batch.finalize(
             on_event=on_event,
-            check_iterative_refinement=lambda ae: (
-                self._check_iterative_refinement(conversation, ae)
+            check_iterative_refinement=lambda ae: self._check_iterative_refinement(
+                conversation, ae
             ),
             mark_finished=lambda: setattr(
                 state,
@@ -470,6 +474,9 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                 ConversationExecutionStatus.FINISHED,
             ),
         )
+
+    def _effective_tools_for_state(self, state: ConversationState) -> EffectiveTools:
+        return effective_tools_for_state(state, self.tools_map)
 
     @observe(name="agent.step", ignore_inputs=["state", "on_event"])
     def step(
@@ -520,12 +527,13 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             "Sending messages to LLM: "
             f"{json.dumps([m.model_dump() for m in _messages[1:]], indent=2)}"
         )
+        effective_tools = self._effective_tools_for_state(state)
 
         try:
             llm_response = make_llm_completion(
                 self.llm,
                 _messages,
-                tools=list(self.tools_map.values()),
+                tools=list(effective_tools.tools_map.values()),
                 on_token=on_token,
             )
         except FunctionCallValidationError as e:
@@ -775,6 +783,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         # Store the normalized tool call to persist correct name/args in events.
         normalized_tool_call = tool_call
         arguments: dict[str, object] | None = None
+        effective_tools = self._effective_tools_for_state(conversation.state)
 
         security_risk: risk.SecurityRisk = risk.SecurityRisk.UNKNOWN
         try:
@@ -790,7 +799,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
 
             tool = self.tools_map.get(tool_name, None)
             if tool is None:
-                available = list(self.tools_map.keys())
+                available = list(effective_tools.tools_map.keys())
                 err = f"Tool '{tool_name}' not found. Available: {available}"
                 logger.error(err)
                 self._emit_tool_error(
@@ -805,6 +814,27 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                     responses_reasoning_item=responses_reasoning_item,
                 )
                 return
+            if tool_name not in effective_tools.tools_map:
+                active_skills = ", ".join(effective_tools.restricted_skill_names)
+                available = list(effective_tools.tools_map.keys())
+                err = (
+                    f"Tool '{tool_name}' is not available while skill(s) "
+                    f"{active_skills} are active. Available: {available}"
+                )
+                logger.error(err)
+                self._emit_tool_error(
+                    error=err,
+                    tool_name=tool_name,
+                    tool_call=tool_call,
+                    llm_response_id=llm_response_id,
+                    on_event=on_event,
+                    thought=thought,
+                    reasoning_content=reasoning_content,
+                    thinking_blocks=thinking_blocks,
+                    responses_reasoning_item=responses_reasoning_item,
+                )
+                return
+            tool = effective_tools.tools_map[tool_name]
 
             arguments = fix_malformed_tool_arguments(arguments, tool.action_type)
             normalized_tool_call = tool_call.model_copy(

--- a/openhands-sdk/openhands/sdk/agent/skill_tool_permissions.py
+++ b/openhands-sdk/openhands/sdk/agent/skill_tool_permissions.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from openhands.sdk.tool import ToolDefinition
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+    from openhands.sdk.skills import Skill
+
+
+ALWAYS_AVAILABLE_TOOL_NAMES = frozenset({"finish", "think"})
+
+_ALLOWED_TOOL_ALIASES = {
+    "bash": "terminal",
+    "terminal": "terminal",
+    "read": "file_editor",
+    "write": "file_editor",
+    "edit": "file_editor",
+    "fileeditor": "file_editor",
+    "file_editor": "file_editor",
+    "grep": "grep",
+    "glob": "glob",
+}
+
+
+@dataclass(frozen=True)
+class EffectiveTools:
+    tools_map: dict[str, ToolDefinition]
+    restricted_skill_names: tuple[str, ...] = ()
+
+    @property
+    def is_restricted(self) -> bool:
+        return bool(self.restricted_skill_names)
+
+
+def _base_allowed_tool_name(raw_name: str) -> str:
+    name = raw_name.strip()
+    if "(" in name:
+        name = name.split("(", 1)[0].strip()
+    return name
+
+
+def _normalize_allowed_tool_names(
+    allowed_tools: list[str],
+    available_tool_names: set[str],
+) -> set[str]:
+    normalized: set[str] = set()
+    for raw_name in allowed_tools:
+        name = _base_allowed_tool_name(raw_name)
+        if not name:
+            continue
+        if name in available_tool_names:
+            normalized.add(name)
+            continue
+
+        alias = _ALLOWED_TOOL_ALIASES.get(name.lower())
+        if alias is not None and alias in available_tool_names:
+            normalized.add(alias)
+    return normalized
+
+
+def _invoked_restricted_skills(state: ConversationState) -> list[Skill]:
+    agent_context = state.agent.agent_context
+    if agent_context is None:
+        return []
+
+    skills_by_name = {skill.name: skill for skill in agent_context.skills}
+    restricted: list[Skill] = []
+    for skill_name in state.invoked_skills:
+        skill = skills_by_name.get(skill_name)
+        if skill is not None and skill.allowed_tools is not None:
+            restricted.append(skill)
+    return restricted
+
+
+def effective_tools_for_state(
+    state: ConversationState,
+    tools_map: dict[str, ToolDefinition],
+) -> EffectiveTools:
+    restricted_skills = _invoked_restricted_skills(state)
+    if not restricted_skills:
+        return EffectiveTools(tools_map=dict(tools_map))
+
+    available_tool_names = set(tools_map)
+    allowed_sets = [
+        _normalize_allowed_tool_names(skill.allowed_tools or [], available_tool_names)
+        for skill in restricted_skills
+    ]
+    allowed_names = set.intersection(*allowed_sets) if allowed_sets else set()
+    allowed_names.update(ALWAYS_AVAILABLE_TOOL_NAMES & available_tool_names)
+
+    return EffectiveTools(
+        tools_map={
+            name: tool for name, tool in tools_map.items() if name in allowed_names
+        },
+        restricted_skill_names=tuple(skill.name for skill in restricted_skills),
+    )

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -53,6 +53,7 @@ class SkillInfo(BaseModel):
     description: str | None = None
     is_agentskills_format: bool = False
     disable_model_invocation: bool = False
+    allowed_tools: list[str] | None = None
 
 
 class SkillResources(BaseModel):
@@ -645,6 +646,7 @@ class Skill(BaseModel):
             description=self.description,
             is_agentskills_format=self.is_agentskills_format,
             disable_model_invocation=self.disable_model_invocation,
+            allowed_tools=self.allowed_tools,
         )
 
     def render_content(

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -833,6 +833,7 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
             description=skill_data.get("description"),
             is_agentskills_format=skill_data.get("is_agentskills_format", False),
             disable_model_invocation=skill_data.get("disable_model_invocation", False),
+            allowed_tools=skill_data.get("allowed_tools"),
         )
 
     def load_skills_from_agent_server(

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -174,6 +174,7 @@ class TestGetSkillsEndpoint:
                         trigger=None,
                         is_agentskills_format=True,
                         disable_model_invocation=True,
+                        allowed_tools=["Bash", "Read"],
                     ),
                 ],
                 sources={"public": 1},
@@ -187,6 +188,7 @@ class TestGetSkillsEndpoint:
             assert skill_info["type"] == "agentskills"
             assert skill_info["is_agentskills_format"] is True
             assert skill_info["disable_model_invocation"] is True
+            assert skill_info["allowed_tools"] == ["Bash", "Read"]
 
     def test_get_skills_response_sources(self, client):
         """Test that source counts are included in response."""

--- a/tests/sdk/agent/test_skill_allowed_tools.py
+++ b/tests/sdk/agent/test_skill_allowed_tools.py
@@ -1,0 +1,287 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+from types import SimpleNamespace
+from typing import Any, ClassVar, cast
+from unittest.mock import MagicMock
+
+from litellm.types.utils import ModelResponse
+from pydantic import PrivateAttr
+
+from openhands.sdk import LLM, Agent, AgentContext, Conversation, LocalConversation
+from openhands.sdk.agent.skill_tool_permissions import effective_tools_for_state
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.event import AgentErrorEvent, ObservationEvent
+from openhands.sdk.llm import (
+    LLMResponse,
+    Message,
+    MessageToolCall,
+    TextContent,
+    TokenCallbackType,
+)
+from openhands.sdk.llm.utils.metrics import MetricsSnapshot, TokenUsage
+from openhands.sdk.skills import Skill
+from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.tool.builtins import FinishTool, ThinkTool
+from openhands.sdk.tool.registry import register_tool
+from openhands.sdk.tool.spec import Tool
+from openhands.sdk.tool.tool import Action, Observation, ToolExecutor
+
+
+class _NoopAction(Action):
+    pass
+
+
+class _NoopObservation(Observation):
+    pass
+
+
+class _NoopExecutor(ToolExecutor[_NoopAction, _NoopObservation]):
+    def __call__(
+        self,
+        action: _NoopAction,  # noqa: ARG002
+        conversation=None,  # noqa: ARG002
+    ) -> _NoopObservation:
+        return _NoopObservation.from_text("done")
+
+
+class _NoopTool(ToolDefinition[_NoopAction, _NoopObservation]):
+    @classmethod
+    def create(cls, conv_state=None, **params) -> Sequence[_NoopTool]:
+        if params:
+            raise ValueError("Noop tools do not accept parameters")
+        return [
+            cls(
+                description=f"{cls.name} test tool",
+                action_type=_NoopAction,
+                observation_type=_NoopObservation,
+                executor=_NoopExecutor(),
+            )
+        ]
+
+
+class _AllowedAlphaTool(_NoopTool):
+    name: ClassVar[str] = "allowed_alpha"
+
+
+class _AllowedBetaTool(_NoopTool):
+    name: ClassVar[str] = "allowed_beta"
+
+
+class _BlockedGammaTool(_NoopTool):
+    name: ClassVar[str] = "blocked_gamma"
+
+
+class _TerminalTool(_NoopTool):
+    name: ClassVar[str] = "terminal"
+
+
+class _FileEditorTool(_NoopTool):
+    name: ClassVar[str] = "file_editor"
+
+
+register_tool(_AllowedAlphaTool.name, _AllowedAlphaTool)
+register_tool(_AllowedBetaTool.name, _AllowedBetaTool)
+register_tool(_BlockedGammaTool.name, _BlockedGammaTool)
+
+
+def _metrics() -> MetricsSnapshot:
+    return MetricsSnapshot(
+        model_name="test-model",
+        accumulated_cost=0.0,
+        max_budget_per_task=0.0,
+        accumulated_token_usage=TokenUsage(model="test-model"),
+    )
+
+
+class _RecordingLLM(LLM):
+    _seen_tool_names: list[str] = PrivateAttr(default_factory=list)
+    _tool_call_name: str | None = PrivateAttr(default=None)
+
+    def __init__(self, tool_call_name: str | None = None):
+        super().__init__(model="test-model", usage_id="test-llm")
+        self._tool_call_name = tool_call_name
+
+    @property
+    def seen_tool_names(self) -> list[str]:
+        return self._seen_tool_names
+
+    def completion(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        _return_metrics: bool = False,
+        add_security_risk_prediction: bool = False,
+        on_token: TokenCallbackType | None = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        self._seen_tool_names = [tool.name for tool in tools or []]
+        if self._tool_call_name is None:
+            message = Message(
+                role="assistant",
+                content=[TextContent(text="done")],
+            )
+        else:
+            message = Message(
+                role="assistant",
+                tool_calls=[
+                    MessageToolCall(
+                        id="call-1",
+                        name=self._tool_call_name,
+                        arguments="{}",
+                        origin="completion",
+                    )
+                ],
+            )
+        return LLMResponse(
+            message=message,
+            metrics=_metrics(),
+            raw_response=MagicMock(spec=ModelResponse, id="response-1"),
+        )
+
+
+def _skill(name: str, allowed_tools: list[str] | None) -> Skill:
+    return Skill(
+        name=name,
+        content="Skill content",
+        description=f"{name} description",
+        source=f"/skills/{name}/SKILL.md",
+        is_agentskills_format=True,
+        allowed_tools=allowed_tools,
+    )
+
+
+def _conversation_with_invoked_skill(
+    llm: LLM,
+    skill: Skill,
+    tool_names: list[str],
+) -> tuple[Agent, LocalConversation]:
+    agent = Agent(
+        llm=llm,
+        tools=[Tool(name=name) for name in tool_names],
+        agent_context=AgentContext(skills=[skill]),
+    )
+    conversation = Conversation(agent=agent, visualizer=None)
+    conversation.send_message("use the skill")
+    conversation.state.invoked_skills.append(skill.name)
+    return agent, conversation
+
+
+def _tool_map(tool_classes: Sequence[type[_NoopTool]]) -> dict[str, ToolDefinition]:
+    tools: list[ToolDefinition] = [
+        tool for tool_class in tool_classes for tool in tool_class.create()
+    ]
+    (finish_tool,) = FinishTool.create()
+    (think_tool,) = ThinkTool.create()
+    tools.extend([finish_tool, think_tool])
+    return {tool.name: tool for tool in tools}
+
+
+def _state_for_skills(skills: list[Skill], invoked_skills: list[str]) -> Any:
+    return SimpleNamespace(
+        agent=SimpleNamespace(agent_context=AgentContext(skills=skills)),
+        invoked_skills=invoked_skills,
+    )
+
+
+def test_invoked_skill_allowed_tools_filter_tools_sent_to_llm():
+    skill = _skill("restricted", allowed_tools=["allowed_alpha"])
+    llm = _RecordingLLM()
+    agent, conversation = _conversation_with_invoked_skill(
+        llm,
+        skill,
+        [_AllowedAlphaTool.name, _BlockedGammaTool.name],
+    )
+
+    agent.step(conversation, on_event=lambda event: None)
+
+    assert set(llm.seen_tool_names) == {"allowed_alpha", "finish", "think"}
+
+
+def test_invoked_skill_without_allowed_tools_keeps_tools_unrestricted():
+    skill = _skill("unrestricted", allowed_tools=None)
+    llm = _RecordingLLM()
+    agent, conversation = _conversation_with_invoked_skill(
+        llm,
+        skill,
+        [_AllowedAlphaTool.name, _BlockedGammaTool.name],
+    )
+
+    agent.step(conversation, on_event=lambda event: None)
+
+    assert _AllowedAlphaTool.name in llm.seen_tool_names
+    assert _BlockedGammaTool.name in llm.seen_tool_names
+    assert "invoke_skill" in llm.seen_tool_names
+
+
+def test_disallowed_tool_call_is_rejected_at_runtime():
+    skill = _skill("restricted", allowed_tools=["allowed_alpha"])
+    llm = _RecordingLLM(tool_call_name=_BlockedGammaTool.name)
+    agent, conversation = _conversation_with_invoked_skill(
+        llm,
+        skill,
+        [_AllowedAlphaTool.name, _BlockedGammaTool.name],
+    )
+    events = []
+
+    agent.step(conversation, on_event=events.append)
+
+    errors = [event for event in events if isinstance(event, AgentErrorEvent)]
+    assert len(errors) == 1
+    assert "blocked_gamma" in errors[0].error
+    assert "not available while skill(s) restricted are active" in errors[0].error
+
+
+def test_allowed_tool_call_still_executes():
+    skill = _skill("restricted", allowed_tools=["allowed_alpha"])
+    llm = _RecordingLLM(tool_call_name=_AllowedAlphaTool.name)
+    agent, conversation = _conversation_with_invoked_skill(
+        llm,
+        skill,
+        [_AllowedAlphaTool.name, _BlockedGammaTool.name],
+    )
+    events = []
+
+    agent.step(conversation, on_event=events.append)
+
+    assert not any(isinstance(event, AgentErrorEvent) for event in events)
+    assert any(isinstance(event, ObservationEvent) for event in events)
+
+
+def test_allowed_tools_empty_keeps_only_control_tools():
+    skill = _skill("no-tools", allowed_tools=[])
+    state = cast(ConversationState, _state_for_skills([skill], [skill.name]))
+    tools_map = _tool_map([_AllowedAlphaTool, _BlockedGammaTool])
+
+    effective = effective_tools_for_state(state, tools_map)
+
+    assert set(effective.tools_map) == {"finish", "think"}
+
+
+def test_allowed_tools_normalizes_aliases_and_scoped_entries():
+    skill = _skill("shell-skill", allowed_tools=["Bash(git:*)", "Read"])
+    state = cast(ConversationState, _state_for_skills([skill], [skill.name]))
+    tools_map = _tool_map([_TerminalTool, _FileEditorTool, _BlockedGammaTool])
+
+    effective = effective_tools_for_state(state, tools_map)
+
+    assert set(effective.tools_map) == {
+        "terminal",
+        "file_editor",
+        "finish",
+        "think",
+    }
+
+
+def test_multiple_restricted_skills_intersect_allowed_tools():
+    skill_a = _skill("skill-a", allowed_tools=["allowed_alpha", "allowed_beta"])
+    skill_b = _skill("skill-b", allowed_tools=["allowed_beta", "blocked_gamma"])
+    state = cast(
+        ConversationState,
+        _state_for_skills([skill_a, skill_b], [skill_a.name, skill_b.name]),
+    )
+    tools_map = _tool_map([_AllowedAlphaTool, _AllowedBetaTool, _BlockedGammaTool])
+
+    effective = effective_tools_for_state(state, tools_map)
+
+    assert set(effective.tools_map) == {"allowed_beta", "finish", "think"}

--- a/tests/sdk/skills/test_skill_info.py
+++ b/tests/sdk/skills/test_skill_info.py
@@ -179,10 +179,12 @@ class TestSkillToSkillInfo:
             trigger=KeywordTrigger(keywords=["trigger-only"]),
             is_agentskills_format=True,
             disable_model_invocation=True,
+            allowed_tools=["Bash", "Read"],
         )
         info = skill.to_skill_info()
 
         assert info.disable_model_invocation is True
+        assert info.allowed_tools == ["Bash", "Read"]
 
     def test_task_skill_to_info(self):
         """Test conversion of task skill to SkillInfo."""

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -883,6 +883,7 @@ def test_load_skills_from_agent_server_calls_api():
                 "triggers": ["test"],
                 "is_agentskills_format": True,
                 "disable_model_invocation": True,
+                "allowed_tools": ["Bash", "Read"],
             }
         ],
         "sources": {"public": 1},
@@ -897,6 +898,7 @@ def test_load_skills_from_agent_server_calls_api():
         assert skills[0].content == "Test content"
         assert skills[0].is_agentskills_format is True
         assert skills[0].disable_model_invocation is True
+        assert skills[0].allowed_tools == ["Bash", "Read"]
         assert context.load_public_skills is False  # Skills were loaded
 
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

`Skill.allowed_tools` is already parsed from AgentSkills frontmatter, but it was not enforced at runtime.

Before this PR, after a skill was invoked, the model could still see and call any registered tool, even if the skill declared a restricted `allowed-tools` list. This made the field metadata-only instead of an actual runtime constraint.

This PR implements the first enforcement layer for invoked skills: once a skill with `allowed_tools` is active, the agent only offers the allowed tools to the model and rejects disallowed tool calls before execution.

## Summary

- Adds effective tool filtering for invoked skills with `allowed_tools`, so only allowed tools are passed to the LLM.
- Rejects disallowed tool calls at runtime if the model still emits one.
- Preserves `allowed_tools` across `SkillInfo`, agent-server skill responses, and remote workspace skill deserialization.

## Issue Number

<!-- Replace with the actual issue number. -->
Fixes #3046

## How to Test

I ran the focused regression tests:

```bash
uv run pytest tests/sdk/agent/test_skill_allowed_tools.py tests/sdk/skills/test_skill_info.py tests/agent_server/test_skills_router.py::TestGetSkillsEndpoint::test_get_skills_agent_skill_format tests/sdk/workspace/remote/test_remote_workspace.py::test_load_skills_from_agent_server_calls_api -q
```

Result:

```text
28 passed
```

I also ran file-scoped pre-commit checks:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/skill_tool_permissions.py openhands-sdk/openhands/sdk/agent/agent.py openhands-sdk/openhands/sdk/skills/skill.py openhands-agent-server/openhands/agent_server/skills_router.py openhands-sdk/openhands/sdk/workspace/remote/base.py tests/sdk/agent/test_skill_allowed_tools.py tests/sdk/skills/test_skill_info.py tests/agent_server/test_skills_router.py tests/sdk/workspace/remote/test_remote_workspace.py
```

Result:

```text
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
Check import dependency rules............................................Passed
Check Tool subclass registration.........................................Passed
```

Before marking this PR ready for review, I plan to add/run a small before-vs-after verification script showing that a skill with restricted `allowed-tools` previously exposed all tools to the model, and now only exposes the allowed tools.

## Video/Screenshots

Focused regression test results:
<img width="3082" height="363" alt="image" src="https://github.com/user-attachments/assets/40e2df34-2fcb-4410-97da-053ac484e85a" />

Pre-commit checks results:
<img width="881" height="188" alt="image" src="https://github.com/user-attachments/assets/5460ab90-7a93-418f-96e5-64ba0b02ab25" />

Before this PR:
<img width="2128" height="315" alt="image" src="https://github.com/user-attachments/assets/4e5108f5-261f-40d5-8891-4f3938d01c84" />
This shows the bug:
- `blocked_gamma` was still offered to the model: `blocked_tool_offered=True`
- calling `blocked_gamma` did not produce an error: `blocked_tool_call_error=False`
- `blocked_gamma` actually executed: `blocked_tool_executed=True`

After this PR:
<img width="2138" height="339" alt="image" src="https://github.com/user-attachments/assets/13c8329b-91e4-4646-a1c3-de56de3d2aa6" />
This shows the PR is working:
- `blocked_gamma` is no longer offered to the model: `locked_tool_offered=False`
- if the model still tries to call it, the call is rejected: `blocked_tool_call_error=True`
- the blocked tool does not execute: `blocked_tool_executed=False`

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR intentionally implements the MVP enforcement scope for explicit `invoke_skill` activation.

Current behavior:
- If an invoked skill has `allowed_tools=None`, tool availability remains unchanged.
- If an invoked skill has `allowed_tools=[]`, only control tools such as `finish` and `think` remain available.
- If multiple invoked skills with restrictions are active, the effective tool set is the intersection of their allowed tool sets.
- AgentSkills-style names such as `Bash(...)` and `Read` are normalized to SDK tool names where possible.

Open scope questions remain around:
- when an invoked skill should stop being active,
- whether multiple active skills should use intersection, union, or latest-skill-wins semantics,
- whether scoped entries such as `Bash(git:*)` require command-level enforcement,
- whether trigger-activated skills should also apply `allowed-tools` restrictions.
