### PR TITLE
chore(agent-server): drop variable-sized payloads from info logs

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -594,9 +594,9 @@ class ConversationService:
                     # tools
             if request.tool_module_qualnames:
                 logger.info(
-                    f"Dynamically registered {len(request.tool_module_qualnames)} "
-                    f"tools for conversation {conversation_id}: "
-                    f"{list(request.tool_module_qualnames.keys())}"
+                    "Dynamically registered %d tools for conversation %s",
+                    len(request.tool_module_qualnames),
+                    conversation_id,
                 )
 
         # Register subagent definitions forwarded from the client
@@ -762,12 +762,13 @@ class ConversationService:
 
         updated_fields = []
         if request.title is not None:
-            updated_fields.append(f"title: {request.title}")
+            updated_fields.append("title")
         if request.tags is not None:
-            updated_fields.append(f"tags: {request.tags}")
+            updated_fields.append("tags")
         logger.info(
-            f"Successfully updated conversation {conversation_id} "
-            f"with {', '.join(updated_fields)}"
+            "Successfully updated conversation %s (%s)",
+            conversation_id,
+            ", ".join(updated_fields),
         )
         return True
 

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -186,10 +186,7 @@ def load_org_skills_from_url(
             except Exception as e:
                 logger.warning(f"Failed to load skills from {microagents_dir}: {e}")
 
-        logger.info(
-            f"Loaded {len(all_skills)} organization skills for {org_name}: "
-            f"{[s.name for s in all_skills]}"
-        )
+        logger.info("Loaded %d organization skills for %s", len(all_skills), org_name)
 
     except Exception as e:
         logger.warning(f"Failed to load organization skills for {org_name}: {e}")
@@ -362,9 +359,7 @@ def load_all_skills(
     # Merge all skills with precedence
     all_skills = merge_skills(skill_lists)
 
-    logger.info(
-        f"Returning {len(all_skills)} total skills: {[s.name for s in all_skills]}"
-    )
+    logger.info("Loaded %d skills", len(all_skills))
 
     return SkillLoadResult(skills=all_skills, sources=sources)
 


### PR DESCRIPTION
Narrow follow-up to the original "tone-down" effort: only strip variable-length lists/values out of the info logs that were dumping them, while leaving the logs themselves at info-level. Per feedback, one-liner info logs that don't trigger often are left alone — this PR only fixes the ones that dump unbounded / variable payloads.

## Changes

- **`conversation_service`**:
  - `Dynamically registered N tools for conversation <id>` no longer appends the full list of tool qualnames.
  - `Successfully updated conversation <id>` now records which fields changed (`title` / `tags`) instead of inlining their values, since those can be arbitrary user-supplied strings.
- **`skills_service`**:
  - `Loaded N organization skills for <org>` and the final `Loaded N skills` summary no longer dump every skill name in the list.

## Tests

Existing `test_conversation_service`, `test_skills_service`, `test_event_router_websocket`, `test_api` all pass (153 tests).

---
_This PR was opened by an AI agent (OpenHands) on behalf of the requester._


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c87d614-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c87d614-python \
  ghcr.io/openhands/agent-server:c87d614-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c87d614-golang-amd64
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-golang-amd64
ghcr.io/openhands/agent-server:tone-down-info-logs-golang-amd64
ghcr.io/openhands/agent-server:c87d614-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c87d614-golang-arm64
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-golang-arm64
ghcr.io/openhands/agent-server:tone-down-info-logs-golang-arm64
ghcr.io/openhands/agent-server:c87d614-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c87d614-java-amd64
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-java-amd64
ghcr.io/openhands/agent-server:tone-down-info-logs-java-amd64
ghcr.io/openhands/agent-server:c87d614-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c87d614-java-arm64
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-java-arm64
ghcr.io/openhands/agent-server:tone-down-info-logs-java-arm64
ghcr.io/openhands/agent-server:c87d614-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c87d614-python-amd64
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-python-amd64
ghcr.io/openhands/agent-server:tone-down-info-logs-python-amd64
ghcr.io/openhands/agent-server:c87d614-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c87d614-python-arm64
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-python-arm64
ghcr.io/openhands/agent-server:tone-down-info-logs-python-arm64
ghcr.io/openhands/agent-server:c87d614-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c87d614-golang
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-golang
ghcr.io/openhands/agent-server:tone-down-info-logs-golang
ghcr.io/openhands/agent-server:c87d614-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c87d614-java
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-java
ghcr.io/openhands/agent-server:tone-down-info-logs-java
ghcr.io/openhands/agent-server:c87d614-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c87d614-python
ghcr.io/openhands/agent-server:c87d614a6e8abff637074bdcb8a52248dc1fdabf-python
ghcr.io/openhands/agent-server:tone-down-info-logs-python
ghcr.io/openhands/agent-server:c87d614-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c87d614-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c87d614-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->