### PR TITLE
fix(sdk): map typed LiteLLM 401/403 exceptions to LLMAuthenticationError

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
@@ -2,9 +2,11 @@ from __future__ import annotations
 
 from litellm.exceptions import (
     APIConnectionError,
+    AuthenticationError,
     BadRequestError,
     ContextWindowExceededError,
     OpenAIError,
+    PermissionDeniedError,
 )
 
 from .types import (
@@ -80,6 +82,10 @@ AUTH_PATTERNS: list[str] = [
 
 
 def looks_like_auth_error(exception: Exception) -> bool:
+    # Trust the typed exception when the provider/LiteLLM raised an explicit
+    # 401/403 — its message text may not contain the heuristic patterns below.
+    if isinstance(exception, (AuthenticationError, PermissionDeniedError)):
+        return True
     if not isinstance(exception, (BadRequestError, OpenAIError)):
         return False
     s = str(exception).lower()

--- a/tests/sdk/llm/test_exception_mapping.py
+++ b/tests/sdk/llm/test_exception_mapping.py
@@ -1,4 +1,9 @@
-from litellm.exceptions import BadRequestError
+import httpx
+from litellm.exceptions import (
+    AuthenticationError,
+    BadRequestError,
+    PermissionDeniedError,
+)
 
 from openhands.sdk.llm.exceptions import (
     LLMAuthenticationError,
@@ -23,6 +28,24 @@ def test_map_auth_error_from_openai_error():
     # auth-like message instead, as providers commonly route auth issues
     # through BadRequestError in LiteLLM
     e = BadRequestError("status 401 Unauthorized: missing API key", MODEL, PROVIDER)
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMAuthenticationError)
+
+
+def test_map_typed_authentication_error_without_pattern_match():
+    # Typed 401 from litellm whose message text doesn't contain any of the
+    # auth heuristic patterns — should still map via the isinstance check.
+    e = AuthenticationError("Bearer token expired", PROVIDER, MODEL)
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMAuthenticationError)
+
+
+def test_map_typed_permission_denied_error():
+    response = httpx.Response(
+        status_code=403,
+        request=httpx.Request("POST", "https://example.test"),
+    )
+    e = PermissionDeniedError("Region not allowed", PROVIDER, MODEL, response)
     mapped = map_provider_exception(e)
     assert isinstance(mapped, LLMAuthenticationError)
 


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary
- looks_like_auth_error only ran substring matching on the exception message, so a typed litellm.AuthenticationError (401) or PermissionDeniedError (403) whose text didn't include a known pattern (e.g. "Bearer 
  token expired", "Region not allowed") was downgraded to LLMBadRequestError or passed through unchanged.
- Trust the typed exception by short-circuiting on isinstance(exc, (AuthenticationError, PermissionDeniedError)) before falling back to the string heuristic.

## Issue Number
Closes #2957

## How to Test

- uv run pytest tests/sdk/llm/test_exception_mapping.py — 7 passed, including two new cases that construct typed 401/403 exceptions with messages that intentionally miss every heuristic pattern.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6f32557-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6f32557-python \
  ghcr.io/openhands/agent-server:6f32557-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6f32557-golang-amd64
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-golang-amd64
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-golang-amd64
ghcr.io/openhands/agent-server:6f32557-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6f32557-golang-arm64
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-golang-arm64
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-golang-arm64
ghcr.io/openhands/agent-server:6f32557-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6f32557-java-amd64
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-java-amd64
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-java-amd64
ghcr.io/openhands/agent-server:6f32557-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6f32557-java-arm64
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-java-arm64
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-java-arm64
ghcr.io/openhands/agent-server:6f32557-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6f32557-python-amd64
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-python-amd64
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-python-amd64
ghcr.io/openhands/agent-server:6f32557-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6f32557-python-arm64
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-python-arm64
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-python-arm64
ghcr.io/openhands/agent-server:6f32557-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6f32557-golang
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-golang
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-golang
ghcr.io/openhands/agent-server:6f32557-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6f32557-java
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-java
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-java
ghcr.io/openhands/agent-server:6f32557-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6f32557-python
ghcr.io/openhands/agent-server:6f325579d13d4b562c3633cedef023395bea3eeb-python
ghcr.io/openhands/agent-server:2957-llm-auth-error-on-startup-python
ghcr.io/openhands/agent-server:6f32557-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6f32557-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6f32557-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->