### PR TITLE
Cap terminal timeout below runtime idle threshold

### DIFF
--- a/openhands-agent-server/openhands/agent_server/server_details_router.py
+++ b/openhands-agent-server/openhands/agent_server/server_details_router.py
@@ -8,6 +8,10 @@ from fastapi import APIRouter, Response
 from pydantic import BaseModel, Field
 
 from openhands.sdk.tool.registry import list_usable_tools
+from openhands.tools.terminal.timeout_policy import (
+    get_max_foreground_timeout_seconds,
+    get_runtime_idle_timeout_seconds,
+)
 
 
 server_details_router = APIRouter(prefix="", tags=["Server Details"])
@@ -51,6 +55,12 @@ class ServerInfo(BaseModel):
     )
     python_version: str = Field(default_factory=lambda: sys.version)
     usable_tools: list[str] = Field(default_factory=lambda: list_usable_tools())
+    runtime_idle_timeout_seconds: float | None = Field(
+        default_factory=lambda: get_runtime_idle_timeout_seconds()
+    )
+    max_foreground_terminal_timeout_seconds: float | None = Field(
+        default_factory=lambda: get_max_foreground_timeout_seconds()
+    )
 
     docs: str = "/docs"
     redoc: str = "/redoc"

--- a/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/terminal_session.py
@@ -22,6 +22,7 @@ from openhands.tools.terminal.terminal.interface import (
     TerminalInterface,
     TerminalSessionBase,
 )
+from openhands.tools.terminal.timeout_policy import foreground_timeout_rejection_for
 from openhands.tools.terminal.utils.command import (
     escape_bash_special_chars,
     split_bash_commands,
@@ -408,6 +409,18 @@ class TerminalSession(TerminalSessionBase):
         logger.debug(f"RECEIVED ACTION: {action}")
         command = action.command.strip()
         is_input: bool = action.is_input
+
+        rejection = foreground_timeout_rejection_for(
+            command=command,
+            is_input=is_input,
+            timeout=action.timeout,
+        )
+        if rejection is not None:
+            return TerminalObservation.from_text(
+                text=rejection,
+                command=command,
+                is_error=True,
+            )
 
         # If the previous command is not completed,
         # we need to check if the command is empty

--- a/openhands-tools/openhands/tools/terminal/timeout_policy.py
+++ b/openhands-tools/openhands/tools/terminal/timeout_policy.py
@@ -1,0 +1,95 @@
+"""Runtime-idle-aware terminal timeout policy."""
+
+import os
+from collections.abc import Mapping
+
+
+RUNTIME_IDLE_TIMEOUT_SECONDS_ENV = "OH_RUNTIME_IDLE_TIMEOUT_SECONDS"
+MAX_FOREGROUND_TIMEOUT_RATIO = 0.9
+
+
+def get_runtime_idle_timeout_seconds(
+    env: Mapping[str, str] | None = None,
+) -> float | None:
+    """Return configured runtime idle timeout in seconds, if any.
+
+    The runtime-api injects this value into managed runtime pods. Local and
+    self-hosted deployments that do not have idle cleanup can leave it unset,
+    which disables the foreground terminal timeout cap.
+    """
+    raw = (env or os.environ).get(RUNTIME_IDLE_TIMEOUT_SECONDS_ENV)
+    if raw is None or raw.strip() == "":
+        return None
+
+    try:
+        value = float(raw)
+    except ValueError:
+        return None
+
+    if value <= 0:
+        return None
+    return value
+
+
+def get_max_foreground_timeout_seconds(
+    runtime_idle_timeout_seconds: float | None = None,
+) -> float | None:
+    """Return max safe foreground terminal timeout, or None when uncapped."""
+    idle_timeout = (
+        get_runtime_idle_timeout_seconds()
+        if runtime_idle_timeout_seconds is None
+        else runtime_idle_timeout_seconds
+    )
+    if idle_timeout is None:
+        return None
+    return idle_timeout * MAX_FOREGROUND_TIMEOUT_RATIO
+
+
+def format_seconds(value: float) -> str:
+    """Format second values compactly for user-facing observations."""
+    return f"{value:g}"
+
+
+def foreground_timeout_rejection_message(
+    requested_timeout_seconds: float,
+    runtime_idle_timeout_seconds: float,
+) -> str:
+    """Build the user-facing rejection for unsafe foreground timeouts."""
+    max_timeout = get_max_foreground_timeout_seconds(runtime_idle_timeout_seconds)
+    assert max_timeout is not None
+    ratio_percent = int(MAX_FOREGROUND_TIMEOUT_RATIO * 100)
+    return (
+        "Refusing to run foreground terminal command with "
+        f"timeout={format_seconds(requested_timeout_seconds)}s.\n\n"
+        "This runtime is subject to idle cleanup after "
+        f"{format_seconds(runtime_idle_timeout_seconds)}s. Foreground terminal "
+        f"commands are capped at {ratio_percent}% of that threshold, currently "
+        f"{format_seconds(max_timeout)}s, so commands can return control before "
+        "the runtime is considered idle.\n\n"
+        "For long-running work, use a shorter timeout, omit the timeout to use "
+        "the terminal soft-timeout/polling flow, or start the command in the "
+        "background and poll its log file."
+    )
+
+
+def foreground_timeout_rejection_for(
+    *,
+    command: str,
+    is_input: bool,
+    timeout: float | None,
+    runtime_idle_timeout_seconds: float | None = None,
+) -> str | None:
+    """Return a rejection message if a terminal action is unsafe to run."""
+    if is_input or not command.strip() or timeout is None:
+        return None
+
+    idle_timeout = (
+        get_runtime_idle_timeout_seconds()
+        if runtime_idle_timeout_seconds is None
+        else runtime_idle_timeout_seconds
+    )
+    max_timeout = get_max_foreground_timeout_seconds(idle_timeout)
+    if idle_timeout is None or max_timeout is None or timeout <= max_timeout:
+        return None
+
+    return foreground_timeout_rejection_message(timeout, idle_timeout)

--- a/tests/agent_server/test_server_details_router.py
+++ b/tests/agent_server/test_server_details_router.py
@@ -70,3 +70,18 @@ def test_server_info_reports_usable_tools(client, monkeypatch: pytest.MonkeyPatc
 
     assert response.status_code == 200
     assert response.json()["usable_tools"] == ["terminal", "file_editor"]
+
+
+def test_server_info_reports_runtime_timeout_cap(
+    client,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """/server_info should expose the idle-derived terminal timeout cap."""
+    monkeypatch.setenv("OH_RUNTIME_IDLE_TIMEOUT_SECONDS", "1200")
+
+    response = client.get("/server_info")
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["runtime_idle_timeout_seconds"] == 1200
+    assert payload["max_foreground_terminal_timeout_seconds"] == 1080

--- a/tests/tools/terminal/test_timeout_policy.py
+++ b/tests/tools/terminal/test_timeout_policy.py
@@ -1,0 +1,93 @@
+from unittest.mock import MagicMock
+
+from openhands.tools.terminal.definition import TerminalAction
+from openhands.tools.terminal.terminal.terminal_session import TerminalSession
+from openhands.tools.terminal.timeout_policy import (
+    RUNTIME_IDLE_TIMEOUT_SECONDS_ENV,
+    foreground_timeout_rejection_for,
+    get_max_foreground_timeout_seconds,
+    get_runtime_idle_timeout_seconds,
+)
+
+
+def test_runtime_idle_timeout_unset_disables_cap(monkeypatch):
+    monkeypatch.delenv(RUNTIME_IDLE_TIMEOUT_SECONDS_ENV, raising=False)
+
+    assert get_runtime_idle_timeout_seconds() is None
+    assert get_max_foreground_timeout_seconds() is None
+    assert (
+        foreground_timeout_rejection_for(
+            command="sleep 9999",
+            is_input=False,
+            timeout=9999,
+        )
+        is None
+    )
+
+
+def test_foreground_timeout_cap_uses_ninety_percent_of_idle_threshold(monkeypatch):
+    monkeypatch.setenv(RUNTIME_IDLE_TIMEOUT_SECONDS_ENV, "1200")
+
+    assert get_runtime_idle_timeout_seconds() == 1200
+    assert get_max_foreground_timeout_seconds() == 1080
+    assert (
+        foreground_timeout_rejection_for(
+            command="sleep 1080",
+            is_input=False,
+            timeout=1080,
+        )
+        is None
+    )
+
+    rejection = foreground_timeout_rejection_for(
+        command="sleep 1500",
+        is_input=False,
+        timeout=1500,
+    )
+
+    assert rejection is not None
+    assert "timeout=1500s" in rejection
+    assert "idle cleanup after 1200s" in rejection
+    assert "currently 1080s" in rejection
+
+
+def test_foreground_timeout_cap_ignores_inputs_empty_commands_and_null_timeout(
+    monkeypatch,
+):
+    monkeypatch.setenv(RUNTIME_IDLE_TIMEOUT_SECONDS_ENV, "1200")
+
+    assert (
+        foreground_timeout_rejection_for(command="C-c", is_input=True, timeout=1500)
+        is None
+    )
+    assert (
+        foreground_timeout_rejection_for(command="", is_input=False, timeout=1500)
+        is None
+    )
+    assert (
+        foreground_timeout_rejection_for(
+            command="sleep 1500",
+            is_input=False,
+            timeout=None,
+        )
+        is None
+    )
+
+
+def test_terminal_session_rejects_unsafe_foreground_timeout_before_execution(
+    monkeypatch,
+):
+    monkeypatch.setenv(RUNTIME_IDLE_TIMEOUT_SECONDS_ENV, "1200")
+    terminal = MagicMock()
+    terminal.work_dir = "/workspace"
+    terminal.username = None
+    session = TerminalSession(terminal=terminal)
+    session._initialized = True
+
+    observation = session.execute(TerminalAction(command="sleep 1500", timeout=1500))
+
+    assert observation.is_error is True
+    assert observation.command == "sleep 1500"
+    assert "currently 1080s" in observation.text
+    terminal.read_screen.assert_not_called()
+    terminal.send_keys.assert_not_called()


### PR DESCRIPTION
## Summary
- Add a terminal timeout policy that derives a foreground command timeout cap from `OH_RUNTIME_IDLE_TIMEOUT_SECONDS * 0.9`
- Reject explicit foreground command timeouts above that cap while leaving the cap unset when no runtime idle threshold is configured
- Expose runtime idle timeout/cap values through `/server_info` and cover policy/router behavior with tests

## Validation
- `uv run pytest tests/tools/terminal/test_timeout_policy.py tests/agent_server/test_server_details_router.py`
- `uv run ruff check openhands-tools/openhands/tools/terminal/timeout_policy.py openhands-tools/openhands/tools/terminal/terminal/terminal_session.py openhands-agent-server/openhands/agent_server/server_details_router.py tests/tools/terminal/test_timeout_policy.py tests/agent_server/test_server_details_router.py`
- `git diff --check`

This PR was created by an AI agent (OpenHands) on behalf of the user.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:37736d5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-37736d5-python \
  ghcr.io/openhands/agent-server:37736d5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:37736d5-golang-amd64
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-golang-amd64
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-golang-amd64
ghcr.io/openhands/agent-server:37736d5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:37736d5-golang-arm64
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-golang-arm64
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-golang-arm64
ghcr.io/openhands/agent-server:37736d5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:37736d5-java-amd64
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-java-amd64
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-java-amd64
ghcr.io/openhands/agent-server:37736d5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:37736d5-java-arm64
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-java-arm64
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-java-arm64
ghcr.io/openhands/agent-server:37736d5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:37736d5-python-amd64
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-python-amd64
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-python-amd64
ghcr.io/openhands/agent-server:37736d5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:37736d5-python-arm64
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-python-arm64
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-python-arm64
ghcr.io/openhands/agent-server:37736d5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:37736d5-golang
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-golang
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-golang
ghcr.io/openhands/agent-server:37736d5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:37736d5-java
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-java
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-java
ghcr.io/openhands/agent-server:37736d5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:37736d5-python
ghcr.io/openhands/agent-server:37736d50c76dfe23070fb90d130f17ab72e2f4f7-python
ghcr.io/openhands/agent-server:fix-runtime-idle-terminal-timeout-cap-python
ghcr.io/openhands/agent-server:37736d5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `37736d5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `37736d5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Issue
Resolves OpenHands/software-agent-sdk#3293