### PR TITLE
feat(agent-server): per-server CRUD for MCP servers

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -38,6 +38,7 @@ from openhands.agent_server.file_router import file_router
 from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
 from openhands.agent_server.llm_router import llm_router
+from openhands.agent_server.mcp_servers_router import mcp_servers_router
 from openhands.agent_server.middleware import LocalhostCORSMiddleware
 from openhands.agent_server.profiles_router import profiles_router
 from openhands.agent_server.server_details_router import (
@@ -289,6 +290,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
     api_router.include_router(settings_router)
+    api_router.include_router(mcp_servers_router)
     api_router.include_router(profiles_router)
     api_router.include_router(cloud_proxy_router)
     # /api/auth/* mints workspace cookies and requires the header to bootstrap,
@@ -493,10 +495,18 @@ def _add_exception_handlers(api: FastAPI) -> None:
             return JSONResponse(
                 status_code=exc.status_code,
                 content=content,
+                headers=exc.headers,
             )
 
-        # Return clean JSON response for all non-5xx HTTP exceptions
-        return JSONResponse(status_code=exc.status_code, content={"detail": exc.detail})
+        # Return clean JSON response for all non-5xx HTTP exceptions.
+        # Propagate ``exc.headers`` so handlers can attach response headers to
+        # error responses (e.g. ``ETag`` on a 412 from optimistic-concurrency
+        # checks, or ``WWW-Authenticate`` on a 401).
+        return JSONResponse(
+            status_code=exc.status_code,
+            content={"detail": exc.detail},
+            headers=exc.headers,
+        )
 
 
 def create_app(config: Config | None = None) -> FastAPI:

--- a/openhands-agent-server/openhands/agent_server/mcp_servers_router.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_servers_router.py
@@ -1,0 +1,665 @@
+"""CRUD endpoints for MCP servers persisted inside agent settings.
+
+Why a dedicated router (rather than going through ``PATCH /api/settings``)
+
+Today, MCP servers live as a dict under
+``agent_settings.mcp_config.mcpServers``. Editing a single server through
+the global settings PATCH means:
+
+* Read-modify-write of the *whole* collection (because ``mcp_config`` is a
+  single Pydantic field that replaces wholesale on assignment-style PATCH;
+  even with deep-merge, ``mcpServers`` is a dict where any individual
+  key-replace via PATCH affects only that key but still forces the client
+  to ship the entire ``mcpServers`` it wants to keep when *adding* or
+  *removing* anything else atomically). In practice clients fetch the
+  whole encrypted config, splice in their edit, and write the whole thing
+  back — which round-trips every *other* server's ``env``/``headers``
+  ciphertexts through the client unnecessarily.
+
+* No per-server concurrency. Two clients each adding a *different* server
+  race; even with optimistic concurrency at the global-settings level,
+  one of them has to retry, having done no work that conflicts with the
+  other.
+
+* No discoverable shape — ``mcp_config`` is documented in OpenAPI as one
+  big blob; adding a server is undocumented in the API surface.
+
+This router exposes the per-server resource directly:
+
+* ``GET    /api/settings/mcp-servers``         list summaries (no secrets)
+* ``GET    /api/settings/mcp-servers/{name}``  read one (X-Expose-Secrets aware)
+* ``PUT    /api/settings/mcp-servers/{name}``  upsert one
+* ``PATCH  /api/settings/mcp-servers/{name}``  partial edit of one
+* ``DELETE /api/settings/mcp-servers/{name}``  remove one
+
+Per-server ``ETag`` / ``If-Match`` (and ``If-None-Match: *`` for
+create-only PUT) gives optimistic concurrency at the right granularity:
+concurrent edits to *different* servers stop conflicting at all;
+concurrent edits to the *same* server get a clean 412 with the current
+ETag echoed back.
+
+ACP variant: ``ACPAgentSettings`` has no ``mcp_config``. Read endpoints
+on the missing collection return ``404``; writes return ``409`` with a
+message pointing the caller at the agent-variant settings endpoint.
+
+All writes still go through the file-locked ``store.update()``, so they
+serialize with each other and with the global ``PATCH /api/settings`` —
+this router does not introduce a separate persistence backend, just a
+finer-grained API.
+"""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import re
+from typing import Any
+
+from fastapi import APIRouter, HTTPException, Request, Response, status
+from pydantic import ValidationError
+
+from openhands.agent_server._secrets_exposure import (
+    build_expose_context,
+    get_config,
+    parse_expose_secrets_header,
+    translate_missing_cipher,
+)
+from openhands.agent_server.persistence import (
+    PersistedSettings,
+    get_settings_store,
+)
+from openhands.sdk.logger import get_logger
+from openhands.sdk.settings import (
+    MCPServerListResponse,
+    MCPServerResponse,
+    MCPServerSummary,
+    OpenHandsAgentSettings,
+)
+
+
+logger = get_logger(__name__)
+
+mcp_servers_router = APIRouter(tags=["MCP Servers"])
+
+MCP_COLLECTION_PATH = "/settings/mcp-servers"
+MCP_ITEM_PATH = "/settings/mcp-servers/{name}"
+
+# MCP server names map 1:1 to dict keys in the underlying ``MCPConfig``;
+# constrain to safe URL-path characters. Slashes are explicitly disallowed
+# because they would collide with FastAPI's path-segment routing (a server
+# called "@scope/server" would never match ``/mcp-servers/{name}``). Names
+# stay 1–128 chars to bound on-disk size.
+_NAME_PATTERN = re.compile(r"^[A-Za-z0-9_.@:-]{1,128}$")
+
+
+def _validate_server_name(name: str) -> None:
+    if not _NAME_PATTERN.fullmatch(name):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=(
+                "Invalid MCP server name. Use 1-128 characters from "
+                "[A-Za-z0-9_.@:-]. Slashes are not allowed because the "
+                "name is a single URL path segment."
+            ),
+        )
+
+
+# ── Secret-walking (local to keep this router decoupled from settings.model) ─
+
+
+def _walk_server_secret_values(server: dict[str, Any], transform) -> dict[str, Any]:
+    """Return a copy of ``server`` with ``transform`` applied to every string
+    value inside ``env`` / ``headers``. Mirrors the equivalent walker in
+    ``openhands.sdk.settings.model`` but scoped to a single server so we
+    don't have to build a synthetic ``MCPConfig`` wrapper around each
+    response.
+    """
+    result = copy.deepcopy(server)
+    for key in ("env", "headers"):
+        mapping = result.get(key)
+        if not isinstance(mapping, dict):
+            continue
+        result[key] = {
+            k: (transform(v) if isinstance(v, str) else v) for k, v in mapping.items()
+        }
+    return result
+
+
+# ── ETag computation ──────────────────────────────────────────────────────
+
+
+def _compute_server_etag(server: dict[str, Any]) -> str:
+    """ETag for a single MCP server config.
+
+    Computed over a **plaintext-canonical** JSON projection of the server's
+    config (sorted keys, no whitespace). Crucially this is *not* a hash of
+    on-disk bytes — those go through Fernet, whose nonce changes every save,
+    which would make identical-state writes look different and defeat
+    idempotency.
+    """
+    canonical = json.dumps(server, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()[:32]
+    return f'"{digest}"'
+
+
+def _parse_if_match(header_value: str | None) -> str | None:
+    """Return the (still-quoted) ETag value from an ``If-Match`` header, or
+    ``None`` if the header is absent. ``"*"`` is returned verbatim and means
+    "any current state is acceptable, but the resource must exist"."""
+    if header_value is None:
+        return None
+    return header_value.strip()
+
+
+def _check_preconditions(
+    current_etag: str,
+    *,
+    resource_exists: bool,
+    if_match: str | None,
+    if_none_match: str | None,
+) -> None:
+    """Apply ``If-Match`` / ``If-None-Match`` precondition checks.
+
+    * ``If-Match: <etag>``      → 412 unless ``<etag>`` equals the current.
+    * ``If-Match: *``           → 412 if the resource does not exist.
+    * ``If-None-Match: *``      → 412 if the resource *does* exist
+                                  (create-only PUT semantics).
+    * ``If-None-Match: <etag>`` → 412 if ``<etag>`` equals the current
+                                  (used by GETs for cache validation; we
+                                  accept the header for write endpoints
+                                  too for symmetry, treating any match as
+                                  a precondition failure).
+
+    On failure, raises ``412 Precondition Failed`` with the current ETag in
+    the ``ETag`` response header so the client can retry against the live
+    state. On a missing resource, raises ``412`` as well (still semantically
+    correct: the precondition failed because the resource isn't there to
+    match against).
+    """
+    if if_match is not None:
+        if if_match == "*":
+            if not resource_exists:
+                raise HTTPException(
+                    status_code=status.HTTP_412_PRECONDITION_FAILED,
+                    detail=(
+                        "If-Match: * requires the resource to exist, "
+                        "but no MCP server with that name was found."
+                    ),
+                )
+        elif if_match != current_etag:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail=(
+                    "If-Match does not match the current ETag. Re-fetch "
+                    "GET /api/settings/mcp-servers/{name} and retry."
+                ),
+                headers={"ETag": current_etag} if resource_exists else None,
+            )
+
+    if if_none_match is not None:
+        if if_none_match == "*":
+            if resource_exists:
+                raise HTTPException(
+                    status_code=status.HTTP_412_PRECONDITION_FAILED,
+                    detail=(
+                        "If-None-Match: * requires the resource to not "
+                        "exist, but an MCP server with that name already "
+                        "does."
+                    ),
+                    headers={"ETag": current_etag},
+                )
+        elif resource_exists and if_none_match == current_etag:
+            raise HTTPException(
+                status_code=status.HTTP_412_PRECONDITION_FAILED,
+                detail=(
+                    "If-None-Match matched the current ETag. Re-fetch the "
+                    "resource and retry."
+                ),
+                headers={"ETag": current_etag},
+            )
+
+
+# ── Settings → MCP servers extraction helpers ─────────────────────────────
+
+
+def _ensure_openhands_variant(
+    settings: PersistedSettings,
+) -> OpenHandsAgentSettings:
+    """Return ``settings.agent_settings`` if it is the OpenHands variant.
+
+    The ACP variant has no ``mcp_config`` field — there is no per-server
+    collection to manipulate. ``409`` signals the request is well-formed
+    but the persisted resource is in an incompatible state; the message
+    points the caller at the settings endpoint that *would* let them
+    switch variants.
+    """
+    agent = settings.agent_settings
+    if not isinstance(agent, OpenHandsAgentSettings):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "MCP servers are not supported by the current agent variant "
+                f"({agent.agent_kind!r}). Switch to an OpenHands-variant "
+                "agent via PATCH /api/settings before managing MCP servers."
+            ),
+        )
+    return agent
+
+
+def _dump_servers_dict(
+    settings: PersistedSettings, *, expose_mode, cipher
+) -> dict[str, dict[str, Any]]:
+    """Dump ``mcp_config.mcpServers`` as a plain ``{name: dict}`` mapping.
+
+    Goes through the model's ``mode="json"`` dump with the appropriate
+    serialization context, so per-server ``env`` / ``headers`` are
+    redacted / encrypted / plaintext exactly as for ``GET /api/settings``.
+    """
+    agent = settings.agent_settings
+    context = build_expose_context(expose_mode, cipher)
+    dumped = agent.model_dump(mode="json", context=context)
+    mcp = dumped.get("mcp_config") or {}
+    servers = mcp.get("mcpServers") or {}
+    if not isinstance(servers, dict):
+        return {}
+    return servers
+
+
+def _plaintext_server_or_404(
+    settings: PersistedSettings, name: str, *, cipher
+) -> dict[str, Any]:
+    """Return the plaintext config for one server, or raise 404."""
+    servers = _dump_servers_dict(settings, expose_mode="plaintext", cipher=cipher)
+    server = servers.get(name)
+    if server is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"No MCP server named {name!r} is configured.",
+        )
+    return server
+
+
+def _server_summary(name: str, server: dict[str, Any]) -> MCPServerSummary:
+    """Build a list-view summary from a server's dumped dict."""
+    if "command" in server:
+        kind = "stdio"
+    elif "url" in server:
+        kind = "remote"
+    else:
+        kind = "unknown"
+    transport = server.get("transport")
+    return MCPServerSummary(
+        name=name,
+        transport_kind=kind,
+        transport=transport if isinstance(transport, str) else None,
+        description=server.get("description"),
+        icon=server.get("icon"),
+    )
+
+
+def _validate_servers_dict(
+    servers: dict[str, dict[str, Any]], *, source_label: str
+) -> dict[str, Any]:
+    """Re-validate the (mutated) ``mcpServers`` dict by passing it through
+    ``OpenHandsAgentSettings`` so all model invariants (including
+    cross-server ones from ``MCPConfig``) are checked. Returns the merged
+    plaintext ``mcp_config`` payload ready to assign back to
+    ``agent_settings``.
+
+    Sanitizes validation errors to avoid leaking secret values that may
+    appear in the input dict.
+    """
+    payload = {"mcp_config": {"mcpServers": servers}}
+    try:
+        # We only need the field to round-trip; the rest of the agent
+        # settings come from the live in-memory ``agent_settings``.
+        OpenHandsAgentSettings.model_validate(
+            payload,
+            context={"expose_secrets": "plaintext"},
+            from_attributes=False,
+        )
+    except ValidationError as exc:
+        # Strip ``input`` from the error reports to avoid echoing secret
+        # values back. The location + message are still informative.
+        errors = [
+            {"loc": e["loc"], "msg": e["msg"], "type": e["type"]} for e in exc.errors()
+        ]
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail={
+                "message": f"Invalid MCP server config ({source_label}).",
+                "errors": errors,
+            },
+        ) from exc
+    return payload["mcp_config"]
+
+
+# ── Endpoints ─────────────────────────────────────────────────────────────
+
+
+@mcp_servers_router.get(MCP_COLLECTION_PATH, response_model=MCPServerListResponse)
+async def list_mcp_servers(request: Request) -> MCPServerListResponse:
+    """List MCP servers as summaries (no ``env`` or ``headers``).
+
+    Returns an empty list when the persisted variant is ACP — list views
+    are non-modifying so the more permissive shape (rather than 409) keeps
+    polling clients simple.
+    """
+    config = get_config(request)
+    store = get_settings_store(config)
+    settings = store.load() or PersistedSettings()
+    agent = settings.agent_settings
+    if not isinstance(agent, OpenHandsAgentSettings):
+        return MCPServerListResponse(servers=[])
+
+    # List view: use ``"plaintext"`` so we can inspect ``description`` /
+    # ``icon`` / ``transport`` directly; we explicitly do *not* include
+    # ``env`` or ``headers`` in the response shape regardless of mode.
+    with translate_missing_cipher():
+        servers = _dump_servers_dict(
+            settings, expose_mode="plaintext", cipher=config.cipher
+        )
+    summaries = [_server_summary(n, s) for n, s in sorted(servers.items())]
+    return MCPServerListResponse(servers=summaries)
+
+
+@mcp_servers_router.get(MCP_ITEM_PATH, response_model=MCPServerResponse)
+async def get_mcp_server(request: Request, name: str) -> Response:
+    """Read one MCP server's full configuration.
+
+    Honours ``X-Expose-Secrets`` exactly like ``GET /api/settings``:
+
+    * absent (default): ``env``/``headers`` values are redacted
+    * ``encrypted``: Fernet-encrypted ciphertext
+    * ``plaintext``: raw secret values
+
+    Emits an ``ETag`` header bound to this server's plaintext-canonical
+    config so write endpoints can use ``If-Match`` to detect concurrent
+    edits to *this server specifically* (without conflicting with edits
+    to other servers).
+    """
+    _validate_server_name(name)
+    expose_mode = parse_expose_secrets_header(request)
+    config = get_config(request)
+    store = get_settings_store(config)
+    settings = store.load() or PersistedSettings()
+    agent = settings.agent_settings
+    if not isinstance(agent, OpenHandsAgentSettings):
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=(
+                "MCP servers are not configured (current agent variant has "
+                "no MCP support)."
+            ),
+        )
+
+    # ETag is always derived from the plaintext state so it's stable across
+    # different ``X-Expose-Secrets`` requests for the same logical content.
+    plaintext_server = _plaintext_server_or_404(settings, name, cipher=config.cipher)
+    etag = _compute_server_etag(plaintext_server)
+
+    # Build the response body with the requested exposure mode.
+    if expose_mode is None:
+        # Redact secrets for the default mode.
+        response_server = _walk_server_secret_values(
+            plaintext_server, lambda _v: "[REDACTED]"
+        )
+    elif expose_mode == "plaintext":
+        response_server = plaintext_server
+    else:
+        # ``encrypted``: dump again with that mode so the model's serializer
+        # runs through its Fernet path.
+        with translate_missing_cipher():
+            servers = _dump_servers_dict(
+                settings, expose_mode="encrypted", cipher=config.cipher
+            )
+        response_server = servers[name]
+
+    client_host = request.client.host if request.client else "unknown"
+    log_extra = {"client_host": client_host, "expose_mode": expose_mode or "redacted"}
+    if expose_mode == "plaintext":
+        logger.warning(
+            "MCP server %r accessed with PLAINTEXT secrets",
+            name,
+            extra=log_extra,
+        )
+    else:
+        logger.info("MCP server %r accessed", name, extra=log_extra)
+
+    payload = MCPServerResponse(name=name, config=response_server)
+    return Response(
+        content=payload.model_dump_json(),
+        media_type="application/json",
+        headers={"ETag": etag},
+    )
+
+
+@mcp_servers_router.put(MCP_ITEM_PATH, response_model=MCPServerResponse)
+async def upsert_mcp_server(
+    request: Request, name: str, server: dict[str, Any]
+) -> Response:
+    """Create or replace an MCP server.
+
+    Body is the raw ``fastmcp`` server config (the value of
+    ``MCPConfig.mcpServers[name]``). The discriminator is implicit
+    (``command``-bearing → stdio, ``url``-bearing → remote) — fastmcp's
+    own validators pick the variant; this endpoint just passes through.
+
+    Preconditions:
+
+    * ``If-Match: <etag>`` succeeds only if the named server currently
+      has that ETag (concurrent-edit detection).
+    * ``If-Match: *`` requires the server to already exist (update-only).
+    * ``If-None-Match: *`` requires the server to *not* exist (create-only).
+
+    Returns the new resource state (with secrets redacted by default; the
+    caller can re-fetch with ``X-Expose-Secrets`` if they need the values
+    in encrypted/plaintext form) and the new ``ETag``.
+    """
+    _validate_server_name(name)
+    config = get_config(request)
+    store = get_settings_store(config)
+    if_match = _parse_if_match(request.headers.get("If-Match"))
+    if_none_match = _parse_if_match(request.headers.get("If-None-Match"))
+
+    created = False
+
+    def apply(settings: PersistedSettings) -> PersistedSettings:
+        nonlocal created
+        agent = _ensure_openhands_variant(settings)
+        servers = _dump_servers_dict(
+            settings, expose_mode="plaintext", cipher=config.cipher
+        )
+        existing = servers.get(name)
+        current_etag = _compute_server_etag(existing) if existing is not None else ""
+        _check_preconditions(
+            current_etag,
+            resource_exists=existing is not None,
+            if_match=if_match,
+            if_none_match=if_none_match,
+        )
+
+        servers[name] = server
+        new_mcp = _validate_servers_dict(servers, source_label=f"server {name!r}")
+
+        agent_dump = agent.model_dump(
+            mode="json",
+            context={"expose_secrets": "plaintext", "cipher": config.cipher},
+        )
+        agent_dump["mcp_config"] = new_mcp
+        with translate_missing_cipher():
+            new_agent = OpenHandsAgentSettings.model_validate(
+                agent_dump,
+                context={"expose_secrets": "plaintext", "cipher": config.cipher},
+            )
+        settings.agent_settings = new_agent
+        created = existing is None
+        return settings
+
+    try:
+        new_settings = store.update(apply)
+    except HTTPException:
+        raise
+    except RuntimeError as exc:
+        # Corrupted-store or cipher-mismatch path, mirroring settings_router.
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Settings store is corrupted or unreadable: {exc}",
+        ) from exc
+
+    # Return the new state with redacted secrets (default) + new ETag.
+    plaintext = _plaintext_server_or_404(new_settings, name, cipher=config.cipher)
+    etag = _compute_server_etag(plaintext)
+    redacted = _walk_server_secret_values(plaintext, lambda _v: "[REDACTED]")
+    payload = MCPServerResponse(name=name, config=redacted)
+    return Response(
+        content=payload.model_dump_json(),
+        media_type="application/json",
+        status_code=(status.HTTP_201_CREATED if created else status.HTTP_200_OK),
+        headers={"ETag": etag},
+    )
+
+
+@mcp_servers_router.patch(MCP_ITEM_PATH, response_model=MCPServerResponse)
+async def patch_mcp_server(
+    request: Request, name: str, patch: dict[str, Any]
+) -> Response:
+    """Partial update of an existing MCP server.
+
+    Only the keys present in ``patch`` are modified. ``env`` and
+    ``headers`` are *replaced* wholesale at the top level (their values
+    are dicts; if you want to remove one entry, send the new map without
+    it) — this matches Pydantic's per-field replace semantics and avoids
+    ambiguity with "is this value being cleared or just absent?".
+
+    Returns 404 if no server with that name exists (use PUT to create).
+    """
+    _validate_server_name(name)
+    config = get_config(request)
+    store = get_settings_store(config)
+    if_match = _parse_if_match(request.headers.get("If-Match"))
+    if_none_match = _parse_if_match(request.headers.get("If-None-Match"))
+
+    def apply(settings: PersistedSettings) -> PersistedSettings:
+        agent = _ensure_openhands_variant(settings)
+        servers = _dump_servers_dict(
+            settings, expose_mode="plaintext", cipher=config.cipher
+        )
+        existing = servers.get(name)
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=(
+                    f"No MCP server named {name!r}; PATCH cannot create. "
+                    "Use PUT instead."
+                ),
+            )
+        _check_preconditions(
+            _compute_server_etag(existing),
+            resource_exists=True,
+            if_match=if_match,
+            if_none_match=if_none_match,
+        )
+
+        merged = {**existing, **patch}
+        servers[name] = merged
+        new_mcp = _validate_servers_dict(servers, source_label=f"server {name!r}")
+
+        agent_dump = agent.model_dump(
+            mode="json",
+            context={"expose_secrets": "plaintext", "cipher": config.cipher},
+        )
+        agent_dump["mcp_config"] = new_mcp
+        with translate_missing_cipher():
+            new_agent = OpenHandsAgentSettings.model_validate(
+                agent_dump,
+                context={"expose_secrets": "plaintext", "cipher": config.cipher},
+            )
+        settings.agent_settings = new_agent
+        return settings
+
+    try:
+        new_settings = store.update(apply)
+    except HTTPException:
+        raise
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Settings store is corrupted or unreadable: {exc}",
+        ) from exc
+
+    plaintext = _plaintext_server_or_404(new_settings, name, cipher=config.cipher)
+    etag = _compute_server_etag(plaintext)
+    redacted = _walk_server_secret_values(plaintext, lambda _v: "[REDACTED]")
+    payload = MCPServerResponse(name=name, config=redacted)
+    return Response(
+        content=payload.model_dump_json(),
+        media_type="application/json",
+        headers={"ETag": etag},
+    )
+
+
+@mcp_servers_router.delete(MCP_ITEM_PATH, status_code=status.HTTP_204_NO_CONTENT)
+async def delete_mcp_server(request: Request, name: str) -> Response:
+    """Remove one MCP server.
+
+    Honours ``If-Match`` to guard against deleting a server that has been
+    re-created or modified by another client since the caller last viewed
+    it. Returns 404 (idempotent in the sense that re-deleting a missing
+    server is reported as such; we don't silently 204 on absence so the
+    client can tell whether their delete actually removed anything).
+    """
+    _validate_server_name(name)
+    config = get_config(request)
+    store = get_settings_store(config)
+    if_match = _parse_if_match(request.headers.get("If-Match"))
+    if_none_match = _parse_if_match(request.headers.get("If-None-Match"))
+
+    def apply(settings: PersistedSettings) -> PersistedSettings:
+        agent = _ensure_openhands_variant(settings)
+        servers = _dump_servers_dict(
+            settings, expose_mode="plaintext", cipher=config.cipher
+        )
+        existing = servers.get(name)
+        if existing is None:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail=f"No MCP server named {name!r} to delete.",
+            )
+        _check_preconditions(
+            _compute_server_etag(existing),
+            resource_exists=True,
+            if_match=if_match,
+            if_none_match=if_none_match,
+        )
+
+        del servers[name]
+        new_mcp = _validate_servers_dict(servers, source_label="after delete")
+        agent_dump = agent.model_dump(
+            mode="json",
+            context={"expose_secrets": "plaintext", "cipher": config.cipher},
+        )
+        agent_dump["mcp_config"] = new_mcp
+        with translate_missing_cipher():
+            new_agent = OpenHandsAgentSettings.model_validate(
+                agent_dump,
+                context={"expose_secrets": "plaintext", "cipher": config.cipher},
+            )
+        settings.agent_settings = new_agent
+        return settings
+
+    try:
+        store.update(apply)
+    except HTTPException:
+        raise
+    except RuntimeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=f"Settings store is corrupted or unreadable: {exc}",
+        ) from exc
+
+    return Response(status_code=status.HTTP_204_NO_CONTENT)
+
+
+__all__ = ["mcp_servers_router"]

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -10,6 +10,9 @@ from .acp_providers import (
     get_acp_provider,
 )
 from .api_models import (
+    MCPServerListResponse,
+    MCPServerResponse,
+    MCPServerSummary,
     SecretCreateRequest,
     SecretItemResponse,
     SecretsListResponse,
@@ -88,6 +91,9 @@ __all__ = [
     "CondenserSettings",
     "ConversationSettings",
     "LLMAgentSettings",
+    "MCPServerListResponse",
+    "MCPServerResponse",
+    "MCPServerSummary",
     "OpenHandsAgentSettings",
     "SETTINGS_METADATA_KEY",
     "SETTINGS_SECTION_METADATA_KEY",

--- a/openhands-sdk/openhands/sdk/settings/api_models.py
+++ b/openhands-sdk/openhands/sdk/settings/api_models.py
@@ -124,3 +124,49 @@ class SecretCreateRequest(BaseModel):
     name: str
     value: SecretStr
     description: str | None = None
+
+
+# ── MCP Server CRUD API Models ────────────────────────────────────────────
+
+
+class MCPServerSummary(BaseModel):
+    """Single-server summary returned by ``GET /api/settings/mcp-servers``.
+
+    The list view never carries ``env`` or ``headers`` values — clients that
+    need the full configuration (including secrets, modulated by
+    ``X-Expose-Secrets``) should call ``GET /api/settings/mcp-servers/{name}``.
+
+    ``transport_kind`` is the high-level shape of the server config
+    (``"stdio"`` for command-launched local processes, ``"remote"`` for
+    HTTP/SSE endpoints). ``transport`` is the more specific value reported by
+    the underlying ``fastmcp`` server model when present (e.g. ``"http"``,
+    ``"sse"``, ``"stdio"``); it's exposed for clients that want to display it
+    without having to fetch each server.
+    """
+
+    name: str
+    transport_kind: str
+    transport: str | None = None
+    description: str | None = None
+    icon: str | None = None
+
+
+class MCPServerListResponse(BaseModel):
+    """Response model for ``GET /api/settings/mcp-servers``."""
+
+    servers: list[MCPServerSummary]
+
+
+class MCPServerResponse(BaseModel):
+    """Response model for ``GET/PUT/PATCH /api/settings/mcp-servers/{name}``.
+
+    ``config`` carries the raw ``fastmcp`` server-config dict (i.e. the
+    ``MCPConfig.mcpServers[name]`` payload). It's kept as ``dict[str, Any]``
+    so the server controls secret serialization via context the same way
+    ``SettingsResponse.agent_settings`` does — typed Pydantic fields would
+    lose the ``X-Expose-Secrets`` modulation during FastAPI's automatic JSON
+    serialization.
+    """
+
+    name: str
+    config: dict[str, Any]

--- a/tests/agent_server/test_mcp_servers_router.py
+++ b/tests/agent_server/test_mcp_servers_router.py
@@ -1,0 +1,546 @@
+"""Tests for the per-server MCP CRUD router.
+
+Covers the win-list from the PR description:
+
+* List / read / upsert / patch / delete a single server, without
+  round-tripping every *other* server's encrypted secrets through the
+  client.
+* Per-server ETag is plaintext-canonical (idempotent across resaves).
+* ``If-Match`` / ``If-None-Match`` give per-server optimistic concurrency:
+  concurrent edits to *different* servers don't collide; concurrent edits
+  to the *same* server get a clean 412 with the current ETag echoed.
+* The ACP variant has no MCP collection — list returns empty, reads return
+  404, writes return 409.
+* ``X-Expose-Secrets`` is honoured on the per-server read.
+* Adding a server through this router does not touch other servers'
+  encrypted env/headers values on disk (the "splice locally" property).
+"""
+
+from __future__ import annotations
+
+import os
+import tempfile
+from base64 import urlsafe_b64encode
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+from openhands.agent_server.persistence import reset_stores
+
+
+@pytest.fixture
+def temp_persistence_dir():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reset_stores()
+        old_val = os.environ.get("OH_PERSISTENCE_DIR")
+        os.environ["OH_PERSISTENCE_DIR"] = tmpdir
+        yield Path(tmpdir)
+        reset_stores()
+        if old_val is not None:
+            os.environ["OH_PERSISTENCE_DIR"] = old_val
+        else:
+            os.environ.pop("OH_PERSISTENCE_DIR", None)
+
+
+@pytest.fixture
+def secret_key():
+    return urlsafe_b64encode(b"a" * 32).decode("ascii")
+
+
+@pytest.fixture
+def client(temp_persistence_dir, secret_key):
+    config = Config(
+        static_files_path=None,
+        session_api_keys=[],
+        secret_key=SecretStr(secret_key),
+    )
+    test_client = TestClient(create_app(config))
+    # Seed the openhands variant by writing a minimal LLM config via the
+    # legacy settings PATCH. (The router we're testing requires the
+    # openhands variant; defaults already are openhands, but seeding a real
+    # save makes the on-disk state deterministic for ETag assertions.)
+    test_client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4"}}},
+    )
+    return test_client
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────
+
+
+def _stdio_server(command: str = "echo", env: dict | None = None) -> dict:
+    body: dict = {"command": command, "args": ["hello"]}
+    if env is not None:
+        body["env"] = env
+    return body
+
+
+def _remote_server(url: str = "http://example.com", headers=None) -> dict:
+    body: dict = {"url": url}
+    if headers is not None:
+        body["headers"] = headers
+    return body
+
+
+# ── Listing ────────────────────────────────────────────────────────────────
+
+
+def test_list_empty(client):
+    response = client.get("/api/settings/mcp-servers")
+    assert response.status_code == 200
+    assert response.json() == {"servers": []}
+
+
+def test_list_after_creates(client):
+    client.put(
+        "/api/settings/mcp-servers/local",
+        json=_stdio_server(command="python", env={"K": "v"}),
+    )
+    client.put(
+        "/api/settings/mcp-servers/remote",
+        json=_remote_server(headers={"Authorization": "Bearer x"}),
+    )
+    response = client.get("/api/settings/mcp-servers")
+    assert response.status_code == 200
+    names = [s["name"] for s in response.json()["servers"]]
+    kinds = {s["name"]: s["transport_kind"] for s in response.json()["servers"]}
+    assert names == ["local", "remote"]  # sorted
+    assert kinds == {"local": "stdio", "remote": "remote"}
+
+
+def test_list_never_contains_secrets(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"TOKEN": "super-secret"}),
+    )
+    response = client.get("/api/settings/mcp-servers")
+    body = response.json()
+    # Summary shape is fixed — no env/headers at all.
+    server = body["servers"][0]
+    assert set(server) == {
+        "name",
+        "transport_kind",
+        "transport",
+        "description",
+        "icon",
+    }
+
+
+# ── Read one ───────────────────────────────────────────────────────────────
+
+
+def test_get_one_redacted_by_default(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"TOKEN": "super-secret"}),
+    )
+    response = client.get("/api/settings/mcp-servers/x")
+    assert response.status_code == 200
+    body = response.json()
+    assert body["name"] == "x"
+    assert body["config"]["env"] == {"TOKEN": "[REDACTED]"}
+    assert response.headers["ETag"].startswith('"')
+
+
+def test_get_one_plaintext_via_header(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"TOKEN": "super-secret"}),
+    )
+    response = client.get(
+        "/api/settings/mcp-servers/x",
+        headers={"X-Expose-Secrets": "plaintext"},
+    )
+    assert response.json()["config"]["env"] == {"TOKEN": "super-secret"}
+
+
+def test_get_one_encrypted_via_header(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"TOKEN": "super-secret"}),
+    )
+    response = client.get(
+        "/api/settings/mcp-servers/x",
+        headers={"X-Expose-Secrets": "encrypted"},
+    )
+    encrypted_value = response.json()["config"]["env"]["TOKEN"]
+    assert encrypted_value.startswith("gAAAAA")  # Fernet token prefix
+
+
+def test_get_missing_returns_404(client):
+    response = client.get("/api/settings/mcp-servers/nope")
+    assert response.status_code == 404
+
+
+def test_get_invalid_name_returns_400(client):
+    response = client.get("/api/settings/mcp-servers/has spaces")
+    # FastAPI routes accept the path; our validator rejects it.
+    assert response.status_code == 400
+
+
+# ── ETag stability and change ─────────────────────────────────────────────
+
+
+def test_etag_stable_across_identical_resaves(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v"}),
+    )
+    etag1 = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+
+    # Re-PUT the exact same body. The on-disk Fernet ciphertext for ``K``
+    # changes (per-save nonce), but the *plaintext-canonical* state is
+    # identical, so the ETag must not move.
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v"}),
+    )
+    etag2 = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+    assert etag1 == etag2
+
+
+def test_etag_changes_on_real_change(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v"}),
+    )
+    etag1 = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v2"}),
+    )
+    etag2 = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+    assert etag1 != etag2
+
+
+# ── Optimistic concurrency ─────────────────────────────────────────────────
+
+
+def test_put_with_matching_if_match_succeeds(client):
+    client.put("/api/settings/mcp-servers/x", json=_stdio_server(env={"K": "v"}))
+    etag = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+    response = client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v2"}),
+        headers={"If-Match": etag},
+    )
+    assert response.status_code == 200
+    assert response.headers["ETag"] != etag
+
+
+def test_put_with_stale_if_match_returns_412(client):
+    client.put("/api/settings/mcp-servers/x", json=_stdio_server(env={"K": "v"}))
+    etag = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+    # Another client mutates first.
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "vA"}),
+    )
+    response = client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "vB"}),
+        headers={"If-Match": etag},
+    )
+    assert response.status_code == 412
+    # The current ETag is echoed so the client can rebase + retry.
+    assert response.headers["ETag"] != etag
+
+
+def test_put_if_none_match_star_creates_when_absent(client):
+    response = client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v"}),
+        headers={"If-None-Match": "*"},
+    )
+    assert response.status_code == 201
+
+
+def test_put_if_none_match_star_rejects_when_exists(client):
+    client.put("/api/settings/mcp-servers/x", json=_stdio_server(env={"K": "v"}))
+    response = client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v2"}),
+        headers={"If-None-Match": "*"},
+    )
+    assert response.status_code == 412
+    # Current ETag is echoed for the client to choose to PUT-update.
+    assert response.headers["ETag"].startswith('"')
+
+
+def test_put_if_match_star_rejects_when_absent(client):
+    response = client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v"}),
+        headers={"If-Match": "*"},
+    )
+    assert response.status_code == 412
+
+
+def test_concurrent_edits_to_different_servers_dont_conflict(client):
+    """The headline win: per-server ETag means two clients each adding a
+    different server can both proceed using their own If-Match, without
+    one of them having to retry. This is the failure mode the global
+    settings PATCH cannot avoid."""
+    # Client A's view: empty.
+    # Client B's view: empty.
+    a = client.put(
+        "/api/settings/mcp-servers/server-a",
+        json=_stdio_server(),
+        headers={"If-None-Match": "*"},
+    )
+    b = client.put(
+        "/api/settings/mcp-servers/server-b",
+        json=_stdio_server(),
+        headers={"If-None-Match": "*"},
+    )
+    assert a.status_code == 201
+    assert b.status_code == 201
+
+    response = client.get("/api/settings/mcp-servers")
+    assert [s["name"] for s in response.json()["servers"]] == [
+        "server-a",
+        "server-b",
+    ]
+
+
+def test_concurrent_edits_to_same_server_one_wins(client):
+    """Same-server collision: the second writer's stale If-Match fails
+    explicitly rather than silently overwriting."""
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"VERSION": "1"}),
+    )
+    shared_etag = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+
+    a = client.patch(
+        "/api/settings/mcp-servers/x",
+        json={"env": {"VERSION": "2"}},
+        headers={"If-Match": shared_etag},
+    )
+    assert a.status_code == 200
+
+    b = client.patch(
+        "/api/settings/mcp-servers/x",
+        json={"env": {"VERSION": "3"}},
+        headers={"If-Match": shared_etag},  # stale
+    )
+    assert b.status_code == 412
+
+    # Only A's write landed.
+    after = client.get(
+        "/api/settings/mcp-servers/x",
+        headers={"X-Expose-Secrets": "plaintext"},
+    )
+    assert after.json()["config"]["env"]["VERSION"] == "2"
+
+
+# ── PATCH ──────────────────────────────────────────────────────────────────
+
+
+def test_patch_partial_keeps_unsent_fields(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json={
+            "command": "python",
+            "args": ["server.py"],
+            "env": {"K": "v"},
+            "description": "important",
+        },
+    )
+
+    # Patch only env.
+    response = client.patch(
+        "/api/settings/mcp-servers/x",
+        json={"env": {"K": "v2"}},
+    )
+    assert response.status_code == 200
+
+    after = client.get(
+        "/api/settings/mcp-servers/x",
+        headers={"X-Expose-Secrets": "plaintext"},
+    ).json()["config"]
+    assert after["command"] == "python"  # preserved
+    assert after["args"] == ["server.py"]  # preserved
+    assert after["description"] == "important"  # preserved
+    assert after["env"] == {"K": "v2"}  # updated
+
+
+def test_patch_on_missing_server_returns_404(client):
+    response = client.patch("/api/settings/mcp-servers/nope", json={"description": "x"})
+    assert response.status_code == 404
+
+
+def test_patch_invalid_body_returns_422(client):
+    client.put("/api/settings/mcp-servers/x", json=_stdio_server())
+    # ``timeout`` is typed as a number — string fails fastmcp validation.
+    response = client.patch(
+        "/api/settings/mcp-servers/x",
+        json={"timeout": "not-a-number"},
+    )
+    assert response.status_code == 422
+
+
+# ── DELETE ─────────────────────────────────────────────────────────────────
+
+
+def test_delete_existing_returns_204(client):
+    client.put("/api/settings/mcp-servers/x", json=_stdio_server())
+    response = client.delete("/api/settings/mcp-servers/x")
+    assert response.status_code == 204
+    # Subsequent GET is 404.
+    assert client.get("/api/settings/mcp-servers/x").status_code == 404
+
+
+def test_delete_missing_returns_404(client):
+    response = client.delete("/api/settings/mcp-servers/nope")
+    assert response.status_code == 404
+
+
+def test_delete_with_stale_if_match_returns_412(client):
+    client.put(
+        "/api/settings/mcp-servers/x",
+        json=_stdio_server(env={"K": "v"}),
+    )
+    etag = client.get("/api/settings/mcp-servers/x").headers["ETag"]
+    # Move the server forward.
+    client.patch("/api/settings/mcp-servers/x", json={"description": "changed"})
+    response = client.delete("/api/settings/mcp-servers/x", headers={"If-Match": etag})
+    assert response.status_code == 412
+    # Server is still there.
+    assert client.get("/api/settings/mcp-servers/x").status_code == 200
+
+
+def test_delete_does_not_disturb_other_servers(client):
+    client.put(
+        "/api/settings/mcp-servers/keep",
+        json=_stdio_server(env={"K": "v-keep"}),
+    )
+    client.put(
+        "/api/settings/mcp-servers/drop",
+        json=_stdio_server(env={"K": "v-drop"}),
+    )
+    client.delete("/api/settings/mcp-servers/drop")
+
+    surviving = client.get(
+        "/api/settings/mcp-servers/keep",
+        headers={"X-Expose-Secrets": "plaintext"},
+    ).json()
+    assert surviving["config"]["env"]["K"] == "v-keep"
+
+
+# ── ACP variant: no MCP collection ─────────────────────────────────────────
+
+
+def _switch_to_acp(client):
+    """Persist an ACP-variant agent_settings so the MCP endpoints have
+    nothing to manipulate."""
+    # Switching variants via the legacy diff replaces the whole
+    # ``agent_settings`` via re-validation. We pass the variant
+    # discriminator and minimum fields needed for ACPAgentSettings to
+    # validate.
+    response = client.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "acp",
+                "acp_server": "claude-code",
+                "llm": {"model": "claude-sonnet-4-20250514"},
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_list_on_acp_variant_returns_empty(client):
+    _switch_to_acp(client)
+    response = client.get("/api/settings/mcp-servers")
+    assert response.status_code == 200
+    assert response.json() == {"servers": []}
+
+
+def test_get_on_acp_variant_returns_404(client):
+    _switch_to_acp(client)
+    response = client.get("/api/settings/mcp-servers/x")
+    assert response.status_code == 404
+
+
+def test_put_on_acp_variant_returns_409(client):
+    _switch_to_acp(client)
+    response = client.put("/api/settings/mcp-servers/x", json=_stdio_server())
+    assert response.status_code == 409
+    assert "agent variant" in response.json()["detail"].lower()
+
+
+def test_delete_on_acp_variant_returns_409(client):
+    _switch_to_acp(client)
+    response = client.delete("/api/settings/mcp-servers/x")
+    assert response.status_code == 409
+
+
+# ── "Splice locally" property: editing one server doesn't touch others ────
+
+
+def test_editing_one_server_does_not_re_encrypt_others_on_change(client):
+    """The conceptual win this router gives over the global settings PATCH:
+    editing server B does not require the *client* to round-trip server A's
+    secret values. (We can't directly observe what the client sent — but we
+    can observe that the server preserved A's plaintext exactly through B's
+    edit cycle, and the request to edit B didn't carry A's env at all.)
+    """
+    client.put(
+        "/api/settings/mcp-servers/A",
+        json=_stdio_server(env={"A_TOKEN": "alpha"}),
+    )
+    client.put(
+        "/api/settings/mcp-servers/B",
+        json=_stdio_server(env={"B_TOKEN": "beta"}),
+    )
+
+    # Edit B by name, sending *only* B's new env. (No A_TOKEN anywhere.)
+    response = client.patch(
+        "/api/settings/mcp-servers/B",
+        json={"env": {"B_TOKEN": "beta-2"}},
+    )
+    assert response.status_code == 200
+
+    a = client.get(
+        "/api/settings/mcp-servers/A",
+        headers={"X-Expose-Secrets": "plaintext"},
+    ).json()
+    b = client.get(
+        "/api/settings/mcp-servers/B",
+        headers={"X-Expose-Secrets": "plaintext"},
+    ).json()
+    assert a["config"]["env"] == {"A_TOKEN": "alpha"}
+    assert b["config"]["env"] == {"B_TOKEN": "beta-2"}
+
+
+# ── Name validation ───────────────────────────────────────────────────────
+
+
+def test_invalid_name_rejected_on_write(client):
+    response = client.put("/api/settings/mcp-servers/bad name", json=_stdio_server())
+    assert response.status_code == 400
+
+
+def test_valid_unusual_names_accepted(client):
+    # Slashes are explicitly disallowed (single URL path segment); the
+    # accepted set covers underscores, hyphens, dots, ``@``, and colons.
+    for n in ["org_a", "github-mcp", "a.b.c", "@scope-server", "host:port"]:
+        response = client.put(f"/api/settings/mcp-servers/{n}", json=_stdio_server())
+        assert response.status_code in (200, 201), (n, response.text)
+
+
+def test_slash_in_name_rejected_as_invalid(client):
+    response = client.put(
+        "/api/settings/mcp-servers/@scope/server", json=_stdio_server()
+    )
+    # FastAPI routes the trailing ``/server`` as the next path segment, so
+    # the request never matches the route — 404 from the router itself.
+    assert response.status_code == 404


### PR DESCRIPTION
_This PR was opened by an AI agent (OpenHands) on behalf of the user._

Follow-up to #3234 (typed settings update endpoints) — that PR called out the MCP-server-as-blob problem; this PR fixes it. The two are independent and don't share code; the small `api.py` `exc.headers` propagation fix appears in both with identical content (trivial merge resolution either way).

## Why `mcp_config` is the worst-fit case for the settings PATCH

MCP servers live as a dict under `agent_settings.mcp_config.mcpServers`. Editing one through the global settings PATCH means:

1. **Read-modify-write of the whole collection.** Even with deep-merge semantics, to add or remove a server atomically you have to PATCH the full new `mcpServers` mapping — which forces the client to ship every *other* server's encrypted `env`/`headers` ciphertexts that they had no business round-tripping.
2. **Cross-server concurrency at the wrong granularity.** Two clients each adding a *different* server race, and one of them has to retry, having done no work that conflicts with the other.
3. **Discoverability.** `mcp_config` is documented in OpenAPI as one shape; adding/removing/editing a server is undocumented and indirect.
4. **`env` / `headers` are dicts of secrets.** Every byte that doesn't need to leave the server shouldn't.

## What this PR adds

A dedicated router that treats each MCP server as its own named resource:

| Verb     | Path                                       | Purpose                                                                |
| -------- | ------------------------------------------ | ---------------------------------------------------------------------- |
| `GET`    | `/api/settings/mcp-servers`                | List summaries (name, transport kind, description, icon — no secrets). |
| `GET`    | `/api/settings/mcp-servers/{name}`         | Read one (honours `X-Expose-Secrets` like `/api/settings`).            |
| `PUT`    | `/api/settings/mcp-servers/{name}`         | Upsert. 201 on create, 200 on update.                                  |
| `PATCH`  | `/api/settings/mcp-servers/{name}`         | Partial update of an existing server. 404 if absent.                   |
| `DELETE` | `/api/settings/mcp-servers/{name}`         | Remove one. 404 if absent.                                             |

Body for PUT/PATCH is the raw `fastmcp` server config dict (the value of `MCPConfig.mcpServers[name]`). fastmcp's own validators discriminate stdio vs remote vs the transforming variants based on `command`/`url` presence; this router passes through. Cross-server invariants from `MCPConfig` re-fire on every write because each mutation re-validates the full `OpenHandsAgentSettings` after splicing.

### Per-server optimistic concurrency

- `ETag` on every read of `/{name}`. Computed over a **plaintext-canonical** JSON projection of just that server's config — *not* on-disk bytes, since Fernet nonces would make identical state hash differently every save and defeat idempotency.
- `If-Match: <etag>` on PUT/PATCH/DELETE → 412 (with current `ETag` echoed in the header) if stale.
- `If-Match: *` → must exist (update-only PUT).
- `If-None-Match: *` → must not exist (create-only PUT).
- `If-None-Match: <etag>` → 412 if it matches current (symmetric to `If-Match`).

The headline win: **concurrent edits to *different* servers don't conflict at all**. Same-server conflicts get a clean 412 with the new state's ETag, so the client can rebase and retry.

### `X-Expose-Secrets` on GET

Same three modes as `GET /api/settings`:
- absent → `env`/`headers` values are `[REDACTED]`
- `encrypted` → Fernet ciphertext
- `plaintext` → raw values

Logged at WARNING level when plaintext is requested, just like the existing settings endpoint.

### ACP variant handling

`ACPAgentSettings` has no `mcp_config` field. Choices for each verb:
- `GET /api/settings/mcp-servers` → `200 {"servers": []}` (list is non-modifying; permissive shape so polling clients stay simple)
- `GET /api/settings/mcp-servers/{name}` → `404`
- `PUT/PATCH/DELETE` → `409 Conflict` with a message pointing the caller at `PATCH /api/settings` to switch agent variant.

### Persistence

All writes go through the existing file-locked `store.update()`, so they remain atomic and serialise with each other and with the global `PATCH /api/settings`. No new persistence backend, no parallel lock. Each write rebuilds the full `OpenHandsAgentSettings` post-splice and re-validates, so encryption-on-save / decryption-on-load all run through the existing tested paths.

## Bonus fix in `api.py`

The shared `HTTPException` handler was constructing the `JSONResponse` from `status_code` + `detail` but dropping `exc.headers`, so any handler-set response header on an error (e.g. our 412 ETag, or `WWW-Authenticate` on a 401) was silently lost. Three-line propagation fix; identical to the same fix in #3234 so either merge order is trivial to resolve.

## SDK additions

New public types in `openhands.sdk.settings`:
- `MCPServerSummary` — list-view shape (no secrets).
- `MCPServerListResponse` — wraps the list.
- `MCPServerResponse` — single-server read/write response: `{name, config: dict[str, Any]}`. `config` is `dict[str, Any]` (not a typed model) so the server controls secret serialization via context the same way `SettingsResponse.agent_settings` does.

## Tests

`tests/agent_server/test_mcp_servers_router.py` — 32 tests covering:

- List / read / upsert / patch / delete happy paths.
- ETag stability across identical resaves (the core idempotency property), changes on real change.
- `If-Match` matching / stale, `If-None-Match: *` create-only, `If-Match: *` update-only, stale 412 returns current ETag.
- Concurrent edits to *different* servers don't conflict; concurrent edits to the *same* server: one 200, one 412.
- PATCH preserves unsent fields; 404 if server doesn't exist; 422 on invalid type.
- DELETE returns 204, 404 on missing, 412 on stale `If-Match`, doesn't disturb other servers.
- ACP variant: list empty, GET 404, PUT 409, DELETE 409.
- `X-Expose-Secrets` honoured: default redacted, `plaintext` raw, `encrypted` Fernet token.
- Splice-locally property: editing server B doesn't require the client to round-trip server A's env.
- Name validator: allows `[A-Za-z0-9_.@:-]{1,128}`; slashes rejected (URL path segment).

## Compatibility

- Strictly additive. No existing endpoints, schemas, or persistence shapes change.
- The global `PATCH /api/settings` continues to work for mcp_config exactly as today; clients can migrate incrementally.
- The `api.py` exception-handler fix is a tiny improvement that only adds headers from `HTTPException(headers=...)` that route handlers explicitly set; it never alters the body, status code, or removes anything.

## Test summary

- `tests/agent_server/test_mcp_servers_router.py`: 32 / 32 pass.
- `tests/agent_server/test_settings_router.py`: 28 / 28 pass (unchanged).
- `tests/sdk/test_settings.py` + `tests/sdk/settings/*`: 87 / 87 pass (unchanged).

## Out of scope (further follow-ups)

- **List-level ETag.** Per-server ETag is sufficient for the mutation flow; a list-level ETag would help bulk-fetch clients avoid re-walking unchanged lists, but it's a cache-validation feature rather than a correctness one.
- **Tools sub-collection.** `mcp_config.mcpServers[name].tools` has its own per-tool transformation config — if that becomes a hot edit target, a `/mcp-servers/{name}/tools/{tool}` sub-router would apply the same logic at the next level down.
- **Single-server ETag bound to global settings ETag.** Currently per-server ETags float independently of the global settings ETag; for clients that want to ensure their MCP edit didn't race against a concurrent `PATCH /api/settings` mutating something else, we could expose a compound ETag. Not needed for the per-server flow.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d75b1fe-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d75b1fe-python \
  ghcr.io/openhands/agent-server:d75b1fe-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d75b1fe-golang-amd64
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-golang-amd64
ghcr.io/openhands/agent-server:feature-mcp-server-crud-golang-amd64
ghcr.io/openhands/agent-server:d75b1fe-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d75b1fe-golang-arm64
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-golang-arm64
ghcr.io/openhands/agent-server:feature-mcp-server-crud-golang-arm64
ghcr.io/openhands/agent-server:d75b1fe-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d75b1fe-java-amd64
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-java-amd64
ghcr.io/openhands/agent-server:feature-mcp-server-crud-java-amd64
ghcr.io/openhands/agent-server:d75b1fe-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d75b1fe-java-arm64
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-java-arm64
ghcr.io/openhands/agent-server:feature-mcp-server-crud-java-arm64
ghcr.io/openhands/agent-server:d75b1fe-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d75b1fe-python-amd64
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-python-amd64
ghcr.io/openhands/agent-server:feature-mcp-server-crud-python-amd64
ghcr.io/openhands/agent-server:d75b1fe-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d75b1fe-python-arm64
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-python-arm64
ghcr.io/openhands/agent-server:feature-mcp-server-crud-python-arm64
ghcr.io/openhands/agent-server:d75b1fe-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d75b1fe-golang
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-golang
ghcr.io/openhands/agent-server:feature-mcp-server-crud-golang
ghcr.io/openhands/agent-server:d75b1fe-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d75b1fe-java
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-java
ghcr.io/openhands/agent-server:feature-mcp-server-crud-java
ghcr.io/openhands/agent-server:d75b1fe-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d75b1fe-python
ghcr.io/openhands/agent-server:d75b1fe2ff75ad4c180433e43e45f2bd1f4bbe00-python
ghcr.io/openhands/agent-server:feature-mcp-server-crud-python
ghcr.io/openhands/agent-server:d75b1fe-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d75b1fe-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d75b1fe-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->