### PR TITLE
Fix browser toolset shared executor deadlock

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/definition.py
+++ b/openhands-tools/openhands/tools/browser_use/definition.py
@@ -795,30 +795,53 @@ class BrowserToolSet(ToolDefinition[BrowserAction, BrowserObservation]):
         return BrowserToolExecutor.check_chromium_available() is not None
 
     @classmethod
+    def _warn_config_ignored(cls, executor_config: dict[str, object]) -> None:
+        if not executor_config:
+            return
+        _logger.warning(
+            "BrowserToolSet.create() called with executor_config but a "
+            "shared executor already exists. The config %s will be "
+            "ignored. This typically happens when a subagent requests "
+            "browser tools — it reuses the parent's browser session.",
+            list(executor_config.keys()),
+        )
+
+    @classmethod
+    def _get_or_create_shared_executor(
+        cls,
+        conv_state: "ConversationState",
+        **executor_config,
+    ) -> "BrowserToolExecutor":
+        with cls._shared_executor_lock:
+            executor = cls._shared_executor
+
+        if executor is not None:
+            cls._warn_config_ignored(executor_config)
+            return executor
+
+        from openhands.tools.browser_use.impl import BrowserToolExecutor
+
+        candidate = BrowserToolExecutor(
+            full_output_save_dir=conv_state.env_observation_persistence_dir,
+            **executor_config,
+        )
+        with cls._shared_executor_lock:
+            if cls._shared_executor is None:
+                cls._shared_executor = candidate
+                return candidate
+            executor = cls._shared_executor
+
+        cls._warn_config_ignored(executor_config)
+        candidate.close()
+        return executor
+
+    @classmethod
     def create(
         cls,
         conv_state: "ConversationState",
         **executor_config,
     ) -> list[ToolDefinition[BrowserAction, BrowserObservation]]:
-        with cls._shared_executor_lock:
-            if cls._shared_executor is not None:
-                if executor_config:
-                    _logger.warning(
-                        "BrowserToolSet.create() called with executor_config but a "
-                        "shared executor already exists. The config %s will be "
-                        "ignored. This typically happens when a subagent requests "
-                        "browser tools — it reuses the parent's browser session.",
-                        list(executor_config.keys()),
-                    )
-                executor = cls._shared_executor
-            else:
-                from openhands.tools.browser_use.impl import BrowserToolExecutor
-
-                executor = BrowserToolExecutor(
-                    full_output_save_dir=conv_state.env_observation_persistence_dir,
-                    **executor_config,
-                )
-                cls._shared_executor = executor
+        executor = cls._get_or_create_shared_executor(conv_state, **executor_config)
 
         # Each tool.create() returns a Sequence[Self], so we flatten the results
         tools: list[ToolDefinition[BrowserAction, BrowserObservation]] = []

--- a/openhands-tools/openhands/tools/browser_use/impl.py
+++ b/openhands-tools/openhands/tools/browser_use/impl.py
@@ -716,13 +716,20 @@ class BrowserToolExecutor(ToolExecutor[BrowserAction, BrowserObservation]):
         finally:
             # Always close the async executor
             self._async_executor.close()
-            # Release the shared executor reference so the class variable
-            # doesn't keep a stale reference that could prevent process exit.
-            from openhands.tools.browser_use.definition import BrowserToolSet
+            self._release_shared_executor_reference()
 
-            with BrowserToolSet._shared_executor_lock:
-                if BrowserToolSet._shared_executor is self:
-                    BrowserToolSet._shared_executor = None
+    def _release_shared_executor_reference(self):
+        # Avoid taking the shared executor lock for ordinary/stale executors.
+        # __del__ can run while BrowserToolSet.create() is creating a new shared
+        # executor; a stale executor finalizer trying to acquire the same lock can
+        # deadlock that create path, especially on Windows.
+        from openhands.tools.browser_use.definition import BrowserToolSet
+
+        if BrowserToolSet._shared_executor is not self:
+            return
+        with BrowserToolSet._shared_executor_lock:
+            if BrowserToolSet._shared_executor is self:
+                BrowserToolSet._shared_executor = None
 
     def __del__(self):
         """Cleanup on deletion."""

--- a/tests/tools/browser_use/test_browser_cleanup.py
+++ b/tests/tools/browser_use/test_browser_cleanup.py
@@ -4,6 +4,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
+from openhands.tools.browser_use import BrowserToolSet
 from openhands.tools.browser_use.impl import BrowserToolExecutor
 
 
@@ -121,6 +122,42 @@ class TestBrowserCleanup:
         mock_executor._async_executor.close = MagicMock()
 
         mock_executor.close()
+
+        mock_executor._async_executor.close.assert_called_once()
+
+    def test_close_method_releases_shared_executor(self, mock_executor):
+        """Test that closing the shared executor clears the singleton reference."""
+        BrowserToolSet._shared_executor = mock_executor
+
+        try:
+            mock_executor.close()
+            assert BrowserToolSet._shared_executor is None
+        finally:
+            BrowserToolSet._shared_executor = None
+
+    def test_close_method_stale_executor_does_not_acquire_shared_lock(
+        self,
+        mock_executor,
+        monkeypatch,
+    ):
+        """Stale executor finalizers should not contend with create()'s lock."""
+
+        class FailOnEnterLock:
+            def __enter__(self):
+                raise AssertionError("stale executor tried to acquire shared lock")
+
+            def __exit__(self, exc_type, exc_value, traceback):
+                return False
+
+        BrowserToolSet._shared_executor = None
+        monkeypatch.setattr(
+            BrowserToolSet,
+            "_shared_executor_lock",
+            FailOnEnterLock(),
+        )
+
+        mock_executor.close()
+        assert BrowserToolSet._shared_executor is None
 
         mock_executor._async_executor.close.assert_called_once()
 

--- a/tests/tools/browser_use/test_browser_toolset.py
+++ b/tests/tools/browser_use/test_browser_toolset.py
@@ -199,6 +199,26 @@ def test_browser_toolset_shared_executor_reset():
         assert executor1 is not executor2
 
 
+def test_browser_toolset_does_not_hold_shared_lock_while_constructing():
+    """Regression test for stale executor finalizers deadlocking create()."""
+
+    def fake_init(self, **_kwargs):
+        assert not BrowserToolSet._shared_executor_lock.locked()
+        self.full_output_save_dir = None
+        self._initialized = False
+        self._cleanup_initiated = True
+        self._action_timeout_seconds = 30.0
+        self._async_executor = MagicMock()
+        self._async_executor.close = MagicMock()
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+        with patch.object(BrowserToolExecutor, "__init__", fake_init):
+            tools = BrowserToolSet.create(conv_state=conv_state)
+
+    assert tools[0].executor is BrowserToolSet._shared_executor
+
+
 def test_browser_toolset_warns_when_config_ignored(caplog):
     """
     Test that a warning is logged when a second create()


### PR DESCRIPTION
## Summary

- Construct the shared browser executor outside `BrowserToolSet._shared_executor_lock` so stale executor finalizers cannot block executor creation.
- Avoid taking the shared executor lock when closing stale/non-shared `BrowserToolExecutor` instances.
- Add regression coverage for both lock-sensitive paths.

Closes #3309.

## Validation

- `uv run pytest tests/tools/browser_use/test_browser_toolset.py tests/tools/browser_use/test_browser_cleanup.py -q`
- `uv run pre-commit run --files openhands-tools/openhands/tools/browser_use/definition.py openhands-tools/openhands/tools/browser_use/impl.py tests/tools/browser_use/test_browser_toolset.py tests/tools/browser_use/test_browser_cleanup.py --show-diff-on-failure`

---
_AI disclosure: This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:210cfce-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-210cfce-python \
  ghcr.io/openhands/agent-server:210cfce-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:210cfce-golang-amd64
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-golang-amd64
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-golang-amd64
ghcr.io/openhands/agent-server:210cfce-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:210cfce-golang-arm64
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-golang-arm64
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-golang-arm64
ghcr.io/openhands/agent-server:210cfce-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:210cfce-java-amd64
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-java-amd64
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-java-amd64
ghcr.io/openhands/agent-server:210cfce-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:210cfce-java-arm64
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-java-arm64
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-java-arm64
ghcr.io/openhands/agent-server:210cfce-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:210cfce-python-amd64
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-python-amd64
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-python-amd64
ghcr.io/openhands/agent-server:210cfce-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:210cfce-python-arm64
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-python-arm64
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-python-arm64
ghcr.io/openhands/agent-server:210cfce-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:210cfce-golang
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-golang
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-golang
ghcr.io/openhands/agent-server:210cfce-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:210cfce-java
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-java
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-java
ghcr.io/openhands/agent-server:210cfce-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:210cfce-python
ghcr.io/openhands/agent-server:210cfce1572864246fead43a71460438e7a42e75-python
ghcr.io/openhands/agent-server:fix-windows-browser-toolset-deadlock-python
ghcr.io/openhands/agent-server:210cfce-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `210cfce-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `210cfce-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->