### PR TITLE
ci(release-binaries): release window binaries

### DIFF
--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -84,6 +84,9 @@ jobs:
                     - runner: macos-14
                       os_label: macos
                       arch: arm64
+                    - runner: windows-2022
+                      os_label: windows
+                      arch: x86_64
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -97,18 +100,30 @@ jobs:
             - name: Install dependencies
               run: uv sync --dev
 
-            - name: Build binary
+            - name: Build binary (Unix)
+              if: runner.os != 'Windows'
               run: make build-server
+
+            - name: Build binary (Windows)
+              if: runner.os == 'Windows'
+              shell: bash
+              run: uv run pyinstaller openhands-agent-server/openhands/agent_server/agent-server.spec
 
             - name: Smoke-test binary
               shell: bash
               run: |
                   set -euo pipefail
 
-                  ./dist/openhands-agent-server --help
+                  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+                      BIN=./dist/openhands-agent-server.exe
+                  else
+                      BIN=./dist/openhands-agent-server
+                  fi
+
+                  "$BIN" --help
 
                   echo "Testing server startup and template loading..."
-                  ./dist/openhands-agent-server --port 8002 > server_test.log 2>&1 &
+                  "$BIN" --port 8002 > server_test.log 2>&1 &
                   SERVER_PID=$!
 
                   cleanup() {
@@ -150,7 +165,11 @@ jobs:
               run: |
                   set -euo pipefail
                   mkdir -p release-assets
-                  cp dist/openhands-agent-server "release-assets/${ASSET}"
+                  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+                      cp dist/openhands-agent-server.exe "release-assets/${ASSET}.exe"
+                  else
+                      cp dist/openhands-agent-server "release-assets/${ASSET}"
+                  fi
                   ls -la release-assets/
 
             - name: Upload binary as workflow artifact

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -31,8 +31,9 @@ jobs:
     build-binary-and-test:
         runs-on: ${{ matrix.os }}
         strategy:
+            fail-fast: false
             matrix:
-                os: [ubuntu-latest, macos-latest]
+                os: [ubuntu-latest, macos-latest, windows-latest]
         steps:
             - uses: actions/checkout@v6
 
@@ -44,52 +45,50 @@ jobs:
             - name: Install dependencies
               run: uv sync --dev
 
-            - name: Build binary
-              run: |
-                  make build-server
+            - name: Build binary (Unix)
+              if: runner.os != 'Windows'
+              run: make build-server
 
-            # FIXME: windows-latest not working due to
-            # Run if [[ "windows-latest" == "windows-latest" ]]; then
-            # [PYI-2160:ERROR] Failed to load Python DLL 'C:\Users\RUNNER~1\AppData\Local\Temp\_MEI5602\python312.dll'.
-            # LoadLibrary: Invalid access to memory location.
-            # - name: Test binary (Windows)
-            #   if: matrix.os == 'windows-latest'
-            #   shell: pwsh
-            #   run: |
-            #       Get-ChildItem dist
-            #       .\dist\openhands-agent-server.exe --help
+            # Windows runners have no `make`; invoke PyInstaller directly.
+            # `--noupx` defends against the historical PYI-2160 "Failed to load
+            # Python DLL" error sometimes triggered by UPX-compressed bundles.
+            - name: Build binary (Windows)
+              if: runner.os == 'Windows'
+              shell: bash
+              run: uv run pyinstaller --noupx openhands-agent-server/openhands/agent_server/agent-server.spec
 
-            - name: Test binary (Linux and macOS)
-              if: matrix.os != 'windows-latest'
+            - name: Test binary
               shell: bash
               run: |
-                  # Test help command
-                  ./dist/openhands-agent-server --help
+                  set -euo pipefail
 
-                  # Test server startup and template loading
+                  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+                      BIN=./dist/openhands-agent-server.exe
+                  else
+                      BIN=./dist/openhands-agent-server
+                  fi
+
+                  "$BIN" --help
+
                   echo "Testing server startup and template loading..."
-                  ./dist/openhands-agent-server --port 8002 > server_test.log 2>&1 &
+                  "$BIN" --port 8002 > server_test.log 2>&1 &
                   SERVER_PID=$!
 
-                  # Wait for server to start
                   sleep 5
 
-                  # Check if server started successfully (no template errors)
                   if grep -q "system_prompt.j2.*not found" server_test.log; then
                       echo "ERROR: Template files not found in binary!"
                       cat server_test.log
-                      kill $SERVER_PID 2>/dev/null || true
+                      kill "$SERVER_PID" 2>/dev/null || true
                       exit 1
                   fi
 
-                  # Check if server is running
-                  if ! kill -0 $SERVER_PID 2>/dev/null; then
+                  if ! kill -0 "$SERVER_PID" 2>/dev/null; then
                       echo "ERROR: Server failed to start!"
                       cat server_test.log
                       exit 1
                   fi
 
-                  # Test basic API endpoint
                   if command -v curl >/dev/null 2>&1; then
                       echo "Testing basic API endpoint..."
                       if curl -f -s http://localhost:8002/health >/dev/null 2>&1; then
@@ -99,9 +98,8 @@ jobs:
                       fi
                   fi
 
-                  # Clean up
-                  kill $SERVER_PID 2>/dev/null || true
-                  wait $SERVER_PID 2>/dev/null || true
+                  kill "$SERVER_PID" 2>/dev/null || true
+                  wait "$SERVER_PID" 2>/dev/null || true
                   rm -f server_test.log
 
                   echo "✓ Binary test completed successfully"
@@ -111,7 +109,7 @@ jobs:
               with:
                   name: openhands-server-${{ matrix.os }}
                   path: |
-                      dist/openhands-server*
+                      dist/openhands-agent-server*
                   retention-days: 7
 
     check-openapi-schema:

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -50,12 +50,10 @@ jobs:
               run: make build-server
 
             # Windows runners have no `make`; invoke PyInstaller directly.
-            # `--noupx` defends against the historical PYI-2160 "Failed to load
-            # Python DLL" error sometimes triggered by UPX-compressed bundles.
             - name: Build binary (Windows)
               if: runner.os == 'Windows'
               shell: bash
-              run: uv run pyinstaller --noupx openhands-agent-server/openhands/agent_server/agent-server.spec
+              run: uv run pyinstaller openhands-agent-server/openhands/agent_server/agent-server.spec
 
             - name: Test binary
               shell: bash

--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -6,11 +6,16 @@ PyInstaller spec for OpenHands Agent Server with PEP 420 (implicit namespace) la
 from pathlib import Path
 import os
 import site
+import sys
 from PyInstaller.utils.hooks import (
     collect_submodules,
     collect_data_files,
     copy_metadata,
 )
+
+# GNU strip on Windows PE files (notably python3XX.dll) can corrupt the binary
+# and cause LoadLibrary to fail at runtime with "Invalid access to memory location".
+IS_WINDOWS = sys.platform == "win32"
 
 # Get the project root directory (current working directory when running PyInstaller)
 project_root = Path.cwd()
@@ -152,7 +157,7 @@ exe = EXE(
     name="openhands-agent-server",
     debug=False,
     bootloader_ignore_signals=False,
-    strip=True,
+    strip=not IS_WINDOWS,
     upx=True,
     upx_exclude=[],
     runtime_tmpdir=None,


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why
Missing Window Binaries

## Summary
- Add Windows (x86_64) to the agent-server binary build matrix so PyInstaller produces a .exe alongside the existing Linux/macOS binaries.
- Added windows-latest to server.yml's build-binary-and-test (PR-time verification) and windows-2022 / x86_64 to release-binaries.yml (release artifact). The previously commented-out FIXME about PYI-2160 ("Failed to load Python DLL LoadLibrary: Invalid access to memory location") is resolved by disabling strip on Windows in the PyInstaller spec — GNU strip corrupts Windows PE files (notably python3XX.dll), which produced that load failure.

## How to Test

- build-binary-and-test (windows-latest) passes on this PR (runs help + /health smoke test on the bundled .exe).
- binary-windows-x86_64 artifact is produced on the release-binaries.yml workflow when it next runs against main / a release.
- Linux and macOS binary jobs continue to pass (no regression from sharing the spec).

## 
- Build step is split: make build-server on Unix, uv run pyinstaller <spec> directly on Windows (no make on Windows runners).
- --noupx is not passed; UPX isn't preinstalled on windows-latest so upx=True is a no-op there anyway.
- Asset is published as agent-server-<version>-windows-x86_64.exe.
## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:831f65b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-831f65b-python \
  ghcr.io/openhands/agent-server:831f65b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:831f65b-golang-amd64
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-golang-amd64
ghcr.io/openhands/agent-server:vasco-window-binaries-golang-amd64
ghcr.io/openhands/agent-server:831f65b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:831f65b-golang-arm64
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-golang-arm64
ghcr.io/openhands/agent-server:vasco-window-binaries-golang-arm64
ghcr.io/openhands/agent-server:831f65b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:831f65b-java-amd64
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-java-amd64
ghcr.io/openhands/agent-server:vasco-window-binaries-java-amd64
ghcr.io/openhands/agent-server:831f65b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:831f65b-java-arm64
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-java-arm64
ghcr.io/openhands/agent-server:vasco-window-binaries-java-arm64
ghcr.io/openhands/agent-server:831f65b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:831f65b-python-amd64
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-python-amd64
ghcr.io/openhands/agent-server:vasco-window-binaries-python-amd64
ghcr.io/openhands/agent-server:831f65b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:831f65b-python-arm64
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-python-arm64
ghcr.io/openhands/agent-server:vasco-window-binaries-python-arm64
ghcr.io/openhands/agent-server:831f65b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:831f65b-golang
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-golang
ghcr.io/openhands/agent-server:vasco-window-binaries-golang
ghcr.io/openhands/agent-server:831f65b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:831f65b-java
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-java
ghcr.io/openhands/agent-server:vasco-window-binaries-java
ghcr.io/openhands/agent-server:831f65b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:831f65b-python
ghcr.io/openhands/agent-server:831f65bdbd243684d5f3273b94d1e5bf063927ca-python
ghcr.io/openhands/agent-server:vasco-window-binaries-python
ghcr.io/openhands/agent-server:831f65b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `831f65b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `831f65b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->