### PR TITLE
fix(sdk): unregister atexit handler in LocalConversation.close()

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -977,6 +977,9 @@ class LocalConversation(BaseConversation):
 
     def close(self) -> None:
         """Close the conversation and clean up all tool executors."""
+        # Remove the atexit reference so the conversation object can be GC'd
+        # after close. atexit.unregister is a no-op if not registered.
+        atexit.unregister(self.close)
         # Use getattr for safety - object may be partially constructed
         if getattr(self, "_cleanup_initiated", False):
             return

--- a/tests/sdk/conversation/test_atexit_cleanup.py
+++ b/tests/sdk/conversation/test_atexit_cleanup.py
@@ -1,0 +1,45 @@
+"""Tests for atexit handler cleanup to prevent memory leaks."""
+
+import gc
+import tempfile
+import weakref
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.llm import LLM
+
+
+def _make_conversation(workspace: str) -> LocalConversation:
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("k"), usage_id="test")
+    return LocalConversation(agent=Agent(llm=llm, tools=[]), workspace=workspace)
+
+
+def test_close_unregisters_atexit_handler():
+    """close() must remove the atexit handler so the object can be GC'd."""
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = str(Path(tmp) / "ws")
+        Path(workspace).mkdir()
+        conv = _make_conversation(workspace)
+
+        conv.close()
+
+        # If atexit still held a reference, the weak-ref would stay alive
+        # after we drop the strong reference.
+        ref = weakref.ref(conv)
+        del conv
+        gc.collect()
+        assert ref() is None, "Conversation was not GC'd — atexit leak"
+
+
+def test_close_is_idempotent_with_atexit():
+    """Calling close() twice must not raise, even with atexit handling."""
+    with tempfile.TemporaryDirectory() as tmp:
+        workspace = str(Path(tmp) / "ws")
+        Path(workspace).mkdir()
+        conv = _make_conversation(workspace)
+
+        conv.close()
+        conv.close()  # second call is a no-op


### PR DESCRIPTION
## Summary

`LocalConversation.__init__` registers `atexit.register(self.close)`, creating a permanent reference from the atexit handler list to the conversation object. When `close()` is called, the atexit registration is never removed, so the entire conversation object graph (agent, LLMs, event log, file store, all events) is pinned in memory forever — an OOM path on long-running servers.

## Fix

Add `atexit.unregister(self.close)` at the top of `close()`, before the re-entry guard. `atexit.unregister()` is a no-op if the function was never registered, so this is safe for partially constructed instances.

## Tests

- `test_close_unregisters_atexit_handler` — verifies a closed conversation is GC'd (weakref goes dead after `del`)
- `test_close_is_idempotent_with_atexit` — verifies double-close doesn't raise

All 485 existing conversation tests continue to pass.

Closes #3136

---
_This PR was created by an AI agent (OpenHands) on behalf of @CalvinSmith._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b8e5cd2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b8e5cd2-python \
  ghcr.io/openhands/agent-server:b8e5cd2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b8e5cd2-golang-amd64
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-golang-amd64
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-golang-amd64
ghcr.io/openhands/agent-server:b8e5cd2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b8e5cd2-golang-arm64
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-golang-arm64
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-golang-arm64
ghcr.io/openhands/agent-server:b8e5cd2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b8e5cd2-java-amd64
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-java-amd64
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-java-amd64
ghcr.io/openhands/agent-server:b8e5cd2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b8e5cd2-java-arm64
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-java-arm64
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-java-arm64
ghcr.io/openhands/agent-server:b8e5cd2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b8e5cd2-python-amd64
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-python-amd64
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-python-amd64
ghcr.io/openhands/agent-server:b8e5cd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b8e5cd2-python-arm64
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-python-arm64
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-python-arm64
ghcr.io/openhands/agent-server:b8e5cd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b8e5cd2-golang
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-golang
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-golang
ghcr.io/openhands/agent-server:b8e5cd2-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b8e5cd2-java
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-java
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-java
ghcr.io/openhands/agent-server:b8e5cd2-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b8e5cd2-python
ghcr.io/openhands/agent-server:b8e5cd200c39ed901f78a8899bb3886b095dbd92-python
ghcr.io/openhands/agent-server:fix-atexit-memory-leak-3136-python
ghcr.io/openhands/agent-server:b8e5cd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b8e5cd2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b8e5cd2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->