### PR TITLE
fix(workflows): skip approved PRs in review reminders

### DIFF
--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -69,18 +69,13 @@ jobs:
                 # Need Reviewer Action
 
                 Find all open PRs where:
-                1. The PR is still waiting on its currently requested reviewers or teams:
-                   - Fetch submitted reviews: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-                   - Collapse them to each reviewer's latest state
-                   - If any HUMAN reviewer's latest state is APPROVED, SKIP the PR entirely
-                   - Ignore approvals from automation/bot accounts when deciding whether a human has approved
-                   - Also skip if there are open review comments, unresolved review threads, or any latest CHANGES_REQUESTED review
-                   - Example: if @alice approved and @bob is still requested, do NOT ping @bob
+                1. The PR is waiting for review (there are no open review comments or change requests, and no human reviewer's latest submitted review is
+                APPROVED; ignore approvals from automation/bot accounts for this check)
                 2. The PR is in a "clean" state (CI passing, no merge conflicts)
                 3. The PR is not marked as draft (draft: false)
                 4. The PR has had no activity (comments, commits, reviews) for more than 3 days.
 
-                In this case, send a message only to the currently requested reviewers or teams:
+                In this case, send a message to the reviewers:
                 [Automatic Post]: This PR seems to be currently waiting for review.
                 {reviewer_names}, could you please take a look when you have a chance?
 

--- a/.github/workflows/assign-reviews.yml
+++ b/.github/workflows/assign-reviews.yml
@@ -69,12 +69,18 @@ jobs:
                 # Need Reviewer Action
 
                 Find all open PRs where:
-                1. The PR is waiting for review (there are no open review comments or change requests)
+                1. The PR is still waiting on its currently requested reviewers or teams:
+                   - Fetch submitted reviews: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+                   - Collapse them to each reviewer's latest state
+                   - If any HUMAN reviewer's latest state is APPROVED, SKIP the PR entirely
+                   - Ignore approvals from automation/bot accounts when deciding whether a human has approved
+                   - Also skip if there are open review comments, unresolved review threads, or any latest CHANGES_REQUESTED review
+                   - Example: if @alice approved and @bob is still requested, do NOT ping @bob
                 2. The PR is in a "clean" state (CI passing, no merge conflicts)
                 3. The PR is not marked as draft (draft: false)
                 4. The PR has had no activity (comments, commits, reviews) for more than 3 days.
 
-                In this case, send a message to the reviewers:
+                In this case, send a message only to the currently requested reviewers or teams:
                 [Automatic Post]: This PR seems to be currently waiting for review.
                 {reviewer_names}, could you please take a look when you have a chance?
 

--- a/examples/03_github_workflows/01_basic_action/assign-reviews.yml
+++ b/examples/03_github_workflows/01_basic_action/assign-reviews.yml
@@ -71,12 +71,18 @@ jobs:
                 # Need Reviewer Action
 
                 Find all open PRs where:
-                1. The PR is waiting for review (there are no open review comments or change requests)
+                1. The PR is still waiting on its currently requested reviewers or teams:
+                   - Fetch submitted reviews: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
+                   - Collapse them to each reviewer's latest state
+                   - If any HUMAN reviewer's latest state is APPROVED, SKIP the PR entirely
+                   - Ignore approvals from automation/bot accounts when deciding whether a human has approved
+                   - Also skip if there are open review comments, unresolved review threads, or any latest CHANGES_REQUESTED review
+                   - Example: if @alice approved and @bob is still requested, do NOT ping @bob
                 2. The PR is in a "clean" state (CI passing, no merge conflicts)
                 3. The PR is not marked as draft (draft: false)
                 4. The PR has had no activity (comments, commits, reviews) for more than 3 days.
 
-                In this case, send a message to the reviewers:
+                In this case, send a message only to the currently requested reviewers or teams:
                 [Automatic Post]: This PR seems to be currently waiting for review.
                 {reviewer_names}, could you please take a look when you have a chance?
 

--- a/examples/03_github_workflows/01_basic_action/assign-reviews.yml
+++ b/examples/03_github_workflows/01_basic_action/assign-reviews.yml
@@ -71,18 +71,13 @@ jobs:
                 # Need Reviewer Action
 
                 Find all open PRs where:
-                1. The PR is still waiting on its currently requested reviewers or teams:
-                   - Fetch submitted reviews: GET /repos/{owner}/{repo}/pulls/{pull_number}/reviews
-                   - Collapse them to each reviewer's latest state
-                   - If any HUMAN reviewer's latest state is APPROVED, SKIP the PR entirely
-                   - Ignore approvals from automation/bot accounts when deciding whether a human has approved
-                   - Also skip if there are open review comments, unresolved review threads, or any latest CHANGES_REQUESTED review
-                   - Example: if @alice approved and @bob is still requested, do NOT ping @bob
+                1. The PR is waiting for review (there are no open review comments or change requests, and no human reviewer's latest submitted review is
+                APPROVED; ignore approvals from automation/bot accounts for this check)
                 2. The PR is in a "clean" state (CI passing, no merge conflicts)
                 3. The PR is not marked as draft (draft: false)
                 4. The PR has had no activity (comments, commits, reviews) for more than 3 days.
 
-                In this case, send a message only to the currently requested reviewers or teams:
+                In this case, send a message to the reviewers:
                 [Automatic Post]: This PR seems to be currently waiting for review.
                 {reviewer_names}, could you please take a look when you have a chance?
 


### PR DESCRIPTION
## Summary
- add a small note to the assign-reviews "Need Reviewer Action" prompt so it skips PRs that already have a human approval
- keep bot/automation approvals ignored for that human-approval check
- mirror the same wording in the example assign-reviews workflow

## Why
PR #3237 already had a human approval, but the scheduled Assign Reviews workflow still posted a reviewer reminder because the prompt did not explicitly tell the agent to skip PRs that were already approved by a human reviewer.

## Validation
- `uv run pre-commit run --files .github/workflows/assign-reviews.yml examples/03_github_workflows/01_basic_action/assign-reviews.yml`

_This PR was created by an AI agent (OpenHands) on behalf of the user._


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:56905bd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-56905bd-python \
  ghcr.io/openhands/agent-server:56905bd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:56905bd-golang-amd64
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-golang-amd64
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-golang-amd64
ghcr.io/openhands/agent-server:56905bd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:56905bd-golang-arm64
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-golang-arm64
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-golang-arm64
ghcr.io/openhands/agent-server:56905bd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:56905bd-java-amd64
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-java-amd64
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-java-amd64
ghcr.io/openhands/agent-server:56905bd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:56905bd-java-arm64
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-java-arm64
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-java-arm64
ghcr.io/openhands/agent-server:56905bd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:56905bd-python-amd64
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-python-amd64
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-python-amd64
ghcr.io/openhands/agent-server:56905bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:56905bd-python-arm64
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-python-arm64
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-python-arm64
ghcr.io/openhands/agent-server:56905bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:56905bd-golang
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-golang
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-golang
ghcr.io/openhands/agent-server:56905bd-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:56905bd-java
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-java
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-java
ghcr.io/openhands/agent-server:56905bd-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:56905bd-python
ghcr.io/openhands/agent-server:56905bd9396811e41fe13eb4cd8fc164853b6fe8-python
ghcr.io/openhands/agent-server:fix-assign-reviews-skip-approved-python
ghcr.io/openhands/agent-server:56905bd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `56905bd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `56905bd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->