### PR TITLE
Add DeepSeek-V4-Pro to verified models

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/verified_models.py
@@ -60,6 +60,7 @@ VERIFIED_GEMINI_MODELS = [
 VERIFIED_DEEPSEEK_MODELS = [
     "deepseek-chat",
     "deepseek-v3.2-reasoner",
+    "deepseek-v4-pro",
 ]
 
 VERIFIED_MOONSHOT_MODELS = [
@@ -110,6 +111,7 @@ VERIFIED_OPENHANDS_MODELS = [
     "gemini-3-pro",
     "deepseek-chat",
     "deepseek-v3.2-reasoner",
+    "deepseek-v4-pro",
     "kimi-k2-thinking",
     "kimi-k2.6",
     "kimi-k2.5",


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Per issue #3313, `deepseek-v4-pro` should be recognized as a verified DeepSeek model so it surfaces in the verified-model lists used by the SDK (and any UI driven from `VERIFIED_MODELS`).

The model identifier is already referenced elsewhere in the repo (e.g. `.github/run-eval/resolve_model_config.py` defines an entry pointing at `litellm_proxy/deepseek/deepseek-v4-pro`), so adding it to `VERIFIED_DEEPSEEK_MODELS` brings the verified-models list in line with what's already configured for evaluation.

## Summary

- Add `"deepseek-v4-pro"` to `VERIFIED_DEEPSEEK_MODELS` in `openhands-sdk/openhands/sdk/llm/utils/verified_models.py`.
- Add `"deepseek-v4-pro"` to `VERIFIED_OPENHANDS_MODELS` so the existing `test_openhands_models_all_have_provider_list` invariant (every OpenHands-provider model must also appear under its real provider) keeps holding, and the new model is exposed through the OpenHands provider too.

## Issue Number

Fixes #3313

## How to Test

Run the existing model-list tests, which already enforce the cross-provider invariant for everything in `VERIFIED_OPENHANDS_MODELS`:

```bash
uv run pytest tests/sdk/llm/test_model_list.py -v
```

All 5 tests pass locally:

```
tests/sdk/llm/test_model_list.py::test_organize_models_and_providers PASSED
tests/sdk/llm/test_model_list.py::test_list_bedrock_models_without_boto3 PASSED
tests/sdk/llm/test_model_list.py::test_list_bedrock_models_with_boto3 PASSED
tests/sdk/llm/test_model_list.py::test_openhands_models_all_have_provider_list PASSED
tests/sdk/llm/test_model_list.py::test_trinity_model_is_openhands_only PASSED
```

You can also confirm the model is now picked up:

```bash
uv run python -c "from openhands.sdk.llm.utils.verified_models import VERIFIED_MODELS; print('deepseek-v4-pro' in VERIFIED_MODELS['deepseek'], 'deepseek-v4-pro' in VERIFIED_MODELS['openhands'])"
# True True
```

Pre-commit hooks (`ruff format`, `ruff lint`, `pycodestyle`, `pyright`, import dependency rules, tool subclass registration) also pass on the changed file:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/verified_models.py
```

## Video/Screenshots

N/A — data-only change to a verified-models list.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is a pure data addition to `VERIFIED_DEEPSEEK_MODELS` / `VERIFIED_OPENHANDS_MODELS`; no functional or API changes. Per the contribution guidelines, no new tests were added because the change is to a configuration list and is already covered by the existing `test_openhands_models_all_have_provider_list` invariant.

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/88d8b509-8ed3-45c0-bea1-f3ba62cc7f56)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1be922a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1be922a-python \
  ghcr.io/openhands/agent-server:1be922a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1be922a-golang-amd64
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-golang-amd64
ghcr.io/openhands/agent-server:1be922a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1be922a-golang-arm64
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-golang-arm64
ghcr.io/openhands/agent-server:1be922a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1be922a-java-amd64
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-java-amd64
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-java-amd64
ghcr.io/openhands/agent-server:1be922a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1be922a-java-arm64
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-java-arm64
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-java-arm64
ghcr.io/openhands/agent-server:1be922a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1be922a-python-amd64
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-python-amd64
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-python-amd64
ghcr.io/openhands/agent-server:1be922a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1be922a-python-arm64
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-python-arm64
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-python-arm64
ghcr.io/openhands/agent-server:1be922a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1be922a-golang
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-golang
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-golang
ghcr.io/openhands/agent-server:1be922a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1be922a-java
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-java
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-java
ghcr.io/openhands/agent-server:1be922a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1be922a-python
ghcr.io/openhands/agent-server:1be922abb960562e7748df45c5b7da68f03ed7f5-python
ghcr.io/openhands/agent-server:openhands-add-deepseek-v4-pro-verified-python
ghcr.io/openhands/agent-server:1be922a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1be922a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1be922a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->