### PR TITLE
fix: write and read installation metadata as utf-8

### DIFF
--- a/openhands-sdk/openhands/sdk/extensions/installation/metadata.py
+++ b/openhands-sdk/openhands/sdk/extensions/installation/metadata.py
@@ -150,7 +150,7 @@ class InstallationMetadata(BaseModel):
             return cls()
 
         try:
-            return cls.model_validate_json(metadata_path.read_text())
+            return cls.model_validate_json(metadata_path.read_text(encoding="utf-8"))
         except Exception as e:
             logger.warning(f"Failed to load installed extension metadata: {e}")
             return cls()
@@ -159,7 +159,7 @@ class InstallationMetadata(BaseModel):
         """Save metadata to the installed extensions directory."""
         metadata_path = self.get_metadata_path(installed_dir)
         metadata_path.parent.mkdir(parents=True, exist_ok=True)
-        metadata_path.write_text(self.model_dump_json(indent=2))
+        metadata_path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
 
     def validate_tracked(self, installed_dir: Path) -> list[InstallationInfo]:
         """Validate tracked extensions exist on disk.

--- a/tests/sdk/extensions/installation/test_installation_metadata.py
+++ b/tests/sdk/extensions/installation/test_installation_metadata.py
@@ -238,6 +238,39 @@ def test_load_from_dir_invalid_json(tmp_path: Path):
     assert metadata.extensions == {}
 
 
+def test_save_and_load_round_trip_non_ascii(tmp_path: Path):
+    """save_to_dir() then load_from_dir() must round-trip non-ASCII content.
+
+    save_to_dir()/load_from_dir() use Path.write_text()/read_text(), which
+    fall back to the platform default encoding (cp1252 on Windows) when no
+    encoding is given. cp1252 cannot represent characters like emoji, so
+    metadata with non-ASCII fields would fail to persist. Both ends must
+    use UTF-8.
+    """
+    installation_dir = tmp_path / "installed"
+    installation_dir.mkdir()
+
+    info = InstallationInfo(
+        name="café-extension",
+        version="1.0.0",
+        description="Adds 🔐 secure access review — supports français",
+        source="github:owner/café-extension",
+        install_path=installation_dir / "café-extension",
+    )
+    metadata = InstallationMetadata(extensions={"café-extension": info})
+    metadata.save_to_dir(installation_dir)
+
+    # The metadata file on disk must be valid UTF-8.
+    metadata_path = InstallationMetadata.get_metadata_path(installation_dir)
+    assert "🔐" in metadata_path.read_bytes().decode("utf-8")
+
+    loaded_metadata = InstallationMetadata.load_from_dir(installation_dir)
+    assert metadata == loaded_metadata
+    assert loaded_metadata.extensions["café-extension"].description == (
+        "Adds 🔐 secure access review — supports français"
+    )
+
+
 # ============================================================================
 # open() Context Manager Tests
 # ============================================================================


### PR DESCRIPTION
## Problem

`InstallationMetadata.save_to_dir()` serialises via Pydantic's `model_dump_json()`, which emits **raw (unescaped) non-ASCII characters**, and writes the result with `Path.write_text()` — with no `encoding` argument. `load_from_dir()` reads it back with `Path.read_text()` — also no `encoding`.

Both calls fall back to the platform default encoding. On Windows that is `cp1252`, which cannot encode characters like emoji:

- An extension whose `name` or `description` contains non-ASCII text fails to **persist**.
- A metadata file written elsewhere as UTF-8 fails to **load** (`UnicodeDecodeError`).

This is the same class of bug as the remote completion-log writer fixed in #3225 (`fix: write remote completion logs as utf-8`).

## Scope — why only this file

While auditing, I checked the other text-mode file I/O in `openhands-sdk` (`hooks/config.py`, `llm/llm_profile_store.py`, `llm/llm.py`). Those serialise via `json.dump()` / `json.dumps()`, which default to `ensure_ascii=True` and therefore emit **pure ASCII** — ASCII round-trips safely through `cp1252`, so they are not affected.

Only `model_dump_json()`, which does **not** escape non-ASCII, hits this bug. The fix is scoped accordingly — one file, the genuinely affected path.

## Fix

`openhands-sdk/openhands/sdk/extensions/installation/metadata.py` — pin both ends to `encoding="utf-8"`:

```python
# load_from_dir()
return cls.model_validate_json(metadata_path.read_text(encoding="utf-8"))

# save_to_dir()
metadata_path.write_text(self.model_dump_json(indent=2), encoding="utf-8")
```

Consistent with how `telemetry.py` and the remote completion-log writer (post-#3225) already specify UTF-8.

## Test

Adds `test_save_and_load_round_trip_non_ascii` to `tests/sdk/extensions/installation/test_installation_metadata.py`. It:

1. Saves an `InstallationMetadata` whose extension `name` and `description` contain emoji (`🔐`) and accented text (`café`, `français`).
2. Asserts the metadata file on disk is valid UTF-8 (`read_bytes().decode("utf-8")` contains the emoji).
3. Asserts `load_from_dir()` round-trips the content exactly.

The bug is Windows-specific (cp1252 default), so the test serves as a contract/regression guard rather than a Linux-CI-failing reproducer — same situation as #3225, which shipped without a test; this PR adds one.

Local run: `uv run pytest tests/sdk/extensions/installation/test_installation_metadata.py` — **15 passed**.

## Checklist

- [x] Scoped to the one genuinely affected code path (verified the json.dump sites are ASCII-safe).
- [x] Regression test added and passing locally.
- [x] `ruff check` and `ruff format --check` pass on the changed files.
- [x] No behaviour change for ASCII metadata; no public API change.