### PR TITLE
Track release-note-required behavioral default changes

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -38,7 +38,7 @@ import sys
 import tomllib
 import urllib.request
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import asdict, dataclass, field
 from pathlib import Path
 
 from packaging import version as pkg_version
@@ -74,7 +74,16 @@ class DeprecatedSymbols:
     metadata: dict[str, DeprecationMetadata] = field(default_factory=dict)
 
 
+@dataclass(frozen=True, slots=True)
+class FieldDefaultChange:
+    package: str
+    object_path: str
+    old_default: str
+    new_default: str
+
+
 DEPRECATION_RUNWAY_MINOR_RELEASES = 5
+FIELD_DEFAULT_CHANGE_REPORT_ENV = "SDK_API_BREAKAGE_REPORT_PATH"
 
 
 PACKAGES: tuple[PackageConfig, ...] = (
@@ -459,6 +468,70 @@ def _filter_field_metadata_kwargs(call: ast.Call) -> ast.Call:
     )
 
 
+def _field_default_node(call: ast.Call) -> ast.AST | None:
+    """Return the AST node representing a ``Field`` default value."""
+    for kw in call.keywords:
+        if kw.arg == "default":
+            return kw.value
+    if call.args:
+        return call.args[0]
+    return None
+
+
+def _remove_field_default(call: ast.Call) -> ast.Call:
+    """Return a copy of a ``Field(...)`` call without its default value."""
+    args = list(call.args)
+    if args:
+        args = args[1:]
+    return ast.Call(
+        func=call.func,
+        args=args,
+        keywords=[kw for kw in call.keywords if kw.arg != "default"],
+    )
+
+
+def _field_default_repr(value: object) -> str | None:
+    """Return the string form of a ``Field`` default value, if present."""
+    call = _parse_field_call(value)
+    if call is None:
+        return None
+    default_node = _field_default_node(call)
+    if default_node is None:
+        return None
+    return ast.unparse(default_node)
+
+
+def _is_field_default_only_change(old_val: object, new_val: object) -> bool:
+    """Check whether only the ``Field`` default value changed.
+
+    Metadata-only kwargs are ignored, but any other semantic ``Field`` argument
+    changes still count as real API breakage.
+    """
+    old_call = _parse_field_call(old_val)
+    new_call = _parse_field_call(new_val)
+    if old_call is None or new_call is None:
+        return False
+
+    old_default = _field_default_node(old_call)
+    new_default = _field_default_node(new_call)
+    if old_default is None or new_default is None:
+        return False
+
+    if ast.dump(old_default, include_attributes=False) == ast.dump(
+        new_default,
+        include_attributes=False,
+    ):
+        return False
+
+    return ast.dump(
+        _remove_field_default(_filter_field_metadata_kwargs(old_call)),
+        include_attributes=False,
+    ) == ast.dump(
+        _remove_field_default(_filter_field_metadata_kwargs(new_call)),
+        include_attributes=False,
+    )
+
+
 def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
     """Check if the change is only in Field metadata (description, title, etc.).
 
@@ -480,6 +553,33 @@ def _is_field_metadata_only_change(old_val: object, new_val: object) -> bool:
     ) == ast.dump(
         _filter_field_metadata_kwargs(new_call),
         include_attributes=False,
+    )
+
+
+def _object_path(obj: object | None) -> str:
+    """Return the most specific path available for a griffe object."""
+    if obj is None:
+        return "<unknown>"
+    return str(
+        getattr(obj, "path", None)
+        or getattr(obj, "canonical_path", None)
+        or getattr(obj, "name", None)
+        or "<unknown>"
+    )
+
+
+def _write_field_default_change_report(changes: list[FieldDefaultChange]) -> None:
+    """Write detected public Field default changes to a JSON report file."""
+    report_path = os.environ.get(FIELD_DEFAULT_CHANGE_REPORT_ENV, "").strip()
+    if not report_path:
+        return
+
+    Path(report_path).write_text(
+        json.dumps(
+            {"field_default_changes": [asdict(change) for change in changes]},
+            indent=2,
+        )
+        + "\n"
     )
 
 
@@ -526,6 +626,8 @@ def _collect_breakages_pairs(
     deprecated: DeprecatedSymbols,
     current_version: str,
     title: str,
+    package: str,
+    field_default_changes: list[FieldDefaultChange] | None = None,
 ) -> tuple[list[object], int]:
     """Find breaking changes between pairs of old/new API objects.
 
@@ -548,8 +650,6 @@ def _collect_breakages_pairs(
                 if not getattr(obj, "is_public", True):
                     continue
 
-                # Skip ATTRIBUTE_CHANGED_VALUE when it's just Field metadata changes
-                # (description, title, examples, etc.) - these don't affect runtime
                 if br.kind == BreakageKind.ATTRIBUTE_CHANGED_VALUE:
                     old_value = getattr(br, "old_value", None)
                     new_value = getattr(br, "new_value", None)
@@ -558,6 +658,25 @@ def _collect_breakages_pairs(
                             f"::notice title={title}::Ignoring Field metadata-only "
                             f"change (non-breaking): {obj.name if obj else 'unknown'}"
                         )
+                        continue
+                    if _is_field_default_only_change(old_value, new_value):
+                        object_path = _object_path(obj)
+                        old_default = _field_default_repr(old_value) or "<unknown>"
+                        new_default = _field_default_repr(new_value) or "<unknown>"
+                        print(
+                            f"::warning title={title}::Public Field default changed "
+                            f"(release-note-required): {object_path} "
+                            f"{old_default} -> {new_default}"
+                        )
+                        if field_default_changes is not None:
+                            field_default_changes.append(
+                                FieldDefaultChange(
+                                    package=package,
+                                    object_path=object_path,
+                                    old_default=old_default,
+                                    new_default=new_default,
+                                )
+                            )
                         continue
 
                 print(br.explain(style=ExplanationStyle.GITHUB))
@@ -902,6 +1021,7 @@ def _compute_breakages(
     cfg: PackageConfig,
     *,
     current_version: str = "9999.0.0",
+    field_default_changes: list[FieldDefaultChange] | None = None,
 ) -> tuple[int, int]:
     """Detect breaking changes between old and new package versions.
 
@@ -980,6 +1100,8 @@ def _compute_breakages(
         deprecated=deprecated,
         current_version=current_version,
         title=title,
+        package=cfg.package,
+        field_default_changes=field_default_changes,
     )
     total_breaks += len(breakages)
     removal_policy_errors += member_policy_errors
@@ -987,7 +1109,13 @@ def _compute_breakages(
     return total_breaks, removal_policy_errors
 
 
-def _check_package(griffe_module, repo_root: str, cfg: PackageConfig) -> int:
+def _check_package(
+    griffe_module,
+    repo_root: str,
+    cfg: PackageConfig,
+    *,
+    field_default_changes: list[FieldDefaultChange] | None = None,
+) -> int:
     """Run breakage checks for a single package. Returns 0 on success."""
     pyproj = os.path.join(repo_root, cfg.source_dir, "pyproject.toml")
     new_version = read_version_from_pyproject(pyproj)
@@ -1017,6 +1145,7 @@ def _check_package(griffe_module, repo_root: str, cfg: PackageConfig) -> int:
             new_root,
             cfg,
             current_version=new_version,
+            field_default_changes=field_default_changes,
         )
     except Exception as e:
         print(f"::error title={title}::Failed to compute breakages: {e}")
@@ -1041,12 +1170,19 @@ def main() -> int:
     ensure_griffe()
     import griffe
 
+    field_default_changes: list[FieldDefaultChange] = []
     for cfg in PACKAGES:
         print(f"\n{'=' * 60}")
         print(f"Checking {cfg.distribution} ({cfg.package})")
         print(f"{'=' * 60}")
-        rc |= _check_package(griffe, repo_root, cfg)
+        rc |= _check_package(
+            griffe,
+            repo_root,
+            cfg,
+            field_default_changes=field_default_changes,
+        )
 
+    _write_field_default_change_report(field_default_changes)
     return rc
 
 

--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -35,6 +35,7 @@ The created PR will include a checklist. Complete the following:
 - [ ] Fix any deprecation deadlines if they exist
 - [ ] Verify integration tests pass (triggered by `integration-tests` label)
 - [ ] Verify example checks pass (triggered by `test-examples` label)
+- [ ] Confirm any merged `release-note-required` PRs are accurately called out in the final release notes
 - [ ] Review and approve the PR
 
 ### Step 3: Create the GitHub Release

--- a/.github/workflows/api-breakage.yml
+++ b/.github/workflows/api-breakage.yml
@@ -33,6 +33,7 @@ jobs:
                   ACP_VERSION_CHECK_BASE_REF: ${{ github.event_name == 'pull_request' && github.base_ref || github.event.before }}
                   ACP_VERSION_CHECK_SKIP: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.body || '', 'skip-acp-check') 
                       }}
+                  SDK_API_BREAKAGE_REPORT_PATH: sdk-api-breakage-report.json
               run: |
                   uv run python .github/scripts/check_sdk_api_breakage.py 2>&1 | tee api-breakage.log
                   exit_code=${PIPESTATUS[0]}
@@ -44,9 +45,11 @@ jobs:
                   EXIT_CODE: ${{ steps.api_breakage.outputs.exit_code }}
                   IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
                   LOG_PATH: api-breakage.log
+                  REPORT_PATH: sdk-api-breakage-report.json
                   RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
               run: |
                   python3 <<'PY' >> "$GITHUB_STEP_SUMMARY"
+                  import json
                   import os
                   from pathlib import Path
 
@@ -55,6 +58,12 @@ jobs:
                   run_url = os.environ['RUN_URL']
                   status = '✅ **PASSED**' if exit_code == 0 else '❌ **FAILED**'
 
+                  try:
+                      report = json.loads(Path(os.environ['REPORT_PATH']).read_text())
+                  except Exception:
+                      report = {}
+                  default_changes = report.get('field_default_changes', [])
+
                   print(f'## Python API breakage checks — {status}')
                   print()
                   print(f"**Result:** {status}")
@@ -62,6 +71,22 @@ jobs:
                       print()
                       print('> ⚠️ Breaking API changes or policy violations detected.')
                   print()
+
+                  if default_changes:
+                      print('### Behavioral default changes detected')
+                      print()
+                      print(
+                          'These public `Field(default=...)` changes were auto-marked '
+                          'with the `release-note-required` label:'
+                      )
+                      print()
+                      for change in default_changes:
+                          print(
+                              '- `{object_path}`: `{old_default}` → `{new_default}`'.format(
+                                  **change,
+                              )
+                          )
+                      print()
 
                   if is_fork:
                       print(
@@ -90,12 +115,58 @@ jobs:
                   print(f'[Action log]({run_url})')
                   PY
 
+            - name: Sync release-note-required label
+              if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
+              uses: actions/github-script@v9
+              env:
+                  REPORT_PATH: sdk-api-breakage-report.json
+              with:
+                  script: |
+                      const fs = require('fs');
+
+                      let defaultChanges = [];
+                      try {
+                        defaultChanges = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, 'utf8')).field_default_changes || [];
+                      } catch (_error) {
+                        defaultChanges = [];
+                      }
+
+                      const { owner, repo } = context.repo;
+                      const issue_number = context.issue.number;
+                      const label = 'release-note-required';
+                      const { data: currentLabels } = await github.rest.issues.listLabelsOnIssue({
+                        owner,
+                        repo,
+                        issue_number,
+                        per_page: 100,
+                      });
+                      const hasLabel = currentLabels.some((item) => item.name === label);
+
+                      if (defaultChanges.length > 0 && !hasLabel) {
+                        await github.rest.issues.addLabels({
+                          owner,
+                          repo,
+                          issue_number,
+                          labels: [label],
+                        });
+                      }
+
+                      if (defaultChanges.length === 0 && hasLabel) {
+                        await github.rest.issues.removeLabel({
+                          owner,
+                          repo,
+                          issue_number,
+                          name: label,
+                        });
+                      }
+
             - name: Post API breakage report to PR
               if: ${{ always() && github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
               uses: actions/github-script@v9
               env:
                   EXIT_CODE: ${{ steps.api_breakage.outputs.exit_code }}
                   LOG_PATH: api-breakage.log
+                  REPORT_PATH: sdk-api-breakage-report.json
               with:
                   script: |
                       const fs = require('fs');
@@ -104,6 +175,13 @@ jobs:
                       const exitCode = Number(process.env.EXIT_CODE || '0');
                       const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
                       const status = exitCode === 0 ? '✅ **PASSED**' : '❌ **FAILED**';
+
+                      let defaultChanges = [];
+                      try {
+                        defaultChanges = JSON.parse(fs.readFileSync(process.env.REPORT_PATH, 'utf8')).field_default_changes || [];
+                      } catch (_error) {
+                        defaultChanges = [];
+                      }
 
                       let body = `${marker}\n## Python API breakage checks — ${status}\n\n**Result:** ${status}\n`;
 
@@ -118,6 +196,14 @@ jobs:
 
                         const excerpt = log.slice(0, 1000).replace(/```/g, '``\\`');
                         body += `\n<details><summary>Log excerpt (first 1000 characters)</summary>\n\n\`\`\`text\n${excerpt}\n\`\`\`\n\n</details>\n`;
+                      }
+
+                      if (defaultChanges.length > 0) {
+                        body += '\n### Behavioral default changes detected\n\n';
+                        body += 'These public `Field(default=...)` changes were auto-marked with the `release-note-required` label:\n\n';
+                        for (const change of defaultChanges) {
+                          body += `- \`${change.object_path}\`: \`${change.old_default}\` → \`${change.new_default}\`\n`;
+                        }
                       }
 
                       body += `\n[Action log](${runUrl})\n`;

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,6 +20,7 @@ jobs:
         permissions:
             actions: write
             contents: write
+            pull-requests: read
         steps:
             - name: Extract version from branch name
               id: version
@@ -60,16 +61,98 @@ jobs:
                   echo "prev_tag=${PREV_TAG}" >> "$GITHUB_OUTPUT"
                   echo "📌 Previous release tag: ${PREV_TAG:-<none>}"
 
+            - name: Build release-note-required preamble
+              if: steps.check.outputs.exists == 'false'
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PREAMBLE_PATH: release-note-preamble.md
+                  PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
+              run: |
+                  python3 <<'PY'
+                  import json
+                  import os
+                  import subprocess
+                  from pathlib import Path
+
+                  repo = os.environ['GITHUB_REPOSITORY']
+                  prev_tag = os.environ.get('PREV_TAG', '').strip()
+                  preamble_path = Path(os.environ['PREAMBLE_PATH'])
+
+                  args = [
+                      'gh',
+                      'search',
+                      'prs',
+                      '--repo',
+                      repo,
+                      '--state',
+                      'closed',
+                      '--merged',
+                      '--label',
+                      'release-note-required',
+                      '--limit',
+                      '200',
+                      '--json',
+                      'number,title,url,author',
+                  ]
+                  if prev_tag:
+                      published_at = subprocess.check_output(
+                          [
+                              'gh',
+                              'release',
+                              'view',
+                              prev_tag,
+                              '--repo',
+                              repo,
+                              '--json',
+                              'publishedAt',
+                              '--jq',
+                              '.publishedAt',
+                          ],
+                          text=True,
+                      ).strip()
+                      if published_at:
+                          args.extend(['--merged-at', f'>={published_at}'])
+
+                  prs = json.loads(subprocess.check_output(args, text=True) or '[]')
+                  prs.sort(key=lambda pr: pr['number'])
+
+                  if not prs:
+                      preamble_path.write_text('')
+                      raise SystemExit(0)
+
+                  lines = [
+                      '## Behavioral compatibility notes',
+                      '',
+                      'The following merged PRs were labeled `release-note-required` and are called out explicitly in this release:',
+                      '',
+                  ]
+                  for pr in prs:
+                      author = (pr.get('author') or {}).get('login')
+                      attribution = f' (@{author})' if author else ''
+                      lines.append(
+                          f"- [#{pr['number']}]({pr['url']}) {pr['title']}{attribution}"
+                      )
+                  lines.append('')
+                  preamble_path.write_text('\n'.join(lines))
+                  PY
+
+
             - name: Create GitHub Release
               if: steps.check.outputs.exists == 'false'
               env:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  PREAMBLE_PATH: release-note-preamble.md
                   VERSION: ${{ steps.version.outputs.version }}
                   PREV_TAG: ${{ steps.prev_tag.outputs.prev_tag }}
               run: |
-                  NOTES_FLAG=()
+                  NOTES_START_FLAG=()
                   if [ -n "$PREV_TAG" ]; then
-                    NOTES_FLAG=(--notes-start-tag "$PREV_TAG")
+                    NOTES_START_FLAG=(--notes-start-tag "$PREV_TAG")
+                  fi
+
+                  PREAMBLE_FLAG=()
+                  if [ -s "$PREAMBLE_PATH" ]; then
+                    PREAMBLE_FLAG=(--notes "$(cat "$PREAMBLE_PATH")")
                   fi
 
                   gh release create "v${VERSION}" \
@@ -77,7 +160,8 @@ jobs:
                     --target "${{ github.event.pull_request.merge_commit_sha }}" \
                     --title "v${VERSION}" \
                     --generate-notes \
-                    "${NOTES_FLAG[@]}"
+                    "${PREAMBLE_FLAG[@]}" \
+                    "${NOTES_START_FLAG[@]}"
 
                   echo "✅ Release v${VERSION} created!"
                   echo "🔗 https://github.com/${{ github.repository }}/releases/tag/v${VERSION}"

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -83,10 +83,11 @@ jobs:
                   - [ ] Behavior tests pass (tagged with `behavior-test`)
                   - [ ] Example tests pass (tagged with `test-examples`)
                   - [ ] Evaluation on OpenHands Index
+                  - [ ] Confirm any `release-note-required` PRs are accurately called out in the final release notes
 
                   ### What happens on merge
                   When this PR is merged, the `create-release.yml` workflow will automatically:
-                  1. Create a GitHub release with tag `v${{ inputs.version }}` and auto-generated notes
+                  1. Create a GitHub release with tag `v${{ inputs.version }}` and auto-generated notes, plus an explicit preamble for merged `release-note-required` PRs
                   2. Trigger `pypi-release.yml` to publish all packages to PyPI
                   3. Trigger `version-bump-prs.yml` to create downstream version bump PRs
                   EOF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -161,6 +161,8 @@ consult each relevant package-level AGENTS.md.
   Pydantic `Field(...)` declarations as non-breaking, including adding,
   removing, or editing `description`, `title`, `examples`,
   `json_schema_extra`, and `deprecated` kwargs.
+- Public SDK `Field(default=...)` changes are treated separately from removals/structural API breakages: the API breakage workflow should surface them as behavioral compatibility changes, auto-apply the green `release-note-required` label on PRs, and the release workflow should prepend those labeled PRs to generated GitHub release notes.
+
 - The SDK API breakage checker compares stringified `Field(...)` values by
   parsing them as Python expressions after escaping literal newlines inside
   quoted strings; this avoids false positives on multiline descriptions that

--- a/tests/cross/test_check_sdk_api_breakage.py
+++ b/tests/cross/test_check_sdk_api_breakage.py
@@ -32,9 +32,12 @@ _prod = _load_prod_module()
 PackageConfig = _prod.PackageConfig
 DeprecationMetadata = _prod.DeprecationMetadata
 DeprecatedSymbols = _prod.DeprecatedSymbols
+FieldDefaultChange = _prod.FieldDefaultChange
 _parse_version = _prod._parse_version
 _check_version_bump = _prod._check_version_bump
 _find_deprecated_symbols = _prod._find_deprecated_symbols
+_field_default_repr = _prod._field_default_repr
+_is_field_default_only_change = _prod._is_field_default_only_change
 _is_field_metadata_only_change = _prod._is_field_metadata_only_change
 _was_deprecated = _prod._was_deprecated
 get_pypi_baseline_version = _prod.get_pypi_baseline_version
@@ -535,6 +538,30 @@ def test_is_field_metadata_only_change_default_changed():
     assert _is_field_metadata_only_change(old, new) is False
 
 
+def test_is_field_default_only_change_detects_keyword_default_change():
+    """Changing only Field default value is classified separately."""
+    old = "Field(default='claude-sonnet-4-20250514', description='desc')"
+    new = "Field(default='gpt-5.5', description='desc')"
+
+    assert _is_field_default_only_change(old, new) is True
+
+
+def test_is_field_default_only_change_ignores_other_runtime_changes():
+    """Changing non-default runtime kwargs is not a default-only change."""
+    old = "Field(default='claude-sonnet-4-20250514', alias='model')"
+    new = "Field(default='gpt-5.5', alias='llm_model')"
+
+    assert _is_field_default_only_change(old, new) is False
+
+
+def test_field_default_repr_supports_positional_default():
+    """Positional Field defaults are normalized for reporting."""
+    assert (
+        _field_default_repr("Field('gpt-5.5', description='Model name.')")
+        == "'gpt-5.5'"
+    )
+
+
 def test_is_field_metadata_only_change_not_field():
     """Non-Field values return False."""
     old = "SomeClass(value=1)"
@@ -784,6 +811,50 @@ def test_field_multiline_description_with_quotes_is_not_breaking(tmp_path):
     )
     assert total_breaks == 0
     assert undeprecated == 0
+
+
+def test_field_default_change_is_reported_but_not_breaking(tmp_path):
+    """Public Field default changes should be collected for release notes."""
+    old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
+    new_pkg = _write_pkg_init(tmp_path, "new", ["Config"])
+
+    old_init = old_pkg / "__init__.py"
+    new_init = new_pkg / "__init__.py"
+
+    old_init.write_text(
+        old_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    model: str = Field(default='claude-sonnet-4-20250514')\n"
+    )
+    new_init.write_text(
+        new_init.read_text()
+        + "\nfrom pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    model: str = Field(default='gpt-5.5')\n"
+    )
+
+    old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])
+    new_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "new")])
+
+    field_default_changes: list[FieldDefaultChange] = []
+    total_breaks, undeprecated = _prod._compute_breakages(
+        old_root,
+        new_root,
+        _SDK_CFG,
+        field_default_changes=field_default_changes,
+    )
+
+    assert total_breaks == 0
+    assert undeprecated == 0
+    assert field_default_changes == [
+        _prod.FieldDefaultChange(
+            package="openhands.sdk",
+            object_path="openhands.sdk.Config.model",
+            old_default="'claude-sonnet-4-20250514'",
+            new_default="'gpt-5.5'",
+        )
+    ]
 
 
 def test_field_json_schema_extra_dict_is_not_breaking(tmp_path):


### PR DESCRIPTION
## Summary
- classify public SDK `Field(default=...)` changes as behavioral compatibility notes instead of SemVer/deprecation failures
- auto-sync a green `release-note-required` label from the API breakage workflow when those changes are detected
- prepend merged `release-note-required` PRs into generated GitHub release notes during release creation
- update release preparation docs/checklist to remind reviewers to verify those notes

## Tests
- `uv run pytest tests/cross/test_check_sdk_api_breakage.py`
- `SDK_API_BREAKAGE_REPORT_PATH=/tmp/sdk-api-breakage-report.json ACP_VERSION_CHECK_BASE_REF=main uv run python .github/scripts/check_sdk_api_breakage.py`
- `uv run pre-commit run --files .github/scripts/check_sdk_api_breakage.py .github/workflows/README-RELEASE.md .github/workflows/api-breakage.yml .github/workflows/create-release.yml .github/workflows/prepare-release.yml AGENTS.md tests/cross/test_check_sdk_api_breakage.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9a6965c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9a6965c-python \
  ghcr.io/openhands/agent-server:9a6965c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9a6965c-golang-amd64
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-golang-amd64
ghcr.io/openhands/agent-server:codex-release-note-required-label-golang-amd64
ghcr.io/openhands/agent-server:9a6965c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9a6965c-golang-arm64
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-golang-arm64
ghcr.io/openhands/agent-server:codex-release-note-required-label-golang-arm64
ghcr.io/openhands/agent-server:9a6965c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9a6965c-java-amd64
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-java-amd64
ghcr.io/openhands/agent-server:codex-release-note-required-label-java-amd64
ghcr.io/openhands/agent-server:9a6965c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9a6965c-java-arm64
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-java-arm64
ghcr.io/openhands/agent-server:codex-release-note-required-label-java-arm64
ghcr.io/openhands/agent-server:9a6965c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9a6965c-python-amd64
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-python-amd64
ghcr.io/openhands/agent-server:codex-release-note-required-label-python-amd64
ghcr.io/openhands/agent-server:9a6965c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9a6965c-python-arm64
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-python-arm64
ghcr.io/openhands/agent-server:codex-release-note-required-label-python-arm64
ghcr.io/openhands/agent-server:9a6965c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9a6965c-golang
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-golang
ghcr.io/openhands/agent-server:codex-release-note-required-label-golang
ghcr.io/openhands/agent-server:9a6965c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9a6965c-java
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-java
ghcr.io/openhands/agent-server:codex-release-note-required-label-java
ghcr.io/openhands/agent-server:9a6965c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9a6965c-python
ghcr.io/openhands/agent-server:9a6965c94b0451fefedda09ebf19421c610d7d46-python
ghcr.io/openhands/agent-server:codex-release-note-required-label-python
ghcr.io/openhands/agent-server:9a6965c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9a6965c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9a6965c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->