### PR TITLE
fix(sdk): minimal ACPAgent.astep override (alternative to #3358)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -909,10 +909,18 @@ class ACPAgent(AgentBase):
         # Render the suffix once, pulling secrets from the conversation's
         # secret_registry to match the regular Agent's get_dynamic_context().
         self._installed_suffix = self._render_suffix(state)
-        # A prior session id in agent_state means we are resuming; the suffix
-        # is already in the subprocess's persisted history from the original
-        # session, so no re-injection is needed.
-        resumed = state.agent_state.get("acp_session_id") is not None
+        # ``acp_suffix_installed`` is persisted by
+        # ``_commit_suffix_installation`` only after the first prompt has
+        # actually returned successfully, so on resume we know whether the
+        # ACP subprocess received the suffix.  ``acp_session_id`` alone is
+        # not a reliable signal — it is persisted at session-creation time
+        # regardless of whether the first prompt succeeded, so inferring
+        # "installed" from session id presence would skip suffix injection
+        # for sessions whose first turn was cancelled mid-prompt.  Older
+        # persisted state (from before this PR introduced the marker)
+        # will re-inject the suffix on the first turn after upgrade, which
+        # is benign — the suffix is additive LLM-context guidance.
+        suffix_already_installed = bool(state.agent_state.get("acp_suffix_installed"))
 
         try:
             self._start_acp_server(state)
@@ -943,7 +951,7 @@ class ACPAgent(AgentBase):
 
         if self._installed_suffix:
             self._suffix_install_state = (
-                "installed" if resumed else "pending_first_prompt"
+                "installed" if suffix_already_installed else "pending_first_prompt"
             )
 
         # Emit a placeholder system prompt so the visualizer shows a section
@@ -1275,16 +1283,26 @@ class ACPAgent(AgentBase):
             return None
         return blocks
 
-    def _commit_suffix_installation(self) -> None:
+    def _commit_suffix_installation(self, state: ConversationState) -> None:
         """Mark the suffix as installed once a turn has completed.
 
-        Called from ``_finalize_successful_turn`` so that
-        ``_suffix_install_state`` only transitions after the ACP server
-        has actually received the suffix.  Idempotent: safe to call when
-        already ``installed`` or when there is no suffix to install.
+        Called from ``_finalize_successful_turn`` so the transition only
+        happens after the ACP server has actually received the suffix.
+        Persists ``acp_suffix_installed=True`` into ``state.agent_state``
+        so a subsequent agent-server restart, reading back the same
+        ``ConversationState``, can tell whether the suffix was actually
+        installed (rather than inferring it from the mere presence of
+        ``acp_session_id``, which is persisted at session-creation time
+        regardless of whether the first prompt succeeded).  Idempotent:
+        safe to call when already ``installed`` or when there is no
+        suffix to install.
         """
         if self._suffix_install_state == "pending_first_prompt":
             self._suffix_install_state = "installed"
+            state.agent_state = {
+                **state.agent_state,
+                "acp_suffix_installed": True,
+            }
 
     async def _do_acp_prompt(self, prompt_blocks: list[Any]) -> PromptResponse | None:
         """One ACP ``conn.prompt`` round-trip + UsageUpdate sync.
@@ -1322,7 +1340,7 @@ class ACPAgent(AgentBase):
         # ACP server has acknowledged the prompt; commit any pending
         # first-turn suffix install so a subsequent turn doesn't try to
         # re-send it (and so a future cancellation can't unmark it).
-        self._commit_suffix_installation()
+        self._commit_suffix_installation(state)
 
         session_id = self._session_id or ""
         usage_update = self._client.pop_turn_usage_update(session_id)

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1266,13 +1266,19 @@ class ACPAgent(AgentBase):
             return None
         return blocks
 
-    async def _do_acp_prompt(self, prompt_blocks: list[Any]) -> PromptResponse:
+    async def _do_acp_prompt(
+        self, prompt_blocks: list[Any]
+    ) -> PromptResponse | None:
         """One ACP ``conn.prompt`` round-trip + UsageUpdate sync.
 
         Always runs on the portal loop (where ``self._conn`` lives).  No
         retry / timeout — callers wrap with their own per-attempt
         strategy so they can pick ``time.sleep`` (sync) or
         ``asyncio.sleep`` (async).
+
+        Return type allows ``None`` because the ACP server is permitted
+        to return an empty body (and test mocks do); downstream
+        ``_finalize_successful_turn`` already accepts ``PromptResponse | None``.
         """
         usage_sync = self._client.prepare_usage_sync(self._session_id or "")
         response = await self._conn.prompt(prompt_blocks, self._session_id)
@@ -1467,7 +1473,7 @@ class ACPAgent(AgentBase):
             response: PromptResponse | None = None
             max_retries = _ACP_PROMPT_MAX_RETRIES
 
-            async def _prompt() -> PromptResponse:
+            async def _prompt() -> PromptResponse | None:
                 # Thin closure so existing mocks of ``_executor.run_async``
                 # that take a single positional callable keep working.
                 return await self._do_acp_prompt(prompt_blocks)

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1266,6 +1266,165 @@ class ACPAgent(AgentBase):
             return None
         return blocks
 
+    async def _do_acp_prompt(self, prompt_blocks: list[Any]) -> PromptResponse:
+        """One ACP ``conn.prompt`` round-trip + UsageUpdate sync.
+
+        Always runs on the portal loop (where ``self._conn`` lives).  No
+        retry / timeout — callers wrap with their own per-attempt
+        strategy so they can pick ``time.sleep`` (sync) or
+        ``asyncio.sleep`` (async).
+        """
+        usage_sync = self._client.prepare_usage_sync(self._session_id or "")
+        response = await self._conn.prompt(prompt_blocks, self._session_id)
+        if self._client.get_turn_usage_update(self._session_id or "") is None:
+            try:
+                await asyncio.wait_for(usage_sync.wait(), timeout=_USAGE_UPDATE_TIMEOUT)
+            except TimeoutError:
+                logger.warning(
+                    "UsageUpdate not received within %.1fs for session %s",
+                    _USAGE_UPDATE_TIMEOUT,
+                    self._session_id,
+                )
+        return response
+
+    def _finalize_successful_turn(
+        self,
+        response: PromptResponse | None,
+        elapsed: float,
+        state: ConversationState,
+        on_event: ConversationCallbackType,
+    ) -> None:
+        """Post-prompt bookkeeping + FinishAction/Observation emission."""
+        session_id = self._session_id or ""
+        usage_update = self._client.pop_turn_usage_update(session_id)
+        self._record_usage(
+            response,
+            session_id,
+            elapsed=elapsed,
+            usage_update=usage_update,
+        )
+
+        # ACPToolCallEvents were already emitted live from
+        # _OpenHandsACPBridge.session_update as each ToolCallStart /
+        # ToolCallProgress notification arrived — no end-of-turn fan-out
+        # here. FinishAction closes out the turn below.
+        response_text = "".join(self._client.accumulated_text)
+        thought_text = "".join(self._client.accumulated_thoughts)
+        if not response_text:
+            response_text = "(No response from ACP server)"
+
+        # ACP step() boundaries are full remote assistant turns, not
+        # partial planning steps. Emit FinishAction to delimit that
+        # completed turn for eval/remote consumers, matching #2190.
+        finish_action = FinishAction(message=response_text)
+        tc_id = str(uuid.uuid4())
+        action_event = ActionEvent(
+            source="agent",
+            thought=[],
+            reasoning_content=thought_text or None,
+            action=finish_action,
+            tool_name="finish",
+            tool_call_id=tc_id,
+            tool_call=MessageToolCall(
+                id=tc_id,
+                name="finish",
+                arguments=json.dumps({"message": response_text}),
+                origin="completion",
+            ),
+            llm_response_id=str(uuid.uuid4()),
+        )
+        on_event(action_event)
+        on_event(
+            ObservationEvent(
+                observation=FinishObservation.from_text(text=response_text),
+                action_id=action_event.id,
+                tool_name="finish",
+                tool_call_id=tc_id,
+            )
+        )
+        state.execution_status = ConversationExecutionStatus.FINISHED
+
+    def _emit_turn_timeout(
+        self,
+        elapsed: float,
+        state: ConversationState,
+        on_event: ConversationCallbackType,
+    ) -> None:
+        """Error path when ``conn.prompt`` exceeded ``acp_prompt_timeout``."""
+        logger.error(
+            "ACP prompt timed out after %.1fs (limit=%.0fs). "
+            "The ACP server may have completed its work but failed to "
+            "send the JSON-RPC response. Accumulated %d text chunks, "
+            "%d tool calls.",
+            elapsed,
+            self.acp_prompt_timeout,
+            len(self._client.accumulated_text),
+            len(self._client.accumulated_tool_calls),
+        )
+        error_message = Message(
+            role="assistant",
+            content=[
+                TextContent(
+                    text=(
+                        f"ACP prompt timed out after {elapsed:.0f}s. "
+                        "The agent may have completed its work but "
+                        "the response was not received."
+                    )
+                )
+            ],
+        )
+        # Close any tool cards left in flight from the timed-out attempt.
+        self._cancel_inflight_tool_calls()
+        on_event(MessageEvent(source="agent", llm_message=error_message))
+        state.execution_status = ConversationExecutionStatus.ERROR
+
+    def _emit_turn_error(
+        self,
+        exc: BaseException,
+        state: ConversationState,
+        on_event: ConversationCallbackType,
+    ) -> None:
+        """Error path for non-timeout exceptions raised out of the prompt."""
+        logger.error("ACP prompt failed: %s", exc, exc_info=True)
+        error_str = str(exc)
+        # Close any tool cards left in flight before surfacing the error.
+        self._cancel_inflight_tool_calls()
+        # Emit error as an agent message (preserved for consumers that
+        # inspect MessageEvents).
+        on_event(
+            MessageEvent(
+                source="agent",
+                llm_message=Message(
+                    role="assistant",
+                    content=[TextContent(text=f"ACP error: {exc}")],
+                ),
+            )
+        )
+        # Emit typed ConversationErrorEvent so RemoteConversation surfaces
+        # the actual detail instead of falling back to
+        # "Remote conversation ended with error".
+        is_aup = (
+            "usage policy" in error_str.lower() or "content policy" in error_str.lower()
+        )
+        on_event(
+            ConversationErrorEvent(
+                source="agent",
+                code="UsagePolicyRefusal" if is_aup else "ACPPromptError",
+                detail=error_str[:500],
+            )
+        )
+        state.execution_status = ConversationExecutionStatus.ERROR
+
+    def _clear_turn_callbacks(self) -> None:
+        """Unwire per-turn bridge callbacks so trailing ``session_update``
+        between turns is a no-op (fires on the portal thread with no
+        FIFOLock held by anyone — without unwiring, a stale ``on_event``
+        there would race with other threads mutating ``state.events``).
+        """
+        self._client.on_event = None
+        self._client.on_token = None
+        self._client.on_activity = None
+
     @observe(name="acp_agent.step", ignore_inputs=["conversation", "on_event"])
     def step(
         self,
@@ -1273,19 +1432,24 @@ class ACPAgent(AgentBase):
         on_event: ConversationCallbackType,
         on_token: ConversationTokenCallbackType | None = None,
     ) -> None:
-        """Send the latest user message to the ACP server and emit the response."""
+        """Send the latest user message to the ACP server and emit the response.
+
+        Sync entry point — used by ``LocalConversation.run`` (sync path),
+        the CLI, and the eval harness.  The async path
+        (``LocalConversation.arun``) goes through :meth:`astep`, which
+        avoids the cross-thread state-lock deadlock described in #3348.
+        """
         state = conversation.state
 
-        # Find the latest user message. Conversation implementations already
-        # attach per-turn AgentContext extensions to MessageEvent.extended_content;
-        # MessageEvent.to_llm_message() merges those extensions with the user text.
-        prompt_blocks = None
+        # Conversation implementations already attach per-turn AgentContext
+        # extensions to MessageEvent.extended_content; MessageEvent.to_llm_message()
+        # merges those extensions with the user text.
+        prompt_blocks: list[Any] | None = None
         for event in reversed(list(state.events)):
             if isinstance(event, MessageEvent) and event.source == "user":
                 prompt_blocks = self._build_acp_prompt(event)
                 if prompt_blocks:
                     break
-
         if prompt_blocks is None:
             logger.warning("No user message found; finishing conversation")
             state.execution_status = ConversationExecutionStatus.FINISHED
@@ -1295,37 +1459,18 @@ class ACPAgent(AgentBase):
 
         t0 = time.monotonic()
         try:
-
-            async def _prompt() -> PromptResponse:
-                usage_sync = self._client.prepare_usage_sync(self._session_id or "")
-                response = await self._conn.prompt(
-                    prompt_blocks,
-                    self._session_id,
-                )
-                if self._client.get_turn_usage_update(self._session_id or "") is None:
-                    try:
-                        await asyncio.wait_for(
-                            usage_sync.wait(), timeout=_USAGE_UPDATE_TIMEOUT
-                        )
-                    except TimeoutError:
-                        logger.warning(
-                            "UsageUpdate not received within %.1fs for session %s",
-                            _USAGE_UPDATE_TIMEOUT,
-                            self._session_id,
-                        )
-                return response
-
-            # Send prompt to ACP server with retry logic for connection errors.
-            # Transient connection failures (network blips, server restarts) are
-            # retried to preserve session state and avoid losing progress.
             logger.info(
                 "Sending ACP prompt (timeout=%.0fs, blocks=%d)",
                 self.acp_prompt_timeout,
                 len(prompt_blocks),
             )
-
             response: PromptResponse | None = None
             max_retries = _ACP_PROMPT_MAX_RETRIES
+
+            async def _prompt() -> PromptResponse:
+                # Thin closure so existing mocks of ``_executor.run_async``
+                # that take a single positional callable keep working.
+                return await self._do_acp_prompt(prompt_blocks)
 
             for attempt in range(max_retries + 1):
                 try:
@@ -1341,8 +1486,8 @@ class ACPAgent(AgentBase):
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
                         ]
                         logger.warning(
-                            "ACP prompt failed with retriable error (attempt %d/%d), "
-                            "retrying in %.0fs: %s",
+                            "ACP prompt failed with retriable error "
+                            "(attempt %d/%d), retrying in %.0fs: %s",
                             attempt + 1,
                             max_retries + 1,
                             delay,
@@ -1355,8 +1500,8 @@ class ACPAgent(AgentBase):
                         raise
                 except ACPRequestError as e:
                     # Retry transient server errors (e.g. "Internal Server
-                    # Error" from Gemini).  These are JSON-RPC -32603 errors
-                    # that indicate a server-side failure, not a client bug.
+                    # Error" from Gemini).  JSON-RPC -32603 = server-side
+                    # failure, not a client bug.
                     if (
                         e.code in _RETRIABLE_SERVER_ERROR_CODES
                         and attempt < max_retries
@@ -1365,8 +1510,8 @@ class ACPAgent(AgentBase):
                             min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
                         ]
                         logger.warning(
-                            "ACP prompt failed with server error (attempt %d/%d), "
-                            "retrying in %.0fs: [%d] %s",
+                            "ACP prompt failed with server error "
+                            "(attempt %d/%d), retrying in %.0fs: [%d] %s",
                             attempt + 1,
                             max_retries + 1,
                             delay,
@@ -1381,135 +1526,154 @@ class ACPAgent(AgentBase):
 
             elapsed = time.monotonic() - t0
             logger.info("ACP prompt returned in %.1fs", elapsed)
-
-            session_id = self._session_id or ""
-            usage_update = self._client.pop_turn_usage_update(session_id)
-            self._record_usage(
-                response,
-                session_id,
-                elapsed=elapsed,
-                usage_update=usage_update,
-            )
-
-            # ACPToolCallEvents were already emitted live from
-            # _OpenHandsACPBridge.session_update as each ToolCallStart /
-            # ToolCallProgress notification arrived — no end-of-turn fan-out
-            # here. FinishAction closes out the turn below.
-
-            # Build response message
-            response_text = "".join(self._client.accumulated_text)
-            thought_text = "".join(self._client.accumulated_thoughts)
-
-            if not response_text:
-                response_text = "(No response from ACP server)"
-
-            # ACP step() boundaries are full remote assistant turns, not
-            # partial planning steps. Emit FinishAction to delimit that
-            # completed turn for eval/remote consumers, matching #2190.
-            finish_action = FinishAction(message=response_text)
-            tc_id = str(uuid.uuid4())
-            action_event = ActionEvent(
-                source="agent",
-                thought=[],
-                reasoning_content=thought_text or None,
-                action=finish_action,
-                tool_name="finish",
-                tool_call_id=tc_id,
-                tool_call=MessageToolCall(
-                    id=tc_id,
-                    name="finish",
-                    arguments=json.dumps({"message": response_text}),
-                    origin="completion",
-                ),
-                llm_response_id=str(uuid.uuid4()),
-            )
-            on_event(action_event)
-            on_event(
-                ObservationEvent(
-                    observation=FinishObservation.from_text(text=response_text),
-                    action_id=action_event.id,
-                    tool_name="finish",
-                    tool_call_id=tc_id,
-                )
-            )
-
-            state.execution_status = ConversationExecutionStatus.FINISHED
-
+            self._finalize_successful_turn(response, elapsed, state, on_event)
         except TimeoutError:
-            elapsed = time.monotonic() - t0
-            logger.error(
-                "ACP prompt timed out after %.1fs (limit=%.0fs). "
-                "The ACP server may have completed its work but failed to "
-                "send the JSON-RPC response. Accumulated %d text chunks, "
-                "%d tool calls.",
-                elapsed,
-                self.acp_prompt_timeout,
-                len(self._client.accumulated_text),
-                len(self._client.accumulated_tool_calls),
-            )
-            error_message = Message(
-                role="assistant",
-                content=[
-                    TextContent(
-                        text=(
-                            f"ACP prompt timed out after {elapsed:.0f}s. "
-                            "The agent may have completed its work but "
-                            "the response was not received."
-                        )
-                    )
-                ],
-            )
-            # Close any tool cards left in flight from the timed-out attempt.
-            self._cancel_inflight_tool_calls()
-            on_event(MessageEvent(source="agent", llm_message=error_message))
-            state.execution_status = ConversationExecutionStatus.ERROR
+            self._emit_turn_timeout(time.monotonic() - t0, state, on_event)
         except Exception as e:
-            logger.error("ACP prompt failed: %s", e, exc_info=True)
-            error_str = str(e)
-
-            # Close any tool cards left in flight before surfacing the error.
-            self._cancel_inflight_tool_calls()
-
-            # Emit error as an agent message (existing behavior, preserved for
-            # consumers that inspect MessageEvents)
-            error_message = Message(
-                role="assistant",
-                content=[TextContent(text=f"ACP error: {e}")],
-            )
-            on_event(MessageEvent(source="agent", llm_message=error_message))
-
-            # Emit typed ConversationErrorEvent so RemoteConversation can
-            # report the actual error detail via _get_last_error_detail()
-            # instead of falling back to "Remote conversation ended with error"
-            is_aup = (
-                "usage policy" in error_str.lower()
-                or "content policy" in error_str.lower()
-            )
-            on_event(
-                ConversationErrorEvent(
-                    source="agent",
-                    code="UsagePolicyRefusal" if is_aup else "ACPPromptError",
-                    detail=error_str[:500],
-                )
-            )
-
-            state.execution_status = ConversationExecutionStatus.ERROR
-
+            self._emit_turn_error(e, state, on_event)
             # Re-raise so LocalConversation.run()'s outer except handler
             # breaks the loop, emits ConversationErrorEvent, and raises
-            # ConversationRunError — matching how the regular Agent works
+            # ConversationRunError — matching how the regular Agent works.
             raise
         finally:
-            # Unwire the per-turn callbacks now that this step has finished
-            # emitting everything it's going to emit.  If the ACP subprocess
-            # later dispatches a trailing ``session_update`` (e.g. between
-            # turns), it fires on the portal thread with no FIFOLock held
-            # by anyone — firing a stale ``on_event`` there would race
-            # with other threads mutating ``state.events``.  Clearing the
-            # callbacks turns any such late update into a no-op emit.
-            self._client.on_event = None
-            self._client.on_token = None
-            self._client.on_activity = None
+            self._clear_turn_callbacks()
+
+    @observe(name="acp_agent.astep", ignore_inputs=["conversation", "on_event"])
+    async def astep(
+        self,
+        conversation: LocalConversation,
+        on_event: ConversationCallbackType,
+        on_token: ConversationTokenCallbackType | None = None,
+    ) -> None:
+        """Native-async variant of :meth:`step`.
+
+        Schedules the ACP ``conn.prompt`` round-trip on the portal loop
+        (where ``self._conn`` lives) via ``BlockingPortal.start_task_soon``
+        and awaits the result back on the caller's loop via
+        ``asyncio.wrap_future``.  Post-prompt work — ``_record_usage``
+        (and the ``stats_callback`` it triggers), ``on_event(action)``,
+        ``on_event(observation)``, ``state.execution_status`` — runs
+        entirely on the caller's thread.
+
+        Why this matters: ``LocalConversation.arun`` holds the
+        conversation state's reentrant ``FIFOLock`` on its loop thread
+        across ``await self.agent.astep(...)``.  The default
+        ``AgentBase.astep`` would wrap sync ``step`` in
+        ``loop.run_in_executor(None, self.step, ...)``, moving every
+        post-prompt callback to a worker thread.  Any ``with state:``
+        inside that chain (today: ``stats_callback``; tomorrow: any
+        callback added to LLM telemetry or the event pipeline) then
+        blocks on a lock owned by the loop thread that is itself
+        ``await``-ing ``astep`` to return.  Keeping post-prompt work on
+        the caller's thread sidesteps the whole class of cross-thread
+        state-lock deadlocks.  See #3348 / #3350 for the full diagnosis.
+
+        Bridge ``session_update`` notifications continue to fire on the
+        portal thread (no marshalling here) — they reach the user's
+        ``on_event`` chain via the agent-server's
+        ``_emit_event_from_thread`` queue, which already handles the
+        thread hop.  Real-time mid-turn delivery of those events is a
+        separate concern (the queue waits for ``arun()`` to release the
+        state lock between iterations); it is not part of the deadlock
+        this fix removes.
+        """
+        state = conversation.state
+
+        prompt_blocks: list[Any] | None = None
+        for event in reversed(list(state.events)):
+            if isinstance(event, MessageEvent) and event.source == "user":
+                prompt_blocks = self._build_acp_prompt(event)
+                if prompt_blocks:
+                    break
+        if prompt_blocks is None:
+            logger.warning("No user message found; finishing conversation")
+            state.execution_status = ConversationExecutionStatus.FINISHED
+            return
+
+        self._reset_client_for_turn(on_token, on_event)
+
+        t0 = time.monotonic()
+        try:
+            logger.info(
+                "Sending ACP prompt (timeout=%.0fs, blocks=%d, async)",
+                self.acp_prompt_timeout,
+                len(prompt_blocks),
+            )
+            portal = self._executor.portal
+
+            response: PromptResponse | None = None
+            max_retries = _ACP_PROMPT_MAX_RETRIES
+            for attempt in range(max_retries + 1):
+                try:
+                    # Schedule the ACP prompt on the portal loop (where the
+                    # connection lives); await the future back on the caller
+                    # loop.  ``asyncio.wait_for`` cancels the wrapped future
+                    # on timeout, which propagates to the portal task via
+                    # ``concurrent.futures.Future`` cancellation.
+                    future = portal.start_task_soon(self._do_acp_prompt, prompt_blocks)
+                    response = await asyncio.wait_for(
+                        asyncio.wrap_future(future),
+                        timeout=self.acp_prompt_timeout,
+                    )
+                    break
+                except TimeoutError as exc:
+                    # ``asyncio.TimeoutError`` is ``TimeoutError`` on 3.11+.
+                    # Re-raise as a clean TimeoutError so the outer handler
+                    # branches the same way as the sync path.
+                    raise TimeoutError(
+                        f"ACP prompt timed out after {self.acp_prompt_timeout:.0f}s"
+                    ) from exc
+                except _RETRIABLE_CONNECTION_ERRORS as e:
+                    if attempt < max_retries:
+                        delay = _ACP_PROMPT_RETRY_DELAYS[
+                            min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
+                        ]
+                        logger.warning(
+                            "ACP prompt failed with retriable error "
+                            "(attempt %d/%d), retrying in %.0fs: %s",
+                            attempt + 1,
+                            max_retries + 1,
+                            delay,
+                            e,
+                        )
+                        await asyncio.sleep(delay)
+                        self._cancel_inflight_tool_calls()
+                        self._reset_client_for_turn(on_token, on_event)
+                    else:
+                        raise
+                except ACPRequestError as e:
+                    if (
+                        e.code in _RETRIABLE_SERVER_ERROR_CODES
+                        and attempt < max_retries
+                    ):
+                        delay = _ACP_PROMPT_RETRY_DELAYS[
+                            min(attempt, len(_ACP_PROMPT_RETRY_DELAYS) - 1)
+                        ]
+                        logger.warning(
+                            "ACP prompt failed with server error "
+                            "(attempt %d/%d), retrying in %.0fs: [%d] %s",
+                            attempt + 1,
+                            max_retries + 1,
+                            delay,
+                            e.code,
+                            e,
+                        )
+                        await asyncio.sleep(delay)
+                        self._cancel_inflight_tool_calls()
+                        self._reset_client_for_turn(on_token, on_event)
+                    else:
+                        raise
+
+            elapsed = time.monotonic() - t0
+            logger.info("ACP prompt returned in %.1fs (async)", elapsed)
+            self._finalize_successful_turn(response, elapsed, state, on_event)
+        except TimeoutError:
+            self._emit_turn_timeout(time.monotonic() - t0, state, on_event)
+        except Exception as e:
+            self._emit_turn_error(e, state, on_event)
+            raise
+        finally:
+            self._clear_turn_callbacks()
 
     def ask_agent(self, question: str) -> str | None:
         """Fork the ACP session, prompt the fork, and return the response."""

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1261,10 +1261,30 @@ class ACPAgent(AgentBase):
             and self._installed_suffix
         ):
             blocks.append(text_block(self._installed_suffix))
-            self._suffix_install_state = "installed"
+            # NOTE: do NOT flip ``_suffix_install_state`` here.  If the
+            # caller (step/astep) is cancelled or fails before the ACP
+            # server persists this first turn (more likely on the async
+            # path, where ``asyncio.wait_for`` / ``task.cancel()`` can
+            # land between block construction and the await), the local
+            # state would say "installed" while the server never received
+            # the suffix — and the next turn would skip it.  The actual
+            # transition happens in ``_commit_suffix_installation``,
+            # called from ``_finalize_successful_turn`` once the prompt
+            # has returned successfully.
         if not blocks:
             return None
         return blocks
+
+    def _commit_suffix_installation(self) -> None:
+        """Mark the suffix as installed once a turn has completed.
+
+        Called from ``_finalize_successful_turn`` so that
+        ``_suffix_install_state`` only transitions after the ACP server
+        has actually received the suffix.  Idempotent: safe to call when
+        already ``installed`` or when there is no suffix to install.
+        """
+        if self._suffix_install_state == "pending_first_prompt":
+            self._suffix_install_state = "installed"
 
     async def _do_acp_prompt(
         self, prompt_blocks: list[Any]
@@ -1301,6 +1321,11 @@ class ACPAgent(AgentBase):
         on_event: ConversationCallbackType,
     ) -> None:
         """Post-prompt bookkeeping + FinishAction/Observation emission."""
+        # ACP server has acknowledged the prompt; commit any pending
+        # first-turn suffix install so a subsequent turn doesn't try to
+        # re-send it (and so a future cancellation can't unmark it).
+        self._commit_suffix_installation()
+
         session_id = self._session_id or ""
         usage_update = self._client.pop_turn_usage_update(session_id)
         self._record_usage(
@@ -1673,6 +1698,19 @@ class ACPAgent(AgentBase):
             elapsed = time.monotonic() - t0
             logger.info("ACP prompt returned in %.1fs (async)", elapsed)
             self._finalize_successful_turn(response, elapsed, state, on_event)
+        except asyncio.CancelledError:
+            # ``asyncio.CancelledError`` inherits from ``BaseException``, not
+            # ``Exception`` — so it would otherwise bypass the generic handler
+            # and only run ``finally``, where ``_clear_turn_callbacks`` unwires
+            # the bridge.  Without closing in-flight tool cards here, any
+            # ``pending`` / ``in_progress`` ``ACPToolCallEvent`` streamed
+            # before cancellation stays live in the event log forever
+            # (``LocalConversation._emit_orphaned_action_errors`` only patches
+            # ``ActionEvent``s, not ``ACPToolCallEvent``s).  Cancel-emit on
+            # the caller thread while callbacks are still wired, then re-raise
+            # so ``arun()`` can transition to PAUSED.
+            self._cancel_inflight_tool_calls()
+            raise
         except TimeoutError:
             self._emit_turn_timeout(time.monotonic() - t0, state, on_event)
         except Exception as e:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1286,9 +1286,7 @@ class ACPAgent(AgentBase):
         if self._suffix_install_state == "pending_first_prompt":
             self._suffix_install_state = "installed"
 
-    async def _do_acp_prompt(
-        self, prompt_blocks: list[Any]
-    ) -> PromptResponse | None:
+    async def _do_acp_prompt(self, prompt_blocks: list[Any]) -> PromptResponse | None:
         """One ACP ``conn.prompt`` round-trip + UsageUpdate sync.
 
         Always runs on the portal loop (where ``self._conn`` lives).  No

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1636,9 +1636,14 @@ class ACPAgent(AgentBase):
                 try:
                     # Schedule the ACP prompt on the portal loop (where the
                     # connection lives); await the future back on the caller
-                    # loop.  ``asyncio.wait_for`` cancels the wrapped future
-                    # on timeout, which propagates to the portal task via
-                    # ``concurrent.futures.Future`` cancellation.
+                    # loop.  On timeout ``asyncio.wait_for`` cancels the
+                    # caller-side asyncio future; the portal task may run to
+                    # completion in the background (anyio starts it
+                    # immediately on ``start_task_soon`` and
+                    # ``concurrent.futures.Future.cancel()`` returns ``False``
+                    # for an already-running task), but
+                    # ``_clear_turn_callbacks()`` in ``finally`` ensures any
+                    # trailing ``session_update`` from that task is a no-op.
                     future = portal.start_task_soon(self._do_acp_prompt, prompt_blocks)
                     response = await asyncio.wait_for(
                         asyncio.wrap_future(future),

--- a/openhands-sdk/openhands/sdk/utils/async_executor.py
+++ b/openhands-sdk/openhands/sdk/utils/async_executor.py
@@ -6,7 +6,7 @@ from collections.abc import Callable
 from typing import Any
 
 import anyio
-from anyio.from_thread import start_blocking_portal
+from anyio.from_thread import BlockingPortal, start_blocking_portal
 
 from openhands.sdk.logger import get_logger
 
@@ -26,7 +26,19 @@ class AsyncExecutor:
         self._lock = threading.Lock()
         self._atexit_registered = False
 
-    def _ensure_portal(self):
+    @property
+    def portal(self) -> BlockingPortal:
+        """The lazily-started ``BlockingPortal`` — public accessor.
+
+        Callers that need to schedule work directly on the portal loop
+        (e.g. ``ACPAgent.astep`` bridges ACP awaits across loops via
+        ``portal.start_task_soon`` + ``asyncio.wrap_future``) use this
+        instead of ``run_async`` because they need the future, not the
+        result.
+        """
+        return self._ensure_portal()
+
+    def _ensure_portal(self) -> BlockingPortal:
         with self._lock:
             if self._portal is None:
                 self._portal_cm = start_blocking_portal()

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import threading
 import uuid
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -1297,6 +1298,155 @@ class TestACPAgentStep:
         assert wired_during_prompt == [on_token]
         # And unwired afterward so a late token chunk is a no-op.
         assert mock_client.on_token is None
+
+
+# ---------------------------------------------------------------------------
+# Async step (astep) — regression coverage for #3348
+# ---------------------------------------------------------------------------
+
+
+class TestACPAgentAstep:
+    """Native ``ACPAgent.astep`` must not fall back to ``AgentBase.astep``
+    (which wraps ``step`` in ``loop.run_in_executor``).  Doing so would
+    move post-prompt callbacks onto an executor worker thread,
+    deadlocking against ``LocalConversation.arun`` which holds the
+    state's reentrant ``FIFOLock`` on the loop thread.  See #3348.
+    """
+
+    def _make_conversation_with_message(self, tmp_path, text="Hello"):
+        state = _make_state(tmp_path)
+        state.events.append(
+            SystemPromptEvent(
+                source="agent",
+                system_prompt=TextContent(text="ACP-managed agent"),
+                tools=[],
+            )
+        )
+        state.events.append(
+            MessageEvent(
+                source="user",
+                llm_message=Message(role="user", content=[TextContent(text=text)]),
+            )
+        )
+        conversation = MagicMock()
+        conversation.state = state
+        return conversation
+
+    def test_astep_overrides_default_agentbase_implementation(self):
+        """Structural guard: if this flips back, ``AgentBase.astep``'s
+        ``run_in_executor`` wrapper resumes and #3348 reopens.
+        """
+        assert ACPAgent.astep is not AgentBase.astep
+
+    def test_astep_runs_post_prompt_callbacks_on_caller_thread(self, tmp_path):
+        """Post-prompt ``on_event`` callbacks must fire on the caller
+        thread (same thread that holds ``state.lock`` in ``arun``).
+        ``FIFOLock`` is reentrant per-thread; if astep schedules ``step``
+        on a worker thread (the buggy default), callbacks run cross-thread
+        and block on the lock owner forever — see #3348.
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+
+        caller_thread_id = threading.get_ident()
+        prompt_thread_id: list[int] = []
+        on_event_thread_ids: list[int] = []
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+
+        async def _fake_prompt(prompt_blocks, session_id):
+            # Must execute on the portal loop's thread, not the caller's
+            # — proves we actually crossed the loop boundary.
+            prompt_thread_id.append(threading.get_ident())
+            mock_client.accumulated_text.append("answer")
+            return None
+
+        agent._conn.prompt = _fake_prompt
+        agent._session_id = "test-session"
+
+        executor = AsyncExecutor()
+        try:
+            agent._executor = executor
+
+            def _capture_event(event):
+                on_event_thread_ids.append(threading.get_ident())
+
+            asyncio.run(agent.astep(conversation, on_event=_capture_event))
+        finally:
+            executor.close()
+
+        assert len(prompt_thread_id) == 1
+        assert prompt_thread_id[0] != caller_thread_id
+
+        # FinishAction + ObservationEvent — both on caller thread.
+        assert len(on_event_thread_ids) >= 2
+        for tid in on_event_thread_ids:
+            assert tid == caller_thread_id, (
+                f"on_event ran on thread {tid} instead of caller "
+                f"{caller_thread_id} — astep regressed to thread-pool path"
+            )
+
+        assert (
+            conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+        )
+
+    def test_astep_does_not_deadlock_under_reentrant_state_lock(self, tmp_path):
+        """End-to-end shape of the #3348 bug.
+
+        Mirrors ``LocalConversation.arun``: holds ``state.lock`` on the
+        loop thread across ``await astep(...)``, while a post-prompt
+        callback re-acquires it (same shape as ``stats_callback``'s
+        ``with state:``).  With astep overridden, the callback runs on
+        the same thread as the lock owner — FIFOLock's reentrancy lets
+        it through.  Without the override, this hangs.
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        state = conversation.state
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+
+        async def _fake_prompt(prompt_blocks, session_id):
+            mock_client.accumulated_text.append("done")
+            return None
+
+        agent._conn.prompt = _fake_prompt
+        agent._session_id = "test-session"
+
+        executor = AsyncExecutor()
+        try:
+            agent._executor = executor
+
+            # stats_callback-shaped re-entry: take the state lock briefly
+            # from each event callback.  Same-thread reentry must succeed.
+            def _capture_event(event):
+                with state:
+                    pass
+
+            async def _arun_shaped() -> None:
+                with state:
+                    await asyncio.wait_for(
+                        agent.astep(conversation, on_event=_capture_event),
+                        timeout=10.0,
+                    )
+
+            asyncio.run(_arun_shaped())
+        finally:
+            executor.close()
+
+        assert (
+            conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -565,7 +565,31 @@ class TestACPAgentInitState:
         assert agent._installed_suffix is not None
         assert "Team rules." in agent._installed_suffix
 
-    def test_init_state_sets_installed_for_resumed_session(self, tmp_path):
+    def test_init_state_sets_installed_when_suffix_marker_persisted(self, tmp_path):
+        """A successful first turn persists ``acp_suffix_installed`` — on resume
+        the ACPAgent reads that marker and skips re-injection."""
+        agent = _make_agent(
+            agent_context=AgentContext(system_message_suffix="Team rules.")
+        )
+        state = _make_state(tmp_path)
+        state.agent_state = {
+            "acp_session_id": "prior-session-id",
+            "acp_suffix_installed": True,
+        }
+
+        with patch("openhands.sdk.agent.acp_agent.ACPAgent._start_acp_server"):
+            agent.init_state(state, on_event=lambda _: None)
+
+        assert agent._suffix_install_state == "installed"
+
+    def test_init_state_pending_when_session_id_only_no_suffix_marker(self, tmp_path):
+        """Persisted ``acp_session_id`` without ``acp_suffix_installed`` means
+        the prior session was created but its first prompt never completed
+        (cancelled / crashed before ``_finalize_successful_turn``).  The
+        ACP subprocess never received the suffix; on resume we must
+        re-inject it on the next turn rather than infer "installed" from
+        session-id presence alone.
+        """
         agent = _make_agent(
             agent_context=AgentContext(system_message_suffix="Team rules.")
         )
@@ -575,7 +599,7 @@ class TestACPAgentInitState:
         with patch("openhands.sdk.agent.acp_agent.ACPAgent._start_acp_server"):
             agent.init_state(state, on_event=lambda _: None)
 
-        assert agent._suffix_install_state == "installed"
+        assert agent._suffix_install_state == "pending_first_prompt"
 
     def test_init_state_includes_registry_secrets_in_suffix(self, tmp_path):
         from pydantic import SecretStr
@@ -1140,7 +1164,11 @@ class TestACPAgentStep:
         assert "Team rules." not in prompt_text
 
     def test_step_suffix_install_state_transitions_to_installed(self, tmp_path):
-        """After the first turn the install state must be 'installed'."""
+        """After the first turn the install state must be 'installed' AND the
+        ``acp_suffix_installed`` marker must be persisted into
+        ``state.agent_state`` so a subsequent agent-server restart can tell
+        the suffix was actually installed (rather than inferring from the
+        mere presence of ``acp_session_id``)."""
         agent = _make_agent(
             agent_context=AgentContext(
                 system_message_suffix="Team rules.", current_datetime=None
@@ -1162,6 +1190,7 @@ class TestACPAgentStep:
         agent.step(conversation, on_event=lambda _: None)
 
         assert agent._suffix_install_state == "installed"
+        assert state.agent_state.get("acp_suffix_installed") is True
 
     def test_step_with_reasoning_surfaces_via_action_event(self, tmp_path):
         """Reasoning traces are preserved in ActionEvent.reasoning_content."""
@@ -1599,6 +1628,14 @@ class TestACPAgentAstep:
         assert agent._suffix_install_state == "pending_first_prompt", (
             f"suffix install state was prematurely flipped to "
             f"{agent._suffix_install_state!r} — next turn would skip suffix"
+        )
+        # ``acp_suffix_installed`` must also not be persisted into
+        # ``agent_state``: otherwise a process restart between this
+        # cancelled turn and the next would read the marker and skip
+        # re-injection (issue #3359 review thread 7).
+        assert conversation.state.agent_state.get("acp_suffix_installed") is not True, (
+            "acp_suffix_installed was persisted despite cancellation — "
+            "a process restart would skip suffix re-injection"
         )
 
     def test_astep_does_not_deadlock_under_reentrant_state_lock(self, tmp_path):

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -1458,6 +1458,153 @@ class TestACPAgentAstep:
             conversation.state.execution_status == ConversationExecutionStatus.ERROR
         )
 
+    def test_astep_emits_failed_tool_calls_on_cancellation(self, tmp_path):
+        """``asyncio.CancelledError`` during astep must close in-flight
+        ``ACPToolCallEvent``s as ``failed`` and re-raise.
+
+        ``asyncio.CancelledError`` inherits from ``BaseException`` (not
+        ``Exception``), so the generic ``except Exception`` handler does
+        not catch it — without an explicit ``except asyncio.CancelledError``
+        branch, the cancel races straight to ``finally`` (which only
+        clears callbacks).  Any ``pending`` / ``in_progress`` tool cards
+        already streamed would then stay live forever
+        (``LocalConversation._emit_orphaned_action_errors`` only patches
+        ``ActionEvent``s, not ``ACPToolCallEvent``s).
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        emitted: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+
+        executor = AsyncExecutor()
+
+        async def _run_with_cancel() -> None:
+            prompt_entered = asyncio.Event()
+            caller_loop = asyncio.get_running_loop()
+
+            async def _fake_prompt(prompt_blocks, session_id):
+                # Seed an in-flight tool call AFTER _reset_client_for_turn
+                # has run (which clears accumulated_tool_calls).  In
+                # production the bridge accumulates these inside
+                # session_update as ToolCallStart / ToolCallProgress
+                # notifications arrive.
+                mock_client.accumulated_tool_calls.append(
+                    {
+                        "tool_call_id": "tc-cancel-1",
+                        "title": "in-flight tool",
+                        "status": "in_progress",
+                        "tool_kind": None,
+                        "raw_input": None,
+                        "raw_output": None,
+                        "content": None,
+                    }
+                )
+                # Signal caller loop that we're holding inside the prompt
+                # so the cancel races deterministically.
+                caller_loop.call_soon_threadsafe(prompt_entered.set)
+                # Block long enough for the cancel to land.
+                await asyncio.sleep(60)
+                return None
+
+            agent._conn.prompt = _fake_prompt
+            agent._session_id = "test-session"
+
+            task = asyncio.create_task(
+                agent.astep(conversation, on_event=emitted.append)
+            )
+            await asyncio.wait_for(prompt_entered.wait(), timeout=5.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        try:
+            agent._executor = executor
+            asyncio.run(_run_with_cancel())
+        finally:
+            executor.close()
+
+        failed_tool_events = [
+            e
+            for e in emitted
+            if isinstance(e, ACPToolCallEvent)
+            and e.tool_call_id == "tc-cancel-1"
+            and e.status == "failed"
+        ]
+        assert len(failed_tool_events) == 1, (
+            f"expected one terminal failed event for tc-cancel-1, "
+            f"got: {[(type(e).__name__, getattr(e, 'status', None)) for e in emitted]}"
+        )
+        assert failed_tool_events[0].is_error is True
+
+    def test_astep_cancellation_does_not_mark_suffix_installed(self, tmp_path):
+        """Cancellation before a turn completes must leave
+        ``_suffix_install_state`` as ``pending_first_prompt``.
+
+        Otherwise the local state would say "installed" while the ACP
+        server never received the suffix (the cancel landed before the
+        portal task could persist it), and the next turn would skip
+        re-injection.  Mirrors the ``_build_acp_prompt`` contract that
+        the install state is only committed via
+        ``_finalize_successful_turn`` → ``_commit_suffix_installation``.
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent(
+            agent_context=AgentContext(
+                system_message_suffix="Team rules.", current_datetime=None
+            )
+        )
+        conversation = self._make_conversation_with_message(tmp_path)
+        agent._installed_suffix = agent.agent_context.to_acp_prompt_context()  # type: ignore[union-attr]
+        agent._suffix_install_state = "pending_first_prompt"
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+
+        executor = AsyncExecutor()
+
+        async def _run_with_cancel() -> None:
+            prompt_entered = asyncio.Event()
+            caller_loop = asyncio.get_running_loop()
+
+            async def _fake_prompt(prompt_blocks, session_id):
+                caller_loop.call_soon_threadsafe(prompt_entered.set)
+                await asyncio.sleep(60)
+                return None
+
+            agent._conn.prompt = _fake_prompt
+            agent._session_id = "test-session"
+
+            task = asyncio.create_task(
+                agent.astep(conversation, on_event=lambda _: None)
+            )
+            await asyncio.wait_for(prompt_entered.wait(), timeout=5.0)
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        try:
+            agent._executor = executor
+            asyncio.run(_run_with_cancel())
+        finally:
+            executor.close()
+
+        # Cancellation hit before _finalize_successful_turn ran, so the
+        # suffix install state must remain pending — a subsequent turn
+        # will re-inject the suffix.
+        assert agent._suffix_install_state == "pending_first_prompt", (
+            f"suffix install state was prematurely flipped to "
+            f"{agent._suffix_install_state!r} — next turn would skip suffix"
+        )
+
     def test_astep_does_not_deadlock_under_reentrant_state_lock(self, tmp_path):
         """End-to-end shape of the #3348 bug.
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -1395,6 +1395,69 @@ class TestACPAgentAstep:
             conversation.state.execution_status == ConversationExecutionStatus.FINISHED
         )
 
+    def test_astep_emits_error_and_reraises_on_exception(self, tmp_path):
+        """astep's error path must call ``_emit_turn_error`` AND re-raise.
+
+        Guards against a silently swallowed ``raise`` in the
+        ``except Exception`` branch — without re-raise,
+        ``LocalConversation.arun()`` would not transition out of the
+        loop and the failure would be invisible to ``RemoteConversation``.
+        Mirrors the contract that sync ``step()`` already enforces.
+        """
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        emitted: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+
+        async def _failing_prompt(prompt_blocks, session_id):
+            raise RuntimeError("simulated upstream failure")
+
+        agent._conn.prompt = _failing_prompt
+
+        executor = AsyncExecutor()
+        try:
+            agent._executor = executor
+            with pytest.raises(RuntimeError, match="simulated upstream failure"):
+                asyncio.run(
+                    agent.astep(conversation, on_event=emitted.append)
+                )
+        finally:
+            executor.close()
+
+        # _emit_turn_error emits exactly two events: MessageEvent + typed
+        # ConversationErrorEvent.  Both must land before re-raise.
+        def _message_text(ev: MessageEvent) -> str:
+            first = ev.llm_message.content[0]
+            return first.text if isinstance(first, TextContent) else ""
+
+        error_messages = [
+            e
+            for e in emitted
+            if isinstance(e, MessageEvent) and "ACP error" in _message_text(e)
+        ]
+        typed_errors = [
+            e
+            for e in emitted
+            if isinstance(e, ConversationErrorEvent) and e.code == "ACPPromptError"
+        ]
+        assert len(error_messages) == 1, (
+            f"expected one error MessageEvent, got {emitted}"
+        )
+        assert len(typed_errors) == 1, (
+            f"expected one ConversationErrorEvent, got {emitted}"
+        )
+        assert (
+            conversation.state.execution_status == ConversationExecutionStatus.ERROR
+        )
+
     def test_astep_does_not_deadlock_under_reentrant_state_lock(self, tmp_path):
         """End-to-end shape of the #3348 bug.
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -1426,9 +1426,7 @@ class TestACPAgentAstep:
         try:
             agent._executor = executor
             with pytest.raises(RuntimeError, match="simulated upstream failure"):
-                asyncio.run(
-                    agent.astep(conversation, on_event=emitted.append)
-                )
+                asyncio.run(agent.astep(conversation, on_event=emitted.append))
         finally:
             executor.close()
 
@@ -1454,9 +1452,7 @@ class TestACPAgentAstep:
         assert len(typed_errors) == 1, (
             f"expected one ConversationErrorEvent, got {emitted}"
         )
-        assert (
-            conversation.state.execution_status == ConversationExecutionStatus.ERROR
-        )
+        assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
 
     def test_astep_emits_failed_tool_calls_on_cancellation(self, tmp_path):
         """``asyncio.CancelledError`` during astep must close in-flight


### PR DESCRIPTION
## Summary

Architectural fix for #3348. `ACPAgent` overrides `astep()` natively instead of inheriting `AgentBase.astep`'s `loop.run_in_executor(None, self.step, ...)` wrapper. Post-prompt work — `_record_usage` (and the `stats_callback` it triggers), `on_event(action)`, `on_event(observation)`, `state.execution_status` — runs on the caller's loop thread, so FIFOLock's per-thread reentrancy works as designed.

For the `arun` path: **lock holder thread == step thread == on_event callback thread** at end of turn.

* `self._conn.prompt(...)` still runs on the AnyIO `BlockingPortal`'s loop — scheduled via `portal.start_task_soon(self._do_acp_prompt, prompt_blocks)`.
* The result is awaited back on the caller's loop via `asyncio.wrap_future(future)`, with `asyncio.wait_for(..., timeout=self.acp_prompt_timeout)` enforcing the same per-attempt timeout as the sync path.
* All post-prompt work (`_record_usage` → telemetry callbacks → `on_event(ActionEvent)` → `on_event(ObservationEvent)` → `state.execution_status = FINISHED`) runs on the caller's loop thread.

`step()` and `astep()` share extracted helpers (`_do_acp_prompt`, `_finalize_successful_turn`, `_emit_turn_timeout`, `_emit_turn_error`, `_clear_turn_callbacks`) so error/timeout/finalize semantics stay symmetric between the sync and async paths.

### Scope notes

* **Bridge `session_update` callbacks are not marshalled back to the caller loop.** They continue to fire on the portal thread, as before. The `_OpenHandsACPBridge` docstring already requires bridge callbacks to be lock-free (`acp_agent.py:445-451`), and the current `on_event` chain (`visualizer.on_event` → `AsyncCallbackWrapper.__call__` → `LocalConversation._default_callback`) doesn't acquire `state.lock` synchronously, so the deadlock doesn't re-emerge mid-turn. If a future bridge consumer ever needs the lock, a marshaller can be added then.
* **`CancelledError` is handled explicitly** in `astep`, not by falling through to `except Exception:` — cancellation inherits from `BaseException`. Without the explicit branch, an interrupt mid-prompt would skip both handlers and run only `finally`, leaving any already-streamed `ACPToolCallEvent` stuck as `pending` / `in_progress` (`LocalConversation._emit_orphaned_action_errors` only patches `ActionEvent`s).
* **Suffix-install commit is deferred to `_finalize_successful_turn`.** Previously `_build_acp_prompt` flipped `_suffix_install_state = "installed"` while constructing the prompt — before the first cancellable await. An interrupt could then cancel the portal prompt before the ACP server received the suffix; the local state would say "installed" but the server never persisted it, and the next turn would skip re-injection. New `_commit_suffix_installation()` helper only runs on prompt success. Also fixes the latent equivalent on the sync path.

### Issue Number

Fixes #3348

Related: #3349 (hotfix this PR makes redundant), #3350 (architectural follow-up issue this resolves).

### How to Test

#### Unit tests

Six regression tests in `tests/sdk/agent/test_acp_agent.py::TestACPAgentAstep`:

1. **`test_astep_overrides_default_agentbase_implementation`** — structural guard that `ACPAgent.astep is not AgentBase.astep`. If this flips back, the buggy default resumes.
2. **`test_astep_runs_post_prompt_callbacks_on_caller_thread`** — spins up a real `AsyncExecutor`/`BlockingPortal`, calls `astep`, asserts the mocked `conn.prompt` ran on the portal thread AND every `on_event` callback (ActionEvent + ObservationEvent) ran on the caller thread.
3. **`test_astep_emits_error_and_reraises_on_exception`** — `_do_acp_prompt` raises `RuntimeError`; asserts both error events emit (`MessageEvent` + typed `ConversationErrorEvent`), status flips to `ERROR`, and the original exception re-raises. Guards against an accidentally swallowed `raise` in the generic `except Exception` branch.
4. **`test_astep_emits_failed_tool_calls_on_cancellation`** — seeds an in-flight tool call, cancels astep mid-prompt; asserts a terminal `failed` `ACPToolCallEvent` is emitted before `CancelledError` re-raises. Guards the explicit `except asyncio.CancelledError` branch.
5. **`test_astep_cancellation_does_not_mark_suffix_installed`** — cancels astep mid-prompt with `_suffix_install_state == "pending_first_prompt"`; asserts state remains pending so the next turn re-injects the suffix.
6. **`test_astep_does_not_deadlock_under_reentrant_state_lock`** — mirrors `LocalConversation.arun`'s shape: holds `state.lock` on the loop thread across `await astep(...)`, with an `on_event` callback that also takes `state.lock`. Must complete within 10s. Fails (hangs) under the old default `AgentBase.astep`.

```
uv run --project openhands-sdk pytest tests/sdk/agent/
# 468 passed (was 462 pre-PR, +5 new + 1 follow-on from helper refactor)
```

#### End-to-end validation against the original bug

A standalone script reintroduces the original buggy `stats_callback` shape (the `with state:` that #3349 removed) and runs `LocalConversation.arun()` twice — once with `ACPAgent.astep` overridden (this PR), once with it restored to `AgentBase.astep` (the bug).

Instrumented output:

```
[1] WITH FIX (this PR's overridden ACPAgent.astep):
    [stats_callback] me=8641978560 owner=8641978560 same_thread=True acquired_after=0.000s
    arun status: ConversationExecutionStatus.FINISHED

[2] WITHOUT FIX (AgentBase.astep — the buggy default):
    [stats_callback] me=6193262592 owner=8641978560 same_thread=False acquired_after=5.000s
    arun status: ConversationExecutionStatus.PAUSED

  WITH fix:     stats_callback `with state:` wait = 0.000s (same-thread reentry) PASS
  WITHOUT fix:  stats_callback `with state:` wait = 5.000s (cross-thread blocked → would hang forever in production) PASS
```

The 5.000s ceiling in the buggy case is the `asyncio.wait_for` cap in the harness — without it, the callback waits forever, exactly as #3348 reproduced.

### Type

Bug fix (architectural)

### Notes

* Sync `step()` retains its existing shape: `self._executor.run_async(_prompt, timeout=...)` via a thin closure that delegates to `self._do_acp_prompt(prompt_blocks)` — keeps the existing mock-based tests passing without churn.
* `asyncio.TimeoutError` is aliased to builtin `TimeoutError` on Python 3.11+, so a single `except TimeoutError:` clause catches both `asyncio.wait_for` timeouts and re-raised ones.
* On timeout, `asyncio.wait_for` cancels the wrapped asyncio future; `concurrent.futures.Future.cancel()` returns `False` for an already-running portal task, so the portal task may run to completion in the background. This is harmless because `_clear_turn_callbacks()` in `finally` makes any trailing `session_update` a no-op.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b775ac4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b775ac4-python \
  ghcr.io/openhands/agent-server:b775ac4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b775ac4-golang-amd64
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-golang-amd64
ghcr.io/openhands/agent-server:b775ac4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b775ac4-golang-arm64
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-golang-arm64
ghcr.io/openhands/agent-server:b775ac4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b775ac4-java-amd64
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-java-amd64
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-java-amd64
ghcr.io/openhands/agent-server:b775ac4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b775ac4-java-arm64
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-java-arm64
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-java-arm64
ghcr.io/openhands/agent-server:b775ac4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b775ac4-python-amd64
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-python-amd64
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-python-amd64
ghcr.io/openhands/agent-server:b775ac4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b775ac4-python-arm64
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-python-arm64
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-python-arm64
ghcr.io/openhands/agent-server:b775ac4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b775ac4-golang
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-golang
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-golang
ghcr.io/openhands/agent-server:b775ac4-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b775ac4-java
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-java
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-java
ghcr.io/openhands/agent-server:b775ac4-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b775ac4-python
ghcr.io/openhands/agent-server:b775ac409185e6e8be0f68f7eeeb663fc336633f-python
ghcr.io/openhands/agent-server:fix-acp-astep-deadlock-minimal-python
ghcr.io/openhands/agent-server:b775ac4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b775ac4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b775ac4-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
