### PR TITLE
fix(version-bump-prs): update mypy pins and regenerate uv.lock on SDK bumps

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -287,10 +287,11 @@ jobs:
                   fi
 
                   echo "📝 Regenerating uv.lock..."
-                  # Pass --exclude-newer=now to override the 7-day freshness guardrail that
-                  # setup-uv writes into ~/.config/uv/uv.toml. A CLI flag takes precedence
-                  # over the config file, and "now" allows just-published packages through.
-                  uv lock --no-cache --exclude-newer "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+                  # --no-config bypasses ~/.config/uv/uv.toml where setup-uv writes its
+                  # 7-day freshness guardrail. Unlike --exclude-newer=<date>, it does not
+                  # bake a timestamp into uv.lock's [options] section (which would create
+                  # noise in every future bump PR).
+                  uv lock --no-cache --no-config
                   echo "✅ Updated uv.lock"
 
                   # 3. Update the version in sandbox_spec_service.py

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -287,9 +287,10 @@ jobs:
                   fi
 
                   echo "📝 Regenerating uv.lock..."
-                  # Unset UV_EXCLUDE_NEWER: setup-uv sets a 7-day freshness guardrail that
-                  # would reject just-published packages. This step intentionally consumes them.
-                  env -u UV_EXCLUDE_NEWER uv lock --no-cache
+                  # Pass --exclude-newer=now to override the 7-day freshness guardrail that
+                  # setup-uv writes into ~/.config/uv/uv.toml. A CLI flag takes precedence
+                  # over the config file, and "now" allows just-published packages through.
+                  uv lock --no-cache --exclude-newer "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
                   echo "✅ Updated uv.lock"
 
                   # 3. Update the version in sandbox_spec_service.py

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -289,7 +289,7 @@ jobs:
                   echo "📝 Regenerating uv.lock..."
                   # Unset UV_EXCLUDE_NEWER: setup-uv sets a 7-day freshness guardrail that
                   # would reject just-published packages. This step intentionally consumes them.
-                  UV_EXCLUDE_NEWER="" uv lock --no-cache
+                  env -u UV_EXCLUDE_NEWER uv lock --no-cache
                   echo "✅ Updated uv.lock"
 
                   # 3. Update the version in sandbox_spec_service.py

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -259,6 +259,10 @@ jobs:
                   sed -i -E 's/"openhands-tools==[^"]*"/"openhands-tools=='"$VERSION"'"/' pyproject.toml
                   sed -i -E 's/"openhands-agent-server==[^"]*"/"openhands-agent-server=='"$VERSION"'"/' pyproject.toml
 
+                  # Update mypy additional_dependencies pins so type-checking uses the same SDK version
+                  sed -i -E 's/"openhands-sdk==[^"]*"/"openhands-sdk=='"$VERSION"'"/' "$PYPROJECT_FMT_CONFIG"
+                  sed -i -E 's/"openhands-tools==[^"]*"/"openhands-tools=='"$VERSION"'"/' "$PYPROJECT_FMT_CONFIG"
+
                   echo "✅ Updated pyproject.toml"
 
                   # 2. Regenerate poetry.lock with the new versions
@@ -281,6 +285,10 @@ jobs:
                     (cd enterprise && poetry lock --no-cache)
                     echo "✅ Updated enterprise/poetry.lock"
                   fi
+
+                  echo "📝 Regenerating uv.lock..."
+                  uv lock --no-cache
+                  echo "✅ Updated uv.lock"
 
                   # 3. Update the version in sandbox_spec_service.py
                   echo "🔧 Updating AGENT_SERVER_IMAGE..."
@@ -306,7 +314,7 @@ jobs:
                   fi
 
                   # Commit and push
-                  git add pyproject.toml poetry.lock "$SANDBOX_SPEC_FILE" "$PYPROJECT_FMT_CONFIG"
+                  git add pyproject.toml poetry.lock uv.lock "$SANDBOX_SPEC_FILE" "$PYPROJECT_FMT_CONFIG"
                   if [ -f "enterprise/poetry.lock" ]; then
                     git add enterprise/poetry.lock
                   fi
@@ -317,7 +325,9 @@ jobs:
                     -m "- Updated SDK packages to v$VERSION with exact pins in pyproject.toml" \
                     -m "- Regenerated poetry.lock" \
                     -m "- Regenerated enterprise/poetry.lock to keep transitive SDK pins aligned" \
+                    -m "- Regenerated uv.lock" \
                     -m "- Updated AGENT_SERVER_IMAGE to ${VERSION}" \
+                    -m "- Updated mypy additional_dependencies pins in pre-commit config" \
                     -m "" \
                     -m "Co-authored-by: openhands <openhands@all-hands.dev>"
                   git push -u origin "$BRANCH"

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -352,7 +352,9 @@ jobs:
                   - Updated SDK packages in \`pyproject.toml\` with exact pins
                   - Regenerated \`poetry.lock\` with the target repo's Poetry version
                   - Regenerated \`enterprise/poetry.lock\` so its transitive SDK pins match the root
+                  - Regenerated \`uv.lock\` to match the updated SDK versions
                   - Updated \`AGENT_SERVER_IMAGE\` to \`${VERSION}\` in \`sandbox_spec_service.py\`
+                  - Updated mypy \`additional_dependencies\` pins in \`.pre-commit-config.yaml\`
 
                   **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
 

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -287,7 +287,9 @@ jobs:
                   fi
 
                   echo "📝 Regenerating uv.lock..."
-                  uv lock --no-cache
+                  # Unset UV_EXCLUDE_NEWER: setup-uv sets a 7-day freshness guardrail that
+                  # would reject just-published packages. This step intentionally consumes them.
+                  UV_EXCLUDE_NEWER="" uv lock --no-cache
                   echo "✅ Updated uv.lock"
 
                   # 3. Update the version in sandbox_spec_service.py


### PR DESCRIPTION
## Why

Each automated SDK bump PR to OpenHands required a manual follow-up commit to fix two gaps:

1. **Stale mypy pins** — `dev_config/python/.pre-commit-config.yaml` has `openhands-sdk==X` and `openhands-tools==X` in the mypy `additional_dependencies` block. These were never updated by the bot, so type-checking ran against an old SDK version.
2. **Stale `uv.lock`** — `uv.lock` was never regenerated, leaving it pinned to a version behind what `pyproject.toml` declared.

Observed in PR OpenHands/OpenHands#14424 where a manual second commit was needed to fix both.

## Changes

- Add two `sed` lines to update the `openhands-sdk` / `openhands-tools` version pins in the mypy `additional_dependencies` block of `.pre-commit-config.yaml`
- Add `uv lock --no-cache` after the poetry lock steps to regenerate `uv.lock`
- Add `uv.lock` to the `git add` in the automated commit

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a391c3e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a391c3e-python \
  ghcr.io/openhands/agent-server:a391c3e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a391c3e-golang-amd64
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-golang-amd64
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-golang-amd64
ghcr.io/openhands/agent-server:a391c3e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a391c3e-golang-arm64
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-golang-arm64
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-golang-arm64
ghcr.io/openhands/agent-server:a391c3e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a391c3e-java-amd64
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-java-amd64
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-java-amd64
ghcr.io/openhands/agent-server:a391c3e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a391c3e-java-arm64
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-java-arm64
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-java-arm64
ghcr.io/openhands/agent-server:a391c3e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a391c3e-python-amd64
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-python-amd64
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-python-amd64
ghcr.io/openhands/agent-server:a391c3e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a391c3e-python-arm64
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-python-arm64
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-python-arm64
ghcr.io/openhands/agent-server:a391c3e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a391c3e-golang
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-golang
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-golang
ghcr.io/openhands/agent-server:a391c3e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a391c3e-java
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-java
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-java
ghcr.io/openhands/agent-server:a391c3e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a391c3e-python
ghcr.io/openhands/agent-server:a391c3e1763fd2dee9305d20c7ba5f7b2330cd51-python
ghcr.io/openhands/agent-server:fix-version-bump-prs-gaps-python
ghcr.io/openhands/agent-server:a391c3e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a391c3e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a391c3e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->