### PR TITLE
Separate configured and effective LLM token limits

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -744,6 +744,7 @@ class OpenAISubscriptionAuth:
         llm._is_subscription = True
         # Ensure these stay None even if model info tried to set them
         llm.max_output_tokens = None
+        llm._effective_max_output_tokens = None
         llm.temperature = None
         return llm
 

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -456,6 +456,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     _is_subscription: bool = PrivateAttr(default=False)
     _litellm_provider: str | None = PrivateAttr(default=None)
     _prompt_cache_key: str | None = PrivateAttr(default=None)
+    _effective_max_input_tokens: int | None = PrivateAttr(default=None)
+    _effective_max_output_tokens: int | None = PrivateAttr(default=None)
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="ignore", arbitrary_types_allowed=True
@@ -789,7 +791,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # 4) request context for telemetry (always include context_window for metrics)
         assert self._telemetry is not None
         # Always pass context_window so metrics are tracked even when logging disabled
-        telemetry_ctx: dict[str, Any] = {"context_window": self.max_input_tokens or 0}
+        telemetry_ctx: dict[str, Any] = {
+            "context_window": self.effective_max_input_tokens or 0
+        }
         if self._telemetry.log_enabled:
             telemetry_ctx.update(
                 {
@@ -937,7 +941,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # Request context for telemetry (always include context_window for metrics)
         assert self._telemetry is not None
         # Always pass context_window so metrics are tracked even when logging disabled
-        telemetry_ctx: dict[str, Any] = {"context_window": self.max_input_tokens or 0}
+        telemetry_ctx: dict[str, Any] = {
+            "context_window": self.effective_max_input_tokens or 0
+        }
         if self._telemetry.log_enabled:
             telemetry_ctx.update(
                 {
@@ -1221,18 +1227,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             model=self._model_name_for_capabilities(),
         )
 
-        # Context window and max_output_tokens
+        self._effective_max_input_tokens = self.max_input_tokens
         if (
-            self.max_input_tokens is None
+            self._effective_max_input_tokens is None
             and self._model_info is not None
             and isinstance(self._model_info.get("max_input_tokens"), int)
         ):
-            self.max_input_tokens = self._model_info.get("max_input_tokens")
+            self._effective_max_input_tokens = self._model_info.get("max_input_tokens")
 
         # Validate context window size
         self._validate_context_window_size()
 
-        if self.max_output_tokens is None:
+        effective_max_output_tokens = self.max_output_tokens
+        if effective_max_output_tokens is None:
             if any(
                 m in self.model
                 for m in [
@@ -1241,16 +1248,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     "kimi-k2-thinking",
                 ]
             ):
-                self.max_output_tokens = (
+                effective_max_output_tokens = (
                     64000  # practical cap (litellm may allow 128k with header)
                 )
                 logger.debug(
-                    f"Setting max_output_tokens to {self.max_output_tokens} "
+                    f"Setting effective max_output_tokens to "
+                    f"{effective_max_output_tokens} "
                     f"for {self.model}"
                 )
             elif self._model_info is not None:
                 if isinstance(self._model_info.get("max_output_tokens"), int):
-                    self.max_output_tokens = self._model_info.get("max_output_tokens")
+                    effective_max_output_tokens = self._model_info.get(
+                        "max_output_tokens"
+                    )
                     # Guard: if max_output_tokens >= the context window,
                     # requesting that many output tokens would leave zero
                     # room for input and strict providers (e.g. AWS Bedrock)
@@ -1258,32 +1268,33 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     # headroom. We check both max_input_tokens and
                     # max_tokens since either may represent the context
                     # window depending on the provider.
-                    context_window = self.max_input_tokens or self._model_info.get(
-                        "max_tokens"
+                    context_window = (
+                        self.effective_max_input_tokens
+                        or self._model_info.get("max_tokens")
                     )
                     if (
                         context_window is not None
-                        and self.max_output_tokens is not None
-                        and self.max_output_tokens >= context_window
+                        and effective_max_output_tokens is not None
+                        and effective_max_output_tokens >= context_window
                     ):
-                        capped = self.max_output_tokens // 2
+                        capped = effective_max_output_tokens // 2
                         logger.debug(
                             "Capping max_output_tokens from %s to %s "
                             "for %s (max_output_tokens >= context "
                             "window %s)",
-                            self.max_output_tokens,
+                            effective_max_output_tokens,
                             capped,
                             self.model,
                             context_window,
                         )
-                        self.max_output_tokens = capped
+                        effective_max_output_tokens = capped
                 elif isinstance(self._model_info.get("max_tokens"), int):
                     # 'max_tokens' is ambiguous: some providers use it for total
                     # context window, not output limit. Cap it to avoid requesting
                     # output that exceeds the context window.
                     max_tokens_value = self._model_info.get("max_tokens")
                     assert isinstance(max_tokens_value, int)  # for type checker
-                    self.max_output_tokens = min(
+                    effective_max_output_tokens = min(
                         max_tokens_value, DEFAULT_MAX_OUTPUT_TOKENS_CAP
                     )
                     if max_tokens_value > DEFAULT_MAX_OUTPUT_TOKENS_CAP:
@@ -1291,19 +1302,24 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                             "Capping max_output_tokens from %s to %s for %s "
                             "(max_tokens may be context window, not output)",
                             max_tokens_value,
-                            self.max_output_tokens,
+                            effective_max_output_tokens,
                             self.model,
                         )
 
         if "o3" in self.model:
             o3_limit = 100000
-            if self.max_output_tokens is None or self.max_output_tokens > o3_limit:
-                self.max_output_tokens = o3_limit
+            if (
+                effective_max_output_tokens is None
+                or effective_max_output_tokens > o3_limit
+            ):
+                effective_max_output_tokens = o3_limit
                 logger.debug(
-                    "Clamping max_output_tokens to %s for %s",
-                    self.max_output_tokens,
+                    "Clamping effective max_output_tokens to %s for %s",
+                    effective_max_output_tokens,
                     self.model,
                 )
+
+        self._effective_max_output_tokens = effective_max_output_tokens
 
     def _validate_context_window_size(self) -> None:
         """Validate that the context window is large enough for OpenHands."""
@@ -1316,13 +1332,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             return
 
         # Unknown context window - cannot validate
-        if self.max_input_tokens is None:
+        if self.effective_max_input_tokens is None:
             return
 
         # Check minimum requirement
-        if self.max_input_tokens < MIN_CONTEXT_WINDOW_TOKENS:
+        if self.effective_max_input_tokens < MIN_CONTEXT_WINDOW_TOKENS:
             raise LLMContextWindowTooSmallError(
-                self.max_input_tokens, MIN_CONTEXT_WINDOW_TOKENS
+                self.effective_max_input_tokens, MIN_CONTEXT_WINDOW_TOKENS
             )
 
     def vision_is_active(self) -> bool:
@@ -1379,6 +1395,24 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def model_info(self) -> dict | None:
         """Returns the model info dictionary."""
         return self._model_info
+
+    @property
+    def effective_max_input_tokens(self) -> int | None:
+        """Resolved context window used at runtime.
+
+        ``max_input_tokens`` remains the user-configured value. When it is
+        unset, this property reflects the value discovered from model metadata.
+        """
+        return self.max_input_tokens or self._effective_max_input_tokens
+
+    @property
+    def effective_max_output_tokens(self) -> int | None:
+        """Resolved output token limit used at runtime.
+
+        ``max_output_tokens`` remains the user-configured value. When it is
+        unset, this property reflects provider/model defaults and safety caps.
+        """
+        return self.max_output_tokens or self._effective_max_output_tokens
 
     # =========================================================================
     # Utilities preserved from previous class

--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -14,12 +14,13 @@ def select_chat_options(
     This keeps the exact provider-aware mappings and precedence.
     """
     # First pass: apply simple defaults without touching user-supplied values
+    max_output_tokens = llm.effective_max_output_tokens
     defaults: dict[str, Any] = {
         "top_k": llm.top_k,
         "top_p": llm.top_p,
         "temperature": llm.temperature,
         # OpenAI-compatible param is `max_completion_tokens`
-        "max_completion_tokens": llm.max_output_tokens,
+        "max_completion_tokens": max_output_tokens,
     }
     out = apply_defaults_if_absent(user_kwargs, defaults)
 
@@ -47,10 +48,13 @@ def select_chat_options(
 
     # Extended thinking models
     if get_features(llm.model).supports_extended_thinking:
-        if llm.extended_thinking_budget:
+        if llm.extended_thinking_budget and max_output_tokens:
             # Anthropic throws errors if thinking budget equals or exceeds max output
             # tokens -- force the thinking budget lower if there's a conflict
-            budget_tokens = min(llm.extended_thinking_budget, llm.max_output_tokens - 1)
+            budget_tokens = min(
+                llm.extended_thinking_budget,
+                max_output_tokens - 1,
+            )
             out["thinking"] = {
                 "type": "enabled",
                 "budget_tokens": budget_tokens,
@@ -63,7 +67,7 @@ def select_chat_options(
                 **existing,
             }
             # Fix litellm behavior
-            out["max_tokens"] = llm.max_output_tokens
+            out["max_tokens"] = max_output_tokens
         # Anthropic models ignore temp/top_p
         out.pop("temperature", None)
         out.pop("top_p", None)

--- a/openhands-sdk/openhands/sdk/llm/options/responses_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/responses_options.py
@@ -18,7 +18,7 @@ def select_responses_options(
     # Note: max_output_tokens is not supported in subscription mode
     defaults = {}
     if not llm.is_subscription:
-        defaults["max_output_tokens"] = llm.max_output_tokens
+        defaults["max_output_tokens"] = llm.effective_max_output_tokens
     out = apply_defaults_if_absent(user_kwargs, defaults)
 
     # Enforce sampling/tool behavior for Responses path

--- a/openhands-sdk/openhands/sdk/llm/router/impl/multimodal.py
+++ b/openhands-sdk/openhands/sdk/llm/router/impl/multimodal.py
@@ -44,11 +44,12 @@ class MultimodalRouter(RouterLLM):
         # compared to the primary model
         secondary_llm = self.llms_for_routing.get(self.SECONDARY_MODEL_KEY)
         if secondary_llm and (
-            secondary_llm.max_input_tokens
-            and secondary_llm.get_token_count(messages) > secondary_llm.max_input_tokens
+            secondary_llm.effective_max_input_tokens
+            and secondary_llm.get_token_count(messages)
+            > secondary_llm.effective_max_input_tokens
         ):
             logger.warning(
-                f"Messages having {secondary_llm.get_token_count(messages)} tokens, exceeded secondary model's max input tokens ({secondary_llm.max_input_tokens} tokens). "  # noqa: E501
+                f"Messages having {secondary_llm.get_token_count(messages)} tokens, exceeded secondary model's max input tokens ({secondary_llm.effective_max_input_tokens} tokens). "  # noqa: E501
                 "Routing to the primary model."
             )
             route_to_primary = True

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -23,8 +23,10 @@ def test_llm_config_defaults():
     assert config.temperature is None  # None to use provider defaults
     assert config.top_p is None  # None to use provider defaults
     assert config.top_k is None
-    assert config.max_input_tokens == 128000  # Auto-populated from model info
-    assert config.max_output_tokens == 16384  # Auto-populated from model info
+    assert config.max_input_tokens is None  # None means use discovered value
+    assert config.max_output_tokens is None  # None means use discovered value
+    assert config.effective_max_input_tokens == 128000
+    assert config.effective_max_output_tokens == 16384
     assert config.input_cost_per_token is None
     assert config.output_cost_per_token is None
     assert config.ollama_base_url is None
@@ -340,12 +342,10 @@ def test_llm_config_optional_fields():
     assert config.aws_region_name is None
     assert config.timeout is None
     assert config.top_k is None
-    assert (
-        config.max_input_tokens == 128000
-    )  # Auto-populated from model info even when set to None
-    assert (
-        config.max_output_tokens == 16384
-    )  # Auto-populated from model info even when set to None
+    assert config.max_input_tokens is None
+    assert config.max_output_tokens is None
+    assert config.effective_max_input_tokens == 128000
+    assert config.effective_max_output_tokens == 16384
     assert config.input_cost_per_token is None
     assert config.output_cost_per_token is None
     assert config.ollama_base_url is None

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -20,6 +20,10 @@ class DummyLLM:
     prompt_cache_retention: str | None = "24h"
     _prompt_cache_key: str | None = None
 
+    @property
+    def effective_max_output_tokens(self) -> int:
+        return self.max_output_tokens
+
 
 def test_opus_4_5_uses_reasoning_effort_and_strips_temp_top_p():
     llm = DummyLLM(

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1017,7 +1017,8 @@ def test_llm_respects_allow_short_context_windows_env_var(mock_get_model_info):
             api_key=SecretStr("test-key"),
             usage_id="test-llm",
         )
-        assert llm.max_input_tokens == 2048
+        assert llm.max_input_tokens is None
+        assert llm.effective_max_input_tokens == 2048
 
 
 # LLM model_copy Tests
@@ -1230,10 +1231,12 @@ def test_max_output_tokens_capped_when_using_max_tokens_fallback(mock_get_model_
         usage_id="test-llm",
     )
 
-    # max_output_tokens should be capped, not set to 200000
-    assert llm.max_output_tokens is not None
-    assert llm.max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS_CAP
-    assert llm.max_output_tokens < 200000
+    # Config remains unset; the effective runtime value is capped.
+    assert llm.max_output_tokens is None
+    effective_max_output_tokens = llm.effective_max_output_tokens
+    assert effective_max_output_tokens is not None
+    assert effective_max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS_CAP
+    assert effective_max_output_tokens < 200000
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
@@ -1252,8 +1255,9 @@ def test_max_output_tokens_uses_actual_value_when_available(mock_get_model_info)
         usage_id="test-llm",
     )
 
-    # Should use the actual max_output_tokens, not capped
-    assert llm.max_output_tokens == 8192
+    # Should use the actual effective max_output_tokens, not capped
+    assert llm.max_output_tokens is None
+    assert llm.effective_max_output_tokens == 8192
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
@@ -1274,9 +1278,10 @@ def test_max_output_tokens_small_max_tokens_not_capped(mock_get_model_info):
         usage_id="test-llm",
     )
 
-    # Should use the actual value since it's below the cap
-    assert llm.max_output_tokens == 4096
-    assert llm.max_output_tokens < DEFAULT_MAX_OUTPUT_TOKENS_CAP
+    # Should use the actual effective value since it's below the cap
+    assert llm.max_output_tokens is None
+    assert llm.effective_max_output_tokens == 4096
+    assert llm.effective_max_output_tokens < DEFAULT_MAX_OUTPUT_TOKENS_CAP
 
 
 def test_explicit_max_output_tokens_not_overridden():
@@ -1290,6 +1295,7 @@ def test_explicit_max_output_tokens_not_overridden():
 
     # Should respect the explicit value
     assert llm.max_output_tokens == 32768
+    assert llm.effective_max_output_tokens == 32768
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
@@ -1312,8 +1318,10 @@ def test_max_output_tokens_capped_when_equal_to_context_window(
         usage_id="test-llm",
     )
 
-    assert llm.max_output_tokens == 262144 // 2
-    assert llm.max_input_tokens == 262144
+    assert llm.max_output_tokens is None
+    assert llm.effective_max_output_tokens == 262144 // 2
+    assert llm.max_input_tokens is None
+    assert llm.effective_max_input_tokens == 262144
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
@@ -1337,7 +1345,8 @@ def test_max_output_tokens_capped_when_equal_to_max_tokens(
         usage_id="test-llm",
     )
 
-    assert llm.max_output_tokens == 131072 // 2
+    assert llm.max_output_tokens is None
+    assert llm.effective_max_output_tokens == 131072 // 2
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
@@ -1356,7 +1365,8 @@ def test_max_output_tokens_not_capped_when_below_context_window(
         usage_id="test-llm",
     )
 
-    assert llm.max_output_tokens == 8192
+    assert llm.max_output_tokens is None
+    assert llm.effective_max_output_tokens == 8192
 
 
 # LLM Registry Tests

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -90,6 +90,8 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
 
     assert llm_fields["llm.model"].value_type == "string"
     assert llm_fields["llm.model"].prominence is SettingProminence.CRITICAL
+    assert llm_fields["llm.max_input_tokens"].default is None
+    assert llm_fields["llm.max_output_tokens"].default is None
     assert llm_fields["llm.api_key"].label == "API Key"
     assert llm_fields["llm.api_key"].secret is True
     assert llm_fields["llm.api_key"].prominence is SettingProminence.CRITICAL


### PR DESCRIPTION
## Summary
- Keep `LLM.max_input_tokens` and `LLM.max_output_tokens` as user-configured settings instead of mutating them with discovered model metadata
- Add `effective_max_input_tokens` / `effective_max_output_tokens` for runtime validation, telemetry, routing, and request option defaults
- Update tests so configured token fields remain `None` when unset, while effective fields contain discovered runtime limits

## Tests
- `uv run pytest tests/sdk/llm/test_llm.py tests/sdk/llm/test_chat_options.py tests/sdk/llm/test_responses_parsing_and_kwargs.py tests/sdk/llm/test_subscription_mode.py tests/sdk/config/test_llm_config.py tests/sdk/test_settings.py::test_llm_agent_settings_export_schema_groups_sections`
- `uv run ruff format ... && uv run ruff check ...` on touched files
- `uv run pyright ...` on touched files

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4f9d51f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4f9d51f-python \
  ghcr.io/openhands/agent-server:4f9d51f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4f9d51f-golang-amd64
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-golang-amd64
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-golang-amd64
ghcr.io/openhands/agent-server:4f9d51f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4f9d51f-golang-arm64
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-golang-arm64
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-golang-arm64
ghcr.io/openhands/agent-server:4f9d51f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4f9d51f-java-amd64
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-java-amd64
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-java-amd64
ghcr.io/openhands/agent-server:4f9d51f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4f9d51f-java-arm64
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-java-arm64
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-java-arm64
ghcr.io/openhands/agent-server:4f9d51f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4f9d51f-python-amd64
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-python-amd64
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-python-amd64
ghcr.io/openhands/agent-server:4f9d51f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4f9d51f-python-arm64
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-python-arm64
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-python-arm64
ghcr.io/openhands/agent-server:4f9d51f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4f9d51f-golang
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-golang
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-golang
ghcr.io/openhands/agent-server:4f9d51f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4f9d51f-java
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-java
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-java
ghcr.io/openhands/agent-server:4f9d51f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4f9d51f-python
ghcr.io/openhands/agent-server:4f9d51f4fae2d1b36daf140d4ff0fdf66fb35469-python
ghcr.io/openhands/agent-server:codex-reset-llm-token-limits-on-model-change-python
ghcr.io/openhands/agent-server:4f9d51f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4f9d51f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4f9d51f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->