### PR TITLE
refactor: optimize caching for public skills loading

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -29,6 +29,7 @@ from openhands.sdk.skills.skill import (
     DEFAULT_MARKETPLACE_PATH,
     PUBLIC_SKILLS_BRANCH,
     PUBLIC_SKILLS_REPO,
+    _invalidate_public_skills_cache,
     load_skills_from_dir,
 )
 from openhands.sdk.skills.utils import (
@@ -380,6 +381,7 @@ def sync_public_skills() -> tuple[bool, str]:
         )
 
         if result:
+            _invalidate_public_skills_cache()
             return (True, "Skills repository synced successfully")
         else:
             return (False, "Failed to sync skills repository")

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -2,6 +2,8 @@ import io
 import json
 import os
 import re
+import threading
+import time
 from pathlib import Path
 from typing import Annotated, ClassVar, Literal, Union
 from xml.sax.saxutils import escape as xml_escape
@@ -931,6 +933,26 @@ PUBLIC_SKILLS_REPO = "https://github.com/OpenHands/extensions"
 PUBLIC_SKILLS_BRANCH = os.environ.get("EXTENSIONS_REF", "main")
 DEFAULT_MARKETPLACE_PATH = "marketplaces/default.json"
 
+# Process-level cache for load_public_skills. Conversation creation re-validates
+# AgentContext several times and each validation re-runs load_public_skills
+# (git fetch + parse ~40 md files ≈ 1s). The cache short-circuits repeated calls
+# within the TTL while still picking up new skills within a minute.
+_PUBLIC_SKILLS_CACHE: dict[
+    tuple[str, str, str | None], tuple[float, list["Skill"]]
+] = {}
+_PUBLIC_SKILLS_CACHE_TTL_SECONDS = 60.0
+_PUBLIC_SKILLS_CACHE_LOCK = threading.Lock()
+
+
+def _invalidate_public_skills_cache() -> None:
+    """Clear the in-memory public-skills cache.
+
+    Called by ``sync_public_skills`` so a forced refresh re-parses immediately
+    instead of waiting for the TTL.
+    """
+    with _PUBLIC_SKILLS_CACHE_LOCK:
+        _PUBLIC_SKILLS_CACHE.clear()
+
 
 def load_marketplace_skill_names(
     repo_path: Path, marketplace_path: str
@@ -1025,6 +1047,15 @@ def load_public_skills(
         >>> # Use with AgentContext
         >>> context = AgentContext(skills=public_skills)
     """
+    cache_key = (repo_url, branch, marketplace_path)
+    with _PUBLIC_SKILLS_CACHE_LOCK:
+        cached = _PUBLIC_SKILLS_CACHE.get(cache_key)
+        if (
+            cached is not None
+            and time.monotonic() - cached[0] < _PUBLIC_SKILLS_CACHE_TTL_SECONDS
+        ):
+            return list(cached[1])
+
     all_skills = []
 
     try:
@@ -1106,6 +1137,13 @@ def load_public_skills(
         logger.warning(f"Failed to load public skills from {repo_url}: {str(e)}")
 
     logger.info("Loaded %d public skills", len(all_skills))
+
+    # Only cache non-empty results so transient errors don't poison the cache
+    # for the full TTL window.
+    if all_skills:
+        with _PUBLIC_SKILLS_CACHE_LOCK:
+            _PUBLIC_SKILLS_CACHE[cache_key] = (time.monotonic(), list(all_skills))
+
     return all_skills
 
 

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -409,6 +409,50 @@ class TestSyncPublicSkills:
             assert success is False
             assert "failed" in message.lower() or "error" in message.lower()
 
+    def test_sync_public_skills_invalidates_in_memory_cache(self):
+        """Successful sync must drop the in-memory cache so the next call
+        re-parses immediately instead of waiting for the TTL."""
+        with (
+            patch(
+                "openhands.agent_server.skills_service.get_skills_cache_dir"
+            ) as mock_cache,
+            patch(
+                "openhands.agent_server.skills_service.update_skills_repository"
+            ) as mock_update,
+            patch(
+                "openhands.agent_server.skills_service._invalidate_public_skills_cache"
+            ) as mock_invalidate,
+        ):
+            mock_cache.return_value = Path("/tmp/cache")
+            mock_update.return_value = Path("/tmp/cache/public-skills")
+
+            success, _ = sync_public_skills()
+
+            assert success is True
+            mock_invalidate.assert_called_once()
+
+    def test_sync_public_skills_failure_does_not_invalidate_cache(self):
+        """A failed sync must not clobber the cache so the previous skills
+        stay available until the next successful refresh."""
+        with (
+            patch(
+                "openhands.agent_server.skills_service.get_skills_cache_dir"
+            ) as mock_cache,
+            patch(
+                "openhands.agent_server.skills_service.update_skills_repository"
+            ) as mock_update,
+            patch(
+                "openhands.agent_server.skills_service._invalidate_public_skills_cache"
+            ) as mock_invalidate,
+        ):
+            mock_cache.return_value = Path("/tmp/cache")
+            mock_update.return_value = None
+
+            success, _ = sync_public_skills()
+
+            assert success is False
+            mock_invalidate.assert_not_called()
+
 
 class TestSkillLoadResult:
     """Tests for SkillLoadResult dataclass."""

--- a/tests/sdk/skills/test_load_public_skills.py
+++ b/tests/sdk/skills/test_load_public_skills.py
@@ -12,8 +12,23 @@ from openhands.sdk.skills import (
     Skill,
     load_public_skills,
 )
-from openhands.sdk.skills.skill import load_marketplace_skill_names
+from openhands.sdk.skills.skill import (
+    _invalidate_public_skills_cache,
+    load_marketplace_skill_names,
+)
 from openhands.sdk.skills.utils import update_skills_repository
+
+
+@pytest.fixture(autouse=True)
+def _clear_public_skills_cache():
+    """Clear the public-skills in-memory cache between tests.
+
+    The cache is process-global, so without clearing it, results from one test
+    leak into later tests that mock ``update_skills_repository`` differently.
+    """
+    _invalidate_public_skills_cache()
+    yield
+    _invalidate_public_skills_cache()
 
 
 @pytest.fixture
@@ -879,3 +894,73 @@ def test_load_public_skills_handles_legacy_md_files_with_marketplace(tmp_path):
         skill_names = {s.name for s in skills}
         assert skill_names == {"git", "docker"}
         assert "internal" not in skill_names
+
+
+def test_load_public_skills_caches_result_within_ttl(mock_repo_dir, tmp_path):
+    """Second call within the TTL window must not re-run update_skills_repository.
+
+    Regression test for the slow conversation-creation path: AgentContext was
+    being (re-)validated several times per request, causing load_public_skills
+    to do a git fetch + parse every time.
+    """
+    update_mock = MagicMock(return_value=mock_repo_dir)
+    with (
+        patch(
+            "openhands.sdk.skills.skill.update_skills_repository",
+            update_mock,
+        ),
+        patch(
+            "openhands.sdk.skills.skill.get_skills_cache_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        first = load_public_skills()
+        second = load_public_skills()
+
+    assert update_mock.call_count == 1
+    assert {s.name for s in first} == {s.name for s in second}
+
+
+def test_invalidate_public_skills_cache_forces_recompute(mock_repo_dir, tmp_path):
+    """After explicit invalidation, the next call re-runs update_skills_repository."""
+    update_mock = MagicMock(return_value=mock_repo_dir)
+    with (
+        patch(
+            "openhands.sdk.skills.skill.update_skills_repository",
+            update_mock,
+        ),
+        patch(
+            "openhands.sdk.skills.skill.get_skills_cache_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        load_public_skills()
+        _invalidate_public_skills_cache()
+        load_public_skills()
+
+    assert update_mock.call_count == 2
+
+
+def test_load_public_skills_does_not_cache_empty_results(mock_repo_dir, tmp_path):
+    """Transient failures must not poison the cache for the full TTL.
+
+    First call simulates a git/repo failure (no skills returned); second call
+    succeeds and should hit the real path again instead of the empty cache.
+    """
+    update_mock = MagicMock(side_effect=[None, mock_repo_dir])
+    with (
+        patch(
+            "openhands.sdk.skills.skill.update_skills_repository",
+            update_mock,
+        ),
+        patch(
+            "openhands.sdk.skills.skill.get_skills_cache_dir",
+            return_value=tmp_path,
+        ),
+    ):
+        first = load_public_skills()
+        second = load_public_skills()
+
+    assert first == []
+    assert {s.name for s in second} == {"git", "docker", "testing"}
+    assert update_mock.call_count == 2


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Conversation creation takes 10+ seconds — `load_public_skills` runs 4× per request

### Description

Creating a new conversation from the agent-server-gui homepage takes **10+ seconds** on a clean dev environment. Profiling the agent-server logs shows that `openhands.sdk.skills.skill.load_public_skills` is invoked **four times** during a single `POST /api/conversations` request. Each call performs a `git fetch` against `github.com/OpenHands/extensions` and re-parses ~40 markdown files (~1 s each), adding ~4–5 s of pure waste to the critical path.

### Steps to reproduce

```bash
git clone <agent-canvas>
cd agent-canvas
export PROJECT_PATH=~/Documents/openhands && npm run dev
# Open the homepage, click "New conversation".
```

The browser waits ~10 s before redirecting to the conversation page.

### Evidence

| Time         | Event                                                   |
| ------------ | ------------------------------------------------------- |
| 05:36:05,729 | "Found 40 skill files in public skills repository" (1) |
| 05:36:06,755 | (2)                                                    |
| 05:36:07,774 | (3)                                                    |
| 05:36:07,812 | "Created new conversation c47ee76c-…"                   |
| 05:36:10,741 | (4)                                                    |
| 05:36:10,771 | `POST /api/conversations` returns 200                   |

### Root cause

The GUI sends `agent_context: { load_public_skills: true, load_user_skills: true }` (see `agent-server-gui/src/api/agent-server-adapter.ts:293-296`). On the server, `AgentContext._load_auto_skills` is a `@model_validator(mode="after")` that calls `load_available_skills(include_public=True, …)` on every (re-)validation. During one conversation creation, `AgentContext` is validated multiple times:

1. `conversation_service._start_conversation` → `StoredConversation.model_validate({...})` rebuilds the nested `AgentContext` from the request dict (load 1).
2. `EventService.start` → `agent_cls.model_validate(self.stored.agent.model_dump(context={"expose_secrets": True}))` round-trips the agent to expose secrets (load 2).
3. Additional validation paths during `LocalConversation` construction and the independent `skills_service.load_all_skills` path account for loads 3/4.

`load_public_skills` itself has **no in-memory cache** — only a disk-level git clone at `~/.openhands/cache/skills/public-skills`. Every call still runs `git fetch` + parses every markdown file.

### Proposed fix

Add a **process-level TTL cache (60 s)** inside `load_public_skills`, keyed by `(repo_url, branch, marketplace_path)`. `sync_public_skills` invalidates the cache so a manual refresh still takes effect immediately.

### Acceptance criteria

* [ ] `load_public_skills` runs once (or at most twice, allowing for races on the first request) per conversation creation in fresh logs.
* [ ] Conversation-creation latency drops from ~10 s to ~2–3 s on the local dev stack.
* [ ] `sync_public_skills` clears the cache so the next call re-parses.
* [ ] Empty / failed loads are **not** cached (so transient git errors don't poison the cache for the full TTL).
* [ ] Existing skills tests continue to pass.


## Summary

<!-- 1-3 bullets describing what changed. -->
* Add a 60 s in-memory TTL cache to `load_public_skills`, keyed by `(repo_url, branch, marketplace_path)`, so the four redundant calls that happen during one conversation creation collapse into one.
* Wire `sync_public_skills` to invalidate the cache so manual refresh keeps working.
* Add focused tests for the new cache behavior.

### Why

`POST /api/conversations` on the local dev stack takes ~10 s. Logs show `load_public_skills` running four times back-to-back, each doing a git fetch + parsing ~40 markdown files. Two of those calls come from `StoredConversation.model_validate(...)` in `conversation_service._start_conversation` and `agent_cls.model_validate(agent.model_dump(...))` in `EventService.start`; both re-trigger `AgentContext._load_auto_skills` (a `@model_validator(mode="after")`). The remaining two come from additional validation paths during conversation init. The function has no in-memory cache today.

Fixing the validator chain would require invasive changes to Pydantic serialization for several models. Caching the slow function instead is a single-file change that benefits every caller — both today's and any future ones (e.g. `subagent.registry.create_agent_factory`).

### What changed

| File                                                              | Change                                                                                                                                                                                                                    |
| ----------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
| `openhands-sdk/openhands/sdk/skills/skill.py`                     | Module-level `_PUBLIC_SKILLS_CACHE` (dict) + `threading.Lock` + 60 s TTL. Cache check at the top of `load_public_skills`; cache write at the end (only when non-empty). Added `_invalidate_public_skills_cache()` helper. |
| `openhands-agent-server/openhands/agent_server/skills_service.py` | `sync_public_skills` calls `_invalidate_public_skills_cache()` after a successful repo update.                                                                                                                            |
| `tests/sdk/skills/test_load_public_skills.py`                     | Autouse fixture to clear cache between tests; three new tests for cache hit / invalidation / no-cache-on-empty.                                                                                                           |
| `tests/agent_server/test_skills_service.py`                       | Two new tests covering the sync→invalidate wiring (success + failure paths).                                                                                                                                              |

### Design notes

* **Cache scope.** Process-local. Each uvicorn worker owns its cache — no shared-memory hazards. The disk git clone (`~/.openhands/cache/skills/`) is still the canonical store and is unchanged.
* **TTL.** 60 s. Short enough that pushed skills appear within a minute; long enough that bursts of conversation creation hit the cache 100 % of the time.
* **Lock.** A single `threading.Lock` guards both reads and writes so two concurrent first-callers can't both run the slow path.
* **Failure handling.** Empty results are not cached. A transient git error (e.g. network blip) won't pin "no skills" for the TTL.
* **Mutation safety.** Reads return `list(cached)` so callers can't mutate the cached list out from under each other.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

```bash
git clone <agent-canvas>
cd agent-canvas
export PROJECT_PATH=~/Documents/openhands && npm run dev
# Open the homepage, click "New conversation".
```

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/4306b2f6-73ca-425f-a936-9da0010053ae

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->

* Cleaning up the duplicated `model_validate(model_dump(...))` round-trips in `event_service.start` and `conversation_service._start_conversation`. They are intentional clones-with-secrets and removing them would change the serialization contract. With the cache in place they are now cheap.
* Caching `load_user_skills` / `load_project_skills`. Their cost is dominated by local filesystem reads (microseconds) and they vary by `work_dir`, so caching adds complexity without measurable benefit.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:885207b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-885207b-python \
  ghcr.io/openhands/agent-server:885207b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:885207b-golang-amd64
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-1677-golang-amd64
ghcr.io/openhands/agent-server:885207b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:885207b-golang-arm64
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-1677-golang-arm64
ghcr.io/openhands/agent-server:885207b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:885207b-java-amd64
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-1677-java-amd64
ghcr.io/openhands/agent-server:885207b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:885207b-java-arm64
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-1677-java-arm64
ghcr.io/openhands/agent-server:885207b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:885207b-python-amd64
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-1677-python-amd64
ghcr.io/openhands/agent-server:885207b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:885207b-python-arm64
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-1677-python-arm64
ghcr.io/openhands/agent-server:885207b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:885207b-golang
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-golang
ghcr.io/openhands/agent-server:hieptl-app-1677-golang
ghcr.io/openhands/agent-server:885207b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:885207b-java
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-java
ghcr.io/openhands/agent-server:hieptl-app-1677-java
ghcr.io/openhands/agent-server:885207b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:885207b-python
ghcr.io/openhands/agent-server:885207b871d7b2065d0a88e64d6c03af06b2c91a-python
ghcr.io/openhands/agent-server:hieptl-app-1677-python
ghcr.io/openhands/agent-server:885207b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `885207b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `885207b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->