### PR TITLE
ci: also relock enterprise/poetry.lock in version-bump PR workflow

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -267,6 +267,21 @@ jobs:
                   echo "📝 Regenerating poetry.lock..."
                   poetry lock
 
+                  # 2b. Regenerate enterprise/poetry.lock so its transitive SDK pins
+                  # match the root. enterprise/pyproject.toml depends on the root via
+                  # `openhands-ai = { path = "../", develop = true }`, but it keeps its
+                  # OWN poetry.lock that pins openhands-sdk/tools/agent-server. Without
+                  # this step the enterprise lockfile drifts behind (see PR #14409 that
+                  # had to be opened manually after PR #14350 missed it).
+                  # --no-cache invalidates the stale build of the path-installed
+                  # openhands-ai package; without it Poetry leaves the entries pinned
+                  # at the previous version.
+                  if [ -f "enterprise/poetry.lock" ] && [ -f "enterprise/pyproject.toml" ]; then
+                    echo "📝 Regenerating enterprise/poetry.lock..."
+                    (cd enterprise && poetry lock --no-cache)
+                    echo "✅ Updated enterprise/poetry.lock"
+                  fi
+
                   # 3. Update the version in sandbox_spec_service.py
                   echo "🔧 Updating AGENT_SERVER_IMAGE..."
                   SANDBOX_SPEC_FILE="openhands/app_server/sandbox/sandbox_spec_service.py"
@@ -292,12 +307,16 @@ jobs:
 
                   # Commit and push
                   git add pyproject.toml poetry.lock "$SANDBOX_SPEC_FILE" "$PYPROJECT_FMT_CONFIG"
+                  if [ -f "enterprise/poetry.lock" ]; then
+                    git add enterprise/poetry.lock
+                  fi
                   git commit -m "Bump openhands-sdk, openhands-tools, openhands-agent-server to $VERSION" \
                     -m "Automated version bump after PyPI release." \
                     -m "" \
                     -m "Changes:" \
                     -m "- Updated SDK packages to v$VERSION with exact pins in pyproject.toml" \
                     -m "- Regenerated poetry.lock" \
+                    -m "- Regenerated enterprise/poetry.lock to keep transitive SDK pins aligned" \
                     -m "- Updated AGENT_SERVER_IMAGE to ${VERSION}" \
                     -m "" \
                     -m "Co-authored-by: openhands <openhands@all-hands.dev>"
@@ -322,6 +341,7 @@ jobs:
                   ### Changes
                   - Updated SDK packages in \`pyproject.toml\` with exact pins
                   - Regenerated \`poetry.lock\` with the target repo's Poetry version
+                  - Regenerated \`enterprise/poetry.lock\` so its transitive SDK pins match the root
                   - Updated \`AGENT_SERVER_IMAGE\` to \`${VERSION}\` in \`sandbox_spec_service.py\`
 
                   **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)


### PR DESCRIPTION
## Summary

- The version-bump workflow that opens \`Bump SDK packages to vX.Y.Z\` PRs against \`OpenHands/OpenHands\` only re-locks the root \`poetry.lock\`. The \`enterprise/\` folder has its own \`poetry.lock\` that pins \`openhands-sdk\`, \`openhands-tools\`, and \`openhands-agent-server\` transitively (via \`openhands-ai = { path = \"../\", develop = true }\`), and that lockfile drifts behind.
- Concretely: PR [OpenHands#14350](https://github.com/OpenHands/OpenHands/pull/14350) bumped root to 1.21.1 but left \`enterprise/poetry.lock\` at 1.19.1, requiring manual follow-up [OpenHands#14409](https://github.com/OpenHands/OpenHands/pull/14409).
- This change adds a step that runs \`poetry lock --no-cache\` inside \`enterprise/\` whenever \`enterprise/pyproject.toml\` and \`enterprise/poetry.lock\` exist, then stages the file in the same commit/PR.

## Why \`--no-cache\`

The manual PR notes — and reproducing locally confirms — that without \`--no-cache\` Poetry reuses the stale build of the path-installed \`openhands-ai\` package and leaves the transitive SDK entries pinned at the previous version. \`--no-cache\` forces a clean resolve.

## Guardrail that stays

The existing check that \`enterprise/pyproject.toml\` does **not** list \`openhands-sdk/tools/agent-server\` explicitly is preserved. We still want those packages to flow transitively via \`openhands-ai\`; we just need to re-lock so the enterprise lockfile picks up the new pins.

## Test plan

- [ ] Trigger \`Create Version Bump PRs\` via \`workflow_dispatch\` against a recent SDK version and confirm the resulting PR against \`OpenHands/OpenHands\` modifies \`enterprise/poetry.lock\` in addition to \`pyproject.toml\`, \`poetry.lock\`, and \`sandbox_spec_service.py\`.
- [ ] In the resulting PR, verify \`cd enterprise && poetry show openhands-sdk openhands-agent-server openhands-tools\` reports the new version.
- [ ] Confirm a rerun on the same version is idempotent (no spurious commits on the existing branch).

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7f7fb21-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7f7fb21-python \
  ghcr.io/openhands/agent-server:7f7fb21-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7f7fb21-golang-amd64
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-golang-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-golang-amd64
ghcr.io/openhands/agent-server:7f7fb21-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7f7fb21-golang-arm64
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-golang-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-golang-arm64
ghcr.io/openhands/agent-server:7f7fb21-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7f7fb21-java-amd64
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-java-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-java-amd64
ghcr.io/openhands/agent-server:7f7fb21-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7f7fb21-java-arm64
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-java-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-java-arm64
ghcr.io/openhands/agent-server:7f7fb21-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7f7fb21-python-amd64
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-python-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-python-amd64
ghcr.io/openhands/agent-server:7f7fb21-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7f7fb21-python-arm64
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-python-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-python-arm64
ghcr.io/openhands/agent-server:7f7fb21-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7f7fb21-golang
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-golang
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-golang
ghcr.io/openhands/agent-server:7f7fb21-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7f7fb21-java
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-java
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-java
ghcr.io/openhands/agent-server:7f7fb21-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7f7fb21-python
ghcr.io/openhands/agent-server:7f7fb219644cb33273a61e1901c81379b343dc5d-python
ghcr.io/openhands/agent-server:av-version-bump-prs-also-bump-enterprise-python
ghcr.io/openhands/agent-server:7f7fb21-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7f7fb21-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7f7fb21-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->