### PR TITLE
chore(sdk): drop variable-sized payloads from info logs

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -473,16 +473,11 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
                 result = future.result()
                 tools.extend(result)
 
-        logger.info(
-            f"Loaded {len(tools)} tools from spec: {[tool.name for tool in tools]}"
-        )
+        logger.info("Loaded %d tools from spec", len(tools))
         if self.filter_tools_regex:
             pattern = re.compile(self.filter_tools_regex)
             tools = [tool for tool in tools if pattern.match(tool.name)]
-            logger.info(
-                f"Filtered to {len(tools)} tools after applying regex filter: "
-                f"{[tool.name for tool in tools]}",
-            )
+            logger.info("Filtered to %d tools after applying regex filter", len(tools))
 
         # Include default tools from include_default_tools; not subject to regex
         # filtering. Use explicit mapping to resolve tool class names.

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -365,11 +365,7 @@ class ConversationState(OpenHandsModel):
             # Note: stats are already deserialized from base_state.json above.
             # Do NOT reset stats here - this would lose accumulated metrics.
 
-            logger.info(
-                f"Resumed conversation {state.id} from persistent storage.\n"
-                f"State: {state.model_dump(exclude={'agent'})}\n"
-                f"Agent: {state.agent.model_dump_succint()}"
-            )
+            logger.info("Resumed conversation %s from persistent storage", state.id)
             return state
 
         # ---- Fresh path ----
@@ -394,11 +390,7 @@ class ConversationState(OpenHandsModel):
 
         state._save_base_state(file_store)  # initial snapshot
         state._autosave_enabled = True
-        logger.info(
-            f"Created new conversation {state.id}\n"
-            f"State: {state.model_dump(exclude={'agent'})}\n"
-            f"Agent: {state.agent.model_dump_succint()}"
-        )
+        logger.info("Created new conversation %s", state.id)
         return state
 
     # ===== Auto-persist base on public field changes =====

--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -87,5 +87,5 @@ def create_mcp_tools(
             )
         raise
 
-    logger.info(f"Created {len(client.tools)} MCP tools: {[t.name for t in client]}")
+    logger.info("Created %d MCP tools", len(client.tools))
     return client

--- a/openhands-sdk/openhands/sdk/plugin/plugin.py
+++ b/openhands-sdk/openhands/sdk/plugin/plugin.py
@@ -477,10 +477,10 @@ def _load_mcp_config(plugin_dir: Path) -> dict[str, Any] | None:
         # expansion with per-conversation secrets. Only SKILL_ROOT is expanded now.
         config = load_mcp_config(mcp_json, skill_root=plugin_dir, expand_defaults=False)
         if config and "mcpServers" in config:
-            server_names = list(config["mcpServers"].keys())
             logger.info(
-                f"Loaded MCP config from {mcp_json} "
-                f"with {len(server_names)} server(s): {server_names}"
+                "Loaded MCP config from %s with %d server(s)",
+                mcp_json,
+                len(config["mcpServers"]),
             )
         return config
     except Exception as e:

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -1105,9 +1105,7 @@ def load_public_skills(
     except Exception as e:
         logger.warning(f"Failed to load public skills from {repo_url}: {str(e)}")
 
-    logger.info(
-        f"Loaded {len(all_skills)} public skills: {[s.name for s in all_skills]}"
-    )
+    logger.info("Loaded %d public skills", len(all_skills))
     return all_skills
 
 


### PR DESCRIPTION
Follow-up to #3216. Same idea — strip variable-length payloads out of info logs — but for the SDK side. Some of these (notably `state.py`) produce log entries that wrap across ~15+ lines on startup because they dump the entire `ConversationState` and agent config via `model_dump(...)`. After this PR the lines stay short and bounded; counts and IDs are still logged.

### Before (representative)
```
[agent-server] INFO     Resumed conversation                   state.py:368
[agent-server] 4cc43bbf-cc6d-4acf-b412-fc73c9282250
[agent-server] from persistent storage.
[agent-server] State: {'id':
[agent-server] UUID('4cc43bbf-cc6d-4acf-b412-fc73c928
[agent-server] 2250'), 'workspace': {'working_dir':
[agent-server] '/tmp/conversation-worktrees/...'},
[agent-server] ...
[agent-server] INFO     Created 34 MCP tools:                   utils.py:90
[agent-server] ['slack_slack_list_channels', 'slack_slack_post_message', ...]
```

### After
```
[agent-server] INFO     Resumed conversation <id> from persistent storage
[agent-server] INFO     Created 34 MCP tools
```

## Changes

- **`conversation/state.py`** — `Resumed conversation <id>` and `Created new conversation <id>` no longer append `state.model_dump(...)` and `agent.model_dump_succint()`.
- **`mcp/utils.py`** — `Created N MCP tools` no longer enumerates every tool name.
- **`agent/base.py`** — `Loaded N tools from spec` and `Filtered to N tools after applying regex filter` no longer enumerate every tool name.
- **`skills/skill.py`** — `Loaded N public skills` no longer enumerates every skill name.
- **`plugin/plugin.py`** — `Loaded MCP config from <path> with N server(s)` no longer enumerates every server name.

## Tests

All 1326 tests in `tests/sdk/{conversation,mcp,agent,skills,plugin}` pass. No tests assert on the stripped substrings.

---
_This PR was opened by an AI agent (OpenHands) on behalf of the requester._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:11f9184-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-11f9184-python \
  ghcr.io/openhands/agent-server:11f9184-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:11f9184-golang-amd64
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-golang-amd64
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-golang-amd64
ghcr.io/openhands/agent-server:11f9184-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:11f9184-golang-arm64
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-golang-arm64
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-golang-arm64
ghcr.io/openhands/agent-server:11f9184-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:11f9184-java-amd64
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-java-amd64
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-java-amd64
ghcr.io/openhands/agent-server:11f9184-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:11f9184-java-arm64
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-java-arm64
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-java-arm64
ghcr.io/openhands/agent-server:11f9184-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:11f9184-python-amd64
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-python-amd64
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-python-amd64
ghcr.io/openhands/agent-server:11f9184-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:11f9184-python-arm64
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-python-arm64
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-python-arm64
ghcr.io/openhands/agent-server:11f9184-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:11f9184-golang
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-golang
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-golang
ghcr.io/openhands/agent-server:11f9184-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:11f9184-java
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-java
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-java
ghcr.io/openhands/agent-server:11f9184-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:11f9184-python
ghcr.io/openhands/agent-server:11f9184fd47dbbdb6390ade7aed54fc80c01e4c7-python
ghcr.io/openhands/agent-server:drop-state-and-tools-info-dumps-python
ghcr.io/openhands/agent-server:11f9184-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `11f9184-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `11f9184-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->