### PR TITLE
feat(agent-server): base conversation worktrees on origin default branch

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -90,15 +90,66 @@ def _append_worktree_guidance(
     return agent.model_copy(update={"agent_context": updated_context})
 
 
-def _get_worktree_start_point(repo_root: Path) -> str:
+def _has_git_remote(repo_root: Path, remote: str = "origin") -> bool:
     try:
-        current_branch = run_git_command(
-            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"],
+        run_git_command(["git", "remote", "get-url", remote], repo_root)
+    except GitCommandError:
+        return False
+    return True
+
+
+def _local_branch_exists(repo_root: Path, branch: str) -> bool:
+    try:
+        run_git_command(
+            ["git", "show-ref", "--verify", "--quiet", f"refs/heads/{branch}"],
             repo_root,
         )
     except GitCommandError:
-        return "HEAD"
-    return current_branch if current_branch and current_branch != "HEAD" else "HEAD"
+        return False
+    return True
+
+
+def _get_worktree_start_point(repo_root: Path) -> str:
+    """Resolve the base ref a new conversation worktree should be created from.
+
+    Policy (in order):
+      1. ``origin/<default_branch>`` if an ``origin`` remote is configured.
+         ``git fetch origin`` is run first so the worktree starts from the
+         latest remote tip; the default branch is resolved via
+         ``refs/remotes/origin/HEAD``.
+      2. Local ``main`` if there is no usable remote default but ``main``
+         exists locally.
+      3. Local ``master`` if neither remote default nor local ``main`` is
+         available.
+      4. Fall back to ``HEAD`` only when none of the above applies, so worktree
+         creation still succeeds on freshly initialized repos.
+    """
+    if _has_git_remote(repo_root):
+        try:
+            run_git_command(["git", "fetch", "origin"], repo_root, timeout=60)
+        except GitCommandError as exc:
+            logger.warning(
+                "git fetch origin failed while choosing worktree start point "
+                "for %s; using cached refs. Error: %s",
+                repo_root,
+                exc,
+            )
+        try:
+            ref = run_git_command(
+                ["git", "symbolic-ref", "refs/remotes/origin/HEAD"],
+                repo_root,
+            )
+        except GitCommandError:
+            ref = ""
+        prefix = "refs/remotes/origin/"
+        if ref.startswith(prefix):
+            return f"origin/{ref[len(prefix) :]}"
+
+    if _local_branch_exists(repo_root, "main"):
+        return "main"
+    if _local_branch_exists(repo_root, "master"):
+        return "master"
+    return "HEAD"
 
 
 def _create_conversation_worktree(

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -21,6 +21,7 @@ from openhands.agent_server.conversation_service import (
     AutoTitleSubscriber,
     ConversationContractMismatchError,
     ConversationService,
+    _get_worktree_start_point,
 )
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import (
@@ -1098,6 +1099,116 @@ class TestConversationServiceStartConversation:
         assert result.workspace.working_dir == str(workspace_dir)
         assert stored.agent.agent_context is None
         assert not (worktree_root / str(conversation_id)).exists()
+
+    def test_get_worktree_start_point_prefers_origin_default_branch(self, tmp_path):
+        """With an ``origin`` remote, fetch first and return ``origin/<default>``.
+
+        Local ``main``/``master`` should not influence the choice when a remote
+        default branch is available.
+        """
+        upstream = tmp_path / "upstream.git"
+        run_git_command(["git", "init", "--bare", "-b", "trunk", str(upstream)])
+
+        repo_dir = tmp_path / "repo"
+        _init_git_repo(repo_dir)
+        # Rename the local default to "trunk" and publish it so origin/HEAD
+        # resolves to origin/trunk (not main/master).
+        run_git_command(["git", "branch", "-m", "main", "trunk"], repo_dir)
+        run_git_command(
+            ["git", "remote", "add", "origin", str(upstream)],
+            repo_dir,
+        )
+        run_git_command(["git", "push", "-u", "origin", "trunk"], repo_dir)
+        run_git_command(
+            ["git", "remote", "set-head", "origin", "trunk"],
+            repo_dir,
+        )
+        # Create a local "main" branch that we expect to be IGNORED in favor of
+        # the remote default, so this test fails if we silently fall through.
+        run_git_command(["git", "branch", "main"], repo_dir)
+
+        # Add a new upstream commit; the start point must reflect this commit,
+        # proving we fetched before resolving.
+        clone_dir = tmp_path / "publisher"
+        run_git_command(
+            ["git", "clone", str(upstream), str(clone_dir)],
+        )
+        (clone_dir / "remote.txt").write_text("remote\n")
+        run_git_command(["git", "add", "remote.txt"], clone_dir)
+        run_git_command(
+            [
+                "git",
+                "-c",
+                "user.name=OpenHands Test",
+                "-c",
+                "user.email=openhands@example.com",
+                "commit",
+                "-m",
+                "remote update",
+            ],
+            clone_dir,
+        )
+        run_git_command(["git", "push", "origin", "trunk"], clone_dir)
+        remote_tip = run_git_command(
+            ["git", "--no-pager", "rev-parse", "trunk"], clone_dir
+        )
+
+        start_point = _get_worktree_start_point(repo_dir)
+
+        assert start_point == "origin/trunk"
+        resolved = run_git_command(
+            ["git", "--no-pager", "rev-parse", start_point], repo_dir
+        )
+        assert resolved == remote_tip
+
+    def test_get_worktree_start_point_falls_back_to_local_main(self, tmp_path):
+        """No ``origin`` remote → fall back to local ``main``."""
+        repo_dir = tmp_path / "repo"
+        _init_git_repo(repo_dir)  # creates local "main"
+        # Move HEAD off main so we prove main is selected by policy, not because
+        # it happens to be the current branch.
+        run_git_command(["git", "checkout", "-b", "feature/x"], repo_dir)
+
+        assert _get_worktree_start_point(repo_dir) == "main"
+
+    def test_get_worktree_start_point_falls_back_to_master(self, tmp_path):
+        """No remote and no local ``main`` → fall back to local ``master``."""
+        repo_dir = tmp_path / "repo"
+        _init_git_repo(repo_dir)
+        run_git_command(["git", "branch", "-m", "main", "master"], repo_dir)
+        # Detach so neither main nor master is the current branch.
+        run_git_command(["git", "checkout", "--detach"], repo_dir)
+
+        assert _get_worktree_start_point(repo_dir) == "master"
+
+    def test_get_worktree_start_point_tolerates_fetch_failure(self, tmp_path):
+        """If ``git fetch origin`` fails, fall back to cached refs.
+
+        Simulate an unreachable remote by pointing ``origin`` at a non-existent
+        path; we still expect to resolve to ``origin/<default>`` using cached
+        refs that were set up before the remote URL was broken.
+        """
+        upstream = tmp_path / "upstream.git"
+        run_git_command(["git", "init", "--bare", "-b", "main", str(upstream)])
+
+        repo_dir = tmp_path / "repo"
+        _init_git_repo(repo_dir)
+        run_git_command(
+            ["git", "remote", "add", "origin", str(upstream)],
+            repo_dir,
+        )
+        run_git_command(["git", "push", "-u", "origin", "main"], repo_dir)
+        run_git_command(
+            ["git", "remote", "set-head", "origin", "main"],
+            repo_dir,
+        )
+        # Break the remote URL so fetch fails, but origin/HEAD is still cached.
+        run_git_command(
+            ["git", "remote", "set-url", "origin", str(tmp_path / "does-not-exist")],
+            repo_dir,
+        )
+
+        assert _get_worktree_start_point(repo_dir) == "origin/main"
 
     @pytest.mark.asyncio
     async def test_start_conversation_with_custom_id(self, conversation_service):


### PR DESCRIPTION
## Summary

When the agent-server creates a per-conversation git worktree, the base branch was previously just the main workspace's current `HEAD` — i.e. whatever the user happened to have checked out. That meant a fresh conversation could silently start from stale, unrelated, or in-progress work.

This PR makes the start-point an explicit policy in `_get_worktree_start_point`:

1. If an `origin` remote is configured, run `git fetch origin` first so we start from the latest remote tip, then return `origin/<default_branch>` (resolved via `refs/remotes/origin/HEAD`). A failed fetch is logged and we fall through to whatever `origin/HEAD` is cached.
2. Otherwise, fall back to local `main` if it exists.
3. Otherwise, fall back to local `master` if it exists.
4. As a last resort (no remote, no `main`, no `master`), return `"HEAD"` so brand-new repos can still spawn a worktree.

## Changes

- `openhands-agent-server/openhands/agent_server/conversation_service.py`
  - Rewrote `_get_worktree_start_point` to implement the policy above, including a `git fetch origin` step and warning-on-failure behavior.
  - Added small helpers `_has_git_remote` and `_local_branch_exists`.
- `tests/agent_server/test_conversation_service.py`
  - `test_get_worktree_start_point_prefers_origin_default_branch` — bare upstream + non-standard `trunk` default + decoy local `main`; asserts we return `origin/trunk` and that it points at a remote commit pushed *after* the local clone (proving we fetched).
  - `test_get_worktree_start_point_falls_back_to_local_main` — no remote, HEAD on a feature branch; asserts `"main"`.
  - `test_get_worktree_start_point_falls_back_to_master` — no remote, only local `master`, detached HEAD; asserts `"master"`.
  - `test_get_worktree_start_point_tolerates_fetch_failure` — broken remote URL; asserts we still resolve to `origin/main` via cached refs.

## Verification

```
uv run --frozen pytest tests/agent_server/test_conversation_service.py -q
# 72 passed
```

The 3 pre-existing worktree tests still pass (they hit the local-`main` fallback, since `_init_git_repo` makes a `main`-only repo with no remote).

---

_This PR was opened by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:59c4edb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-59c4edb-python \
  ghcr.io/openhands/agent-server:59c4edb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:59c4edb-golang-amd64
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-golang-amd64
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-golang-amd64
ghcr.io/openhands/agent-server:59c4edb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:59c4edb-golang-arm64
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-golang-arm64
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-golang-arm64
ghcr.io/openhands/agent-server:59c4edb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:59c4edb-java-amd64
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-java-amd64
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-java-amd64
ghcr.io/openhands/agent-server:59c4edb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:59c4edb-java-arm64
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-java-arm64
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-java-arm64
ghcr.io/openhands/agent-server:59c4edb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:59c4edb-python-amd64
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-python-amd64
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-python-amd64
ghcr.io/openhands/agent-server:59c4edb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:59c4edb-python-arm64
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-python-arm64
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-python-arm64
ghcr.io/openhands/agent-server:59c4edb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:59c4edb-golang
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-golang
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-golang
ghcr.io/openhands/agent-server:59c4edb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:59c4edb-java
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-java
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-java
ghcr.io/openhands/agent-server:59c4edb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:59c4edb-python
ghcr.io/openhands/agent-server:59c4edbb942c80be0a4dc394e229d464ccefdf63-python
ghcr.io/openhands/agent-server:feat-worktree-base-branch-policy-python
ghcr.io/openhands/agent-server:59c4edb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `59c4edb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `59c4edb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->