### PR TITLE
perf(sdk): cache subclass hierarchy lookups in DiscriminatedUnionMixin

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/models.py
+++ b/openhands-sdk/openhands/sdk/utils/models.py
@@ -92,9 +92,42 @@ def _get_all_subclasses(cls) -> set[type]:
     return result
 
 
-def get_known_concrete_subclasses(cls) -> list[type]:
+# ---------------------------------------------------------------------------
+# Subclass-hierarchy caching
+#
+# get_known_concrete_subclasses() and _get_checked_concrete_subclasses() are
+# called on every event deserialization (via _validate_subtype).  Walking the
+# full class hierarchy each time dominated per-step CPU (~47 % of self-time
+# in wall profiles).
+#
+# The cache is keyed by (cls, _subclass_generation).  The generation counter
+# is bumped automatically via DiscriminatedUnionMixin.__init_subclass__
+# whenever a new subclass is defined, so callers never need to invalidate
+# manually — the cache self-invalidates.
+# ---------------------------------------------------------------------------
+_subclass_generation: int = 0
+_subclass_generation_lock = threading.Lock()
+_concrete_cache: dict[type, tuple[int, tuple[type, ...]]] = {}
+_checked_cache: dict[type, tuple[int, dict[str, type]]] = {}
+
+
+def _bump_subclass_generation() -> None:
+    global _subclass_generation
+    with _subclass_generation_lock:
+        _subclass_generation += 1
+
+
+def get_known_concrete_subclasses(cls) -> tuple[type, ...]:
     """Recursively returns all concrete subclasses in a stable order,
-    without deduping classes that share the same (module, name)."""
+    without deduping classes that share the same (module, name).
+
+    Results are cached and automatically invalidated when new
+    DiscriminatedUnionMixin subclasses are defined.
+    """
+    cached = _concrete_cache.get(cls)
+    if cached is not None and cached[0] == _subclass_generation:
+        return cached[1]
+
     out: list[type] = []
     for sub in cls.__subclasses__():
         # Recurse first so deeper classes appear after their parents
@@ -104,11 +137,17 @@ def get_known_concrete_subclasses(cls) -> list[type]:
 
     # Use qualname to distinguish nested/local classes (like test-local Cat)
     out.sort(key=lambda t: (t.__module__, getattr(t, "__qualname__", t.__name__)))
-    return out
+    result = tuple(out)
+    _concrete_cache[cls] = (_subclass_generation, result)
+    return result
 
 
 def _get_checked_concrete_subclasses(cls: type) -> dict[str, type]:
-    result = {}
+    cached = _checked_cache.get(cls)
+    if cached is not None and cached[0] == _subclass_generation:
+        return cached[1]
+
+    result: dict[str, type] = {}
     for sub in get_known_concrete_subclasses(cls):
         existing = result.get(sub.__name__)
         if existing:
@@ -124,7 +163,19 @@ def _get_checked_concrete_subclasses(cls: type) -> dict[str, type]:
                 "(Since they may not exist at deserialization time)"
             )
         result[sub.__name__] = sub
+    _checked_cache[cls] = (_subclass_generation, result)
     return result
+
+
+def clear_subclass_cache() -> None:
+    """Invalidate cached results of :func:`get_known_concrete_subclasses`
+    and :func:`_get_checked_concrete_subclasses`.
+
+    Normally not needed — the cache auto-invalidates when new
+    DiscriminatedUnionMixin subclasses are defined.  This function exists
+    for edge cases involving non-DiscriminatedUnionMixin hierarchies.
+    """
+    _bump_subclass_generation()
 
 
 class OpenHandsModel(BaseModel):
@@ -139,6 +190,10 @@ class OpenHandsModel(BaseModel):
 
 
 class DiscriminatedUnionMixin(OpenHandsModel):
+    def __init_subclass__(cls, **kwargs: Any) -> None:
+        super().__init_subclass__(**kwargs)
+        _bump_subclass_generation()
+
     @computed_field
     @property
     def kind(self) -> str:

--- a/tests/sdk/utils/test_subclass_cache.py
+++ b/tests/sdk/utils/test_subclass_cache.py
@@ -1,0 +1,144 @@
+"""Tests for subclass hierarchy caching.
+
+The generation-counter cache in models.py auto-invalidates via
+DiscriminatedUnionMixin.__init_subclass__.  These tests verify that the
+cache is correct in scenarios that could easily break:
+  - basic cache hits
+  - auto-invalidation on new subclass definition (including deep hierarchy)
+  - auto-invalidation from dynamic type() calls (what tool.py does)
+  - _get_checked_concrete_subclasses stays in sync with concrete cache
+  - concurrent subclass definition from multiple threads
+"""
+
+import threading
+from abc import ABC
+
+from openhands.sdk.utils.models import (
+    DiscriminatedUnionMixin,
+    _get_checked_concrete_subclasses,
+    get_known_concrete_subclasses,
+)
+
+
+class _Base(DiscriminatedUnionMixin, ABC):
+    pass
+
+
+class _ConcreteA(_Base):
+    x: int = 1
+
+
+class _ConcreteB(_Base):
+    x: int = 2
+
+
+# Separate hierarchy for _get_checked_concrete_subclasses tests
+# (which rejects <locals> classes).
+class _CheckedBase(DiscriminatedUnionMixin, ABC):
+    pass
+
+
+class _CheckedA(_CheckedBase):
+    x: int = 1
+
+
+def test_cache_hit():
+    """Consecutive calls return the exact same tuple object."""
+    first = get_known_concrete_subclasses(_Base)
+    second = get_known_concrete_subclasses(_Base)
+    assert first is second
+
+
+def test_returns_tuple():
+    """Cached result is a tuple (immutable)."""
+    assert isinstance(get_known_concrete_subclasses(_Base), tuple)
+
+
+def test_auto_invalidates_on_new_subclass():
+    """Defining a new direct subclass invalidates the parent's cache."""
+    first = get_known_concrete_subclasses(_Base)
+
+    class _ConcreteNew(_Base):
+        x: int = 99
+
+    second = get_known_concrete_subclasses(_Base)
+    assert first is not second
+    assert _ConcreteNew in second
+
+
+def test_deep_hierarchy_invalidation():
+    """A subclass of a subclass still invalidates the root ancestor's cache."""
+
+    class _Mid(_Base, ABC):
+        pass
+
+    class _Leaf(_Mid):
+        x: int = 42
+
+    result = get_known_concrete_subclasses(_Base)
+    assert _Leaf in result
+
+    # Now add a deeper leaf — the _Base cache must see it.
+    class _Leaf2(_Mid):
+        x: int = 43
+
+    result2 = get_known_concrete_subclasses(_Base)
+    assert result2 is not result
+    assert _Leaf2 in result2
+
+
+def test_dynamic_type_invalidates_cache():
+    """type() call (what tool.py uses) triggers __init_subclass__."""
+    before = get_known_concrete_subclasses(_Base)
+
+    DynClass = type("_DynSubclass", (_Base,), {"__annotations__": {"x": int}})
+
+    after = get_known_concrete_subclasses(_Base)
+    assert after is not before
+    assert DynClass in after
+
+
+def test_checked_cache_stays_in_sync():
+    """_get_checked_concrete_subclasses invalidates alongside the concrete cache."""
+    checked_before = _get_checked_concrete_subclasses(_CheckedBase)
+    assert "_CheckedA" in checked_before
+
+    # Dynamically add a module-level subclass so qualname has no <locals>.
+    cls = type("_CheckedB", (_CheckedBase,), {"__annotations__": {"x": int}})
+    cls.__module__ = __name__
+    cls.__qualname__ = "_CheckedB"
+
+    checked_after = _get_checked_concrete_subclasses(_CheckedBase)
+    assert checked_after is not checked_before
+    assert "_CheckedB" in checked_after
+
+
+def test_concurrent_subclass_creation():
+    """Multiple threads defining subclasses — cache is correct after all finish."""
+
+    class _ThreadBase(_Base, ABC):
+        pass
+
+    barrier = threading.Barrier(8)
+    created: list[type] = []
+    lock = threading.Lock()
+
+    def worker(idx: int) -> None:
+        barrier.wait()
+        cls = type(
+            f"_Thread{idx}",
+            (_ThreadBase,),
+            {"__annotations__": {"x": int}, "x": idx},
+        )
+        with lock:
+            created.append(cls)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    result = get_known_concrete_subclasses(_ThreadBase)
+    for cls in created:
+        assert cls in result, f"{cls.__name__} missing from cache result"


### PR DESCRIPTION
## Summary

`get_known_concrete_subclasses()` and `_get_checked_concrete_subclasses()` are called on every event deserialization via `_validate_subtype()`. Both walk the full class hierarchy recursively, which dominates per-step CPU (~47% of self-time in 100-step wall profiles).

This PR caches both functions with a generation counter that auto-invalidates via `DiscriminatedUnionMixin.__init_subclass__` whenever a new subclass is defined. No manual cache clearing is needed — existing tests pass without modification.

## Changes

**`openhands-sdk/openhands/sdk/utils/models.py`:**
- Added `__init_subclass__` to `DiscriminatedUnionMixin` that bumps a generation counter
- Replaced uncached functions with generation-counter cache (`_concrete_cache`, `_checked_cache`)
- Thread-safe generation bump via `threading.Lock`
- Changed return type of `get_known_concrete_subclasses` from `list` to `tuple` for immutability
- `clear_subclass_cache()` retained as public API for non-`DiscriminatedUnionMixin` edge cases

**`tests/sdk/utils/test_subclass_cache.py`** (new — 7 tests):
| Test | Risk covered |
|---|---|
| `test_cache_hit` | Basic cache correctness |
| `test_returns_tuple` | Immutability of cached results |
| `test_auto_invalidates_on_new_subclass` | `__init_subclass__` fires for `class` statements |
| `test_deep_hierarchy_invalidation` | Subclass-of-subclass invalidates root ancestor |
| `test_dynamic_type_invalidates_cache` | `type()` calls (what `tool.py` uses) trigger invalidation |
| `test_checked_cache_stays_in_sync` | Both caches invalidate together |
| `test_concurrent_subclass_creation` | 8 threads defining subclasses — all appear in result |

Zero existing tests modified. 3697 tests pass.

Partial fix for #3134

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:67e0946-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-67e0946-python \
  ghcr.io/openhands/agent-server:67e0946-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:67e0946-golang-amd64
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-golang-amd64
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-golang-amd64
ghcr.io/openhands/agent-server:67e0946-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:67e0946-golang-arm64
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-golang-arm64
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-golang-arm64
ghcr.io/openhands/agent-server:67e0946-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:67e0946-java-amd64
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-java-amd64
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-java-amd64
ghcr.io/openhands/agent-server:67e0946-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:67e0946-java-arm64
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-java-arm64
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-java-arm64
ghcr.io/openhands/agent-server:67e0946-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:67e0946-python-amd64
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-python-amd64
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-python-amd64
ghcr.io/openhands/agent-server:67e0946-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:67e0946-python-arm64
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-python-arm64
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-python-arm64
ghcr.io/openhands/agent-server:67e0946-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:67e0946-golang
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-golang
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-golang
ghcr.io/openhands/agent-server:67e0946-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:67e0946-java
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-java
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-java
ghcr.io/openhands/agent-server:67e0946-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:67e0946-python
ghcr.io/openhands/agent-server:67e0946b512132557b3bd77fef39d432835b171f-python
ghcr.io/openhands/agent-server:perf-cache-subclass-hierarchy-3134-python
ghcr.io/openhands/agent-server:67e0946-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `67e0946-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `67e0946-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->