### PR TITLE
fix(agent-server): bundle rich submodules for unicode width data

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -108,6 +108,9 @@ a = Analysis(
         *collect_submodules("fastmcp"),
         *collect_submodules("fakeredis"),
         *collect_submodules("lupa"),  # Required for fakeredis[lua] Lua scripting support
+        # rich._unicode_data.unicodeX_Y_Z is imported dynamically based on
+        # unicodedata.unidata_version (e.g. unicode17_0_0 on Python 3.13).
+        *collect_submodules("rich"),
 
         # mcp subpackages used at runtime (avoid CLI)
         "mcp.types",


### PR DESCRIPTION
## Summary

`rich.logging` dynamically imports `rich._unicode_data.unicode<X>_<Y>_<Z>` based on `unicodedata.unidata_version` (e.g. `unicode17_0_0` on Python 3.13) the first time it renders text that needs east-asian-width measurement — anything containing emoji is enough to trip it.

PyInstaller's default `rich` hook does not enumerate those version-suffixed data submodules, so the bundled binary crashes with:

```
ModuleNotFoundError: No module named 'rich._unicode_data.unicode17_0_0'
```

This was observed when running the Windows binary from PR #3228: startup logs the `⚠️ OH_SECRET_KEY was not defined` warning, which contains an emoji, and Rich's measurement codepath fails. The server itself still starts (the crash is inside the log handler), but the traceback is noisy and could mask other failures.

The same defect affects the Linux/macOS binaries with Python 3.13 — the CI smoke test simply never logged emoji-bearing output before `/health` responded.

The fix adds `collect_submodules("rich")` to the PyInstaller spec so every `_unicode_data.unicode*` submodule is bundled.

## Test plan
- [ ] `build-binary-and-test` is green on all three OS matrix entries.
- [ ] Download the `openhands-server-windows-latest` artifact and run `openhands-agent-server.exe`; the `⚠️ OH_SECRET_KEY` warning prints cleanly without the `ModuleNotFoundError` traceback.
- [ ] Spot-check the macOS/Linux artifacts (same Python 3.13 build) to confirm no regression.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9588220-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9588220-python \
  ghcr.io/openhands/agent-server:9588220-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9588220-golang-amd64
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-golang-amd64
ghcr.io/openhands/agent-server:9588220-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9588220-golang-arm64
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-golang-arm64
ghcr.io/openhands/agent-server:9588220-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9588220-java-amd64
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-java-amd64
ghcr.io/openhands/agent-server:9588220-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9588220-java-arm64
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-java-arm64
ghcr.io/openhands/agent-server:9588220-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9588220-python-amd64
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-python-amd64
ghcr.io/openhands/agent-server:9588220-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9588220-python-arm64
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-python-arm64
ghcr.io/openhands/agent-server:9588220-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9588220-golang
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-golang
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-golang
ghcr.io/openhands/agent-server:9588220-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9588220-java
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-java
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-java
ghcr.io/openhands/agent-server:9588220-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9588220-python
ghcr.io/openhands/agent-server:9588220796ae5f933382c512ee4a65482d2ec092-python
ghcr.io/openhands/agent-server:vasco-fix-rich-unicode-data-python
ghcr.io/openhands/agent-server:9588220-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9588220-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9588220-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->