### PR TITLE
Add conversation observability metadata

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -393,6 +393,10 @@ def _sanitize_validation_errors(errors: Sequence[Any]) -> list[dict]:
         error = dict(error)  # shallow copy so we don't mutate the original
         if "input" in error:
             error["input"] = sanitize_dict(error["input"])
+        if isinstance(error.get("ctx"), dict) and isinstance(
+            error["ctx"].get("error"), Exception
+        ):
+            error["ctx"] = {**error["ctx"], "error": str(error["ctx"]["error"])}
         sanitized.append(error)
     return sanitized
 

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -781,6 +781,8 @@ class EventService:
             hook_config=self.stored.hook_config,
             tags=self.stored.tags,
             user_id=self.stored.user_id,
+            observability_metadata=self.stored.observability_metadata,
+            observability_tags=self.stored.observability_tags,
         )
 
         conversation.set_confirmation_policy(self.stored.confirmation_policy)

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -10,6 +10,7 @@ from openhands.sdk.conversation.types import (
     ConversationCallbackType,
     ConversationID,
     ConversationTokenCallbackType,
+    TraceMetadataValue,
 )
 from openhands.sdk.llm.llm import LLM
 from openhands.sdk.llm.message import Message
@@ -128,13 +129,19 @@ class BaseConversation(ABC):
         self._observability_root_span: RootSpan | None = None
 
     def _start_observability_span(
-        self, session_id: str, user_id: str | None = None
+        self,
+        session_id: str,
+        user_id: str | None = None,
+        metadata: dict[str, TraceMetadataValue] | None = None,
+        tags: list[str] | None = None,
     ) -> None:
         """Start a per-conversation observability root span.
 
         Args:
             session_id: The session ID to associate with the trace
             user_id: Optional user ID to associate with the trace
+            metadata: Optional trace-level metadata to attach to observability backends
+            tags: Optional span tags to attach to the conversation root span
         """
         if not should_enable_observability():
             return
@@ -142,7 +149,11 @@ class BaseConversation(ABC):
             # Idempotent: never start two roots for one conversation.
             return
         self._observability_root_span = start_root_span(
-            "conversation", session_id=session_id, user_id=user_id
+            "conversation",
+            session_id=session_id,
+            user_id=user_id,
+            metadata=metadata,
+            tags=tags,
         )
 
     def _end_observability_span(self) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -9,6 +9,7 @@ from openhands.sdk.conversation.types import (
     ConversationID,
     ConversationTokenCallbackType,
     StuckDetectionThresholds,
+    TraceMetadataValue,
 )
 from openhands.sdk.conversation.visualizer import (
     ConversationVisualizerBase,
@@ -83,6 +84,8 @@ class Conversation:
         tags: dict[str, str] | None = None,
         user_id: str | None = None,
         client_tools: list[ClientToolSpec] | None = None,
+        observability_metadata: dict[str, TraceMetadataValue] | None = None,
+        observability_tags: list[str] | None = None,
     ) -> "LocalConversation": ...
 
     @overload
@@ -109,6 +112,8 @@ class Conversation:
         tags: dict[str, str] | None = None,
         user_id: str | None = None,
         client_tools: list[ClientToolSpec] | None = None,
+        observability_metadata: dict[str, TraceMetadataValue] | None = None,
+        observability_tags: list[str] | None = None,
     ) -> "RemoteConversation": ...
 
     def __new__(
@@ -135,6 +140,8 @@ class Conversation:
         tags: dict[str, str] | None = None,
         user_id: str | None = None,
         client_tools: list[ClientToolSpec] | None = None,
+        observability_metadata: dict[str, TraceMetadataValue] | None = None,
+        observability_tags: list[str] | None = None,
     ) -> BaseConversation:
         from openhands.sdk.conversation.impl.local_conversation import LocalConversation
         from openhands.sdk.conversation.impl.remote_conversation import (
@@ -190,6 +197,8 @@ class Conversation:
                 tags=effective_tags if effective_tags else None,
                 user_id=user_id,
                 client_tools=client_tools,
+                observability_metadata=observability_metadata,
+                observability_tags=observability_tags,
             )
 
         return LocalConversation(
@@ -210,4 +219,6 @@ class Conversation:
             tags=tags,
             user_id=user_id,
             client_tools=client_tools,
+            observability_metadata=observability_metadata,
+            observability_tags=observability_tags,
         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -27,6 +27,7 @@ from openhands.sdk.conversation.types import (
     ConversationID,
     ConversationTokenCallbackType,
     StuckDetectionThresholds,
+    TraceMetadataValue,
 )
 from openhands.sdk.conversation.visualizer import (
     ConversationVisualizerBase,
@@ -151,6 +152,8 @@ class LocalConversation(BaseConversation):
         tags: dict[str, str] | None = None,
         user_id: str | None = None,
         client_tools: list[ClientToolSpec] | None = None,
+        observability_metadata: dict[str, TraceMetadataValue] | None = None,
+        observability_tags: list[str] | None = None,
         **_: object,
     ):
         """Initialize the conversation.
@@ -192,11 +195,14 @@ class LocalConversation(BaseConversation):
                    (lost) on serialization.
             tags: Optional key-value tags for the conversation. Keys must be
                   lowercase alphanumeric, values up to 256 characters.
+            user_id: Optional user ID to associate with observability traces
             client_tools: Optional list of client-defined tool specs. Each spec
                   is registered and injected into the agent so it can call the
                   tool; the executor returns an acknowledgment and the real
                   execution is expected to be handled by a callback/consumer
                   (e.g. a frontend) observing the emitted ActionEvent.
+            observability_metadata: Optional trace metadata for observability backends.
+            observability_tags: Optional root span tags for observability backends.
         """
         super().__init__()  # Initialize with span tracking
         # Mark cleanup as initiated as early as possible to avoid races or partially
@@ -372,7 +378,12 @@ class LocalConversation(BaseConversation):
             self.update_secrets(secret_values)
 
         atexit.register(self.close)
-        self._start_observability_span(str(desired_id), user_id=user_id)
+        self._start_observability_span(
+            str(desired_id),
+            user_id=user_id,
+            metadata=observability_metadata,
+            tags=observability_tags,
+        )
         self.delete_on_close = delete_on_close
 
     def _recover_persisted_client_tools(

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -796,9 +796,13 @@ class RemoteConversation(BaseConversation):
                     else []
                 ),
                 # Include tags and observability metadata if provided
-                "tags": tags or {},
-                "observability_metadata": observability_metadata or {},
-                "observability_tags": observability_tags or [],
+                "tags": tags if tags is not None else {},
+                "observability_metadata": observability_metadata
+                if observability_metadata is not None
+                else {},
+                "observability_tags": observability_tags
+                if observability_tags is not None
+                else [],
                 "user_id": user_id,
             }
             if stuck_detection_thresholds is not None:

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -32,6 +32,7 @@ from openhands.sdk.conversation.types import (
     ConversationCallbackType,
     ConversationID,
     StuckDetectionThresholds,
+    TraceMetadataValue,
 )
 from openhands.sdk.conversation.visualizer import (
     ConversationVisualizerBase,
@@ -673,6 +674,8 @@ class RemoteConversation(BaseConversation):
         tags: dict[str, str] | None = None,
         user_id: str | None = None,
         client_tools: list[ClientToolSpec] | None = None,
+        observability_metadata: dict[str, TraceMetadataValue] | None = None,
+        observability_tags: list[str] | None = None,
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -706,6 +709,8 @@ class RemoteConversation(BaseConversation):
                       have no server-side executor — when the agent calls them an
                       ActionEvent is emitted over the WebSocket and the client
                       handles execution via callbacks.
+            observability_metadata: Optional trace metadata for observability backends.
+            observability_tags: Optional root span tags for observability backends.
         """
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
@@ -790,8 +795,10 @@ class RemoteConversation(BaseConversation):
                     if client_tools
                     else []
                 ),
-                # Include tags if provided
+                # Include tags and observability metadata if provided
                 "tags": tags or {},
+                "observability_metadata": observability_metadata or {},
+                "observability_tags": observability_tags or [],
             }
             if stuck_detection_thresholds is not None:
                 # Convert to StuckDetectionThresholds if dict, then serialize
@@ -957,7 +964,12 @@ class RemoteConversation(BaseConversation):
             secret_values: dict[str, SecretValue] = {k: v for k, v in secrets.items()}
             self.update_secrets(secret_values)
 
-        self._start_observability_span(str(self._id), user_id=user_id)
+        self._start_observability_span(
+            str(self._id),
+            user_id=user_id,
+            metadata=observability_metadata,
+            tags=observability_tags,
+        )
         # All hooks (including SessionStart/SessionEnd) are executed server-side.
         # hook_config is sent in the creation payload.
         self.delete_on_close = delete_on_close

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -799,6 +799,7 @@ class RemoteConversation(BaseConversation):
                 "tags": tags or {},
                 "observability_metadata": observability_metadata or {},
                 "observability_tags": observability_tags or [],
+                "user_id": user_id,
             }
             if stuck_detection_thresholds is not None:
                 # Convert to StuckDetectionThresholds if dict, then serialize

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -18,6 +18,7 @@ from openhands.sdk.agent.agent import Agent as Agent
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.types import (
     ConversationObservabilityMetadata,
+    ConversationObservabilityTags,
     ConversationTags,
 )
 from openhands.sdk.hooks import HookConfig
@@ -200,7 +201,7 @@ class StartConversationRequest(BaseModel):
             "be scalars or homogeneous scalar lists supported by OpenTelemetry."
         ),
     )
-    observability_tags: list[str] = Field(
+    observability_tags: ConversationObservabilityTags = Field(
         default_factory=list,
         description="Tags to attach to the conversation root observability span.",
     )

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -16,7 +16,10 @@ from pydantic import BaseModel, Discriminator, Field, Tag, model_validator
 from openhands.sdk.agent.acp_agent import ACPAgent as ACPAgent
 from openhands.sdk.agent.agent import Agent as Agent
 from openhands.sdk.agent.base import AgentBase
-from openhands.sdk.conversation.types import ConversationTags
+from openhands.sdk.conversation.types import (
+    ConversationObservabilityMetadata,
+    ConversationTags,
+)
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm.message import ImageContent, Message, TextContent
 from openhands.sdk.plugin import PluginSource
@@ -189,6 +192,17 @@ class StartConversationRequest(BaseModel):
             "When set, this is passed to Laminar.set_trace_user_id() so "
             "traces can be queried by user."
         ),
+    )
+    observability_metadata: ConversationObservabilityMetadata = Field(
+        default_factory=dict,
+        description=(
+            "Trace-level metadata to attach to observability backends. Values must "
+            "be scalars or homogeneous scalar lists supported by OpenTelemetry."
+        ),
+    )
+    observability_tags: list[str] = Field(
+        default_factory=list,
+        description="Tags to attach to the conversation root observability span.",
     )
     autotitle: bool = Field(
         default=True,

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -1,7 +1,7 @@
 import re
 import uuid
 from collections.abc import Callable, Sequence
-from typing import Annotated
+from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, Field
 
@@ -57,10 +57,12 @@ type TraceMetadataValue = (
 
 
 def _validate_observability_metadata(
-    v: dict[str, TraceMetadataValue] | None,
+    v: Any,
 ) -> dict[str, TraceMetadataValue]:
     if v is None:
         return {}
+    if not isinstance(v, dict):
+        raise ValueError("Observability metadata must be a dictionary")
     for key, value in v.items():
         if not isinstance(key, str) or not key:
             raise ValueError("Observability metadata keys must be non-empty strings")

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -93,6 +93,23 @@ ConversationObservabilityMetadata = Annotated[
 """Validated dict of Laminar/OTel trace metadata for a conversation."""
 
 
+def _validate_observability_tags(v: Any) -> list[str]:
+    if v is None:
+        return []
+    if not isinstance(v, list):
+        raise ValueError("Observability tags must be a list")
+    if not all(isinstance(tag, str) for tag in v):
+        raise ValueError("Observability tags must contain only strings")
+    return v
+
+
+ConversationObservabilityTags = Annotated[
+    list[str],
+    BeforeValidator(_validate_observability_tags),
+]
+"""Validated list of Laminar/OTel span tags for a conversation."""
+
+
 class StuckDetectionThresholds(BaseModel):
     """Configuration for stuck detection thresholds.
 

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -92,8 +92,8 @@ def _validate_observability_tags(v: Any) -> list[str]:
         return []
     if not isinstance(v, list):
         raise ValueError("Observability tags must be a list")
-    if not all(isinstance(tag, str) for tag in v):
-        raise ValueError("Observability tags must contain only strings")
+    if not all(isinstance(tag, str) and tag for tag in v):
+        raise ValueError("Observability tags must be non-empty strings")
     return v
 
 

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -1,6 +1,6 @@
 import re
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Sequence
 from typing import Annotated
 
 from pydantic import BaseModel, BeforeValidator, Field
@@ -43,6 +43,52 @@ ConversationTags = Annotated[dict[str, str], BeforeValidator(_validate_tags)]
 
 Keys must be lowercase alphanumeric. Values are arbitrary strings up to 256 chars.
 """
+
+type TraceMetadataValue = (
+    str
+    | bool
+    | int
+    | float
+    | Sequence[str]
+    | Sequence[bool]
+    | Sequence[int]
+    | Sequence[float]
+)
+
+
+def _validate_observability_metadata(
+    v: dict[str, TraceMetadataValue] | None,
+) -> dict[str, TraceMetadataValue]:
+    if v is None:
+        return {}
+    for key, value in v.items():
+        if not isinstance(key, str) or not key:
+            raise ValueError("Observability metadata keys must be non-empty strings")
+        if isinstance(value, str | bool | int | float):
+            continue
+        if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
+            if all(isinstance(item, str) for item in value):
+                continue
+            if all(isinstance(item, bool) for item in value):
+                continue
+            if all(
+                isinstance(item, int) and not isinstance(item, bool) for item in value
+            ):
+                continue
+            if all(isinstance(item, float) for item in value):
+                continue
+        raise ValueError(
+            f"Observability metadata value for '{key}' must be a scalar "
+            "or a sequence of strings, booleans, integers, or floats"
+        )
+    return v
+
+
+ConversationObservabilityMetadata = Annotated[
+    dict[str, TraceMetadataValue],
+    BeforeValidator(_validate_observability_metadata),
+]
+"""Validated dict of Laminar/OTel trace metadata for a conversation."""
 
 
 class StuckDetectionThresholds(BaseModel):

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -81,7 +81,8 @@ def _validate_observability_metadata(
                 continue
         raise ValueError(
             f"Observability metadata value for '{key}' must be a scalar "
-            "or a sequence of strings, booleans, integers, or floats"
+            "or a homogeneous sequence of strings, booleans, integers, or floats "
+            "(mixed numeric types such as [1, 1.5] are not supported by OpenTelemetry)"
         )
     return v
 

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -1,6 +1,6 @@
 import re
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 from typing import Annotated, Any
 
 from pydantic import BaseModel, BeforeValidator, Field
@@ -45,14 +45,7 @@ Keys must be lowercase alphanumeric. Values are arbitrary strings up to 256 char
 """
 
 type TraceMetadataValue = (
-    str
-    | bool
-    | int
-    | float
-    | Sequence[str]
-    | Sequence[bool]
-    | Sequence[int]
-    | Sequence[float]
+    str | bool | int | float | list[str] | list[bool] | list[int] | list[float]
 )
 
 
@@ -68,7 +61,7 @@ def _validate_observability_metadata(
             raise ValueError("Observability metadata keys must be non-empty strings")
         if isinstance(value, str | bool | int | float):
             continue
-        if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
+        if isinstance(value, list):
             if all(isinstance(item, str) for item in value):
                 continue
             if all(isinstance(item, bool) for item in value):

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -265,7 +265,11 @@ class RootSpan:
             # These trace/span helpers require an active span; briefly enter
             # the span context to apply conversation-level observability data.
             with contextlib.suppress(Exception):
-                with Laminar.use_span(self.span):
+                with Laminar.use_span(
+                    self.span,
+                    record_exception=False,
+                    set_status_on_exception=False,
+                ):
                     if session_id:
                         Laminar.set_trace_session_id(session_id)
                     if user_id:

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -269,6 +269,7 @@ class RootSpan:
             with contextlib.suppress(Exception):
                 with Laminar.use_span(
                     self.span,
+                    # Don't mark the span ERROR if a helper raises.
                     record_exception=False,
                     set_status_on_exception=False,
                 ):

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -253,21 +253,27 @@ class RootSpan:
         name: str,
         session_id: str | None = None,
         user_id: str | None = None,
+        metadata: dict[str, Any] | None = None,
+        tags: list[str] | None = None,
     ) -> None:
         from lmnr import Laminar
 
         # ``start_span`` returns a span without attaching it as the current
         # OTel context; we'll restore it on every entry point via ``use_span``.
         self.span = Laminar.start_span(name)
-        if session_id or user_id:
-            # ``set_trace_session_id`` / ``set_trace_user_id`` require an
-            # active span; briefly enter the span context to apply them.
+        if session_id or user_id or metadata or tags:
+            # These trace/span helpers require an active span; briefly enter
+            # the span context to apply conversation-level observability data.
             with contextlib.suppress(Exception):
                 with Laminar.use_span(self.span):
                     if session_id:
                         Laminar.set_trace_session_id(session_id)
                     if user_id:
                         Laminar.set_trace_user_id(user_id)
+                    if metadata:
+                        Laminar.set_trace_metadata(metadata)
+                    if tags:
+                        Laminar.set_span_tags(tags)
         self._ended = False
 
     def end(self) -> None:
@@ -285,6 +291,8 @@ def start_root_span(
     name: str,
     session_id: str | None = None,
     user_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
+    tags: list[str] | None = None,
 ) -> RootSpan | None:
     """Create a long-lived root span for an owning object.
 
@@ -293,7 +301,13 @@ def start_root_span(
     if not should_enable_observability():
         return None
     try:
-        return RootSpan(name, session_id=session_id, user_id=user_id)
+        return RootSpan(
+            name,
+            session_id=session_id,
+            user_id=user_id,
+            metadata=metadata,
+            tags=tags,
+        )
     except Exception:
         logger.debug("Failed to create observability root span", exc_info=True)
         return None

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -277,8 +277,8 @@ class RootSpan:
                     if user_id:
                         Laminar.set_trace_user_id(user_id)
                     if metadata:
-                        # cast: list[T] satisfies Sequence[T]; dict invariance
-                        # prevents direct assignment without the explicit cast.
+                        # dict is invariant: dict[str, TraceMetadataValue] is
+                        # not assignable to dict[str, Any] without a cast.
                         Laminar.set_trace_metadata(cast(dict[str, Any], metadata))
                     if tags:
                         Laminar.set_span_tags(tags)

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -1,16 +1,18 @@
+from __future__ import annotations
+
 import contextlib
 import functools
 import inspect
 import sys
 from collections.abc import Callable, Iterator
-from typing import TYPE_CHECKING, Any, Final, Literal
+from typing import TYPE_CHECKING, Any, Final, Literal, cast
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.utils import get_env
 
 
 if TYPE_CHECKING:
-    pass
+    from openhands.sdk.conversation.types import TraceMetadataValue
 
 
 logger = get_logger(__name__)
@@ -253,7 +255,7 @@ class RootSpan:
         name: str,
         session_id: str | None = None,
         user_id: str | None = None,
-        metadata: dict[str, Any] | None = None,
+        metadata: dict[str, TraceMetadataValue] | None = None,
         tags: list[str] | None = None,
     ) -> None:
         from lmnr import Laminar
@@ -275,7 +277,9 @@ class RootSpan:
                     if user_id:
                         Laminar.set_trace_user_id(user_id)
                     if metadata:
-                        Laminar.set_trace_metadata(metadata)
+                        # cast: list[T] satisfies Sequence[T]; dict invariance
+                        # prevents direct assignment without the explicit cast.
+                        Laminar.set_trace_metadata(cast(dict[str, Any], metadata))
                     if tags:
                         Laminar.set_span_tags(tags)
         self._ended = False
@@ -295,7 +299,7 @@ def start_root_span(
     name: str,
     session_id: str | None = None,
     user_id: str | None = None,
-    metadata: dict[str, Any] | None = None,
+    metadata: dict[str, TraceMetadataValue] | None = None,
     tags: list[str] | None = None,
 ) -> RootSpan | None:
     """Create a long-lived root span for an owning object.

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -36,6 +36,7 @@ from pydantic.fields import FieldInfo
 
 from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.conversation.request import SendMessageRequest
+from openhands.sdk.conversation.types import TraceMetadataValue
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.openhands_provider import (
@@ -783,6 +784,16 @@ class ConversationSettings(BaseModel):
         exclude=True,
         description="Repository selected for the conversation.",
     )
+    observability_metadata: dict[str, TraceMetadataValue] | None = Field(
+        default=None,
+        exclude=True,
+        description="Trace-level metadata for observability backends.",
+    )
+    observability_tags: list[str] | None = Field(
+        default=None,
+        exclude=True,
+        description="Tags for the conversation root observability span.",
+    )
 
     # --- persisted fields ---------------------------------------------------
     max_iterations: int = Field(
@@ -903,6 +914,10 @@ class ConversationSettings(BaseModel):
             payload.setdefault("plugins", self.plugins)
         if self.hook_config is not None:
             payload.setdefault("hook_config", self.hook_config)
+        if self.observability_metadata is not None:
+            payload.setdefault("observability_metadata", self.observability_metadata)
+        if self.observability_tags is not None:
+            payload.setdefault("observability_tags", self.observability_tags)
 
         # --- persisted defaults ---------------------------------------------
         payload.setdefault("confirmation_policy", self._build_confirmation_policy())

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -36,7 +36,10 @@ from pydantic.fields import FieldInfo
 
 from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.conversation.request import SendMessageRequest
-from openhands.sdk.conversation.types import ConversationObservabilityMetadata
+from openhands.sdk.conversation.types import (
+    ConversationObservabilityMetadata,
+    ConversationObservabilityTags,
+)
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.openhands_provider import (
@@ -789,7 +792,7 @@ class ConversationSettings(BaseModel):
         exclude=True,
         description="Trace-level metadata for observability backends.",
     )
-    observability_tags: list[str] | None = Field(
+    observability_tags: ConversationObservabilityTags | None = Field(
         default=None,
         exclude=True,
         description="Tags for the conversation root observability span.",

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -36,7 +36,10 @@ from pydantic.fields import FieldInfo
 
 from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.conversation.request import SendMessageRequest
-from openhands.sdk.conversation.types import TraceMetadataValue
+from openhands.sdk.conversation.types import (
+    ConversationObservabilityMetadata,
+    TraceMetadataValue,
+)
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.openhands_provider import (
@@ -784,7 +787,7 @@ class ConversationSettings(BaseModel):
         exclude=True,
         description="Repository selected for the conversation.",
     )
-    observability_metadata: dict[str, TraceMetadataValue] | None = Field(
+    observability_metadata: ConversationObservabilityMetadata | None = Field(
         default=None,
         exclude=True,
         description="Trace-level metadata for observability backends.",

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -36,10 +36,7 @@ from pydantic.fields import FieldInfo
 
 from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.conversation.request import SendMessageRequest
-from openhands.sdk.conversation.types import (
-    ConversationObservabilityMetadata,
-    TraceMetadataValue,
-)
+from openhands.sdk.conversation.types import ConversationObservabilityMetadata
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.utils.openhands_provider import (

--- a/tests/agent_server/test_validation_error_sanitization.py
+++ b/tests/agent_server/test_validation_error_sanitization.py
@@ -165,6 +165,20 @@ class TestSanitizeValidationErrors:
         assert inp["x_session_id"] == "<redacted>"
         assert inp["name"] == "safe_value"
 
+    def test_stringifies_value_error_context(self):
+        """ValueError in ctx should not break JSONResponse rendering."""
+        errors = [
+            {
+                "type": "value_error",
+                "loc": ["body", "observability_metadata"],
+                "msg": "Value error, bad metadata",
+                "input": {"nested": {"bad": True}},
+                "ctx": {"error": ValueError("bad metadata")},
+            }
+        ]
+        result = _sanitize_validation_errors(errors)
+        assert result[0]["ctx"]["error"] == "bad metadata"
+
     def test_empty_errors_list(self):
         """An empty error list should return an empty list."""
         assert _sanitize_validation_errors([]) == []

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -232,6 +232,7 @@ class TestRemoteConversation:
             workspace=self.workspace,
             observability_metadata={"repo": "OpenHands/software-agent-sdk"},
             observability_tags=["sdk", "remote"],
+            user_id="test-user-42",
         )
 
         create_call = next(
@@ -244,6 +245,7 @@ class TestRemoteConversation:
             "repo": "OpenHands/software-agent-sdk"
         }
         assert payload["observability_tags"] == ["sdk", "remote"]
+        assert payload["user_id"] == "test-user-42"
 
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -236,10 +236,14 @@ class TestRemoteConversation:
         )
 
         create_call = next(
-            call
-            for call in mock_client_instance.request.call_args_list
-            if call[0][0] == "POST" and call[0][1] == "/api/conversations"
+            (
+                call
+                for call in mock_client_instance.request.call_args_list
+                if call[0][0] == "POST" and call[0][1] == "/api/conversations"
+            ),
+            None,
         )
+        assert create_call is not None, "No POST /api/conversations call found"
         payload = create_call.kwargs["json"]
         assert payload["observability_metadata"] == {
             "repo": "OpenHands/software-agent-sdk"

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -222,6 +222,32 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_remote_conversation_sends_observability_fields(self, mock_ws_client):
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+        mock_ws_client.return_value = Mock()
+
+        RemoteConversation(
+            agent=self.agent,
+            workspace=self.workspace,
+            observability_metadata={"repo": "OpenHands/software-agent-sdk"},
+            observability_tags=["sdk", "remote"],
+        )
+
+        create_call = next(
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "POST" and call[0][1] == "/api/conversations"
+        )
+        payload = create_call.kwargs["json"]
+        assert payload["observability_metadata"] == {
+            "repo": "OpenHands/software-agent-sdk"
+        }
+        assert payload["observability_tags"] == ["sdk", "remote"]
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_llm_completion_log_callback_writes_utf8(self, mock_ws_client, tmp_path):
         llm = LLM(
             model="gpt-4o-mini",

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -254,6 +254,31 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_remote_conversation_user_id_none_sends_explicit_null(self, mock_ws_client):
+        """user_id=None sends an explicit null key (not omitted) so the server
+        receives a consistent payload regardless of whether user_id was supplied."""
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+        mock_ws_client.return_value = Mock()
+
+        RemoteConversation(agent=self.agent, workspace=self.workspace)
+
+        create_call = next(
+            (
+                call
+                for call in mock_client_instance.request.call_args_list
+                if call[0][0] == "POST" and call[0][1] == "/api/conversations"
+            ),
+            None,
+        )
+        assert create_call is not None, "No POST /api/conversations call found"
+        payload = create_call.kwargs["json"]
+        assert "user_id" in payload
+        assert payload["user_id"] is None
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_llm_completion_log_callback_writes_utf8(self, mock_ws_client, tmp_path):
         llm = LLM(
             model="gpt-4o-mini",

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -94,7 +94,11 @@ def test_base_conversation_span_management():
         # Start span
         conversation._start_observability_span("test-session-id")
         mock_start_span.assert_called_once_with(
-            "conversation", session_id="test-session-id", user_id=None
+            "conversation",
+            session_id="test-session-id",
+            user_id=None,
+            metadata=None,
+            tags=None,
         )
         assert conversation._span_ended is False
         assert conversation._observability_root_span is fake_root
@@ -114,6 +118,31 @@ def test_base_conversation_span_management():
         conversation._end_observability_span()
         assert mock_end_span.call_count == 1  # Still only called once
         assert conversation._span_ended is True
+
+
+def test_base_conversation_passes_observability_metadata():
+    conversation = MockConversation()
+
+    with (
+        patch(
+            "openhands.sdk.conversation.base.should_enable_observability",
+            return_value=True,
+        ),
+        patch("openhands.sdk.conversation.base.start_root_span") as mock_start_span,
+    ):
+        metadata = {"repo_name": "OpenHands/software-agent-sdk"}
+        tags = ["repo:OpenHands/software-agent-sdk"]
+
+        conversation._start_observability_span(
+            "test-session-id", metadata=metadata, tags=tags
+        )
+
+        mock_start_span.assert_called_once_with(
+            "conversation",
+            session_id="test-session-id",
+            metadata=metadata,
+            tags=tags,
+        )
 
 
 def test_base_conversation_span_management_disabled():

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -143,6 +143,7 @@ def test_base_conversation_passes_observability_metadata():
         mock_start_span.assert_called_once_with(
             "conversation",
             session_id="test-session-id",
+            user_id=None,
             metadata=metadata,
             tags=tags,
         )

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -7,6 +7,7 @@ from uuid import UUID
 
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.conversation_stats import ConversationStats
+from openhands.sdk.conversation.types import TraceMetadataValue
 from openhands.sdk.llm.llm import LLM
 from openhands.sdk.tool.schema import Action, Observation
 
@@ -130,7 +131,9 @@ def test_base_conversation_passes_observability_metadata():
         ),
         patch("openhands.sdk.conversation.base.start_root_span") as mock_start_span,
     ):
-        metadata = {"repo_name": "OpenHands/software-agent-sdk"}
+        metadata: dict[str, TraceMetadataValue] = {
+            "repo_name": "OpenHands/software-agent-sdk"
+        }
         tags = ["repo:OpenHands/software-agent-sdk"]
 
         conversation._start_observability_span(

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -114,6 +114,11 @@ def test_validate_observability_metadata_rejects_nested_values():
         _validate_observability_metadata({"repo": {"name": "openhands"}})  # type: ignore[dict-item]
 
 
+def test_validate_observability_metadata_rejects_mixed_numeric_list():
+    with pytest.raises(ValueError, match="mixed numeric types"):
+        _validate_observability_metadata({"scores": [1, 1.5]})  # type: ignore[dict-item]
+
+
 def test_observability_metadata_in_pydantic_model():
     from pydantic import BaseModel
 

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -121,4 +121,4 @@ def test_observability_metadata_in_pydantic_model():
     assert m.observability_metadata == {}
 
     with pytest.raises(ValidationError):
-        TestModel(observability_metadata={"nested": {"bad": True}})
+        TestModel.model_validate({"observability_metadata": {"nested": {"bad": True}}})

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -5,7 +5,9 @@ from pydantic import ValidationError
 
 from openhands.sdk.conversation.types import (
     TAG_VALUE_MAX_LENGTH,
+    ConversationObservabilityMetadata,
     ConversationTags,
+    _validate_observability_metadata,
     _validate_tags,
 )
 
@@ -84,3 +86,39 @@ def test_tags_in_pydantic_model():
     # Invalid key rejected
     with pytest.raises(ValidationError):
         TestModel(tags={"BAD": "value"})
+
+
+def test_validate_observability_metadata_valid():
+    metadata = {
+        "repo_name": "OpenHands/software-agent-sdk",
+        "private": True,
+        "retry_count": 3,
+        "cost": 1.5,
+        "labels": ["repo", "cloud"],
+        "flags": [True, False],
+        "counts": [1, 2],
+        "scores": [0.1, 0.2],
+    }
+
+    assert _validate_observability_metadata(metadata) == metadata
+
+
+def test_validate_observability_metadata_rejects_nested_values():
+    with pytest.raises(ValueError, match="must be a scalar"):
+        _validate_observability_metadata({"repo": {"name": "openhands"}})  # type: ignore[dict-item]
+
+
+def test_observability_metadata_in_pydantic_model():
+    from pydantic import BaseModel
+
+    class TestModel(BaseModel):
+        observability_metadata: ConversationObservabilityMetadata = {}
+
+    m = TestModel(observability_metadata={"repo_name": "OpenHands/OpenHands"})
+    assert m.observability_metadata == {"repo_name": "OpenHands/OpenHands"}
+
+    m = TestModel.model_validate({"observability_metadata": None})
+    assert m.observability_metadata == {}
+
+    with pytest.raises(ValidationError):
+        TestModel(observability_metadata={"nested": {"bad": True}})

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 from openhands.sdk.conversation.types import (
     TAG_VALUE_MAX_LENGTH,
     ConversationObservabilityMetadata,
+    ConversationObservabilityTags,
     ConversationTags,
     _validate_observability_metadata,
     _validate_tags,
@@ -127,3 +128,19 @@ def test_observability_metadata_in_pydantic_model():
 
     with pytest.raises(ValidationError):
         TestModel.model_validate({"observability_metadata": {"nested": {"bad": True}}})
+
+
+def test_observability_tags_in_pydantic_model():
+    from pydantic import BaseModel
+
+    class TestModel(BaseModel):
+        observability_tags: ConversationObservabilityTags = []
+
+    m = TestModel(observability_tags=["repo", "cloud"])
+    assert m.observability_tags == ["repo", "cloud"]
+
+    m = TestModel.model_validate({"observability_tags": None})
+    assert m.observability_tags == []
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"observability_tags": [1, 2]})

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -149,3 +149,6 @@ def test_observability_tags_in_pydantic_model():
 
     with pytest.raises(ValidationError):
         TestModel.model_validate({"observability_tags": [1, 2]})
+
+    with pytest.raises(ValidationError):
+        TestModel.model_validate({"observability_tags": [""]})

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -103,6 +103,11 @@ def test_validate_observability_metadata_valid():
     assert _validate_observability_metadata(metadata) == metadata
 
 
+def test_validate_observability_metadata_rejects_non_dict():
+    with pytest.raises(ValueError, match="must be a dictionary"):
+        _validate_observability_metadata([])
+
+
 def test_validate_observability_metadata_rejects_nested_values():
     with pytest.raises(ValueError, match="must be a scalar"):
         _validate_observability_metadata({"repo": {"name": "openhands"}})  # type: ignore[dict-item]

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -502,11 +502,9 @@ def test_root_span_sets_trace_metadata_and_tags():
     from openhands.sdk.observability.laminar import RootSpan
 
     fake_span = MagicMock()
-    fake_context = MagicMock()
 
     with patch("lmnr.Laminar") as mock_laminar:
         mock_laminar.start_span.return_value = fake_span
-        mock_laminar.use_span.return_value.__enter__.return_value = fake_context
 
         RootSpan(
             "conversation",

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -498,6 +498,34 @@ def contextlib_compat():
     return contextlib.contextmanager
 
 
+def test_root_span_sets_trace_metadata_and_tags():
+    from openhands.sdk.observability.laminar import RootSpan
+
+    fake_span = MagicMock()
+    fake_context = MagicMock()
+
+    with patch("lmnr.Laminar") as mock_laminar:
+        mock_laminar.start_span.return_value = fake_span
+        mock_laminar.use_span.return_value.__enter__.return_value = fake_context
+
+        RootSpan(
+            "conversation",
+            session_id="session-1",
+            metadata={"repo_name": "OpenHands/software-agent-sdk"},
+            tags=["repo:OpenHands/software-agent-sdk"],
+        )
+
+        mock_laminar.start_span.assert_called_once_with("conversation")
+        mock_laminar.use_span.assert_called_once_with(fake_span)
+        mock_laminar.set_trace_session_id.assert_called_once_with("session-1")
+        mock_laminar.set_trace_metadata.assert_called_once_with(
+            {"repo_name": "OpenHands/software-agent-sdk"}
+        )
+        mock_laminar.set_span_tags.assert_called_once_with(
+            ["repo:OpenHands/software-agent-sdk"]
+        )
+
+
 def test_deprecated_shims_are_removed():
     """The legacy global-stack API (deprecated 1.22.0) was removed in 1.27.0."""
     from openhands.sdk.observability import laminar as lam

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -516,7 +516,11 @@ def test_root_span_sets_trace_metadata_and_tags():
         )
 
         mock_laminar.start_span.assert_called_once_with("conversation")
-        mock_laminar.use_span.assert_called_once_with(fake_span)
+        mock_laminar.use_span.assert_called_once_with(
+            fake_span,
+            record_exception=False,
+            set_status_on_exception=False,
+        )
         mock_laminar.set_trace_session_id.assert_called_once_with("session-1")
         mock_laminar.set_trace_metadata.assert_called_once_with(
             {"repo_name": "OpenHands/software-agent-sdk"}

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -221,6 +221,9 @@ def test_conversation_settings_validates_observability_metadata() -> None:
     with pytest.raises(ValidationError):
         ConversationSettings(observability_metadata=[])  # type: ignore[arg-type]
 
+    with pytest.raises(ValidationError):
+        ConversationSettings(observability_tags=[1, 2])  # type: ignore[list-item]
+
 
 def test_conversation_settings_model_dump_roundtrip() -> None:
     settings = ConversationSettings(

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -211,6 +211,17 @@ def test_conversation_settings_export_schema_groups_sections() -> None:
     assert verification_fields["security_analyzer"].depends_on == ["confirmation_mode"]
 
 
+def test_conversation_settings_validates_observability_metadata() -> None:
+    settings = ConversationSettings(observability_metadata={"repo": "OpenHands/sdk"})
+    assert settings.observability_metadata == {"repo": "OpenHands/sdk"}
+
+    with pytest.raises(ValidationError):
+        ConversationSettings(observability_metadata={"": "missing-key"})
+
+    with pytest.raises(ValidationError):
+        ConversationSettings(observability_metadata=[])  # type: ignore[arg-type]
+
+
 def test_conversation_settings_model_dump_roundtrip() -> None:
     settings = ConversationSettings(
         max_iterations=42,


### PR DESCRIPTION
## Summary
- add validated conversation-level `observability_metadata` and `observability_tags` fields to start requests
- pass metadata through local/remote conversation construction and the agent server into Laminar root spans
- apply trace metadata and span tags when creating the Laminar root span
- **bug fix**: `user_id` was silently missing from the remote `POST /api/conversations` creation payload before this PR — remote conversations now correctly propagate `user_id` to the server for user-level observability filtering

## Tests
- `uv run pytest -q tests/sdk/conversation/test_base_span_management.py tests/sdk/conversation/test_tags.py tests/sdk/observability/test_laminar.py`
- `uv run ruff check openhands-sdk/openhands/sdk/conversation/base.py openhands-sdk/openhands/sdk/conversation/conversation.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py openhands-sdk/openhands/sdk/conversation/request.py openhands-sdk/openhands/sdk/conversation/types.py openhands-sdk/openhands/sdk/observability/laminar.py openhands-sdk/openhands/sdk/settings/model.py openhands-agent-server/openhands/agent_server/event_service.py tests/sdk/conversation/test_base_span_management.py tests/sdk/conversation/test_tags.py tests/sdk/observability/test_laminar.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8b2a17bb-bd77-4a6a-a44b-6fcd26545ccc)




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c29377b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c29377b-python \
  ghcr.io/openhands/agent-server:c29377b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c29377b-golang-amd64
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-golang-amd64
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-golang-amd64
ghcr.io/openhands/agent-server:c29377b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c29377b-golang-arm64
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-golang-arm64
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-golang-arm64
ghcr.io/openhands/agent-server:c29377b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c29377b-java-amd64
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-java-amd64
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-java-amd64
ghcr.io/openhands/agent-server:c29377b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c29377b-java-arm64
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-java-arm64
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-java-arm64
ghcr.io/openhands/agent-server:c29377b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c29377b-python-amd64
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-python-amd64
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-python-amd64
ghcr.io/openhands/agent-server:c29377b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c29377b-python-arm64
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-python-arm64
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-python-arm64
ghcr.io/openhands/agent-server:c29377b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c29377b-golang
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-golang
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-golang
ghcr.io/openhands/agent-server:c29377b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c29377b-java
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-java
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-java
ghcr.io/openhands/agent-server:c29377b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c29377b-python
ghcr.io/openhands/agent-server:c29377b2b09acab36f60ee2372445aa219407631-python
ghcr.io/openhands/agent-server:openhands-laminar-conversation-metadata-python
ghcr.io/openhands/agent-server:c29377b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c29377b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c29377b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Issue

Related issue: OpenHands/OpenHands#14457

_This PR description update was created by an AI agent (OpenHands) on behalf of Graham Neubig._

## Tracking issue

Fixes #3344

_This PR description update was created by an AI agent (OpenHands) on behalf of Graham Neubig._
