### PR TITLE
feat: apply OH_EXTRA_PYTHON_PATH before importing custom tools

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -5,7 +5,7 @@ on:
     push:
         branches: [main]
         tags:
-            - '*'  # Trigger on any tag (e.g., 1.0.0, 1.0.0a5, build-docker)
+            - '*'      # Trigger on any tag (e.g., 1.0.0, 1.0.0a5, build-docker)
     pull_request:
         branches: [main]
     workflow_dispatch:
@@ -49,7 +49,7 @@ jobs:
               if: runner.os != 'Windows'
               run: make build-server
 
-            # Windows runners have no `make`; invoke PyInstaller directly.
+                # Windows runners have no `make`; invoke PyInstaller directly.
             - name: Build binary (Windows)
               if: runner.os == 'Windows'
               shell: bash
@@ -102,6 +102,107 @@ jobs:
 
                   echo "✓ Binary test completed successfully"
 
+            - name: Test --extra-python-path custom tool import
+              shell: bash
+              run: |
+                  set -euo pipefail
+
+                  if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+                      BIN=./dist/openhands-agent-server.exe
+                  else
+                      BIN=./dist/openhands-agent-server
+                  fi
+
+                  # Create a temporary directory with an external tool module
+                  TOOL_DIR=$(mktemp -d)
+                  cat > "$TOOL_DIR/ci_test_tool.py" << 'TOOL_EOF'
+                  """CI smoke-test tool: NOT bundled in the binary.
+
+                  Importing this module proves that --extra-python-path /
+                  OH_EXTRA_PYTHON_PATH correctly extends sys.path at runtime
+                  so external .py files are reachable from a frozen build.
+                  """
+                  CI_TOOL_LOADED = True
+                  TOOL_EOF
+
+                  echo "=== Negative test: import WITHOUT extra path (should fail) ==="
+                  "$BIN" --import-modules ci_test_tool --port 8003 \
+                      > neg_test.log 2>&1 &
+                  NEG_PID=$!
+                  sleep 5
+
+                  if grep -q "No module named 'ci_test_tool'" neg_test.log; then
+                      echo "✓ Negative test passed: import correctly failed without --extra-python-path"
+                  else
+                      echo "ERROR: Expected ModuleNotFoundError but got:"
+                      cat neg_test.log
+                      kill "$NEG_PID" 2>/dev/null || true
+                      wait "$NEG_PID" 2>/dev/null || true
+                      rm -rf "$TOOL_DIR" neg_test.log
+                      exit 1
+                  fi
+                  kill "$NEG_PID" 2>/dev/null || true
+                  wait "$NEG_PID" 2>/dev/null || true
+                  rm -f neg_test.log
+
+                  echo "=== Positive test: import WITH OH_EXTRA_PYTHON_PATH ==="
+                  OH_EXTRA_PYTHON_PATH="$TOOL_DIR" \
+                      "$BIN" --import-modules ci_test_tool --port 8004 \
+                      > pos_test.log 2>&1 &
+                  POS_PID=$!
+                  sleep 5
+
+                  if grep -q "Imported module: ci_test_tool" pos_test.log; then
+                      echo "✓ Positive test passed: external module imported via OH_EXTRA_PYTHON_PATH"
+                  else
+                      echo "ERROR: Module was not imported. Server log:"
+                      cat pos_test.log
+                      kill "$POS_PID" 2>/dev/null || true
+                      wait "$POS_PID" 2>/dev/null || true
+                      rm -rf "$TOOL_DIR" pos_test.log
+                      exit 1
+                  fi
+
+                  if grep -q "Added to sys.path: $TOOL_DIR" pos_test.log; then
+                      echo "✓ sys.path was extended with the tool directory"
+                  else
+                      echo "ERROR: sys.path was not extended. Server log:"
+                      cat pos_test.log
+                      kill "$POS_PID" 2>/dev/null || true
+                      wait "$POS_PID" 2>/dev/null || true
+                      rm -rf "$TOOL_DIR" pos_test.log
+                      exit 1
+                  fi
+
+                  kill "$POS_PID" 2>/dev/null || true
+                  wait "$POS_PID" 2>/dev/null || true
+
+                  echo "=== Positive test: import WITH --extra-python-path CLI flag ==="
+                  "$BIN" --extra-python-path "$TOOL_DIR" \
+                      --import-modules ci_test_tool --port 8005 \
+                      > cli_test.log 2>&1 &
+                  CLI_PID=$!
+                  sleep 5
+
+                  if grep -q "Imported module: ci_test_tool" cli_test.log; then
+                      echo "✓ CLI flag test passed: external module imported via --extra-python-path"
+                  else
+                      echo "ERROR: Module was not imported via CLI flag. Server log:"
+                      cat cli_test.log
+                      kill "$CLI_PID" 2>/dev/null || true
+                      wait "$CLI_PID" 2>/dev/null || true
+                      rm -rf "$TOOL_DIR" cli_test.log pos_test.log
+                      exit 1
+                  fi
+
+                  kill "$CLI_PID" 2>/dev/null || true
+                  wait "$CLI_PID" 2>/dev/null || true
+
+                  # Cleanup
+                  rm -rf "$TOOL_DIR" pos_test.log neg_test.log cli_test.log
+
+                  echo "✓ All --extra-python-path tests passed"
+
             - name: Upload binary artifact
               uses: actions/upload-artifact@v7
               with:
@@ -125,7 +226,6 @@ jobs:
               with:
                   version: latest
                   python-version: '3.13'
-
             - name: Install Node.js (for npx)
               uses: actions/setup-node@v6
               with:
@@ -144,8 +244,8 @@ jobs:
 
     build-and-push-image:
         name: Build & Push (${{ matrix.variant }}-${{ matrix.arch }})
-        # Run on push events, pull requests from the same repository (not forks), and manual workflow_dispatch
-        # Fork PRs cannot push to GHCR and would fail authentication
+            # Run on push events, pull requests from the same repository (not forks), and manual workflow_dispatch
+            # Fork PRs cannot push to GHCR and would fail authentication
         if: >
             github.event_name == 'push' ||
             github.event_name == 'workflow_dispatch' ||
@@ -154,10 +254,10 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                # Explicit matrix: 3 variants × 2 architectures = 6 jobs
-                # Each job specifies exactly what it builds and where it runs
+                    # Explicit matrix: 3 variants × 2 architectures = 6 jobs
+                    # Each job specifies exactly what it builds and where it runs
                 include:
-                    # Python variant
+                        # Python variant
                     - variant: python
                       arch: amd64
                       base_image: nikolaik/python-nodejs:python3.13-nodejs22-slim
@@ -170,7 +270,7 @@ jobs:
                       runner: ubuntu-24.04-arm
                       platform: linux/arm64
 
-                    # Java variant
+                        # Java variant
                     - variant: java
                       arch: amd64
                       base_image: eclipse-temurin:17-jdk
@@ -183,7 +283,7 @@ jobs:
                       runner: ubuntu-24.04-arm
                       platform: linux/arm64
 
-                    # Golang variant
+                        # Golang variant
                     - variant: golang
                       arch: amd64
                       base_image: golang:1.21-bookworm
@@ -206,13 +306,12 @@ jobs:
             ARCH: ${{ matrix.arch }}
             TARGET: binary
             PLATFORM: ${{ matrix.platform }}
-            # Use SDK_SHA/SDK_REF so build.py tags PR images with the head commit and branch.
-            # GITHUB_SHA/GITHUB_REF point at the synthetic merge ref on pull_request events.
+                # Use SDK_SHA/SDK_REF so build.py tags PR images with the head commit and branch.
+                # GITHUB_SHA/GITHUB_REF point at the synthetic merge ref on pull_request events.
             SDK_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
             SDK_REF: ${{ github.head_ref != '' && format('refs/heads/{0}', github.head_ref) || github.ref }}
             GITHUB_REF: ${{ github.ref }}
             CI: 'true'
-
         steps:
             - name: Checkout
               uses: actions/checkout@v6
@@ -222,7 +321,6 @@ jobs:
               with:
                   version: latest
                   python-version: '3.13'
-
             - name: Set up Docker Buildx
               uses: docker/setup-buildx-action@v4
 
@@ -442,7 +540,7 @@ jobs:
     consolidate-build-info:
         name: Consolidate Build Information
         needs: [build-and-push-image, merge-manifests]
-        # Run if it's a PR and the matrix job completed (even if some variants failed)
+            # Run if it's a PR and the matrix job completed (even if some variants failed)
         if: github.event_name == 'pull_request' && always() && (needs.build-and-push-image.result == 'success' || needs.build-and-push-image.result ==
             'failure')
         runs-on: ubuntu-24.04
@@ -605,7 +703,7 @@ jobs:
     update-pr-description:
         name: Update PR description with agent server image
         needs: consolidate-build-info
-        # Only on PRs, and only if the consolidation succeeded
+            # Only on PRs, and only if the consolidation succeeded
         if: github.event_name == 'pull_request' && needs.consolidate-build-info.result == 'success'
         runs-on: ubuntu-24.04
         permissions:

--- a/openhands-agent-server/openhands/agent_server/__main__.py
+++ b/openhands-agent-server/openhands/agent_server/__main__.py
@@ -10,6 +10,10 @@ from types import FrameType
 import uvicorn
 from uvicorn import Config
 
+from openhands.agent_server.extra_python_path import (
+    OH_EXTRA_PYTHON_PATH_ENV,
+    apply_extra_python_path,
+)
 from openhands.agent_server.logging_config import LOGGING_CONFIG
 from openhands.sdk.logger import DEBUG, get_logger
 
@@ -171,6 +175,16 @@ def main() -> None:
             "(e.g. 'myapp.tools,myapp.plugins')"
         ),
     )
+    parser.add_argument(
+        "--extra-python-path",
+        type=str,
+        default=os.environ.get(OH_EXTRA_PYTHON_PATH_ENV),
+        help=(
+            "OS-pathsep-separated directories to prepend to sys.path before "
+            "importing custom tools. Lets PyInstaller frozen binaries pick up "
+            f"external .py files. Defaults to {OH_EXTRA_PYTHON_PATH_ENV}."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -180,6 +194,10 @@ def main() -> None:
             sys.exit(0)
         else:
             sys.exit(1)
+
+    # Extend sys.path BEFORE any user-module imports so both --import-modules
+    # and later tool_module_qualnames imports can resolve external .py files.
+    apply_extra_python_path(args.extra_python_path)
 
     # Import user modules after early-exit checks
     preload_modules(args.import_modules)

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 from openhands.agent_server.config import Config, WebhookSpec
 from openhands.agent_server.conversation_lease import ConversationLeaseHeldError
 from openhands.agent_server.event_service import EventService
+from openhands.agent_server.extra_python_path import apply_extra_python_path_from_env
 from openhands.agent_server.models import (
     ConversationInfo,
     ConversationPage,
@@ -555,6 +556,11 @@ class ConversationService:
         if request.tool_module_qualnames:
             import importlib
 
+            # Defensive: ensure OH_EXTRA_PYTHON_PATH directories are on sys.path
+            # in case the env was changed in-process after server startup.
+            # Idempotent — already-present paths are skipped.
+            apply_extra_python_path_from_env()
+
             for tool_name, module_qualname in request.tool_module_qualnames.items():
                 try:
                     # Import the module to trigger tool auto-registration
@@ -878,6 +884,7 @@ class ConversationService:
                 )
                 # Dynamically register tools when resuming persisted conversations
                 if stored.tool_module_qualnames:
+                    apply_extra_python_path_from_env()
                     for (
                         tool_name,
                         module_qualname,

--- a/openhands-agent-server/openhands/agent_server/extra_python_path.py
+++ b/openhands-agent-server/openhands/agent_server/extra_python_path.py
@@ -1,0 +1,39 @@
+"""Helper for prepending external directories to ``sys.path``.
+
+Used so PyInstaller frozen binaries can import external custom-tool ``.py``
+files via ``importlib.PathFinder`` (which stays active alongside
+``FrozenImporter``). The directories come from the ``--extra-python-path`` CLI
+flag or the ``OH_EXTRA_PYTHON_PATH`` environment variable.
+"""
+
+import os
+import sys
+
+from openhands.sdk.logger import get_logger
+
+
+logger = get_logger(__name__)
+
+OH_EXTRA_PYTHON_PATH_ENV = "OH_EXTRA_PYTHON_PATH"
+
+
+def apply_extra_python_path(extra_paths_arg: str | None) -> None:
+    """Prepend OS-pathsep-separated paths to ``sys.path``.
+
+    No-ops when ``extra_paths_arg`` is None/empty. Skips paths already on
+    ``sys.path`` so repeated calls are idempotent.
+    """
+    if not extra_paths_arg:
+        return
+    for raw in extra_paths_arg.split(os.pathsep):
+        path = raw.strip()
+        if not path:
+            continue
+        if path not in sys.path:
+            sys.path.insert(0, path)
+            logger.info("Added to sys.path (extra_python_path): %s", path)
+
+
+def apply_extra_python_path_from_env() -> None:
+    """Apply ``OH_EXTRA_PYTHON_PATH`` from the environment, if set."""
+    apply_extra_python_path(os.environ.get(OH_EXTRA_PYTHON_PATH_ENV))

--- a/tests/agent_server/test_extra_python_path.py
+++ b/tests/agent_server/test_extra_python_path.py
@@ -1,0 +1,183 @@
+"""Tests for the OH_EXTRA_PYTHON_PATH helper."""
+
+import os
+import sys
+import textwrap
+
+import pytest
+
+from openhands.agent_server.extra_python_path import (
+    OH_EXTRA_PYTHON_PATH_ENV,
+    apply_extra_python_path,
+    apply_extra_python_path_from_env,
+)
+
+
+@pytest.fixture
+def sys_path_snapshot():
+    """Restore sys.path to its pre-test state so tests don't leak into each other."""
+    snapshot = list(sys.path)
+    yield snapshot
+    sys.path[:] = snapshot
+
+
+class TestApplyExtraPythonPath:
+    def test_none_is_noop(self, sys_path_snapshot):
+        apply_extra_python_path(None)
+        assert sys.path == sys_path_snapshot
+
+    def test_empty_string_is_noop(self, sys_path_snapshot):
+        apply_extra_python_path("")
+        assert sys.path == sys_path_snapshot
+
+    def test_single_path_is_prepended(self, tmp_path, sys_path_snapshot):
+        apply_extra_python_path(str(tmp_path))
+        assert sys.path[0] == str(tmp_path)
+
+    def test_multiple_paths_separated_by_os_pathsep(self, tmp_path, sys_path_snapshot):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+
+        apply_extra_python_path(os.pathsep.join([str(a), str(b)]))
+
+        assert str(a) in sys.path
+        assert str(b) in sys.path
+
+    def test_idempotent_for_already_present_path(self, tmp_path, sys_path_snapshot):
+        apply_extra_python_path(str(tmp_path))
+        before = list(sys.path)
+
+        apply_extra_python_path(str(tmp_path))
+
+        assert sys.path == before
+
+    def test_empty_segments_and_whitespace_skipped(self, tmp_path, sys_path_snapshot):
+        a = tmp_path / "a"
+        a.mkdir()
+        apply_extra_python_path(f"  {a}  {os.pathsep}{os.pathsep}  ")
+
+        assert str(a) in sys.path
+        assert "" not in sys.path
+
+
+class TestApplyExtraPythonPathFromEnv:
+    def test_reads_env_var(self, tmp_path, monkeypatch, sys_path_snapshot):
+        monkeypatch.setenv(OH_EXTRA_PYTHON_PATH_ENV, str(tmp_path))
+
+        apply_extra_python_path_from_env()
+
+        assert str(tmp_path) in sys.path
+
+    def test_missing_env_var_is_noop(self, monkeypatch, sys_path_snapshot):
+        monkeypatch.delenv(OH_EXTRA_PYTHON_PATH_ENV, raising=False)
+
+        apply_extra_python_path_from_env()
+
+        assert sys.path == sys_path_snapshot
+
+
+class TestExternalModuleBecomesImportable:
+    """Integration: a .py file in a directory added via apply_extra_python_path
+    must become importable, which is the whole point of the helper.
+    """
+
+    @pytest.fixture
+    def external_tool_module(self, tmp_path, sys_path_snapshot):
+        """Drop a fake custom-tool .py file outside sys.path."""
+        module_name = "extra_python_path_test_tool_xyz"
+        (tmp_path / f"{module_name}.py").write_text(
+            textwrap.dedent(
+                """\
+                LOADED = True
+                """
+            )
+        )
+        sys.modules.pop(module_name, None)
+        yield tmp_path, module_name
+        sys.modules.pop(module_name, None)
+
+    def test_module_unimportable_before_apply(self, external_tool_module):
+        _, module_name = external_tool_module
+        with pytest.raises(ModuleNotFoundError):
+            __import__(module_name)
+
+    def test_module_importable_after_apply(self, external_tool_module):
+        tmp_path, module_name = external_tool_module
+
+        apply_extra_python_path(str(tmp_path))
+        imported = __import__(module_name)
+
+        assert imported.LOADED is True
+
+
+class TestMainCliWiring:
+    """Verify the --extra-python-path flag and OH_EXTRA_PYTHON_PATH env var
+    apply paths before preload_modules runs — the ordering this exists to
+    fix.
+    """
+
+    def test_env_var_applied_before_preload(
+        self, tmp_path, monkeypatch, sys_path_snapshot
+    ):
+        from unittest.mock import patch
+
+        observed = {}
+
+        def fake_preload(arg):
+            observed["sys_path_at_preload"] = list(sys.path)
+
+        monkeypatch.setenv(OH_EXTRA_PYTHON_PATH_ENV, str(tmp_path))
+
+        with (
+            patch("sys.argv", ["prog"]),
+            patch(
+                "openhands.agent_server.__main__.preload_modules",
+                side_effect=fake_preload,
+            ),
+            patch("openhands.agent_server.__main__.LoggingServer") as mock_server_cls,
+        ):
+            mock_server_cls.return_value.run.side_effect = SystemExit(0)
+
+            from openhands.agent_server.__main__ import main
+
+            with pytest.raises(SystemExit):
+                main()
+
+        assert str(tmp_path) in observed["sys_path_at_preload"], (
+            "OH_EXTRA_PYTHON_PATH must be applied to sys.path before "
+            "preload_modules runs"
+        )
+
+    def test_cli_flag_overrides_env_default(
+        self, tmp_path, monkeypatch, sys_path_snapshot
+    ):
+        from unittest.mock import patch
+
+        flag_dir = tmp_path / "from_flag"
+        env_dir = tmp_path / "from_env"
+        flag_dir.mkdir()
+        env_dir.mkdir()
+
+        monkeypatch.setenv(OH_EXTRA_PYTHON_PATH_ENV, str(env_dir))
+
+        with (
+            patch(
+                "sys.argv",
+                ["prog", "--extra-python-path", str(flag_dir)],
+            ),
+            patch("openhands.agent_server.__main__.preload_modules"),
+            patch("openhands.agent_server.__main__.LoggingServer") as mock_server_cls,
+        ):
+            mock_server_cls.return_value.run.side_effect = SystemExit(0)
+
+            from openhands.agent_server.__main__ import main
+
+            with pytest.raises(SystemExit):
+                main()
+
+        assert str(flag_dir) in sys.path
+        assert str(env_dir) not in sys.path, (
+            "--extra-python-path should take precedence over the env-var default"
+        )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [ ] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:122e8c9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-122e8c9-python \
  ghcr.io/openhands/agent-server:122e8c9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:122e8c9-golang-amd64
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-1731-golang-amd64
ghcr.io/openhands/agent-server:122e8c9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:122e8c9-golang-arm64
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-1731-golang-arm64
ghcr.io/openhands/agent-server:122e8c9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:122e8c9-java-amd64
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-1731-java-amd64
ghcr.io/openhands/agent-server:122e8c9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:122e8c9-java-arm64
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-1731-java-arm64
ghcr.io/openhands/agent-server:122e8c9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:122e8c9-python-amd64
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-1731-python-amd64
ghcr.io/openhands/agent-server:122e8c9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:122e8c9-python-arm64
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-1731-python-arm64
ghcr.io/openhands/agent-server:122e8c9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:122e8c9-golang
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-golang
ghcr.io/openhands/agent-server:hieptl-app-1731-golang
ghcr.io/openhands/agent-server:122e8c9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:122e8c9-java
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-java
ghcr.io/openhands/agent-server:hieptl-app-1731-java
ghcr.io/openhands/agent-server:122e8c9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:122e8c9-python
ghcr.io/openhands/agent-server:122e8c93c15d00ec2c6bc08a58517dd076aea805-python
ghcr.io/openhands/agent-server:hieptl-app-1731-python
ghcr.io/openhands/agent-server:122e8c9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `122e8c9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `122e8c9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->