### PR TITLE
feat(agent-server): typed settings update endpoints + ETag/If-Match

### DIFF
--- a/openhands-agent-server/openhands/agent_server/_settings_etag.py
+++ b/openhands-agent-server/openhands/agent_server/_settings_etag.py
@@ -1,0 +1,91 @@
+"""ETag and ``If-Match`` helpers for settings endpoints.
+
+The legacy ``PATCH /api/settings`` had no version stamp and no
+``If-Match`` support, so concurrent writes silently lost each other (the
+file lock only prevented on-disk corruption, not lost updates). The new
+typed endpoints emit an ``ETag`` on every read and write and accept
+``If-Match`` for optimistic concurrency.
+
+ETag stability
+--------------
+
+The ETag is computed over a *plaintext-canonical* projection of the
+persisted settings, **not** over the encrypted bytes on disk. Fernet
+includes a fresh nonce on every encryption, so two saves of the same
+state produce different ciphertexts — hashing those would defeat the
+ETag entirely (identical PATCHes would each look like a change).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+
+from fastapi import HTTPException, status
+
+from openhands.agent_server.persistence import PersistedSettings
+
+
+def compute_settings_etag(settings: PersistedSettings) -> str:
+    """Compute a stable, quoted ETag over the plaintext-canonical state.
+
+    Hashes a sort-keyed, separator-canonical JSON of the plaintext
+    serialisation. Returns a quoted hex string suitable for the
+    ``ETag``/``If-Match`` HTTP headers.
+    """
+    canonical = settings.model_dump(
+        mode="json", context={"expose_secrets": "plaintext"}
+    )
+    blob = json.dumps(canonical, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    digest = hashlib.sha256(blob).hexdigest()[:32]
+    return f'"{digest}"'
+
+
+def parse_if_match(if_match: str | None) -> set[str] | None:
+    """Parse an ``If-Match`` header value into a set of acceptable ETags.
+
+    Returns ``None`` when no precondition is supplied. Returns an empty
+    sentinel when the wildcard ``*`` is supplied (caller treats this as
+    "resource must exist", which always holds because settings default).
+    """
+    if if_match is None:
+        return None
+    candidates = {tok.strip() for tok in if_match.split(",") if tok.strip()}
+    if "*" in candidates:
+        return {"*"}
+    return candidates
+
+
+def check_if_match(if_match: str | None, current_etag: str) -> None:
+    """Raise ``412 Precondition Failed`` if ``If-Match`` does not match.
+
+    Behaviour
+    ---------
+    * ``If-Match`` absent: no precondition is enforced — the request is
+      allowed through. (Strict mode is left to deployments that wrap this
+      with middleware; we default to permissive so existing single-client
+      flows keep working.)
+    * ``If-Match: *``: precondition succeeds because the settings
+      resource always exists (defaults are returned when no file is on
+      disk).
+    * ``If-Match: "etag"`` (comma-separated list allowed): the current
+      ETag must be in the set, otherwise 412.
+
+    The response carries the current ETag back to the client so it can
+    retry against the live state.
+    """
+    candidates = parse_if_match(if_match)
+    if candidates is None or "*" in candidates:
+        return
+    if current_etag not in candidates:
+        raise HTTPException(
+            status_code=status.HTTP_412_PRECONDITION_FAILED,
+            detail=(
+                "If-Match does not match the current settings ETag. "
+                "Re-fetch /api/settings and retry with the new ETag."
+            ),
+            headers={"ETag": current_etag},
+        )
+
+
+__all__ = ["check_if_match", "compute_settings_etag", "parse_if_match"]

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -493,10 +493,18 @@ def _add_exception_handlers(api: FastAPI) -> None:
             return JSONResponse(
                 status_code=exc.status_code,
                 content=content,
+                headers=exc.headers,
             )
 
-        # Return clean JSON response for all non-5xx HTTP exceptions
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+        # Return clean JSON response for all non-5xx HTTP exceptions.
+        # Propagate ``exc.headers`` so handlers can attach response headers
+        # to error responses (e.g. ``ETag`` on a 412 from optimistic-
+        # concurrency checks, or ``WWW-Authenticate`` on a 401).
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.detail},
+            headers=exc.headers,
+        )
 
 
 def create_app(config: Config | None = None) -> FastAPI:

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -1,7 +1,8 @@
+from collections.abc import Callable
 from functools import lru_cache
-from typing import cast
+from typing import Any, cast
 
-from fastapi import APIRouter, HTTPException, Request, Response, status
+from fastapi import APIRouter, Header, HTTPException, Request, Response, status
 from pydantic import ValidationError
 
 from openhands.agent_server._secrets_exposure import (
@@ -9,6 +10,10 @@ from openhands.agent_server._secrets_exposure import (
     get_config,
     parse_expose_secrets_header,
     translate_missing_cipher,
+)
+from openhands.agent_server._settings_etag import (
+    check_if_match,
+    compute_settings_etag,
 )
 from openhands.agent_server.persistence import (
     SECRET_NAME_PATTERN,
@@ -27,6 +32,15 @@ from openhands.sdk.settings import (
     SettingsSchema,
     SettingsUpdateRequest,
     export_agent_settings_schema,
+    validate_agent_settings,
+)
+from openhands.sdk.settings.update_models import (
+    ACPAgentSettingsUpdate,
+    ConversationSettingsUpdate,
+    OpenHandsAgentSettingsUpdate,
+    apply_agent_update,
+    apply_conversation_update,
+    validate_agent_settings_update,
 )
 
 
@@ -39,6 +53,8 @@ logger = get_logger(__name__)
 # while this router uses relative paths. The paths are intentionally separate
 # to match their respective contexts (router prefix vs full URL path).
 SETTINGS_PATH = ""  # -> /api/settings
+AGENT_SETTINGS_PATH = "/agent"  # -> /api/settings/agent  (new, typed)
+CONVERSATION_SETTINGS_PATH = "/conversation"  # -> /api/settings/conversation
 SECRETS_PATH = "/secrets"  # -> /api/settings/secrets
 SECRET_VALUE_PATH = "/secrets/{name}"  # -> /api/settings/secrets/{name}
 
@@ -100,8 +116,49 @@ def _validate_secret_name(name: str) -> None:
         )
 
 
-@settings_router.get(SETTINGS_PATH, response_model=SettingsResponse)
-async def get_settings(request: Request) -> SettingsResponse:
+def _build_settings_response(
+    settings: PersistedSettings, expose_mode: str | None, request: Request
+) -> SettingsResponse:
+    """Render :class:`PersistedSettings` into the wire response shape.
+
+    Pulled out so that the legacy ``PATCH /api/settings`` handler, the new
+    typed ``PATCH/PUT /api/settings/{agent,conversation}`` handlers, and
+    ``GET /api/settings`` all serialise via the same code path.
+    """
+    config = get_config(request)
+    context = build_expose_context(expose_mode, config.cipher)
+    with translate_missing_cipher():
+        return SettingsResponse(
+            agent_settings=settings.agent_settings.model_dump(
+                mode="json", context=context
+            ),
+            conversation_settings=settings.conversation_settings.model_dump(
+                mode="json"
+            ),
+            llm_api_key_is_set=settings.llm_api_key_is_set,
+        )
+
+
+def _settings_response_with_etag(
+    settings: PersistedSettings, expose_mode: str | None, request: Request
+) -> Response:
+    """Wrap a :class:`SettingsResponse` in a Response with an ``ETag`` header.
+
+    Computed over the plaintext-canonical settings projection so two
+    physical saves of identical state share the same ETag (the on-disk
+    Fernet bytes change on every encryption).
+    """
+    payload = _build_settings_response(settings, expose_mode, request)
+    etag = compute_settings_etag(settings)
+    return Response(
+        content=payload.model_dump_json(),
+        media_type="application/json",
+        headers={"ETag": etag},
+    )
+
+
+@settings_router.get(SETTINGS_PATH)
+async def get_settings(request: Request) -> Response:
     """Get current settings.
 
     Returns the persisted settings including agent configuration,
@@ -111,6 +168,11 @@ async def get_settings(request: Request) -> SettingsResponse:
     - ``encrypted``: Returns cipher-encrypted values (safe for frontend clients)
     - ``plaintext``: Returns raw secret values (backend clients only!)
     - (absent): Returns redacted values ("**********")
+
+    The response carries an ``ETag`` header. Clients can pass that value
+    back as ``If-Match`` on subsequent ``PUT``/``PATCH`` calls (on the
+    settings resource or its ``/agent`` / ``/conversation`` sub-resources)
+    to detect concurrent writes and avoid silent lost updates.
 
     Security:
         When the server is configured with ``session_api_keys``, all endpoints
@@ -150,24 +212,101 @@ async def get_settings(request: Request) -> SettingsResponse:
     else:
         logger.info("Settings accessed", extra=log_extra)
 
-    context = build_expose_context(expose_mode, config.cipher)
-    with translate_missing_cipher():
-        return SettingsResponse(
-            agent_settings=settings.agent_settings.model_dump(
-                mode="json", context=context
-            ),
-            conversation_settings=settings.conversation_settings.model_dump(
-                mode="json"
-            ),
-            llm_api_key_is_set=settings.llm_api_key_is_set,
+    return _settings_response_with_etag(settings, expose_mode, request)
+
+
+def _run_settings_update(
+    request: Request,
+    apply: Callable[[PersistedSettings], PersistedSettings],
+    *,
+    if_match: str | None,
+    audit_extra: dict[str, Any],
+) -> Response:
+    """Shared write path for all settings mutations.
+
+    Wraps the store's file-locked ``update`` with:
+
+    * ``If-Match`` precondition checking — read the current state under
+      the lock, hash it, compare to the caller's ``If-Match`` header. On
+      mismatch return 412 with the live ETag so the client can retry
+      against the new state. This is the missing optimistic-concurrency
+      primitive on the legacy endpoint.
+    * Uniform error translation (validation → 422, corruption → 409,
+      I/O → 500), so all settings endpoints behave the same way.
+    * ``ETag`` header on the response so clients always receive the new
+      version stamp without a follow-up ``GET``.
+    """
+    config = get_config(request)
+    store = get_settings_store(config)
+
+    def _apply_with_precondition(settings: PersistedSettings) -> PersistedSettings:
+        # Both the precondition and the apply run inside the store's file
+        # lock, so the ETag we hash is identical to the state that the
+        # write will be based on.
+        check_if_match(if_match, compute_settings_etag(settings))
+        return apply(settings)
+
+    client_host = request.client.host if request.client else "unknown"
+    try:
+        settings = store.update(_apply_with_precondition)
+    except HTTPException:
+        # If-Match 412 (or any other HTTPException raised inside apply)
+        raise
+    except (ValueError, ValidationError):
+        # PersistedSettings.update() raises ValueError (sanitized message),
+        # Pydantic raises ValidationError. Both indicate a 422.
+        logger.warning(
+            "Settings update validation failed",
+            extra={"client_host": client_host, **audit_extra},
         )
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Settings validation failed",
+        )
+    except RuntimeError as e:
+        logger.error(f"Settings update blocked: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Settings file is corrupted or encrypted with a different key",
+        )
+    except (OSError, PermissionError):
+        # exc_info omitted to prevent secrets in scope from leaking in tracebacks
+        logger.error("Settings update failed - file I/O error")
+        raise HTTPException(status_code=500, detail="Failed to update settings")
+
+    logger.info("Settings updated", extra={"client_host": client_host, **audit_extra})
+    # PATCH/PUT responses redact secrets, consistent with the legacy GET default.
+    return _settings_response_with_etag(settings, expose_mode=None, request=request)
 
 
 @settings_router.patch(SETTINGS_PATH, response_model=SettingsResponse)
 async def update_settings(
-    request: Request, payload: SettingsUpdateRequest
-) -> SettingsResponse:
-    """Update settings with partial changes.
+    request: Request,
+    payload: SettingsUpdateRequest,
+    if_match: str | None = Header(default=None, alias="If-Match"),
+) -> Response:
+    """Update settings with partial changes (legacy ``dict[str, Any]`` shape).
+
+    .. deprecated::
+        Prefer the typed endpoints below. This endpoint accepts an
+        untyped ``agent_settings_diff`` / ``conversation_settings_diff``
+        payload and applies them via deep merge — semantics that are hard
+        for clients to reason about and impossible to discover from the
+        OpenAPI schema:
+
+        * :http:patch:`/api/settings/agent` — typed partial update for
+          agent settings (validated against ``OpenHandsAgentSettingsUpdate``
+          / ``ACPAgentSettingsUpdate`` with ``extra="forbid"``).
+        * :http:patch:`/api/settings/conversation` — typed partial update
+          for conversation settings.
+        * :http:put:`/api/settings/agent` — full replace (also allows
+          switching ``agent_kind``).
+        * :http:put:`/api/settings/conversation` — full replace.
+
+        New clients should not use this endpoint. It is retained for
+        backwards compatibility and now also honours ``If-Match`` and
+        returns an ``ETag`` header, so legacy clients can opt into
+        optimistic concurrency without switching shapes.
 
     Accepts ``agent_settings_diff`` and/or ``conversation_settings_diff``
     for incremental updates. Values are deep-merged with existing settings.
@@ -175,14 +314,11 @@ async def update_settings(
     Uses file locking to prevent concurrent updates from overwriting each other.
 
     Raises:
-        HTTPException: 400 if the update payload contains invalid values.
+        HTTPException: 400 if no diffs were provided, 412 on ``If-Match``
+        mismatch, 422 if the update payload contains invalid values.
     """
-    config = get_config(request)
-    store = get_settings_store(config)
-
     update_data = payload.model_dump(exclude_none=True)
     if not update_data:
-        # No updates provided - this is a client error
         raise HTTPException(
             status_code=400,
             detail=(
@@ -191,57 +327,223 @@ async def update_settings(
             ),
         )
 
-    # Apply updates atomically with file locking
     def apply_update(settings: PersistedSettings) -> PersistedSettings:
         settings.update(cast(SettingsUpdatePayload, update_data))
         return settings
 
-    client_host = request.client.host if request.client else "unknown"
+    response = _run_settings_update(
+        request,
+        apply_update,
+        if_match=if_match,
+        audit_extra={
+            "endpoint": "PATCH /api/settings",
+            "agent_settings_modified": "agent_settings_diff" in update_data,
+            "conversation_settings_modified": (
+                "conversation_settings_diff" in update_data
+            ),
+        },
+    )
+    # Signal deprecation to forward-compatible clients (RFC 8594 + RFC 9745).
+    response.headers["Deprecation"] = "true"
+    response.headers["Link"] = (
+        '</api/settings/agent>; rel="successor-version", '
+        '</api/settings/conversation>; rel="successor-version"'
+    )
+    return response
+
+
+# ── Typed Settings Endpoints (new) ───────────────────────────────────────
+#
+# These endpoints replace the untyped ``PATCH /api/settings`` for new
+# clients. They split the settings resource along the same boundary as
+# the persistence layer (``agent_settings`` vs ``conversation_settings``)
+# and accept typed partial-update bodies validated against Pydantic
+# models with ``extra="forbid"``. The ETag covers the whole settings
+# resource, so cross-section concurrency is still detected.
+
+
+@settings_router.put(AGENT_SETTINGS_PATH, response_model=SettingsResponse)
+async def replace_agent_settings(
+    request: Request,
+    payload: dict,  # validated below via ``validate_agent_settings``
+    if_match: str | None = Header(default=None, alias="If-Match"),
+) -> Response:
+    """Replace agent settings (full PUT).
+
+    Accepts a complete :data:`~openhands.sdk.settings.AgentSettingsConfig`
+    payload (an ``OpenHandsAgentSettings`` or ``ACPAgentSettings``
+    discriminated by ``agent_kind``). The current agent settings are
+    replaced wholesale. Use this when switching variants
+    (``openhands`` → ``acp``); for in-variant changes, prefer
+    :http:patch:`/api/settings/agent`.
+
+    Sends ``Deprecation``-style headers? No — this is the recommended
+    path. Sends an ``ETag`` reflecting the post-write state.
+
+    Raises:
+        HTTPException: 412 on ``If-Match`` mismatch, 422 if the body
+            fails :data:`AgentSettingsConfig` validation.
+    """
     try:
-        settings = store.update(apply_update)
-        # Audit log: settings modified
-        logger.info(
-            "Settings updated",
-            extra={
-                "client_host": client_host,
-                "agent_settings_modified": "agent_settings_diff" in update_data,
-                "conversation_settings_modified": (
-                    "conversation_settings_diff" in update_data
-                ),
-            },
-        )
-    except (ValueError, ValidationError):
-        # Audit log: validation failed
-        # Note: PersistedSettings.update() raises ValueError (sanitized message)
-        # while Pydantic validation raises ValidationError
-        logger.warning(
-            "Settings update validation failed",
-            extra={"client_host": client_host},
-        )
-        # 422 Unprocessable Entity - semantic validation failure
-        # Don't expose error details - could contain secrets in tracebacks
+        new_agent = validate_agent_settings(payload)
+    except ValidationError:
+        logger.warning("PUT /api/settings/agent validation failed")
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail="Settings validation failed",
+            detail="Agent settings validation failed",
         )
-    except RuntimeError as e:
-        # Data corruption protection triggered (file exists but unreadable)
-        logger.error(f"Settings update blocked: {e}")
-        raise HTTPException(
-            status_code=status.HTTP_409_CONFLICT,
-            detail="Settings file is corrupted or encrypted with a different key",
-        )
-    except (OSError, PermissionError):
-        # Note: exc_info omitted to prevent secrets in scope from leaking in tracebacks
-        logger.error("Settings update failed - file I/O error")
-        raise HTTPException(status_code=500, detail="Failed to update settings")
 
-    # Don't expose secrets in PATCH response (consistent with GET behavior)
-    return SettingsResponse(
-        agent_settings=settings.agent_settings.model_dump(mode="json"),
-        conversation_settings=settings.conversation_settings.model_dump(mode="json"),
-        llm_api_key_is_set=settings.llm_api_key_is_set,
+    def apply_replace(settings: PersistedSettings) -> PersistedSettings:
+        settings.agent_settings = new_agent
+        return settings
+
+    return _run_settings_update(
+        request,
+        apply_replace,
+        if_match=if_match,
+        audit_extra={
+            "endpoint": "PUT /api/settings/agent",
+            "agent_kind": new_agent.agent_kind,
+        },
     )
+
+
+@settings_router.patch(AGENT_SETTINGS_PATH, response_model=SettingsResponse)
+async def patch_agent_settings(
+    request: Request,
+    payload: dict,  # validated below via ``validate_agent_settings_update``
+    if_match: str | None = Header(default=None, alias="If-Match"),
+) -> Response:
+    """Apply a typed partial update to agent settings.
+
+    The request body is validated as an
+    :data:`~openhands.sdk.settings.AgentSettingsUpdate` discriminated
+    union (``OpenHandsAgentSettingsUpdate`` or ``ACPAgentSettingsUpdate``)
+    with ``extra="forbid"``, so unknown fields fail loudly. Only fields
+    the client explicitly sent are applied; the rest are preserved.
+
+    Variant invariance
+        PATCH does not switch ``agent_kind``. If the body's ``agent_kind``
+        differs from the persisted variant, 422 is returned (use PUT to
+        switch variants).
+
+    Nested partials
+        ``llm``, ``condenser``, ``verification`` accept their own typed
+        ``*Update`` partials and are merged at the immediate top level of
+        that sub-object (so e.g. ``{"llm": {"model": "..."}}`` preserves
+        the existing ``api_key``).
+
+    Raises:
+        HTTPException: 412 on ``If-Match`` mismatch, 422 on validation
+            or variant mismatch.
+    """
+    try:
+        update = validate_agent_settings_update(payload)
+    except ValidationError:
+        logger.warning("PATCH /api/settings/agent validation failed")
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Agent settings update validation failed",
+        )
+
+    def apply_partial(settings: PersistedSettings) -> PersistedSettings:
+        try:
+            settings.agent_settings = apply_agent_update(
+                settings.agent_settings, update
+            )
+        except ValueError as e:
+            # Variant mismatch and post-merge validation errors land here.
+            # Surface as 422 with a sanitised message (no payload contents
+            # — they may carry secrets through stale tracebacks).
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail=str(e),
+            )
+        return settings
+
+    return _run_settings_update(
+        request,
+        apply_partial,
+        if_match=if_match,
+        audit_extra={
+            "endpoint": "PATCH /api/settings/agent",
+            "fields": sorted(update.model_fields_set),
+        },
+    )
+
+
+@settings_router.put(CONVERSATION_SETTINGS_PATH, response_model=SettingsResponse)
+async def replace_conversation_settings(
+    request: Request,
+    payload: ConversationSettings,
+    if_match: str | None = Header(default=None, alias="If-Match"),
+) -> Response:
+    """Replace conversation settings (full PUT).
+
+    Accepts a complete :class:`ConversationSettings` payload. The current
+    conversation settings are replaced wholesale.
+
+    Raises:
+        HTTPException: 412 on ``If-Match`` mismatch, 422 if the body
+            fails :class:`ConversationSettings` validation.
+    """
+
+    def apply_replace(settings: PersistedSettings) -> PersistedSettings:
+        settings.conversation_settings = payload
+        return settings
+
+    return _run_settings_update(
+        request,
+        apply_replace,
+        if_match=if_match,
+        audit_extra={"endpoint": "PUT /api/settings/conversation"},
+    )
+
+
+@settings_router.patch(CONVERSATION_SETTINGS_PATH, response_model=SettingsResponse)
+async def patch_conversation_settings(
+    request: Request,
+    payload: ConversationSettingsUpdate,
+    if_match: str | None = Header(default=None, alias="If-Match"),
+) -> Response:
+    """Apply a typed partial update to conversation settings.
+
+    Body is validated as :class:`ConversationSettingsUpdate` with
+    ``extra="forbid"``. Only fields the client explicitly sent are
+    applied; the rest are preserved. After merge the result is
+    re-validated by :class:`ConversationSettings` (so ``max_iterations >=
+    1`` etc. still fire).
+
+    Raises:
+        HTTPException: 412 on ``If-Match`` mismatch, 422 on validation.
+    """
+
+    def apply_partial(settings: PersistedSettings) -> PersistedSettings:
+        try:
+            settings.conversation_settings = apply_conversation_update(
+                settings.conversation_settings, payload
+            )
+        except ValidationError:
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                detail="Conversation settings update validation failed",
+            )
+        return settings
+
+    return _run_settings_update(
+        request,
+        apply_partial,
+        if_match=if_match,
+        audit_extra={
+            "endpoint": "PATCH /api/settings/conversation",
+            "fields": sorted(payload.model_fields_set),
+        },
+    )
+
+
+# Re-export the typed update model classes for OpenAPI clients that import
+# from this router module directly.
+_ = OpenHandsAgentSettingsUpdate, ACPAgentSettingsUpdate  # noqa: F841
 
 
 # ── Secrets CRUD Endpoints ───────────────────────────────────────────────

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -50,6 +50,18 @@ if TYPE_CHECKING:
         export_settings_schema,
         validate_agent_settings,
     )
+    from .update_models import (
+        ACPAgentSettingsUpdate,
+        AgentSettingsUpdate,
+        CondenserSettingsUpdate,
+        ConversationSettingsUpdate,
+        LLMUpdate,
+        OpenHandsAgentSettingsUpdate,
+        VerificationSettingsUpdate,
+        apply_agent_update,
+        apply_conversation_update,
+        validate_agent_settings_update,
+    )
 
 _MODEL_EXPORTS = {
     "AGENT_SETTINGS_SCHEMA_VERSION",
@@ -72,6 +84,23 @@ _MODEL_EXPORTS = {
     "export_agent_settings_schema",
     "export_settings_schema",
     "validate_agent_settings",
+}
+
+# Lazy-loaded to avoid a circular import: ``update_models`` imports ``LLM`` and
+# ``AgentContext`` which themselves import ``settings.metadata`` during module
+# initialisation. Loading these eagerly here would re-enter
+# ``settings/__init__.py`` while it's still being constructed.
+_UPDATE_MODEL_EXPORTS = {
+    "ACPAgentSettingsUpdate",
+    "AgentSettingsUpdate",
+    "CondenserSettingsUpdate",
+    "ConversationSettingsUpdate",
+    "LLMUpdate",
+    "OpenHandsAgentSettingsUpdate",
+    "VerificationSettingsUpdate",
+    "apply_agent_update",
+    "apply_conversation_update",
+    "validate_agent_settings_update",
 }
 
 __all__ = [
@@ -105,6 +134,17 @@ __all__ = [
     "SettingsSectionSchema",
     "SettingsUpdateRequest",
     "VerificationSettings",
+    # Typed partial-update models (new endpoints)
+    "ACPAgentSettingsUpdate",
+    "AgentSettingsUpdate",
+    "CondenserSettingsUpdate",
+    "ConversationSettingsUpdate",
+    "LLMUpdate",
+    "OpenHandsAgentSettingsUpdate",
+    "VerificationSettingsUpdate",
+    "apply_agent_update",
+    "apply_conversation_update",
+    "validate_agent_settings_update",
     "create_agent_from_settings",
     "default_agent_settings",
     "detect_acp_provider_by_agent_name",
@@ -137,4 +177,8 @@ def __getattr__(name: str) -> Any:
         from . import model
 
         return getattr(model, name)
+    if name in _UPDATE_MODEL_EXPORTS:
+        from . import update_models
+
+        return getattr(update_models, name)
     raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openhands-sdk/openhands/sdk/settings/update_models.py
+++ b/openhands-sdk/openhands/sdk/settings/update_models.py
@@ -1,0 +1,321 @@
+"""Typed partial-update models for the settings API.
+
+These models replace the legacy ``dict[str, Any]`` request bodies used by
+``PATCH /api/settings``. They mirror the persisted settings shape with every
+field optional and ``extra="forbid"``, so the OpenAPI schema is meaningful
+and typos / stale fields fail loudly with 422 instead of being silently
+ignored.
+
+Update semantics
+----------------
+
+* A field that is absent from the request body means "do not change this
+  field". Sending an explicit ``null`` for an ``Optional`` field on the
+  source model means "clear it"; for a non-optional field, ``null`` is a
+  422 (rejected by re-validation).
+* Nested objects (``llm``, ``condenser``, ``verification``) accept their
+  own typed ``*Update`` shape and are merged at the immediate top level of
+  that sub-object — they are *not* recursively deep-merged below that. To
+  change one field of LLM, send only that field inside ``llm``; the rest
+  of the current LLM is preserved.
+* Lists and dicts (``tools``, ``acp_env``, ``mcp_config``) **replace** the
+  current value when present. Send an empty collection to clear; send the
+  full new collection to add/remove members.
+* PATCH requires the request body's ``agent_kind`` to match the currently
+  persisted variant (treating ``"llm"`` as an alias of ``"openhands"``).
+  To switch variants, use ``PUT``.
+
+After applying a partial update, the result is re-validated through the
+source model's full validator chain (constraints, secret validators, MCP
+config normalisation), so all the usual invariants still hold.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Annotated, Any, Literal, Union, get_args
+
+from fastmcp.mcp_config import MCPConfig
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    TypeAdapter,
+    create_model,
+)
+
+from openhands.sdk.context.agent_context import AgentContext
+from openhands.sdk.llm import LLM
+from openhands.sdk.tool import Tool
+
+from .model import (
+    ACPAgentSettings,
+    CondenserSettings,
+    ConversationSettings,
+    LLMAgentSettings,
+    OpenHandsAgentSettings,
+    SecurityAnalyzerType,
+    VerificationSettings,
+    validate_agent_settings,
+)
+
+
+if TYPE_CHECKING:
+    pass
+
+
+# ── Base ──────────────────────────────────────────────────────────────────
+
+
+class _UpdateBase(BaseModel):
+    """Common config for partial-update models.
+
+    - ``extra="forbid"`` makes typos / stale field names a 422 instead of a
+      silent ignore (this is the single biggest fix vs. the legacy
+      ``dict[str, Any]`` payload).
+    - ``populate_by_name=True`` preserves alias compatibility with the
+      source models.
+    """
+
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+
+
+def _make_partial(model_cls: type[BaseModel], name: str) -> type[_UpdateBase]:
+    """Build an all-Optional partial of ``model_cls``.
+
+    Each field is widened to ``T | None`` with default ``None``. Constraints
+    on the source field (``ge``, ``le``, regex, etc.) are NOT carried over —
+    this model only checks structural shape. Real validation happens when
+    the apply helpers re-build the source model from the merged dict.
+    """
+    fields: dict[str, tuple[Any, Any]] = {}
+    for fname, finfo in model_cls.model_fields.items():
+        ann = finfo.annotation
+        if ann is None:
+            continue
+        # Widen to Optional unless already nullable
+        args = get_args(ann)
+        if type(None) in args:
+            widened: Any = ann
+        else:
+            widened = Union[ann, None]  # noqa: UP007 — keep Union for create_model
+        fields[fname] = (widened, Field(default=None, description=finfo.description))
+
+    return create_model(  # type: ignore[call-overload,return-value]
+        name,
+        __base__=_UpdateBase,
+        **fields,
+    )
+
+
+# ── Nested partials (auto-generated) ──────────────────────────────────────
+
+LLMUpdate = _make_partial(LLM, "LLMUpdate")
+"""All-optional partial of :class:`~openhands.sdk.llm.LLM`.
+
+Sent as the ``llm`` field of an agent settings update. Only fields explicitly
+present are applied; the rest of the current LLM (including ``api_key`` and
+other secrets) is preserved untouched.
+"""
+
+CondenserSettingsUpdate = _make_partial(CondenserSettings, "CondenserSettingsUpdate")
+"""All-optional partial of :class:`CondenserSettings`."""
+
+VerificationSettingsUpdate = _make_partial(
+    VerificationSettings, "VerificationSettingsUpdate"
+)
+"""All-optional partial of :class:`VerificationSettings`."""
+
+
+# ── Agent settings partials (hand-written) ────────────────────────────────
+
+
+class OpenHandsAgentSettingsUpdate(_UpdateBase):
+    """Typed partial update for :class:`OpenHandsAgentSettings`.
+
+    The discriminator literal ``"llm"`` is also accepted for backwards
+    compatibility with the deprecated :class:`LLMAgentSettings` alias.
+    """
+
+    agent_kind: Literal["openhands", "llm"] = "openhands"
+    agent: str | None = None
+    llm: LLMUpdate | None = None  # type: ignore[valid-type]
+    tools: list[Tool] | None = None
+    enable_sub_agents: bool | None = None
+    enable_switch_llm_tool: bool | None = None
+    mcp_config: MCPConfig | None = None
+    agent_context: AgentContext | None = None
+    condenser: CondenserSettingsUpdate | None = None  # type: ignore[valid-type]
+    verification: VerificationSettingsUpdate | None = None  # type: ignore[valid-type]
+
+
+class ACPAgentSettingsUpdate(_UpdateBase):
+    """Typed partial update for :class:`ACPAgentSettings`."""
+
+    agent_kind: Literal["acp"] = "acp"
+    acp_server: str | None = None  # validated against ACPServerKind by re-validation
+    acp_command: list[str] | None = None
+    acp_args: list[str] | None = None
+    acp_env: dict[str, str] | None = None
+    acp_model: str | None = None
+    acp_session_mode: str | None = None
+    acp_prompt_timeout: float | None = None
+    llm: LLMUpdate | None = None  # type: ignore[valid-type]
+    agent_context: AgentContext | None = None
+
+
+def _agent_update_discriminator(value: Any) -> str:
+    """Map the deprecated ``"llm"`` tag onto ``"openhands"`` for routing."""
+    if isinstance(value, BaseModel):
+        kind = getattr(value, "agent_kind", "openhands")
+    elif isinstance(value, dict):
+        kind = value.get("agent_kind", "openhands")
+    else:
+        return "openhands"
+    return "openhands" if kind in ("openhands", "llm") else str(kind)
+
+
+AgentSettingsUpdate = Annotated[
+    Annotated[OpenHandsAgentSettingsUpdate, Tag("openhands")]
+    | Annotated[ACPAgentSettingsUpdate, Tag("acp")],
+    Discriminator(_agent_update_discriminator),
+]
+"""Discriminated union of agent settings update variants."""
+
+
+_AGENT_UPDATE_ADAPTER: TypeAdapter[
+    OpenHandsAgentSettingsUpdate | ACPAgentSettingsUpdate
+] = TypeAdapter(AgentSettingsUpdate)
+
+
+def validate_agent_settings_update(
+    data: Any,
+) -> OpenHandsAgentSettingsUpdate | ACPAgentSettingsUpdate:
+    """Validate ``data`` as an :data:`AgentSettingsUpdate` discriminated union."""
+    return _AGENT_UPDATE_ADAPTER.validate_python(data)
+
+
+# ── Conversation settings partial ─────────────────────────────────────────
+
+
+class ConversationSettingsUpdate(_UpdateBase):
+    """Typed partial update for :class:`ConversationSettings`."""
+
+    max_iterations: int | None = Field(default=None, ge=1)
+    confirmation_mode: bool | None = None
+    security_analyzer: SecurityAnalyzerType | None = None
+
+
+# ── Apply helpers ─────────────────────────────────────────────────────────
+
+
+def _normalize_agent_kind(kind: str) -> str:
+    """Treat ``"llm"`` and ``"openhands"`` as the same variant."""
+    return "openhands" if kind in ("openhands", "llm") else kind
+
+
+def _explicitly_set_fields(model: BaseModel) -> dict[str, Any]:
+    """Return only the fields the caller actually sent.
+
+    Uses ``model_fields_set`` so we distinguish "absent" (no change) from
+    "explicitly null" (clear, where allowed). The result is a plain dict —
+    nested ``*Update`` instances are themselves reduced to their explicitly
+    set fields, so the recursive merge does the right thing.
+    """
+    out: dict[str, Any] = {}
+    for fname in model.model_fields_set:
+        value = getattr(model, fname)
+        if isinstance(value, _UpdateBase):
+            out[fname] = _explicitly_set_fields(value)
+        else:
+            out[fname] = value
+    return out
+
+
+def apply_agent_update(
+    current: OpenHandsAgentSettings | LLMAgentSettings | ACPAgentSettings,
+    update: OpenHandsAgentSettingsUpdate | ACPAgentSettingsUpdate,
+) -> OpenHandsAgentSettings | LLMAgentSettings | ACPAgentSettings:
+    """Apply a typed partial update onto a current agent settings object.
+
+    Variant invariance
+    ------------------
+    The update's ``agent_kind`` must match ``current.agent_kind`` (treating
+    ``"llm"`` and ``"openhands"`` as the same variant). PATCH does not switch
+    variants — callers that want to switch should use a full PUT instead.
+
+    Re-validation
+    -------------
+    After merging the explicitly-set fields onto ``current``'s plaintext
+    dump, the merged dict is re-validated through
+    :func:`validate_agent_settings`. All field validators, constraints, and
+    normalisation (e.g. MCP env decryption) run as usual.
+
+    Raises
+    ------
+    ValueError
+        If the variant differs or re-validation fails.
+    """
+    current_kind = _normalize_agent_kind(current.agent_kind)
+    update_kind = _normalize_agent_kind(update.agent_kind)
+    if current_kind != update_kind:
+        raise ValueError(
+            "PATCH cannot switch agent_kind "
+            f"(current={current.agent_kind!r}, requested={update.agent_kind!r}); "
+            "use PUT to replace the whole agent settings object."
+        )
+
+    # Plaintext-canonical projection of current state.
+    base = current.model_dump(mode="json", context={"expose_secrets": "plaintext"})
+    overlay = _explicitly_set_fields(update)
+    # Drop the discriminator from the overlay; we keep current's value below.
+    overlay.pop("agent_kind", None)
+
+    merged: dict[str, Any] = dict(base)
+    for key, value in overlay.items():
+        existing = base.get(key)
+        if isinstance(value, dict) and isinstance(existing, dict):
+            # One-level merge: explicit keys in value override existing keys.
+            nested = dict(existing)
+            nested.update(value)
+            merged[key] = nested
+        else:
+            merged[key] = value
+
+    # Preserve the canonical discriminator (don't accidentally upgrade "llm"
+    # to "openhands" — the union routes both to the right class anyway).
+    merged["agent_kind"] = current.agent_kind
+
+    return validate_agent_settings(merged)
+
+
+def apply_conversation_update(
+    current: ConversationSettings,
+    update: ConversationSettingsUpdate,
+) -> ConversationSettings:
+    """Apply a typed partial update onto current conversation settings.
+
+    Only fields the client explicitly sent are applied; the rest of
+    ``current`` is preserved. The result is re-validated by
+    :class:`ConversationSettings` so constraints (``ge=1`` on
+    ``max_iterations``, etc.) still fire.
+    """
+    base = current.model_dump(mode="json")
+    overlay = _explicitly_set_fields(update)
+    merged = {**base, **overlay}
+    return ConversationSettings.model_validate(merged)
+
+
+__all__ = [
+    "ACPAgentSettingsUpdate",
+    "AgentSettingsUpdate",
+    "CondenserSettingsUpdate",
+    "ConversationSettingsUpdate",
+    "LLMUpdate",
+    "OpenHandsAgentSettingsUpdate",
+    "VerificationSettingsUpdate",
+    "apply_agent_update",
+    "apply_conversation_update",
+    "validate_agent_settings_update",
+]

--- a/tests/agent_server/test_typed_settings_router.py
+++ b/tests/agent_server/test_typed_settings_router.py
@@ -1,0 +1,380 @@
+"""Tests for the typed settings endpoints + ETag / If-Match support.
+
+These exercise:
+
+* GET ``/api/settings`` now returns an ``ETag`` header.
+* The legacy ``PATCH /api/settings`` honours ``If-Match`` (412 on mismatch)
+  and emits a ``Deprecation`` header.
+* New ``PUT/PATCH /api/settings/agent`` (typed, ``extra="forbid"``).
+* New ``PUT/PATCH /api/settings/conversation`` (typed, ``extra="forbid"``).
+* Variant invariance on PATCH agent (no implicit ``openhands`` ↔ ``acp`` switch).
+* Optimistic concurrency: 412 when the persisted state has moved since the
+  client captured an ETag.
+
+Shares fixtures with ``test_settings_router.py``.
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+from openhands.agent_server.persistence import reset_stores
+
+
+@pytest.fixture
+def temp_persistence_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reset_stores()
+        old_val = os.environ.get("OH_PERSISTENCE_DIR")
+        os.environ["OH_PERSISTENCE_DIR"] = tmpdir
+        yield Path(tmpdir)
+        reset_stores()
+        if old_val is not None:
+            os.environ["OH_PERSISTENCE_DIR"] = old_val
+        else:
+            os.environ.pop("OH_PERSISTENCE_DIR", None)
+
+
+@pytest.fixture
+def secret_key():
+    return urlsafe_b64encode(b"a" * 32).decode("ascii")
+
+
+@pytest.fixture
+def client(temp_persistence_dir, secret_key):
+    config = Config(
+        static_files_path=None,
+        session_api_keys=[],
+        secret_key=SecretStr(secret_key),
+    )
+    test_client = TestClient(create_app(config))
+    # Seed a deterministic settings file. ``PersistedSettings()`` defaults
+    # include ``AgentContext.current_datetime = datetime.now()`` which makes
+    # two fresh instances genuinely-different state (and therefore different
+    # ETags). For these tests we want a stable starting point so a captured
+    # ETag survives until something actually changes.
+    test_client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4"}}},
+    )
+    return test_client
+
+
+# ── ETag on GET ────────────────────────────────────────────────────────────
+
+
+def test_get_settings_returns_etag_header(client):
+    response = client.get("/api/settings")
+    assert response.status_code == 200
+    assert response.headers.get("ETag", "").startswith('"')
+
+
+def test_etag_stable_across_identical_saves(client):
+    """Two no-op PATCHes (writing the same agent.llm.model) yield the same
+    ETag, even though the on-disk Fernet ciphertext changes per save.
+
+    This is the core idempotency property the legacy byte-hash ETag
+    couldn't provide.
+    """
+    client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4o"}},
+    )
+    etag1 = client.get("/api/settings").headers["ETag"]
+
+    client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4o"}},
+    )
+    etag2 = client.get("/api/settings").headers["ETag"]
+    assert etag1 == etag2
+
+
+def test_etag_changes_on_real_change(client):
+    client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4"}},
+    )
+    etag1 = client.get("/api/settings").headers["ETag"]
+
+    client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4o"}},
+    )
+    etag2 = client.get("/api/settings").headers["ETag"]
+    assert etag1 != etag2
+
+
+# ── If-Match / optimistic concurrency ─────────────────────────────────────
+
+
+def test_patch_agent_with_matching_if_match_succeeds(client):
+    etag = client.get("/api/settings").headers["ETag"]
+    response = client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4o"}},
+        headers={"If-Match": etag},
+    )
+    assert response.status_code == 200
+    assert response.headers["ETag"] != etag  # new state, new ETag
+
+
+def test_patch_agent_with_stale_if_match_returns_412(client):
+    etag = client.get("/api/settings").headers["ETag"]
+    # Another client mutates first.
+    client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4o"}},
+    )
+
+    # Stale etag → 412 + current ETag echoed back.
+    response = client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4"}},
+        headers={"If-Match": etag},
+    )
+    assert response.status_code == 412
+    assert response.headers["ETag"] != etag
+
+
+def test_put_agent_with_wildcard_if_match_succeeds(client):
+    """``If-Match: *`` only requires the resource to exist; it always does
+    here because settings default."""
+    response = client.put(
+        "/api/settings/agent",
+        json={
+            "agent_kind": "openhands",
+            "llm": {"model": "gpt-4o", "usage_id": "u"},
+        },
+        headers={"If-Match": "*"},
+    )
+    assert response.status_code == 200
+
+
+def test_legacy_patch_honours_if_match(client):
+    """The legacy PATCH /api/settings now also honours If-Match, so existing
+    clients can opt into safety without switching shapes."""
+    etag = client.get("/api/settings").headers["ETag"]
+    # Move state forward.
+    client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4o"}}},
+    )
+
+    response = client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4"}}},
+        headers={"If-Match": etag},
+    )
+    assert response.status_code == 412
+
+
+def test_legacy_patch_sends_deprecation_header(client):
+    response = client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4o"}}},
+    )
+    assert response.status_code == 200
+    assert response.headers.get("Deprecation") == "true"
+    assert "/api/settings/agent" in response.headers.get("Link", "")
+
+
+# ── Typed PATCH /api/settings/agent ───────────────────────────────────────
+
+
+def test_patch_agent_partial_preserves_api_key(client):
+    """The big practical win: a partial ``llm`` update keeps ``api_key``
+    intact, so clients don't have to round-trip secrets just to change a
+    model name."""
+    # Seed an API key via legacy PATCH (the only way to set secrets here).
+    client.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {"llm": {"model": "gpt-4", "api_key": "sk-original"}}
+        },
+    )
+
+    # Typed partial: change only the model.
+    response = client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 200
+
+    # Read back with plaintext exposure: api_key must still be 'sk-original'.
+    response = client.get("/api/settings", headers={"X-Expose-Secrets": "plaintext"})
+    agent_settings = response.json()["agent_settings"]
+    assert agent_settings["llm"]["model"] == "gpt-4o"
+    assert agent_settings["llm"]["api_key"] == "sk-original"
+
+
+def test_patch_agent_unknown_field_returns_422(client):
+    """``extra="forbid"`` on the typed update model — typos fail loudly
+    instead of being silently merged."""
+    response = client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "lllm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 422
+
+
+def test_patch_agent_variant_mismatch_returns_422(client):
+    """PATCH /agent does NOT switch ``agent_kind``. To go openhands → acp,
+    callers must use PUT."""
+    response = client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "acp", "acp_model": "claude"},
+    )
+    assert response.status_code == 422
+    assert "agent_kind" in response.json()["detail"].lower()
+
+
+def test_patch_agent_legacy_llm_discriminator_accepted(client):
+    """The deprecated ``agent_kind: 'llm'`` alias maps to the openhands
+    variant for PATCH compatibility."""
+    response = client.patch(
+        "/api/settings/agent",
+        json={"agent_kind": "llm", "llm": {"model": "gpt-4o"}},
+    )
+    assert response.status_code == 200
+
+
+# ── PUT /api/settings/agent (full replace + variant switch) ───────────────
+
+
+def test_put_agent_full_replace(client):
+    response = client.put(
+        "/api/settings/agent",
+        json={
+            "agent_kind": "openhands",
+            "llm": {"model": "gpt-4o", "usage_id": "u"},
+            "agent": "CodeActAgent",
+        },
+    )
+    assert response.status_code == 200
+    new_etag = response.headers["ETag"]
+    assert new_etag.startswith('"')
+
+    # PUT does *not* honour the legacy "extra ignored" behaviour — it
+    # validates against the source model fully.
+    response = client.get("/api/settings")
+    assert response.json()["agent_settings"]["llm"]["model"] == "gpt-4o"
+
+
+def test_put_agent_can_switch_variant_to_acp(client):
+    """The new endpoint is the canonical way to switch agent variants —
+    something the legacy deep-merge endpoint could only do incidentally
+    (and with leftover junk fields)."""
+    response = client.put(
+        "/api/settings/agent",
+        json={
+            "agent_kind": "acp",
+            "acp_server": "claude-code",
+            "llm": {"model": "claude-sonnet-4-20250514", "usage_id": "u"},
+        },
+    )
+    assert response.status_code == 200
+    agent = response.json()["agent_settings"]
+    assert agent["agent_kind"] == "acp"
+    assert agent["acp_server"] == "claude-code"
+
+
+def test_put_agent_invalid_body_returns_422(client):
+    response = client.put(
+        "/api/settings/agent",
+        json={"agent_kind": "openhands", "tools": "not-a-list"},
+    )
+    assert response.status_code == 422
+
+
+# ── PATCH / PUT /api/settings/conversation ────────────────────────────────
+
+
+def test_patch_conversation_partial(client):
+    client.put(
+        "/api/settings/conversation",
+        json={"max_iterations": 500, "confirmation_mode": False},
+    )
+    response = client.patch("/api/settings/conversation", json={"max_iterations": 200})
+    assert response.status_code == 200
+    conv = response.json()["conversation_settings"]
+    assert conv["max_iterations"] == 200
+    assert conv["confirmation_mode"] is False  # preserved
+
+
+def test_patch_conversation_extra_field_forbidden(client):
+    response = client.patch("/api/settings/conversation", json={"max_iterationz": 200})
+    assert response.status_code == 422
+
+
+def test_patch_conversation_validation_error_returns_422(client):
+    response = client.patch("/api/settings/conversation", json={"max_iterations": 0})
+    assert response.status_code == 422
+
+
+def test_put_conversation_full_replace(client):
+    response = client.put(
+        "/api/settings/conversation",
+        json={"max_iterations": 42, "confirmation_mode": True},
+    )
+    assert response.status_code == 200
+    conv = response.json()["conversation_settings"]
+    assert conv["max_iterations"] == 42
+    assert conv["confirmation_mode"] is True
+
+
+# ── Concurrency end-to-end ────────────────────────────────────────────────
+
+
+def test_concurrent_clients_lose_update_without_if_match(client):
+    """Mirrors the failure mode of the legacy API: without If-Match, the
+    last writer wins silently."""
+    client.put(
+        "/api/settings/conversation",
+        json={"max_iterations": 100, "confirmation_mode": False},
+    )
+    # Both "clients" capture the same view, both PATCH a different field's
+    # value, neither sends If-Match — the second write clobbers the first
+    # at the leaf level.
+    client.patch("/api/settings/conversation", json={"max_iterations": 200})
+    client.patch("/api/settings/conversation", json={"max_iterations": 300})
+    final = client.get("/api/settings").json()["conversation_settings"]
+    assert final["max_iterations"] == 300  # last writer wins; data loss possible
+
+
+def test_concurrent_clients_detected_with_if_match(client):
+    """With If-Match, the second writer's stale view is rejected with 412 —
+    the lost-update is now visible and actionable."""
+    client.put(
+        "/api/settings/conversation",
+        json={"max_iterations": 100, "confirmation_mode": False},
+    )
+    etag = client.get("/api/settings").headers["ETag"]
+
+    # Client A succeeds.
+    a = client.patch(
+        "/api/settings/conversation",
+        json={"max_iterations": 200},
+        headers={"If-Match": etag},
+    )
+    assert a.status_code == 200
+
+    # Client B has the stale ETag.
+    b = client.patch(
+        "/api/settings/conversation",
+        json={"max_iterations": 300},
+        headers={"If-Match": etag},
+    )
+    assert b.status_code == 412
+    # State is still A's, not B's.
+    final = client.get("/api/settings").json()["conversation_settings"]
+    assert final["max_iterations"] == 200


### PR DESCRIPTION
_This PR was opened by an AI agent (OpenHands) on behalf of the user._

## What's wrong with `PATCH /api/settings` today

The current endpoint accepts:

```python
class SettingsUpdateRequest(BaseModel):
    agent_settings_diff: dict[str, Any] | None = None
    conversation_settings_diff: dict[str, Any] | None = None
```

and applies the diffs via `_deep_merge` onto the persisted settings. A few of the consequences:

1. **The API contract is `dict[str, Any]`.** Generated clients are useless; typos like `lllm` are silently merged and forgotten; field renames in `OpenHandsAgentSettings` aren't even breaking changes at the wire level.
2. **The public schema lies about itself.** The internal `SettingsUpdatePayload` accepts an `active_profile` key that the public `SettingsUpdateRequest` doesn't expose. The handler `cast`s past this mismatch.
3. **"Diff" is undocumented deep-merge.** Dicts merge, lists replace, and there is no way to *delete* a key — to clear `mcp.headers["Authorization"]` you must overwrite the parent dict, which has all the read-modify-write hazards below.
4. **Discriminated-union variants are not respected.** A PATCH that switches `agent_kind: openhands → acp` ends up with leftover OpenHands-only fields silently dropped by re-validation, with no warning.
5. **No optimistic concurrency.** The file lock prevents on-disk corruption, *not* lost updates. Two clients each doing `GET → modify → PATCH` cheerfully clobber each other; the server has no ETag/If-Match/version to detect it. Most concerning case: list/dict fields (`tools`, `mcp_config.mcpServers`) which *replace wholesale*, so concurrent edits to *different* MCP servers silently undo one another.
6. **No way for a client to confirm what was stored.** The PATCH response intentionally strips secrets and there is no version stamp, so verifying "did my change land?" requires a follow-up `GET` whose result may already include another writer's interleaved changes.
7. **Generic 422 with no field info.** Even errors that carry no secret (`max_iterations: 0`) collapse to `"Settings validation failed"`. The client cannot point at the bad field.

Idempotency is *accidentally* preserved for the common single-client case, but breaks under concurrent writers, encrypted-secret round-trips, and migration scenarios.

## What this PR does

### 1. Typed update models in the SDK (`openhands.sdk.settings.update_models`)

```python
class OpenHandsAgentSettingsUpdate(_UpdateBase):  # extra="forbid"
    agent_kind: Literal["openhands", "llm"] = "openhands"
    agent: str | None = None
    llm: LLMUpdate | None = None          # all-Optional partial of LLM
    tools: list[Tool] | None = None
    enable_sub_agents: bool | None = None
    enable_switch_llm_tool: bool | None = None
    mcp_config: MCPConfig | None = None
    agent_context: AgentContext | None = None
    condenser: CondenserSettingsUpdate | None = None
    verification: VerificationSettingsUpdate | None = None

class ACPAgentSettingsUpdate(_UpdateBase): ...
class ConversationSettingsUpdate(_UpdateBase): ...

AgentSettingsUpdate = Annotated[..., Discriminator(_agent_update_discriminator)]
```

With `apply_agent_update(current, update)` and `apply_conversation_update(current, update)` helpers that:

- Merge only the fields the client explicitly sent (`model_fields_set`).
- Treat nested partials (`llm`, `condenser`, `verification`) as one-level merges into the current sub-object, so e.g. `{"llm": {"model": "gpt-4o"}}` preserves the existing `api_key`.
- Re-validate the merged result through the source model's full validator chain (constraints, secret validators, MCP env decryption — all the usual invariants).
- Refuse to switch `agent_kind` (use `PUT` to switch variants).

### 2. New endpoints in `settings_router.py`

```
PATCH /api/settings/agent          — typed partial update (extra="forbid")
PUT   /api/settings/agent          — full replace (allows variant switching)
PATCH /api/settings/conversation   — typed partial update
PUT   /api/settings/conversation   — full replace
```

All four:

- Read the body as a Pydantic model with `extra="forbid"` (typos → 422).
- Honour `If-Match` against the global settings ETag.
- Return the new resource state with `ETag` header in the response.
- Reuse the existing file-locked `store.update()` so writes remain atomic and serialise with each other and with the legacy endpoint.

### 3. ETag / If-Match plumbing (`_settings_etag.py`)

- `compute_settings_etag()` hashes a **plaintext-canonical** projection of `PersistedSettings`. Crucially **not** the on-disk bytes — Fernet nonces would make identical state look like a change on every save, defeating idempotency.
- `check_if_match()` returns `412 Precondition Failed` on stale `If-Match`, with the current ETag echoed in the response so the client can retry against the live state. `If-Match: *` is accepted (resource always exists, since settings default).
- The shared `_run_settings_update` helper performs the If-Match check **inside** the file lock, so the ETag and the state the apply will run against are the same.

### 4. Bonus fix in `api.py`

The shared `HTTPException` handler in `_add_exception_handlers` was constructing the `JSONResponse` from `status_code` + `detail` but dropping `exc.headers`, so any handler-set response header on an error (e.g. our 412 ETag, or a `WWW-Authenticate: ...` on 401) was lost. Propagate it.

### 5. Legacy endpoint preserved + upgraded

`PATCH /api/settings` is unchanged in semantics and still accepts the old `dict[str, Any]` diff payload. In addition it now:

- Honours `If-Match` and emits the new `ETag` header in success responses.
- Emits `Deprecation: true` and `Link: </api/settings/agent>; rel="successor-version", </api/settings/conversation>; rel="successor-version"` (RFC 8594 / RFC 9745) so forward-compatible clients can migrate at their leisure.

No existing tests were modified; the legacy suite (28 tests) still passes unchanged.

## Tests

`tests/agent_server/test_typed_settings_router.py` (21 tests) covers:

- ETag stability across identical writes (the core idempotency property).
- ETag changes on real change.
- `If-Match` matching, stale → 412, wildcard.
- Legacy `PATCH /api/settings` honouring `If-Match` and emitting the deprecation headers.
- Typed PATCH: `extra="forbid"`, variant invariance, `agent_kind: "llm"` alias, partial LLM preserving `api_key`.
- PUT: full replace, variant switch (`openhands` → `acp`), 422 on invalid body.
- Conversation: partial preserve, forbid extra, validation re-fires.
- End-to-end concurrency: documented loss without `If-Match`, detected with `If-Match`.

Legacy: 28/28 `tests/agent_server/test_settings_router.py` still pass.
SDK: 87/87 `tests/sdk/test_settings.py` + `tests/sdk/settings/` still pass.

(The 15 unrelated failures in `tests/agent_server/test_skills_router.py` and `test_terminal_service.py` exist on `main` before this PR.)

## Compatibility

- Wire-compatible: no existing request body shape changes; `SettingsUpdateRequest` is unchanged.
- New response *header* (`ETag`) on `GET /api/settings`, `PATCH /api/settings`, and the new endpoints. Old clients that ignore unknown headers see no change.
- `Deprecation` / `Link` on the legacy `PATCH /api/settings` response are advisory; old clients ignore them.

## Follow-ups (not in this PR)

- **MCP servers should move to per-server CRUD** (`GET /api/settings/mcp-servers`, `GET/PUT/PATCH/DELETE /api/settings/mcp-servers/{name}`). Today even the new typed PATCH still treats `mcp_config` as one blob: editing one server's `env` requires round-tripping every *other* server's encrypted secrets. The CRUD shape would also give per-server ETags so concurrent edits to different servers stop conflicting at all. Mirroring the existing `/api/settings/secrets` router design.
- **Strict-mode `If-Match`**: a config flag to require `If-Match` on all settings writes, for deployments that want concurrency safety to be mandatory rather than opt-in.
- **Field-level 422 errors**: today the typed handlers still collapse re-validation errors to a generic message to avoid leaking secret values in tracebacks. We could pass through `loc` + a sanitised `msg` for fields known not to carry secrets.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7d67356-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7d67356-python \
  ghcr.io/openhands/agent-server:7d67356-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7d67356-golang-amd64
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-golang-amd64
ghcr.io/openhands/agent-server:feature-typed-settings-update-golang-amd64
ghcr.io/openhands/agent-server:7d67356-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7d67356-golang-arm64
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-golang-arm64
ghcr.io/openhands/agent-server:feature-typed-settings-update-golang-arm64
ghcr.io/openhands/agent-server:7d67356-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7d67356-java-amd64
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-java-amd64
ghcr.io/openhands/agent-server:feature-typed-settings-update-java-amd64
ghcr.io/openhands/agent-server:7d67356-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7d67356-java-arm64
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-java-arm64
ghcr.io/openhands/agent-server:feature-typed-settings-update-java-arm64
ghcr.io/openhands/agent-server:7d67356-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7d67356-python-amd64
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-python-amd64
ghcr.io/openhands/agent-server:feature-typed-settings-update-python-amd64
ghcr.io/openhands/agent-server:7d67356-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7d67356-python-arm64
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-python-arm64
ghcr.io/openhands/agent-server:feature-typed-settings-update-python-arm64
ghcr.io/openhands/agent-server:7d67356-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7d67356-golang
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-golang
ghcr.io/openhands/agent-server:feature-typed-settings-update-golang
ghcr.io/openhands/agent-server:7d67356-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7d67356-java
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-java
ghcr.io/openhands/agent-server:feature-typed-settings-update-java
ghcr.io/openhands/agent-server:7d67356-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7d67356-python
ghcr.io/openhands/agent-server:7d67356e72102f378012ac81dbd67f569485f8cd-python
ghcr.io/openhands/agent-server:feature-typed-settings-update-python
ghcr.io/openhands/agent-server:7d67356-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7d67356-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7d67356-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->