### PR TITLE
feat(acp): materialize Codex and Gemini auth secrets

### DIFF
--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -49,9 +49,13 @@ from openhands.sdk.mcp import (
 )
 from openhands.sdk.plugin import Plugin
 from openhands.sdk.settings import (
+    ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+    ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET,
     ACP_PROVIDERS,
+    ACP_SUBSCRIPTION_AUTH_SECRETS,
     ACPAgentSettings,
     ACPProviderInfo,
+    ACPSubscriptionAuthSecretInfo,
     AgentSettings,
     AgentSettingsBase,
     AgentSettingsConfig,
@@ -192,8 +196,12 @@ __all__ = [
     "ConversationSettings",
     "VerificationSettings",
     "ACP_PROVIDERS",
+    "ACP_CODEX_SUBSCRIPTION_AUTH_SECRET",
+    "ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET",
+    "ACP_SUBSCRIPTION_AUTH_SECRETS",
     "ACPAgentSettings",
     "ACPProviderInfo",
+    "ACPSubscriptionAuthSecretInfo",
     "AgentSettings",
     "AgentSettingsBase",
     "AgentSettingsConfig",

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -179,6 +179,10 @@ _AUTH_METHOD_ENV_MAP: dict[str, str] = {
 _CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
 _CODEX_AUTH_JSON_SECRET = ACP_CODEX_SUBSCRIPTION_AUTH_SECRET.secret_name
 _GEMINI_CREDENTIALS_JSON_SECRET = ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET.secret_name
+_VERTEX_AI_AUTH_METHOD = "vertex-ai"
+_VERTEX_AI_CREDENTIALS_ENV = "GOOGLE_APPLICATION_CREDENTIALS"
+_VERTEX_AI_LOCATION_ENV = "GOOGLE_CLOUD_LOCATION"
+_VERTEX_AI_PROJECT_ENV_VARS = ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_PROJECT_ID")
 
 
 def _has_chatgpt_auth_file(env: dict[str, str]) -> bool:
@@ -187,6 +191,20 @@ def _has_chatgpt_auth_file(env: dict[str, str]) -> bool:
     if codex_home:
         return (Path(codex_home) / "auth.json").is_file()
     return (Path.home() / _CHATGPT_AUTH_PATH).is_file()
+
+
+def _has_vertex_ai_credentials_file(env: dict[str, str]) -> bool:
+    """Return whether Vertex AI service-account credentials are on disk."""
+    credentials_path = env.get(_VERTEX_AI_CREDENTIALS_ENV)
+    return bool(credentials_path and Path(credentials_path).is_file())
+
+
+def _has_vertex_ai_project_location(env: dict[str, str]) -> bool:
+    """Return whether Gemini CLI has the required Vertex AI routing env."""
+    return bool(
+        env.get(_VERTEX_AI_LOCATION_ENV)
+        and any(env.get(name) for name in _VERTEX_AI_PROJECT_ENV_VARS)
+    )
 
 
 def _write_secret_file(path: Path, value: str) -> None:
@@ -208,6 +226,8 @@ def _write_secret_file(path: Path, value: str) -> None:
 def _select_auth_method(
     auth_methods: list[Any],
     env: dict[str, str],
+    *,
+    prefer_vertex_ai: bool = False,
 ) -> str | None:
     """Pick an auth method whose required credentials are present.
 
@@ -222,6 +242,12 @@ def _select_auth_method(
     # Prefer ChatGPT subscription login when the auth file is present.
     if "chatgpt" in method_ids and _has_chatgpt_auth_file(env):
         return "chatgpt"
+    if (
+        prefer_vertex_ai
+        and _VERTEX_AI_AUTH_METHOD in method_ids
+        and _has_vertex_ai_credentials_file(env)
+    ):
+        return _VERTEX_AI_AUTH_METHOD
     # Fall back to explicit API key env vars.
     for method_id, env_var in _AUTH_METHOD_ENV_MAP.items():
         if method_id in method_ids and env_var in env:
@@ -1095,11 +1121,19 @@ class ACPAgent(AgentBase):
                     self._file_auth_base_dir() / "gemini" / "gcloud-credentials.json"
                 )
                 _write_secret_file(credentials_path, value)
-                env["GOOGLE_APPLICATION_CREDENTIALS"] = str(credentials_path)
+                env[_VERTEX_AI_CREDENTIALS_ENV] = str(credentials_path)
             else:
                 logger.info(
                     "Preserving configured GOOGLE_APPLICATION_CREDENTIALS over %s",
                     _GEMINI_CREDENTIALS_JSON_SECRET,
+                )
+            if not _has_vertex_ai_project_location(env):
+                logger.warning(
+                    "%s also requires %s and one of %s for Gemini CLI Vertex AI "
+                    "authentication",
+                    _GEMINI_CREDENTIALS_JSON_SECRET,
+                    _VERTEX_AI_LOCATION_ENV,
+                    ", ".join(_VERTEX_AI_PROJECT_ENV_VARS),
                 )
 
         return consumed
@@ -1114,6 +1148,8 @@ class ACPAgent(AgentBase):
         env.update(os.environ)
         env.update(self.acp_env)
         file_secret_names = self._materialize_provider_auth_files(env)
+        for name in self._provider_file_secret_names():
+            env.pop(name, None)
         # Inject regular secrets from agent_context. acp_env entries take
         # precedence, but runtime secrets intentionally override inherited
         # os.environ values.
@@ -1215,7 +1251,12 @@ class ACPAgent(AgentBase):
             # the env vars that are available to the process.
             auth_methods = init_response.auth_methods or []
             if auth_methods:
-                method_id = _select_auth_method(auth_methods, env)
+                method_id = _select_auth_method(
+                    auth_methods,
+                    env,
+                    prefer_vertex_ai=_GEMINI_CREDENTIALS_JSON_SECRET
+                    in file_secret_names,
+                )
                 if method_id is not None:
                     logger.info("Authenticating with ACP method: %s", method_id)
                     auth_kwargs: dict[str, Any] = {}

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 import asyncio
 import json
 import os
+import tempfile
 import threading
 import time
 import uuid
@@ -59,6 +60,8 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
 from openhands.sdk.secret import SecretSource
 from openhands.sdk.settings.acp_providers import (
+    ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+    ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
 )
@@ -174,6 +177,32 @@ _AUTH_METHOD_ENV_MAP: dict[str, str] = {
     "gemini-api-key": "GEMINI_API_KEY",
 }
 _CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
+_CODEX_AUTH_JSON_SECRET = ACP_CODEX_SUBSCRIPTION_AUTH_SECRET.secret_name
+_GEMINI_CREDENTIALS_JSON_SECRET = ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET.secret_name
+
+
+def _has_chatgpt_auth_file(env: dict[str, str]) -> bool:
+    """Return whether Codex ChatGPT auth is available on disk."""
+    codex_home = env.get("CODEX_HOME")
+    if codex_home:
+        return (Path(codex_home) / "auth.json").is_file()
+    return (Path.home() / _CHATGPT_AUTH_PATH).is_file()
+
+
+def _write_secret_file(path: Path, value: str) -> None:
+    """Create or replace a secret file without a world-readable intermediate."""
+    path.parent.mkdir(mode=0o700, parents=True, exist_ok=True)
+    path.parent.chmod(0o700)
+    flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+    fd = os.open(path, flags, 0o600)
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            fd = -1
+            f.write(value)
+    finally:
+        if fd >= 0:
+            os.close(fd)
+    path.chmod(0o600)
 
 
 def _select_auth_method(
@@ -191,9 +220,8 @@ def _select_auth_method(
     """
     method_ids = {m.id for m in auth_methods}
     # Prefer ChatGPT subscription login when the auth file is present.
-    if "chatgpt" in method_ids:
-        if (Path.home() / _CHATGPT_AUTH_PATH).is_file():
-            return "chatgpt"
+    if "chatgpt" in method_ids and _has_chatgpt_auth_file(env):
+        return "chatgpt"
     # Fall back to explicit API key env vars.
     for method_id, env_var in _AUTH_METHOD_ENV_MAP.items():
         if method_id in method_ids and env_var in env:
@@ -758,6 +786,7 @@ class ACPAgent(AgentBase):
     # "installed"            — already in subprocess history; skip further injection
     _suffix_install_state: str = PrivateAttr(default="unused")
     _installed_suffix: str | None = PrivateAttr(default=None)
+    _file_auth_tempdir: Any = PrivateAttr(default=None)
 
     # -- Helpers -----------------------------------------------------------
 
@@ -972,9 +1001,108 @@ class ACPAgent(AgentBase):
         if not self.agent_context:
             return None
         secret_infos = state.secret_registry.get_secret_infos()
-        return self.agent_context.to_acp_prompt_context(
+        prompt_context = self.agent_context
+        file_secret_names = self._provider_file_secret_names()
+        if file_secret_names and self.agent_context.secrets:
+            prompt_context = self.agent_context.model_copy(
+                update={
+                    "secrets": {
+                        name: secret
+                        for name, secret in self.agent_context.secrets.items()
+                        if name not in file_secret_names
+                    }
+                }
+            )
+            secret_infos = [
+                info
+                for info in secret_infos
+                if info.get("name") not in file_secret_names
+            ]
+        return prompt_context.to_acp_prompt_context(
             additional_secret_infos=secret_infos
         )
+
+    def _uses_codex_auth_file(self) -> bool:
+        return any("codex-acp" in part for part in self.acp_command)
+
+    def _uses_gemini_credentials_file(self) -> bool:
+        return any("gemini-cli" in part for part in self.acp_command)
+
+    def _provider_file_secret_names(self) -> set[str]:
+        names: set[str] = set()
+        if self._uses_codex_auth_file():
+            names.add(_CODEX_AUTH_JSON_SECRET)
+        if self._uses_gemini_credentials_file():
+            names.add(_GEMINI_CREDENTIALS_JSON_SECRET)
+        return names
+
+    def _get_agent_secret_value(self, name: str) -> str | None:
+        if not self.agent_context or not self.agent_context.secrets:
+            return None
+        secret = self.agent_context.secrets.get(name)
+        if secret is None:
+            return None
+        if isinstance(secret, SecretSource):
+            return secret.get_value()
+        return str(secret)
+
+    def _file_auth_base_dir(self) -> Path:
+        if self._file_auth_tempdir is None:
+            self._file_auth_tempdir = tempfile.TemporaryDirectory(
+                prefix="acp-provider-auth-"
+            )
+            Path(self._file_auth_tempdir.name).chmod(0o700)
+        return Path(self._file_auth_tempdir.name)
+
+    def _materialize_provider_auth_files(self, env: dict[str, str]) -> set[str]:
+        """Write Codex/Gemini auth secrets to the files their CLIs expect."""
+        if not self.agent_context or not self.agent_context.secrets:
+            return set()
+
+        consumed: set[str] = set()
+        if (
+            self._uses_codex_auth_file()
+            and _CODEX_AUTH_JSON_SECRET in self.agent_context.secrets
+        ):
+            consumed.add(_CODEX_AUTH_JSON_SECRET)
+            value = self._get_agent_secret_value(_CODEX_AUTH_JSON_SECRET)
+            if not value:
+                logger.warning(
+                    "Configured %s is empty; skipping", _CODEX_AUTH_JSON_SECRET
+                )
+            elif "CODEX_HOME" not in self.acp_env:
+                codex_home = self._file_auth_base_dir() / "codex"
+                _write_secret_file(codex_home / "auth.json", value)
+                env["CODEX_HOME"] = str(codex_home)
+            else:
+                logger.info(
+                    "Preserving configured CODEX_HOME over %s", _CODEX_AUTH_JSON_SECRET
+                )
+
+        if (
+            self._uses_gemini_credentials_file()
+            and _GEMINI_CREDENTIALS_JSON_SECRET in self.agent_context.secrets
+        ):
+            consumed.add(_GEMINI_CREDENTIALS_JSON_SECRET)
+            value = self._get_agent_secret_value(_GEMINI_CREDENTIALS_JSON_SECRET)
+            if not value:
+                logger.warning(
+                    "Configured %s is empty; skipping",
+                    _GEMINI_CREDENTIALS_JSON_SECRET,
+                )
+            elif "GOOGLE_APPLICATION_CREDENTIALS" not in self.acp_env:
+                credentials_path = (
+                    self._file_auth_base_dir() / "gemini" / "gcloud-credentials.json"
+                )
+                _write_secret_file(credentials_path, value)
+                env["GOOGLE_APPLICATION_CREDENTIALS"] = str(credentials_path)
+            else:
+                logger.info(
+                    "Preserving configured GOOGLE_APPLICATION_CREDENTIALS over %s",
+                    _GEMINI_CREDENTIALS_JSON_SECRET,
+                )
+
+        return consumed
 
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
@@ -985,13 +1113,15 @@ class ACPAgent(AgentBase):
         env = default_environment()
         env.update(os.environ)
         env.update(self.acp_env)
-        # Inject secrets from agent_context. acp_env entries take precedence
-        # (already set above), so we only fill keys not already present.
+        file_secret_names = self._materialize_provider_auth_files(env)
+        # Inject regular secrets from agent_context. acp_env entries take
+        # precedence, but runtime secrets intentionally override inherited
+        # os.environ values.
         # SecretSource.get_value() is synchronous; calling it here is safe
         # because _start_acp_server is a regular (non-async) method.
         if self.agent_context and self.agent_context.secrets:
             for name, secret in self.agent_context.secrets.items():
-                if name not in env:
+                if name not in file_secret_names and name not in self.acp_env:
                     value = (
                         secret.get_value()
                         if isinstance(secret, SecretSource)
@@ -1602,6 +1732,13 @@ class ACPAgent(AgentBase):
             except Exception as e:
                 logger.debug("Error closing executor: %s", e)
             self._executor = None
+
+        if self._file_auth_tempdir is not None:
+            try:
+                self._file_auth_tempdir.cleanup()
+            except Exception as e:
+                logger.debug("Error cleaning ACP auth files: %s", e)
+            self._file_auth_tempdir = None
 
     def __del__(self) -> None:
         try:

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -3,8 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .acp_providers import (
+    ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+    ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET,
     ACP_PROVIDERS,
+    ACP_SUBSCRIPTION_AUTH_SECRETS,
     ACPProviderInfo,
+    ACPSubscriptionAuthSecretInfo,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
     get_acp_provider,
@@ -76,7 +80,11 @@ _MODEL_EXPORTS = {
 
 __all__ = [
     "ACP_PROVIDERS",
+    "ACP_CODEX_SUBSCRIPTION_AUTH_SECRET",
+    "ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET",
+    "ACP_SUBSCRIPTION_AUTH_SECRETS",
     "ACPProviderInfo",
+    "ACPSubscriptionAuthSecretInfo",
     "build_session_model_meta",
     "AGENT_SETTINGS_SCHEMA_VERSION",
     "CONVERSATION_SETTINGS_SCHEMA_VERSION",

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -137,12 +137,16 @@ ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET = ACPSubscriptionAuthSecretInfo(
     description=(
         "Paste a Google service account credentials JSON document. The SDK "
         "writes it to a credentials file and sets GOOGLE_APPLICATION_CREDENTIALS "
-        "for the Gemini CLI ACP subprocess."
+        "for the Gemini CLI ACP subprocess. Gemini CLI uses this secret with "
+        "Vertex AI, so the subprocess also needs GOOGLE_CLOUD_PROJECT and "
+        "GOOGLE_CLOUD_LOCATION configured."
     ),
     value_description="The full JSON contents of a Google service account key file.",
     setup_steps=(
-        "Create or choose a Google service account with access to the target project.",
+        "Create or choose a Google service account with the Vertex AI User role.",
         "Copy the full service account key JSON into this secret.",
+        "Set GOOGLE_CLOUD_PROJECT and GOOGLE_CLOUD_LOCATION for the Gemini CLI "
+        "ACP subprocess.",
     ),
 )
 

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -13,6 +13,8 @@ Each record captures the static properties that are known at configuration time
                             used by ``ACPAgent`` to auto-detect mode / protocol
 - ``supports_set_session_model``  whether to use the ``set_session_model``
                                   protocol call (vs ``_meta``) for model selection
+- ``subscription_auth_secret`` UX metadata for providers that can authenticate
+                               from a custom secret
 
 Callers outside the SDK (e.g. ``openhands-agent-server``, the ``OpenHands``
 frontend) can import :data:`ACP_PROVIDERS` and :func:`get_acp_provider` instead
@@ -25,6 +27,26 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
+
+
+@dataclass(frozen=True)
+class ACPSubscriptionAuthSecretInfo:
+    """Instructions for configuring subscription-style ACP authentication."""
+
+    secret_name: str
+    """Name of the custom secret users should create."""
+
+    label: str
+    """Human-readable label for the secret."""
+
+    description: str
+    """Short explanation suitable for settings UIs."""
+
+    value_description: str
+    """Description of the expected secret value."""
+
+    setup_steps: tuple[str, ...] = ()
+    """Ordered setup instructions for users."""
 
 
 @dataclass(frozen=True)
@@ -91,6 +113,39 @@ class ACPProviderInfo:
     - ``None``         — codex-acp, gemini-cli
     """
 
+    subscription_auth_secret: ACPSubscriptionAuthSecretInfo | None = None
+    """Custom-secret instructions for subscription-style auth, if supported."""
+
+
+ACP_CODEX_SUBSCRIPTION_AUTH_SECRET = ACPSubscriptionAuthSecretInfo(
+    secret_name="CODEX_AUTH_JSON",
+    label="Codex ChatGPT subscription auth",
+    description=(
+        "Paste the contents of the Codex CLI auth.json file. The SDK writes it "
+        "to auth.json and sets CODEX_HOME for the Codex ACP subprocess."
+    ),
+    value_description="The full JSON contents of ~/.codex/auth.json.",
+    setup_steps=(
+        "Sign in with the Codex CLI on a trusted machine.",
+        "Copy the full contents of ~/.codex/auth.json into this secret.",
+    ),
+)
+
+ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET = ACPSubscriptionAuthSecretInfo(
+    secret_name="GOOGLE_APPLICATION_CREDENTIALS_JSON",
+    label="Gemini CLI service account credentials",
+    description=(
+        "Paste a Google service account credentials JSON document. The SDK "
+        "writes it to a credentials file and sets GOOGLE_APPLICATION_CREDENTIALS "
+        "for the Gemini CLI ACP subprocess."
+    ),
+    value_description="The full JSON contents of a Google service account key file.",
+    setup_steps=(
+        "Create or choose a Google service account with access to the target project.",
+        "Copy the full service account key JSON into this secret.",
+    ),
+)
+
 
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
     {
@@ -115,6 +170,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             agent_name_patterns=("codex-acp",),
             supports_set_session_model=True,
             session_meta_key=None,
+            subscription_auth_secret=ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
         ),
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
@@ -126,10 +182,22 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             agent_name_patterns=("gemini-cli",),
             supports_set_session_model=True,
             session_meta_key=None,
+            subscription_auth_secret=ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET,
         ),
     }
 )
 """Read-only registry of built-in ACP providers keyed by ``acp_server`` value."""
+
+ACP_SUBSCRIPTION_AUTH_SECRETS: Mapping[str, ACPSubscriptionAuthSecretInfo] = (
+    MappingProxyType(
+        {
+            key: info.subscription_auth_secret
+            for key, info in ACP_PROVIDERS.items()
+            if info.subscription_auth_secret is not None
+        }
+    )
+)
+"""Built-in ACP subscription-auth secret instructions keyed by provider."""
 
 
 def get_acp_provider(key: str) -> ACPProviderInfo | None:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2772,6 +2772,38 @@ class TestSelectAuthMethod:
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, env) is None
 
+    def test_vertex_ai_credentials_file_selected_when_preferred(self, tmp_path):
+        methods = [
+            self._make_auth_method("gemini-api-key"),
+            self._make_auth_method("vertex-ai"),
+        ]
+        credentials_path = tmp_path / "gcloud-credentials.json"
+        credentials_path.write_text("{}", encoding="utf-8")
+        env = {
+            "GEMINI_API_KEY": "gemini-api-key",
+            "GOOGLE_APPLICATION_CREDENTIALS": str(credentials_path),
+            "GOOGLE_CLOUD_PROJECT": "test-project",
+            "GOOGLE_CLOUD_LOCATION": "us-central1",
+        }
+
+        assert _select_auth_method(methods, env, prefer_vertex_ai=True) == "vertex-ai"
+
+    def test_vertex_ai_credentials_file_not_selected_without_preference(self, tmp_path):
+        methods = [
+            self._make_auth_method("gemini-api-key"),
+            self._make_auth_method("vertex-ai"),
+        ]
+        credentials_path = tmp_path / "gcloud-credentials.json"
+        credentials_path.write_text("{}", encoding="utf-8")
+        env = {
+            "GEMINI_API_KEY": "gemini-api-key",
+            "GOOGLE_APPLICATION_CREDENTIALS": str(credentials_path),
+            "GOOGLE_CLOUD_PROJECT": "test-project",
+            "GOOGLE_CLOUD_LOCATION": "us-central1",
+        }
+
+        assert _select_auth_method(methods, env) == "gemini-api-key"
+
 
 # ---------------------------------------------------------------------------
 # ACP model overrides
@@ -3580,13 +3612,19 @@ class TestACPSecretsEnvInjection:
     """
 
     @staticmethod
-    def _make_conn():
+    def _make_conn(
+        *,
+        agent_name: str = "claude-agent-acp",
+        auth_methods: list[str] | None = None,
+    ):
         conn = MagicMock()
         init_response = MagicMock()
         init_response.agent_info = MagicMock()
-        init_response.agent_info.name = "claude-agent-acp"
+        init_response.agent_info.name = agent_name
         init_response.agent_info.version = "1.0"
-        init_response.auth_methods = []
+        init_response.auth_methods = [
+            MagicMock(id=method_id) for method_id in auth_methods or []
+        ]
         conn.initialize = AsyncMock(return_value=init_response)
         new_response = MagicMock()
         new_response.session_id = "sess-1"
@@ -3603,6 +3641,7 @@ class TestACPSecretsEnvInjection:
         agent,
         tmp_path,
         extra_os_env: dict[str, str] | None = None,
+        conn: Any = None,
     ) -> dict:
         """Run _start_acp_server and return the env dict passed to the subprocess."""
         from contextlib import ExitStack
@@ -3610,7 +3649,7 @@ class TestACPSecretsEnvInjection:
         from openhands.sdk.utils.async_executor import AsyncExecutor
 
         captured: dict = {}
-        conn = TestACPSecretsEnvInjection._make_conn()
+        conn = conn or TestACPSecretsEnvInjection._make_conn()
 
         mock_process = MagicMock()
         mock_process.stdin = MagicMock()
@@ -3743,11 +3782,14 @@ class TestACPProviderFileAuth:
     """Codex/Gemini JSON auth secrets are written to provider-native files."""
 
     @staticmethod
-    def _run_start_capturing_env(agent, tmp_path, *, extra_os_env=None) -> dict:
+    def _run_start_capturing_env(
+        agent, tmp_path, *, extra_os_env=None, conn: Any = None
+    ) -> dict:
         return TestACPSecretsEnvInjection._run_start_capturing_env(
             agent,
             tmp_path,
             extra_os_env=extra_os_env,
+            conn=conn,
         )
 
     def test_codex_auth_json_materialised_with_codex_home(self, tmp_path):
@@ -3795,6 +3837,71 @@ class TestACPProviderFileAuth:
         assert credentials_path.is_file()
         assert credentials_path.read_text() == payload
         assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
+
+    def test_google_credentials_authenticates_with_vertex_ai(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        conn = TestACPSecretsEnvInjection._make_conn(
+            agent_name="gemini-cli",
+            auth_methods=["gemini-api-key", "vertex-ai"],
+        )
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@google/gemini-cli", "--acp"],
+            agent_context=AgentContext(
+                secrets={
+                    "GOOGLE_APPLICATION_CREDENTIALS_JSON": StaticSecret(
+                        value=SecretStr('{"type":"service_account"}')
+                    )
+                }
+            ),
+        )
+
+        self._run_start_capturing_env(
+            agent,
+            tmp_path,
+            extra_os_env={
+                "GEMINI_API_KEY": "inherited-gemini-api-key",
+                "GOOGLE_CLOUD_PROJECT": "test-project",
+                "GOOGLE_CLOUD_LOCATION": "us-central1",
+            },
+            conn=conn,
+        )
+
+        conn.authenticate.assert_awaited_once_with(method_id="vertex-ai")
+
+    @pytest.mark.parametrize(
+        ("command", "secret_name"),
+        [
+            (["npx", "-y", "@zed-industries/codex-acp"], "CODEX_AUTH_JSON"),
+            (
+                ["npx", "-y", "@google/gemini-cli", "--acp"],
+                "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+            ),
+        ],
+    )
+    def test_inherited_provider_file_secret_removed_from_env(
+        self, tmp_path, command, secret_name
+    ):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = ACPAgent(
+            acp_command=command,
+            agent_context=AgentContext(
+                secrets={secret_name: StaticSecret(value=SecretStr("{}"))}
+            ),
+        )
+
+        env = self._run_start_capturing_env(
+            agent,
+            tmp_path,
+            extra_os_env={secret_name: "inherited-raw-json"},
+        )
+
+        assert secret_name not in env
 
     def test_provider_auth_file_is_readable_only_by_owner(self, tmp_path):
         import stat as stat_mod

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -2736,6 +2737,31 @@ class TestSelectAuthMethod:
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, {}) == "chatgpt"
 
+    def test_chatgpt_auth_file_from_codex_home_env(self, tmp_path):
+        methods = [self._make_auth_method("chatgpt")]
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+
+        assert _select_auth_method(methods, {"CODEX_HOME": str(codex_home)}) == (
+            "chatgpt"
+        )
+
+    def test_codex_home_without_auth_file_disables_home_fallback(self, tmp_path):
+        methods = [
+            self._make_auth_method("chatgpt"),
+            self._make_auth_method("openai-api-key"),
+        ]
+        codex_home = tmp_path / "codex-home"
+        codex_home.mkdir()
+        home_auth_dir = tmp_path / ".codex"
+        home_auth_dir.mkdir()
+        (home_auth_dir / "auth.json").write_text("{}", encoding="utf-8")
+
+        env = {"CODEX_HOME": str(codex_home), "OPENAI_API_KEY": "sk-test"}
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, env) == "openai-api-key"
+
     def test_empty_auth_methods(self):
         assert _select_auth_method([], {}) is None
 
@@ -3573,7 +3599,11 @@ class TestACPSecretsEnvInjection:
         return conn
 
     @staticmethod
-    def _run_start_capturing_env(agent, tmp_path) -> dict:
+    def _run_start_capturing_env(
+        agent,
+        tmp_path,
+        extra_os_env: dict[str, str] | None = None,
+    ) -> dict:
         """Run _start_acp_server and return the env dict passed to the subprocess."""
         from contextlib import ExitStack
 
@@ -3621,6 +3651,8 @@ class TestACPSecretsEnvInjection:
                     return_value=MagicMock(),
                 )
             )
+            if extra_os_env is not None:
+                stack.enter_context(patch.dict("os.environ", extra_os_env, clear=False))
             agent._start_acp_server(state)
 
         return captured
@@ -3643,6 +3675,27 @@ class TestACPSecretsEnvInjection:
         )
         env = self._run_start_capturing_env(agent, tmp_path)
         assert env.get("GITHUB_TOKEN") == "ghp_test123"
+
+    def test_agent_context_secret_overrides_inherited_env(self, tmp_path):
+        """A runtime secret wins over the same key inherited from os.environ."""
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(
+            agent_context=AgentContext(
+                secrets={
+                    "GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp_agent_secret"))
+                }
+            )
+        )
+        env = self._run_start_capturing_env(
+            agent,
+            tmp_path,
+            extra_os_env={"GITHUB_TOKEN": "ghp_inherited"},
+        )
+
+        assert env.get("GITHUB_TOKEN") == "ghp_agent_secret"
 
     def test_acp_env_takes_precedence_over_agent_context_secret(self, tmp_path):
         """An explicit acp_env entry wins over the same key in agent_context.secrets."""
@@ -3684,6 +3737,163 @@ class TestACPSecretsEnvInjection:
         )
         env = self._run_start_capturing_env(agent, tmp_path)
         assert "EMPTY_SECRET" not in env
+
+
+class TestACPProviderFileAuth:
+    """Codex/Gemini JSON auth secrets are written to provider-native files."""
+
+    @staticmethod
+    def _run_start_capturing_env(agent, tmp_path, *, extra_os_env=None) -> dict:
+        return TestACPSecretsEnvInjection._run_start_capturing_env(
+            agent,
+            tmp_path,
+            extra_os_env=extra_os_env,
+        )
+
+    def test_codex_auth_json_materialised_with_codex_home(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        payload = '{"auth_mode":"chatgpt","tokens":{"id_token":"tok"}}'
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@zed-industries/codex-acp"],
+            agent_context=AgentContext(
+                secrets={"CODEX_AUTH_JSON": StaticSecret(value=SecretStr(payload))}
+            ),
+        )
+
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        codex_home = env.get("CODEX_HOME")
+        assert codex_home
+        auth_path = Path(codex_home) / "auth.json"
+        assert auth_path.is_file()
+        assert auth_path.read_text() == payload
+        assert "CODEX_AUTH_JSON" not in env
+
+    def test_google_credentials_materialised_with_path_env(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        payload = '{"type":"service_account","project_id":"p"}'
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@google/gemini-cli", "--acp"],
+            agent_context=AgentContext(
+                secrets={
+                    "GOOGLE_APPLICATION_CREDENTIALS_JSON": StaticSecret(
+                        value=SecretStr(payload)
+                    )
+                }
+            ),
+        )
+
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        credentials_path = Path(env["GOOGLE_APPLICATION_CREDENTIALS"])
+        assert credentials_path.is_file()
+        assert credentials_path.read_text() == payload
+        assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
+
+    def test_provider_auth_file_is_readable_only_by_owner(self, tmp_path):
+        import stat as stat_mod
+
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@zed-industries/codex-acp"],
+            agent_context=AgentContext(
+                secrets={"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
+            ),
+        )
+
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        auth_path = Path(env["CODEX_HOME"]) / "auth.json"
+        assert stat_mod.S_IMODE(auth_path.stat().st_mode) == 0o600
+
+    def test_acp_env_takes_precedence_over_generated_provider_auth_env(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        explicit_path = "/mounted/gcloud-credentials.json"
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@google/gemini-cli", "--acp"],
+            acp_env={"GOOGLE_APPLICATION_CREDENTIALS": explicit_path},
+            agent_context=AgentContext(
+                secrets={
+                    "GOOGLE_APPLICATION_CREDENTIALS_JSON": StaticSecret(
+                        value=SecretStr('{"type":"service_account"}')
+                    )
+                }
+            ),
+        )
+
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        assert env["GOOGLE_APPLICATION_CREDENTIALS"] == explicit_path
+        assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
+
+    def test_custom_command_does_not_materialise_codex_secret(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = ACPAgent(
+            acp_command=["custom-acp"],
+            agent_context=AgentContext(
+                secrets={"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
+            ),
+        )
+
+        env = self._run_start_capturing_env(agent, tmp_path)
+
+        assert "CODEX_HOME" not in env
+        assert env["CODEX_AUTH_JSON"] == "{}"
+
+    def test_render_suffix_omits_provider_file_secret_env_vars(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@zed-industries/codex-acp"],
+            agent_context=AgentContext(
+                secrets={
+                    "CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}")),
+                    "GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp_secret")),
+                },
+                current_datetime=None,
+            ),
+        )
+
+        prompt = agent._render_suffix(_make_state(tmp_path))
+
+        assert prompt is not None
+        assert "$CODEX_AUTH_JSON" not in prompt
+        assert "$GITHUB_TOKEN" in prompt
+
+    def test_close_removes_materialised_provider_auth_files(self, tmp_path):
+        from pydantic import SecretStr
+
+        from openhands.sdk.secret import StaticSecret
+
+        agent = ACPAgent(
+            acp_command=["npx", "-y", "@zed-industries/codex-acp"],
+            agent_context=AgentContext(
+                secrets={"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
+            ),
+        )
+        env = self._run_start_capturing_env(agent, tmp_path)
+        codex_home = Path(env["CODEX_HOME"])
+
+        assert codex_home.is_dir()
+        agent.close()
+        assert not codex_home.exists()
 
 
 class TestACPEnvConflictSuppression:

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -46,6 +46,9 @@ class TestACPProviderInfo:
             ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET.secret_name
             == "GOOGLE_APPLICATION_CREDENTIALS_JSON"
         )
+        gemini_steps = "\n".join(ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET.setup_steps)
+        assert "GOOGLE_CLOUD_PROJECT" in gemini_steps
+        assert "GOOGLE_CLOUD_LOCATION" in gemini_steps
 
     def test_claude_code_metadata(self):
         info = ACP_PROVIDERS["claude-code"]

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -7,8 +7,12 @@ from types import MappingProxyType
 import pytest
 
 from openhands.sdk.settings.acp_providers import (
+    ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+    ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET,
     ACP_PROVIDERS,
+    ACP_SUBSCRIPTION_AUTH_SECRETS,
     ACPProviderInfo,
+    ACPSubscriptionAuthSecretInfo,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
     get_acp_provider,
@@ -23,6 +27,26 @@ class TestACPProviderInfo:
         for info in ACP_PROVIDERS.values():
             assert isinstance(info, ACPProviderInfo)
 
+    def test_subscription_auth_metadata_is_exported_for_codex_and_gemini(self):
+        assert set(ACP_SUBSCRIPTION_AUTH_SECRETS) == {"codex", "gemini-cli"}
+        assert isinstance(
+            ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+            ACPSubscriptionAuthSecretInfo,
+        )
+        assert (
+            ACP_CODEX_SUBSCRIPTION_AUTH_SECRET
+            is ACP_PROVIDERS["codex"].subscription_auth_secret
+        )
+        assert (
+            ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET
+            is ACP_PROVIDERS["gemini-cli"].subscription_auth_secret
+        )
+        assert ACP_CODEX_SUBSCRIPTION_AUTH_SECRET.secret_name == "CODEX_AUTH_JSON"
+        assert (
+            ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET.secret_name
+            == "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+        )
+
     def test_claude_code_metadata(self):
         info = ACP_PROVIDERS["claude-code"]
         assert info.key == "claude-code"
@@ -35,6 +59,7 @@ class TestACPProviderInfo:
         assert "claude-agent" in info.agent_name_patterns
         assert info.supports_set_session_model is False
         assert info.session_meta_key == "claudeCode"
+        assert info.subscription_auth_secret is None
 
     def test_codex_metadata(self):
         info = ACP_PROVIDERS["codex"]
@@ -47,6 +72,7 @@ class TestACPProviderInfo:
         assert "codex-acp" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.session_meta_key is None
+        assert info.subscription_auth_secret is ACP_CODEX_SUBSCRIPTION_AUTH_SECRET
 
     def test_gemini_cli_metadata(self):
         info = ACP_PROVIDERS["gemini-cli"]
@@ -59,6 +85,7 @@ class TestACPProviderInfo:
         assert "gemini-cli" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.session_meta_key is None
+        assert info.subscription_auth_secret is ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -7,6 +7,9 @@ from pydantic import SecretStr
 
 from openhands.agent_server.models import StartConversationRequest
 from openhands.sdk import (
+    ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+    ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET,
+    ACP_SUBSCRIPTION_AUTH_SECRETS,
     LLM,
     ACPAgentSettings,
     Agent,
@@ -29,6 +32,7 @@ from openhands.sdk.security.confirmation_policy import AlwaysConfirm, ConfirmRis
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
+    ACPSubscriptionAuthSecretInfo,
     CondenserSettings,
     VerificationSettings,
 )
@@ -37,6 +41,23 @@ from openhands.sdk.workspace import LocalWorkspace
 
 # Fields on LLM that have ``exclude=True`` and should not appear in the schema.
 _LLM_EXCLUDED_FIELDS = {name for name, fi in LLM.model_fields.items() if fi.exclude}
+
+
+def test_acp_subscription_auth_secret_infos_are_exported_package_level() -> None:
+    assert isinstance(
+        ACP_CODEX_SUBSCRIPTION_AUTH_SECRET,
+        ACPSubscriptionAuthSecretInfo,
+    )
+    assert ACP_CODEX_SUBSCRIPTION_AUTH_SECRET.secret_name == "CODEX_AUTH_JSON"
+    assert (
+        ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET.secret_name
+        == "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+    )
+    assert ACP_SUBSCRIPTION_AUTH_SECRETS["codex"] is ACP_CODEX_SUBSCRIPTION_AUTH_SECRET
+    assert (
+        ACP_SUBSCRIPTION_AUTH_SECRETS["gemini-cli"]
+        is ACP_GEMINI_CLI_SUBSCRIPTION_AUTH_SECRET
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Materialize only the built-in Codex and Gemini CLI auth JSON secrets into provider-native files
- Add package-level subscription-auth secret metadata for Codex and Gemini CLI so clients can expose UX guidance
- Keep custom ACP servers unchanged: no generic file-secret settings or custom mapping API

## Behavior
- `CODEX_AUTH_JSON` + Codex ACP command writes `auth.json` and sets `CODEX_HOME`
- `GOOGLE_APPLICATION_CREDENTIALS_JSON` + Gemini CLI ACP command writes a credentials JSON file and sets `GOOGLE_APPLICATION_CREDENTIALS`
- Raw JSON file-auth secrets are not also exported as subprocess env vars or advertised in `<CUSTOM_SECRETS>`

## Validation
- `ruff check` on changed files
- `ruff format --check` on changed files
- `pyright` on changed files
- `pytest tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod tests/sdk/agent/test_acp_agent.py::TestACPSecretsEnvInjection tests/sdk/agent/test_acp_agent.py::TestACPProviderFileAuth tests/sdk/settings/test_acp_providers.py tests/sdk/test_settings.py::test_acp_subscription_auth_secret_infos_are_exported_package_level -q`
- `pytest tests/sdk/settings/test_acp_providers.py tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py tests/sdk/conversation/remote/test_remote_conversation.py tests/agent_server/test_conversation_router_acp.py -q`

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:46e479f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-46e479f-python \
  ghcr.io/openhands/agent-server:46e479f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:46e479f-golang-amd64
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-golang-amd64
ghcr.io/openhands/agent-server:46e479f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:46e479f-golang-arm64
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-golang-arm64
ghcr.io/openhands/agent-server:46e479f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:46e479f-java-amd64
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-java-amd64
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-java-amd64
ghcr.io/openhands/agent-server:46e479f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:46e479f-java-arm64
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-java-arm64
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-java-arm64
ghcr.io/openhands/agent-server:46e479f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:46e479f-python-amd64
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-python-amd64
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-python-amd64
ghcr.io/openhands/agent-server:46e479f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:46e479f-python-arm64
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-python-arm64
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-python-arm64
ghcr.io/openhands/agent-server:46e479f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:46e479f-golang
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-golang
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-golang
ghcr.io/openhands/agent-server:46e479f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:46e479f-java
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-java
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-java
ghcr.io/openhands/agent-server:46e479f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:46e479f-python
ghcr.io/openhands/agent-server:46e479fb25ffd18ee2d45b3f5f292b3993eab19b-python
ghcr.io/openhands/agent-server:fix-acp-codex-gemini-file-auth-python
ghcr.io/openhands/agent-server:46e479f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `46e479f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `46e479f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->