### PR TITLE
fix(llm): stop bleeding LLM credentials through os.environ (#3138)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -504,24 +504,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         return d
 
     @model_validator(mode="after")
-    def _set_env_side_effects(self):
-        if self.openrouter_site_url:
-            os.environ["OR_SITE_URL"] = self.openrouter_site_url
-        if self.openrouter_app_name:
-            os.environ["OR_APP_NAME"] = self.openrouter_app_name
-        if self.aws_access_key_id:
-            assert isinstance(self.aws_access_key_id, SecretStr)
-            os.environ["AWS_ACCESS_KEY_ID"] = self.aws_access_key_id.get_secret_value()
-        if self.aws_secret_access_key:
-            assert isinstance(self.aws_secret_access_key, SecretStr)
-            os.environ["AWS_SECRET_ACCESS_KEY"] = (
-                self.aws_secret_access_key.get_secret_value()
-            )
-        if self.aws_session_token:
-            assert isinstance(self.aws_session_token, SecretStr)
-            os.environ["AWS_SESSION_TOKEN"] = self.aws_session_token.get_secret_value()
-        if self.aws_region_name:
-            os.environ["AWS_REGION_NAME"] = self.aws_region_name
+    def _post_init(self):
+        # NOTE: AWS credentials and OpenRouter site/app identifiers are NOT
+        # written to ``os.environ`` here. Doing so in a multi-tenant agent
+        # server would let one conversation's credentials bleed into another
+        # via the shared process environment (see issue #3138). Instead,
+        # AWS credentials flow per-call through ``_aws_kwargs()`` and the
+        # OpenRouter ``HTTP-Referer`` / ``X-Title`` headers flow per-call
+        # through ``_openrouter_headers()``.
 
         # Metrics + Telemetry wiring. Guard both: this validator re-runs whenever
         # the LLM is passed into another Pydantic model (e.g. RegistryEvent),
@@ -553,6 +543,21 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             f"temperature={self.temperature}"
         )
         return self
+
+    def _openrouter_headers(self) -> dict[str, str]:
+        """Build OpenRouter HTTP-Referer / X-Title headers for per-call use.
+
+        Returns an empty dict when neither field is set. Passed via
+        ``extra_headers`` so litellm forwards them on the OpenRouter request
+        without us having to mutate ``os.environ`` (which would leak across
+        conversations in a multi-tenant server; see issue #3138).
+        """
+        headers: dict[str, str] = {}
+        if self.openrouter_site_url:
+            headers["HTTP-Referer"] = self.openrouter_site_url
+        if self.openrouter_app_name:
+            headers["X-Title"] = self.openrouter_app_name
+        return headers
 
     def _aws_kwargs(self) -> dict[str, str]:
         """Build kwargs dict for AWS params to pass to litellm calls."""

--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -32,6 +32,14 @@ def select_chat_options(
     if llm.extra_headers is not None and "extra_headers" not in out:
         out["extra_headers"] = dict(llm.extra_headers)
 
+    # Inject OpenRouter HTTP-Referer / X-Title via extra_headers so we don't
+    # have to mutate os.environ (which would leak across conversations in a
+    # multi-tenant server; see issue #3138). User-supplied headers win.
+    openrouter_headers = llm._openrouter_headers()
+    if openrouter_headers:
+        existing = out.get("extra_headers") or {}
+        out["extra_headers"] = {**openrouter_headers, **existing}
+
     # Reasoning-model quirks
     supports_reasoning_effort = get_features(llm.model).supports_reasoning_effort
     if supports_reasoning_effort:

--- a/openhands-sdk/openhands/sdk/llm/options/responses_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/responses_options.py
@@ -31,6 +31,14 @@ def select_responses_options(
     if llm.extra_headers is not None and "extra_headers" not in out:
         out["extra_headers"] = dict(llm.extra_headers)
 
+    # Inject OpenRouter HTTP-Referer / X-Title via extra_headers so we don't
+    # have to mutate os.environ (which would leak across conversations in a
+    # multi-tenant server; see issue #3138). User-supplied headers win.
+    openrouter_headers = llm._openrouter_headers()
+    if openrouter_headers:
+        existing = out.get("extra_headers") or {}
+        out["extra_headers"] = {**openrouter_headers, **existing}
+
     # Store defaults to False (stateless) unless explicitly provided
     if store is not None:
         out["store"] = bool(store)

--- a/tests/sdk/config/test_llm_config.py
+++ b/tests/sdk/config/test_llm_config.py
@@ -143,17 +143,29 @@ def test_llm_config_openrouter_defaults():
     assert config.openrouter_app_name == "OpenHands"
 
 
-def test_llm_config_post_init_openrouter_env_vars():
-    """Test that OpenRouter environment variables are set in post_init."""
+def test_llm_config_post_init_openrouter_does_not_set_env():
+    """OpenRouter site/app must NOT bleed into os.environ.
+
+    Constructing an LLM (potentially per-conversation in a multi-tenant
+    agent server) used to set ``OR_SITE_URL`` / ``OR_APP_NAME``, which
+    leaks across conversations via the shared process environment
+    (issue #3138). The values should now flow per-call via
+    ``extra_headers`` instead.
+    """
     with patch.dict(os.environ, {}, clear=True):
-        LLM(
+        llm = LLM(
             model="gpt-4o-mini",
             openrouter_site_url="https://custom.site.com",
             openrouter_app_name="CustomApp",
             usage_id="test-llm",
         )
-        assert os.environ.get("OR_SITE_URL") == "https://custom.site.com"
-        assert os.environ.get("OR_APP_NAME") == "CustomApp"
+        assert "OR_SITE_URL" not in os.environ
+        assert "OR_APP_NAME" not in os.environ
+        # Values still travel through the per-call helper.
+        assert llm._openrouter_headers() == {
+            "HTTP-Referer": "https://custom.site.com",
+            "X-Title": "CustomApp",
+        }
 
 
 def test_llm_config_post_init_reasoning_effort_default():
@@ -188,19 +200,29 @@ def test_llm_config_post_init_azure_api_version():
     assert config.api_version == "custom-version"
 
 
-def test_llm_config_post_init_aws_env_vars():
-    """Test that AWS credentials are set as environment variables."""
+def test_llm_config_post_init_aws_does_not_set_env():
+    """AWS credentials must NOT be written to os.environ on init.
+
+    Doing so would leak credentials across conversations in a multi-tenant
+    agent server (issue #3138). They are forwarded per-call via
+    ``_aws_kwargs()`` instead.
+    """
     with patch.dict(os.environ, {}, clear=True):
-        LLM(
+        llm = LLM(
             usage_id="test-llm",
             model="gpt-4o-mini",
             aws_access_key_id=SecretStr("test-access-key"),
             aws_secret_access_key=SecretStr("test-secret-key"),
             aws_region_name="us-west-2",
         )
-        assert os.environ.get("AWS_ACCESS_KEY_ID") == "test-access-key"
-        assert os.environ.get("AWS_SECRET_ACCESS_KEY") == "test-secret-key"
-        assert os.environ.get("AWS_REGION_NAME") == "us-west-2"
+        assert "AWS_ACCESS_KEY_ID" not in os.environ
+        assert "AWS_SECRET_ACCESS_KEY" not in os.environ
+        assert "AWS_REGION_NAME" not in os.environ
+        # Values still travel through the per-call helper.
+        kw = llm._aws_kwargs()
+        assert kw["aws_access_key_id"] == "test-access-key"
+        assert kw["aws_secret_access_key"] == "test-secret-key"
+        assert kw["aws_region_name"] == "us-west-2"
 
 
 def test_llm_config_log_completions_folder_default():

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -56,7 +56,7 @@ def mock_llm() -> LLM:
     )
     mock_llm.format_messages_for_llm = lambda messages: messages
 
-    # Mock the required attributes that are checked in _set_env_side_effects
+    # Mock the required attributes that the LLM validator reads
     mock_llm.openrouter_site_url = "https://docs.all-hands.dev/"
     mock_llm.openrouter_app_name = "OpenHands"
     mock_llm.aws_access_key_id = None

--- a/tests/sdk/llm/test_api_key_validation.py
+++ b/tests/sdk/llm/test_api_key_validation.py
@@ -248,8 +248,14 @@ def test_aws_bedrock_params_forwarded_to_litellm():
         assert kw["aws_bedrock_runtime_endpoint"] == "https://my-proxy.example.com"
 
 
-def test_aws_env_vars_set_on_init(monkeypatch):
-    """Verify pre-existing AWS env vars are still set for backward compatibility."""
+def test_aws_env_vars_not_leaked_on_init(monkeypatch):
+    """Constructing an LLM with AWS creds must not bleed into os.environ.
+
+    Writing credentials into the process environment would let one
+    conversation's credentials be picked up by another in a multi-tenant
+    agent server (issue #3138). They must flow per-call via
+    ``_aws_kwargs()`` instead.
+    """
     for k in [
         "AWS_ACCESS_KEY_ID",
         "AWS_SECRET_ACCESS_KEY",
@@ -268,10 +274,10 @@ def test_aws_env_vars_set_on_init(monkeypatch):
         aws_region_name="us-west-2",
     )
 
-    assert os.environ["AWS_ACCESS_KEY_ID"] == "AKID"
-    assert os.environ["AWS_SECRET_ACCESS_KEY"] == "SECRET"
-    assert os.environ["AWS_SESSION_TOKEN"] == "TOKEN"
-    assert os.environ["AWS_REGION_NAME"] == "us-west-2"
+    assert "AWS_ACCESS_KEY_ID" not in os.environ
+    assert "AWS_SECRET_ACCESS_KEY" not in os.environ
+    assert "AWS_SESSION_TOKEN" not in os.environ
+    assert "AWS_REGION_NAME" not in os.environ
 
 
 def test_aws_kwargs_returns_all_params():

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -19,6 +19,16 @@ class DummyLLM:
     # Align with LLM default; only emitted for models that support it
     prompt_cache_retention: str | None = "24h"
     _prompt_cache_key: str | None = None
+    openrouter_site_url: str = ""
+    openrouter_app_name: str = ""
+
+    def _openrouter_headers(self) -> dict[str, str]:
+        headers: dict[str, str] = {}
+        if self.openrouter_site_url:
+            headers["HTTP-Referer"] = self.openrouter_site_url
+        if self.openrouter_app_name:
+            headers["X-Title"] = self.openrouter_app_name
+        return headers
 
 
 def test_opus_4_5_uses_reasoning_effort_and_strips_temp_top_p():
@@ -196,3 +206,36 @@ def test_chat_options_omits_prompt_cache_key_when_unset():
     assert "prompt_cache_key" not in select_chat_options(
         llm, user_kwargs={}, has_tools=True
     )
+
+
+def test_chat_options_injects_openrouter_headers_via_extra_headers():
+    """OpenRouter site/app must flow per-call (issue #3138), not via env."""
+    llm = DummyLLM(
+        model="openrouter/anthropic/claude-3-5-sonnet",
+        openrouter_site_url="https://app.example.com/",
+        openrouter_app_name="ExampleApp",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=False)
+    assert out["extra_headers"]["HTTP-Referer"] == "https://app.example.com/"
+    assert out["extra_headers"]["X-Title"] == "ExampleApp"
+
+
+def test_chat_options_user_extra_headers_win_over_openrouter_defaults():
+    """User-supplied extra_headers must override per-call OpenRouter values."""
+    llm = DummyLLM(
+        model="openrouter/anthropic/claude-3-5-sonnet",
+        openrouter_site_url="https://app.example.com/",
+        openrouter_app_name="ExampleApp",
+        extra_headers={"X-Title": "UserOverride"},
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=False)
+    assert out["extra_headers"]["X-Title"] == "UserOverride"
+    # Site URL still injected since user didn't override it
+    assert out["extra_headers"]["HTTP-Referer"] == "https://app.example.com/"
+
+
+def test_chat_options_omits_openrouter_headers_when_unset():
+    """Empty site/app must not add extra_headers."""
+    llm = DummyLLM(model="gpt-4o")
+    out = select_chat_options(llm, user_kwargs={}, has_tools=False)
+    assert "extra_headers" not in out

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -338,8 +338,11 @@ def test_llm_forwards_extra_headers_to_litellm(mock_completion):
 
     assert mock_completion.call_count == 1
     _, kwargs = mock_completion.call_args
-    # extra_headers forwarded either directly or inside **kwargs
-    assert kwargs.get("extra_headers") == headers
+    # User-supplied extra_headers must reach litellm. The LLM may also inject
+    # OpenRouter HTTP-Referer / X-Title defaults (issue #3138), so only assert
+    # the user's headers are a subset of the forwarded dict.
+    forwarded = kwargs.get("extra_headers") or {}
+    assert headers.items() <= forwarded.items()
 
 
 @patch("openhands.sdk.llm.llm.litellm_responses")
@@ -386,7 +389,9 @@ def test_llm_responses_forwards_extra_headers_to_litellm(mock_responses):
 
     assert mock_responses.call_count == 1
     _, kwargs = mock_responses.call_args
-    assert kwargs.get("extra_headers") == headers
+    # See test_llm_forwards_extra_headers_to_litellm for the same rationale.
+    forwarded = kwargs.get("extra_headers") or {}
+    assert headers.items() <= forwarded.items()
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")


### PR DESCRIPTION
## Summary

Fixes #3138 (sub-issue of the tracking issue #3153).

`LLM`'s `model_validator` wrote AWS credentials (`AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION_NAME`) and OpenRouter identifiers (`OR_SITE_URL`, `OR_APP_NAME`) directly into `os.environ`. In a multi-tenant agent server one conversation's credentials were therefore visible to every other conversation in the same process — and the last `LLM` constructed silently won. Combined with the `litellm.modify_params` global-state race tracked in #3137, this could even cause a conversation to use another tenant's credentials.

This change removes the `os.environ` writes from the LLM validator and replaces them with per-call flow:

- **AWS credentials**: already passed per-call via `LLM._aws_kwargs()` into both `litellm_completion(...)` (chat path) and `litellm_responses(...)` (responses path). No new wiring needed — just stop writing the env vars.
- **OpenRouter `HTTP-Referer` / `X-Title`**: a new `LLM._openrouter_headers()` helper builds them from `openrouter_site_url` / `openrouter_app_name`. `select_chat_options` and `select_responses_options` merge them into `extra_headers` so litellm forwards them on each request. User-supplied `extra_headers` still win on conflicts.

The validator is renamed from `_set_env_side_effects` to `_post_init` to reflect that it no longer mutates the environment — it only wires up `Metrics` / `Telemetry` / tokenizer.

## Why this is safe

- `litellm`'s OpenRouter handler already merges user-supplied headers on top of the `OR_SITE_URL` / `OR_APP_NAME` env-derived defaults (`litellm/main.py` around the `custom_llm_provider == "openrouter"` block), so passing them via `extra_headers` matches the previous behavior bit-for-bit when both LLMs in a process agreed on these values.
- AWS credentials have been per-call-passable since `_aws_kwargs()` was added, and `_aws_kwargs()` is already spread into both `litellm_completion(...)` and `litellm_responses(...)`.
- No public Pydantic field signatures change, so this is a non-breaking SDK change.

## Tests

- Rewrote `test_aws_env_vars_set_on_init` → `test_aws_env_vars_not_leaked_on_init` to assert the opposite contract: constructing an LLM with AWS creds must **not** populate `os.environ`. Same for the OpenRouter and AWS variants in `tests/sdk/config/test_llm_config.py`.
- Added `test_chat_options_injects_openrouter_headers_via_extra_headers`, `test_chat_options_user_extra_headers_win_over_openrouter_defaults`, and `test_chat_options_omits_openrouter_headers_when_unset` in `tests/sdk/llm/test_chat_options.py` to lock in the new contract.
- Relaxed the two `test_llm_forwards_extra_headers_to_litellm*` tests in `tests/sdk/llm/test_llm.py` from equality to "user headers ⊆ forwarded headers", because the LLM now injects OpenRouter defaults alongside whatever the caller supplied.
- All 812 tests in `tests/sdk/llm/`, `tests/sdk/config/`, and `tests/sdk/context/condenser/` pass; pre-commit (ruff, pyright, …) is clean.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user, resolving sub-issue #3138 from the #3153 profiling investigation tracking issue._

@csmith49 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bca07e23-9bda-497d-9b97-2396685e1c5b)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6c5a435-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6c5a435-python \
  ghcr.io/openhands/agent-server:6c5a435-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6c5a435-golang-amd64
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-golang-amd64
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-golang-amd64
ghcr.io/openhands/agent-server:6c5a435-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6c5a435-golang-arm64
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-golang-arm64
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-golang-arm64
ghcr.io/openhands/agent-server:6c5a435-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6c5a435-java-amd64
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-java-amd64
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-java-amd64
ghcr.io/openhands/agent-server:6c5a435-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6c5a435-java-arm64
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-java-arm64
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-java-arm64
ghcr.io/openhands/agent-server:6c5a435-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6c5a435-python-amd64
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-python-amd64
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-python-amd64
ghcr.io/openhands/agent-server:6c5a435-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6c5a435-python-arm64
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-python-arm64
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-python-arm64
ghcr.io/openhands/agent-server:6c5a435-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6c5a435-golang
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-golang
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-golang
ghcr.io/openhands/agent-server:6c5a435-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6c5a435-java
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-java
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-java
ghcr.io/openhands/agent-server:6c5a435-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6c5a435-python
ghcr.io/openhands/agent-server:6c5a4358409642211e649426d7e2b7e3d4206371-python
ghcr.io/openhands/agent-server:fix-3138-osenviron-credential-bleed-python
ghcr.io/openhands/agent-server:6c5a435-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6c5a435-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6c5a435-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->