### PR TITLE
Match verified model name nemotron-3-super to infra name nemotron-3-super-120b-a12b

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -82,7 +82,7 @@ VERIFIED_GLM_MODELS = [
 
 VERIFIED_NVIDIA_MODELS = [
     "nemotron-3-nano",
-    "nemotron-3-super",
+    "nemotron-3-super-120b-a12b",
 ]
 
 VERIFIED_QWEN_MODELS = [
@@ -122,7 +122,7 @@ VERIFIED_OPENHANDS_MODELS = [
     "glm-5",
     "glm-5.1",
     "nemotron-3-nano",
-    "nemotron-3-super",
+    "nemotron-3-super-120b-a12b",
     "qwen3-6-plus",
     "qwen3-coder-480b",
     "trinity-large-thinking",

--- a/tests/sdk/llm/test_model_list.py
+++ b/tests/sdk/llm/test_model_list.py
@@ -108,6 +108,19 @@ def test_openhands_models_all_have_provider_list():
     )
 
 
+def test_nemotron_3_super_uses_full_infra_name():
+    """The verified Nemotron Super entry must match the infra model name
+    (``nemotron-3-super-120b-a12b``) and the short alias should not be listed.
+    """
+    full_name = "nemotron-3-super-120b-a12b"
+    assert full_name in VERIFIED_MODELS["nvidia"]
+    assert full_name in VERIFIED_OPENHANDS_MODELS
+    for provider, models in VERIFIED_MODELS.items():
+        assert "nemotron-3-super" not in models, (
+            f"Short alias 'nemotron-3-super' should not be in provider {provider!r}"
+        )
+
+
 def test_trinity_model_is_openhands_only():
     """trinity-large-thinking should be available only via the OpenHands provider
     and must not be listed under any other provider.


### PR DESCRIPTION
## Summary

The verified models list contained the short alias `nemotron-3-super`, but the actual model identifier exposed by the infrastructure is `nemotron-3-super-120b-a12b`. This caused a mismatch between the verified-models surface and the real provider model name.

This PR renames the entry in both `VERIFIED_NVIDIA_MODELS` and `VERIFIED_OPENHANDS_MODELS` to the full infra name.

## Changes

- `openhands-sdk/openhands/sdk/llm/utils/verified_models.py`: replaced `"nemotron-3-super"` with `"nemotron-3-super-120b-a12b"` in both lists.
- `tests/sdk/llm/test_model_list.py`: added `test_nemotron_3_super_uses_full_infra_name` to lock in the full infra name and ensure the short alias is not present in any provider list. The existing `test_openhands_models_all_have_provider_list` continues to verify that the openhands list stays in sync with the provider list.

## Verification

- `uv run pytest tests/sdk/llm/test_model_list.py` → 6 passed
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/verified_models.py tests/sdk/llm/test_model_list.py` → all hooks passed

Fixes #3274.

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/85d58506-55bb-4e0d-9b6e-55daeeab2513)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d499fa6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d499fa6-python \
  ghcr.io/openhands/agent-server:d499fa6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d499fa6-golang-amd64
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-golang-amd64
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-golang-amd64
ghcr.io/openhands/agent-server:d499fa6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d499fa6-golang-arm64
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-golang-arm64
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-golang-arm64
ghcr.io/openhands/agent-server:d499fa6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d499fa6-java-amd64
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-java-amd64
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-java-amd64
ghcr.io/openhands/agent-server:d499fa6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d499fa6-java-arm64
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-java-arm64
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-java-arm64
ghcr.io/openhands/agent-server:d499fa6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d499fa6-python-amd64
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-python-amd64
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-python-amd64
ghcr.io/openhands/agent-server:d499fa6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d499fa6-python-arm64
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-python-arm64
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-python-arm64
ghcr.io/openhands/agent-server:d499fa6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d499fa6-golang
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-golang
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-golang
ghcr.io/openhands/agent-server:d499fa6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d499fa6-java
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-java
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-java
ghcr.io/openhands/agent-server:d499fa6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d499fa6-python
ghcr.io/openhands/agent-server:d499fa67c7867014df703c5fcc93419cf6963b43-python
ghcr.io/openhands/agent-server:openhands-fix-nemotron-3-super-model-name-python
ghcr.io/openhands/agent-server:d499fa6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d499fa6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d499fa6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->