### PR TITLE
Fix async retry losing temperature→1.0 on LLMNoResponseError

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -785,6 +785,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             (formatted_messages, cc_tools, use_mock_tools, call_kwargs,
              telemetry_ctx)
         """
+        # Defensive copy — this method mutates kwargs (e.g. kwargs["tools"])
+        # and the caller should not observe those side-effects.
+        kwargs = dict(kwargs)
+
         formatted_messages = self.format_messages_for_llm(messages)
         use_native_fc = self.native_tool_calling
         original_fncall_msgs = copy.deepcopy(formatted_messages)
@@ -857,6 +861,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             (instructions, input_items, resp_tools, call_kwargs,
              telemetry_ctx)
         """
+        # Defensive copy — select_responses_options may mutate kwargs.
+        kwargs = dict(kwargs)
+
         instructions, input_items = self.format_messages_for_responses(messages)
 
         # Responses path always supports function tools

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -766,6 +766,128 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             accumulated_token_usage=self.metrics.accumulated_token_usage,
         )
 
+    def _make_retry_decorator(
+        self,
+    ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
+        """Return a configured retry decorator using this LLM's retry settings."""
+        return self.retry_decorator(
+            num_retries=self.num_retries,
+            retry_exceptions=LLM_RETRY_EXCEPTIONS,
+            retry_min_wait=self.retry_min_wait,
+            retry_max_wait=self.retry_max_wait,
+            retry_multiplier=self.retry_multiplier,
+            retry_listener=self._retry_listener_fn,
+        )
+
+    def _build_completion_result(self, resp: ModelResponse) -> LLMResponse:
+        """Convert a raw :class:`ModelResponse` into an :class:`LLMResponse`."""
+        first_choice = resp["choices"][0]
+        message = Message.from_llm_chat_message(first_choice["message"])
+        return LLMResponse(
+            message=message,
+            metrics=self._current_metrics_snapshot(),
+            raw_response=resp,
+        )
+
+    def _build_responses_result(self, resp: ResponsesAPIResponse) -> LLMResponse:
+        """Convert a raw :class:`ResponsesAPIResponse` into an :class:`LLMResponse`."""
+        output_seq = cast(Sequence[Any], resp.output or [])
+        message = Message.from_llm_responses_output(output_seq)
+        return LLMResponse(
+            message=message,
+            metrics=self._current_metrics_snapshot(),
+            raw_response=resp,
+        )
+
+    def _build_responses_call_kwargs(
+        self,
+        input_items: list[dict[str, Any]],
+        instructions: str | None,
+        resp_tools: list[Any] | None,
+        final_kwargs: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Build the shared kwargs dict for litellm_responses / litellm_aresponses."""
+        typed_input: ResponseInputParam | str = (
+            cast(ResponseInputParam, input_items) if input_items else ""
+        )
+        api_key_value = self._get_litellm_api_key_value()
+        return {
+            "model": self.model,
+            "input": typed_input,
+            "instructions": instructions,
+            "tools": resp_tools,
+            "api_key": api_key_value,
+            "api_base": self.base_url,
+            "api_version": self.api_version,
+            "timeout": self.timeout,
+            "drop_params": self.drop_params,
+            "seed": self.seed,
+            **self._aws_kwargs(),
+            **final_kwargs,
+        }
+
+    def _process_stream_event(
+        self, event: Any
+    ) -> tuple[Any | None, ModelResponseStream | None]:
+        """Extract output item and delta chunk from a Responses stream event.
+
+        Returns:
+            (output_item, delta_chunk) — either or both may be ``None``.
+        """
+        output_item: Any | None = None
+        delta_chunk: ModelResponseStream | None = None
+
+        evt_type = getattr(event, "type", None)
+        if evt_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+            item = getattr(event, "item", None)
+            if item is not None:
+                output_item = item
+
+        if isinstance(
+            event,
+            (
+                OutputTextDeltaEvent,
+                RefusalDeltaEvent,
+                ReasoningSummaryTextDeltaEvent,
+            ),
+        ):
+            delta = event.delta
+            if delta:
+                delta_chunk = ModelResponseStream(
+                    choices=[StreamingChoices(delta=Delta(content=delta))]
+                )
+
+        return output_item, delta_chunk
+
+    def _finalize_stream_response(
+        self,
+        completed_response: Any,
+        collected_output_items: list[Any],
+    ) -> ResponsesAPIResponse:
+        """Validate and patch the completed response from a Responses stream.
+
+        Raises:
+            LLMNoResponseError: If the stream finished without a completed
+                response or with an unexpected event type.
+        """
+        if completed_response is None:
+            raise LLMNoResponseError(
+                "Responses stream finished without a completed response"
+            )
+        if not isinstance(completed_response, ResponseCompletedEvent):
+            raise LLMNoResponseError(
+                f"Unexpected completed event: {type(completed_response)}"
+            )
+
+        completed_resp = completed_response.response
+        # Patch empty output with items collected from stream
+        if not completed_resp.output and collected_output_items:
+            completed_resp.output = collected_output_items
+
+        assert self._telemetry is not None
+        self._telemetry.on_response(completed_resp)
+        return completed_resp
+
     def _prepare_completion_params(
         self,
         messages: list[Message],
@@ -1000,14 +1122,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             messages, tools, add_security_risk_prediction, kwargs
         )
 
-        @self.retry_decorator(
-            num_retries=self.num_retries,
-            retry_exceptions=LLM_RETRY_EXCEPTIONS,
-            retry_min_wait=self.retry_min_wait,
-            retry_max_wait=self.retry_max_wait,
-            retry_multiplier=self.retry_multiplier,
-            retry_listener=self._retry_listener_fn,
-        )
+        @self._make_retry_decorator()
         def _one_attempt(**retry_kwargs: Any) -> ModelResponse:
             assert self._telemetry is not None
             self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
@@ -1028,14 +1143,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             return resp
 
         try:
-            resp = _one_attempt()
-            first_choice = resp["choices"][0]
-            message = Message.from_llm_chat_message(first_choice["message"])
-            return LLMResponse(
-                message=message,
-                metrics=self._current_metrics_snapshot(),
-                raw_response=resp,
-            )
+            return self._build_completion_result(_one_attempt())
         except Exception as e:
             return self._handle_error(
                 e,
@@ -1081,14 +1189,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             messages, tools, add_security_risk_prediction, kwargs
         )
 
-        @self.retry_decorator(
-            num_retries=self.num_retries,
-            retry_exceptions=LLM_RETRY_EXCEPTIONS,
-            retry_min_wait=self.retry_min_wait,
-            retry_max_wait=self.retry_max_wait,
-            retry_multiplier=self.retry_multiplier,
-            retry_listener=self._retry_listener_fn,
-        )
+        @self._make_retry_decorator()
         async def _one_attempt(**retry_kwargs: Any) -> ModelResponse:
             assert self._telemetry is not None
             self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
@@ -1109,14 +1210,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             return resp
 
         try:
-            resp = await _one_attempt()
-            first_choice = resp["choices"][0]
-            message = Message.from_llm_chat_message(first_choice["message"])
-            return LLMResponse(
-                message=message,
-                metrics=self._current_metrics_snapshot(),
-                raw_response=resp,
-            )
+            return self._build_completion_result(await _one_attempt())
         except Exception as e:
             # Fallback is synchronous; cast the token callback since the
             # fallback LLM's sync path accepts TokenCallbackType.
@@ -1181,14 +1275,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             messages, tools, include, store, add_security_risk_prediction, kwargs
         )
 
-        @self.retry_decorator(
-            num_retries=self.num_retries,
-            retry_exceptions=LLM_RETRY_EXCEPTIONS,
-            retry_min_wait=self.retry_min_wait,
-            retry_max_wait=self.retry_max_wait,
-            retry_multiplier=self.retry_multiplier,
-            retry_listener=self._retry_listener_fn,
-        )
+        @self._make_retry_decorator()
         def _one_attempt(**retry_kwargs: Any) -> ResponsesAPIResponse:
             assert self._telemetry is not None
             self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
@@ -1196,30 +1283,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             with self._litellm_modify_params_ctx(self.modify_params):
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=DeprecationWarning)
-                    typed_input: ResponseInputParam | str = (
-                        cast(ResponseInputParam, input_items) if input_items else ""
+                    litellm_kwargs = self._build_responses_call_kwargs(
+                        input_items, instructions, resp_tools, final_kwargs
                     )
-                    api_key_value = self._get_litellm_api_key_value()
+                    ret = litellm_responses(**litellm_kwargs)
 
-                    ret = litellm_responses(
-                        model=self.model,
-                        input=typed_input,
-                        instructions=instructions,
-                        tools=resp_tools,
-                        api_key=api_key_value,
-                        api_base=self.base_url,
-                        api_version=self.api_version,
-                        timeout=self.timeout,
-                        drop_params=self.drop_params,
-                        seed=self.seed,
-                        **{**self._aws_kwargs(), **final_kwargs},
-                    )
                     if isinstance(ret, ResponsesAPIResponse):
                         if user_enable_streaming:
                             logger.warning(
-                                "Responses streaming was requested, but the provider "
-                                "returned a non-streaming response; no on_token deltas "
-                                "will be emitted."
+                                "Responses streaming was requested, but the "
+                                "provider returned a non-streaming response; "
+                                "no on_token deltas will be emitted."
                             )
                         self._telemetry.on_response(ret)
                         return ret
@@ -1232,7 +1306,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                             raise AssertionError(
                                 f"Expected Responses stream iterator, got {type(ret)}"
                             )
-
                         stream_callback = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
                         # Some endpoints (e.g., Codex subscription) send
@@ -1244,64 +1317,22 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         for event in ret:
                             if event is None:
                                 continue
-                            evt_type = getattr(event, "type", None)
-                            if evt_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
-                                item = getattr(event, "item", None)
-                                if item is not None:
-                                    collected_output_items.append(item)
-                            if stream_callback is None:
-                                continue
-                            if isinstance(
-                                event,
-                                (
-                                    OutputTextDeltaEvent,
-                                    RefusalDeltaEvent,
-                                    ReasoningSummaryTextDeltaEvent,
-                                ),
-                            ):
-                                delta = event.delta
-                                if delta:
-                                    stream_callback(
-                                        ModelResponseStream(
-                                            choices=[
-                                                StreamingChoices(
-                                                    delta=Delta(content=delta)
-                                                )
-                                            ]
-                                        )
-                                    )
+                            output_item, delta_chunk = self._process_stream_event(event)
+                            if output_item is not None:
+                                collected_output_items.append(output_item)
+                            if stream_callback is not None and delta_chunk is not None:
+                                stream_callback(delta_chunk)
 
-                        completed_event = ret.completed_response
-                        if completed_event is None:
-                            raise LLMNoResponseError(
-                                "Responses stream finished without a completed response"
-                            )
-                        if not isinstance(completed_event, ResponseCompletedEvent):
-                            raise LLMNoResponseError(
-                                f"Unexpected completed event: {type(completed_event)}"
-                            )
-
-                        completed_resp = completed_event.response
-                        # Patch empty output with items collected from stream
-                        if not completed_resp.output and collected_output_items:
-                            completed_resp.output = collected_output_items
-
-                        self._telemetry.on_response(completed_resp)
-                        return completed_resp
+                        return self._finalize_stream_response(
+                            ret.completed_response, collected_output_items
+                        )
 
                     raise AssertionError(
                         f"Expected ResponsesAPIResponse, got {type(ret)}"
                     )
 
         try:
-            resp: ResponsesAPIResponse = _one_attempt()
-            output_seq = cast(Sequence[Any], resp.output or [])
-            message = Message.from_llm_responses_output(output_seq)
-            return LLMResponse(
-                message=message,
-                metrics=self._current_metrics_snapshot(),
-                raw_response=resp,
-            )
+            return self._build_responses_result(_one_attempt())
         except Exception as e:
             return self._handle_error(
                 e,
@@ -1352,14 +1383,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             messages, tools, include, store, add_security_risk_prediction, kwargs
         )
 
-        @self.retry_decorator(
-            num_retries=self.num_retries,
-            retry_exceptions=LLM_RETRY_EXCEPTIONS,
-            retry_min_wait=self.retry_min_wait,
-            retry_max_wait=self.retry_max_wait,
-            retry_multiplier=self.retry_multiplier,
-            retry_listener=self._retry_listener_fn,
-        )
+        @self._make_retry_decorator()
         async def _one_attempt(
             **retry_kwargs: Any,
         ) -> ResponsesAPIResponse:
@@ -1369,24 +1393,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             with self._litellm_modify_params_ctx(self.modify_params):
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=DeprecationWarning)
-                    typed_input: ResponseInputParam | str = (
-                        cast(ResponseInputParam, input_items) if input_items else ""
+                    litellm_kwargs = self._build_responses_call_kwargs(
+                        input_items, instructions, resp_tools, final_kwargs
                     )
-                    api_key_value = self._get_litellm_api_key_value()
+                    ret = await litellm_aresponses(**litellm_kwargs)
 
-                    ret = await litellm_aresponses(
-                        model=self.model,
-                        input=typed_input,
-                        instructions=instructions,
-                        tools=resp_tools,
-                        api_key=api_key_value,
-                        api_base=self.base_url,
-                        api_version=self.api_version,
-                        timeout=self.timeout,
-                        drop_params=self.drop_params,
-                        seed=self.seed,
-                        **{**self._aws_kwargs(), **final_kwargs},
-                    )
                     if isinstance(ret, ResponsesAPIResponse):
                         if user_enable_streaming:
                             logger.warning(
@@ -1406,7 +1417,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                                 "Expected Responses async stream "
                                 f"iterator, got {type(ret)}"
                             )
-
                         stream_cb = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
                         # Some endpoints (e.g., Codex subscription) send
@@ -1418,65 +1428,22 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         async for event in ret:
                             if event is None:
                                 continue
-                            evt_type = getattr(event, "type", None)
-                            if evt_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
-                                item = getattr(event, "item", None)
-                                if item is not None:
-                                    collected_output_items.append(item)
-                            if stream_cb is None:
-                                continue
-                            if isinstance(
-                                event,
-                                (
-                                    OutputTextDeltaEvent,
-                                    RefusalDeltaEvent,
-                                    ReasoningSummaryTextDeltaEvent,
-                                ),
-                            ):
-                                delta = event.delta
-                                if delta:
-                                    await _invoke_token_callback(
-                                        stream_cb,
-                                        ModelResponseStream(
-                                            choices=[
-                                                StreamingChoices(
-                                                    delta=Delta(content=delta)
-                                                )
-                                            ]
-                                        ),
-                                    )
+                            output_item, delta_chunk = self._process_stream_event(event)
+                            if output_item is not None:
+                                collected_output_items.append(output_item)
+                            if stream_cb is not None and delta_chunk is not None:
+                                await _invoke_token_callback(stream_cb, delta_chunk)
 
-                        completed_event = ret.completed_response
-                        if completed_event is None:
-                            raise LLMNoResponseError(
-                                "Responses stream finished without a completed response"
-                            )
-                        if not isinstance(completed_event, ResponseCompletedEvent):
-                            raise LLMNoResponseError(
-                                f"Unexpected completed event: {type(completed_event)}"
-                            )
-
-                        completed_resp = completed_event.response
-                        # Patch empty output with items collected from stream
-                        if not completed_resp.output and collected_output_items:
-                            completed_resp.output = collected_output_items
-
-                        self._telemetry.on_response(completed_resp)
-                        return completed_resp
+                        return self._finalize_stream_response(
+                            ret.completed_response, collected_output_items
+                        )
 
                     raise AssertionError(
                         f"Expected ResponsesAPIResponse, got {type(ret)}"
                     )
 
         try:
-            completed: ResponsesAPIResponse = await _one_attempt()
-            output_seq = cast(Sequence[Any], completed.output or [])
-            message = Message.from_llm_responses_output(output_seq)
-            return LLMResponse(
-                message=message,
-                metrics=self._current_metrics_snapshot(),
-                raw_response=completed,
-            )
+            return self._build_responses_result(await _one_attempt())
         except Exception as e:
             _fb_token = cast("TokenCallbackType | None", on_token)
             return await self._ahandle_error(

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -827,9 +827,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         }
 
     def _process_stream_event(
-        self, event: Any
+        self, event: Any, *, emit_deltas: bool = True
     ) -> tuple[Any | None, ModelResponseStream | None]:
         """Extract output item and delta chunk from a Responses stream event.
+
+        Args:
+            event: A single Responses streaming event.
+            emit_deltas: When ``False`` the delta chunk is never built — skip
+                the allocation when there is no stream callback to receive it.
 
         Returns:
             (output_item, delta_chunk) — either or both may be ``None``.
@@ -837,13 +842,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         output_item: Any | None = None
         delta_chunk: ModelResponseStream | None = None
 
+        # Collect finished output items
         evt_type = getattr(event, "type", None)
         if evt_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
             item = getattr(event, "item", None)
             if item is not None:
                 output_item = item
 
-        if isinstance(
+        if emit_deltas and isinstance(
             event,
             (
                 OutputTextDeltaEvent,
@@ -911,10 +917,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # and the caller should not observe those side-effects.
         kwargs = dict(kwargs)
 
+        # 1) serialize messages
         formatted_messages = self.format_messages_for_llm(messages)
+
+        # 2) choose function-calling strategy
         use_native_fc = self.native_tool_calling
         original_fncall_msgs = copy.deepcopy(formatted_messages)
 
+        # Convert Tool objects to ChatCompletionToolParam once here
         cc_tools: list[ChatCompletionToolParam] = []
         if tools:
             cc_tools = [
@@ -926,6 +936,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         use_mock_tools = self.should_mock_tool_calls(cc_tools)
         if use_mock_tools:
+            logger.debug(
+                "LLM.completion: mocking function-calling via prompt "
+                f"for model {self.model}"
+            )
             formatted_messages, kwargs = self.pre_request_prompt_mock(
                 formatted_messages,
                 cc_tools or [],
@@ -933,10 +947,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 include_security_params=add_security_risk_prediction,
             )
 
+        # 3) normalize provider params
+        # Only pass tools when native FC is active
         kwargs["tools"] = cc_tools if (bool(cc_tools) and use_native_fc) else None
         has_tools_flag = bool(cc_tools) and use_native_fc
+        # Behavior-preserving: delegate to select_chat_options
         call_kwargs = select_chat_options(self, kwargs, has_tools=has_tools_flag)
 
+        # 4) request context for telemetry (always include context_window for metrics)
         # Always pass context_window so metrics are tracked even when
         # logging is disabled.
         assert self._telemetry is not None
@@ -946,7 +964,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         if self._telemetry.log_enabled:
             telemetry_ctx.update(
                 {
-                    "messages": formatted_messages[:],
+                    "messages": formatted_messages[:],  # already simple dicts
                     "tools": tools,
                     "kwargs": {k: v for k, v in call_kwargs.items()},
                 }
@@ -986,9 +1004,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # Defensive copy — select_responses_options may mutate kwargs.
         kwargs = dict(kwargs)
 
+        # Build instructions + input list using dedicated Responses formatter
         instructions, input_items = self.format_messages_for_responses(messages)
 
-        # Responses path always supports function tools
+        # Convert Tool objects to Responses ToolParam
+        # (Responses path always supports function tools)
         resp_tools = (
             [
                 t.to_responses_tool(
@@ -1000,10 +1020,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             else None
         )
 
+        # Normalize/override Responses kwargs consistently
         call_kwargs = select_responses_options(
             self, kwargs, include=include, store=store
         )
 
+        # Request context for telemetry (always include context_window for metrics)
         # Always pass context_window so metrics are tracked even when
         # logging is disabled.
         assert self._telemetry is not None
@@ -1031,11 +1053,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         formatted_messages: list[dict[str, Any]],
         cc_tools: list[ChatCompletionToolParam],
         add_security_risk_prediction: bool,
-    ) -> tuple[ModelResponse, ModelResponse | None]:
+    ) -> ModelResponse:
         """Post-process a chat completion response inside the retry boundary.
 
-        Returns ``(resp, raw_resp)`` where *raw_resp* is non-``None`` only
-        when mock-tool post-processing was applied.
+        The raw (pre-mock) response is consumed internally by
+        ``Telemetry.on_response`` and is not returned to the caller.
 
         Raises:
             LLMNoResponseError: If the response has no choices
@@ -1052,14 +1074,18 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 include_security_params=add_security_risk_prediction,
             )
 
+        # 6) telemetry
         assert self._telemetry is not None
         self._telemetry.on_response(resp, raw_resp=raw_resp)
 
+        # Ensure at least one choice.
+        # Gemini sometimes returns empty choices; we raise LLMNoResponseError here
+        # inside the retry boundary so it is retried.
         if not resp.get("choices") or len(resp["choices"]) < 1:
             raise LLMNoResponseError(
                 "Response choices is less than 1. Response: " + str(resp)
             )
-        return resp, raw_resp
+        return resp
 
     # =========================================================================
     # Chat Completion API
@@ -1133,7 +1159,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 enable_streaming=enable_streaming,
                 on_token=on_token,
             )
-            resp, _ = self._validate_chat_response(
+            resp = self._validate_chat_response(
                 resp,
                 use_mock_tools=use_mock_tools,
                 formatted_messages=formatted_messages,
@@ -1200,7 +1226,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 enable_streaming=enable_streaming,
                 on_token=on_token,
             )
-            resp, _ = self._validate_chat_response(
+            resp = self._validate_chat_response(
                 resp,
                 use_mock_tools=use_mock_tools,
                 formatted_messages=formatted_messages,
@@ -1317,7 +1343,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         for event in ret:
                             if event is None:
                                 continue
-                            output_item, delta_chunk = self._process_stream_event(event)
+                            output_item, delta_chunk = self._process_stream_event(
+                                event, emit_deltas=stream_callback is not None
+                            )
                             if output_item is not None:
                                 collected_output_items.append(output_item)
                             if stream_callback is not None and delta_chunk is not None:
@@ -1428,7 +1456,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         async for event in ret:
                             if event is None:
                                 continue
-                            output_item, delta_chunk = self._process_stream_event(event)
+                            output_item, delta_chunk = self._process_stream_event(
+                                event, emit_deltas=stream_cb is not None
+                            )
                             if output_item is not None:
                                 collected_output_items.append(output_item)
                             if stream_cb is not None and delta_chunk is not None:

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -753,6 +753,189 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             raise mapped from error
         raise
 
+    # =========================================================================
+    # Shared helpers for completion / acompletion / responses / aresponses
+    # =========================================================================
+
+    def _current_metrics_snapshot(self) -> MetricsSnapshot:
+        """Snapshot current LLM metrics for an :class:`LLMResponse`."""
+        return MetricsSnapshot(
+            model_name=self.metrics.model_name,
+            accumulated_cost=self.metrics.accumulated_cost,
+            max_budget_per_task=self.metrics.max_budget_per_task,
+            accumulated_token_usage=self.metrics.accumulated_token_usage,
+        )
+
+    def _prepare_completion_params(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None,
+        add_security_risk_prediction: bool,
+        kwargs: dict[str, Any],
+    ) -> tuple[
+        list[dict[str, Any]],
+        list[ChatCompletionToolParam],
+        bool,
+        dict[str, Any],
+        dict[str, Any],
+    ]:
+        """Shared setup for :meth:`completion` and :meth:`acompletion`.
+
+        Returns:
+            (formatted_messages, cc_tools, use_mock_tools, call_kwargs,
+             telemetry_ctx)
+        """
+        formatted_messages = self.format_messages_for_llm(messages)
+        use_native_fc = self.native_tool_calling
+        original_fncall_msgs = copy.deepcopy(formatted_messages)
+
+        cc_tools: list[ChatCompletionToolParam] = []
+        if tools:
+            cc_tools = [
+                t.to_openai_tool(
+                    add_security_risk_prediction=add_security_risk_prediction,
+                )
+                for t in tools
+            ]
+
+        use_mock_tools = self.should_mock_tool_calls(cc_tools)
+        if use_mock_tools:
+            formatted_messages, kwargs = self.pre_request_prompt_mock(
+                formatted_messages,
+                cc_tools or [],
+                kwargs,
+                include_security_params=add_security_risk_prediction,
+            )
+
+        kwargs["tools"] = cc_tools if (bool(cc_tools) and use_native_fc) else None
+        has_tools_flag = bool(cc_tools) and use_native_fc
+        call_kwargs = select_chat_options(self, kwargs, has_tools=has_tools_flag)
+
+        # Always pass context_window so metrics are tracked even when
+        # logging is disabled.
+        assert self._telemetry is not None
+        telemetry_ctx: dict[str, Any] = {
+            "context_window": self.effective_max_input_tokens or 0
+        }
+        if self._telemetry.log_enabled:
+            telemetry_ctx.update(
+                {
+                    "messages": formatted_messages[:],
+                    "tools": tools,
+                    "kwargs": {k: v for k, v in call_kwargs.items()},
+                }
+            )
+            if tools and not use_native_fc:
+                telemetry_ctx["raw_messages"] = original_fncall_msgs
+
+        return (
+            formatted_messages,
+            cc_tools,
+            use_mock_tools,
+            call_kwargs,
+            telemetry_ctx,
+        )
+
+    def _prepare_responses_params(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None,
+        include: list[str] | None,
+        store: bool | None,
+        add_security_risk_prediction: bool,
+        kwargs: dict[str, Any],
+    ) -> tuple[
+        str | None,
+        list[dict[str, Any]],
+        list[Any] | None,
+        dict[str, Any],
+        dict[str, Any],
+    ]:
+        """Shared setup for :meth:`responses` and :meth:`aresponses`.
+
+        Returns:
+            (instructions, input_items, resp_tools, call_kwargs,
+             telemetry_ctx)
+        """
+        instructions, input_items = self.format_messages_for_responses(messages)
+
+        # Responses path always supports function tools
+        resp_tools = (
+            [
+                t.to_responses_tool(
+                    add_security_risk_prediction=add_security_risk_prediction,
+                )
+                for t in tools
+            ]
+            if tools
+            else None
+        )
+
+        call_kwargs = select_responses_options(
+            self, kwargs, include=include, store=store
+        )
+
+        # Always pass context_window so metrics are tracked even when
+        # logging is disabled.
+        assert self._telemetry is not None
+        telemetry_ctx: dict[str, Any] = {
+            "context_window": self.effective_max_input_tokens or 0
+        }
+        if self._telemetry.log_enabled:
+            telemetry_ctx.update(
+                {
+                    "llm_path": "responses",
+                    "instructions": instructions,
+                    "input": input_items[:],
+                    "tools": tools,
+                    "kwargs": {k: v for k, v in call_kwargs.items()},
+                }
+            )
+
+        return instructions, input_items, resp_tools, call_kwargs, telemetry_ctx
+
+    def _validate_chat_response(
+        self,
+        resp: ModelResponse,
+        *,
+        use_mock_tools: bool,
+        formatted_messages: list[dict[str, Any]],
+        cc_tools: list[ChatCompletionToolParam],
+        add_security_risk_prediction: bool,
+    ) -> tuple[ModelResponse, ModelResponse | None]:
+        """Post-process a chat completion response inside the retry boundary.
+
+        Returns ``(resp, raw_resp)`` where *raw_resp* is non-``None`` only
+        when mock-tool post-processing was applied.
+
+        Raises:
+            LLMNoResponseError: If the response has no choices
+                (Gemini sometimes returns empty choices; raising here
+                inside the retry boundary ensures it is retried).
+        """
+        raw_resp: ModelResponse | None = None
+        if use_mock_tools:
+            raw_resp = copy.deepcopy(resp)
+            resp = self.post_response_prompt_mock(
+                resp,
+                nonfncall_msgs=formatted_messages,
+                tools=cc_tools,
+                include_security_params=add_security_risk_prediction,
+            )
+
+        assert self._telemetry is not None
+        self._telemetry.on_response(resp, raw_resp=raw_resp)
+
+        if not resp.get("choices") or len(resp["choices"]) < 1:
+            raise LLMNoResponseError(
+                "Response choices is less than 1. Response: " + str(resp)
+            )
+        return resp, raw_resp
+
+    # =========================================================================
+    # Chat Completion API
+    # =========================================================================
+
     def completion(
         self,
         messages: list[Message],
@@ -800,61 +983,16 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 raise ValueError("Streaming requires an on_token callback")
             kwargs["stream"] = True
 
-        # 1) serialize messages
-        formatted_messages = self.format_messages_for_llm(messages)
+        (
+            formatted_messages,
+            cc_tools,
+            use_mock_tools,
+            call_kwargs,
+            telemetry_ctx,
+        ) = self._prepare_completion_params(
+            messages, tools, add_security_risk_prediction, kwargs
+        )
 
-        # 2) choose function-calling strategy
-        use_native_fc = self.native_tool_calling
-        original_fncall_msgs = copy.deepcopy(formatted_messages)
-
-        # Convert Tool objects to ChatCompletionToolParam once here
-        cc_tools: list[ChatCompletionToolParam] = []
-        if tools:
-            cc_tools = [
-                t.to_openai_tool(
-                    add_security_risk_prediction=add_security_risk_prediction,
-                )
-                for t in tools
-            ]
-
-        use_mock_tools = self.should_mock_tool_calls(cc_tools)
-        if use_mock_tools:
-            logger.debug(
-                "LLM.completion: mocking function-calling via prompt "
-                f"for model {self.model}"
-            )
-            formatted_messages, kwargs = self.pre_request_prompt_mock(
-                formatted_messages,
-                cc_tools or [],
-                kwargs,
-                include_security_params=add_security_risk_prediction,
-            )
-
-        # 3) normalize provider params
-        # Only pass tools when native FC is active
-        kwargs["tools"] = cc_tools if (bool(cc_tools) and use_native_fc) else None
-        has_tools_flag = bool(cc_tools) and use_native_fc
-        # Behavior-preserving: delegate to select_chat_options
-        call_kwargs = select_chat_options(self, kwargs, has_tools=has_tools_flag)
-
-        # 4) request context for telemetry (always include context_window for metrics)
-        assert self._telemetry is not None
-        # Always pass context_window so metrics are tracked even when logging disabled
-        telemetry_ctx: dict[str, Any] = {
-            "context_window": self.effective_max_input_tokens or 0
-        }
-        if self._telemetry.log_enabled:
-            telemetry_ctx.update(
-                {
-                    "messages": formatted_messages[:],  # already simple dicts
-                    "tools": tools,
-                    "kwargs": {k: v for k, v in call_kwargs.items()},
-                }
-            )
-            if tools and not use_native_fc:
-                telemetry_ctx["raw_messages"] = original_fncall_msgs
-
-        # 5) do the call with retries
         @self.retry_decorator(
             num_retries=self.num_retries,
             retry_exceptions=LLM_RETRY_EXCEPTIONS,
@@ -863,10 +1001,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             retry_multiplier=self.retry_multiplier,
             retry_listener=self._retry_listener_fn,
         )
-        def _one_attempt(**retry_kwargs) -> ModelResponse:
+        def _one_attempt(**retry_kwargs: Any) -> ModelResponse:
             assert self._telemetry is not None
             self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
-            # Merge retry-modified kwargs (like temperature) with call_kwargs
             final_kwargs = {**call_kwargs, **retry_kwargs}
             resp = self._transport_call(
                 messages=formatted_messages,
@@ -874,46 +1011,23 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 enable_streaming=enable_streaming,
                 on_token=on_token,
             )
-            raw_resp: ModelResponse | None = None
-            if use_mock_tools:
-                raw_resp = copy.deepcopy(resp)
-                resp = self.post_response_prompt_mock(
-                    resp,
-                    nonfncall_msgs=formatted_messages,
-                    tools=cc_tools,
-                    include_security_params=add_security_risk_prediction,
-                )
-            # 6) telemetry
-            self._telemetry.on_response(resp, raw_resp=raw_resp)
-
-            # Ensure at least one choice.
-            # Gemini sometimes returns empty choices; we raise LLMNoResponseError here
-            # inside the retry boundary so it is retried.
-            if not resp.get("choices") or len(resp["choices"]) < 1:
-                raise LLMNoResponseError(
-                    "Response choices is less than 1. Response: " + str(resp)
-                )
-
+            resp, _ = self._validate_chat_response(
+                resp,
+                use_mock_tools=use_mock_tools,
+                formatted_messages=formatted_messages,
+                cc_tools=cc_tools,
+                add_security_risk_prediction=add_security_risk_prediction,
+            )
             return resp
 
         try:
             resp = _one_attempt()
-
-            # Convert the first choice to an OpenHands Message
             first_choice = resp["choices"][0]
             message = Message.from_llm_chat_message(first_choice["message"])
-
-            # Get current metrics snapshot
-            metrics_snapshot = MetricsSnapshot(
-                model_name=self.metrics.model_name,
-                accumulated_cost=self.metrics.accumulated_cost,
-                max_budget_per_task=self.metrics.max_budget_per_task,
-                accumulated_token_usage=self.metrics.accumulated_token_usage,
-            )
-
-            # Create and return LLMResponse
             return LLMResponse(
-                message=message, metrics=metrics_snapshot, raw_response=resp
+                message=message,
+                metrics=self._current_metrics_snapshot(),
+                raw_response=resp,
             )
         except Exception as e:
             return self._handle_error(
@@ -950,93 +1064,51 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 raise ValueError("Streaming requires an on_token callback")
             kwargs["stream"] = True
 
-        formatted_messages = self.format_messages_for_llm(messages)
+        (
+            formatted_messages,
+            cc_tools,
+            use_mock_tools,
+            call_kwargs,
+            telemetry_ctx,
+        ) = self._prepare_completion_params(
+            messages, tools, add_security_risk_prediction, kwargs
+        )
 
-        use_native_fc = self.native_tool_calling
-        original_fncall_msgs = copy.deepcopy(formatted_messages)
-
-        cc_tools: list[ChatCompletionToolParam] = []
-        if tools:
-            cc_tools = [
-                t.to_openai_tool(
-                    add_security_risk_prediction=add_security_risk_prediction,
-                )
-                for t in tools
-            ]
-
-        use_mock_tools = self.should_mock_tool_calls(cc_tools)
-        if use_mock_tools:
-            formatted_messages, kwargs = self.pre_request_prompt_mock(
-                formatted_messages,
-                cc_tools or [],
-                kwargs,
-                include_security_params=add_security_risk_prediction,
-            )
-
-        kwargs["tools"] = cc_tools if (bool(cc_tools) and use_native_fc) else None
-        has_tools_flag = bool(cc_tools) and use_native_fc
-        call_kwargs = select_chat_options(self, kwargs, has_tools=has_tools_flag)
-
-        assert self._telemetry is not None
-        telemetry_ctx: dict[str, Any] = {
-            "context_window": self.effective_max_input_tokens or 0
-        }
-        if self._telemetry.log_enabled:
-            telemetry_ctx.update(
-                {
-                    "messages": formatted_messages[:],
-                    "tools": tools,
-                    "kwargs": {k: v for k, v in call_kwargs.items()},
-                }
-            )
-            if tools and not use_native_fc:
-                telemetry_ctx["raw_messages"] = original_fncall_msgs
-
-        resp: ModelResponse | None = None
-        async for attempt in self.async_retry(
+        @self.retry_decorator(
             num_retries=self.num_retries,
             retry_exceptions=LLM_RETRY_EXCEPTIONS,
             retry_min_wait=self.retry_min_wait,
             retry_max_wait=self.retry_max_wait,
             retry_multiplier=self.retry_multiplier,
             retry_listener=self._retry_listener_fn,
-        ):
-            with attempt:
-                assert self._telemetry is not None
-                self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
-                resp = await self._atransport_call(
-                    messages=formatted_messages,
-                    **call_kwargs,
-                    enable_streaming=enable_streaming,
-                    on_token=on_token,
-                )
-                raw_resp: ModelResponse | None = None
-                if use_mock_tools:
-                    raw_resp = copy.deepcopy(resp)
-                    resp = self.post_response_prompt_mock(
-                        resp,
-                        nonfncall_msgs=formatted_messages,
-                        tools=cc_tools,
-                        include_security_params=add_security_risk_prediction,
-                    )
-                self._telemetry.on_response(resp, raw_resp=raw_resp)
-                if not resp.get("choices") or len(resp["choices"]) < 1:
-                    raise LLMNoResponseError(
-                        "Response choices is less than 1. Response: " + str(resp)
-                    )
+        )
+        async def _one_attempt(**retry_kwargs: Any) -> ModelResponse:
+            assert self._telemetry is not None
+            self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
+            final_kwargs = {**call_kwargs, **retry_kwargs}
+            resp = await self._atransport_call(
+                messages=formatted_messages,
+                **final_kwargs,
+                enable_streaming=enable_streaming,
+                on_token=on_token,
+            )
+            resp, _ = self._validate_chat_response(
+                resp,
+                use_mock_tools=use_mock_tools,
+                formatted_messages=formatted_messages,
+                cc_tools=cc_tools,
+                add_security_risk_prediction=add_security_risk_prediction,
+            )
+            return resp
 
         try:
-            assert resp is not None
+            resp = await _one_attempt()
             first_choice = resp["choices"][0]
             message = Message.from_llm_chat_message(first_choice["message"])
-            metrics_snapshot = MetricsSnapshot(
-                model_name=self.metrics.model_name,
-                accumulated_cost=self.metrics.accumulated_cost,
-                max_budget_per_task=self.metrics.max_budget_per_task,
-                accumulated_token_usage=self.metrics.accumulated_token_usage,
-            )
             return LLMResponse(
-                message=message, metrics=metrics_snapshot, raw_response=resp
+                message=message,
+                metrics=self._current_metrics_snapshot(),
+                raw_response=resp,
             )
         except Exception as e:
             # Fallback is synchronous; cast the token callback since the
@@ -1087,50 +1159,21 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
         if user_enable_streaming:
+            # We allow on_token to be None for subscription mode
             if on_token is None and not self.is_subscription:
-                # We allow on_token to be None for subscription mode
                 raise ValueError("Streaming requires an on_token callback")
             kwargs["stream"] = True
 
-        # Build instructions + input list using dedicated Responses formatter
-        instructions, input_items = self.format_messages_for_responses(messages)
-
-        # Convert Tool objects to Responses ToolParam
-        # (Responses path always supports function tools)
-        resp_tools = (
-            [
-                t.to_responses_tool(
-                    add_security_risk_prediction=add_security_risk_prediction,
-                )
-                for t in tools
-            ]
-            if tools
-            else None
+        (
+            instructions,
+            input_items,
+            resp_tools,
+            call_kwargs,
+            telemetry_ctx,
+        ) = self._prepare_responses_params(
+            messages, tools, include, store, add_security_risk_prediction, kwargs
         )
 
-        # Normalize/override Responses kwargs consistently
-        call_kwargs = select_responses_options(
-            self, kwargs, include=include, store=store
-        )
-
-        # Request context for telemetry (always include context_window for metrics)
-        assert self._telemetry is not None
-        # Always pass context_window so metrics are tracked even when logging disabled
-        telemetry_ctx: dict[str, Any] = {
-            "context_window": self.effective_max_input_tokens or 0
-        }
-        if self._telemetry.log_enabled:
-            telemetry_ctx.update(
-                {
-                    "llm_path": "responses",
-                    "instructions": instructions,
-                    "input": input_items[:],
-                    "tools": tools,
-                    "kwargs": {k: v for k, v in call_kwargs.items()},
-                }
-            )
-
-        # Perform call with retries
         @self.retry_decorator(
             num_retries=self.num_retries,
             retry_exceptions=LLM_RETRY_EXCEPTIONS,
@@ -1139,7 +1182,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             retry_multiplier=self.retry_multiplier,
             retry_listener=self._retry_listener_fn,
         )
-        def _one_attempt(**retry_kwargs) -> ResponsesAPIResponse:
+        def _one_attempt(**retry_kwargs: Any) -> ResponsesAPIResponse:
             assert self._telemetry is not None
             self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
             final_kwargs = {**call_kwargs, **retry_kwargs}
@@ -1174,9 +1217,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         self._telemetry.on_response(ret)
                         return ret
 
-                    # When stream=True, LiteLLM returns a streaming iterator rather than
-                    # a single ResponsesAPIResponse. Drain the iterator and use the
-                    # completed response.
+                    # When stream=True, LiteLLM returns a streaming
+                    # iterator rather than a single ResponsesAPIResponse.
+                    # Drain the iterator and use the completed response.
                     if final_kwargs.get("stream", False):
                         if not isinstance(ret, SyncResponsesAPIStreamingIterator):
                             raise AssertionError(
@@ -1185,15 +1228,15 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
                         stream_callback = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
-                        # Some endpoints (e.g., Codex subscription) send output
-                        # items as separate events but the final response.completed
-                        # event has output=[].  We accumulate them here and patch
-                        # the completed response if needed.
+                        # Some endpoints (e.g., Codex subscription) send
+                        # output items as separate events but the final
+                        # response.completed event has output=[].  We
+                        # accumulate them here and patch the completed
+                        # response if needed.
                         collected_output_items: list[Any] = []
                         for event in ret:
                             if event is None:
                                 continue
-                            # Collect finished output items
                             evt_type = getattr(event, "type", None)
                             if evt_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
                                 item = getattr(event, "item", None)
@@ -1232,7 +1275,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                             )
 
                         completed_resp = completed_event.response
-
                         # Patch empty output with items collected from stream
                         if not completed_resp.output and collected_output_items:
                             completed_resp.output = collected_output_items
@@ -1246,22 +1288,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         try:
             resp: ResponsesAPIResponse = _one_attempt()
-
-            # Parse output -> Message (typed)
-            # Cast to a typed sequence
-            # accepted by from_llm_responses_output
             output_seq = cast(Sequence[Any], resp.output or [])
             message = Message.from_llm_responses_output(output_seq)
-
-            metrics_snapshot = MetricsSnapshot(
-                model_name=self.metrics.model_name,
-                accumulated_cost=self.metrics.accumulated_cost,
-                max_budget_per_task=self.metrics.max_budget_per_task,
-                accumulated_token_usage=self.metrics.accumulated_token_usage,
-            )
-
             return LLMResponse(
-                message=message, metrics=metrics_snapshot, raw_response=resp
+                message=message,
+                metrics=self._current_metrics_snapshot(),
+                raw_response=resp,
             )
         except Exception as e:
             return self._handle_error(
@@ -1298,163 +1330,145 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
         if user_enable_streaming:
+            # We allow on_token to be None for subscription mode
             if on_token is None and not self.is_subscription:
                 raise ValueError("Streaming requires an on_token callback")
             kwargs["stream"] = True
 
-        instructions, input_items = self.format_messages_for_responses(messages)
-
-        resp_tools = (
-            [
-                t.to_responses_tool(
-                    add_security_risk_prediction=add_security_risk_prediction,
-                )
-                for t in tools
-            ]
-            if tools
-            else None
+        (
+            instructions,
+            input_items,
+            resp_tools,
+            call_kwargs,
+            telemetry_ctx,
+        ) = self._prepare_responses_params(
+            messages, tools, include, store, add_security_risk_prediction, kwargs
         )
 
-        call_kwargs = select_responses_options(
-            self, kwargs, include=include, store=store
-        )
-
-        assert self._telemetry is not None
-        telemetry_ctx: dict[str, Any] = {
-            "context_window": self.effective_max_input_tokens or 0
-        }
-        if self._telemetry.log_enabled:
-            telemetry_ctx.update(
-                {
-                    "llm_path": "responses",
-                    "instructions": instructions,
-                    "input": input_items[:],
-                    "tools": tools,
-                    "kwargs": {k: v for k, v in call_kwargs.items()},
-                }
-            )
-
-        completed: ResponsesAPIResponse | None = None
-        async for attempt in self.async_retry(
+        @self.retry_decorator(
             num_retries=self.num_retries,
             retry_exceptions=LLM_RETRY_EXCEPTIONS,
             retry_min_wait=self.retry_min_wait,
             retry_max_wait=self.retry_max_wait,
             retry_multiplier=self.retry_multiplier,
             retry_listener=self._retry_listener_fn,
-        ):
-            with attempt:
-                assert self._telemetry is not None
-                self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
-                final_kwargs = {**call_kwargs}
-                with self._litellm_modify_params_ctx(self.modify_params):
-                    with warnings.catch_warnings():
-                        warnings.filterwarnings("ignore", category=DeprecationWarning)
-                        typed_input: ResponseInputParam | str = (
-                            cast(ResponseInputParam, input_items) if input_items else ""
-                        )
-                        api_key_value = self._get_litellm_api_key_value()
+        )
+        async def _one_attempt(
+            **retry_kwargs: Any,
+        ) -> ResponsesAPIResponse:
+            assert self._telemetry is not None
+            self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
+            final_kwargs = {**call_kwargs, **retry_kwargs}
+            with self._litellm_modify_params_ctx(self.modify_params):
+                with warnings.catch_warnings():
+                    warnings.filterwarnings("ignore", category=DeprecationWarning)
+                    typed_input: ResponseInputParam | str = (
+                        cast(ResponseInputParam, input_items) if input_items else ""
+                    )
+                    api_key_value = self._get_litellm_api_key_value()
 
-                        ret = await litellm_aresponses(
-                            model=self.model,
-                            input=typed_input,
-                            instructions=instructions,
-                            tools=resp_tools,
-                            api_key=api_key_value,
-                            api_base=self.base_url,
-                            api_version=self.api_version,
-                            timeout=self.timeout,
-                            drop_params=self.drop_params,
-                            seed=self.seed,
-                            **{**self._aws_kwargs(), **final_kwargs},
-                        )
-                        if isinstance(ret, ResponsesAPIResponse):
-                            if user_enable_streaming:
-                                logger.warning(
-                                    "Responses streaming was requested, but the "
-                                    "provider returned a non-streaming response; "
-                                    "no on_token deltas will be emitted."
-                                )
-                            self._telemetry.on_response(ret)
-                            completed = ret
-                        elif final_kwargs.get("stream", False):
-                            if not isinstance(ret, ResponsesAPIStreamingIterator):
-                                raise AssertionError(
-                                    "Expected Responses async stream "
-                                    f"iterator, got {type(ret)}"
-                                )
+                    ret = await litellm_aresponses(
+                        model=self.model,
+                        input=typed_input,
+                        instructions=instructions,
+                        tools=resp_tools,
+                        api_key=api_key_value,
+                        api_base=self.base_url,
+                        api_version=self.api_version,
+                        timeout=self.timeout,
+                        drop_params=self.drop_params,
+                        seed=self.seed,
+                        **{**self._aws_kwargs(), **final_kwargs},
+                    )
+                    if isinstance(ret, ResponsesAPIResponse):
+                        if user_enable_streaming:
+                            logger.warning(
+                                "Responses streaming was requested, but the "
+                                "provider returned a non-streaming response; "
+                                "no on_token deltas will be emitted."
+                            )
+                        self._telemetry.on_response(ret)
+                        return ret
 
-                            stream_cb = on_token if user_enable_streaming else None
-                            collected_output_items: list[Any] = []
-                            async for event in ret:
-                                if event is None:
-                                    continue
-                                evt_type = getattr(event, "type", None)
-                                if (
-                                    evt_type
-                                    == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE
-                                ):
-                                    item = getattr(event, "item", None)
-                                    if item is not None:
-                                        collected_output_items.append(item)
-                                if stream_cb is None:
-                                    continue
-                                if isinstance(
-                                    event,
-                                    (
-                                        OutputTextDeltaEvent,
-                                        RefusalDeltaEvent,
-                                        ReasoningSummaryTextDeltaEvent,
-                                    ),
-                                ):
-                                    delta = event.delta
-                                    if delta:
-                                        await _invoke_token_callback(
-                                            stream_cb,
-                                            ModelResponseStream(
-                                                choices=[
-                                                    StreamingChoices(
-                                                        delta=Delta(content=delta)
-                                                    )
-                                                ]
-                                            ),
-                                        )
-
-                            completed_event = ret.completed_response
-                            if completed_event is None:
-                                raise LLMNoResponseError(
-                                    "Responses stream finished without a "
-                                    "completed response"
-                                )
-                            if not isinstance(completed_event, ResponseCompletedEvent):
-                                raise LLMNoResponseError(
-                                    "Unexpected completed event: "
-                                    f"{type(completed_event)}"
-                                )
-
-                            completed_resp = completed_event.response
-                            if not completed_resp.output and collected_output_items:
-                                completed_resp.output = collected_output_items
-
-                            self._telemetry.on_response(completed_resp)
-                            completed = completed_resp
-                        else:
+                    # When stream=True, LiteLLM returns a streaming
+                    # iterator rather than a single ResponsesAPIResponse.
+                    # Drain the iterator and use the completed response.
+                    if final_kwargs.get("stream", False):
+                        if not isinstance(ret, ResponsesAPIStreamingIterator):
                             raise AssertionError(
-                                f"Expected ResponsesAPIResponse, got {type(ret)}"
+                                "Expected Responses async stream "
+                                f"iterator, got {type(ret)}"
                             )
 
+                        stream_cb = on_token if user_enable_streaming else None
+                        # Collect output items from streaming events.
+                        # Some endpoints (e.g., Codex subscription) send
+                        # output items as separate events but the final
+                        # response.completed event has output=[].  We
+                        # accumulate them here and patch the completed
+                        # response if needed.
+                        collected_output_items: list[Any] = []
+                        async for event in ret:
+                            if event is None:
+                                continue
+                            evt_type = getattr(event, "type", None)
+                            if evt_type == ResponsesAPIStreamEvents.OUTPUT_ITEM_DONE:
+                                item = getattr(event, "item", None)
+                                if item is not None:
+                                    collected_output_items.append(item)
+                            if stream_cb is None:
+                                continue
+                            if isinstance(
+                                event,
+                                (
+                                    OutputTextDeltaEvent,
+                                    RefusalDeltaEvent,
+                                    ReasoningSummaryTextDeltaEvent,
+                                ),
+                            ):
+                                delta = event.delta
+                                if delta:
+                                    await _invoke_token_callback(
+                                        stream_cb,
+                                        ModelResponseStream(
+                                            choices=[
+                                                StreamingChoices(
+                                                    delta=Delta(content=delta)
+                                                )
+                                            ]
+                                        ),
+                                    )
+
+                        completed_event = ret.completed_response
+                        if completed_event is None:
+                            raise LLMNoResponseError(
+                                "Responses stream finished without a completed response"
+                            )
+                        if not isinstance(completed_event, ResponseCompletedEvent):
+                            raise LLMNoResponseError(
+                                f"Unexpected completed event: {type(completed_event)}"
+                            )
+
+                        completed_resp = completed_event.response
+                        # Patch empty output with items collected from stream
+                        if not completed_resp.output and collected_output_items:
+                            completed_resp.output = collected_output_items
+
+                        self._telemetry.on_response(completed_resp)
+                        return completed_resp
+
+                    raise AssertionError(
+                        f"Expected ResponsesAPIResponse, got {type(ret)}"
+                    )
+
         try:
-            assert completed is not None
+            completed: ResponsesAPIResponse = await _one_attempt()
             output_seq = cast(Sequence[Any], completed.output or [])
             message = Message.from_llm_responses_output(output_seq)
-            metrics_snapshot = MetricsSnapshot(
-                model_name=self.metrics.model_name,
-                accumulated_cost=self.metrics.accumulated_cost,
-                max_budget_per_task=self.metrics.max_budget_per_task,
-                accumulated_token_usage=self.metrics.accumulated_token_usage,
-            )
             return LLMResponse(
-                message=message, metrics=metrics_snapshot, raw_response=completed
+                message=message,
+                metrics=self._current_metrics_snapshot(),
+                raw_response=completed,
             )
         except Exception as e:
             _fb_token = cast("TokenCallbackType | None", on_token)

--- a/openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py
@@ -2,7 +2,6 @@ from collections.abc import Callable, Iterable
 from typing import Any, cast
 
 from tenacity import (
-    AsyncRetrying,
     RetryCallState,
     retry,
     retry_if_exception_type,
@@ -93,37 +92,6 @@ class RetryMixin:
             ),
         )
         return retry_decorator
-
-    def async_retry(
-        self,
-        num_retries: int = 5,
-        retry_exceptions: tuple[type[BaseException], ...] = (LLMNoResponseError,),
-        retry_min_wait: int = 8,
-        retry_max_wait: int = 64,
-        retry_multiplier: float = 2.0,
-        retry_listener: RetryListener | None = None,
-    ) -> AsyncRetrying:
-        """Return an ``AsyncRetrying`` instance for use in ``async for`` blocks.
-
-        Usage::
-
-            async for attempt in self.async_retry(...):
-                with attempt:
-                    result = await _do_work()
-        """
-        before_sleep = self._build_before_sleep(num_retries, retry_listener)
-
-        return AsyncRetrying(
-            before_sleep=before_sleep,
-            stop=stop_after_attempt(num_retries),
-            reraise=True,
-            retry=retry_if_exception_type(retry_exceptions),
-            wait=wait_exponential(
-                multiplier=retry_multiplier,
-                min=retry_min_wait,
-                max=retry_max_wait,
-            ),
-        )
 
     def log_retry_attempt(self, retry_state: RetryCallState) -> None:
         """Log retry attempts."""

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -1,7 +1,10 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
+from litellm.responses.streaming_iterator import (
+    ResponsesAPIStreamingIterator,
+    SyncResponsesAPIStreamingIterator,
+)
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
@@ -282,8 +285,110 @@ async def test_async_aresponses_exhausts_retries(
 
 
 # ------------------------------------------------------------------
+# Sync responses tests (exercise the shared helper extraction)
+# ------------------------------------------------------------------
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_responses_retry_bumps_temperature(mock_responses, base_llm: LLM) -> None:
+    """Sync responses must apply the temperature bump on retry after the
+    _prepare_responses_params / _build_responses_call_kwargs extraction."""
+    assert base_llm.temperature == 0.0
+
+    mock_responses.side_effect = [
+        LLMNoResponseError("empty response"),
+        create_mock_responses_api_response("ok"),
+    ]
+
+    resp = base_llm.responses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])]
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_responses.call_count == 2
+    _, second_kwargs = mock_responses.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_responses_retries_then_succeeds(mock_responses, base_llm: LLM) -> None:
+    mock_responses.side_effect = [
+        LLMNoResponseError("empty response"),
+        create_mock_responses_api_response("success"),
+    ]
+
+    resp = base_llm.responses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])]
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert resp.message is not None
+    assert mock_responses.call_count == 2
+
+
+# ------------------------------------------------------------------
 # Streaming-path retry tests (stream completes without ResponseCompletedEvent)
 # ------------------------------------------------------------------
+
+
+class _FakeSyncStreamIterator(SyncResponsesAPIStreamingIterator):
+    """Minimal sync stream iterator for testing stream-path failures.
+
+    Mirrors :class:`_FakeAsyncStreamIterator` for the synchronous
+    ``responses`` path: inherits from ``SyncResponsesAPIStreamingIterator``
+    so it passes the ``isinstance`` check inside ``responses._one_attempt``,
+    but skips the heavyweight parent ``__init__``.
+    """
+
+    def __init__(
+        self,
+        events: list,
+        completed_response=None,
+    ) -> None:
+        # Intentionally skip parent __init__; we only need iteration
+        # and the completed_response attribute.
+        self._events = list(events)
+        self.completed_response = completed_response
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if not self._events:
+            raise StopIteration
+        return self._events.pop(0)
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_responses_stream_path_retry_bumps_temperature(mock_responses) -> None:
+    """Sync streaming counterpart of the aresponses stream-path test: an
+    iterator that ends without a completed event raises LLMNoResponseError
+    inside the retry boundary, and the retry bumps temperature 0→1.0."""
+    streaming_llm = LLM(
+        usage_id="test-stream-sync",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+        temperature=0.0,
+        stream=True,
+    )
+
+    mock_responses.side_effect = [
+        _FakeSyncStreamIterator(events=[], completed_response=None),
+        create_mock_responses_api_response("ok"),
+    ]
+
+    resp = streaming_llm.responses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_responses.call_count == 2
+    _, second_kwargs = mock_responses.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0
 
 
 class _FakeAsyncStreamIterator(ResponsesAPIStreamingIterator):

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -1,7 +1,9 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from pydantic import SecretStr
 
 from openhands.sdk.llm import LLM, LLMResponse, Message, TextContent
@@ -180,3 +182,99 @@ async def test_async_no_response_exhausts_retries(
         )
 
     assert mock_acompletion.call_count == base_llm.num_retries
+
+
+# ------------------------------------------------------------------
+# Async aresponses tests
+# ------------------------------------------------------------------
+
+
+def create_mock_responses_api_response(
+    text: str = "ok",
+) -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="resp-1",
+        created_at=1,
+        output=[
+            ResponseOutputMessage(
+                id="msg-1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    ResponseOutputText(type="output_text", text=text, annotations=[])
+                ],
+            )
+        ],
+        model="gpt-4o",
+        object="response",
+    )
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_aresponses",
+    new_callable=AsyncMock,
+)
+async def test_async_aresponses_retry_bumps_temperature(
+    mock_aresponses: AsyncMock, base_llm: LLM
+) -> None:
+    """aresponses must apply the temperature bump on retry (B2 regression)."""
+    assert base_llm.temperature == 0.0
+
+    mock_aresponses.side_effect = [
+        LLMNoResponseError("empty response"),
+        create_mock_responses_api_response("ok"),
+    ]
+
+    resp = await base_llm.aresponses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])]
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_aresponses.call_count == 2
+    _, second_kwargs = mock_aresponses.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_aresponses",
+    new_callable=AsyncMock,
+)
+async def test_async_aresponses_retries_then_succeeds(
+    mock_aresponses: AsyncMock, base_llm: LLM
+) -> None:
+    mock_aresponses.side_effect = [
+        LLMNoResponseError("empty response"),
+        create_mock_responses_api_response("success"),
+    ]
+
+    resp = await base_llm.aresponses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])]
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert resp.message is not None
+    assert mock_aresponses.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_aresponses",
+    new_callable=AsyncMock,
+)
+async def test_async_aresponses_exhausts_retries(
+    mock_aresponses: AsyncMock, base_llm: LLM
+) -> None:
+    mock_aresponses.side_effect = [
+        LLMNoResponseError("empty-1"),
+        LLMNoResponseError("empty-2"),
+    ]
+
+    with pytest.raises(LLMNoResponseError):
+        await base_llm.aresponses(
+            messages=[Message(role="user", content=[TextContent(text="hi")])]
+        )
+
+    assert mock_aresponses.call_count == base_llm.num_retries

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -1,6 +1,7 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
+from litellm.responses.streaming_iterator import ResponsesAPIStreamingIterator
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
@@ -278,3 +279,77 @@ async def test_async_aresponses_exhausts_retries(
         )
 
     assert mock_aresponses.call_count == base_llm.num_retries
+
+
+# ------------------------------------------------------------------
+# Streaming-path retry tests (stream completes without ResponseCompletedEvent)
+# ------------------------------------------------------------------
+
+
+class _FakeAsyncStreamIterator(ResponsesAPIStreamingIterator):
+    """Minimal async stream iterator for testing stream-path failures.
+
+    Inherits from ``ResponsesAPIStreamingIterator`` so it passes the
+    ``isinstance`` check inside ``aresponses._one_attempt``, but skips
+    the heavyweight parent ``__init__``.
+    """
+
+    def __init__(
+        self,
+        events: list,
+        completed_response=None,
+    ) -> None:
+        # Intentionally skip parent __init__; we only need iteration
+        # and the completed_response attribute.
+        self._events = list(events)
+        self.completed_response = completed_response
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_aresponses",
+    new_callable=AsyncMock,
+)
+async def test_async_aresponses_stream_path_retry_bumps_temperature(
+    mock_aresponses: AsyncMock,
+) -> None:
+    """When a streaming response has no completed event, _finalize_stream_response
+    raises LLMNoResponseError inside the retry boundary. On retry the temperature
+    should be bumped from 0→1.0, just like the non-streaming path.
+    """
+    streaming_llm = LLM(
+        usage_id="test-stream",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+        temperature=0.0,
+        stream=True,
+    )
+
+    # First call: return an iterator that ends without a completed event
+    # → _finalize_stream_response raises LLMNoResponseError
+    # Second call: return a valid non-streaming response (fast path)
+    mock_aresponses.side_effect = [
+        _FakeAsyncStreamIterator(events=[], completed_response=None),
+        create_mock_responses_api_response("ok"),
+    ]
+
+    resp = await streaming_llm.aresponses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_aresponses.call_count == 2
+    _, second_kwargs = mock_aresponses.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
@@ -106,3 +106,77 @@ def test_no_response_retry_bumps_temperature(mock_completion, base_llm: LLM) -> 
     # Grab kwargs from the second call
     _, second_kwargs = mock_completion.call_args_list[1]
     assert second_kwargs.get("temperature") == 1.0
+
+
+# ------------------------------------------------------------------
+# Async acompletion tests
+# ------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_acompletion",
+    new_callable=AsyncMock,
+)
+async def test_async_no_response_retry_bumps_temperature(
+    mock_acompletion: AsyncMock, base_llm: LLM
+) -> None:
+    """Async acompletion must apply the temperature bump on retry (B2 regression)."""
+    assert base_llm.temperature == 0.0
+
+    mock_acompletion.side_effect = [
+        create_empty_choices_response("empty-1"),
+        create_mock_response("ok"),
+    ]
+
+    resp = await base_llm.acompletion(
+        messages=[Message(role="user", content=[TextContent(text="hi")])]
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_acompletion.call_count == 2
+    _, second_kwargs = mock_acompletion.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_acompletion",
+    new_callable=AsyncMock,
+)
+async def test_async_no_response_retries_then_succeeds(
+    mock_acompletion: AsyncMock, base_llm: LLM
+) -> None:
+    mock_acompletion.side_effect = [
+        create_empty_choices_response("empty-1"),
+        create_mock_response("success"),
+    ]
+
+    resp = await base_llm.acompletion(
+        messages=[Message(role="user", content=[TextContent(text="hi")])]
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert resp.message is not None
+    assert mock_acompletion.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_acompletion",
+    new_callable=AsyncMock,
+)
+async def test_async_no_response_exhausts_retries(
+    mock_acompletion: AsyncMock, base_llm: LLM
+) -> None:
+    mock_acompletion.side_effect = [
+        create_empty_choices_response("empty-1"),
+        create_empty_choices_response("empty-2"),
+    ]
+
+    with pytest.raises(LLMNoResponseError):
+        await base_llm.acompletion(
+            messages=[Message(role="user", content=[TextContent(text="hi")])]
+        )
+
+    assert mock_acompletion.call_count == base_llm.num_retries

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -369,8 +369,8 @@ def test_responses_stream_path_retry_bumps_temperature(mock_responses) -> None:
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
-        retry_min_wait=1,
-        retry_max_wait=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
         temperature=0.0,
         stream=True,
     )
@@ -435,8 +435,8 @@ async def test_async_aresponses_stream_path_retry_bumps_temperature(
         model="gpt-4o",
         api_key=SecretStr("test_key"),
         num_retries=2,
-        retry_min_wait=1,
-        retry_max_wait=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
         temperature=0.0,
         stream=True,
     )


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

The `before_sleep` callback bumps temperature from 0→1.0 on `LLMNoResponseError` by mutating `retry_state.kwargs`. In the sync path, tenacity's `@retry` decorator wraps `_one_attempt` and automatically threads `retry_state.kwargs` into each retry call — so the temperature override is picked up via `final_kwargs = {**call_kwargs, **retry_kwargs}`.

The async methods (`acompletion`, `aresponses`) instead used an `async for attempt in AsyncRetrying` loop. This pattern has **no wrapped function** for tenacity to re-invoke with updated kwargs. `before_sleep` wrote `temperature=1.0` to `retry_state.kwargs`, but the loop body used a local `call_kwargs` that was never updated — so the bump was silently lost.

With temperature=0 the model tends to repeat the same empty response, so all retries fail identically.

**Repro** (temperatures per attempt): sync `[0, 1.0, 1.0]`, async `[0, 0, 0]` (before fix).

## Summary

- Replace the `AsyncRetrying` loop in `acompletion` and `aresponses` with the same `@retry` decorator pattern used by the sync methods — tenacity's decorator natively handles `async def` functions and automatically threads `retry_state.kwargs` into each retry
- Deduplicate shared logic across completion/acompletion and responses/aresponses:
  - `_current_metrics_snapshot()` — replaces 4 identical `MetricsSnapshot` constructions
  - `_prepare_completion_params()` — shared setup (format messages, tools, mock tools, select_chat_options, telemetry ctx)
  - `_prepare_responses_params()` — shared setup for responses path
  - `_validate_chat_response()` — shared post-processing (mock tools, telemetry, empty-choices check)
- Remove the now-unused `async_retry()` method and `AsyncRetrying` import from `RetryMixin`
- Add 3 async regression tests

## How to Test

```bash
uv run pytest tests/sdk/llm/ -v
```

All 742 LLM tests pass (including 3 new async regression tests):
```
test_async_no_response_retry_bumps_temperature PASSED
test_async_no_response_retries_then_succeeds PASSED
test_async_no_response_exhausts_retries PASSED
```

The key regression test (`test_async_no_response_retry_bumps_temperature`) asserts that on the second attempt, `litellm_acompletion` is called with `temperature=1.0`.

## Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `RetryMixin._build_before_sleep` and `retry_decorator` are unchanged
- _This PR was created by an AI agent (OpenHands) on behalf of the user._












<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b24f12a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b24f12a-python \
  ghcr.io/openhands/agent-server:b24f12a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b24f12a-golang-amd64
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-golang-amd64
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-golang-amd64
ghcr.io/openhands/agent-server:b24f12a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b24f12a-golang-arm64
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-golang-arm64
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-golang-arm64
ghcr.io/openhands/agent-server:b24f12a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b24f12a-java-amd64
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-java-amd64
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-java-amd64
ghcr.io/openhands/agent-server:b24f12a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b24f12a-java-arm64
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-java-arm64
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-java-arm64
ghcr.io/openhands/agent-server:b24f12a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b24f12a-python-amd64
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-python-amd64
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-python-amd64
ghcr.io/openhands/agent-server:b24f12a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b24f12a-python-arm64
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-python-arm64
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-python-arm64
ghcr.io/openhands/agent-server:b24f12a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b24f12a-golang
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-golang
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-golang
ghcr.io/openhands/agent-server:b24f12a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b24f12a-java
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-java
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-java
ghcr.io/openhands/agent-server:b24f12a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b24f12a-python
ghcr.io/openhands/agent-server:b24f12ab6a02b19d2083957665845797dc298f77-python
ghcr.io/openhands/agent-server:fix-async-retry-temperature-bump-python
ghcr.io/openhands/agent-server:b24f12a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b24f12a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b24f12a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->