### PR TITLE
feat(agent-server): add POST /api/mcp/test endpoint to validate MCP configs

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -38,6 +38,7 @@ from openhands.agent_server.file_router import file_router
 from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
 from openhands.agent_server.llm_router import llm_router
+from openhands.agent_server.mcp_router import mcp_router
 from openhands.agent_server.middleware import LocalhostCORSMiddleware
 from openhands.agent_server.profiles_router import profiles_router
 from openhands.agent_server.server_details_router import (
@@ -288,6 +289,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(skills_router)
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
+    api_router.include_router(mcp_router)
     api_router.include_router(settings_router)
     api_router.include_router(profiles_router)
     api_router.include_router(cloud_proxy_router)

--- a/openhands-agent-server/openhands/agent_server/mcp_router.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_router.py
@@ -1,0 +1,225 @@
+"""MCP router for OpenHands SDK.
+
+Exposes a single endpoint, ``POST /api/mcp/test``, that lets clients verify
+a candidate MCP server configuration in isolation -- before persisting it
+to settings, where a misconfiguration would otherwise surface only at
+conversation start (and there manifest as a noisy traceback that aborts
+agent initialization).
+
+The endpoint is intentionally side-effect-free: it spins up the MCP
+connection, lists the advertised tools, then tears the connection down.
+It never mutates server state or touches stored settings.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Annotated, Any, Literal
+
+from fastapi import APIRouter
+from pydantic import BaseModel, Field, model_validator
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.mcp import create_mcp_tools
+from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
+
+
+logger = get_logger(__name__)
+
+mcp_router = APIRouter(prefix="/mcp", tags=["MCP"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+#
+# We accept a single server spec instead of the full ``MCPConfig`` map. The
+# UI flow this powers ("add a new MCP server") always validates one server
+# at a time, and keeping the request shape narrow avoids exposing tuple-of-
+# transports semantics the caller doesn't need.
+
+_DEFAULT_SERVER_NAME = "test-server"
+
+
+class _StdioMCPServerSpec(BaseModel):
+    """Stdio (subprocess) MCP server spec.
+
+    Mirrors the subset of ``fastmcp.mcp_config.StdioMCPServer`` fields the
+    OpenHands UI exposes today.
+    """
+
+    type: Literal["stdio"] = "stdio"
+    command: str = Field(..., min_length=1, description="Executable to invoke")
+    args: list[str] = Field(default_factory=list)
+    env: dict[str, str] = Field(default_factory=dict)
+    cwd: str | None = None
+
+
+class _RemoteMCPServerSpec(BaseModel):
+    """Remote (HTTP / SSE) MCP server spec."""
+
+    # ``shttp`` is the alias the OpenHands settings layer uses for
+    # streamable-http; we accept both spellings so the UI can forward
+    # its own value unchanged.
+    type: Literal["http", "shttp", "streamable-http", "sse"]
+    url: str = Field(..., min_length=1)
+    headers: dict[str, str] = Field(default_factory=dict)
+    api_key: str | None = Field(
+        default=None,
+        description=(
+            "Bearer token. If provided, sent as 'Authorization: Bearer <token>'."
+        ),
+    )
+
+    def to_fastmcp_dict(self) -> dict[str, Any]:
+        # fastmcp's RemoteMCPServer accepts "http", "streamable-http", "sse";
+        # collapse the OpenHands-specific "shttp" alias to "http".
+        transport = "http" if self.type == "shttp" else self.type
+        out: dict[str, Any] = {"url": self.url, "transport": transport}
+        headers = dict(self.headers)
+        if self.api_key:
+            # Don't clobber a caller-provided Authorization header.
+            headers.setdefault("Authorization", f"Bearer {self.api_key}")
+        if headers:
+            out["headers"] = headers
+        return out
+
+
+class MCPTestRequest(BaseModel):
+    """Body for ``POST /api/mcp/test``."""
+
+    name: str = Field(
+        default=_DEFAULT_SERVER_NAME,
+        min_length=1,
+        max_length=128,
+        description=(
+            "Name to use for the server inside the temporary MCPConfig. "
+            "Only affects error messages -- does not need to match any "
+            "persisted setting."
+        ),
+    )
+    server: Annotated[
+        _StdioMCPServerSpec | _RemoteMCPServerSpec,
+        Field(discriminator="type"),
+    ]
+    timeout: float = Field(
+        default=15.0,
+        gt=0,
+        le=120,
+        description="Seconds to wait for connection + tools/list to complete.",
+    )
+
+    @model_validator(mode="after")
+    def _strip_name(self) -> MCPTestRequest:
+        # Mirror the validation MCPConfig itself applies to server keys --
+        # whitespace-only names would silently bypass min_length=1 above.
+        self.name = self.name.strip() or _DEFAULT_SERVER_NAME
+        return self
+
+
+class MCPTestSuccess(BaseModel):
+    """Response when the candidate server connects and lists its tools."""
+
+    ok: Literal[True] = True
+    tools: list[str] = Field(
+        default_factory=list,
+        description="Names of tools advertised by the MCP server.",
+    )
+
+
+class MCPTestFailure(BaseModel):
+    """Response when the candidate server fails to connect or list tools.
+
+    The endpoint returns HTTP 200 in both success and failure cases: a
+    failure here is the *expected* outcome of validating a user-supplied
+    config, not a server-side error. The structured shape makes it easy
+    for the UI to render an actionable message.
+    """
+
+    ok: Literal[False] = False
+    error: str = Field(description="Human-readable error message.")
+    error_kind: Literal["timeout", "connection", "unknown"] = Field(
+        description="Coarse error classification, useful for branching UI."
+    )
+
+
+MCPTestResponse = MCPTestSuccess | MCPTestFailure
+
+
+# ---------------------------------------------------------------------------
+# Endpoint
+# ---------------------------------------------------------------------------
+
+
+def _server_to_fastmcp_dict(spec: _StdioMCPServerSpec | _RemoteMCPServerSpec) -> dict:
+    if isinstance(spec, _StdioMCPServerSpec):
+        out: dict[str, Any] = {"command": spec.command, "args": list(spec.args)}
+        if spec.env:
+            out["env"] = dict(spec.env)
+        if spec.cwd:
+            out["cwd"] = spec.cwd
+        return out
+    return spec.to_fastmcp_dict()
+
+
+def _probe_mcp_server(request: MCPTestRequest) -> MCPTestResponse:
+    """Synchronous probe -- safe to run inside ``run_in_executor``.
+
+    ``create_mcp_tools`` already runs its own event loop in a background
+    thread via ``MCPClient.call_async_from_sync``. We deliberately do not
+    call it from the FastAPI request task; instead the caller hops into a
+    threadpool first.
+    """
+
+    config = {"mcpServers": {request.name: _server_to_fastmcp_dict(request.server)}}
+
+    try:
+        # ``create_mcp_tools`` returns a client that owns a background loop
+        # and a (possibly long-lived) subprocess. Use the context-manager
+        # form so we always tear it down, even when listing succeeded.
+        with create_mcp_tools(config, timeout=request.timeout) as client:
+            return MCPTestSuccess(tools=[tool.name for tool in client.tools])
+    except MCPTimeoutError as exc:
+        logger.info("MCP test timed out for server %r: %s", request.name, exc)
+        return MCPTestFailure(error=str(exc), error_kind="timeout")
+    except MCPError as exc:
+        # ``MCPError("MCP Connection Failure")`` is what client.connect()
+        # raises when the underlying fastmcp client fails to start. Surface
+        # the root-cause message (e.g. "sh: 1: mcp-server-github: Permission
+        # denied") because the wrapper alone isn't useful.
+        cause = exc.__cause__ or exc.__context__
+        detail = str(cause) if cause else str(exc) or "Failed to connect to MCP server"
+        logger.info(
+            "MCP test connection failed for server %r: %s", request.name, detail
+        )
+        return MCPTestFailure(error=detail, error_kind="connection")
+    except Exception as exc:  # noqa: BLE001 - we want to surface anything else
+        # Any other exception is unexpected but should still return a
+        # structured response: the UI can't recover from a 500.
+        logger.warning(
+            "MCP test failed unexpectedly for server %r",
+            request.name,
+            exc_info=True,
+        )
+        return MCPTestFailure(
+            error=f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__,
+            error_kind="unknown",
+        )
+
+
+@mcp_router.post(
+    "/test",
+    response_model=MCPTestResponse,
+    summary="Test an MCP server configuration",
+    description=(
+        "Attempt to connect to a candidate MCP server and list its tools, "
+        "without persisting any settings. Useful for validating user input "
+        "in 'add MCP server' flows before storing the config. "
+        "Returns 200 with `ok=false` for connection / timeout failures "
+        "(those are expected during validation, not server errors)."
+    ),
+)
+async def test_mcp_server(request: MCPTestRequest) -> MCPTestResponse:
+    """Probe a single MCP server config and report whether it works."""
+    loop = asyncio.get_running_loop()
+    return await loop.run_in_executor(None, _probe_mcp_server, request)

--- a/tests/agent_server/test_mcp_router.py
+++ b/tests/agent_server/test_mcp_router.py
@@ -1,0 +1,227 @@
+"""Tests for mcp_router.py endpoints."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+
+# Reuse the real FastMCP-based test-server helper from the SDK tests; spinning
+# up a real subprocess MCP server inside a unit test is unreliable across CI
+# images (depends on npx, network, etc.), but an in-process FastMCP HTTP server
+# is perfectly portable and exercises the same connect/list-tools code path
+# the endpoint relies on.
+from tests.sdk.mcp.test_create_mcp_tool import (  # noqa: E402
+    MCPTestServer,
+    _find_free_port,
+)
+
+
+@pytest.fixture
+def client() -> TestClient:
+    config = Config(session_api_keys=[])  # Disable authentication.
+    return TestClient(create_app(config), raise_server_exceptions=False)
+
+
+@pytest.fixture
+def http_mcp_server():
+    server = MCPTestServer("test-mcp-router")
+
+    @server.add_tool
+    def echo(message: str) -> str:
+        """Echo a message back."""
+        return message
+
+    @server.add_tool
+    def add(a: int, b: int) -> int:
+        """Add two integers."""
+        return a + b
+
+    server.start(transport="http")
+    yield server
+    server.stop()
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_test_remote_success(client: TestClient, http_mcp_server: MCPTestServer):
+    """A reachable HTTP MCP server should report ok=True with the tool names."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "name": "happy-server",
+            "server": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{http_mcp_server.port}/mcp",
+            },
+            "timeout": 10.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert set(body["tools"]) == {"echo", "add"}
+
+
+def test_mcp_test_shttp_alias_is_accepted(
+    client: TestClient, http_mcp_server: MCPTestServer
+):
+    """The OpenHands-specific 'shttp' transport alias should map to http."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {
+                "type": "shttp",
+                "url": f"http://127.0.0.1:{http_mcp_server.port}/mcp",
+            },
+            "timeout": 10.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True
+
+
+def test_mcp_test_stdio_success(client: TestClient):
+    """A working stdio MCP server (FastMCP run via current python) should connect.
+
+    We run a tiny FastMCP script via the current Python interpreter so the
+    test stays hermetic (no npx, no network).
+    """
+    script = (
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('stdio-test')\n"
+        "@mcp.tool()\n"
+        "def ping() -> str:\n"
+        "    return 'pong'\n"
+        "mcp.run()\n"
+    )
+
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "name": "stdio-happy",
+            "server": {
+                "type": "stdio",
+                "command": sys.executable,
+                "args": ["-c", script],
+            },
+            "timeout": 20.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True, body
+    assert "ping" in body["tools"]
+
+
+# ---------------------------------------------------------------------------
+# Failure paths -- all should return HTTP 200 with ok=False
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_test_stdio_failure_returns_structured_error(client: TestClient):
+    """A bad stdio command should return ok=False with a useful error."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "name": "broken",
+            "server": {
+                "type": "stdio",
+                "command": "/this/path/does/not/exist/definitely-not-a-binary",
+                "args": [],
+            },
+            "timeout": 5.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error_kind"] in {"connection", "timeout", "unknown"}
+    assert body["error"], "expected a non-empty error message"
+
+
+def test_mcp_test_remote_unreachable(client: TestClient):
+    """Connecting to a port nothing is listening on should fail cleanly."""
+    free_port = _find_free_port()
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{free_port}/mcp",
+            },
+            "timeout": 3.0,
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is False
+    assert body["error_kind"] in {"connection", "timeout"}
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_test_rejects_empty_command(client: TestClient):
+    response = client.post(
+        "/api/mcp/test",
+        json={"server": {"type": "stdio", "command": ""}},
+    )
+    assert response.status_code == 422
+
+
+def test_mcp_test_rejects_unknown_transport(client: TestClient):
+    response = client.post(
+        "/api/mcp/test",
+        json={"server": {"type": "websocket", "url": "ws://example.com"}},
+    )
+    assert response.status_code == 422
+
+
+def test_mcp_test_clamps_timeout_range(client: TestClient):
+    """Timeout must be > 0 and <= 120; 0 should be rejected at the schema layer."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {"type": "stdio", "command": "true"},
+            "timeout": 0,
+        },
+    )
+    assert response.status_code == 422
+
+
+def test_mcp_test_bearer_token_in_auth_header(
+    client: TestClient, http_mcp_server: MCPTestServer
+):
+    """Providing api_key should not break the connect (request must succeed)."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{http_mcp_server.port}/mcp",
+                "api_key": "test-token-123",
+            },
+            "timeout": 10.0,
+        },
+    )
+
+    # FastMCP's HTTP server doesn't enforce auth in this fixture, so the
+    # request should still succeed; this guards against the api_key wiring
+    # itself blowing up (e.g. malformed headers crashing the transport).
+    assert response.status_code == 200, response.text
+    assert response.json()["ok"] is True


### PR DESCRIPTION
## Why

A misconfigured MCP server (bad token, missing binary, unreachable URL, etc.) currently only surfaces when a conversation starts: `init_state` calls into `create_mcp_tools`, that connect attempt raises, and the whole agent initialization aborts with a wall of tracebacks. There's no way for a UI client to validate a candidate server before persisting it to settings, so the failure mode is jarring (the user does something unrelated 20 minutes later and watches an unrelated conversation refuse to start).

Concretely, this kind of trace ends every conversation start until the bad MCP is removed:

```
sh: 1: mcp-server-github: Permission denied
Failed to connect to MCP server 'github', skipping
…
openhands.sdk.mcp.exceptions.MCPError: MCP Connection Failure
```

## What

A new `POST /api/mcp/test` endpoint that probes a single MCP server config in isolation and reports whether it works.

- Accepts a discriminated union of stdio / http / sse / shttp server specs (the same shapes the OpenHands settings layer already stores).
- Reuses `create_mcp_tools` — the **same** connect + `tools/list` path used at conversation init — so a successful probe is a real guarantee, not a shape check.
- Always returns **HTTP 200**: a failed connection during user-input validation is not a server error, it's the expected outcome we want the UI to render. Failures come back as `{ok: false, error, error_kind: 'timeout'|'connection'|'unknown'}`.
- Bounds the probe with a configurable timeout (default 15 s, hard cap 120 s) and tears down the subprocess / HTTP client in all paths via the existing `MCPClient` sync-context-manager.

### Example

Success:
```bash
curl -X POST $HOST/api/mcp/test -H 'content-type: application/json' -d '{
  "server": {"type": "http", "url": "http://127.0.0.1:8765/mcp"}
}'
# {"ok": true, "tools": ["echo", "add"]}
```

Failure:
```bash
curl -X POST $HOST/api/mcp/test -H 'content-type: application/json' -d '{
  "server": {"type": "stdio", "command": "npx", "args": ["-y", "@modelcontextprotocol/server-github"]}
}'
# {"ok": false, "error": "sh: 1: mcp-server-github: Permission denied",
#  "error_kind": "connection"}
```

## Tests

Nine tests in `tests/agent_server/test_mcp_router.py`, all running real MCP servers (no mocks):

- HTTP success path (reuses the in-process `FastMCP` server fixture from the existing SDK tests).
- The OpenHands `shttp` transport alias maps cleanly to `http`.
- Stdio success path via `python -c "<tiny FastMCP server>"` — hermetic, no npx.
- Stdio failure path (bogus command).
- Remote failure path (free port nobody is listening on).
- Validation: empty command, unknown transport, and zero-second timeout are rejected at the schema layer (422).
- `api_key` bearer token wiring round-trips through the request without crashing the transport.

`tests/agent_server/test_api.py` + `test_api_authentication.py` (60 tests) still pass; ruff + pyright are clean on the new files.

## Follow-up

A small `agent-canvas` change will call this endpoint from the "Install MCP server" modal before persisting via the existing settings patch, so the failure surfaces inline next to the form fields the user can actually fix — instead of breaking a future conversation.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2e9cf7e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2e9cf7e-python \
  ghcr.io/openhands/agent-server:2e9cf7e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2e9cf7e-golang-amd64
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-golang-amd64
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-golang-amd64
ghcr.io/openhands/agent-server:2e9cf7e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2e9cf7e-golang-arm64
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-golang-arm64
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-golang-arm64
ghcr.io/openhands/agent-server:2e9cf7e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2e9cf7e-java-amd64
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-java-amd64
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-java-amd64
ghcr.io/openhands/agent-server:2e9cf7e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2e9cf7e-java-arm64
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-java-arm64
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-java-arm64
ghcr.io/openhands/agent-server:2e9cf7e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2e9cf7e-python-amd64
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-python-amd64
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-python-amd64
ghcr.io/openhands/agent-server:2e9cf7e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2e9cf7e-python-arm64
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-python-arm64
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-python-arm64
ghcr.io/openhands/agent-server:2e9cf7e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2e9cf7e-golang
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-golang
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-golang
ghcr.io/openhands/agent-server:2e9cf7e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2e9cf7e-java
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-java
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-java
ghcr.io/openhands/agent-server:2e9cf7e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2e9cf7e-python
ghcr.io/openhands/agent-server:2e9cf7ee67846da4e27affca17e9cba3537d7784-python
ghcr.io/openhands/agent-server:feat-mcp-test-endpoint-python
ghcr.io/openhands/agent-server:2e9cf7e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2e9cf7e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2e9cf7e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->