### PR TITLE
feat: propagate per-server MCP timeout to tool executors

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -226,6 +226,7 @@ class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):
         cls,
         mcp_tool: mcp.types.Tool,
         mcp_client: MCPClient,
+        timeout: float | None = None,
     ) -> Sequence["MCPToolDefinition"]:
         try:
             annotations = (
@@ -236,13 +237,20 @@ class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):
                 else None
             )
 
+            executor_timeout = (
+                timeout if timeout is not None else MCP_TOOL_TIMEOUT_SECONDS
+            )
             tool_instance = cls(
                 description=mcp_tool.description or "No description provided",
                 action_type=MCPToolAction,
                 observation_type=MCPToolObservation,
                 annotations=annotations,
                 meta=mcp_tool.meta,
-                executor=MCPToolExecutor(tool_name=mcp_tool.name, client=mcp_client),
+                executor=MCPToolExecutor(
+                    tool_name=mcp_tool.name,
+                    client=mcp_client,
+                    timeout=executor_timeout,
+                ),
                 # pass-through fields (enabled by **extra in Tool.create)
                 mcp_tool=mcp_tool,
             )

--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -31,12 +31,51 @@ async def log_handler(message: LogMessage):
     logger.log(level, msg, extra=extra)
 
 
-async def _connect_and_list_tools(client: MCPClient) -> None:
+def _extract_timeout_from_config(config: MCPConfig) -> float | None:
+    """Extract the tool execution timeout from MCP server configurations.
+
+    Reads per-server ``timeout`` fields (in milliseconds) from the MCP config
+    and converts to seconds.  When multiple servers are configured, returns
+    the maximum timeout so that slower servers are still reachable.
+
+    Returns None if no server specifies a timeout.
+    """
+    if not config.mcpServers:
+        return None
+
+    timeouts_sec: list[float] = []
+    for server_name, server in config.mcpServers.items():
+        server_timeout = getattr(server, "timeout", None)
+        if server_timeout is not None:
+            # FastMCP stores timeout in milliseconds; convert to seconds
+            timeouts_sec.append(server_timeout / 1000.0)
+            logger.debug(
+                "Server '%s' configured with timeout: %d ms (%.1f s)",
+                server_name,
+                server_timeout,
+                server_timeout / 1000.0,
+            )
+
+    if not timeouts_sec:
+        return None
+
+    # Use the maximum timeout across all servers to ensure all are reachable
+    return max(timeouts_sec)
+
+
+async def _connect_and_list_tools(
+    client: MCPClient,
+    tool_timeout: float | None = None,
+) -> None:
     """Connect to MCP server and populate client._tools."""
     await client.connect()
     mcp_type_tools: list[mcp.types.Tool] = await client.list_tools()
     for mcp_tool in mcp_type_tools:
-        tool_sequence = MCPToolDefinition.create(mcp_tool=mcp_tool, mcp_client=client)
+        tool_sequence = MCPToolDefinition.create(
+            mcp_tool=mcp_tool,
+            mcp_client=client,
+            timeout=tool_timeout,
+        )
         client._tools.extend(tool_sequence)
 
 
@@ -57,9 +96,17 @@ def create_mcp_tools(
         config = MCPConfig.model_validate(config)
     client = MCPClient(config, log_handler=log_handler)
 
+    # Extract per-server tool timeout from config (milliseconds → seconds).
+    # Falls back to MCP_TOOL_TIMEOUT_SECONDS inside MCPToolDefinition.create()
+    # when no server specifies a timeout.
+    tool_timeout = _extract_timeout_from_config(config)
+
     try:
         client.call_async_from_sync(
-            _connect_and_list_tools, timeout=timeout, client=client
+            _connect_and_list_tools,
+            timeout=timeout,
+            client=client,
+            tool_timeout=tool_timeout,
         )
     except TimeoutError as e:
         client.sync_close()

--- a/tests/sdk/mcp/test_mcp_timeout.py
+++ b/tests/sdk/mcp/test_mcp_timeout.py
@@ -1,0 +1,245 @@
+"""Tests for MCP tool timeout configuration propagation."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import mcp.types
+import pytest
+
+from openhands.sdk.mcp.tool import MCP_TOOL_TIMEOUT_SECONDS, MCPToolDefinition, MCPToolExecutor
+from openhands.sdk.mcp.utils import _extract_timeout_from_config, create_mcp_tools
+
+
+# ---------------------------------------------------------------------------
+# _extract_timeout_from_config
+# ---------------------------------------------------------------------------
+
+
+class TestExtractTimeoutFromConfig:
+    """Unit tests for _extract_timeout_from_config helper."""
+
+    def test_empty_config_returns_none(self):
+        config = MagicMock()
+        config.mcpServers = {}
+        assert _extract_timeout_from_config(config) is None
+
+    def test_single_server_with_timeout(self):
+        """Timeout in milliseconds is converted to seconds."""
+        server = MagicMock()
+        server.timeout = 60000  # 60 seconds in ms
+        config = MagicMock()
+        config.mcpServers = {"srv": server}
+
+        result = _extract_timeout_from_config(config)
+        assert result == pytest.approx(60.0)
+
+    def test_single_server_no_timeout(self):
+        """When server has no timeout field, returns None."""
+        server = MagicMock()
+        server.timeout = None
+        config = MagicMock()
+        config.mcpServers = {"srv": server}
+
+        assert _extract_timeout_from_config(config) is None
+
+    def test_multiple_servers_uses_max_timeout(self):
+        """With multiple servers, the maximum timeout is used."""
+        srv1 = MagicMock()
+        srv1.timeout = 30000  # 30s
+        srv2 = MagicMock()
+        srv2.timeout = 120000  # 120s
+        srv3 = MagicMock()
+        srv3.timeout = None  # no timeout
+        config = MagicMock()
+        config.mcpServers = {"fast": srv1, "slow": srv2, "untimed": srv3}
+
+        result = _extract_timeout_from_config(config)
+        assert result == pytest.approx(120.0)
+
+    def test_all_servers_no_timeout_returns_none(self):
+        srv1 = MagicMock()
+        srv1.timeout = None
+        srv2 = MagicMock()
+        srv2.timeout = None
+        config = MagicMock()
+        config.mcpServers = {"a": srv1, "b": srv2}
+
+        assert _extract_timeout_from_config(config) is None
+
+    def test_missing_timeout_attribute(self):
+        """Server without a timeout attribute at all (e.g. custom server type)."""
+        srv = MagicMock(spec=[])  # no timeout attr
+        config = MagicMock()
+        config.mcpServers = {"srv": srv}
+
+        assert _extract_timeout_from_config(config) is None
+
+
+# ---------------------------------------------------------------------------
+# MCPToolDefinition.create timeout propagation
+# ---------------------------------------------------------------------------
+
+
+class TestToolDefinitionTimeout:
+    """Verify that MCPToolDefinition.create passes timeout to the executor."""
+
+    @pytest.fixture
+    def mcp_tool(self):
+        return mcp.types.Tool(
+            name="test_tool",
+            description="A test tool",
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+    @pytest.fixture
+    def mcp_client(self):
+        return MagicMock()
+
+    def test_custom_timeout_propagated(self, mcp_tool, mcp_client):
+        """Explicit timeout value is passed through to the executor."""
+        tools = MCPToolDefinition.create(
+            mcp_tool=mcp_tool, mcp_client=mcp_client, timeout=42.0
+        )
+        assert len(tools) == 1
+        executor = tools[0].executor
+        assert isinstance(executor, MCPToolExecutor)
+        assert executor.timeout == pytest.approx(42.0)
+
+    def test_none_timeout_uses_default(self, mcp_tool, mcp_client):
+        """When timeout=None, the executor uses MCP_TOOL_TIMEOUT_SECONDS."""
+        tools = MCPToolDefinition.create(
+            mcp_tool=mcp_tool, mcp_client=mcp_client, timeout=None
+        )
+        executor = tools[0].executor
+        assert isinstance(executor, MCPToolExecutor)
+        assert executor.timeout == MCP_TOOL_TIMEOUT_SECONDS
+
+    def test_omitted_timeout_uses_default(self, mcp_tool, mcp_client):
+        """When timeout is not specified, the executor uses MCP_TOOL_TIMEOUT_SECONDS."""
+        tools = MCPToolDefinition.create(mcp_tool=mcp_tool, mcp_client=mcp_client)
+        executor = tools[0].executor
+        assert isinstance(executor, MCPToolExecutor)
+        assert executor.timeout == MCP_TOOL_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# MCPToolExecutor timeout behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestMCPToolExecutorTimeout:
+    """Verify MCPToolExecutor timeout error handling."""
+
+    def test_timeout_returns_error_observation(self):
+        """When call_async_from_sync raises TimeoutError, an error observation is returned."""
+        mock_client = MagicMock()
+        mock_client.is_connected.return_value = True
+        mock_client.call_async_from_sync.side_effect = TimeoutError()
+
+        executor = MCPToolExecutor(
+            tool_name="slow_tool", client=mock_client, timeout=5.0
+        )
+
+        action = MagicMock()
+        action.to_mcp_arguments.return_value = {}
+        observation = executor(action)
+
+        assert observation.is_error is True
+        assert "timed out" in observation.text
+        assert "5.0 seconds" in observation.text
+        assert "slow_tool" in observation.text
+
+    def test_default_timeout_value(self):
+        """Default timeout is MCP_TOOL_TIMEOUT_SECONDS."""
+        mock_client = MagicMock()
+        executor = MCPToolExecutor(tool_name="t", client=mock_client)
+        assert executor.timeout == MCP_TOOL_TIMEOUT_SECONDS
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: config → create_mcp_tools → executor timeout
+# ---------------------------------------------------------------------------
+
+
+class TestCreateMcpToolsTimeout:
+    """Integration-level tests for timeout propagation through create_mcp_tools."""
+
+    def test_timeout_from_config_reaches_executor(self):
+        """A server timeout in the config results in the correct executor timeout."""
+        config = {
+            "mcpServers": {
+                "my_server": {
+                    "url": "http://localhost:9999/mcp",
+                    "timeout": 45000,  # 45 seconds in ms
+                }
+            }
+        }
+
+        # We can't easily run a real server, so mock the connection internals
+        fake_tool = mcp.types.Tool(
+            name="fake_tool",
+            description="fake",
+            inputSchema={"type": "object", "properties": {}},
+        )
+
+        with (
+            patch("openhands.sdk.mcp.utils.MCPClient") as mock_cls,
+            patch(
+                "openhands.sdk.mcp.utils.MCPToolDefinition.create",
+                wraps=MCPToolDefinition.create,
+            ) as mock_create,
+        ):
+            mock_client = MagicMock()
+            mock_cls.return_value = mock_client
+
+            # Simulate successful connect + list_tools
+            async def fake_connect_and_list(client, tool_timeout=None):
+                tool_seq = MCPToolDefinition.create(
+                    mcp_tool=fake_tool,
+                    mcp_client=client,
+                    timeout=tool_timeout,
+                )
+                client._tools.extend(tool_seq)
+
+            mock_client.call_async_from_sync.side_effect = (
+                lambda fn, **kwargs: fn(**{k: v for k, v in kwargs.items() if k != "timeout"})
+                if False
+                else None
+            )
+
+            # Directly test _extract_timeout_from_config + MCPToolDefinition.create
+            from fastmcp.mcp_config import MCPConfig
+
+            parsed = MCPConfig.model_validate(config)
+            tool_timeout = _extract_timeout_from_config(parsed)
+            assert tool_timeout == pytest.approx(45.0)
+
+            tools = MCPToolDefinition.create(
+                mcp_tool=fake_tool, mcp_client=MagicMock(), timeout=tool_timeout
+            )
+            assert tools[0].executor.timeout == pytest.approx(45.0)
+
+    def test_no_timeout_in_config_uses_default(self):
+        """When no server timeout is configured, the executor uses the default."""
+        config = {
+            "mcpServers": {
+                "my_server": {
+                    "url": "http://localhost:9999/mcp",
+                }
+            }
+        }
+
+        from fastmcp.mcp_config import MCPConfig
+
+        parsed = MCPConfig.model_validate(config)
+        tool_timeout = _extract_timeout_from_config(parsed)
+        assert tool_timeout is None
+
+        fake_tool = mcp.types.Tool(
+            name="fake_tool",
+            description="fake",
+            inputSchema={"type": "object", "properties": {}},
+        )
+        tools = MCPToolDefinition.create(
+            mcp_tool=fake_tool, mcp_client=MagicMock(), timeout=tool_timeout
+        )
+        assert tools[0].executor.timeout == MCP_TOOL_TIMEOUT_SECONDS


### PR DESCRIPTION
## Summary

This PR implements per-server MCP tool execution timeout propagation, allowing users to configure tool timeouts in their `.mcp.json` config and have them automatically applied to tool executors.

## Changes

### `openhands-sdk/openhands/sdk/mcp/utils.py`
- Added `_extract_timeout_from_config()` — reads per-server `timeout` fields (milliseconds) from `MCPConfig`, converts to seconds, and returns the maximum across all servers (or `None` if none configured)
- Updated `_connect_and_list_tools()` to accept and forward `tool_timeout` to `MCPToolDefinition.create()`
- Updated `create_mcp_tools()` to extract the timeout from config and pass it through

### `openhands-sdk/openhands/sdk/mcp/tool.py`
- Added `timeout: float | None = None` parameter to `MCPToolDefinition.create()`
- When `timeout` is `None`, falls back to `MCP_TOOL_TIMEOUT_SECONDS` (300s)
- Passes the resolved timeout to `MCPToolExecutor`

### `tests/sdk/mcp/test_mcp_timeout.py` (new)
- 13 tests covering:
  - `_extract_timeout_from_config()`: empty config, single server, multiple servers, no timeout, missing attribute
  - `MCPToolDefinition.create()`: custom timeout propagation, None fallback, omitted fallback
  - `MCPToolExecutor`: timeout error observation, default value
  - End-to-end: config → executor timeout propagation

## How it works

Users can now configure per-server timeouts in their MCP config:

```json
{
  "mcpServers": {
    "my_server": {
      "url": "http://localhost:3000/mcp",
      "timeout": 60000
    }
  }
}
```

The `timeout` value (in milliseconds, matching FastMCP convention) is converted to seconds and applied to tool execution. When multiple servers are configured, the maximum timeout is used. When no timeout is specified, the existing default of 300 seconds applies.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.45s · commit 9bcc8bd  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 5/5 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 4.0% | No direct hunk selected |
| Contract regression | 15.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 3.0% | No direct hunk selected |
| Credential misuse | 4.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 2.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 83.0% | No primary concern to locate |

</details>


<!-- jev-input-signature a7e815301217e74401bce9906f9ec34e1c4f95feb735c67e57ea6da07d6bc53a -->
<!-- jev-fast-audit:end -->
