### PR TITLE
test: cover agent_settings conversation start defaults

### DIFF
--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -25,6 +25,8 @@ from openhands.agent_server.utils import utc_now
 from openhands.sdk import LLM, Agent, TextContent, Tool
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.llm import llm_profile_store
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.workspace import LocalWorkspace
 
@@ -604,6 +606,64 @@ def test_start_conversation_accepts_openhands_agent_settings(
         assert request.agent.kind == "Agent"
         assert request.agent.llm.model == "settings-model"
         assert "agent_settings" not in request.model_dump(mode="json")
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_start_conversation_agent_settings_uses_sdk_default_tools(
+    client, mock_conversation_service, monkeypatch, tmp_path
+):
+    profile_dir = tmp_path / "profiles"
+    profile_dir.mkdir()
+    monkeypatch.setattr(llm_profile_store, "_DEFAULT_PROFILE_DIR", profile_dir)
+    LLMProfileStore(base_dir=profile_dir).save(
+        "fast", LLM(model="fast-model", usage_id="fast")
+    )
+
+    now = utc_now()
+    info = ConversationInfo(
+        id=uuid4(),
+        agent=Agent(llm=LLM(model="settings-model", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir="/tmp/test"),
+        execution_status=ConversationExecutionStatus.IDLE,
+        title="Settings Conversation",
+        created_at=now,
+        updated_at=now,
+    )
+    mock_conversation_service.start_conversation.return_value = (info, True)
+    client.app.dependency_overrides[get_conversation_service] = (
+        lambda: mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            "/api/conversations",
+            json={
+                "agent_settings": {
+                    "schema_version": 1,
+                    "agent_kind": "llm",
+                    "llm": {"model": "settings-model", "usage_id": "test-llm"},
+                    "enable_switch_llm_tool": True,
+                    "tools": [
+                        {"name": "terminal", "params": {}},
+                        {"name": "file_editor", "params": {}},
+                        {"name": "task_tracker", "params": {}},
+                        {"name": "browser_tool_set", "params": {}},
+                    ],
+                },
+                "workspace": {"working_dir": "/tmp/test"},
+            },
+        )
+
+        assert response.status_code == 201
+        request = mock_conversation_service.start_conversation.call_args.args[0]
+        assert "SwitchLLMTool" in request.agent.include_default_tools
+        assert {tool.name for tool in request.agent.tools} == {
+            "terminal",
+            "file_editor",
+            "task_tracker",
+            "browser_tool_set",
+        }
     finally:
         client.app.dependency_overrides.clear()
 


### PR DESCRIPTION
## Summary

- add a route-level regression for starting a conversation with `agent_settings` and no concrete `agent`
- verify the server request model delegates to SDK `create_agent()` so SDK default tools, including `SwitchLLMTool` when profiles exist, are present
- verify explicitly supplied runtime tools survive the `agent_settings` path

## Verification

- `uv run pytest tests/agent_server/test_conversation_router.py -k agent_settings`

## Context

Agent Canvas should send `agent_settings` instead of pre-building a concrete `agent`, so the agent server SDK can own `create_agent()` behavior. The currently published PyPI `openhands-agent-server==1.22.0` rejects this payload shape at runtime, while main accepts it. This test locks the intended release behavior before the frontend switches over.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3f42bb8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3f42bb8-python \
  ghcr.io/openhands/agent-server:3f42bb8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3f42bb8-golang-amd64
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-golang-amd64
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-golang-amd64
ghcr.io/openhands/agent-server:3f42bb8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3f42bb8-golang-arm64
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-golang-arm64
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-golang-arm64
ghcr.io/openhands/agent-server:3f42bb8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3f42bb8-java-amd64
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-java-amd64
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-java-amd64
ghcr.io/openhands/agent-server:3f42bb8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3f42bb8-java-arm64
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-java-arm64
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-java-arm64
ghcr.io/openhands/agent-server:3f42bb8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3f42bb8-python-amd64
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-python-amd64
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-python-amd64
ghcr.io/openhands/agent-server:3f42bb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3f42bb8-python-arm64
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-python-arm64
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-python-arm64
ghcr.io/openhands/agent-server:3f42bb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3f42bb8-golang
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-golang
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-golang
ghcr.io/openhands/agent-server:3f42bb8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3f42bb8-java
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-java
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-java
ghcr.io/openhands/agent-server:3f42bb8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3f42bb8-python
ghcr.io/openhands/agent-server:3f42bb88d40ee6b887c9f4620d70ac5ddb5f8df9-python
ghcr.io/openhands/agent-server:codex-agent-settings-switch-llm-regression-python
ghcr.io/openhands/agent-server:3f42bb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3f42bb8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3f42bb8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->