### PR TITLE
fix(sdk): cap effective_max_output_tokens with DEFAULT_MAX_OUTPUT_TOKENS_CAP

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1314,6 +1314,22 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                             self.model,
                         )
 
+            # For providers where litellm model metadata may be inaccurate
+            # (e.g., moonshot/deepseek models through custom base_url), apply
+            # a universal safety cap to prevent BadRequestError from exceeding
+            # the model's actual API limit.
+            if (
+                effective_max_output_tokens is not None
+                and effective_max_output_tokens > DEFAULT_MAX_OUTPUT_TOKENS_CAP
+            ):
+                effective_max_output_tokens = DEFAULT_MAX_OUTPUT_TOKENS_CAP
+                logger.debug(
+                    "Capping max_output_tokens to %s for %s "
+                    "(litellm metadata may be inaccurate for this provider)",
+                    effective_max_output_tokens,
+                    self.model,
+                )
+
         if "o3" in self.model:
             o3_limit = 100000
             if (


### PR DESCRIPTION
Fixes #3317. When litellm model metadata reports a max_output_tokens value that exceeds the model's actual API limit (e.g., moonshot/kimi-k2.5 through custom base_url), apply DEFAULT_MAX_OUTPUT_TOKENS_CAP (16384) as a universal safety cap. This generalizes the fix from #2264 which only handled bedrock/ models.