### PR TITLE
feat: add bash_events_retention_seconds for automatic bash event cleanup

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -3,7 +3,7 @@ import os
 import tempfile
 import traceback
 from collections.abc import AsyncIterator, Sequence
-from contextlib import asynccontextmanager
+from contextlib import asynccontextmanager, suppress
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
@@ -17,6 +17,7 @@ from starlette.requests import Request
 
 from openhands.agent_server.auth_router import auth_router
 from openhands.agent_server.bash_router import bash_router
+from openhands.agent_server.bash_service import get_default_bash_event_service
 from openhands.agent_server.cloud_proxy_router import cloud_proxy_router
 from openhands.agent_server.config import (
     Config,
@@ -185,12 +186,30 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
         mark_initialization_complete()
         logger.info("Server initialization complete - ready to serve requests")
 
+        config = get_default_config()
+        retention_task: asyncio.Task | None = None
+        if config.bash_events_retention_seconds is not None:
+            retention_task = asyncio.create_task(
+                get_default_bash_event_service().run_retention_cleanup_loop(
+                    config.bash_events_retention_seconds
+                )
+            )
+            logger.info(
+                "Bash events retention cleanup started (retention: %ds)",
+                config.bash_events_retention_seconds,
+            )
+
         async with service:
             # Store the initialized service in app state for dependency injection
             api.state.conversation_service = service
             try:
                 yield
             finally:
+                if retention_task is not None:
+                    retention_task.cancel()
+                    with suppress(asyncio.CancelledError):
+                        await retention_task
+
                 # Define async functions for stopping each service
                 async def stop_vscode_service():
                     if vscode_service is not None:

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -186,22 +186,23 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
         mark_initialization_complete()
         logger.info("Server initialization complete - ready to serve requests")
 
-        config = get_default_config()
-        retention_task: asyncio.Task | None = None
-        if config.bash_events_retention_seconds is not None:
-            retention_task = asyncio.create_task(
-                get_default_bash_event_service().run_retention_cleanup_loop(
-                    config.bash_events_retention_seconds
-                )
-            )
-            logger.info(
-                "Bash events retention cleanup started (retention: %ds)",
-                config.bash_events_retention_seconds,
-            )
-
         async with service:
             # Store the initialized service in app state for dependency injection
             api.state.conversation_service = service
+
+            config = get_default_config()
+            retention_task: asyncio.Task | None = None
+            if config.bash_events_retention_seconds is not None:
+                retention_task = asyncio.create_task(
+                    get_default_bash_event_service().run_retention_cleanup_loop(
+                        config.bash_events_retention_seconds
+                    )
+                )
+                logger.info(
+                    "Bash events retention cleanup started (retention: %ds)",
+                    config.bash_events_retention_seconds,
+                )
+
             try:
                 yield
             finally:

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -190,7 +190,7 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
             # Store the initialized service in app state for dependency injection
             api.state.conversation_service = service
 
-            config = get_default_config()
+            config = api.state.config
             retention_task: asyncio.Task | None = None
             if config.bash_events_retention_seconds is not None:
                 retention_task = asyncio.create_task(

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -4,7 +4,7 @@ import json
 import os
 import signal
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from uuid import UUID
 
@@ -18,7 +18,7 @@ from openhands.agent_server.models import (
 )
 from openhands.agent_server.pub_sub import PubSub, Subscriber
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils import sanitized_env
+from openhands.sdk.utils import sanitized_env, utc_now
 
 
 logger = get_logger(__name__)
@@ -343,6 +343,60 @@ class BashEventService:
 
             self._save_event_to_file(error_output)
             await self._pub_sub(error_output)
+
+    async def delete_events_older_than(self, cutoff: datetime) -> int:
+        """Delete bash event files with a recorded timestamp older than ``cutoff``.
+
+        File names are prefixed with ``YYYYMMDDHHMMSS`` in ascending sort order,
+        so scanning stops as soon as a file at or after the cutoff is reached.
+
+        Returns:
+            int: The number of event files deleted.
+        """
+        cutoff_str = self._timestamp_to_str(cutoff)
+        files = self._get_event_files_by_pattern("*")  # ascending chronological order
+        count = 0
+        for path in files:
+            if path.name >= cutoff_str:
+                break  # remaining files are at or newer than cutoff
+            try:
+                path.unlink()
+                count += 1
+            except Exception as e:
+                logger.warning("Failed to delete bash event file %s: %s", path, e)
+        if count:
+            logger.info(
+                "Deleted %d bash event file(s) older than %s", count, cutoff_str
+            )
+        return count
+
+    async def run_retention_cleanup_loop(
+        self,
+        retention_seconds: int,
+        interval_seconds: float | None = None,
+    ) -> None:
+        """Periodically purge bash event files older than ``retention_seconds``.
+
+        Runs until cancelled (e.g. during application shutdown).
+
+        Args:
+            retention_seconds: Age threshold in seconds; older files are deleted.
+            interval_seconds: How often to run the cleanup. Defaults to
+                ``max(60, retention_seconds / 2)``. Pass a smaller value in
+                tests to avoid long waits.
+        """
+        interval = (
+            interval_seconds
+            if interval_seconds is not None
+            else max(60.0, retention_seconds / 2)
+        )
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                cutoff = utc_now() - timedelta(seconds=retention_seconds)
+                await self.delete_events_older_than(cutoff)
+            except Exception as e:
+                logger.warning("Bash events retention cleanup error: %s", e)
 
     async def subscribe_to_events(self, subscriber: Subscriber[BashEventBase]) -> UUID:
         """Subscribe to bash events.

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -410,6 +410,8 @@ class BashEventService:
                 # (e.g. permission error, full disk). Cap at the normal interval so
                 # we don't over-delay in low-retention configurations.
                 await asyncio.sleep(min(interval, 60.0))
+            # Always sleep the full interval after the error back-off, so total
+            # wait on error = min(interval, 60) + interval ≈ 2× normal cadence.
             await asyncio.sleep(interval)
 
     async def subscribe_to_events(self, subscriber: Subscriber[BashEventBase]) -> UUID:

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -344,8 +344,13 @@ class BashEventService:
             self._save_event_to_file(error_output)
             await self._pub_sub(error_output)
 
-    async def delete_events_older_than(self, cutoff: datetime) -> int:
+    def delete_events_older_than(self, cutoff: datetime) -> int:
         """Delete bash event files with a recorded timestamp older than ``cutoff``.
+
+        This is a synchronous method — all operations are blocking filesystem
+        I/O. Callers on the asyncio event loop should use
+        ``await asyncio.to_thread(service.delete_events_older_than, cutoff)``
+        to avoid stalling the loop.
 
         File names are prefixed with ``YYYYMMDDHHMMSS`` in ascending sort order,
         so scanning stops as soon as a file at or after the cutoff is reached.
@@ -377,7 +382,12 @@ class BashEventService:
     ) -> None:
         """Periodically purge bash event files older than ``retention_seconds``.
 
-        Runs until cancelled (e.g. during application shutdown).
+        Runs until cancelled (e.g. during application shutdown). Cleanup runs
+        immediately on entry so that files accumulated across a server restart
+        are purged without waiting for the first interval to elapse.
+
+        Blocking filesystem work is dispatched to a thread via
+        ``asyncio.to_thread`` to keep the event loop free.
 
         Args:
             retention_seconds: Age threshold in seconds; older files are deleted.
@@ -391,12 +401,12 @@ class BashEventService:
             else max(60.0, retention_seconds / 2)
         )
         while True:
-            await asyncio.sleep(interval)
             try:
                 cutoff = utc_now() - timedelta(seconds=retention_seconds)
-                await self.delete_events_older_than(cutoff)
+                await asyncio.to_thread(self.delete_events_older_than, cutoff)
             except Exception as e:
                 logger.warning("Bash events retention cleanup error: %s", e)
+            await asyncio.sleep(interval)
 
     async def subscribe_to_events(self, subscriber: Subscriber[BashEventBase]) -> UUID:
         """Subscribe to bash events.

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -365,7 +365,7 @@ class BashEventService:
             if path.name >= cutoff_str:
                 break  # remaining files are at or newer than cutoff
             try:
-                path.unlink()
+                path.unlink(missing_ok=True)
                 count += 1
             except Exception as e:
                 logger.warning("Failed to delete bash event file %s: %s", path, e)

--- a/openhands-agent-server/openhands/agent_server/bash_service.py
+++ b/openhands-agent-server/openhands/agent_server/bash_service.py
@@ -406,6 +406,10 @@ class BashEventService:
                 await asyncio.to_thread(self.delete_events_older_than, cutoff)
             except Exception as e:
                 logger.warning("Bash events retention cleanup error: %s", e)
+                # Brief back-off to prevent log flooding if the failure is persistent
+                # (e.g. permission error, full disk). Cap at the normal interval so
+                # we don't over-delay in low-retention configurations.
+                await asyncio.sleep(min(interval, 60.0))
             await asyncio.sleep(interval)
 
     async def subscribe_to_events(self, subscriber: Subscriber[BashEventBase]) -> UUID:

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -139,6 +139,15 @@ class Config(BaseModel):
             "Defaults to 'workspace/bash_events'."
         ),
     )
+    bash_events_retention_seconds: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "How long bash event files are retained on disk, in seconds. "
+            "A background task purges events older than this window on a "
+            "rolling basis. None (default) retains events indefinitely."
+        ),
+    )
     static_files_path: Path | None = Field(
         default=None,
         description=(

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -145,7 +145,11 @@ class Config(BaseModel):
         description=(
             "How long bash event files are retained on disk, in seconds. "
             "A background task purges events older than this window on a "
-            "rolling basis. None (default) retains events indefinitely."
+            "rolling basis. None (default) retains events indefinitely. "
+            "Should be set higher than the longest expected command timeout: "
+            "a command whose BashCommand file is purged mid-execution will "
+            "complete normally, but its on-disk event history will be "
+            "incomplete. A value >= 2x max command timeout avoids this."
         ),
     )
     static_files_path: Path | None = Field(

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -1,8 +1,10 @@
 """Tests for bash_service.py."""
 
 import asyncio
+import contextlib
 import time
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 from pathlib import Path
 from uuid import UUID
 
@@ -14,6 +16,7 @@ from fastapi import FastAPI
 from openhands.agent_server import bash_router as bash_router_module
 from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config
+from openhands.agent_server.models import BashCommand
 from openhands.agent_server.server_details_router import (
     mark_initialization_complete,
     server_details_router,
@@ -80,3 +83,90 @@ async def test_bash_timeout_runs_sigterm_trap(
 
     await asyncio.sleep(0.2)  # let the trap's filesystem write land
     assert marker.exists(), "SIGTERM trap did not run; cleanup skipped."
+
+
+# ---------------------------------------------------------------------------
+# delete_events_older_than
+# ---------------------------------------------------------------------------
+
+_OLD = datetime(2020, 1, 1, tzinfo=UTC)
+_NEW = datetime(2022, 1, 1, tzinfo=UTC)
+_CUTOFF = datetime(2021, 1, 1, tzinfo=UTC)
+
+
+async def test_delete_events_older_than_removes_old_keeps_new(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+
+    old_cmd = BashCommand(command="echo old", timestamp=_OLD)
+    new_cmd = BashCommand(command="echo new", timestamp=_NEW)
+    service._save_event_to_file(old_cmd)
+    service._save_event_to_file(new_cmd)
+
+    count = await service.delete_events_older_than(_CUTOFF)
+
+    assert count == 1
+    remaining = service._get_event_files_by_pattern("*")
+    assert len(remaining) == 1
+    assert new_cmd.id.hex in remaining[0].name
+
+
+async def test_delete_events_older_than_empty_directory(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+    count = await service.delete_events_older_than(_CUTOFF)
+    assert count == 0
+
+
+async def test_delete_events_older_than_all_newer_are_skipped(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+
+    new_cmd = BashCommand(command="echo new", timestamp=_NEW)
+    service._save_event_to_file(new_cmd)
+
+    count = await service.delete_events_older_than(_CUTOFF)
+
+    assert count == 0
+    assert len(service._get_event_files_by_pattern("*")) == 1
+
+
+async def test_delete_events_older_than_returns_correct_count(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+
+    for i in range(3):
+        service._save_event_to_file(BashCommand(command=f"echo {i}", timestamp=_OLD))
+    service._save_event_to_file(BashCommand(command="echo new", timestamp=_NEW))
+
+    count = await service.delete_events_older_than(_CUTOFF)
+
+    assert count == 3
+    assert len(service._get_event_files_by_pattern("*")) == 1
+
+
+# ---------------------------------------------------------------------------
+# run_retention_cleanup_loop
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.timeout(5)
+async def test_run_retention_cleanup_loop_purges_old_events(tmp_path: Path):
+    service = BashEventService(bash_events_dir=tmp_path / "bash_events")
+
+    # Write an event whose recorded timestamp is well in the past.
+    service._save_event_to_file(BashCommand(command="echo old", timestamp=_OLD))
+    assert len(service._get_event_files_by_pattern("*")) == 1
+
+    # Run the loop with a 1-second retention window and a 50 ms tick so
+    # the test doesn't have to wait for the default 60-second interval.
+    task = asyncio.create_task(
+        service.run_retention_cleanup_loop(retention_seconds=1, interval_seconds=0.05)
+    )
+    try:
+        # Give the loop time to fire at least once.
+        await asyncio.sleep(0.15)
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task
+
+    assert len(service._get_event_files_by_pattern("*")) == 0, (
+        "Old event file should have been purged by the retention loop"
+    )

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -94,7 +94,7 @@ _NEW = datetime(2022, 1, 1, tzinfo=UTC)
 _CUTOFF = datetime(2021, 1, 1, tzinfo=UTC)
 
 
-async def test_delete_events_older_than_removes_old_keeps_new(tmp_path: Path):
+def test_delete_events_older_than_removes_old_keeps_new(tmp_path: Path):
     service = BashEventService(bash_events_dir=tmp_path / "bash_events")
 
     old_cmd = BashCommand(command="echo old", timestamp=_OLD)
@@ -102,7 +102,7 @@ async def test_delete_events_older_than_removes_old_keeps_new(tmp_path: Path):
     service._save_event_to_file(old_cmd)
     service._save_event_to_file(new_cmd)
 
-    count = await service.delete_events_older_than(_CUTOFF)
+    count = service.delete_events_older_than(_CUTOFF)
 
     assert count == 1
     remaining = service._get_event_files_by_pattern("*")
@@ -110,32 +110,32 @@ async def test_delete_events_older_than_removes_old_keeps_new(tmp_path: Path):
     assert new_cmd.id.hex in remaining[0].name
 
 
-async def test_delete_events_older_than_empty_directory(tmp_path: Path):
+def test_delete_events_older_than_empty_directory(tmp_path: Path):
     service = BashEventService(bash_events_dir=tmp_path / "bash_events")
-    count = await service.delete_events_older_than(_CUTOFF)
+    count = service.delete_events_older_than(_CUTOFF)
     assert count == 0
 
 
-async def test_delete_events_older_than_all_newer_are_skipped(tmp_path: Path):
+def test_delete_events_older_than_all_newer_are_skipped(tmp_path: Path):
     service = BashEventService(bash_events_dir=tmp_path / "bash_events")
 
     new_cmd = BashCommand(command="echo new", timestamp=_NEW)
     service._save_event_to_file(new_cmd)
 
-    count = await service.delete_events_older_than(_CUTOFF)
+    count = service.delete_events_older_than(_CUTOFF)
 
     assert count == 0
     assert len(service._get_event_files_by_pattern("*")) == 1
 
 
-async def test_delete_events_older_than_returns_correct_count(tmp_path: Path):
+def test_delete_events_older_than_returns_correct_count(tmp_path: Path):
     service = BashEventService(bash_events_dir=tmp_path / "bash_events")
 
     for i in range(3):
         service._save_event_to_file(BashCommand(command=f"echo {i}", timestamp=_OLD))
     service._save_event_to_file(BashCommand(command="echo new", timestamp=_NEW))
 
-    count = await service.delete_events_older_than(_CUTOFF)
+    count = service.delete_events_older_than(_CUTOFF)
 
     assert count == 3
     assert len(service._get_event_files_by_pattern("*")) == 1


### PR DESCRIPTION
## Summary

Adds `bash_events_retention_seconds` to the agent server config. When set, a background task in the app lifespan periodically purges bash event files older than the configured window. Addresses unbounded disk growth from high-frequency polling of `GET /bash/bash_events/search`.

## Motivation

Every `start_bash_command` or `execute_bash_command` call writes one or more files to `workspace/bash_events/`. Polling loops that use `order__gt` for incremental reads never trigger any cleanup, so the directory grows without bound. This feature bounds that growth with no changes to the REST API.

## How it works

| Component | Change |
|---|---|
| `Config.bash_events_retention_seconds` | New `int \| None` field (default `None` = keep forever). Set via `OH_BASH_EVENTS_RETENTION_SECONDS` env var. |
| `BashEventService.delete_events_older_than(cutoff)` | Deletes event files with a recorded timestamp before `cutoff`. Uses the `YYYYMMDDHHMMSS_` filename prefix for early-exit sorted scanning — no file reads needed, O(deleted) not O(total). |
| `BashEventService.run_retention_cleanup_loop(retention_seconds)` | Cancellable background coroutine; sleeps `max(60, retention_seconds / 2)` then calls `delete_events_older_than`. |
| `api_lifespan` | Starts the cleanup task (if configured) before `yield`; cancels/awaits it in the `finally` block on shutdown. |

## Usage

```bash
# Retain bash events for 10 minutes
OH_BASH_EVENTS_RETENTION_SECONDS=600 agent-server
```

## Edge case to note

`bash_events_retention_seconds` should be set higher than the longest expected command `timeout`. A command that starts at `t=0` has its `BashCommand` file written then; if the retention window expires before the command finishes, that file is deleted while the in-flight task still writes output chunks. The execution is unaffected, but the on-disk history for that command will be incomplete. Setting retention >= 2x max command timeout avoids this.

## Tests

Added to `tests/agent_server/test_bash_service.py`:

- `test_delete_events_older_than_removes_old_keeps_new` — core delete/keep behaviour
- `test_delete_events_older_than_empty_directory` — no-op on empty dir
- `test_delete_events_older_than_all_newer_are_skipped` — all-newer early-exit path
- `test_delete_events_older_than_returns_correct_count` — count accuracy with mixed ages
- `test_run_retention_cleanup_loop_purges_old_events` — end-to-end loop test using `interval_seconds=0.05` to avoid 60s wait

_This PR was created by an AI agent (OpenHands) on behalf of the user._






<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fa9b780-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fa9b780-python \
  ghcr.io/openhands/agent-server:fa9b780-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fa9b780-golang-amd64
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-golang-amd64
ghcr.io/openhands/agent-server:feat-bash-events-retention-golang-amd64
ghcr.io/openhands/agent-server:fa9b780-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fa9b780-golang-arm64
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-golang-arm64
ghcr.io/openhands/agent-server:feat-bash-events-retention-golang-arm64
ghcr.io/openhands/agent-server:fa9b780-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fa9b780-java-amd64
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-java-amd64
ghcr.io/openhands/agent-server:feat-bash-events-retention-java-amd64
ghcr.io/openhands/agent-server:fa9b780-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fa9b780-java-arm64
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-java-arm64
ghcr.io/openhands/agent-server:feat-bash-events-retention-java-arm64
ghcr.io/openhands/agent-server:fa9b780-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fa9b780-python-amd64
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-python-amd64
ghcr.io/openhands/agent-server:feat-bash-events-retention-python-amd64
ghcr.io/openhands/agent-server:fa9b780-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:fa9b780-python-arm64
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-python-arm64
ghcr.io/openhands/agent-server:feat-bash-events-retention-python-arm64
ghcr.io/openhands/agent-server:fa9b780-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:fa9b780-golang
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-golang
ghcr.io/openhands/agent-server:feat-bash-events-retention-golang
ghcr.io/openhands/agent-server:fa9b780-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:fa9b780-java
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-java
ghcr.io/openhands/agent-server:feat-bash-events-retention-java
ghcr.io/openhands/agent-server:fa9b780-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:fa9b780-python
ghcr.io/openhands/agent-server:fa9b780dd79b52bc3a3af9eb4117be64451e738c-python
ghcr.io/openhands/agent-server:feat-bash-events-retention-python
ghcr.io/openhands/agent-server:fa9b780-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fa9b780-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fa9b780-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->