### PR TITLE
feat(agent-server): Add CRUD API endpoints for skills management

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -23,6 +23,7 @@ from openhands.agent_server.skills_service import (
     service_update_skill,
     sync_public_skills,
 )
+from openhands.sdk.extensions.fetch import ExtensionFetchError
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     SkillFetchError,
@@ -365,7 +366,7 @@ def install_skill_endpoint(request: InstallSkillRequest) -> InstalledSkillRespon
             status_code=409,
             detail="Skill already installed. Use force=true to overwrite.",
         )
-    except SkillFetchError:
+    except (SkillFetchError, ExtensionFetchError):
         raise HTTPException(
             status_code=400,
             detail="Failed to fetch skill source. Check that the source is valid.",

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -6,13 +6,25 @@ Business logic is delegated to skills_service.py.
 
 from typing import Literal
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
 from openhands.agent_server.skills_service import (
     ExposedUrlData,
     load_all_skills,
+    service_disable_skill,
+    service_enable_skill,
+    service_get_installed_skill,
+    service_install_skill,
+    service_list_installed_skills,
+    service_uninstall_skill,
+    service_update_skill,
     sync_public_skills,
+)
+from openhands.sdk.skills import (
+    InstalledSkillInfo,
+    SkillFetchError,
+    SkillValidationError,
 )
 from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
 
@@ -112,6 +124,90 @@ class SyncResponse(BaseModel):
     message: str
 
 
+# ---------------------------------------------------------------------------
+# Installed Skills Management Models
+# ---------------------------------------------------------------------------
+
+
+class InstallSkillRequest(BaseModel):
+    """Request body for installing a skill."""
+
+    source: str = Field(
+        description=(
+            "Skill source - git URL, GitHub shorthand, or local path. "
+            "Examples: "
+            "'https://github.com/OpenHands/extensions/tree/main/skills/github', "
+            "'github:OpenHands/extensions/skills/github', "
+            "'/path/to/skill'"
+        )
+    )
+    ref: str | None = Field(
+        default=None,
+        description="Optional branch, tag, or commit to install",
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description="Subdirectory path within the repository (for monorepos)",
+    )
+    force: bool = Field(
+        default=False,
+        description="If true, overwrite existing installation",
+    )
+
+
+class InstalledSkillResponse(BaseModel):
+    """Response containing installed skill information."""
+
+    name: str = Field(description="Skill name")
+    version: str = Field(default="", description="Skill version")
+    description: str = Field(default="", description="Skill description")
+    enabled: bool = Field(default=True, description="Whether the skill is enabled")
+    source: str = Field(description="Original source (e.g., 'github:owner/repo')")
+    resolved_ref: str | None = Field(
+        default=None, description="Resolved git commit SHA"
+    )
+    repo_path: str | None = Field(
+        default=None, description="Subdirectory path within the repository"
+    )
+    installed_at: str = Field(description="ISO 8601 timestamp of installation")
+    install_path: str = Field(description="Path where the skill is installed")
+
+
+class InstalledSkillsListResponse(BaseModel):
+    """Response containing list of installed skills."""
+
+    skills: list[InstalledSkillResponse]
+
+
+class UpdateSkillStateRequest(BaseModel):
+    """Request body for updating skill state (enable/disable)."""
+
+    enabled: bool = Field(description="Whether to enable or disable the skill")
+
+
+class UpdateSkillStateResponse(BaseModel):
+    """Response from skill state update operation."""
+
+    success: bool
+    name: str
+    enabled: bool
+
+
+class UninstallSkillResponse(BaseModel):
+    """Response from skill uninstall operation."""
+
+    success: bool
+    message: str
+
+
+class UpdateSkillResponse(BaseModel):
+    """Response from skill update operation."""
+
+    success: bool
+    message: str
+    skill: InstalledSkillResponse | None = None
+
+
 @skills_router.post("", response_model=SkillsResponse)
 def get_skills(request: SkillsRequest) -> SkillsResponse:
     """Load and merge skills from all configured sources.
@@ -189,4 +285,196 @@ def sync_skills() -> SyncResponse:
     return SyncResponse(
         status="success" if success else "error",
         message=message,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Installed Skills Management Endpoints
+# ---------------------------------------------------------------------------
+
+
+def _info_to_response(info: InstalledSkillInfo) -> InstalledSkillResponse:
+    """Convert an InstalledSkillInfo to an InstalledSkillResponse."""
+    return InstalledSkillResponse(
+        name=info.name,
+        version=info.version,
+        description=info.description,
+        enabled=info.enabled,
+        source=info.source,
+        resolved_ref=info.resolved_ref,
+        repo_path=info.repo_path,
+        installed_at=info.installed_at,
+        install_path=str(info.install_path),
+    )
+
+
+@skills_router.post("/install", response_model=InstalledSkillResponse)
+def install_skill_endpoint(request: InstallSkillRequest) -> InstalledSkillResponse:
+    """Install a skill from a source.
+
+    Installs a skill from a git URL, GitHub shorthand, or local path into
+    the user's installed skills directory (~/.openhands/skills/installed/).
+
+    Args:
+        request: InstallSkillRequest containing source and options.
+
+    Returns:
+        InstalledSkillResponse with details about the installation.
+
+    Raises:
+        HTTPException 409: If skill is already installed and force=False.
+        HTTPException 400: If fetching the skill source fails.
+        HTTPException 422: If the skill is invalid.
+    """
+    try:
+        info = service_install_skill(
+            source=request.source,
+            ref=request.ref,
+            repo_path=request.repo_path,
+            force=request.force,
+        )
+        return _info_to_response(info)
+    except FileExistsError as e:
+        raise HTTPException(
+            status_code=409,
+            detail=f"Skill already installed. Use force=true to overwrite. {e}",
+        )
+    except SkillFetchError as e:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Failed to fetch skill source: {e}",
+        )
+    except SkillValidationError as e:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Invalid skill: {e}",
+        )
+
+
+@skills_router.get("/installed", response_model=InstalledSkillsListResponse)
+def list_installed_skills_endpoint() -> InstalledSkillsListResponse:
+    """List all installed skills.
+
+    Returns a list of all skills installed in the user's installed skills
+    directory (~/.openhands/skills/installed/).
+
+    Returns:
+        InstalledSkillsListResponse containing list of installed skills.
+    """
+    skills = service_list_installed_skills()
+    return InstalledSkillsListResponse(
+        skills=[_info_to_response(info) for info in skills]
+    )
+
+
+@skills_router.get("/installed/{skill_name}", response_model=InstalledSkillResponse)
+def get_installed_skill_endpoint(skill_name: str) -> InstalledSkillResponse:
+    """Get information about a specific installed skill.
+
+    Args:
+        skill_name: Name of the skill to get.
+
+    Returns:
+        InstalledSkillResponse with skill details.
+
+    Raises:
+        HTTPException 404: If the skill is not installed.
+    """
+    info = service_get_installed_skill(name=skill_name)
+    if info is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Skill '{skill_name}' is not installed",
+        )
+    return _info_to_response(info)
+
+
+@skills_router.patch("/installed/{skill_name}", response_model=UpdateSkillStateResponse)
+def update_skill_state_endpoint(
+    skill_name: str, request: UpdateSkillStateRequest
+) -> UpdateSkillStateResponse:
+    """Enable or disable an installed skill.
+
+    Args:
+        skill_name: Name of the skill to update.
+        request: UpdateSkillStateRequest with enabled state.
+
+    Returns:
+        UpdateSkillStateResponse indicating success and new state.
+
+    Raises:
+        HTTPException 404: If the skill is not installed.
+    """
+    if request.enabled:
+        success = service_enable_skill(name=skill_name)
+    else:
+        success = service_disable_skill(name=skill_name)
+
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Skill '{skill_name}' is not installed",
+        )
+
+    return UpdateSkillStateResponse(
+        success=True,
+        name=skill_name,
+        enabled=request.enabled,
+    )
+
+
+@skills_router.delete("/installed/{skill_name}", response_model=UninstallSkillResponse)
+def uninstall_skill_endpoint(skill_name: str) -> UninstallSkillResponse:
+    """Uninstall a skill by name.
+
+    Removes a skill from the user's installed skills directory.
+
+    Args:
+        skill_name: Name of the skill to uninstall.
+
+    Returns:
+        UninstallSkillResponse indicating success.
+
+    Raises:
+        HTTPException 404: If the skill is not installed.
+    """
+    success = service_uninstall_skill(name=skill_name)
+    if not success:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Skill '{skill_name}' is not installed",
+        )
+    return UninstallSkillResponse(
+        success=True,
+        message=f"Skill '{skill_name}' uninstalled",
+    )
+
+
+@skills_router.post(
+    "/installed/{skill_name}/update", response_model=UpdateSkillResponse
+)
+def update_skill_endpoint(skill_name: str) -> UpdateSkillResponse:
+    """Update an installed skill to the latest version.
+
+    Re-fetches the skill from its original source and updates the installation.
+
+    Args:
+        skill_name: Name of the skill to update.
+
+    Returns:
+        UpdateSkillResponse with updated skill information.
+
+    Raises:
+        HTTPException 404: If the skill is not installed.
+    """
+    info = service_update_skill(name=skill_name)
+    if info is None:
+        raise HTTPException(
+            status_code=404,
+            detail=f"Skill '{skill_name}' is not installed",
+        )
+    return UpdateSkillResponse(
+        success=True,
+        message=f"Skill '{skill_name}' updated",
+        skill=_info_to_response(info),
     )

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -11,6 +11,7 @@ from pydantic import BaseModel, Field
 
 from openhands.agent_server.skills_service import (
     ExposedUrlData,
+    MarketplaceSkillInfo,
     load_all_skills,
     service_disable_skill,
     service_enable_skill,
@@ -28,6 +29,7 @@ from openhands.sdk.skills import (
     SkillValidationError,
 )
 from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
+from openhands.sdk.skills.utils import SKILL_NAME_PATTERN
 
 
 skills_router = APIRouter(prefix="/skills", tags=["Skills"])
@@ -39,8 +41,8 @@ SkillNamePath = Annotated[
     Path(
         min_length=1,
         max_length=255,
-        pattern=r"^[a-zA-Z0-9_-]+$",
-        description="Skill name (alphanumeric, hyphens, underscores)",
+        pattern=SKILL_NAME_PATTERN.pattern,
+        description="Skill name (lowercase alphanumeric, hyphens)",
     ),
 ]
 
@@ -186,6 +188,20 @@ class InstalledSkillResponse(BaseModel):
     installed_at: str = Field(description="ISO 8601 timestamp of installation")
     install_path: str = Field(description="Path where the skill is installed")
 
+    @classmethod
+    def from_skill_info(cls, info: InstalledSkillInfo) -> "InstalledSkillResponse":
+        return cls(
+            name=info.name,
+            version=info.version,
+            description=info.description,
+            enabled=info.enabled,
+            source=info.source,
+            resolved_ref=info.resolved_ref,
+            repo_path=info.repo_path,
+            installed_at=info.installed_at,
+            install_path=str(info.install_path),
+        )
+
 
 class InstalledSkillsListResponse(BaseModel):
     """Response containing list of installed skills."""
@@ -196,7 +212,7 @@ class InstalledSkillsListResponse(BaseModel):
 class UpdateSkillStateRequest(BaseModel):
     """Request body for updating skill state (enable/disable)."""
 
-    enabled: bool = Field(description="Whether to enable or disable the skill")
+    enabled: bool
 
 
 class UpdateSkillStateResponse(BaseModel):
@@ -216,22 +232,13 @@ class UpdateSkillResponse(BaseModel):
     """Response from skill update operation."""
 
     message: str
-    skill: InstalledSkillResponse | None = None
-
-
-class MarketplaceSkillItem(BaseModel):
-    """A skill entry in the marketplace catalog."""
-
-    name: str = Field(description="Skill name")
-    description: str | None = Field(default=None, description="Skill description")
-    source: str = Field(description="Source URL or path for installation")
-    installed: bool = Field(description="Whether the skill is currently installed")
+    skill: InstalledSkillResponse
 
 
 class MarketplaceCatalogResponse(BaseModel):
     """Response containing the marketplace catalog."""
 
-    skills: list[MarketplaceSkillItem]
+    skills: list[MarketplaceSkillInfo]
 
 
 @skills_router.post("", response_model=SkillsResponse)
@@ -319,22 +326,15 @@ def sync_skills() -> SyncResponse:
 # ---------------------------------------------------------------------------
 
 
-def _info_to_response(info: InstalledSkillInfo) -> InstalledSkillResponse:
-    """Convert an InstalledSkillInfo to an InstalledSkillResponse."""
-    return InstalledSkillResponse(
-        name=info.name,
-        version=info.version,
-        description=info.description,
-        enabled=info.enabled,
-        source=info.source,
-        resolved_ref=info.resolved_ref,
-        repo_path=info.repo_path,
-        installed_at=info.installed_at,
-        install_path=str(info.install_path),
-    )
-
-
-@skills_router.post("/install", response_model=InstalledSkillResponse)
+@skills_router.post(
+    "/install",
+    response_model=InstalledSkillResponse,
+    responses={
+        400: {"description": "Failed to fetch skill source"},
+        409: {"description": "Skill already installed (use force=true)"},
+        422: {"description": "Invalid skill (missing SKILL.md, etc.)"},
+    },
+)
 def install_skill_endpoint(request: InstallSkillRequest) -> InstalledSkillResponse:
     """Install a skill from a source.
 
@@ -359,7 +359,7 @@ def install_skill_endpoint(request: InstallSkillRequest) -> InstalledSkillRespon
             repo_path=request.repo_path,
             force=request.force,
         )
-        return _info_to_response(info)
+        return InstalledSkillResponse.from_skill_info(info)
     except FileExistsError:
         raise HTTPException(
             status_code=409,
@@ -389,11 +389,15 @@ def list_installed_skills_endpoint() -> InstalledSkillsListResponse:
     """
     skills = service_list_installed_skills()
     return InstalledSkillsListResponse(
-        skills=[_info_to_response(info) for info in skills]
+        skills=[InstalledSkillResponse.from_skill_info(info) for info in skills]
     )
 
 
-@skills_router.get("/installed/{skill_name}", response_model=InstalledSkillResponse)
+@skills_router.get(
+    "/installed/{skill_name}",
+    response_model=InstalledSkillResponse,
+    responses={404: {"description": "Skill not installed"}},
+)
 def get_installed_skill_endpoint(skill_name: SkillNamePath) -> InstalledSkillResponse:
     """Get information about a specific installed skill.
 
@@ -412,11 +416,15 @@ def get_installed_skill_endpoint(skill_name: SkillNamePath) -> InstalledSkillRes
             status_code=404,
             detail=f"Skill '{skill_name}' is not installed",
         )
-    return _info_to_response(info)
+    return InstalledSkillResponse.from_skill_info(info)
 
 
-@skills_router.patch("/installed/{skill_name}", response_model=UpdateSkillStateResponse)
-def update_skill_state_endpoint(
+@skills_router.patch(
+    "/installed/{skill_name}",
+    response_model=UpdateSkillStateResponse,
+    responses={404: {"description": "Skill not installed"}},
+)
+def set_skill_enabled_endpoint(
     skill_name: SkillNamePath, request: UpdateSkillStateRequest
 ) -> UpdateSkillStateResponse:
     """Enable or disable an installed skill.
@@ -431,12 +439,8 @@ def update_skill_state_endpoint(
     Raises:
         HTTPException 404: If the skill is not installed.
     """
-    if request.enabled:
-        success = service_enable_skill(name=skill_name)
-    else:
-        success = service_disable_skill(name=skill_name)
-
-    if not success:
+    fn = service_enable_skill if request.enabled else service_disable_skill
+    if not fn(name=skill_name):
         raise HTTPException(
             status_code=404,
             detail=f"Skill '{skill_name}' is not installed",
@@ -448,7 +452,11 @@ def update_skill_state_endpoint(
     )
 
 
-@skills_router.delete("/installed/{skill_name}", response_model=UninstallSkillResponse)
+@skills_router.delete(
+    "/installed/{skill_name}",
+    response_model=UninstallSkillResponse,
+    responses={404: {"description": "Skill not installed"}},
+)
 def uninstall_skill_endpoint(skill_name: SkillNamePath) -> UninstallSkillResponse:
     """Uninstall a skill by name.
 
@@ -475,15 +483,17 @@ def uninstall_skill_endpoint(skill_name: SkillNamePath) -> UninstallSkillRespons
 
 
 @skills_router.post(
-    "/installed/{skill_name}/update", response_model=UpdateSkillResponse
+    "/installed/{skill_name}/refresh",
+    response_model=UpdateSkillResponse,
+    responses={404: {"description": "Skill not installed"}},
 )
-def update_skill_endpoint(skill_name: SkillNamePath) -> UpdateSkillResponse:
-    """Update an installed skill to the latest version.
+def refresh_skill_endpoint(skill_name: SkillNamePath) -> UpdateSkillResponse:
+    """Refresh an installed skill to the latest version.
 
     Re-fetches the skill from its original source and updates the installation.
 
     Args:
-        skill_name: Name of the skill to update.
+        skill_name: Name of the skill to refresh.
 
     Returns:
         UpdateSkillResponse with updated skill information.
@@ -499,7 +509,7 @@ def update_skill_endpoint(skill_name: SkillNamePath) -> UpdateSkillResponse:
         )
     return UpdateSkillResponse(
         message=f"Skill '{skill_name}' updated",
-        skill=_info_to_response(info),
+        skill=InstalledSkillResponse.from_skill_info(info),
     )
 
 
@@ -516,15 +526,4 @@ def get_marketplace_catalog() -> MarketplaceCatalogResponse:
     Returns:
         MarketplaceCatalogResponse containing list of available skills.
     """
-    catalog = service_get_marketplace_catalog()
-    return MarketplaceCatalogResponse(
-        skills=[
-            MarketplaceSkillItem(
-                name=item.name,
-                description=item.description,
-                source=item.source,
-                installed=item.installed,
-            )
-            for item in catalog
-        ]
-    )
+    return MarketplaceCatalogResponse(skills=service_get_marketplace_catalog())

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -15,6 +15,7 @@ from openhands.agent_server.skills_service import (
     service_disable_skill,
     service_enable_skill,
     service_get_installed_skill,
+    service_get_marketplace_catalog,
     service_install_skill,
     service_list_installed_skills,
     service_uninstall_skill,
@@ -206,6 +207,21 @@ class UpdateSkillResponse(BaseModel):
     success: bool
     message: str
     skill: InstalledSkillResponse | None = None
+
+
+class MarketplaceSkillItem(BaseModel):
+    """A skill entry in the marketplace catalog."""
+
+    name: str = Field(description="Skill name")
+    description: str | None = Field(default=None, description="Skill description")
+    source: str = Field(description="Source URL or path for installation")
+    installed: bool = Field(description="Whether the skill is currently installed")
+
+
+class MarketplaceCatalogResponse(BaseModel):
+    """Response containing the marketplace catalog."""
+
+    skills: list[MarketplaceSkillItem]
 
 
 @skills_router.post("", response_model=SkillsResponse)
@@ -477,4 +493,31 @@ def update_skill_endpoint(skill_name: str) -> UpdateSkillResponse:
         success=True,
         message=f"Skill '{skill_name}' updated",
         skill=_info_to_response(info),
+    )
+
+
+@skills_router.get("/marketplace", response_model=MarketplaceCatalogResponse)
+def get_marketplace_catalog() -> MarketplaceCatalogResponse:
+    """Get the marketplace catalog with installation status.
+
+    Returns a list of available skills from the OpenHands extensions
+    repository marketplace, along with their installation status.
+
+    This enables frontend applications to display a "Marketplace" tab
+    with installable skills.
+
+    Returns:
+        MarketplaceCatalogResponse containing list of available skills.
+    """
+    catalog = service_get_marketplace_catalog()
+    return MarketplaceCatalogResponse(
+        skills=[
+            MarketplaceSkillItem(
+                name=item.name,
+                description=item.description,
+                source=item.source,
+                installed=item.installed,
+            )
+            for item in catalog
+        ]
     )

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -4,9 +4,9 @@ This module defines the HTTP API endpoints for skill operations.
 Business logic is delegated to skills_service.py.
 """
 
-from typing import Literal
+from typing import Annotated, Literal
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, Path
 from pydantic import BaseModel, Field
 
 from openhands.agent_server.skills_service import (
@@ -31,6 +31,18 @@ from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
 
 
 skills_router = APIRouter(prefix="/skills", tags=["Skills"])
+
+# Validated skill name path parameter
+# Prevents empty strings, path traversal, and invalid characters
+SkillNamePath = Annotated[
+    str,
+    Path(
+        min_length=1,
+        max_length=255,
+        pattern=r"^[a-zA-Z0-9_-]+$",
+        description="Skill name (alphanumeric, hyphens, underscores)",
+    ),
+]
 
 
 class ExposedUrl(BaseModel):
@@ -134,13 +146,14 @@ class InstallSkillRequest(BaseModel):
     """Request body for installing a skill."""
 
     source: str = Field(
+        min_length=1,
         description=(
             "Skill source - git URL, GitHub shorthand, or local path. "
             "Examples: "
             "'https://github.com/OpenHands/extensions/tree/main/skills/github', "
             "'github:OpenHands/extensions/skills/github', "
             "'/path/to/skill'"
-        )
+        ),
     )
     ref: str | None = Field(
         default=None,
@@ -189,7 +202,6 @@ class UpdateSkillStateRequest(BaseModel):
 class UpdateSkillStateResponse(BaseModel):
     """Response from skill state update operation."""
 
-    success: bool
     name: str
     enabled: bool
 
@@ -197,14 +209,12 @@ class UpdateSkillStateResponse(BaseModel):
 class UninstallSkillResponse(BaseModel):
     """Response from skill uninstall operation."""
 
-    success: bool
     message: str
 
 
 class UpdateSkillResponse(BaseModel):
     """Response from skill update operation."""
 
-    success: bool
     message: str
     skill: InstalledSkillResponse | None = None
 
@@ -350,20 +360,20 @@ def install_skill_endpoint(request: InstallSkillRequest) -> InstalledSkillRespon
             force=request.force,
         )
         return _info_to_response(info)
-    except FileExistsError as e:
+    except FileExistsError:
         raise HTTPException(
             status_code=409,
-            detail=f"Skill already installed. Use force=true to overwrite. {e}",
+            detail="Skill already installed. Use force=true to overwrite.",
         )
-    except SkillFetchError as e:
+    except SkillFetchError:
         raise HTTPException(
             status_code=400,
-            detail=f"Failed to fetch skill source: {e}",
+            detail="Failed to fetch skill source. Check that the source is valid.",
         )
-    except SkillValidationError as e:
+    except SkillValidationError:
         raise HTTPException(
             status_code=422,
-            detail=f"Invalid skill: {e}",
+            detail="Invalid skill. Ensure the source contains a valid SKILL.md.",
         )
 
 
@@ -384,7 +394,7 @@ def list_installed_skills_endpoint() -> InstalledSkillsListResponse:
 
 
 @skills_router.get("/installed/{skill_name}", response_model=InstalledSkillResponse)
-def get_installed_skill_endpoint(skill_name: str) -> InstalledSkillResponse:
+def get_installed_skill_endpoint(skill_name: SkillNamePath) -> InstalledSkillResponse:
     """Get information about a specific installed skill.
 
     Args:
@@ -407,7 +417,7 @@ def get_installed_skill_endpoint(skill_name: str) -> InstalledSkillResponse:
 
 @skills_router.patch("/installed/{skill_name}", response_model=UpdateSkillStateResponse)
 def update_skill_state_endpoint(
-    skill_name: str, request: UpdateSkillStateRequest
+    skill_name: SkillNamePath, request: UpdateSkillStateRequest
 ) -> UpdateSkillStateResponse:
     """Enable or disable an installed skill.
 
@@ -416,7 +426,7 @@ def update_skill_state_endpoint(
         request: UpdateSkillStateRequest with enabled state.
 
     Returns:
-        UpdateSkillStateResponse indicating success and new state.
+        UpdateSkillStateResponse indicating new state.
 
     Raises:
         HTTPException 404: If the skill is not installed.
@@ -433,14 +443,13 @@ def update_skill_state_endpoint(
         )
 
     return UpdateSkillStateResponse(
-        success=True,
         name=skill_name,
         enabled=request.enabled,
     )
 
 
 @skills_router.delete("/installed/{skill_name}", response_model=UninstallSkillResponse)
-def uninstall_skill_endpoint(skill_name: str) -> UninstallSkillResponse:
+def uninstall_skill_endpoint(skill_name: SkillNamePath) -> UninstallSkillResponse:
     """Uninstall a skill by name.
 
     Removes a skill from the user's installed skills directory.
@@ -449,7 +458,7 @@ def uninstall_skill_endpoint(skill_name: str) -> UninstallSkillResponse:
         skill_name: Name of the skill to uninstall.
 
     Returns:
-        UninstallSkillResponse indicating success.
+        UninstallSkillResponse with uninstall message.
 
     Raises:
         HTTPException 404: If the skill is not installed.
@@ -461,7 +470,6 @@ def uninstall_skill_endpoint(skill_name: str) -> UninstallSkillResponse:
             detail=f"Skill '{skill_name}' is not installed",
         )
     return UninstallSkillResponse(
-        success=True,
         message=f"Skill '{skill_name}' uninstalled",
     )
 
@@ -469,7 +477,7 @@ def uninstall_skill_endpoint(skill_name: str) -> UninstallSkillResponse:
 @skills_router.post(
     "/installed/{skill_name}/update", response_model=UpdateSkillResponse
 )
-def update_skill_endpoint(skill_name: str) -> UpdateSkillResponse:
+def update_skill_endpoint(skill_name: SkillNamePath) -> UpdateSkillResponse:
     """Update an installed skill to the latest version.
 
     Re-fetches the skill from its original source and updates the installation.
@@ -490,7 +498,6 @@ def update_skill_endpoint(skill_name: str) -> UpdateSkillResponse:
             detail=f"Skill '{skill_name}' is not installed",
         )
     return UpdateSkillResponse(
-        success=True,
         message=f"Skill '{skill_name}' updated",
         skill=_info_to_response(info),
     )

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -44,6 +44,7 @@ from openhands.sdk.skills.utils import (
     update_skills_repository,
 )
 from openhands.sdk.utils import sanitized_env
+from openhands.sdk.utils.path import to_posix_path
 
 
 logger = get_logger(__name__)
@@ -539,3 +540,105 @@ def service_update_skill(
         Updated InstalledSkillInfo if successful, None if skill not found.
     """
     return update_skill(name=name, installed_dir=installed_dir)
+
+
+@dataclass
+class MarketplaceSkillInfo:
+    """Information about a skill in the marketplace catalog."""
+
+    name: str
+    description: str | None
+    source: str
+    installed: bool
+
+
+def service_get_marketplace_catalog(
+    marketplace_path: str = DEFAULT_MARKETPLACE_PATH,
+    installed_dir: Path | None = None,
+) -> list[MarketplaceSkillInfo]:
+    """Get the marketplace catalog with installation status.
+
+    Loads the marketplace JSON from the public extensions repository and
+    enriches each entry with installation status.
+
+    Args:
+        marketplace_path: Relative path to marketplace JSON file.
+            Defaults to marketplaces/default.json.
+        installed_dir: Directory for installed skills to check status.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        List of MarketplaceSkillInfo with skill details and installation status.
+    """
+    from openhands.sdk.marketplace import Marketplace
+
+    # Ensure the public skills repository is cloned/updated
+    cache_dir = get_skills_cache_dir()
+    repo_path = update_skills_repository(
+        PUBLIC_SKILLS_REPO, PUBLIC_SKILLS_BRANCH, cache_dir
+    )
+
+    if repo_path is None:
+        logger.warning("Failed to access public skills repository")
+        return []
+
+    # Load the marketplace manifest
+    marketplace_file = repo_path / marketplace_path
+    if not marketplace_file.exists():
+        logger.warning(f"Marketplace file not found: {marketplace_file}")
+        return []
+
+    try:
+        marketplace = Marketplace.load(repo_path)
+    except (FileNotFoundError, ValueError) as e:
+        # Fallback to loading from specific path
+        try:
+            import json
+
+            with open(marketplace_file, encoding="utf-8") as f:
+                data = json.load(f)
+            marketplace = Marketplace.model_validate(
+                {**data, "path": to_posix_path(repo_path)}
+            )
+        except Exception as e2:
+            logger.warning(f"Failed to load marketplace: {e}, {e2}")
+            return []
+
+    # Get installed skill names for status check
+    installed_skills = service_list_installed_skills(installed_dir=installed_dir)
+    installed_names = {skill.name for skill in installed_skills}
+
+    # Build catalog from plugins (skills listed in marketplace)
+    catalog: list[MarketplaceSkillInfo] = []
+
+    for plugin in marketplace.plugins:
+        # Resolve source URL
+        source, ref, subpath = marketplace.resolve_plugin_source(plugin)
+
+        # Build full source string
+        if ref:
+            source = f"{source}@{ref}"
+        if subpath:
+            source = f"{source}/{subpath}"
+
+        catalog.append(
+            MarketplaceSkillInfo(
+                name=plugin.name,
+                description=plugin.description,
+                source=source,
+                installed=plugin.name in installed_names,
+            )
+        )
+
+    # Also include standalone skills from the marketplace
+    for skill_entry in marketplace.skills:
+        catalog.append(
+            MarketplaceSkillInfo(
+                name=skill_entry.name,
+                description=skill_entry.description,
+                source=skill_entry.source,
+                installed=skill_entry.name in installed_names,
+            )
+        )
+
+    return catalog

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -22,8 +22,16 @@ from pathlib import Path
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.skills import (
+    InstalledSkillInfo,
     Skill,
+    disable_skill,
+    enable_skill,
+    get_installed_skill,
+    install_skill,
+    list_installed_skills,
     load_available_skills,
+    uninstall_skill,
+    update_skill,
 )
 from openhands.sdk.skills.skill import (
     DEFAULT_MARKETPLACE_PATH,
@@ -386,3 +394,148 @@ def sync_public_skills() -> tuple[bool, str]:
     except Exception as e:
         logger.warning(f"Failed to sync skills repository: {e}")
         return (False, f"Sync failed: {str(e)}")
+
+
+# ---------------------------------------------------------------------------
+# Installed Skills Management (CRUD Operations)
+# ---------------------------------------------------------------------------
+
+
+def service_install_skill(
+    source: str,
+    ref: str | None = None,
+    repo_path: str | None = None,
+    force: bool = False,
+    installed_dir: Path | None = None,
+) -> InstalledSkillInfo:
+    """Install a skill from a source.
+
+    Args:
+        source: Skill source - git URL, GitHub shorthand, or local path.
+            Supports formats like:
+            - GitHub URL: https://github.com/OpenHands/extensions/tree/main/skills/github
+            - GitHub shorthand: github:OpenHands/extensions/skills/github
+            - Local path: /path/to/skill
+        ref: Optional branch, tag, or commit to install.
+        repo_path: Subdirectory path within the repository (for monorepos).
+        force: If True, overwrite existing installation.
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        InstalledSkillInfo with details about the installation.
+
+    Raises:
+        FileExistsError: If skill is already installed and force=False.
+        SkillFetchError: If fetching the skill source fails.
+        SkillValidationError: If the skill is invalid.
+    """
+    return install_skill(
+        source=source,
+        ref=ref,
+        repo_path=repo_path,
+        force=force,
+        installed_dir=installed_dir,
+    )
+
+
+def service_uninstall_skill(
+    name: str,
+    installed_dir: Path | None = None,
+) -> bool:
+    """Uninstall a skill by name.
+
+    Args:
+        name: Name of the skill to uninstall.
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        True if the skill was uninstalled, False if it wasn't installed.
+    """
+    return uninstall_skill(name=name, installed_dir=installed_dir)
+
+
+def service_enable_skill(
+    name: str,
+    installed_dir: Path | None = None,
+) -> bool:
+    """Enable an installed skill by name.
+
+    Args:
+        name: Name of the skill to enable.
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        True if the skill was enabled, False if it wasn't found.
+    """
+    return enable_skill(name=name, installed_dir=installed_dir)
+
+
+def service_disable_skill(
+    name: str,
+    installed_dir: Path | None = None,
+) -> bool:
+    """Disable an installed skill by name.
+
+    Args:
+        name: Name of the skill to disable.
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        True if the skill was disabled, False if it wasn't found.
+    """
+    return disable_skill(name=name, installed_dir=installed_dir)
+
+
+def service_list_installed_skills(
+    installed_dir: Path | None = None,
+) -> list[InstalledSkillInfo]:
+    """List all installed skills.
+
+    Self-healing: reconciles metadata with what is on disk.
+
+    Args:
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        List of InstalledSkillInfo objects for all installed skills.
+    """
+    return list_installed_skills(installed_dir=installed_dir)
+
+
+def service_get_installed_skill(
+    name: str,
+    installed_dir: Path | None = None,
+) -> InstalledSkillInfo | None:
+    """Get information about a specific installed skill.
+
+    Args:
+        name: Name of the skill to get.
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        InstalledSkillInfo if found, None otherwise.
+    """
+    return get_installed_skill(name=name, installed_dir=installed_dir)
+
+
+def service_update_skill(
+    name: str,
+    installed_dir: Path | None = None,
+) -> InstalledSkillInfo | None:
+    """Update an installed skill to the latest version.
+
+    Args:
+        name: Name of the skill to update.
+        installed_dir: Directory for installed skills.
+            Defaults to ~/.openhands/skills/installed/.
+
+    Returns:
+        Updated InstalledSkillInfo if successful, None if skill not found.
+    """
+    return update_skill(name=name, installed_dir=installed_dir)

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -20,6 +20,7 @@ import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
+from time import monotonic
 
 from pydantic import BaseModel, ValidationError
 
@@ -555,6 +556,23 @@ class MarketplaceSkillInfo(BaseModel):
     installed: bool
 
 
+# ---------------------------------------------------------------------------
+# Marketplace catalog cache
+# ---------------------------------------------------------------------------
+# Each call to service_get_marketplace_catalog triggers a git fetch via
+# update_skills_repository, which is a network-bound operation that takes
+# multiple seconds. A short TTL cache avoids that hit on every tab open.
+#
+# Only the catalog structure (name, description, source) is cached; the
+# `installed` field is always derived fresh from the local FS so that
+# install/uninstall actions are reflected immediately.
+#
+# Type: (timestamp, list-of-(name, description, source)) or None
+_CatalogEntry = tuple[str, str | None, str]
+_catalog_cache: tuple[float, list[_CatalogEntry]] | None = None
+_CATALOG_TTL_SECONDS = 300  # 5 minutes
+
+
 def service_get_marketplace_catalog(
     marketplace_path: str = DEFAULT_MARKETPLACE_PATH,
     installed_dir: Path | None = None,
@@ -563,6 +581,10 @@ def service_get_marketplace_catalog(
 
     Loads the marketplace JSON from the public extensions repository and
     enriches each entry with installation status.
+
+    The catalog structure (name, description, source) is cached for
+    _CATALOG_TTL_SECONDS to avoid a git fetch on every call. The
+    ``installed`` field is always resolved fresh from the local FS.
 
     Args:
         marketplace_path: Relative path to marketplace JSON file.
@@ -573,7 +595,36 @@ def service_get_marketplace_catalog(
     Returns:
         List of MarketplaceSkillInfo with skill details and installation status.
     """
-    # Ensure the public skills repository is cloned/updated
+    global _catalog_cache
+
+    now = monotonic()
+    if _catalog_cache is not None and now - _catalog_cache[0] < _CATALOG_TTL_SECONDS:
+        entries = _catalog_cache[1]
+    else:
+        entries = _fetch_catalog_entries(marketplace_path)
+        _catalog_cache = (now, entries)
+
+    # Always-fresh installed check — local FS scan, not a network call.
+    installed_names = {
+        s.name for s in service_list_installed_skills(installed_dir=installed_dir)
+    }
+    return [
+        MarketplaceSkillInfo(
+            name=name, description=desc, source=src, installed=name in installed_names
+        )
+        for name, desc, src in entries
+    ]
+
+
+def _fetch_catalog_entries(marketplace_path: str) -> list[_CatalogEntry]:
+    """Fetch marketplace catalog entries from the public extensions repository.
+
+    This is the slow path: it does a git fetch + reads the marketplace JSON.
+    Results are cached by the caller.
+
+    Returns:
+        List of (name, description, source) tuples, or an empty list on error.
+    """
     cache_dir = get_skills_cache_dir()
     repo_path = update_skills_repository(
         PUBLIC_SKILLS_REPO, PUBLIC_SKILLS_BRANCH, cache_dir
@@ -583,7 +634,6 @@ def service_get_marketplace_catalog(
         logger.warning("Failed to access public skills repository")
         return []
 
-    # Load the marketplace manifest
     marketplace_file = repo_path / marketplace_path
     if not marketplace_file.exists():
         logger.warning(f"Marketplace file not found: {marketplace_file}")
@@ -603,19 +653,13 @@ def service_get_marketplace_catalog(
             logger.warning(f"Failed to load marketplace: {e}, {e2}")
             return []
 
-    # Get installed skill names for status check
-    installed_skills = service_list_installed_skills(installed_dir=installed_dir)
-    installed_names = {skill.name for skill in installed_skills}
-
     # Build catalog from plugins and skills.
     # Plugins take priority: if a name appears in both plugins and skills,
     # the plugin version is used (since plugins are added first).
-    catalog_dict: dict[str, MarketplaceSkillInfo] = {}
+    entries: dict[str, _CatalogEntry] = {}
 
     for plugin in marketplace.plugins:
-        # Resolve source URL
         source, ref, subpath = marketplace.resolve_plugin_source(plugin)
-
         # Build full source string for marketplace catalog.
         # Format: "github:owner/repo@ref/path" - the SDK's install_skill
         # can parse this format, so frontends can pass it directly to the
@@ -624,22 +668,14 @@ def service_get_marketplace_catalog(
             source = f"{source}@{ref}"
         if subpath:
             source = f"{source}/{subpath}"
+        entries[plugin.name] = (plugin.name, plugin.description, source)
 
-        catalog_dict[plugin.name] = MarketplaceSkillInfo(
-            name=plugin.name,
-            description=plugin.description,
-            source=source,
-            installed=plugin.name in installed_names,
-        )
-
-    # Also include standalone skills from the marketplace (if not already present)
     for skill_entry in marketplace.skills:
-        if skill_entry.name not in catalog_dict:
-            catalog_dict[skill_entry.name] = MarketplaceSkillInfo(
-                name=skill_entry.name,
-                description=skill_entry.description,
-                source=skill_entry.source,
-                installed=skill_entry.name in installed_names,
+        if skill_entry.name not in entries:
+            entries[skill_entry.name] = (
+                skill_entry.name,
+                skill_entry.description,
+                skill_entry.source,
             )
 
-    return list(catalog_dict.values())
+    return list(entries.values())

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -608,14 +608,19 @@ def service_get_marketplace_catalog(
     installed_skills = service_list_installed_skills(installed_dir=installed_dir)
     installed_names = {skill.name for skill in installed_skills}
 
-    # Build catalog from plugins and skills, deduplicating by name
+    # Build catalog from plugins and skills.
+    # Plugins take priority: if a name appears in both plugins and skills,
+    # the plugin version is used (since plugins are added first).
     catalog_dict: dict[str, MarketplaceSkillInfo] = {}
 
     for plugin in marketplace.plugins:
         # Resolve source URL
         source, ref, subpath = marketplace.resolve_plugin_source(plugin)
 
-        # Build full source string
+        # Build full source string for marketplace catalog.
+        # Format: "github:owner/repo@ref/path" - the SDK's install_skill
+        # can parse this format, so frontends can pass it directly to the
+        # install endpoint's source field.
         if ref:
             source = f"{source}@{ref}"
         if subpath:

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -567,6 +567,11 @@ class MarketplaceSkillInfo(BaseModel):
 # `installed` field is always derived fresh from the local FS so that
 # install/uninstall actions are reflected immediately.
 #
+# Thread safety: concurrent cache misses (cold start or TTL expiry) may
+# trigger parallel git fetches, but each fetch is idempotent and produces
+# the same result (last writer wins). For this low-traffic endpoint the
+# thundering-herd risk is acceptable without an explicit lock.
+#
 # Type: (timestamp, list-of-(name, description, source)) or None
 _CatalogEntry = tuple[str, str | None, str]
 _catalog_cache: tuple[float, list[_CatalogEntry]] | None = None

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -21,7 +21,7 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace import Marketplace
@@ -546,8 +546,7 @@ def service_update_skill(
     return update_skill(name=name, installed_dir=installed_dir)
 
 
-@dataclass
-class MarketplaceSkillInfo:
+class MarketplaceSkillInfo(BaseModel):
     """Information about a skill in the marketplace catalog."""
 
     name: str

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -14,13 +14,17 @@ Precedence (later overrides earlier):
 sandbox < public < user < org < project
 """
 
+import json
 import shutil
 import subprocess
 import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from pydantic import ValidationError
+
 from openhands.sdk.logger import get_logger
+from openhands.sdk.marketplace import Marketplace
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     Skill,
@@ -570,8 +574,6 @@ def service_get_marketplace_catalog(
     Returns:
         List of MarketplaceSkillInfo with skill details and installation status.
     """
-    from openhands.sdk.marketplace import Marketplace
-
     # Ensure the public skills repository is cloned/updated
     cache_dir = get_skills_cache_dir()
     repo_path = update_skills_repository(
@@ -593,14 +595,12 @@ def service_get_marketplace_catalog(
     except (FileNotFoundError, ValueError) as e:
         # Fallback to loading from specific path
         try:
-            import json
-
             with open(marketplace_file, encoding="utf-8") as f:
                 data = json.load(f)
             marketplace = Marketplace.model_validate(
                 {**data, "path": to_posix_path(repo_path)}
             )
-        except Exception as e2:
+        except (json.JSONDecodeError, ValidationError, OSError) as e2:
             logger.warning(f"Failed to load marketplace: {e}, {e2}")
             return []
 
@@ -608,8 +608,8 @@ def service_get_marketplace_catalog(
     installed_skills = service_list_installed_skills(installed_dir=installed_dir)
     installed_names = {skill.name for skill in installed_skills}
 
-    # Build catalog from plugins (skills listed in marketplace)
-    catalog: list[MarketplaceSkillInfo] = []
+    # Build catalog from plugins and skills, deduplicating by name
+    catalog_dict: dict[str, MarketplaceSkillInfo] = {}
 
     for plugin in marketplace.plugins:
         # Resolve source URL
@@ -621,24 +621,21 @@ def service_get_marketplace_catalog(
         if subpath:
             source = f"{source}/{subpath}"
 
-        catalog.append(
-            MarketplaceSkillInfo(
-                name=plugin.name,
-                description=plugin.description,
-                source=source,
-                installed=plugin.name in installed_names,
-            )
+        catalog_dict[plugin.name] = MarketplaceSkillInfo(
+            name=plugin.name,
+            description=plugin.description,
+            source=source,
+            installed=plugin.name in installed_names,
         )
 
-    # Also include standalone skills from the marketplace
+    # Also include standalone skills from the marketplace (if not already present)
     for skill_entry in marketplace.skills:
-        catalog.append(
-            MarketplaceSkillInfo(
+        if skill_entry.name not in catalog_dict:
+            catalog_dict[skill_entry.name] = MarketplaceSkillInfo(
                 name=skill_entry.name,
                 description=skill_entry.description,
                 source=skill_entry.source,
                 installed=skill_entry.name in installed_names,
             )
-        )
 
-    return catalog
+    return list(catalog_dict.values())

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -525,7 +525,6 @@ class TestUpdateSkillStateEndpoint:
 
             assert response.status_code == 200
             data = response.json()
-            assert data["success"] is True
             assert data["name"] == "test-skill"
             assert data["enabled"] is True
 
@@ -543,7 +542,6 @@ class TestUpdateSkillStateEndpoint:
 
             assert response.status_code == 200
             data = response.json()
-            assert data["success"] is True
             assert data["enabled"] is False
 
     def test_update_skill_state_not_found(self, client):
@@ -575,7 +573,6 @@ class TestUninstallSkillEndpoint:
 
             assert response.status_code == 200
             data = response.json()
-            assert data["success"] is True
             assert "uninstalled" in data["message"].lower()
 
     def test_uninstall_skill_not_found(self, client):
@@ -604,7 +601,6 @@ class TestUpdateSkillEndpoint:
 
             assert response.status_code == 200
             data = response.json()
-            assert data["success"] is True
             assert data["skill"]["name"] == "test-skill"
 
     def test_update_skill_not_found(self, client):

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.skills_service import MarketplaceSkillInfo, SkillLoadResult
+from openhands.sdk.extensions.fetch import ExtensionFetchError
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     KeywordTrigger,
@@ -427,6 +428,24 @@ class TestInstallSkillEndpoint:
             response = client.post(
                 "/api/skills/install",
                 json={"source": "github:owner/repo/skills/test-skill"},
+            )
+
+            assert response.status_code == 400
+            assert "fetch" in response.json()["detail"].lower()
+
+    def test_install_skill_extension_fetch_error(self, client):
+        """ExtensionFetchError (raised by the SDK for GitHub URL/shorthand failures)
+        must map to 400, not 500."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.side_effect = ExtensionFetchError(
+                "Could not fetch from GitHub"
+            )
+
+            response = client.post(
+                "/api/skills/install",
+                json={"source": "https://github.com/Owner/repo/tree/main/path"},
             )
 
             assert response.status_code == 400

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -8,7 +8,7 @@ from fastapi.testclient import TestClient
 
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
-from openhands.agent_server.skills_service import SkillLoadResult
+from openhands.agent_server.skills_service import MarketplaceSkillInfo, SkillLoadResult
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     KeywordTrigger,
@@ -617,3 +617,76 @@ class TestUpdateSkillEndpoint:
             response = client.post("/api/skills/installed/nonexistent/update")
 
             assert response.status_code == 404
+
+
+class TestMarketplaceCatalogEndpoint:
+    """Tests for GET /skills/marketplace endpoint."""
+
+    def test_get_marketplace_catalog_empty(self, client):
+        """Test getting marketplace when no skills are available."""
+        with patch(
+            "openhands.agent_server.skills_router.service_get_marketplace_catalog"
+        ) as mock_catalog:
+            mock_catalog.return_value = []
+
+            response = client.get("/api/skills/marketplace")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["skills"] == []
+
+    def test_get_marketplace_catalog_with_skills(self, client):
+        """Test getting marketplace with available skills."""
+        with patch(
+            "openhands.agent_server.skills_router.service_get_marketplace_catalog"
+        ) as mock_catalog:
+            mock_catalog.return_value = [
+                MarketplaceSkillInfo(
+                    name="github",
+                    description="GitHub integration skill",
+                    source="github:OpenHands/extensions/skills/github",
+                    installed=True,
+                ),
+                MarketplaceSkillInfo(
+                    name="docker",
+                    description="Docker management skill",
+                    source="github:OpenHands/extensions/skills/docker",
+                    installed=False,
+                ),
+            ]
+
+            response = client.get("/api/skills/marketplace")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["skills"]) == 2
+
+            # Check first skill
+            assert data["skills"][0]["name"] == "github"
+            assert data["skills"][0]["description"] == "GitHub integration skill"
+            assert data["skills"][0]["installed"] is True
+
+            # Check second skill
+            assert data["skills"][1]["name"] == "docker"
+            assert data["skills"][1]["installed"] is False
+
+    def test_get_marketplace_catalog_skill_without_description(self, client):
+        """Test marketplace skill with no description."""
+        with patch(
+            "openhands.agent_server.skills_router.service_get_marketplace_catalog"
+        ) as mock_catalog:
+            mock_catalog.return_value = [
+                MarketplaceSkillInfo(
+                    name="minimal-skill",
+                    description=None,
+                    source="github:owner/repo",
+                    installed=False,
+                ),
+            ]
+
+            response = client.get("/api/skills/marketplace")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["skills"]) == 1
+            assert data["skills"][0]["description"] is None

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -1,19 +1,44 @@
 """Tests for skills router endpoints."""
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
 
-from openhands.agent_server.api import api
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
 from openhands.agent_server.skills_service import SkillLoadResult
-from openhands.sdk.skills import KeywordTrigger, Skill
+from openhands.sdk.skills import (
+    InstalledSkillInfo,
+    KeywordTrigger,
+    Skill,
+    SkillFetchError,
+    SkillValidationError,
+)
 
 
 @pytest.fixture
 def client():
-    """Create a test client for the FastAPI app."""
-    return TestClient(api)
+    """Create a test client for the FastAPI app without authentication."""
+    config = Config(session_api_keys=[])  # Disable authentication
+    return TestClient(create_app(config), raise_server_exceptions=False)
+
+
+@pytest.fixture
+def mock_installed_skill_info():
+    """Create a mock InstalledSkillInfo for testing."""
+    return InstalledSkillInfo(
+        name="test-skill",
+        version="1.0.0",
+        description="A test skill",
+        enabled=True,
+        source="github:owner/repo/skills/test-skill",
+        resolved_ref="abc123",
+        repo_path=None,
+        installed_at="2024-01-01T00:00:00Z",
+        install_path=Path("/home/user/.openhands/skills/installed/test-skill"),
+    )
 
 
 class TestGetSkillsEndpoint:
@@ -312,3 +337,283 @@ class TestPydanticModels:
             },
         )
         assert response.status_code == 422
+
+
+class TestInstallSkillEndpoint:
+    """Tests for POST /skills/install endpoint."""
+
+    def test_install_skill_success(self, client, mock_installed_skill_info):
+        """Test successful skill installation."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.return_value = mock_installed_skill_info
+
+            response = client.post(
+                "/api/skills/install",
+                json={"source": "github:owner/repo/skills/test-skill"},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["name"] == "test-skill"
+            assert data["source"] == "github:owner/repo/skills/test-skill"
+            assert data["enabled"] is True
+
+    def test_install_skill_with_force(self, client, mock_installed_skill_info):
+        """Test skill installation with force option."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.return_value = mock_installed_skill_info
+
+            response = client.post(
+                "/api/skills/install",
+                json={
+                    "source": "github:owner/repo/skills/test-skill",
+                    "force": True,
+                },
+            )
+
+            assert response.status_code == 200
+            mock_install.assert_called_once()
+            call_kwargs = mock_install.call_args[1]
+            assert call_kwargs["force"] is True
+
+    def test_install_skill_with_ref(self, client, mock_installed_skill_info):
+        """Test skill installation with specific ref."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.return_value = mock_installed_skill_info
+
+            response = client.post(
+                "/api/skills/install",
+                json={
+                    "source": "github:owner/repo",
+                    "ref": "v1.0.0",
+                    "repo_path": "skills/test-skill",
+                },
+            )
+
+            assert response.status_code == 200
+            mock_install.assert_called_once()
+            call_kwargs = mock_install.call_args[1]
+            assert call_kwargs["ref"] == "v1.0.0"
+            assert call_kwargs["repo_path"] == "skills/test-skill"
+
+    def test_install_skill_already_exists(self, client):
+        """Test skill installation when skill already exists."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.side_effect = FileExistsError("Skill already exists")
+
+            response = client.post(
+                "/api/skills/install",
+                json={"source": "github:owner/repo/skills/test-skill"},
+            )
+
+            assert response.status_code == 409
+            assert "already installed" in response.json()["detail"].lower()
+
+    def test_install_skill_fetch_error(self, client):
+        """Test skill installation with fetch error."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.side_effect = SkillFetchError("Network error")
+
+            response = client.post(
+                "/api/skills/install",
+                json={"source": "github:owner/repo/skills/test-skill"},
+            )
+
+            assert response.status_code == 400
+            assert "fetch" in response.json()["detail"].lower()
+
+    def test_install_skill_validation_error(self, client):
+        """Test skill installation with validation error."""
+        with patch(
+            "openhands.agent_server.skills_router.service_install_skill"
+        ) as mock_install:
+            mock_install.side_effect = SkillValidationError("Missing SKILL.md")
+
+            response = client.post(
+                "/api/skills/install",
+                json={"source": "/path/to/invalid-skill"},
+            )
+
+            assert response.status_code == 422
+            assert "invalid" in response.json()["detail"].lower()
+
+
+class TestListInstalledSkillsEndpoint:
+    """Tests for GET /skills/installed endpoint."""
+
+    def test_list_installed_skills_empty(self, client):
+        """Test listing when no skills are installed."""
+        with patch(
+            "openhands.agent_server.skills_router.service_list_installed_skills"
+        ) as mock_list:
+            mock_list.return_value = []
+
+            response = client.get("/api/skills/installed")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["skills"] == []
+
+    def test_list_installed_skills_with_skills(self, client, mock_installed_skill_info):
+        """Test listing installed skills."""
+        with patch(
+            "openhands.agent_server.skills_router.service_list_installed_skills"
+        ) as mock_list:
+            mock_list.return_value = [mock_installed_skill_info]
+
+            response = client.get("/api/skills/installed")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data["skills"]) == 1
+            assert data["skills"][0]["name"] == "test-skill"
+
+
+class TestGetInstalledSkillEndpoint:
+    """Tests for GET /skills/installed/{skill_name} endpoint."""
+
+    def test_get_installed_skill_found(self, client, mock_installed_skill_info):
+        """Test getting an installed skill that exists."""
+        with patch(
+            "openhands.agent_server.skills_router.service_get_installed_skill"
+        ) as mock_get:
+            mock_get.return_value = mock_installed_skill_info
+
+            response = client.get("/api/skills/installed/test-skill")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["name"] == "test-skill"
+
+    def test_get_installed_skill_not_found(self, client):
+        """Test getting a skill that is not installed."""
+        with patch(
+            "openhands.agent_server.skills_router.service_get_installed_skill"
+        ) as mock_get:
+            mock_get.return_value = None
+
+            response = client.get("/api/skills/installed/nonexistent")
+
+            assert response.status_code == 404
+            assert "not installed" in response.json()["detail"].lower()
+
+
+class TestUpdateSkillStateEndpoint:
+    """Tests for PATCH /skills/installed/{skill_name} endpoint."""
+
+    def test_enable_skill_success(self, client):
+        """Test enabling a skill."""
+        with patch(
+            "openhands.agent_server.skills_router.service_enable_skill"
+        ) as mock_enable:
+            mock_enable.return_value = True
+
+            response = client.patch(
+                "/api/skills/installed/test-skill",
+                json={"enabled": True},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["name"] == "test-skill"
+            assert data["enabled"] is True
+
+    def test_disable_skill_success(self, client):
+        """Test disabling a skill."""
+        with patch(
+            "openhands.agent_server.skills_router.service_disable_skill"
+        ) as mock_disable:
+            mock_disable.return_value = True
+
+            response = client.patch(
+                "/api/skills/installed/test-skill",
+                json={"enabled": False},
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["enabled"] is False
+
+    def test_update_skill_state_not_found(self, client):
+        """Test updating state of non-existent skill."""
+        with patch(
+            "openhands.agent_server.skills_router.service_enable_skill"
+        ) as mock_enable:
+            mock_enable.return_value = False
+
+            response = client.patch(
+                "/api/skills/installed/nonexistent",
+                json={"enabled": True},
+            )
+
+            assert response.status_code == 404
+
+
+class TestUninstallSkillEndpoint:
+    """Tests for DELETE /skills/installed/{skill_name} endpoint."""
+
+    def test_uninstall_skill_success(self, client):
+        """Test successful skill uninstallation."""
+        with patch(
+            "openhands.agent_server.skills_router.service_uninstall_skill"
+        ) as mock_uninstall:
+            mock_uninstall.return_value = True
+
+            response = client.delete("/api/skills/installed/test-skill")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert "uninstalled" in data["message"].lower()
+
+    def test_uninstall_skill_not_found(self, client):
+        """Test uninstalling a non-existent skill."""
+        with patch(
+            "openhands.agent_server.skills_router.service_uninstall_skill"
+        ) as mock_uninstall:
+            mock_uninstall.return_value = False
+
+            response = client.delete("/api/skills/installed/nonexistent")
+
+            assert response.status_code == 404
+
+
+class TestUpdateSkillEndpoint:
+    """Tests for POST /skills/installed/{skill_name}/update endpoint."""
+
+    def test_update_skill_success(self, client, mock_installed_skill_info):
+        """Test successful skill update."""
+        with patch(
+            "openhands.agent_server.skills_router.service_update_skill"
+        ) as mock_update:
+            mock_update.return_value = mock_installed_skill_info
+
+            response = client.post("/api/skills/installed/test-skill/update")
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["success"] is True
+            assert data["skill"]["name"] == "test-skill"
+
+    def test_update_skill_not_found(self, client):
+        """Test updating a non-existent skill."""
+        with patch(
+            "openhands.agent_server.skills_router.service_update_skill"
+        ) as mock_update:
+            mock_update.return_value = None
+
+            response = client.post("/api/skills/installed/nonexistent/update")
+
+            assert response.status_code == 404

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -587,30 +587,30 @@ class TestUninstallSkillEndpoint:
             assert response.status_code == 404
 
 
-class TestUpdateSkillEndpoint:
-    """Tests for POST /skills/installed/{skill_name}/update endpoint."""
+class TestRefreshSkillEndpoint:
+    """Tests for POST /skills/installed/{skill_name}/refresh endpoint."""
 
-    def test_update_skill_success(self, client, mock_installed_skill_info):
-        """Test successful skill update."""
+    def test_refresh_skill_success(self, client, mock_installed_skill_info):
+        """Test successful skill refresh."""
         with patch(
             "openhands.agent_server.skills_router.service_update_skill"
         ) as mock_update:
             mock_update.return_value = mock_installed_skill_info
 
-            response = client.post("/api/skills/installed/test-skill/update")
+            response = client.post("/api/skills/installed/test-skill/refresh")
 
             assert response.status_code == 200
             data = response.json()
             assert data["skill"]["name"] == "test-skill"
 
-    def test_update_skill_not_found(self, client):
-        """Test updating a non-existent skill."""
+    def test_refresh_skill_not_found(self, client):
+        """Test refreshing a non-existent skill."""
         with patch(
             "openhands.agent_server.skills_router.service_update_skill"
         ) as mock_update:
             mock_update.return_value = None
 
-            response = client.post("/api/skills/installed/nonexistent/update")
+            response = client.post("/api/skills/installed/nonexistent/refresh")
 
             assert response.status_code == 404
 

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -429,3 +429,124 @@ class TestSkillLoadResult:
 
         assert result.skills == []
         assert result.sources == {}
+
+
+class TestMarketplaceCatalogCache:
+    """Tests for TTL caching in service_get_marketplace_catalog."""
+
+    def setup_method(self):
+        """Reset the module-level cache before each test."""
+        import openhands.agent_server.skills_service as svc
+
+        svc._catalog_cache = None
+
+    def test_cache_miss_calls_fetch(self):
+        """First call (cold cache) fetches from the repository."""
+        entries = [("github", "GitHub skill", "github:org/repo")]
+        with (
+            patch(
+                "openhands.agent_server.skills_service._fetch_catalog_entries",
+                return_value=entries,
+            ) as mock_fetch,
+            patch(
+                "openhands.agent_server.skills_service.service_list_installed_skills",
+                return_value=[],
+            ),
+        ):
+            from openhands.agent_server.skills_service import (
+                service_get_marketplace_catalog,
+            )
+
+            result = service_get_marketplace_catalog()
+
+        mock_fetch.assert_called_once()
+        assert len(result) == 1
+        assert result[0].name == "github"
+        assert result[0].installed is False
+
+    def test_cache_hit_skips_fetch(self):
+        """Second call within TTL reuses cached entries without another fetch."""
+        entries = [("github", "GitHub skill", "github:org/repo")]
+        with (
+            patch(
+                "openhands.agent_server.skills_service._fetch_catalog_entries",
+                return_value=entries,
+            ) as mock_fetch,
+            patch(
+                "openhands.agent_server.skills_service.service_list_installed_skills",
+                return_value=[],
+            ),
+        ):
+            from openhands.agent_server.skills_service import (
+                service_get_marketplace_catalog,
+            )
+
+            service_get_marketplace_catalog()
+            service_get_marketplace_catalog()
+
+        mock_fetch.assert_called_once()  # only one fetch despite two calls
+
+    def test_installed_status_always_fresh(self):
+        """installed flag is derived fresh on every call, not from the cache."""
+        from unittest.mock import MagicMock
+
+        from openhands.agent_server.skills_service import (
+            InstalledSkillInfo,
+            service_get_marketplace_catalog,
+        )
+
+        entries = [("github", "GitHub skill", "github:org/repo")]
+        installed_skill = MagicMock(spec=InstalledSkillInfo)
+        installed_skill.name = "github"
+
+        with (
+            patch(
+                "openhands.agent_server.skills_service._fetch_catalog_entries",
+                return_value=entries,
+            ),
+            patch(
+                "openhands.agent_server.skills_service.service_list_installed_skills",
+            ) as mock_installed,
+        ):
+            # First call: skill not installed
+            mock_installed.return_value = []
+            result1 = service_get_marketplace_catalog()
+            assert result1[0].installed is False
+
+            # Second call (cache hit): skill now installed
+            mock_installed.return_value = [installed_skill]
+            result2 = service_get_marketplace_catalog()
+            assert result2[0].installed is True
+
+        # service_list_installed_skills called twice (once per request)
+        assert mock_installed.call_count == 2
+
+    def test_cache_expires_after_ttl(self):
+        """After TTL expires, the next call fetches from the repository again."""
+        import openhands.agent_server.skills_service as svc
+
+        entries = [("github", "GitHub skill", "github:org/repo")]
+        with (
+            patch(
+                "openhands.agent_server.skills_service._fetch_catalog_entries",
+                return_value=entries,
+            ) as mock_fetch,
+            patch(
+                "openhands.agent_server.skills_service.service_list_installed_skills",
+                return_value=[],
+            ),
+        ):
+            from openhands.agent_server.skills_service import (
+                service_get_marketplace_catalog,
+            )
+
+            service_get_marketplace_catalog()
+            # Artificially expire the cache
+            assert svc._catalog_cache is not None
+            svc._catalog_cache = (
+                svc._catalog_cache[0] - svc._CATALOG_TTL_SECONDS - 1,
+                entries,
+            )
+            service_get_marketplace_catalog()
+
+        assert mock_fetch.call_count == 2  # fetched again after expiry


### PR DESCRIPTION
## Summary

Add HTTP endpoints to the agent-server's `skills_router.py` to expose the existing SDK skill management functions, enabling frontend applications to install, uninstall, and manage skills.

Fixes [AGE-1524](https://linear.app/all-hands-ai/issue/AGE-1524/add-crud-api-endpoints-for-skills-management)
Closes #3230

## Changes

### New Endpoints

| Endpoint | Method | Description |
|----------|--------|-------------|
| `/api/skills/install` | POST | Install a skill from a source (GitHub URL, shorthand, or local path) |
| `/api/skills/installed` | GET | List all installed skills |
| `/api/skills/installed/{skill_name}` | GET | Get information about a specific installed skill |
| `/api/skills/installed/{skill_name}` | PATCH | Enable or disable an installed skill |
| `/api/skills/installed/{skill_name}` | DELETE | Uninstall a skill |
| `/api/skills/installed/{skill_name}/refresh` | POST | Update an installed skill to the latest version |
| `/api/skills/marketplace` | GET | Get marketplace catalog with installation status (TTL-cached) |

### Example Requests

**Get marketplace catalog:**
```bash
curl /api/skills/marketplace
```

**Install a skill:**
```bash
curl -X POST /api/skills/install \
  -H "Content-Type: application/json" \
  -d '{"source": "https://github.com/OpenHands/extensions/tree/main/skills/github"}'
```

**List installed skills:**
```bash
curl /api/skills/installed
```

**Enable/Disable a skill:**
```bash
curl -X PATCH /api/skills/installed/github \
  -H "Content-Type: application/json" \
  -d '{"enabled": false}'
```

**Uninstall a skill:**
```bash
curl -X DELETE /api/skills/installed/github
```

### Implementation Notes

- All endpoints use the standard `~/.openhands/skills/installed/` directory
- The install endpoint supports:
  - GitHub URLs (e.g., `https://github.com/owner/repo/tree/branch/path`)
  - GitHub shorthand (e.g., `github:owner/repo/skills/skill-name`)
  - Local filesystem paths
  - `force` parameter for overwriting existing installations
  - `ref` parameter for specific branches/tags/commits
  - `repo_path` parameter for monorepo subdirectories
- The marketplace endpoint caches the catalog structure (name, description, source) for 5 minutes to avoid a git fetch on every call; the `installed` field is always resolved fresh from the local FS
- Error responses follow existing API patterns with appropriate status codes:
  - 409: Skill already installed (use force=true)
  - 400: Failed to fetch skill source (covers both `SkillFetchError` and `ExtensionFetchError`)
  - 422: Invalid skill (e.g., missing SKILL.md)
  - 404: Skill not found

## Files Changed

- `openhands-agent-server/openhands/agent_server/skills_router.py` - Added new endpoints and Pydantic models
- `openhands-agent-server/openhands/agent_server/skills_service.py` - Added service functions wrapping SDK functions, with TTL cache for marketplace
- `tests/agent_server/test_skills_router.py` - Added tests for all new endpoints (35 tests total)
- `tests/agent_server/test_skills_service.py` - Added TTL cache tests (4 tests)

## Testing

All tests pass:
```
$ uv run pytest tests/agent_server/test_skills_router.py tests/agent_server/test_skills_service.py -v
...
======================== 66 passed, 5 warnings in 5.86s ========================
```

---

_This PR was created by an AI agent (OpenHands)._