### PR TITLE
Add named profile support to workspace get_llm

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -413,6 +413,7 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
 
         if profile_name:
             llm_data = self._fetch_llm_profile_config(profile_name)
+            llm_data["usage_id"] = f"profile:{profile_name}"
         else:
             settings = self._fetch_agent_settings()
             if not llm_kwargs:

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -2,6 +2,7 @@ import os
 from collections.abc import Generator
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
+from urllib.parse import quote
 from urllib.request import urlopen
 
 import httpx
@@ -359,34 +360,50 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         data = SettingsResponse.model_validate(response.json())
         return data.get_agent_settings()
 
+    def _fetch_llm_profile_config(self, profile_name: str) -> dict[str, Any]:
+        """Call ``GET /api/profiles/{name}`` and return plaintext LLM config."""
+        headers = dict(self._headers)
+        headers["X-Expose-Secrets"] = "plaintext"
+
+        response = self.client.get(
+            f"/api/profiles/{quote(profile_name, safe='')}",
+            headers=headers,
+        )
+        if response.status_code == 404:
+            raise FileNotFoundError(f"LLM profile '{profile_name}' not found")
+        response.raise_for_status()
+
+        config = response.json().get("config")
+        if not isinstance(config, dict):
+            raise ValueError(f"LLM profile '{profile_name}' has invalid config")
+        return dict(config)
+
     @tenacity.retry(
         stop=tenacity.stop_after_attempt(_MAX_RETRIES),
         wait=tenacity.wait_exponential(multiplier=1, min=1, max=5),
         retry=tenacity.retry_if_exception(_is_retryable_error),
         reraise=True,
     )
-    def get_llm(self, **llm_kwargs: Any) -> "LLM":
-        """Fetch LLM settings from the agent-server's persisted settings.
-
-        Calls ``GET /api/settings`` with ``X-Expose-Secrets: plaintext`` header
-        to retrieve the full LLM configuration and returns a fully usable
-        ``LLM`` instance.  All persisted LLM fields (model, api_key,
-        base_url, temperature, max_output_tokens, …) are preserved.
+    def get_llm(self, profile_name: str | None = None, **llm_kwargs: Any) -> "LLM":
+        """Fetch LLM settings from persisted settings or a named profile.
 
         Args:
-            **llm_kwargs: Additional keyword arguments that override
-                persisted values (e.g., ``model``, ``temperature``).
+            profile_name: Optional LLM profile name. When provided, loads that
+                named profile instead of the active persisted LLM settings.
+            **llm_kwargs: Additional keyword arguments that override persisted
+                or profile values (e.g., ``model``, ``temperature``).
 
         Returns:
-            An LLM instance configured with the persisted settings.
+            An LLM instance configured with the persisted settings or profile.
 
         Raises:
+            FileNotFoundError: If ``profile_name`` does not exist.
             httpx.HTTPStatusError: If the API request fails.
             RuntimeError: If the workspace host is not set.
 
         Example:
             >>> with DockerWorkspace(...) as workspace:
-            ...     llm = workspace.get_llm()
+            ...     llm = workspace.get_llm(profile_name="fast")
             ...     agent = Agent(llm=llm, tools=get_default_tools())
         """
         from openhands.sdk.llm.llm import LLM
@@ -394,14 +411,14 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         if not self.host or self.host == "undefined":
             raise RuntimeError("Workspace host is not set")
 
-        settings = self._fetch_agent_settings()
+        if profile_name:
+            llm_data = self._fetch_llm_profile_config(profile_name)
+        else:
+            settings = self._fetch_agent_settings()
+            if not llm_kwargs:
+                return settings.llm
+            llm_data = settings.llm.model_dump(context={"expose_secrets": "plaintext"})
 
-        if not llm_kwargs:
-            return settings.llm
-
-        # Dump persisted LLM config and merge overrides, then
-        # reconstruct so Pydantic validators run on the merged values
-        llm_data = settings.llm.model_dump(context={"expose_secrets": "plaintext"})
         llm_data.update(llm_kwargs)
         return LLM(**llm_data)
 

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -569,15 +569,17 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         retry=tenacity.retry_if_exception(_is_retryable_error),
         reraise=True,
     )
-    def get_llm(self, **llm_kwargs: Any) -> LLM:
+    def get_llm(self, profile_name: str | None = None, **llm_kwargs: Any) -> LLM:
         """Fetch LLM settings from the user's SaaS account and return an LLM.
 
         Calls ``GET /api/v1/users/me?expose_secrets=true`` to retrieve the
-        user's LLM configuration (model, api_key, base_url) and returns a
-        fully usable ``LLM`` instance.  Retries up to 3 times on transient
-        errors (network issues, server 5xx).
+        user's LLM configuration or a named LLM profile and returns a fully
+        usable ``LLM`` instance. Retries up to 3 times on transient errors
+        (network issues, server 5xx).
 
         Args:
+            profile_name: Optional LLM profile name. When provided, loads that
+                named profile instead of the default SaaS LLM fields.
             **llm_kwargs: Additional keyword arguments passed to the LLM
                 constructor, allowing overrides of any LLM parameter
                 (e.g. ``model``, ``temperature``).
@@ -586,12 +588,13 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             An LLM instance configured with the user's SaaS credentials.
 
         Raises:
+            FileNotFoundError: If ``profile_name`` does not exist.
             httpx.HTTPStatusError: If the API request fails.
             RuntimeError: If the sandbox is not running.
 
         Example:
             >>> with OpenHandsCloudWorkspace(...) as workspace:
-            ...     llm = workspace.get_llm()
+            ...     llm = workspace.get_llm(profile_name="fast")
             ...     agent = Agent(llm=llm, tools=get_default_tools())
         """
         from openhands.sdk.llm.llm import LLM
@@ -607,13 +610,27 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
         )
         data = resp.json()
 
-        kwargs: dict[str, Any] = {}
-        if data.get("llm_model"):
-            kwargs["model"] = data["llm_model"]
-        if data.get("llm_api_key"):
-            kwargs["api_key"] = data["llm_api_key"]
-        if data.get("llm_base_url"):
-            kwargs["base_url"] = data["llm_base_url"]
+        if profile_name:
+            profiles_payload = data.get("llm_profiles") or {}
+            profiles = (
+                profiles_payload.get("profiles")
+                if isinstance(profiles_payload, dict)
+                else None
+            )
+            profile_config = (
+                profiles.get(profile_name) if isinstance(profiles, dict) else None
+            )
+            if not isinstance(profile_config, dict):
+                raise FileNotFoundError(f"LLM profile '{profile_name}' not found")
+            kwargs = dict(profile_config)
+        else:
+            kwargs = {}
+            if data.get("llm_model"):
+                kwargs["model"] = data["llm_model"]
+            if data.get("llm_api_key"):
+                kwargs["api_key"] = data["llm_api_key"]
+            if data.get("llm_base_url"):
+                kwargs["base_url"] = data["llm_base_url"]
 
         # User-provided kwargs take precedence
         kwargs.update(llm_kwargs)

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -623,6 +623,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             if not isinstance(profile_config, dict):
                 raise FileNotFoundError(f"LLM profile '{profile_name}' not found")
             kwargs = dict(profile_config)
+            kwargs["usage_id"] = f"profile:{profile_name}"
         else:
             kwargs = {}
             if data.get("llm_model"):

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -508,7 +508,7 @@ def test_get_llm_with_profile_name(monkeypatch):
     mock_response = Mock()
     mock_response.status_code = 200
     mock_response.json.return_value = {
-        "name": "fast/model",
+        "name": "fast-model",
         "config": {
             "model": "openai/gpt-4o",
             "api_key": "sk-profile-key",
@@ -521,23 +521,23 @@ def test_get_llm_with_profile_name(monkeypatch):
     mock_client.get.return_value = mock_response
     workspace._client = mock_client
 
-    llm = workspace.get_llm(profile_name="fast/model", temperature=0.3)
+    llm = workspace.get_llm(profile_name="fast-model", temperature=0.3)
 
     assert llm.model == "openai/gpt-4o"
     assert llm.temperature == 0.3
     assert isinstance(llm.api_key, SecretStr)
     assert llm.api_key.get_secret_value() == "sk-profile-key"
     assert llm.base_url == "https://litellm.example.com"
-    assert llm.usage_id == "profile:fast/model"
+    assert llm.usage_id == "profile:fast-model"
 
     mock_client.get.assert_called_once()
     call_args = mock_client.get.call_args
-    assert call_args[0][0] == "/api/profiles/fast%2Fmodel"
+    assert call_args[0][0] == "/api/profiles/fast-model"
     assert call_args[1]["headers"]["X-Expose-Secrets"] == "plaintext"
     assert call_args[1]["headers"]["X-Session-API-Key"] == "test-key"
 
     llm_with_override = workspace.get_llm(
-        profile_name="fast/model", usage_id="custom-usage"
+        profile_name="fast-model", usage_id="custom-usage"
     )
 
     assert llm_with_override.usage_id == "custom-usage"

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -494,6 +494,66 @@ def test_get_llm_with_kwargs_override(monkeypatch):
         assert llm.api_key == "sk-persisted-key"
 
 
+def test_get_llm_with_profile_name(monkeypatch):
+    """Test get_llm can load a named LLM profile."""
+    from pydantic import SecretStr
+
+    monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
+
+    workspace = RemoteWorkspace(
+        host="http://localhost:8000", working_dir="/tmp", api_key="test-key"
+    )
+
+    mock_client = MagicMock()
+    mock_response = Mock()
+    mock_response.status_code = 200
+    mock_response.json.return_value = {
+        "name": "fast/model",
+        "config": {
+            "model": "openai/gpt-4o",
+            "api_key": "sk-profile-key",
+            "base_url": "https://litellm.example.com",
+        },
+        "api_key_set": True,
+    }
+    mock_response.raise_for_status = Mock()
+    mock_client.get.return_value = mock_response
+    workspace._client = mock_client
+
+    llm = workspace.get_llm(profile_name="fast/model", temperature=0.3)
+
+    assert llm.model == "openai/gpt-4o"
+    assert llm.temperature == 0.3
+    assert isinstance(llm.api_key, SecretStr)
+    assert llm.api_key.get_secret_value() == "sk-profile-key"
+    assert llm.base_url == "https://litellm.example.com"
+
+    mock_client.get.assert_called_once()
+    call_args = mock_client.get.call_args
+    assert call_args[0][0] == "/api/profiles/fast%2Fmodel"
+    assert call_args[1]["headers"]["X-Expose-Secrets"] == "plaintext"
+    assert call_args[1]["headers"]["X-Session-API-Key"] == "test-key"
+
+
+def test_get_llm_with_missing_profile_raises(monkeypatch):
+    """Test get_llm raises FileNotFoundError for a missing profile."""
+    monkeypatch.setenv("ALLOW_SHORT_CONTEXT_WINDOWS", "true")
+
+    workspace = RemoteWorkspace(
+        host="http://localhost:8000", working_dir="/tmp", api_key="test-key"
+    )
+
+    mock_client = MagicMock()
+    mock_response = Mock()
+    mock_response.status_code = 404
+    mock_response.raise_for_status = Mock()
+    mock_client.get.return_value = mock_response
+    workspace._client = mock_client
+
+    with pytest.raises(FileNotFoundError, match="missing"):
+        workspace.get_llm(profile_name="missing")
+
+
 def test_get_llm_raises_on_undefined_host():
     """Test get_llm raises RuntimeError when host is undefined."""
     workspace = RemoteWorkspace(host="undefined", working_dir="/tmp")

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -513,6 +513,7 @@ def test_get_llm_with_profile_name(monkeypatch):
             "model": "openai/gpt-4o",
             "api_key": "sk-profile-key",
             "base_url": "https://litellm.example.com",
+            "usage_id": "default",
         },
         "api_key_set": True,
     }
@@ -527,12 +528,19 @@ def test_get_llm_with_profile_name(monkeypatch):
     assert isinstance(llm.api_key, SecretStr)
     assert llm.api_key.get_secret_value() == "sk-profile-key"
     assert llm.base_url == "https://litellm.example.com"
+    assert llm.usage_id == "profile:fast/model"
 
     mock_client.get.assert_called_once()
     call_args = mock_client.get.call_args
     assert call_args[0][0] == "/api/profiles/fast%2Fmodel"
     assert call_args[1]["headers"]["X-Expose-Secrets"] == "plaintext"
     assert call_args[1]["headers"]["X-Session-API-Key"] == "test-key"
+
+    llm_with_override = workspace.get_llm(
+        profile_name="fast/model", usage_id="custom-usage"
+    )
+
+    assert llm_with_override.usage_id == "custom-usage"
 
 
 def test_get_llm_with_missing_profile_raises(monkeypatch):

--- a/tests/workspace/test_cloud_workspace_sdk_settings.py
+++ b/tests/workspace/test_cloud_workspace_sdk_settings.py
@@ -102,6 +102,7 @@ class TestGetLLM:
                         "model": "openai/gpt-4o",
                         "api_key": "sk-profile-key",
                         "base_url": "https://litellm.example.com",
+                        "usage_id": "default",
                     }
                 },
                 "active_profile": "fast",
@@ -125,6 +126,16 @@ class TestGetLLM:
         assert isinstance(llm.api_key, SecretStr)
         assert llm.api_key.get_secret_value() == "sk-profile-key"
         assert llm.base_url == "https://litellm.example.com"
+        assert llm.usage_id == "profile:fast"
+
+        with patch.object(
+            mock_workspace, "_send_api_request", return_value=mock_response
+        ):
+            llm_with_override = mock_workspace.get_llm(
+                profile_name="fast", usage_id="custom-usage"
+            )
+
+        assert llm_with_override.usage_id == "custom-usage"
 
     def test_get_llm_missing_profile_raises(self, mock_workspace):
         """get_llm raises FileNotFoundError for unknown SaaS profiles."""

--- a/tests/workspace/test_cloud_workspace_sdk_settings.py
+++ b/tests/workspace/test_cloud_workspace_sdk_settings.py
@@ -37,7 +37,9 @@ def mock_workspace():
     # Simulate a running sandbox
     workspace._sandbox_id = SANDBOX_ID
     workspace._session_api_key = SESSION_KEY
-    return workspace
+    yield workspace
+    workspace._sandbox_id = None
+    workspace._session_api_key = None
 
 
 class TestGetLLM:

--- a/tests/workspace/test_cloud_workspace_sdk_settings.py
+++ b/tests/workspace/test_cloud_workspace_sdk_settings.py
@@ -89,6 +89,57 @@ class TestGetLLM:
         assert llm.temperature == 0.5
         assert isinstance(llm.api_key, SecretStr)
 
+    def test_get_llm_with_profile_name(self, mock_workspace):
+        """get_llm can load a named profile from SaaS metadata."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "llm_model": "anthropic/claude-sonnet-4-20250514",
+            "llm_api_key": "sk-default-key",
+            "llm_base_url": None,
+            "llm_profiles": {
+                "profiles": {
+                    "fast": {
+                        "model": "openai/gpt-4o",
+                        "api_key": "sk-profile-key",
+                        "base_url": "https://litellm.example.com",
+                    }
+                },
+                "active_profile": "fast",
+            },
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            mock_workspace, "_send_api_request", return_value=mock_response
+        ) as mock_req:
+            llm = mock_workspace.get_llm(profile_name="fast", temperature=0.3)
+
+        mock_req.assert_called_once_with(
+            "GET",
+            f"{CLOUD_URL}/api/v1/users/me",
+            params={"expose_secrets": "true"},
+            headers={"X-Session-API-Key": SESSION_KEY},
+        )
+        assert llm.model == "openai/gpt-4o"
+        assert llm.temperature == 0.3
+        assert isinstance(llm.api_key, SecretStr)
+        assert llm.api_key.get_secret_value() == "sk-profile-key"
+        assert llm.base_url == "https://litellm.example.com"
+
+    def test_get_llm_missing_profile_raises(self, mock_workspace):
+        """get_llm raises FileNotFoundError for unknown SaaS profiles."""
+        mock_response = MagicMock()
+        mock_response.json.return_value = {
+            "llm_profiles": {"profiles": {"fast": {"model": "gpt-4o"}}}
+        }
+        mock_response.raise_for_status = MagicMock()
+
+        with patch.object(
+            mock_workspace, "_send_api_request", return_value=mock_response
+        ):
+            with pytest.raises(FileNotFoundError, match="missing"):
+                mock_workspace.get_llm(profile_name="missing")
+
     def test_get_llm_no_api_key_still_works(self, mock_workspace):
         """If no API key is configured, the LLM gets api_key=None."""
         mock_response = MagicMock()


### PR DESCRIPTION
## Summary

- Add `profile_name` support to `RemoteWorkspace.get_llm()` via the agent-server `/api/profiles/{name}` endpoint
- Add `profile_name` support to `OpenHandsCloudWorkspace.get_llm()` using SaaS `llm_profiles` metadata from `/api/v1/users/me?expose_secrets=true`
- Preserve existing default settings behavior and allow kwargs to override profile values
- Add focused tests for remote and cloud workspace profile loading and missing-profile errors

## Testing

- `uv run pre-commit run --files openhands-sdk/openhands/sdk/workspace/remote/base.py openhands-workspace/openhands/workspace/cloud/workspace.py tests/sdk/workspace/remote/test_remote_workspace.py tests/workspace/test_cloud_workspace_sdk_settings.py --show-diff-on-failure`
- `uv run pytest -q tests/sdk/workspace/remote/test_remote_workspace.py tests/workspace/test_cloud_workspace_sdk_settings.py`

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0fb48cc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0fb48cc-python \
  ghcr.io/openhands/agent-server:0fb48cc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0fb48cc-golang-amd64
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-golang-amd64
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-golang-amd64
ghcr.io/openhands/agent-server:0fb48cc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0fb48cc-golang-arm64
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-golang-arm64
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-golang-arm64
ghcr.io/openhands/agent-server:0fb48cc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0fb48cc-java-amd64
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-java-amd64
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-java-amd64
ghcr.io/openhands/agent-server:0fb48cc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0fb48cc-java-arm64
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-java-arm64
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-java-arm64
ghcr.io/openhands/agent-server:0fb48cc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0fb48cc-python-amd64
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-python-amd64
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-python-amd64
ghcr.io/openhands/agent-server:0fb48cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0fb48cc-python-arm64
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-python-arm64
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-python-arm64
ghcr.io/openhands/agent-server:0fb48cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0fb48cc-golang
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-golang
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-golang
ghcr.io/openhands/agent-server:0fb48cc-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0fb48cc-java
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-java
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-java
ghcr.io/openhands/agent-server:0fb48cc-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0fb48cc-python
ghcr.io/openhands/agent-server:0fb48ccdc90924367f9160a6bd33efd46c980ab8-python
ghcr.io/openhands/agent-server:openhands-get-llm-profile-name-python
ghcr.io/openhands/agent-server:0fb48cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0fb48cc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0fb48cc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->