### PR TITLE
agent-server: make /skills endpoint tolerant of non-git workspace

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -24,6 +24,8 @@ from openhands.agent_server.skills_service import (
     sync_public_skills,
 )
 from openhands.sdk.extensions.fetch import ExtensionFetchError
+from openhands.sdk.git.exceptions import GitError
+from openhands.sdk.logger import get_logger
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     SkillFetchError,
@@ -33,6 +35,7 @@ from openhands.sdk.skills.skill import DEFAULT_MARKETPLACE_PATH
 from openhands.sdk.skills.utils import SKILL_NAME_PATTERN
 
 
+logger = get_logger(__name__)
 skills_router = APIRouter(prefix="/skills", tags=["Skills"])
 
 # Validated skill name path parameter
@@ -274,18 +277,39 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
         org_repo_url = request.org_config.org_repo_url
         org_name = request.org_config.org_name
 
-    # Call the service
-    result = load_all_skills(
-        load_public=request.load_public,
-        load_user=request.load_user,
-        load_project=request.load_project,
-        load_org=request.load_org,
-        project_dir=request.project_dir,
-        org_repo_url=org_repo_url,
-        org_name=org_name,
-        sandbox_exposed_urls=sandbox_urls,
-        marketplace_path=request.marketplace_path,
-    )
+    # Call the service.
+    #
+    # Skills loading is best-effort: it pulls from several independent sources
+    # (public, user, project, org, sandbox), and the consumer (the SDK's
+    # RemoteWorkspace.load_skills_from_agent_server) expects this endpoint to
+    # succeed even when some sources fail. The service layer already catches
+    # most failure modes per-source, but git-related errors from the project
+    # workspace are an explicit known case: when the workspace isn't a git
+    # repository (e.g. the request arrives before EventService.start has had
+    # a chance to `git init` the workspace), any git invocation triggered by
+    # project-skill discovery raises GitError. We mirror git_router's
+    # defensive pattern and degrade to an empty response with a warning log,
+    # so the agent still gets public/user/org skills and the SDK consumer
+    # doesn't blow up over workspace state it has no way to control.
+    try:
+        result = load_all_skills(
+            load_public=request.load_public,
+            load_user=request.load_user,
+            load_project=request.load_project,
+            load_org=request.load_org,
+            project_dir=request.project_dir,
+            org_repo_url=org_repo_url,
+            org_name=org_name,
+            sandbox_exposed_urls=sandbox_urls,
+            marketplace_path=request.marketplace_path,
+        )
+    except GitError as e:
+        logger.warning(
+            "Skills loading failed due to workspace git state (%s); "
+            "returning empty skills",
+            e,
+        )
+        return SkillsResponse(skills=[], sources={})
 
     # Convert Skill objects to SkillInfo for response
     skills_info = [

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -24,6 +24,7 @@ from time import monotonic
 
 from pydantic import BaseModel, ValidationError
 
+from openhands.sdk.git.exceptions import GitError
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace import Marketplace
 from openhands.sdk.skills import (
@@ -362,12 +363,31 @@ def load_all_skills(
     skill_lists.append(org_skills)
 
     # 5. Load project skills (highest precedence)
-    project_skills = load_available_skills(
-        work_dir=project_dir if load_project else None,
-        include_user=False,
-        include_project=load_project,
-        include_public=False,
-    )
+    #
+    # Project-skill discovery walks the workspace directory and may, in some
+    # code paths, invoke git (e.g. to resolve a repo root or read repo state).
+    # When the workspace isn't a git repository yet — for example, when this
+    # endpoint is called before a conversation has been created, so
+    # EventService._ensure_workspace_is_git_repo hasn't run — that git call
+    # raises GitError. Skills loading is best-effort, so we mirror the
+    # defensive pattern used by git_router._get_git_changes: log and return
+    # empty project skills rather than letting the request 500. This keeps
+    # the agent usable (with public/user/org skills only) instead of failing
+    # the entire load_skills_from_agent_server call.
+    project_skills: dict[str, Skill] = {}
+    try:
+        project_skills = load_available_skills(
+            work_dir=project_dir if load_project else None,
+            include_user=False,
+            include_project=load_project,
+            include_public=False,
+        )
+    except GitError as e:
+        logger.warning(
+            "Project skills unavailable (workspace git state error at %s): %s",
+            project_dir,
+            e,
+        )
     sources["project"] = len(project_skills)
     skill_lists.append(list(project_skills.values()))
 

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -10,6 +10,7 @@ from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.skills_service import MarketplaceSkillInfo, SkillLoadResult
 from openhands.sdk.extensions.fetch import ExtensionFetchError
+from openhands.sdk.git.exceptions import GitRepositoryError
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     KeywordTrigger,
@@ -63,6 +64,36 @@ class TestGetSkillsEndpoint:
             assert "sources" in data
             assert len(data["skills"]) == 1
             assert data["skills"][0]["name"] == "test-skill"
+
+    def test_get_skills_returns_empty_response_on_git_error(self, client):
+        """The /skills endpoint must degrade to an empty 200 when the
+        underlying service raises a GitError.
+
+        Regression for the prompt-preset failure mode where the workspace is
+        not yet a git repository (EventService.start has not run) and the
+        SDK's RemoteWorkspace.load_skills_from_agent_server would otherwise
+        receive a 500 it has no sensible way to recover from.
+        """
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.side_effect = GitRepositoryError(
+                "fatal: not a git repository (or any of the parent "
+                "directories): .git",
+                command="git rev-parse",
+                exit_code=128,
+            )
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "project_dir": "/workspace/myproject",
+                    "load_project": True,
+                },
+            )
+
+            assert response.status_code == 200
+            data = response.json()
+            assert data["skills"] == []
+            assert data["sources"] == {}
 
     def test_get_skills_with_project_dir(self, client):
         """Test skills request with project directory."""

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -14,6 +14,7 @@ from openhands.agent_server.skills_service import (
     merge_skills,
     sync_public_skills,
 )
+from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.skills import Skill
 
 
@@ -330,6 +331,73 @@ class TestLoadAllSkills:
             )
 
             assert result.sources["sdk_base"] == 1
+
+    def test_load_all_skills_swallows_git_repository_error_for_project_dir(self):
+        """Project skills load must not 500 when the workspace isn't a git repo.
+
+        Regression for the prompt-preset failure mode where
+        load_skills_from_agent_server is called before EventService.start()
+        has had a chance to `git init` the workspace. The endpoint should
+        degrade gracefully: other sources are returned, project sources are
+        empty, and no exception escapes.
+        """
+        user_skill = Skill(name="user1", content="user-content", trigger=None)
+
+        # First call (sdk_base / public+user) returns a skill; second call
+        # (project) raises GitRepositoryError, simulating a workspace that
+        # isn't a git repo.
+        with patch(
+            self._PATCH_TARGET,
+            side_effect=[
+                {"user1": user_skill},
+                GitRepositoryError(
+                    "fatal: not a git repository (or any of the parent "
+                    "directories): .git",
+                    command="git rev-parse",
+                    exit_code=128,
+                ),
+            ],
+        ):
+            result = load_all_skills(
+                load_public=True,
+                load_user=True,
+                load_project=True,
+                load_org=False,
+                project_dir="/workspace",
+            )
+
+        assert isinstance(result, SkillLoadResult)
+        assert result.sources["sdk_base"] == 1
+        assert result.sources["project"] == 0
+        assert [s.name for s in result.skills] == ["user1"]
+
+    def test_load_all_skills_swallows_git_command_error_for_project_dir(self):
+        """Project skills load must not 500 on arbitrary git command failures."""
+        user_skill = Skill(name="user1", content="user-content", trigger=None)
+
+        with patch(
+            self._PATCH_TARGET,
+            side_effect=[
+                {"user1": user_skill},
+                GitCommandError(
+                    "git command failed",
+                    command=["git", "rev-parse", "HEAD"],
+                    exit_code=128,
+                    stderr="fatal: not a git repository",
+                ),
+            ],
+        ):
+            result = load_all_skills(
+                load_public=True,
+                load_user=True,
+                load_project=True,
+                load_org=False,
+                project_dir="/workspace",
+            )
+
+        assert result.sources["sdk_base"] == 1
+        assert result.sources["project"] == 0
+        assert [s.name for s in result.skills] == ["user1"]
 
     def test_load_all_skills_merge_precedence(self):
         """Test that skills are merged with correct precedence."""


### PR DESCRIPTION
## Problem

`RemoteWorkspace.load_skills_from_agent_server` calls the agent server's `POST /skills` endpoint. In the prompt-preset automation path (`sdk_main.py`), this is called **before** the conversation is created — which means **before** `EventService.start()` has had a chance to run `_ensure_workspace_is_git_repo`. If anything in the project-skill discovery path on the server invokes git on the workspace dir (or grows that dependency in the future), it raises `GitError` and bubbles out as a 500. The SDK consumer has no sensible way to recover from that — workspace git state is not something it can influence.

This was hit in practice by a prompt-preset automation that didn't pass `repos`. Runs surfaced as:

```
exit_code=128
stderr: fatal: not a git repository (or any of the parent directories): .git
```

## What this PR does

Mirrors the defensive pattern already used by `git_router._get_git_changes` / `_get_git_diff` (collapse `GitRepositoryError` to an empty result rather than 5xx-ing), but at the `/skills` boundary:

1. **`skills_service.load_all_skills`** — wraps the project-skills `load_available_skills(work_dir=project_dir, ...)` call in `try/except GitError`. On failure: warning log, empty `project_skills`, other sources still returned. Mirrors the existing org-skills defensive wrap a few lines above.
2. **`skills_router.get_skills`** — wraps `load_all_skills(...)` in `try/except GitError`. On failure: warning log, return empty `SkillsResponse(skills=[], sources={})` with HTTP 200.

Skills loading is best-effort: the agent stays usable with public/user/org skills, and the SDK consumer no longer raises on workspace state it can't control.

Each catch site has an explanatory comment so future readers see *why* the swallow is intentional, not just *that* it's there.

## Tests

Three regression tests, all passing:

- `test_load_all_skills_swallows_git_repository_error_for_project_dir` — service raises `GitRepositoryError` on the project loader; assert service returns successfully with `sources["project"] == 0`, other sources intact.
- `test_load_all_skills_swallows_git_command_error_for_project_dir` — same shape with `GitCommandError`, covering the other `GitError` subclass that can come out of `openhands.sdk.git.utils`.
- `test_get_skills_returns_empty_response_on_git_error` — endpoint returns 200 + empty skills/sources when the underlying service raises `GitError`.

```
tests/agent_server/test_skills_service.py ............................... [ 49%]
tests/agent_server/test_skills_router.py ................................. [100%]
============================== 71 passed in 2.38s ==============================
```

`ruff check` clean on all touched files.

## What this PR does NOT do

It does not fix the underlying ordering bug — `_ensure_workspace_is_git_repo` still runs only from `EventService.start()`, so other endpoints that may grow workspace-git dependencies could hit the same problem. Moving the git-init to app lifespan startup (so it's a precondition for every workspace-touching endpoint) is the complementary fix; intentionally out of scope here to keep this PR small and reviewable.

---

Filed as a draft so you can take a look before it's marked ready.

_This PR was opened by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6ae4060-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6ae4060-python \
  ghcr.io/openhands/agent-server:6ae4060-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6ae4060-golang-amd64
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-golang-amd64
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-golang-amd64
ghcr.io/openhands/agent-server:6ae4060-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6ae4060-golang-arm64
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-golang-arm64
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-golang-arm64
ghcr.io/openhands/agent-server:6ae4060-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6ae4060-java-amd64
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-java-amd64
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-java-amd64
ghcr.io/openhands/agent-server:6ae4060-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6ae4060-java-arm64
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-java-arm64
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-java-arm64
ghcr.io/openhands/agent-server:6ae4060-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6ae4060-python-amd64
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-python-amd64
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-python-amd64
ghcr.io/openhands/agent-server:6ae4060-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6ae4060-python-arm64
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-python-arm64
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-python-arm64
ghcr.io/openhands/agent-server:6ae4060-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6ae4060-golang
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-golang
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-golang
ghcr.io/openhands/agent-server:6ae4060-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6ae4060-java
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-java
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-java
ghcr.io/openhands/agent-server:6ae4060-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6ae4060-python
ghcr.io/openhands/agent-server:6ae4060976371fc96c99ac78140f82ba9d2e9468-python
ghcr.io/openhands/agent-server:fix-skills-endpoint-git-error-tolerance-python
ghcr.io/openhands/agent-server:6ae4060-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6ae4060-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6ae4060-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->