### PR TITLE
fix(agent-server): bundle built-in subagent .md files in PyInstaller binary

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -89,7 +89,7 @@ a = Analysis(
         # Built-in subagent definitions consumed by register_builtins_agents()
         # at agent-server startup. Without these, the registry stays empty in
         # PyInstaller builds and downstream clients see an unpopulated
-        # task_tool_set description (see issue #3289).
+        # task_tool_set description.
         *collect_data_files("openhands.tools.preset", includes=["subagents/*.md"]),
 
         # Package metadata for importlib.metadata

--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -86,6 +86,12 @@ a = Analysis(
         # OpenHands Tools browser recording JS files
         *collect_data_files("openhands.tools.browser_use", includes=["js/*.js"]),
 
+        # Built-in subagent definitions consumed by register_builtins_agents()
+        # at agent-server startup. Without these, the registry stays empty in
+        # PyInstaller builds and downstream clients see an unpopulated
+        # task_tool_set description (see issue #3289).
+        *collect_data_files("openhands.tools.preset", includes=["subagents/*.md"]),
+
         # Package metadata for importlib.metadata
         *copy_metadata("openhands-agent-server"),
         *copy_metadata("openhands-sdk"),


### PR DESCRIPTION
## Summary

The PyInstaller spec at `openhands-agent-server/openhands/agent_server/agent-server.spec` collected SDK prompt templates and a handful of JS assets, but never collected the four built-in subagent definitions at `openhands/tools/preset/subagents/*.md`.

In binary Docker builds (the `binary` target, used by `ghcr.io/openhands/agent-server:*-python`) the bundle therefore shipped without those files. At startup, `tool_router.py` runs `register_builtins_agents(enable_browser=True)`, which calls `load_agents_from_dir(Path(__file__).parent / "subagents")`. That directory has no `.md` files inside the PyInstaller bundle, so `load_agents_from_dir` returns `[]` (per `openhands-sdk/openhands/sdk/subagent/load.py:137-138`) and the registry silently stays empty.

Downstream clients that rely on the documented "agent-server auto-registers built-ins" contract then see a `task_tool_set` whose description reads `"No user-registered agents yet..."` instead of the four built-ins. Reported in agent-canvas as [OpenHands/agent-canvas#2232](https://github.com/OpenHands/agent-canvas/issues/2232).

## Fix

Add an explicit `collect_data_files()` entry for `openhands.tools.preset` with `includes=["subagents/*.md"]` so the four definitions are included in the bundle:

```python
*collect_data_files("openhands.tools.preset", includes=["subagents/*.md"]),
```

The corresponding `[tool.setuptools.package-data]` entry in `openhands-tools/pyproject.toml` already exists, which is why wheel/source-based installs (e.g. `uvx --from openhands-agent-server==1.22.1 ...`) have always worked — PyInstaller just doesn't read setuptools `package-data` and needs an explicit collector.

## Verification

Before this change:

```sh
$ docker run --rm --entrypoint /bin/sh ghcr.io/openhands/agent-server:1.22.1-python \
    -c "find / -name 'subagents' -type d 2>/dev/null; find / -name 'general*.md' 2>/dev/null"
(empty)
```

After this change, the same probe should return the bundled `subagents/` directory containing `bash_runner.md`, `code_explorer.md`, `default.md`, and `web_researcher.md`, and `register_builtins_agents()` will populate the registry as it already does for source installs.

A source-install sanity check (already passes today, included as a baseline):

```sh
$ uvx --python 3.13 --from openhands-agent-server==1.22.1 --with openhands-tools==1.22.1 \
    python -c "from openhands.agent_server.api import api; \
                from openhands.sdk.subagent.registry import get_registered_agent_definitions; \
                print([d.name for d in get_registered_agent_definitions()])"
['bash-runner', 'code-explorer', 'general-purpose', 'web-researcher']
```

## Follow-ups (out of scope for this PR)

A CI smoke test that pulls the freshly-built binary image and asserts the four built-ins are in the registry would prevent this from regressing — happy to add it in a follow-up if there's interest.

Fixes OpenHands/OpenHands#3289

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f69716c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f69716c-python \
  ghcr.io/openhands/agent-server:f69716c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f69716c-golang-amd64
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-golang-amd64
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-golang-amd64
ghcr.io/openhands/agent-server:f69716c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f69716c-golang-arm64
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-golang-arm64
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-golang-arm64
ghcr.io/openhands/agent-server:f69716c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f69716c-java-amd64
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-java-amd64
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-java-amd64
ghcr.io/openhands/agent-server:f69716c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f69716c-java-arm64
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-java-arm64
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-java-arm64
ghcr.io/openhands/agent-server:f69716c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f69716c-python-amd64
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-python-amd64
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-python-amd64
ghcr.io/openhands/agent-server:f69716c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f69716c-python-arm64
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-python-arm64
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-python-arm64
ghcr.io/openhands/agent-server:f69716c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f69716c-golang
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-golang
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-golang
ghcr.io/openhands/agent-server:f69716c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f69716c-java
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-java
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-java
ghcr.io/openhands/agent-server:f69716c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f69716c-python
ghcr.io/openhands/agent-server:f69716c9fa1faef4a0b5e47981cb29316869da97-python
ghcr.io/openhands/agent-server:vasco-bundle-builtin-subagents-python
ghcr.io/openhands/agent-server:f69716c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f69716c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f69716c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->