### PR TITLE
chore(tools): replace bashlex (GPLv3) with tree-sitter-bash (MIT)

### DIFF
--- a/openhands-tools/openhands/tools/terminal/utils/command.py
+++ b/openhands-tools/openhands/tools/terminal/utils/command.py
@@ -1,150 +1,130 @@
-import re
-import traceback
-from typing import Any
+"""Tree-sitter-bash backed command splitting and escape utilities.
 
-import bashlex
-from bashlex.errors import ParsingError
+Replaces the previous bashlex implementation. bashlex is GPLv3+ and
+unmaintained; tree-sitter and tree-sitter-bash are MIT-licensed and
+recover gracefully on malformed input (no exception path needed).
+
+Public API and fallback semantics are preserved: when the parse contains
+``ERROR`` nodes, the input is returned unchanged — same behavior the
+terminal session relied on with bashlex.
+"""
+
+from __future__ import annotations
+
+import re
+
+import tree_sitter_bash
+from tree_sitter import Language, Node, Parser, Tree
 
 from openhands.sdk.logger import get_logger
 
 
 logger = get_logger(__name__)
 
+_BASH_LANGUAGE = Language(tree_sitter_bash.language())
+
+# Regions whose contents bash takes verbatim — escape doubling stops at
+# their boundaries so operators nested inside (e.g.) a double-quoted
+# string remain untouched. Walking does not recurse into these nodes.
+_PRESERVE_TYPES: frozenset[str] = frozenset(
+    {
+        "string",
+        "raw_string",
+        "ansi_c_string",
+        "translated_string",
+        "command_substitution",
+        "expansion",
+        "simple_expansion",
+        "heredoc_body",
+        "comment",
+    }
+)
+
+_ESCAPE_PATTERN: re.Pattern[bytes] = re.compile(rb"\\([;&|<>])")
+
+
+def _parse(source: bytes) -> Tree:
+    # Parser is not thread-safe; the Language is. Construct a fresh
+    # Parser per call so concurrent callers cannot trample each other.
+    return Parser(_BASH_LANGUAGE).parse(source)
+
 
 def split_bash_commands(commands: str) -> list[str]:
+    """Split a multi-statement bash input into top-level statements.
+
+    Statements separated by a newline (with or without intermediate
+    whitespace/comments) become separate entries; statements joined by
+    ``;``, ``&&``, ``||``, ``|``, or ``&`` stay together. Comments and
+    whitespace between two statements are folded into the preceding
+    entry. On parse failure the input is returned as a single-element
+    list.
+    """
     if not commands.strip():
         return [""]
-    try:
-        parsed = bashlex.parse(commands)
-    except (
-        ParsingError,
-        NotImplementedError,
-        TypeError,
-        AttributeError,
-    ):
-        # Added AttributeError to catch 'str' object has no attribute 'kind' error
-        # (issue #8369)
+
+    source = commands.encode()
+    tree = _parse(source)
+    root = tree.root_node
+
+    if root.has_error:
         logger.debug(
-            f"Failed to parse bash commands\n[input]: {commands}\n[warning]: "
-            f"{traceback.format_exc()}\nThe original command will be returned as is."
+            "tree-sitter-bash reported parse errors; returning input as-is\n"
+            "[input]: %s",
+            commands,
         )
-        # If parsing fails, return the original commands
         return [commands]
 
-    result: list[str] = []
-    last_end = 0
+    statements = [c for c in root.named_children if c.type != "comment"]
+    if not statements:
+        return [commands]
 
-    for node in parsed:
-        start, end = node.pos
+    boundaries = [statements[0].start_byte]
+    for cur, nxt in zip(statements, statements[1:]):
+        if b"\n" in source[cur.end_byte : nxt.start_byte]:
+            boundaries.append(nxt.start_byte)
+    boundaries.append(len(source))
 
-        # Include any text between the last command and this one
-        if start > last_end:
-            between = commands[last_end:start]
-            logger.debug(f"BASH PARSING between: {between}")
-            if result:
-                result[-1] += between.rstrip()
-            elif between.strip():
-                # THIS SHOULD NOT HAPPEN
-                result.append(between.rstrip())
-
-        # Extract the command, preserving original formatting
-        command = commands[start:end].rstrip()
-        logger.debug(f"BASH PARSING command: {command}")
-        result.append(command)
-
-        last_end = end
-
-    # Add any remaining text after the last command to the last command
-    remaining = commands[last_end:].rstrip()
-    logger.debug(f"BASH PARSING remaining: {remaining}")
-    if last_end < len(commands) and result:
-        result[-1] += remaining
-        logger.debug(f"BASH PARSING result[-1] += remaining: {result[-1]}")
-    elif last_end < len(commands):
-        if remaining:
-            result.append(remaining)
-            logger.debug(f"BASH PARSING result.append(remaining): {result[-1]}")
-    return result
+    return [source[a:b].decode().rstrip() for a, b in zip(boundaries, boundaries[1:])]
 
 
 def escape_bash_special_chars(command: str) -> str:
-    r"""Escapes characters that have different interpretations in bash vs python.
-    Specifically handles escape sequences like \;, \|, \&, etc.
+    r"""Double the escape on ``\;``, ``\&``, ``\|``, ``\<``, ``\>``.
+
+    Sequences inside regions bash takes verbatim — single- and
+    double-quoted strings, command substitutions, parameter expansions,
+    heredoc bodies, and comments — are left untouched. On parse failure
+    the input is returned unchanged.
     """
     if command.strip() == "":
         return ""
 
-    try:
-        parts = []
-        last_pos = 0
-
-        def visit_node(node: Any) -> None:
-            nonlocal last_pos
-            if (
-                node.kind == "redirect"
-                and hasattr(node, "heredoc")
-                and node.heredoc is not None
-            ):
-                # We're entering a heredoc - preserve everything as-is until we see EOF
-                # Store the heredoc end marker (usually 'EOF' but could be different)
-                between = command[last_pos : node.pos[0]]
-                parts.append(between)
-                # Add the heredoc start marker
-                parts.append(command[node.pos[0] : node.heredoc.pos[0]])
-                # Add the heredoc content as-is
-                parts.append(command[node.heredoc.pos[0] : node.heredoc.pos[1]])
-                last_pos = node.pos[1]
-                return
-
-            if node.kind == "word":
-                # Get the raw text between the last position and current word
-                between = command[last_pos : node.pos[0]]
-                word_text = command[node.pos[0] : node.pos[1]]
-
-                # Add the between text, escaping special characters
-                between = re.sub(r"\\([;&|><])", r"\\\\\1", between)
-                parts.append(between)
-
-                # Check if word_text is a quoted string or command substitution
-                if (
-                    (word_text.startswith('"') and word_text.endswith('"'))
-                    or (word_text.startswith("'") and word_text.endswith("'"))
-                    or (word_text.startswith("$(") and word_text.endswith(")"))
-                    or (word_text.startswith("`") and word_text.endswith("`"))
-                ):
-                    # Preserve quoted strings, command substitutions, and heredoc
-                    # content as-is
-                    parts.append(word_text)
-                else:
-                    # Escape special chars in unquoted text
-                    word_text = re.sub(r"\\([;&|><])", r"\\\\\1", word_text)
-                    parts.append(word_text)
-
-                last_pos = node.pos[1]
-                return
-
-            # Visit child nodes
-            if hasattr(node, "parts"):
-                for part in node.parts:
-                    visit_node(part)
-
-        # Process all nodes in the AST
-        nodes = list(bashlex.parse(command))
-        for node in nodes:
-            between = command[last_pos : node.pos[0]]
-            between = re.sub(r"\\([;&|><])", r"\\\\\1", between)
-            parts.append(between)
-            last_pos = node.pos[0]
-            visit_node(node)
-
-        # Handle any remaining text after the last word
-        remaining = command[last_pos:]
-        parts.append(remaining)
-        return "".join(parts)
-    except (ParsingError, NotImplementedError, TypeError, AttributeError):
+    source = command.encode()
+    tree = _parse(source)
+    if tree.root_node.has_error:
         logger.debug(
-            f"Failed to parse bash commands for special characters escape\n[input]: "
-            f"{command}\n[warning]: {traceback.format_exc()}\nThe original command "
-            f"will be returned as is."
+            "tree-sitter-bash reported parse errors; returning input as-is\n"
+            "[input]: %s",
+            command,
         )
         return command
+
+    preserved: list[tuple[int, int]] = []
+
+    def collect(node: Node) -> None:
+        if node.type in _PRESERVE_TYPES:
+            preserved.append((node.start_byte, node.end_byte))
+            return
+        for child in node.children:
+            collect(child)
+
+    collect(tree.root_node)
+
+    out = bytearray()
+    cursor = 0
+    for start, end in preserved:
+        out.extend(_ESCAPE_PATTERN.sub(rb"\\\\\1", source[cursor:start]))
+        out.extend(source[start:end])
+        cursor = end
+    out.extend(_ESCAPE_PATTERN.sub(rb"\\\\\1", source[cursor:]))
+
+    return out.decode()

--- a/openhands-tools/openhands/tools/terminal/utils/command.py
+++ b/openhands-tools/openhands/tools/terminal/utils/command.py
@@ -1,15 +1,4 @@
-"""Tree-sitter-bash backed command splitting and escape utilities.
-
-Replaces the previous bashlex implementation. bashlex is GPLv3+ and
-unmaintained; tree-sitter and tree-sitter-bash are MIT-licensed and
-recover gracefully on malformed input (no exception path needed).
-
-Public API and fallback semantics are preserved: when the parse contains
-``ERROR`` nodes, the input is returned unchanged — same behavior the
-terminal session relied on with bashlex.
-"""
-
-from __future__ import annotations
+"""Command splitting and escape utilities backed by tree-sitter-bash."""
 
 import re
 

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -6,7 +6,8 @@ description = "OpenHands Tools - Runtime tools for AI agents"
 requires-python = ">=3.12"
 dependencies = [
     "openhands-sdk",
-    "bashlex>=0.18",
+    "tree-sitter>=0.24",
+    "tree-sitter-bash>=0.23",
     "binaryornot>=0.4.4",
     "cachetools",
     "libtmux>=0.53.0",

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-05-06T10:04:47.375927Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -320,15 +320,6 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/47/d7/5bbeb12c44d7c4f2fb5b56abce497eb5ed9f34d85701de869acedd602619/backoff-2.2.1.tar.gz", hash = "sha256:03f829f5bb1923180821643f8753b0502c3b682293992485b0eef2807afa5cba", size = 17001, upload-time = "2022-10-05T19:19:32.061Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/73/b6e24bd22e6720ca8ee9a85a0c4a2971af8497d8f3193fa05390cbd46e09/backoff-2.2.1-py3-none-any.whl", hash = "sha256:63579f9a0628e06278f7e47b7d7d5b6ce20dc65c5e96a6f3ca99a6adca0396e8", size = 15148, upload-time = "2022-10-05T19:19:30.546Z" },
-]
-
-[[package]]
-name = "bashlex"
-version = "0.18"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/76/60/aae0bb54f9af5e0128ba90eb83d8d0d506ee8f0475c4fdda3deeda20b1d2/bashlex-0.18.tar.gz", hash = "sha256:5bb03a01c6d5676338c36fd1028009c8ad07e7d61d8a1ce3f513b7fff52796ee", size = 68742, upload-time = "2023-01-18T15:21:26.402Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/be/6985abb1011fda8a523cfe21ed9629e397d6e06fb5bae99750402b25c95b/bashlex-0.18-py2.py3-none-any.whl", hash = "sha256:91d73a23a3e51711919c1c899083890cdecffc91d8c088942725ac13e9dcfffa", size = 69539, upload-time = "2023-01-18T15:21:24.167Z" },
 ]
 
 [[package]]
@@ -2545,7 +2536,6 @@ name = "openhands-tools"
 version = "1.22.0"
 source = { editable = "openhands-tools" }
 dependencies = [
-    { name = "bashlex" },
     { name = "binaryornot" },
     { name = "browser-use" },
     { name = "cachetools" },
@@ -2554,11 +2544,12 @@ dependencies = [
     { name = "openhands-sdk" },
     { name = "pydantic" },
     { name = "tom-swe" },
+    { name = "tree-sitter" },
+    { name = "tree-sitter-bash" },
 ]
 
 [package.metadata]
 requires-dist = [
-    { name = "bashlex", specifier = ">=0.18" },
     { name = "binaryornot", specifier = ">=0.4.4" },
     { name = "browser-use", specifier = ">=0.8.0" },
     { name = "cachetools" },
@@ -2567,6 +2558,8 @@ requires-dist = [
     { name = "openhands-sdk", editable = "openhands-sdk" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "tom-swe", specifier = ">=1.0.3" },
+    { name = "tree-sitter", specifier = ">=0.24" },
+    { name = "tree-sitter-bash", specifier = ">=0.23" },
 ]
 
 [[package]]
@@ -6936,6 +6929,51 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a8/4b/29b4ef32e036bb34e4ab51796dd745cdba7ed47ad142a9f4a1eb8e0c744d/tqdm-4.67.1.tar.gz", hash = "sha256:f8aef9c52c08c13a65f30ea34f4e5aac3fd1a34959879d7e59e63027286627f2", size = 169737, upload-time = "2024-11-24T20:12:22.481Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/30/dc54f88dd4a2b5dc8a0279bdd7270e735851848b762aeb1c1184ed1f6b14/tqdm-4.67.1-py3-none-any.whl", hash = "sha256:26445eca388f82e72884e0d580d5464cd801a3ea01e63e5601bdff9ba6a48de2", size = 78540, upload-time = "2024-11-24T20:12:19.698Z" },
+]
+
+[[package]]
+name = "tree-sitter"
+version = "0.25.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/7c/0350cfc47faadc0d3cf7d8237a4e34032b3014ddf4a12ded9933e1648b55/tree-sitter-0.25.2.tar.gz", hash = "sha256:fe43c158555da46723b28b52e058ad444195afd1db3ca7720c59a254544e9c20", size = 177961, upload-time = "2025-09-25T17:37:59.751Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3c/9e/20c2a00a862f1c2897a436b17edb774e831b22218083b459d0d081c9db33/tree_sitter-0.25.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:ddabfff809ffc983fc9963455ba1cecc90295803e06e140a4c83e94c1fa3d960", size = 146941, upload-time = "2025-09-25T17:37:34.813Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/04/8512e2062e652a1016e840ce36ba1cc33258b0dcc4e500d8089b4054afec/tree_sitter-0.25.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:c0c0ab5f94938a23fe81928a21cc0fac44143133ccc4eb7eeb1b92f84748331c", size = 137699, upload-time = "2025-09-25T17:37:36.349Z" },
+    { url = "https://files.pythonhosted.org/packages/47/8a/d48c0414db19307b0fb3bb10d76a3a0cbe275bb293f145ee7fba2abd668e/tree_sitter-0.25.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd12d80d91d4114ca097626eb82714618dcdfacd6a5e0955216c6485c350ef99", size = 607125, upload-time = "2025-09-25T17:37:37.725Z" },
+    { url = "https://files.pythonhosted.org/packages/39/d1/b95f545e9fc5001b8a78636ef942a4e4e536580caa6a99e73dd0a02e87aa/tree_sitter-0.25.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b43a9e4c89d4d0839de27cd4d6902d33396de700e9ff4c5ab7631f277a85ead9", size = 635418, upload-time = "2025-09-25T17:37:38.922Z" },
+    { url = "https://files.pythonhosted.org/packages/de/4d/b734bde3fb6f3513a010fa91f1f2875442cdc0382d6a949005cd84563d8f/tree_sitter-0.25.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fbb1706407c0e451c4f8cc016fec27d72d4b211fdd3173320b1ada7a6c74c3ac", size = 631250, upload-time = "2025-09-25T17:37:40.039Z" },
+    { url = "https://files.pythonhosted.org/packages/46/f2/5f654994f36d10c64d50a192239599fcae46677491c8dd53e7579c35a3e3/tree_sitter-0.25.2-cp312-cp312-win_amd64.whl", hash = "sha256:6d0302550bbe4620a5dc7649517c4409d74ef18558276ce758419cf09e578897", size = 127156, upload-time = "2025-09-25T17:37:41.132Z" },
+    { url = "https://files.pythonhosted.org/packages/67/23/148c468d410efcf0a9535272d81c258d840c27b34781d625f1f627e2e27d/tree_sitter-0.25.2-cp312-cp312-win_arm64.whl", hash = "sha256:0c8b6682cac77e37cfe5cf7ec388844957f48b7bd8d6321d0ca2d852994e10d5", size = 113984, upload-time = "2025-09-25T17:37:42.074Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/67/67492014ce32729b63d7ef318a19f9cfedd855d677de5773476caf771e96/tree_sitter-0.25.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:0628671f0de69bb279558ef6b640bcfc97864fe0026d840f872728a86cd6b6cd", size = 146926, upload-time = "2025-09-25T17:37:43.041Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/9c/a278b15e6b263e86c5e301c82a60923fa7c59d44f78d7a110a89a413e640/tree_sitter-0.25.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:f5ddcd3e291a749b62521f71fc953f66f5fd9743973fd6dd962b092773569601", size = 137712, upload-time = "2025-09-25T17:37:44.039Z" },
+    { url = "https://files.pythonhosted.org/packages/54/9a/423bba15d2bf6473ba67846ba5244b988cd97a4b1ea2b146822162256794/tree_sitter-0.25.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:bd88fbb0f6c3a0f28f0a68d72df88e9755cf5215bae146f5a1bdc8362b772053", size = 607873, upload-time = "2025-09-25T17:37:45.477Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/4c/b430d2cb43f8badfb3a3fa9d6cd7c8247698187b5674008c9d67b2a90c8e/tree_sitter-0.25.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b878e296e63661c8e124177cc3084b041ba3f5936b43076d57c487822426f614", size = 636313, upload-time = "2025-09-25T17:37:46.68Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/27/5f97098dbba807331d666a0997662e82d066e84b17d92efab575d283822f/tree_sitter-0.25.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:d77605e0d353ba3fe5627e5490f0fbfe44141bafa4478d88ef7954a61a848dae", size = 631370, upload-time = "2025-09-25T17:37:47.993Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/3c/87caaed663fabc35e18dc704cd0e9800a0ee2f22bd18b9cbe7c10799895d/tree_sitter-0.25.2-cp313-cp313-win_amd64.whl", hash = "sha256:463c032bd02052d934daa5f45d183e0521ceb783c2548501cf034b0beba92c9b", size = 127157, upload-time = "2025-09-25T17:37:48.967Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/23/f8467b408b7988aff4ea40946a4bd1a2c1a73d17156a9d039bbaff1e2ceb/tree_sitter-0.25.2-cp313-cp313-win_arm64.whl", hash = "sha256:b3f63a1796886249bd22c559a5944d64d05d43f2be72961624278eff0dcc5cb8", size = 113975, upload-time = "2025-09-25T17:37:49.922Z" },
+    { url = "https://files.pythonhosted.org/packages/07/e3/d9526ba71dfbbe4eba5e51d89432b4b333a49a1e70712aa5590cd22fc74f/tree_sitter-0.25.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:65d3c931013ea798b502782acab986bbf47ba2c452610ab0776cf4a8ef150fc0", size = 146776, upload-time = "2025-09-25T17:37:50.898Z" },
+    { url = "https://files.pythonhosted.org/packages/42/97/4bd4ad97f85a23011dd8a535534bb1035c4e0bac1234d58f438e15cff51f/tree_sitter-0.25.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bda059af9d621918efb813b22fb06b3fe00c3e94079c6143fcb2c565eb44cb87", size = 137732, upload-time = "2025-09-25T17:37:51.877Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/19/1e968aa0b1b567988ed522f836498a6a9529a74aab15f09dd9ac1e41f505/tree_sitter-0.25.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:eac4e8e4c7060c75f395feec46421eb61212cb73998dbe004b7384724f3682ab", size = 609456, upload-time = "2025-09-25T17:37:52.925Z" },
+    { url = "https://files.pythonhosted.org/packages/48/b6/cf08f4f20f4c9094006ef8828555484e842fc468827ad6e56011ab668dbd/tree_sitter-0.25.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:260586381b23be33b6191a07cea3d44ecbd6c01aa4c6b027a0439145fcbc3358", size = 636772, upload-time = "2025-09-25T17:37:54.647Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e2/d42d55bf56360987c32bc7b16adb06744e425670b823fb8a5786a1cea991/tree_sitter-0.25.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7d2ee1acbacebe50ba0f85fff1bc05e65d877958f00880f49f9b2af38dce1af0", size = 631522, upload-time = "2025-09-25T17:37:55.833Z" },
+    { url = "https://files.pythonhosted.org/packages/03/87/af9604ebe275a9345d88c3ace0cf2a1341aa3f8ef49dd9fc11662132df8a/tree_sitter-0.25.2-cp314-cp314-win_amd64.whl", hash = "sha256:4973b718fcadfb04e59e746abfbb0288694159c6aeecd2add59320c03368c721", size = 130864, upload-time = "2025-09-25T17:37:57.453Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/6e/e64621037357acb83d912276ffd30a859ef117f9c680f2e3cb955f47c680/tree_sitter-0.25.2-cp314-cp314-win_arm64.whl", hash = "sha256:b8d4429954a3beb3e844e2872610d2a4800ba4eb42bb1990c6a4b1949b18459f", size = 117470, upload-time = "2025-09-25T17:37:58.431Z" },
+]
+
+[[package]]
+name = "tree-sitter-bash"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/0e/f0108be910f1eef6499eabce517e79fe3b12057280ed398da67ce2426cba/tree_sitter_bash-0.25.1.tar.gz", hash = "sha256:bfc0bdaa77bc1e86e3c6652e5a6e140c40c0a16b84185c2b63ad7cd809b88f14", size = 419703, upload-time = "2025-12-02T17:01:08.849Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/30/8e/37e7364d9c9c58da89e05c510671d8c45818afd7b31c6939ab72f8dc6c04/tree_sitter_bash-0.25.1-cp310-abi3-macosx_10_9_x86_64.whl", hash = "sha256:0e6235f59e366d220dde7d830196bed597d01e853e44d8ccd1a82c5dd2500acf", size = 194160, upload-time = "2025-12-02T17:00:59.047Z" },
+    { url = "https://files.pythonhosted.org/packages/23/bb/2d2cfbb1f89aaeb1ec892624f069d92d058d06bb66f16b9ec9fb5873ab60/tree_sitter_bash-0.25.1-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:f4a34a6504c7c5b2a9b8c5c4065531dea19ca2c35026e706cf2eeeebe2c92512", size = 202659, upload-time = "2025-12-02T17:01:00.275Z" },
+    { url = "https://files.pythonhosted.org/packages/25/f0/1bb25519be27460255d3899db677313cfa1e6306988fbf456a3d7e211bbb/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e76c4cfb20b076552406782b7f8c2a3946835993df0a44df006de54b7030c7dc", size = 230596, upload-time = "2025-12-02T17:01:01.759Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/22/9f70bc3d3b942ab9fc0f89c1dc9e087519a3a94f64ae6b7377aae3a7a0f0/tree_sitter_bash-0.25.1-cp310-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3f484c4bb8796cde7a87ca351e6116f09653edac0eb3c6d238566359dd28b117", size = 231981, upload-time = "2025-12-02T17:01:02.859Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/c3/f1540e42cd41b323c6821e45e52e1aed6ed386209aad52db996f05703963/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:5e76af6df46d958c7f5b6d5884c9743218e3902a00ccb493ec92728b1084430b", size = 228364, upload-time = "2025-12-02T17:01:03.997Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/a0/c3050a6277dfcac8c480f514dc4fe49f3f65f0eac68b4702cbaca2584e85/tree_sitter_bash-0.25.1-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a3332d71c7b7d5f78259b19d02d0ea111fcb82b72712ee4a93aaa5b226d3f0a8", size = 230074, upload-time = "2025-12-02T17:01:05.05Z" },
+    { url = "https://files.pythonhosted.org/packages/71/0f/203fe6b27211387f4b9ba8c4a321567ca4ded2624dae6ccdbd2b6e940e17/tree_sitter_bash-0.25.1-cp310-abi3-win_amd64.whl", hash = "sha256:52a6802d9218f86278aa3e8b459c3abdad67eed0fde1f9f13aca5b6c634217a6", size = 195574, upload-time = "2025-12-02T17:01:06.412Z" },
+    { url = "https://files.pythonhosted.org/packages/47/75/4ca1a9fabd8fb5aea78cea70f7837ce4dbf2afae115f62051e5fa99cba1c/tree_sitter_bash-0.25.1-cp310-abi3-win_arm64.whl", hash = "sha256:59115057ec2bae319e8082ff29559861045002964c3431ccb0fc92aa4bc9bccb", size = 191196, upload-time = "2025-12-02T17:01:07.486Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

bashlex is GPLv3+ while this repo is MIT — a transitive copyleft dependency we want to drop. It's also unmaintained (last meaningful release ~2020) and crashes on a variety of valid shell constructs, which is why the wrapper currently catches four exception types and silently falls back to the raw string.

tree-sitter and tree-sitter-bash are both MIT, actively maintained, and recover gracefully on malformed input (an ERROR node in the tree, not an exception).

## Summary

- openhands-tools/pyproject.toml: bashlex>=0.18 → tree-sitter>=0.24, tree-sitter-bash>=0.23
- openhands-tools/openhands/tools/terminal/utils/command.py: rewritten against tree-sitter (130 lines, 19 fewer than the bashlex version)
- uv.lock: regenerated

## API & behavior

Public surface unchanged: split_bash_commands(commands: str) -> list[str] and escape_bash_special_chars(command: str) -> str.

Splitting contract preserved: statements separated by a newline split into separate entries; statements joined by ;, &&, ||, |, or & stay together. Comments and whitespace between statements fold into the preceding entry. On parse failure the input is returned unchanged — same silent-passthrough as the bashlex era.

## Issue Number
Refs #2721

## How to Test
- tests/tools/terminal/test_terminal_parsing.py: 30/30 pass, unchanged.
- tests/tools/terminal/test_terminal_session.py integration tests touching split_bash_commands (test_long_running_command_follow_by_execute, test_complex_commands, test_multiple_multiline_commands,
  test_multiline_command_loop) pass on both tmux and subprocess backends.
- Pre-commit clean: Ruff format/lint, pycodestyle, pyright, import dependency rules.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bf3b062-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bf3b062-python \
  ghcr.io/openhands/agent-server:bf3b062-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bf3b062-golang-amd64
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-golang-amd64
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-golang-amd64
ghcr.io/openhands/agent-server:bf3b062-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bf3b062-golang-arm64
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-golang-arm64
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-golang-arm64
ghcr.io/openhands/agent-server:bf3b062-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bf3b062-java-amd64
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-java-amd64
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-java-amd64
ghcr.io/openhands/agent-server:bf3b062-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bf3b062-java-arm64
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-java-arm64
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-java-arm64
ghcr.io/openhands/agent-server:bf3b062-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bf3b062-python-amd64
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-python-amd64
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-python-amd64
ghcr.io/openhands/agent-server:bf3b062-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bf3b062-python-arm64
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-python-arm64
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-python-arm64
ghcr.io/openhands/agent-server:bf3b062-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bf3b062-golang
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-golang
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-golang
ghcr.io/openhands/agent-server:bf3b062-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:bf3b062-java
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-java
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-java
ghcr.io/openhands/agent-server:bf3b062-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:bf3b062-python
ghcr.io/openhands/agent-server:bf3b062753b7a2041cca82ecf3eeb7a552423b92-python
ghcr.io/openhands/agent-server:vasco-move-away-from-bashlex-python
ghcr.io/openhands/agent-server:bf3b062-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bf3b062-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bf3b062-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->