### PR TITLE
refactor: share run/arun loop logic via generator pattern

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -3,7 +3,7 @@ import atexit
 import contextlib
 import copy
 import uuid
-from collections.abc import Mapping
+from collections.abc import Generator, Mapping
 from pathlib import Path
 
 from openhands.sdk.agent.acp_agent import ACPAgent
@@ -70,6 +70,10 @@ from openhands.sdk.workspace import LocalWorkspace
 
 
 logger = get_logger(__name__)
+
+# Sentinel used by run()/arun() to detect generator exhaustion via
+# ``next(gen, _LOOP_DONE)``.
+_LOOP_DONE = object()
 
 
 class LocalConversation(BaseConversation):
@@ -765,22 +769,22 @@ class LocalConversation(BaseConversation):
             )
             self._on_event(user_msg_event)
 
-    @observe(name="conversation.run")
-    def run(self) -> None:
-        """Runs the conversation until the agent finishes.
+    def _run_loop(self) -> Generator[None]:
+        """Core run loop shared by :meth:`run` and :meth:`arun`.
 
-        In confirmation mode:
-        - First call: creates actions but doesn't execute them, stops and waits
-        - Second call: executes pending actions (implicit confirmation)
+        Yields once per iteration, at the point where the agent should
+        take a step.  The caller drives the generator and performs either
+        a sync ``agent.step()`` or ``await agent.astep()`` at each yield.
 
-        In normal mode:
-        - Creates and executes actions immediately
+        All control-flow logic (status transitions, stuck detection,
+        stop hooks, iteration cap, error handling) lives here so it is
+        defined exactly once.
 
-        Can be paused between steps
+        Raises:
+            ConversationRunError: Wraps any exception from the loop body
+                with the conversation ID and persistence dir.
         """
-        # Ensure agent is fully initialized (loads plugins and initializes agent)
         self._ensure_agent_ready()
-        self._cancel_token = CancellationToken()
 
         with self._state:
             if self._state.execution_status in [
@@ -796,9 +800,10 @@ class LocalConversation(BaseConversation):
             while True:
                 logger.debug(f"Conversation run iteration {iteration}")
                 with self._state:
-                    # Pause attempts to acquire the state lock
-                    # Before value can be modified step can be taken
-                    # Ensure step conditions are checked when lock is already acquired
+                    # Pause attempts to acquire the state lock.
+                    # Before value can be modified step can be taken.
+                    # Ensure step conditions are checked when lock is
+                    # already acquired.
                     if self._state.execution_status in [
                         ConversationExecutionStatus.PAUSED,
                         ConversationExecutionStatus.STUCK,
@@ -830,13 +835,11 @@ class LocalConversation(BaseConversation):
                                     ConversationExecutionStatus.RUNNING
                                 )
                                 continue
-                        # No hooks or hooks allowed stopping
                         break
 
                     # Check for stuck patterns if enabled
                     if self._stuck_detector:
                         is_stuck = self._stuck_detector.is_stuck()
-
                         if is_stuck:
                             logger.warning("Stuck pattern detected.")
                             self._state.execution_status = (
@@ -844,7 +847,7 @@ class LocalConversation(BaseConversation):
                             )
                             continue
 
-                    # clear the flag before calling agent.step() (user approved)
+                    # Clear the flag before the agent step (user approved)
                     if (
                         self._state.execution_status
                         == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
@@ -853,19 +856,18 @@ class LocalConversation(BaseConversation):
                             ConversationExecutionStatus.RUNNING
                         )
 
-                    self.agent.step(
-                        self, on_event=self._on_event, on_token=self._on_token
-                    )
+                    # Caller performs sync or async agent step here.
+                    yield
                     iteration += 1
 
-                    # Check for non-finished terminal conditions
-                    # Note: We intentionally do NOT check for FINISHED status here.
-                    # This allows concurrent user messages to be processed:
+                    # Check for non-finished terminal conditions.
+                    # We intentionally do NOT check for FINISHED status
+                    # here.  This allows concurrent user messages to be
+                    # processed:
                     # 1. Agent finishes and sets status to FINISHED
                     # 2. User sends message concurrently via send_message()
-                    # 3. send_message() waits for FIFO lock, then sets status to IDLE
-                    # 4. Run loop continues to next iteration and processes the message
-                    # 5. Without this design, concurrent messages would be lost
+                    # 3. send_message() waits for FIFO lock, sets IDLE
+                    # 4. Run loop continues and processes the message
                     if (
                         self.state.execution_status
                         == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
@@ -898,8 +900,6 @@ class LocalConversation(BaseConversation):
         except Exception as e:
             with self._state:
                 self._state.execution_status = ConversationExecutionStatus.ERROR
-
-                # Add an error event
                 self._on_event(
                     ConversationErrorEvent(
                         source="environment",
@@ -907,14 +907,39 @@ class LocalConversation(BaseConversation):
                         detail=str(e),
                     )
                 )
-
-            # Re-raise with conversation id and persistence dir for better UX
             raise ConversationRunError(
                 self._state.id, e, persistence_dir=self._state.persistence_dir
             ) from e
+
+    @observe(name="conversation.run")
+    def run(self) -> None:
+        """Runs the conversation until the agent finishes.
+
+        In confirmation mode:
+        - First call: creates actions but doesn't execute them, stops and waits
+        - Second call: executes pending actions (implicit confirmation)
+
+        In normal mode:
+        - Creates and executes actions immediately
+
+        Can be paused between steps
+        """
+        self._cancel_token = CancellationToken()
+        loop = self._run_loop()
+        try:
+            while next(loop, _LOOP_DONE) is not _LOOP_DONE:
+                try:
+                    self.agent.step(
+                        self, on_event=self._on_event, on_token=self._on_token
+                    )
+                except Exception as step_error:
+                    # Route the exception into the generator so its
+                    # try/except can wrap it in ConversationRunError.
+                    loop.throw(step_error)
         finally:
             self._cancel_token = None
 
+    @observe(name="conversation.arun")
     async def arun(self) -> None:
         """Async variant of :meth:`run`.
 
@@ -933,137 +958,34 @@ class LocalConversation(BaseConversation):
         observation is patched with a synthetic ``AgentErrorEvent`` so
         the LLM conversation history stays consistent.
         """
-        self._ensure_agent_ready()
         self._arun_task = asyncio.current_task()
         self._cancel_token = CancellationToken()
-
-        with self._state:
-            if self._state.execution_status in [
-                ConversationExecutionStatus.IDLE,
-                ConversationExecutionStatus.PAUSED,
-                ConversationExecutionStatus.ERROR,
-                ConversationExecutionStatus.STUCK,
-            ]:
-                self._state.execution_status = ConversationExecutionStatus.RUNNING
-
-        iteration = 0
+        loop = self._run_loop()
         try:
-            while True:
-                logger.debug(f"Conversation arun iteration {iteration}")
-                with self._state:
-                    if self._state.execution_status in [
-                        ConversationExecutionStatus.PAUSED,
-                        ConversationExecutionStatus.STUCK,
-                    ]:
-                        break
-
-                    if (
-                        self._state.execution_status
-                        == ConversationExecutionStatus.FINISHED
-                    ):
-                        if self._hook_processor is not None:
-                            should_stop, feedback = self._hook_processor.run_stop(
-                                reason="agent_finished"
-                            )
-                            if not should_stop:
-                                logger.info("Stop hook denied agent stopping")
-                                if feedback:
-                                    prefixed = f"[Stop hook feedback] {feedback}"
-                                    feedback_msg = MessageEvent(
-                                        source="environment",
-                                        llm_message=Message(
-                                            role="user",
-                                            content=[TextContent(text=prefixed)],
-                                        ),
-                                    )
-                                    self._on_event(feedback_msg)
-                                self._state.execution_status = (
-                                    ConversationExecutionStatus.RUNNING
-                                )
-                                continue
-                        break
-
-                    if self._stuck_detector:
-                        is_stuck = self._stuck_detector.is_stuck()
-                        if is_stuck:
-                            logger.warning("Stuck pattern detected.")
-                            self._state.execution_status = (
-                                ConversationExecutionStatus.STUCK
-                            )
-                            continue
-
-                    if (
-                        self._state.execution_status
-                        == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
-                    ):
-                        self._state.execution_status = (
-                            ConversationExecutionStatus.RUNNING
-                        )
-
+            while next(loop, _LOOP_DONE) is not _LOOP_DONE:
+                try:
                     await self.agent.astep(
                         self,
                         on_event=self._on_event,
                         on_token=self._on_token,
                     )
-                    iteration += 1
-
-                    if (
-                        self.state.execution_status
-                        == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
-                    ):
-                        break
-
-                    if iteration >= self.max_iteration_per_run:
-                        if (
-                            self._state.execution_status
-                            == ConversationExecutionStatus.FINISHED
-                        ):
-                            break
-                        error_msg = (
-                            f"Agent reached maximum iterations limit "
-                            f"({self.max_iteration_per_run})."
-                        )
-                        logger.error(error_msg)
-                        self._state.execution_status = ConversationExecutionStatus.ERROR
-                        self._on_event(
-                            ConversationErrorEvent(
-                                source="environment",
-                                code="MaxIterationsReached",
-                                detail=error_msg,
-                            )
-                        )
-                        break
+                except asyncio.CancelledError:
+                    raise  # handled by outer except
+                except Exception as step_error:
+                    loop.throw(step_error)
         except asyncio.CancelledError:
-            # CancelledError is intentionally NOT re-raised.  ``interrupt()``
-            # uses ``asyncio.Task.cancel()`` to break out of ``arun()`` and
-            # expects the task to terminate cleanly.  Re-raising would
-            # propagate the cancellation to EventService/caller which would
-            # surface it as an unexpected error.  Instead we transition to
-            # PAUSED so the conversation can be resumed later.
+            # CancelledError is intentionally NOT re-raised.
+            # ``interrupt()`` uses ``asyncio.Task.cancel()`` to break
+            # out of ``arun()`` and expects the task to terminate
+            # cleanly.  Re-raising would propagate the cancellation to
+            # EventService/caller which would surface it as an
+            # unexpected error.  Instead we transition to PAUSED so the
+            # conversation can be resumed later.
             logger.info("arun() interrupted via task cancellation")
             with self._state:
-                # Emit synthetic error observations for any ActionEvents
-                # that were in-flight when the interrupt landed.  Without
-                # these the LLM history would contain tool-call requests
-                # with no tool-result, which causes provider errors on
-                # the next completion call.
                 self._emit_orphaned_action_errors()
-
                 self._state.execution_status = ConversationExecutionStatus.PAUSED
                 self._on_event(InterruptEvent())
-        except Exception as e:
-            with self._state:
-                self._state.execution_status = ConversationExecutionStatus.ERROR
-                self._on_event(
-                    ConversationErrorEvent(
-                        source="environment",
-                        code=e.__class__.__name__,
-                        detail=str(e),
-                    )
-                )
-            raise ConversationRunError(
-                self._state.id, e, persistence_dir=self._state.persistence_dir
-            ) from e
         finally:
             self._cancel_token = None
             self._arun_task = None


### PR DESCRIPTION
<!-- AI/LLM agents: 

Evidence of end-to-end testing below in "How to Test" section.
-->

- [ ] A human has tested these changes.

---

## Why

`LocalConversation.run()` and `arun()` contained ~150 lines of nearly identical loop logic — status transitions, stuck detection, stop hooks, iteration cap, and error handling. The only meaningful difference was `agent.step()` vs `await agent.astep()`. This duplication made it easy for the two code paths to drift out of sync.

The codebase already has a proven pattern for this: `RemoteWorkspaceMixin` uses generators to share business logic between sync `RemoteWorkspace` and `AsyncRemoteWorkspace`, where the generator yields effects and the caller decides whether to execute them synchronously or asynchronously.

## Summary

- Extracted the duplicated run loop into a `_run_loop()` generator that yields once per iteration at the point where the agent should step
- `run()` drives the generator calling `agent.step()` at each yield; `arun()` drives it with `await agent.astep()`
- Exceptions from agent steps are routed back into the generator via `throw()` so the generator's `try/except` can set ERROR status and wrap them in `ConversationRunError` — preserving identical error semantics
- Net reduction of 78 lines (148 removed, 70 added)

## Issue Number

N/A — refactoring opportunity identified from existing `RemoteWorkspaceMixin` pattern.

## How to Test

All conversation-related tests pass:

```bash
# Core run/arun behavior tests (37 tests)
uv run pytest tests/sdk/conversation/local/test_run_exception_includes_conversation_id.py \
  tests/sdk/conversation/local/test_conversation_pause_functionality.py \
  tests/sdk/conversation/local/test_confirmation_mode.py \
  tests/sdk/conversation/local/test_agent_status_transition.py \
  tests/sdk/conversation/local/test_conversation_send_message.py \
  tests/sdk/conversation/local/test_conversation_default_callback.py \
  -x -q --timeout=10

# Interrupt/CancelledError tests (14 tests)
uv run pytest tests/sdk/conversation/test_interrupt.py -x -q --timeout=10
```

All 51 tests pass. Pre-commit (ruff format, ruff lint, pycodestyle, pyright, import deps) all pass.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

The same generator pattern could be applied to `Agent.step()`/`astep()` in the future, though those have heterogeneous async boundary points (LLM completion, message preparation, action execution) which makes the pattern a less clean fit compared to the uniform yield-per-iteration approach used here.


@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/b66fc800-f589-4508-bc8b-9f84e2f0bb6e)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3f3ea71-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3f3ea71-python \
  ghcr.io/openhands/agent-server:3f3ea71-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3f3ea71-golang-amd64
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-golang-amd64
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-golang-amd64
ghcr.io/openhands/agent-server:3f3ea71-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3f3ea71-golang-arm64
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-golang-arm64
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-golang-arm64
ghcr.io/openhands/agent-server:3f3ea71-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3f3ea71-java-amd64
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-java-amd64
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-java-amd64
ghcr.io/openhands/agent-server:3f3ea71-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3f3ea71-java-arm64
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-java-arm64
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-java-arm64
ghcr.io/openhands/agent-server:3f3ea71-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3f3ea71-python-amd64
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-python-amd64
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-python-amd64
ghcr.io/openhands/agent-server:3f3ea71-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3f3ea71-python-arm64
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-python-arm64
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-python-arm64
ghcr.io/openhands/agent-server:3f3ea71-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3f3ea71-golang
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-golang
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-golang
ghcr.io/openhands/agent-server:3f3ea71-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3f3ea71-java
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-java
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-java
ghcr.io/openhands/agent-server:3f3ea71-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3f3ea71-python
ghcr.io/openhands/agent-server:3f3ea713f27b3d547cb8206f1d83594aeebad7c2-python
ghcr.io/openhands/agent-server:refactor-share-run-arun-via-generator-python
ghcr.io/openhands/agent-server:3f3ea71-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3f3ea71-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3f3ea71-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->