### PR TITLE
Fix planning agent PLAN.md path references

### DIFF
--- a/examples/01_standalone_sdk/24_planning_agent_workflow.py
+++ b/examples/01_standalone_sdk/24_planning_agent_workflow.py
@@ -33,6 +33,7 @@ def get_event_content(event):
 
 # Create a temporary workspace
 workspace_dir = Path(tempfile.mkdtemp())
+plan_path = workspace_dir / ".agents_tmp" / "PLAN.md"
 print(f"Working in: {workspace_dir}")
 
 # Configure LLM
@@ -82,7 +83,7 @@ planning_conversation.run()
 print("\n" + "=" * 80)
 print("PLANNING COMPLETE")
 print("=" * 80)
-print(f"Implementation plan saved to: {workspace_dir}/PLAN.md")
+print(f"Implementation plan saved to: {plan_path}")
 
 print("\n" + "=" * 80)
 print("PHASE 2: EXECUTION")
@@ -101,9 +102,10 @@ execution_conversation = Conversation(
 execution_prompt = f"""
 Please implement the web scraping project according to the implementation plan.
 
-The detailed implementation plan has been created and saved at: {workspace_dir}/PLAN.md
+The detailed implementation plan has been created and saved at: {plan_path}
 
-Please read the plan from PLAN.md and implement all components according to it.
+Please read the plan from .agents_tmp/PLAN.md and implement all components
+according to it.
 
 Create all necessary files, implement the functionality, and ensure everything
 works together properly.

--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt_planning.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt_planning.j2
@@ -61,7 +61,9 @@ Follow this enhanced planning workflow to create well-researched, user-aligned p
 
 **Goal:** Ensure the plan aligns with the user's intentions.
 
-1. **Write the initial plan to PLAN.md** at the root of your workspace. The file already contains the required section headers - fill in the content under each section.
+1. **Write the initial plan to the configured PLAN.md file.** By default, this
+   file is `.agents_tmp/PLAN.md` under the workspace root. The file already
+   contains the required section headers - fill in the content under each section.
 
 2. **Ask the user about any remaining tradeoffs** or decisions that could affect the implementation.
 

--- a/openhands-tools/openhands/tools/planning_file_editor/definition.py
+++ b/openhands-tools/openhands/tools/planning_file_editor/definition.py
@@ -52,7 +52,8 @@ TOOL_DESCRIPTION = (
 IMPORTANT RESTRICTION FOR PLANNING AGENT:
 * You can VIEW any file in the workspace using the 'view' command
 * You can ONLY EDIT the PLAN.md file (all other edit operations will be rejected)
-* PLAN.md is automatically initialized with section headers at the workspace root
+* PLAN.md is automatically initialized with section headers at the configured
+  plan path (by default, .agents_tmp/PLAN.md under the workspace root)
 * All editing commands (create, str_replace, insert, undo_edit) are restricted to PLAN.md only
 * The PLAN.md file already contains the required section structure - you just need to fill in the content
 """  # noqa


### PR DESCRIPTION

- [x] A human has tested these changes.

---

## Why

The Planning Agent prompt, planning file editor tool description, and planning workflow example referenced `PLAN.md` at the workspace root.

The actual default implementation stores the planning file at `{working_dir}/.agents_tmp/PLAN.md`, introduced by #1876 following the intent in #1861 to keep `PLAN.md` out of the repo root.

This PR aligns the user-facing text and example with the existing implementation.

## Summary

- Updated the Planning Agent system prompt to describe the configured `PLAN.md` path and the default `.agents_tmp/PLAN.md` location.
- Updated the planning file editor tool description to match the configured plan path.
- Updated `examples/01_standalone_sdk/24_planning_agent_workflow.py` to reference `.agents_tmp/PLAN.md`.

## Issue Number

Related to #1861. Context: #1876.

## How to Test

Ran:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/prompts/system_prompt_planning.j2 openhands-tools/openhands/tools/planning_file_editor/definition.py examples/01_standalone_sdk/24_planning_agent_workflow.py
```

Result: passed.

Ran:

```bash
uv run pytest tests/tools/planning_file_editor/test_planning_file_editor_tool.py tests/tools/test_planning_preset.py
```

Result: 7 passed.

I did not run the full LLM-backed planning workflow example because this PR only updates displayed paths and prompt/tool/example text, with no runtime behavior change.

## Video/Screenshots

N/A. This is a prompt/tool-description/example text alignment change with no UI change.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

No behavior change. The default `PLAN.md` location remains `.agents_tmp/PLAN.md`.

Out of scope: exposing `plan_path` through `get_planning_agent()`, which is a separate API concern.

This PR touches a prompt template and tool description, so it should receive the `integration-test` label.
