### PR TITLE
fix(agent-server): ignore redundant WebSocket auth control frames

### DIFF
--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -295,6 +295,12 @@ async def events_socket(
         while True:
             try:
                 data = await websocket.receive_json()
+                if _is_auth_control_message(data):
+                    logger.debug(
+                        "ignoring redundant auth control frame: %s",
+                        conversation_id,
+                    )
+                    continue
                 logger.info(f"Received message: {conversation_id}")
                 message = Message.model_validate(data)
                 await event_service.send_message(message, True)
@@ -427,6 +433,17 @@ async def _send_event(event: Event, websocket: WebSocket):
         logger.debug("error_sending_event_disconnected: %r (%s)", event, e)
     except Exception:
         logger.exception("error_sending_event: %r", event, stack_info=True)
+
+
+def _is_auth_control_message(data: object) -> bool:
+    """Return True for ``{"type": "auth", ...}`` first-message-auth frames.
+
+    Clients that handle both legacy and first-message auth may send this
+    frame even after legacy (query/header) auth has already succeeded.
+    The post-auth receive loops must ignore it instead of validating it
+    as a regular message payload.
+    """
+    return isinstance(data, dict) and data.get("type") == "auth"
 
 
 async def _safe_close_websocket(

--- a/tests/agent_server/test_websocket_first_message_auth.py
+++ b/tests/agent_server/test_websocket_first_message_auth.py
@@ -252,6 +252,54 @@ async def test_events_socket_first_message_auth_e2e():
 
 
 @pytest.mark.asyncio
+async def test_events_socket_ignores_redundant_auth_control_frame():
+    """A redundant ``{"type": "auth", ...}`` frame after legacy auth is ignored.
+
+    Regression for issue #3127: mixed-mode clients can authenticate via the
+    legacy query param / header and *also* send a first-message auth frame.
+    The post-auth receive loop must skip that frame instead of validating
+    it as a ``Message`` (which fails on the missing ``role`` field and
+    emits a noisy ``ServerErrorEvent``).
+    """
+    from openhands.agent_server.event_service import EventService
+    from openhands.agent_server.sockets import events_socket
+
+    ws = _make_mock_websocket()
+    # First frame on the post-auth loop is the redundant auth control
+    # message; second frame is a real user message; third closes the loop.
+    real_user_message = {"role": "user", "content": []}
+    ws.receive_json.side_effect = [
+        {"type": "auth", "session_api_key": "sk-oh-valid"},
+        real_user_message,
+        WebSocketDisconnect(),
+    ]
+
+    mock_event_service = MagicMock(spec=EventService)
+    mock_event_service.subscribe_to_events = AsyncMock(return_value=uuid4())
+    mock_event_service.unsubscribe_from_events = AsyncMock(return_value=True)
+    mock_event_service.send_message = AsyncMock()
+
+    with (
+        patch(
+            "openhands.agent_server.sockets.conversation_service"
+        ) as mock_conv_service,
+        patch("openhands.agent_server.sockets.get_default_config") as mock_config,
+    ):
+        mock_config.return_value.session_api_keys = ["sk-oh-valid"]
+        mock_conv_service.get_event_service = AsyncMock(return_value=mock_event_service)
+
+        # Authenticate via legacy query param so receive_text is never called.
+        await events_socket(uuid4(), ws, session_api_key="sk-oh-valid")
+
+    # No ServerErrorEvent should be emitted for the auth control frame.
+    ws.send_json.assert_not_called()
+    # send_message is only called for the real user message, exactly once.
+    assert mock_event_service.send_message.await_count == 1
+    sent_message = mock_event_service.send_message.await_args.args[0]
+    assert sent_message.role == "user"
+
+
+@pytest.mark.asyncio
 async def test_events_socket_first_message_auth_rejected():
     """events_socket returns early when first-message auth fails."""
     from openhands.agent_server.sockets import events_socket


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary

The post-auth receive loop in events_socket() validated every incoming frame as Message. Mixed-mode clients that authenticate via the legacy query param / header and also send
  {"type":"auth","session_api_key":"..."} as their first frame caused that frame to fail Message validation (no role) and emit a noisy ServerErrorEvent on the conversation event stream.

- Add _is_auth_control_message() helper in sockets.py.
- In events_socket()'s post-auth receive loop, skip auth control frames at debug level before calling Message.model_validate(data).

Scoped to events_socket() only — bash_events_socket() doesn't hit this bug in practice.

## Issue Number
Closes #3127.

## How to Test
- New regression test test_events_socket_ignores_redundant_auth_control_frame: legacy-auths via query param, feeds {"type":"auth", ...} then a real user message then WebSocketDisconnect; asserts no send_json (no
   ServerErrorEvent) and send_message awaited exactly once with role="user".
- tests/agent_server/test_websocket_first_message_auth.py — 16/16 pass.
- tests/agent_server/test_agent_server_wsproto.py — 6/6 pass.
- tests/agent_server/test_event_router_websocket.py — 17/17 pass.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore