### PR TITLE
docs(pr-review): describe new manifest-based diff payload accurately

### DIFF
--- a/examples/03_github_workflows/02_pr_review/README.md
+++ b/examples/03_github_workflows/02_pr_review/README.md
@@ -27,10 +27,10 @@ This example demonstrates how to set up a GitHub Actions workflow for automated 
 - **Skills-Based Review**: Uses public skills from <https://github.com/OpenHands/extensions>:
   - **`/codereview`**: Standard pragmatic code review focusing on simplicity, type safety, and backward compatibility
   - **`/codereview-roasted`**: Linus Torvalds style brutally honest review with emphasis on "good taste" and data structures
-- **Complete Diff Upfront**: The agent receives the complete git diff in the initial message for efficient review
-  - Large file diffs are automatically truncated to 10,000 characters per file
-  - Total diff is capped at 100,000 characters
-  - The agent can still access the repository for additional context if needed
+- **Complete Diff Upfront**: The agent receives a per-file diff payload in the initial message, preceded by a `Files Changed` manifest listing every file in the PR (so the agent always knows the full file set even when individual patches are abbreviated)
+  - Each file's patch is capped at `MAX_PER_FILE_PATCH` (12,000 chars) so a single large file can't starve smaller ones
+  - The combined patch block is capped at `MAX_TOTAL_DIFF` (150,000 chars); files past the cap appear in the manifest but their patch is replaced with a `[patch omitted: ...]` marker
+  - The agent has full repository access and is instructed to read truncated files directly from the workspace rather than treating them as missing
 - **Comprehensive Analysis**: Analyzes code changes in context of the entire repository
 - **Detailed Feedback**: Provides structured review comments covering:
   - Overall assessment of changes

--- a/examples/03_github_workflows/02_pr_review/README.md
+++ b/examples/03_github_workflows/02_pr_review/README.md
@@ -28,8 +28,8 @@ This example demonstrates how to set up a GitHub Actions workflow for automated 
   - **`/codereview`**: Standard pragmatic code review focusing on simplicity, type safety, and backward compatibility
   - **`/codereview-roasted`**: Linus Torvalds style brutally honest review with emphasis on "good taste" and data structures
 - **Complete Diff Upfront**: The agent receives a per-file diff payload in the initial message, preceded by a `Files Changed` manifest listing every file in the PR (so the agent always knows the full file set even when individual patches are abbreviated)
-  - Each file's patch is capped at `MAX_PER_FILE_PATCH` (12,000 chars) so a single large file can't starve smaller ones
-  - The combined patch block is capped at `MAX_TOTAL_DIFF` (150,000 chars); files past the cap appear in the manifest but their patch is replaced with a `[patch omitted: ...]` marker
+  - Each file's patch is capped at `MAX_PER_FILE_PATCH` (8,000 chars) so a single large file can't starve smaller ones
+  - The combined patch block is capped at `MAX_TOTAL_DIFF` (100,000 chars); files past the cap appear in the manifest but their patch is replaced with a `[patch omitted: ...]` marker
   - The agent has full repository access and is instructed to read truncated files directly from the workspace rather than treating them as missing
 - **Comprehensive Analysis**: Analyzes code changes in context of the entire repository
 - **Detailed Feedback**: Provides structured review comments covering:


### PR DESCRIPTION
## Summary

The example README claimed the PR review action truncates "10,000 characters per file" — but no per-file cap ever existed in the actual code (only a global 100K byte cap). [OpenHands/extensions#234](https://github.com/OpenHands/extensions/pull/234) introduces a real per-file budget plus a manifest; this PR updates the docs to match.

Fixes the docs side of the bot-hallucination bug reported in OpenHands/extensions#233 (transferred from this repo's #3238).

## Test plan

- [x] Diff is a 4-line text-only change in the example README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b62b934-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b62b934-python \
  ghcr.io/openhands/agent-server:b62b934-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b62b934-golang-amd64
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-golang-amd64
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-golang-amd64
ghcr.io/openhands/agent-server:b62b934-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b62b934-golang-arm64
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-golang-arm64
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-golang-arm64
ghcr.io/openhands/agent-server:b62b934-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b62b934-java-amd64
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-java-amd64
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-java-amd64
ghcr.io/openhands/agent-server:b62b934-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b62b934-java-arm64
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-java-arm64
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-java-arm64
ghcr.io/openhands/agent-server:b62b934-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b62b934-python-amd64
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-python-amd64
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-python-amd64
ghcr.io/openhands/agent-server:b62b934-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b62b934-python-arm64
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-python-arm64
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-python-arm64
ghcr.io/openhands/agent-server:b62b934-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b62b934-golang
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-golang
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-golang
ghcr.io/openhands/agent-server:b62b934-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b62b934-java
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-java
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-java
ghcr.io/openhands/agent-server:b62b934-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b62b934-python
ghcr.io/openhands/agent-server:b62b9347514a76bc665e4836fd20206edbd0a16d-python
ghcr.io/openhands/agent-server:fix-pr-review-readme-truncation-python
ghcr.io/openhands/agent-server:b62b934-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b62b934-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b62b934-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->