### PR TITLE
Add LLM subscription auth endpoints

### DIFF
--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -242,9 +242,10 @@ async def poll_openai_subscription_device_login(
             return SubscriptionStatusResponse(connected=False)
         if pending.epoch != current_epoch:
             return SubscriptionStatusResponse(connected=False)
-
-    auth.save_credentials(credentials)
-    return SubscriptionStatusResponse(connected=True, expires_at=credentials.expires_at)
+        auth.save_credentials(credentials)
+        return SubscriptionStatusResponse(
+            connected=True, expires_at=credentials.expires_at
+        )
 
 
 @llm_router.post(
@@ -255,8 +256,8 @@ async def logout_openai_subscription() -> SubscriptionStatusResponse:
     global _OPENAI_DEVICE_LOGIN_EPOCH
 
     auth = _get_openai_subscription_auth()
-    auth.logout()
     async with _OPENAI_DEVICE_LOGIN_LOCK:
         _OPENAI_DEVICE_LOGIN_EPOCH += 1
         _PENDING_OPENAI_DEVICE_LOGINS.clear()
+        auth.logout()
     return SubscriptionStatusResponse(connected=False)

--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -224,21 +224,18 @@ async def poll_openai_subscription_device_login(
         _IN_FLIGHT_OPENAI_DEVICE_LOGINS.add(request.device_code)
 
     auth = _get_openai_subscription_auth()
+    credentials = None
     try:
         credentials = await auth.poll_device_login(pending.device_code, persist=False)
-    except BaseException:
+    finally:
         async with _OPENAI_DEVICE_LOGIN_LOCK:
             _IN_FLIGHT_OPENAI_DEVICE_LOGINS.discard(request.device_code)
-            if pending.epoch == _OPENAI_DEVICE_LOGIN_EPOCH:
+            if credentials is None and pending.epoch == _OPENAI_DEVICE_LOGIN_EPOCH:
                 _PENDING_OPENAI_DEVICE_LOGINS[request.device_code] = pending
-        raise
 
     async with _OPENAI_DEVICE_LOGIN_LOCK:
-        _IN_FLIGHT_OPENAI_DEVICE_LOGINS.discard(request.device_code)
         current_epoch = _OPENAI_DEVICE_LOGIN_EPOCH
         if credentials is None:
-            if pending.epoch == current_epoch:
-                _PENDING_OPENAI_DEVICE_LOGINS[request.device_code] = pending
             return SubscriptionStatusResponse(connected=False)
         if pending.epoch != current_epoch:
             return SubscriptionStatusResponse(connected=False)

--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -1,8 +1,20 @@
-"""Router for LLM model and provider information endpoints."""
+"""Router for LLM model, provider, and subscription information endpoints."""
 
-from fastapi import APIRouter, Query
-from pydantic import BaseModel
+from __future__ import annotations
 
+import secrets
+import time
+from dataclasses import dataclass
+
+from fastapi import APIRouter, HTTPException, Query, status
+from pydantic import BaseModel, Field
+
+from openhands.sdk.llm.auth.openai import (
+    DEVICE_CODE_TIMEOUT_SECONDS,
+    OPENAI_CODEX_MODELS,
+    DeviceCode,
+    OpenAISubscriptionAuth,
+)
 from openhands.sdk.llm.utils.unverified_models import (
     _extract_model_and_provider,
     _get_litellm_provider_names,
@@ -12,6 +24,17 @@ from openhands.sdk.llm.utils.verified_models import VERIFIED_MODELS
 
 
 llm_router = APIRouter(prefix="/llm", tags=["LLM"])
+
+
+@dataclass(frozen=True)
+class PendingDeviceLogin:
+    """Server-side state for an in-progress device-code login."""
+
+    device_code: DeviceCode
+    expires_at: int
+
+
+_PENDING_OPENAI_DEVICE_LOGINS: dict[str, PendingDeviceLogin] = {}
 
 
 class ProvidersResponse(BaseModel):
@@ -27,9 +50,60 @@ class ModelsResponse(BaseModel):
 
 
 class VerifiedModelsResponse(BaseModel):
-    """Response containing verified models organized by provider."""
+    """Response containing verified LLM models organized by provider."""
 
     models: dict[str, list[str]]
+
+
+class SubscriptionStatusResponse(BaseModel):
+    """Safe subscription authentication status."""
+
+    vendor: str = "openai"
+    connected: bool
+    account_email: str | None = None
+    expires_at: int | None = None
+
+
+class SubscriptionDeviceStartResponse(BaseModel):
+    """Device-code challenge details for browser sign-in."""
+
+    device_code: str = Field(description="Opaque server-side polling token.")
+    user_code: str
+    verification_uri: str
+    verification_uri_complete: str | None = None
+    expires_at: int
+    interval_seconds: int
+
+
+class SubscriptionDevicePollRequest(BaseModel):
+    """Poll request for a previously-started subscription device login."""
+
+    device_code: str
+
+
+class SubscriptionModelsResponse(BaseModel):
+    """Models available through a subscription provider."""
+
+    vendor: str = "openai"
+    models: list[str]
+
+
+def _get_openai_subscription_auth() -> OpenAISubscriptionAuth:
+    return OpenAISubscriptionAuth()
+
+
+def _status_from_auth(auth: OpenAISubscriptionAuth) -> SubscriptionStatusResponse:
+    creds = auth.get_credentials()
+    if creds is None or creds.is_expired():
+        return SubscriptionStatusResponse(connected=False)
+    return SubscriptionStatusResponse(connected=True, expires_at=creds.expires_at)
+
+
+def _drop_expired_device_logins() -> None:
+    now = int(time.time() * 1000)
+    for key, pending in list(_PENDING_OPENAI_DEVICE_LOGINS.items()):
+        if pending.expires_at <= now:
+            _PENDING_OPENAI_DEVICE_LOGINS.pop(key, None)
 
 
 @llm_router.get("/providers", response_model=ProvidersResponse)
@@ -76,3 +150,82 @@ async def list_verified_models() -> VerifiedModelsResponse:
     with OpenHands.
     """
     return VerifiedModelsResponse(models=VERIFIED_MODELS)
+
+
+@llm_router.get(
+    "/subscription/openai/models", response_model=SubscriptionModelsResponse
+)
+async def list_openai_subscription_models() -> SubscriptionModelsResponse:
+    """List models available through ChatGPT subscription authentication."""
+    return SubscriptionModelsResponse(models=sorted(OPENAI_CODEX_MODELS))
+
+
+@llm_router.get(
+    "/subscription/openai/status", response_model=SubscriptionStatusResponse
+)
+async def get_openai_subscription_status() -> SubscriptionStatusResponse:
+    """Return safe ChatGPT subscription connection state without tokens."""
+    auth = _get_openai_subscription_auth()
+    try:
+        await auth.refresh_if_needed()
+    except RuntimeError:
+        return SubscriptionStatusResponse(connected=False)
+    return _status_from_auth(auth)
+
+
+@llm_router.post(
+    "/subscription/openai/device/start",
+    response_model=SubscriptionDeviceStartResponse,
+)
+async def start_openai_subscription_device_login() -> SubscriptionDeviceStartResponse:
+    """Start ChatGPT device-code sign-in without returning tokens."""
+    auth = _get_openai_subscription_auth()
+    challenge = await auth.start_device_login()
+    token = secrets.token_urlsafe(32)
+    expires_at = int(time.time() * 1000) + (DEVICE_CODE_TIMEOUT_SECONDS * 1000)
+    _drop_expired_device_logins()
+    _PENDING_OPENAI_DEVICE_LOGINS[token] = PendingDeviceLogin(
+        device_code=challenge,
+        expires_at=expires_at,
+    )
+    return SubscriptionDeviceStartResponse(
+        device_code=token,
+        user_code=challenge.user_code,
+        verification_uri=challenge.verification_url,
+        expires_at=expires_at,
+        interval_seconds=challenge.interval,
+    )
+
+
+@llm_router.post(
+    "/subscription/openai/device/poll", response_model=SubscriptionStatusResponse
+)
+async def poll_openai_subscription_device_login(
+    request: SubscriptionDevicePollRequest,
+) -> SubscriptionStatusResponse:
+    """Poll a ChatGPT device-code sign-in without returning tokens."""
+    _drop_expired_device_logins()
+    pending = _PENDING_OPENAI_DEVICE_LOGINS.get(request.device_code)
+    if pending is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Subscription device login not found or expired",
+        )
+
+    auth = _get_openai_subscription_auth()
+    credentials = await auth.poll_device_login(pending.device_code)
+    if credentials is None:
+        return SubscriptionStatusResponse(connected=False)
+
+    _PENDING_OPENAI_DEVICE_LOGINS.pop(request.device_code, None)
+    return SubscriptionStatusResponse(connected=True, expires_at=credentials.expires_at)
+
+
+@llm_router.post(
+    "/subscription/openai/logout", response_model=SubscriptionStatusResponse
+)
+async def logout_openai_subscription() -> SubscriptionStatusResponse:
+    """Remove stored ChatGPT subscription credentials."""
+    auth = _get_openai_subscription_auth()
+    auth.logout()
+    return SubscriptionStatusResponse(connected=False)

--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import secrets
 import time
 from dataclasses import dataclass
@@ -32,9 +33,13 @@ class PendingDeviceLogin:
 
     device_code: DeviceCode
     expires_at: int
+    epoch: int
 
 
 _PENDING_OPENAI_DEVICE_LOGINS: dict[str, PendingDeviceLogin] = {}
+_IN_FLIGHT_OPENAI_DEVICE_LOGINS: set[str] = set()
+_OPENAI_DEVICE_LOGIN_LOCK = asyncio.Lock()
+_OPENAI_DEVICE_LOGIN_EPOCH = 0
 
 
 class ProvidersResponse(BaseModel):
@@ -183,11 +188,13 @@ async def start_openai_subscription_device_login() -> SubscriptionDeviceStartRes
     challenge = await auth.start_device_login()
     token = secrets.token_urlsafe(32)
     expires_at = int(time.time() * 1000) + (DEVICE_CODE_TIMEOUT_SECONDS * 1000)
-    _drop_expired_device_logins()
-    _PENDING_OPENAI_DEVICE_LOGINS[token] = PendingDeviceLogin(
-        device_code=challenge,
-        expires_at=expires_at,
-    )
+    async with _OPENAI_DEVICE_LOGIN_LOCK:
+        _drop_expired_device_logins()
+        _PENDING_OPENAI_DEVICE_LOGINS[token] = PendingDeviceLogin(
+            device_code=challenge,
+            expires_at=expires_at,
+            epoch=_OPENAI_DEVICE_LOGIN_EPOCH,
+        )
     return SubscriptionDeviceStartResponse(
         device_code=token,
         user_code=challenge.user_code,
@@ -204,20 +211,36 @@ async def poll_openai_subscription_device_login(
     request: SubscriptionDevicePollRequest,
 ) -> SubscriptionStatusResponse:
     """Poll a ChatGPT device-code sign-in without returning tokens."""
-    _drop_expired_device_logins()
-    pending = _PENDING_OPENAI_DEVICE_LOGINS.get(request.device_code)
-    if pending is None:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="Subscription device login not found or expired",
-        )
+    async with _OPENAI_DEVICE_LOGIN_LOCK:
+        _drop_expired_device_logins()
+        pending = _PENDING_OPENAI_DEVICE_LOGINS.pop(request.device_code, None)
+        if pending is None:
+            if request.device_code in _IN_FLIGHT_OPENAI_DEVICE_LOGINS:
+                return SubscriptionStatusResponse(connected=False)
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="Subscription device login not found or expired",
+            )
+        _IN_FLIGHT_OPENAI_DEVICE_LOGINS.add(request.device_code)
 
     auth = _get_openai_subscription_auth()
-    credentials = await auth.poll_device_login(pending.device_code)
-    if credentials is None:
+    try:
+        credentials = await auth.poll_device_login(pending.device_code)
+    finally:
+        async with _OPENAI_DEVICE_LOGIN_LOCK:
+            _IN_FLIGHT_OPENAI_DEVICE_LOGINS.discard(request.device_code)
+
+    async with _OPENAI_DEVICE_LOGIN_LOCK:
+        current_epoch = _OPENAI_DEVICE_LOGIN_EPOCH
+        if credentials is None:
+            if pending.epoch == current_epoch:
+                _PENDING_OPENAI_DEVICE_LOGINS[request.device_code] = pending
+            return SubscriptionStatusResponse(connected=False)
+
+    if pending.epoch != current_epoch:
+        auth.logout()
         return SubscriptionStatusResponse(connected=False)
 
-    _PENDING_OPENAI_DEVICE_LOGINS.pop(request.device_code, None)
     return SubscriptionStatusResponse(connected=True, expires_at=credentials.expires_at)
 
 
@@ -226,6 +249,11 @@ async def poll_openai_subscription_device_login(
 )
 async def logout_openai_subscription() -> SubscriptionStatusResponse:
     """Remove stored ChatGPT subscription credentials."""
+    global _OPENAI_DEVICE_LOGIN_EPOCH
+
     auth = _get_openai_subscription_auth()
     auth.logout()
+    async with _OPENAI_DEVICE_LOGIN_LOCK:
+        _OPENAI_DEVICE_LOGIN_EPOCH += 1
+        _PENDING_OPENAI_DEVICE_LOGINS.clear()
     return SubscriptionStatusResponse(connected=False)

--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -230,6 +230,8 @@ async def poll_openai_subscription_device_login(
     finally:
         async with _OPENAI_DEVICE_LOGIN_LOCK:
             _IN_FLIGHT_OPENAI_DEVICE_LOGINS.discard(request.device_code)
+            # Keep the opaque poll token usable if the provider is still pending
+            # or if the polling request fails before credentials are obtained.
             if credentials is None and pending.epoch == _OPENAI_DEVICE_LOGIN_EPOCH:
                 _PENDING_OPENAI_DEVICE_LOGINS[request.device_code] = pending
 

--- a/openhands-agent-server/openhands/agent_server/llm_router.py
+++ b/openhands-agent-server/openhands/agent_server/llm_router.py
@@ -225,22 +225,25 @@ async def poll_openai_subscription_device_login(
 
     auth = _get_openai_subscription_auth()
     try:
-        credentials = await auth.poll_device_login(pending.device_code)
-    finally:
+        credentials = await auth.poll_device_login(pending.device_code, persist=False)
+    except BaseException:
         async with _OPENAI_DEVICE_LOGIN_LOCK:
             _IN_FLIGHT_OPENAI_DEVICE_LOGINS.discard(request.device_code)
+            if pending.epoch == _OPENAI_DEVICE_LOGIN_EPOCH:
+                _PENDING_OPENAI_DEVICE_LOGINS[request.device_code] = pending
+        raise
 
     async with _OPENAI_DEVICE_LOGIN_LOCK:
+        _IN_FLIGHT_OPENAI_DEVICE_LOGINS.discard(request.device_code)
         current_epoch = _OPENAI_DEVICE_LOGIN_EPOCH
         if credentials is None:
             if pending.epoch == current_epoch:
                 _PENDING_OPENAI_DEVICE_LOGINS[request.device_code] = pending
             return SubscriptionStatusResponse(connected=False)
+        if pending.epoch != current_epoch:
+            return SubscriptionStatusResponse(connected=False)
 
-    if pending.epoch != current_epoch:
-        auth.logout()
-        return SubscriptionStatusResponse(connected=False)
-
+    auth.save_credentials(credentials)
     return SubscriptionStatusResponse(connected=True, expires_at=credentials.expires_at)
 
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -873,7 +873,7 @@ class LocalConversation(BaseConversation):
         skip_lock = self._step_holds_state_lock and not self._state.owned()
         lock = contextlib.nullcontext() if skip_lock else self._state
         with lock:
-            update = {"llm": new_llm}
+            update: dict[str, object] = {"llm": new_llm}
             if new_llm.is_subscription:
                 update["condenser"] = None
             self.agent = self.agent.model_copy(update=update)

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -126,6 +126,7 @@ class LocalConversation(BaseConversation):
     _resolved_plugins: list[ResolvedPluginSource] | None
     _plugins_loaded: bool
     _pending_hook_config: HookConfig | None  # Hook config to combine with plugin hooks
+    _subscription_disabled_condenser: Any | None
 
     def __init__(
         self,
@@ -213,6 +214,7 @@ class LocalConversation(BaseConversation):
         self._plugins_loaded = False
         self._pending_hook_config = hook_config  # Will be combined with plugin hooks
         self._agent_ready = False  # Agent initialized lazily after plugins loaded
+        self._subscription_disabled_condenser = None
 
         # Create-or-resume: factory inspects BASE_STATE to decide
         desired_id = conversation_id or uuid.uuid4()
@@ -875,7 +877,15 @@ class LocalConversation(BaseConversation):
         with lock:
             update: dict[str, object] = {"llm": new_llm}
             if new_llm.is_subscription:
+                if self.agent.condenser is not None:
+                    self._subscription_disabled_condenser = self.agent.condenser
                 update["condenser"] = None
+            elif (
+                self.agent.condenser is None
+                and self._subscription_disabled_condenser is not None
+            ):
+                update["condenser"] = self._subscription_disabled_condenser
+                self._subscription_disabled_condenser = None
             self.agent = self.agent.model_copy(update=update)
             self._state.agent = self.agent
             self._pin_prompt_cache_key()

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -873,7 +873,10 @@ class LocalConversation(BaseConversation):
         skip_lock = self._step_holds_state_lock and not self._state.owned()
         lock = contextlib.nullcontext() if skip_lock else self._state
         with lock:
-            self.agent = self.agent.model_copy(update={"llm": new_llm})
+            update = {"llm": new_llm}
+            if new_llm.is_subscription:
+                update["condenser"] = None
+            self.agent = self.agent.model_copy(update=update)
             self._state.agent = self.agent
             self._pin_prompt_cache_key()
             self._pin_session_affinity_header(new_llm)

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -45,7 +45,7 @@ from openhands.sdk.event import (
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.hooks import HookConfig, HookEventProcessor, create_hook_callback
-from openhands.sdk.io import LocalFileStore
+from openhands.sdk.llm.auth.openai import create_subscription_llm_from_config
 from openhands.sdk.llm import LLM, Message, TextContent, content_to_str
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
@@ -860,7 +860,7 @@ class LocalConversation(BaseConversation):
         try:
             new_llm = self.llm_registry.get(llm.usage_id)
         except KeyError:
-            new_llm = llm
+            new_llm = create_subscription_llm_from_config(llm)
             self.llm_registry.add(new_llm)
         # A switch_llm tool runs on a worker thread while run()/arun() holds the
         # state lock across the agent step on another thread, blocked awaiting

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from collections.abc import Mapping
 from pathlib import Path
-from typing import TypeGuard
+from typing import Any, TypeGuard
 
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
@@ -45,8 +45,9 @@ from openhands.sdk.event import (
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.hooks import HookConfig, HookEventProcessor, create_hook_callback
-from openhands.sdk.llm.auth.openai import create_subscription_llm_from_config
+from openhands.sdk.io import LocalFileStore
 from openhands.sdk.llm import LLM, Message, TextContent, content_to_str
+from openhands.sdk.llm.auth.openai import create_subscription_llm_from_config
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger

--- a/openhands-sdk/openhands/sdk/llm/auth/__init__.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/__init__.py
@@ -12,6 +12,7 @@ from openhands.sdk.llm.auth.openai import (
     OPENAI_CODEX_MODELS,
     OpenAISubscriptionAuth,
     SupportedVendor,
+    create_subscription_llm_from_config,
     inject_system_prefix,
     transform_for_subscription,
 )
@@ -23,6 +24,7 @@ __all__ = [
     "OpenAISubscriptionAuth",
     "OPENAI_CODEX_MODELS",
     "SupportedVendor",
+    "create_subscription_llm_from_config",
     "inject_system_prefix",
     "transform_for_subscription",
 ]

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -830,6 +830,8 @@ class OpenAISubscriptionAuth:
         llm.temperature = None
         llm.auth_type = "subscription"
         llm.subscription_vendor = "openai"
+        llm._subscription_credential_store = self._credential_store
+        llm._subscription_credentials = creds
         return llm
 
 

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -899,6 +899,8 @@ def create_subscription_llm_from_config(llm: LLM) -> LLM:
     """Create a runtime subscription LLM from a serialized LLM config."""
     if getattr(llm, "auth_type", "api_key") != "subscription":
         return llm
+    if llm.is_subscription:
+        return llm
 
     vendor = llm.subscription_vendor or "openai"
     if vendor != "openai":

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -386,6 +386,23 @@ async def _refresh_access_token(refresh_token: str) -> dict[str, Any]:
         return response.json()
 
 
+def _refresh_access_token_sync(refresh_token: str) -> dict[str, Any]:
+    """Synchronously refresh the access token using a refresh token."""
+    with Client() as client:
+        response = client.post(
+            f"{ISSUER}/oauth/token",
+            data={
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": CLIENT_ID,
+            },
+            headers={"Content-Type": "application/x-www-form-urlencoded"},
+        )
+        if not response.is_success:
+            raise RuntimeError(f"Token refresh failed: {response.status_code}")
+        return response.json()
+
+
 # HTML templates for OAuth callback
 _HTML_SUCCESS = """<!DOCTYPE html>
 <html>
@@ -491,6 +508,24 @@ class OpenAISubscriptionAuth:
             expires_in=tokens.get("expires_in", 3600),
         )
         return updated
+
+    def refresh_if_needed_sync(self) -> OAuthCredentials | None:
+        """Synchronously refresh credentials if they are expired."""
+        creds = self.get_credentials()
+        if creds is None:
+            return None
+
+        if not creds.is_expired():
+            return creds
+
+        logger.info("Refreshing OpenAI access token")
+        tokens = _refresh_access_token_sync(creds.refresh_token)
+        return self._credential_store.update_tokens(
+            vendor=self.vendor,
+            access_token=tokens["access_token"],
+            refresh_token=tokens.get("refresh_token"),
+            expires_in=tokens.get("expires_in", 3600),
+        )
 
     async def login(
         self,
@@ -772,6 +807,8 @@ class OpenAISubscriptionAuth:
             temperature=None,
             max_output_tokens=None,
             stream=True,
+            auth_type="subscription",
+            subscription_vendor="openai",
             **llm_kwargs,
         )
         llm._is_subscription = True
@@ -779,6 +816,8 @@ class OpenAISubscriptionAuth:
         llm.max_output_tokens = None
         llm._effective_max_output_tokens = None
         llm.temperature = None
+        llm.auth_type = "subscription"
+        llm.subscription_vendor = "openai"
         return llm
 
 
@@ -856,18 +895,32 @@ def create_subscription_llm_from_config(llm: LLM) -> LLM:
         model = model.removeprefix("openai/")
 
     auth = OpenAISubscriptionAuth()
-    credentials = auth.get_credentials()
-    if credentials is None or credentials.is_expired():
+    credentials = auth.refresh_if_needed_sync()
+    if credentials is None:
         raise ValueError("OpenAI subscription login is required")
 
-    runtime_llm = auth.create_llm(
+    llm_kwargs = llm.model_dump(
+        exclude_none=True,
+        exclude_defaults=True,
+        exclude={
+            "model",
+            "api_key",
+            "base_url",
+            "auth_type",
+            "subscription_vendor",
+            "extra_headers",
+            "max_output_tokens",
+            "stream",
+            "temperature",
+        },
+    )
+    llm_kwargs["usage_id"] = llm.usage_id
+
+    return auth.create_llm(
         model=model,
         credentials=credentials,
-        usage_id=llm.usage_id,
+        **llm_kwargs,
     )
-    runtime_llm.auth_type = "subscription"
-    runtime_llm.subscription_vendor = "openai"
-    return runtime_llm
 
 
 def subscription_login(

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -329,31 +329,42 @@ async def _request_device_code() -> DeviceCode:
     )
 
 
+async def _poll_device_code_once(device_code: DeviceCode) -> dict[str, Any] | None:
+    """Poll once for an OpenAI device login result.
+
+    Returns ``None`` while authorization is still pending.
+    """
+    async with AsyncClient() as client:
+        response = await client.post(
+            f"{ISSUER}/api/accounts/deviceauth/token",
+            json={
+                "device_auth_id": device_code.device_auth_id,
+                "user_code": device_code.user_code,
+            },
+            headers={"Content-Type": "application/json"},
+        )
+
+    if response.is_success:
+        return response.json()
+
+    if response.status_code in (403, 404):
+        return None
+
+    raise RuntimeError(f"Device auth failed with status {response.status_code}")
+
+
 async def _poll_device_code(device_code: DeviceCode) -> dict[str, Any]:
     """Poll until OpenAI issues an authorization code for a device login."""
     deadline = time.monotonic() + DEVICE_CODE_TIMEOUT_SECONDS
 
-    async with AsyncClient() as client:
-        while time.monotonic() < deadline:
-            response = await client.post(
-                f"{ISSUER}/api/accounts/deviceauth/token",
-                json={
-                    "device_auth_id": device_code.device_auth_id,
-                    "user_code": device_code.user_code,
-                },
-                headers={"Content-Type": "application/json"},
-            )
+    while time.monotonic() < deadline:
+        token_response = await _poll_device_code_once(device_code)
+        if token_response is not None:
+            return token_response
 
-            if response.is_success:
-                return response.json()
-
-            if response.status_code in (403, 404):
-                await asyncio.sleep(
-                    min(device_code.interval, max(0, deadline - time.monotonic()))
-                )
-                continue
-
-            raise RuntimeError(f"Device auth failed with status {response.status_code}")
+        await asyncio.sleep(
+            min(device_code.interval, max(0, deadline - time.monotonic()))
+        )
 
     raise RuntimeError("Device auth timed out after 15 minutes")
 
@@ -623,6 +634,22 @@ class OpenAISubscriptionAuth:
         finally:
             await runner.cleanup()
 
+    async def start_device_login(self) -> DeviceCode:
+        """Start a device-code OAuth login flow without polling."""
+        return await _request_device_code()
+
+    async def poll_device_login(
+        self, device_code: DeviceCode
+    ) -> OAuthCredentials | None:
+        """Poll once for a device-code OAuth login result.
+
+        Returns ``None`` while authorization is still pending.
+        """
+        code_response = await _poll_device_code_once(device_code)
+        if code_response is None:
+            return None
+        return await self._complete_device_login(code_response)
+
     async def _login_with_device_code(self) -> OAuthCredentials:
         """Perform device-code OAuth login flow."""
         device_code = await _request_device_code()
@@ -640,6 +667,12 @@ class OpenAISubscriptionAuth:
         )
 
         code_response = await _poll_device_code(device_code)
+        return await self._complete_device_login(code_response)
+
+    async def _complete_device_login(
+        self, code_response: dict[str, Any]
+    ) -> OAuthCredentials:
+        """Exchange a completed device auth response and persist credentials."""
         try:
             authorization_code = code_response["authorization_code"]
             code_verifier = code_response["code_verifier"]
@@ -807,6 +840,34 @@ async def subscription_login_async(
     # Perform login
     creds = await auth.login(open_browser=open_browser, auth_method=auth_method)
     return auth.create_llm(model=model, credentials=creds, **llm_kwargs)
+
+
+def create_subscription_llm_from_config(llm: LLM) -> LLM:
+    """Create a runtime subscription LLM from a serialized LLM config."""
+    if getattr(llm, "auth_type", "api_key") != "subscription":
+        return llm
+
+    vendor = llm.subscription_vendor or "openai"
+    if vendor != "openai":
+        raise ValueError(f"Unsupported subscription vendor: {vendor}")
+
+    model = llm.model
+    if model.startswith("openai/"):
+        model = model.removeprefix("openai/")
+
+    auth = OpenAISubscriptionAuth()
+    credentials = auth.get_credentials()
+    if credentials is None or credentials.is_expired():
+        raise ValueError("OpenAI subscription login is required")
+
+    runtime_llm = auth.create_llm(
+        model=model,
+        credentials=credentials,
+        usage_id=llm.usage_id,
+    )
+    runtime_llm.auth_type = "subscription"
+    runtime_llm.subscription_vendor = "openai"
+    return runtime_llm
 
 
 def subscription_login(

--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -674,7 +674,7 @@ class OpenAISubscriptionAuth:
         return await _request_device_code()
 
     async def poll_device_login(
-        self, device_code: DeviceCode
+        self, device_code: DeviceCode, *, persist: bool = True
     ) -> OAuthCredentials | None:
         """Poll once for a device-code OAuth login result.
 
@@ -683,7 +683,7 @@ class OpenAISubscriptionAuth:
         code_response = await _poll_device_code_once(device_code)
         if code_response is None:
             return None
-        return await self._complete_device_login(code_response)
+        return await self._complete_device_login(code_response, persist=persist)
 
     async def _login_with_device_code(self) -> OAuthCredentials:
         """Perform device-code OAuth login flow."""
@@ -705,9 +705,12 @@ class OpenAISubscriptionAuth:
         return await self._complete_device_login(code_response)
 
     async def _complete_device_login(
-        self, code_response: dict[str, Any]
+        self, code_response: dict[str, Any], *, persist: bool = True
     ) -> OAuthCredentials:
-        """Exchange a completed device auth response and persist credentials."""
+        """Exchange a completed device auth response.
+
+        Optionally persists credentials after the exchange succeeds.
+        """
         try:
             authorization_code = code_response["authorization_code"]
             code_verifier = code_response["code_verifier"]
@@ -727,9 +730,18 @@ class OpenAISubscriptionAuth:
             refresh_token=tokens["refresh_token"],
             expires_at=expires_at,
         )
-        self._credential_store.save(credentials)
+        if persist:
+            self.save_credentials(credentials)
         logger.info("OpenAI device-code login successful")
         return credentials
+
+    def save_credentials(self, credentials: OAuthCredentials) -> None:
+        """Persist OpenAI subscription credentials."""
+        self._credential_store.save(credentials)
+
+    def extract_chatgpt_account_id(self, credentials: OAuthCredentials) -> str | None:
+        """Return the ChatGPT account id for request headers, if present."""
+        return _extract_chatgpt_account_id(credentials.access_token)
 
     def logout(self) -> bool:
         """Remove stored credentials.
@@ -801,7 +813,7 @@ class OpenAISubscriptionAuth:
         llm = LLM(
             model=f"openai/{model}",
             base_url=CODEX_API_ENDPOINT.rsplit("/", 1)[0],
-            api_key=creds.access_token,
+            api_key=None,
             extra_headers=extra_headers,
             litellm_extra_body=extra_body,
             temperature=None,

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1762,7 +1762,20 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
     def _get_litellm_api_key_value(self) -> str | None:
         api_key_value: str | None = None
-        if self.api_key:
+        if self.is_subscription:
+            from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
+
+            auth = OpenAISubscriptionAuth()
+            credentials = auth.refresh_if_needed_sync()
+            if credentials is None:
+                raise ValueError("OpenAI subscription login is required")
+            api_key_value = credentials.access_token
+            account_id = auth.extract_chatgpt_account_id(credentials)
+            self.extra_headers = {
+                **(self.extra_headers or {}),
+                **({"chatgpt-account-id": account_id} if account_id else {}),
+            }
+        elif self.api_key:
             assert isinstance(self.api_key, SecretStr)
             api_key_value = self.api_key.get_secret_value()
 
@@ -2366,6 +2379,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def to_persisted(self, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
         """Serialize this LLM for profile persistence."""
         data = self.model_dump(mode="json", exclude_none=True, context=context)
+        if data.get("auth_type") == "subscription":
+            data.pop("api_key", None)
+            data.pop("base_url", None)
+            data.pop("extra_headers", None)
         data["schema_version"] = LLM_PROFILE_SCHEMA_VERSION
         return data
 

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -845,17 +845,29 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         instructions: str | None,
         resp_tools: list[Any] | None,
         final_kwargs: dict[str, Any],
+        auth_values: tuple[str | None, dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         """Build the shared kwargs dict for litellm_responses / litellm_aresponses."""
         typed_input: ResponseInputParam | str = (
             cast(ResponseInputParam, input_items) if input_items else ""
         )
+        api_key_value, subscription_headers = (
+            auth_values if auth_values is not None else self._get_litellm_auth_values()
+        )
+        if subscription_headers:
+            final_kwargs = {
+                **final_kwargs,
+                "extra_headers": {
+                    **(final_kwargs.get("extra_headers") or {}),
+                    **subscription_headers,
+                },
+            }
         return {
             **self._litellm_call_kwargs(),
             "input": typed_input,
             "instructions": instructions,
             "tools": resp_tools,
-            "api_key": self._get_litellm_api_key_value(),
+            "api_key": api_key_value,
             "api_version": self.api_version,
             "timeout": self.timeout,
             "drop_params": self.drop_params,
@@ -1649,8 +1661,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             with self._litellm_modify_params_ctx(self.modify_params):
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=DeprecationWarning)
+                    auth_values = await self._aget_litellm_auth_values()
                     litellm_kwargs = self._build_responses_call_kwargs(
-                        input_items, instructions, resp_tools, final_kwargs
+                        input_items,
+                        instructions,
+                        resp_tools,
+                        final_kwargs,
+                        auth_values=auth_values,
                     )
                     ret = await litellm_aresponses(**litellm_kwargs)
 
@@ -1762,36 +1779,79 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         return self._infer_litellm_provider()
 
-    def _get_litellm_api_key_value(self) -> str | None:
-        api_key_value: str | None = None
-        if self.is_subscription:
-            from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
+    def _subscription_headers_from_credentials(
+        self, auth: Any, credentials: Any
+    ) -> dict[str, str]:
+        account_id = auth.extract_chatgpt_account_id(credentials)
+        if not account_id:
+            return {}
+        return {"chatgpt-account-id": account_id}
 
-            auth = OpenAISubscriptionAuth(
-                credential_store=self._subscription_credential_store
-            )
-            credentials = auth.refresh_if_needed_sync()
-            if credentials is None:
-                credentials = self._subscription_credentials
-            if credentials is None:
-                raise ValueError("OpenAI subscription login is required")
-            api_key_value = credentials.access_token
-            account_id = auth.extract_chatgpt_account_id(credentials)
-            self.extra_headers = {
-                **(self.extra_headers or {}),
-                **({"chatgpt-account-id": account_id} if account_id else {}),
-            }
-        elif self.api_key:
-            assert isinstance(self.api_key, SecretStr)
-            api_key_value = self.api_key.get_secret_value()
+    def _subscription_api_key_from_credentials(self, credentials: Any) -> str:
+        return credentials.access_token
 
+    def _normalize_litellm_api_key_value(self, api_key_value: str | None) -> str | None:
         # LiteLLM treats api_key for Bedrock as an AWS bearer token.
         # Passing a non-Bedrock key (e.g. OpenAI/Anthropic) can cause Bedrock
         # to reject the request with an "Invalid API Key format" error.
         # For IAM/SigV4 auth (the default Bedrock path), do not forward api_key.
         if api_key_value is not None and self._infer_litellm_provider() == "bedrock":
             return None
+        return api_key_value
 
+    def _get_litellm_auth_values(self) -> tuple[str | None, dict[str, str]]:
+        api_key_value: str | None = None
+        extra_headers: dict[str, str] = {}
+        if self.is_subscription:
+            from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
+
+            auth = OpenAISubscriptionAuth(
+                credential_store=self._subscription_credential_store
+            )
+            credentials = self._subscription_credentials
+            if credentials is None or credentials.is_expired():
+                credentials = auth.refresh_if_needed_sync()
+            if credentials is None:
+                credentials = self._subscription_credentials
+            if credentials is None:
+                raise ValueError("OpenAI subscription login is required")
+            api_key_value = self._subscription_api_key_from_credentials(credentials)
+            extra_headers = self._subscription_headers_from_credentials(
+                auth, credentials
+            )
+        elif self.api_key:
+            assert isinstance(self.api_key, SecretStr)
+            api_key_value = self.api_key.get_secret_value()
+
+        return self._normalize_litellm_api_key_value(api_key_value), extra_headers
+
+    def _get_litellm_api_key_value(self) -> str | None:
+        api_key_value, _ = self._get_litellm_auth_values()
+        return api_key_value
+
+    async def _aget_litellm_auth_values(self) -> tuple[str | None, dict[str, str]]:
+        if not self.is_subscription:
+            return self._get_litellm_auth_values()
+
+        from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
+
+        auth = OpenAISubscriptionAuth(
+            credential_store=self._subscription_credential_store
+        )
+        credentials = await auth.refresh_if_needed()
+        if credentials is None:
+            credentials = self._subscription_credentials
+        if credentials is None:
+            raise ValueError("OpenAI subscription login is required")
+        api_key_value = self._normalize_litellm_api_key_value(
+            self._subscription_api_key_from_credentials(credentials)
+        )
+        return api_key_value, self._subscription_headers_from_credentials(
+            auth, credentials
+        )
+
+    async def _aget_litellm_api_key_value(self) -> str | None:
+        api_key_value, _ = await self._aget_litellm_auth_values()
         return api_key_value
 
     @contextmanager
@@ -1829,6 +1889,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         *,
         messages: list[dict[str, Any]],
         enable_streaming: bool,
+        auth_values: tuple[str | None, dict[str, str]] | None = None,
         **kwargs,
     ) -> dict[str, Any]:
         """Build the keyword arguments for a litellm (a)completion call."""
@@ -1837,9 +1898,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # not silently discarded by litellm's streaming handler.
         if enable_streaming:
             kwargs.setdefault("stream_options", {"include_usage": True})
+        api_key_value, subscription_headers = (
+            auth_values if auth_values is not None else self._get_litellm_auth_values()
+        )
+        if subscription_headers:
+            kwargs["extra_headers"] = {
+                **(kwargs.get("extra_headers") or {}),
+                **subscription_headers,
+            }
         return {
             **self._litellm_call_kwargs(),
-            "api_key": self._get_litellm_api_key_value(),
+            "api_key": api_key_value,
             "api_version": self.api_version,
             "timeout": self.timeout,
             "drop_params": self.drop_params,
@@ -1885,10 +1954,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         **kwargs,
     ) -> ModelResponse:
         """Async variant of :meth:`_transport_call`."""
+        auth_values = await self._aget_litellm_auth_values()
         with self._transport_ctx():
             ret = await litellm_acompletion(
                 **self._prepare_transport_kwargs(
-                    messages=messages, enable_streaming=enable_streaming, **kwargs
+                    messages=messages,
+                    enable_streaming=enable_streaming,
+                    auth_values=auth_values,
+                    **kwargs,
                 )
             )
             if enable_streaming and on_token is not None:
@@ -2473,7 +2546,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             v = _cast_value(value, fields[field_name])
             if v is not None:
                 data[field_name] = v
-        return cls(**data)
+        llm = cls(**data)
+        if llm.auth_type == "subscription":
+            from openhands.sdk.llm.auth.openai import (
+                create_subscription_llm_from_config,
+            )
+
+            return create_subscription_llm_from_config(llm)
+        return llm
 
     @classmethod
     def subscription_login(

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -221,6 +221,23 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             label="API Key",
         ),
     )
+    auth_type: Literal["api_key", "subscription"] = Field(
+        default="api_key",
+        description="Authentication mode for the LLM.",
+        json_schema_extra=field_meta(
+            SettingProminence.CRITICAL,
+            label="Authentication",
+        ),
+    )
+    subscription_vendor: Literal["openai"] | None = Field(
+        default=None,
+        description="Subscription provider for subscription-backed LLM access.",
+        json_schema_extra=field_meta(
+            SettingProminence.CRITICAL,
+            label="Subscription provider",
+            depends_on=("auth_type",),
+        ),
+    )
     base_url: str | None = Field(
         default=None,
         description="Custom base URL.",

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -519,6 +519,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     _tokenizer: Any = PrivateAttr(default=None)
     _telemetry: Telemetry | None = PrivateAttr(default=None)
     _is_subscription: bool = PrivateAttr(default=False)
+    _subscription_credential_store: Any = PrivateAttr(default=None)
+    _subscription_credentials: Any = PrivateAttr(default=None)
     _litellm_provider: str | None = PrivateAttr(default=None)
     _prompt_cache_key: str | None = PrivateAttr(default=None)
     _effective_max_input_tokens: int | None = PrivateAttr(default=None)
@@ -1765,8 +1767,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         if self.is_subscription:
             from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
 
-            auth = OpenAISubscriptionAuth()
+            auth = OpenAISubscriptionAuth(
+                credential_store=self._subscription_credential_store
+            )
             credentials = auth.refresh_if_needed_sync()
+            if credentials is None:
+                credentials = self._subscription_credentials
             if credentials is None:
                 raise ValueError("OpenAI subscription login is required")
             api_key_value = credentials.access_token
@@ -2374,7 +2380,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         payload.pop("schema_version", None)
         payload = canonicalize_openhands_llm_payload(payload)
-        return cls.model_validate(payload, context=context)
+        llm = cls.model_validate(payload, context=context)
+        if llm.auth_type == "subscription":
+            from openhands.sdk.llm.auth.openai import (
+                create_subscription_llm_from_config,
+            )
+
+            return create_subscription_llm_from_config(llm)
+        return llm
 
     def to_persisted(self, *, context: dict[str, Any] | None = None) -> dict[str, Any]:
         """Serialize this LLM for profile persistence."""

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1100,6 +1100,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             agent = settings.create_agent()
         """
         from openhands.sdk.agent import Agent
+        from openhands.sdk.llm.auth.openai import create_subscription_llm_from_config
         from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, SwitchLLMTool
 
         # Bypass ``_serialize_mcp_config``: MCP servers need real env/headers.
@@ -1112,13 +1113,14 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         if self.enable_switch_llm_tool:
             include_default_tools.append(SwitchLLMTool.__name__)
 
+        llm = create_subscription_llm_from_config(self.llm)
         return Agent(
-            llm=self.llm,
+            llm=llm,
             tools=self.tools,
             mcp_config=mcp_config,
             include_default_tools=include_default_tools,
             agent_context=self.agent_context,
-            condenser=self.build_condenser(self.llm),
+            condenser=self.build_condenser(llm),
             critic=self.build_critic(),
             tool_concurrency_limit=self.tool_concurrency_limit,
         )

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1114,13 +1114,14 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             include_default_tools.append(SwitchLLMTool.__name__)
 
         llm = create_subscription_llm_from_config(self.llm)
+        condenser = None if llm.is_subscription else self.build_condenser(llm)
         return Agent(
             llm=llm,
             tools=self.tools,
             mcp_config=mcp_config,
             include_default_tools=include_default_tools,
             agent_context=self.agent_context,
-            condenser=self.build_condenser(llm),
+            condenser=condenser,
             critic=self.build_critic(),
             tool_concurrency_limit=self.tool_concurrency_limit,
         )

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -110,3 +110,146 @@ def test_verified_models_endpoint_integration(client):
     assert "models" in data
     assert "openai" in data["models"]
     assert "anthropic" in data["models"]
+
+
+def test_openai_subscription_status_endpoint_does_not_return_tokens(
+    client, monkeypatch
+):
+    """Status reports safe metadata without exposing OAuth tokens."""
+    from openhands.agent_server import llm_router
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+
+    class FakeAuth:
+        async def refresh_if_needed(self):
+            return OAuthCredentials(
+                vendor="openai",
+                access_token="access-token",
+                refresh_token="refresh-token",
+                expires_at=4_102_444_800_000,
+            )
+
+        def get_credentials(self):
+            return OAuthCredentials(
+                vendor="openai",
+                access_token="access-token",
+                refresh_token="refresh-token",
+                expires_at=4_102_444_800_000,
+            )
+
+    monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
+
+    response = client.get("/api/llm/subscription/openai/status")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data == {
+        "vendor": "openai",
+        "connected": True,
+        "account_email": None,
+        "expires_at": 4_102_444_800_000,
+    }
+    assert "access_token" not in response.text
+    assert "refresh_token" not in response.text
+
+
+def test_openai_subscription_device_start_returns_opaque_poll_token(
+    client, monkeypatch
+):
+    """Device start stores OpenAI internals server-side."""
+    from openhands.agent_server import llm_router
+    from openhands.sdk.llm.auth.openai import DeviceCode
+
+    class FakeAuth:
+        async def start_device_login(self):
+            return DeviceCode(
+                verification_url="https://auth.example/device",
+                user_code="ABCD-EFGH",
+                device_auth_id="openai-device-auth-id",
+                interval=7,
+            )
+
+    monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
+    monkeypatch.setattr(llm_router.secrets, "token_urlsafe", lambda _: "opaque-token")
+
+    response = client.post("/api/llm/subscription/openai/device/start")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["device_code"] == "opaque-token"
+    assert data["user_code"] == "ABCD-EFGH"
+    assert data["verification_uri"] == "https://auth.example/device"
+    assert data["interval_seconds"] == 7
+    assert "openai-device-auth-id" not in response.text
+
+
+def test_openai_subscription_device_poll_pending_and_success(client, monkeypatch):
+    """Polling returns disconnected while pending and connected after success."""
+    from openhands.agent_server import llm_router
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+    from openhands.sdk.llm.auth.openai import DeviceCode
+
+    llm_router._PENDING_OPENAI_DEVICE_LOGINS.clear()
+    llm_router._PENDING_OPENAI_DEVICE_LOGINS["opaque-token"] = (
+        llm_router.PendingDeviceLogin(
+            device_code=DeviceCode(
+                verification_url="https://auth.example/device",
+                user_code="ABCD-EFGH",
+                device_auth_id="openai-device-auth-id",
+                interval=1,
+            ),
+            expires_at=int(llm_router.time.time() * 1000) + 60_000,
+        )
+    )
+
+    class FakeAuth:
+        calls = 0
+
+        async def poll_device_login(self, device_code):
+            self.__class__.calls += 1
+            if self.__class__.calls == 1:
+                return None
+            return OAuthCredentials(
+                vendor="openai",
+                access_token="access-token",
+                refresh_token="refresh-token",
+                expires_at=4_102_444_800_000,
+            )
+
+    monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
+
+    pending = client.post(
+        "/api/llm/subscription/openai/device/poll",
+        json={"device_code": "opaque-token"},
+    )
+    success = client.post(
+        "/api/llm/subscription/openai/device/poll",
+        json={"device_code": "opaque-token"},
+    )
+
+    assert pending.status_code == 200
+    assert pending.json()["connected"] is False
+    assert success.status_code == 200
+    assert success.json()["connected"] is True
+    assert success.json()["expires_at"] == 4_102_444_800_000
+    assert "access-token" not in success.text
+    assert "opaque-token" not in llm_router._PENDING_OPENAI_DEVICE_LOGINS
+
+
+def test_openai_subscription_logout_endpoint(client, monkeypatch):
+    """Logout removes credentials and returns disconnected status."""
+    from openhands.agent_server import llm_router
+
+    class FakeAuth:
+        logged_out = False
+
+        def logout(self):
+            self.__class__.logged_out = True
+            return True
+
+    monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
+
+    response = client.post("/api/llm/subscription/openai/logout")
+
+    assert response.status_code == 200
+    assert response.json()["connected"] is False
+    assert FakeAuth.logged_out is True

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -136,9 +136,6 @@ def test_openai_subscription_status_endpoint_does_not_return_tokens(
                 expires_at=4_102_444_800_000,
             )
 
-        def save_credentials(self, credentials):
-            self.__class__.saved_credentials = credentials
-
     monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
 
     response = client.get("/api/llm/subscription/openai/status")

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -136,6 +136,9 @@ def test_openai_subscription_status_endpoint_does_not_return_tokens(
                 expires_at=4_102_444_800_000,
             )
 
+        def save_credentials(self, credentials):
+            self.__class__.saved_credentials = credentials
+
     monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
 
     response = client.get("/api/llm/subscription/openai/status")
@@ -205,7 +208,10 @@ def test_openai_subscription_device_poll_pending_and_success(client, monkeypatch
     class FakeAuth:
         calls = 0
 
-        async def poll_device_login(self, device_code):
+        saved_credentials = None
+
+        async def poll_device_login(self, device_code, *, persist=True):
+            assert persist is False
             self.__class__.calls += 1
             if self.__class__.calls == 1:
                 return None
@@ -215,6 +221,9 @@ def test_openai_subscription_device_poll_pending_and_success(client, monkeypatch
                 refresh_token="refresh-token",
                 expires_at=4_102_444_800_000,
             )
+
+        def save_credentials(self, credentials):
+            self.__class__.saved_credentials = credentials
 
     monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
 
@@ -232,6 +241,7 @@ def test_openai_subscription_device_poll_pending_and_success(client, monkeypatch
     assert success.status_code == 200
     assert success.json()["connected"] is True
     assert success.json()["expires_at"] == 4_102_444_800_000
+    assert FakeAuth.saved_credentials is not None
     assert "access-token" not in success.text
     assert "opaque-token" not in llm_router._PENDING_OPENAI_DEVICE_LOGINS
 

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -243,6 +243,67 @@ def test_openai_subscription_device_poll_pending_and_success(client, monkeypatch
     assert "opaque-token" not in llm_router._PENDING_OPENAI_DEVICE_LOGINS
 
 
+@pytest.mark.asyncio
+async def test_openai_subscription_device_poll_failure_keeps_pending_login(
+    monkeypatch,
+):
+    """Transient provider failures do not consume the opaque poll token."""
+    from openhands.agent_server import llm_router
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+    from openhands.sdk.llm.auth.openai import DeviceCode
+
+    llm_router._PENDING_OPENAI_DEVICE_LOGINS.clear()
+    llm_router._IN_FLIGHT_OPENAI_DEVICE_LOGINS.clear()
+    llm_router._PENDING_OPENAI_DEVICE_LOGINS["opaque-token"] = (
+        llm_router.PendingDeviceLogin(
+            device_code=DeviceCode(
+                verification_url="https://auth.example/device",
+                user_code="ABCD-EFGH",
+                device_auth_id="openai-device-auth-id",
+                interval=1,
+            ),
+            expires_at=int(llm_router.time.time() * 1000) + 60_000,
+            epoch=llm_router._OPENAI_DEVICE_LOGIN_EPOCH,
+        )
+    )
+
+    class FakeAuth:
+        calls = 0
+        saved_credentials = None
+
+        async def poll_device_login(self, device_code, *, persist=True):
+            assert persist is False
+            self.__class__.calls += 1
+            if self.__class__.calls == 1:
+                raise RuntimeError("temporary provider failure")
+            return OAuthCredentials(
+                vendor="openai",
+                access_token="access-token",
+                refresh_token="refresh-token",
+                expires_at=4_102_444_800_000,
+            )
+
+        def save_credentials(self, credentials):
+            self.__class__.saved_credentials = credentials
+
+    monkeypatch.setattr(llm_router, "_get_openai_subscription_auth", FakeAuth)
+
+    with pytest.raises(RuntimeError, match="temporary provider failure"):
+        await llm_router.poll_openai_subscription_device_login(
+            llm_router.SubscriptionDevicePollRequest(device_code="opaque-token")
+        )
+    assert "opaque-token" in llm_router._PENDING_OPENAI_DEVICE_LOGINS
+
+    success = await llm_router.poll_openai_subscription_device_login(
+        llm_router.SubscriptionDevicePollRequest(device_code="opaque-token")
+    )
+
+    assert success.connected is True
+    assert FakeAuth.saved_credentials is not None
+    assert "opaque-token" not in llm_router._PENDING_OPENAI_DEVICE_LOGINS
+    assert "opaque-token" not in llm_router._IN_FLIGHT_OPENAI_DEVICE_LOGINS
+
+
 def test_openai_subscription_logout_endpoint(client, monkeypatch):
     """Logout removes credentials and returns disconnected status."""
     from openhands.agent_server import llm_router

--- a/tests/agent_server/test_llm_router.py
+++ b/tests/agent_server/test_llm_router.py
@@ -198,6 +198,7 @@ def test_openai_subscription_device_poll_pending_and_success(client, monkeypatch
                 interval=1,
             ),
             expires_at=int(llm_router.time.time() * 1000) + 60_000,
+            epoch=llm_router._OPENAI_DEVICE_LOGIN_EPOCH,
         )
     )
 
@@ -239,6 +240,19 @@ def test_openai_subscription_logout_endpoint(client, monkeypatch):
     """Logout removes credentials and returns disconnected status."""
     from openhands.agent_server import llm_router
 
+    llm_router._PENDING_OPENAI_DEVICE_LOGINS["opaque-token"] = (
+        llm_router.PendingDeviceLogin(
+            device_code=llm_router.DeviceCode(
+                verification_url="https://auth.example/device",
+                user_code="ABCD-EFGH",
+                device_auth_id="openai-device-auth-id",
+                interval=1,
+            ),
+            expires_at=int(llm_router.time.time() * 1000) + 60_000,
+            epoch=llm_router._OPENAI_DEVICE_LOGIN_EPOCH,
+        )
+    )
+
     class FakeAuth:
         logged_out = False
 
@@ -253,3 +267,4 @@ def test_openai_subscription_logout_endpoint(client, monkeypatch):
     assert response.status_code == 200
     assert response.json()["connected"] is False
     assert FakeAuth.logged_out is True
+    assert llm_router._PENDING_OPENAI_DEVICE_LOGINS == {}

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -487,7 +487,8 @@ def test_switch_llm_to_subscription_profile_disables_condenser(
 
     def fake_create_subscription_llm_from_config(llm: LLM) -> LLM:
         runtime = llm.model_copy()
-        runtime._is_subscription = True
+        if llm.auth_type == "subscription":
+            runtime._is_subscription = True
         return runtime
 
     monkeypatch.setattr(
@@ -508,3 +509,9 @@ def test_switch_llm_to_subscription_profile_disables_condenser(
     assert conv.agent.llm.is_subscription
     assert conv.agent.condenser is None
     assert conv.state.agent.condenser is None
+
+    conv.switch_llm(_make_llm("regular-model", "regular"))
+
+    assert conv.agent.llm.model == "regular-model"
+    assert conv.agent.condenser is condenser
+    assert conv.state.agent.condenser is condenser

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -463,3 +463,48 @@ def test_switch_llm_tool_during_arun_does_not_deadlock(profile_store, tmp_path):
     assert conv.state.execution_status == ConversationExecutionStatus.FINISHED
     # The switch took effect: the agent now carries the 'fast' profile's model.
     assert conv.agent.llm.model == "fast-model"
+
+
+def test_switch_llm_to_subscription_profile_disables_condenser(
+    monkeypatch, empty_profile_store
+):
+    import openhands.sdk.conversation.impl.local_conversation as local_conversation
+
+    condenser = LLMSummarizingCondenser(
+        llm=_make_llm("condenser-model", "condenser"),
+        max_size=100,
+        keep_first=5,
+    )
+    conv = LocalConversation(
+        agent=Agent(
+            llm=_make_llm("default-model", "test-llm"),
+            tools=[],
+            condenser=condenser,
+        ),
+        workspace=Path.cwd(),
+    )
+    assert conv.agent.condenser is condenser
+
+    def fake_create_subscription_llm_from_config(llm: LLM) -> LLM:
+        runtime = llm.model_copy()
+        runtime._is_subscription = True
+        return runtime
+
+    monkeypatch.setattr(
+        local_conversation,
+        "create_subscription_llm_from_config",
+        fake_create_subscription_llm_from_config,
+    )
+
+    conv.switch_llm(
+        LLM(
+            model="gpt-5.2-codex",
+            usage_id="profile:codex",
+            auth_type="subscription",
+            subscription_vendor="openai",
+        )
+    )
+
+    assert conv.agent.llm.is_subscription
+    assert conv.agent.condenser is None
+    assert conv.state.agent.condenser is None

--- a/tests/sdk/llm/auth/test_openai.py
+++ b/tests/sdk/llm/auth/test_openai.py
@@ -205,6 +205,7 @@ def test_openai_subscription_auth_create_llm_success(tmp_path):
 
     assert llm.model == "openai/gpt-5.2-codex"
     assert llm.api_key is None
+    assert llm._get_litellm_api_key_value() == "test_access_token"
     assert llm.auth_type == "subscription"
     assert llm.subscription_vendor == "openai"
     assert llm.extra_headers is not None

--- a/tests/sdk/llm/auth/test_openai.py
+++ b/tests/sdk/llm/auth/test_openai.py
@@ -204,7 +204,9 @@ def test_openai_subscription_auth_create_llm_success(tmp_path):
     llm = auth.create_llm(model="gpt-5.2-codex")
 
     assert llm.model == "openai/gpt-5.2-codex"
-    assert llm.api_key is not None
+    assert llm.api_key is None
+    assert llm.auth_type == "subscription"
+    assert llm.subscription_vendor == "openai"
     assert llm.extra_headers is not None
     # Uses codex_cli_rs to match official Codex CLI for compatibility
     assert llm.extra_headers.get("originator") == "codex_cli_rs"

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1735,3 +1735,75 @@ def test_llm_create_agent_resolves_subscription_llm(monkeypatch) -> None:
 
     assert agent.llm is runtime_llm
     assert agent.llm.is_subscription is True
+
+
+def test_openai_subscription_create_llm_serializes_subscription_auth(
+    monkeypatch,
+) -> None:
+    import openhands.sdk.llm.auth.openai as openai_auth
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+    from openhands.sdk.llm.auth.openai import OpenAISubscriptionAuth
+
+    monkeypatch.setattr(openai_auth, "_extract_chatgpt_account_id", lambda _: None)
+
+    llm = OpenAISubscriptionAuth().create_llm(
+        model="gpt-5.2-codex",
+        credentials=OAuthCredentials(
+            vendor="openai",
+            access_token="access-token",
+            refresh_token="refresh-token",
+            expires_at=4_102_444_800_000,
+        ),
+        usage_id="profile:test",
+    )
+
+    assert llm.auth_type == "subscription"
+    assert llm.subscription_vendor == "openai"
+    assert llm.to_persisted()["auth_type"] == "subscription"
+    assert llm.to_persisted()["subscription_vendor"] == "openai"
+
+
+def test_create_subscription_llm_from_config_preserves_non_auth_options(
+    monkeypatch,
+) -> None:
+    import openhands.sdk.llm.auth.openai as openai_auth
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+
+    captured: dict[str, object] = {}
+
+    class FakeAuth:
+        def refresh_if_needed_sync(self):
+            return OAuthCredentials(
+                vendor="openai",
+                access_token="access-token",
+                refresh_token="refresh-token",
+                expires_at=4_102_444_800_000,
+            )
+
+        def create_llm(self, **kwargs):
+            captured.update(kwargs)
+            return LLM(
+                model=f"openai/{kwargs['model']}",
+                auth_type="subscription",
+                subscription_vendor="openai",
+                usage_id=kwargs["usage_id"],
+                timeout=kwargs["timeout"],
+            )
+
+    monkeypatch.setattr(openai_auth, "OpenAISubscriptionAuth", FakeAuth)
+    source = LLM(
+        model="gpt-5.2-codex",
+        auth_type="subscription",
+        subscription_vendor="openai",
+        usage_id="profile:test",
+        timeout=123,
+    )
+
+    runtime = openai_auth.create_subscription_llm_from_config(source)
+
+    assert runtime.usage_id == "profile:test"
+    assert runtime.timeout == 123
+    assert captured["usage_id"] == "profile:test"
+    assert captured["timeout"] == 123
+    assert "api_key" not in captured
+    assert "base_url" not in captured

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1846,9 +1846,49 @@ async def test_async_subscription_api_key_uses_async_refresh(monkeypatch) -> Non
     )
     llm._is_subscription = True
 
-    assert await llm._aget_litellm_api_key_value() == "access-token"
-    assert llm.extra_headers is not None
-    assert llm.extra_headers["chatgpt-account-id"] == "account-id"
+    api_key, extra_headers = await llm._aget_litellm_auth_values()
+    assert api_key == "access-token"
+    assert extra_headers["chatgpt-account-id"] == "account-id"
+    assert llm.extra_headers is None
+
+
+def test_sync_subscription_api_key_uses_valid_runtime_credentials(
+    monkeypatch,
+) -> None:
+    import openhands.sdk.llm.auth.openai as openai_auth
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+
+    credentials = OAuthCredentials(
+        vendor="openai",
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=4_102_444_800_000,
+    )
+
+    class FakeAuth:
+        def __init__(self, credential_store=None):
+            self.credential_store = credential_store
+
+        def refresh_if_needed_sync(self):
+            raise AssertionError("valid runtime credentials should not sync-refresh")
+
+        def extract_chatgpt_account_id(self, refreshed_credentials):
+            assert refreshed_credentials is credentials
+            return "account-id"
+
+    monkeypatch.setattr(openai_auth, "OpenAISubscriptionAuth", FakeAuth)
+    llm = LLM(
+        model="openai/gpt-5.2-codex",
+        auth_type="subscription",
+        subscription_vendor="openai",
+    )
+    llm._is_subscription = True
+    llm._subscription_credentials = credentials
+
+    api_key, extra_headers = llm._get_litellm_auth_values()
+    assert api_key == "access-token"
+    assert extra_headers["chatgpt-account-id"] == "account-id"
+    assert llm.extra_headers is None
 
 
 def test_openai_subscription_create_llm_serializes_subscription_auth(

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1759,8 +1759,11 @@ def test_openai_subscription_create_llm_serializes_subscription_auth(
 
     assert llm.auth_type == "subscription"
     assert llm.subscription_vendor == "openai"
+    assert llm.api_key is None
     assert llm.to_persisted()["auth_type"] == "subscription"
     assert llm.to_persisted()["subscription_vendor"] == "openai"
+    assert "api_key" not in llm.to_persisted(context={"expose_secrets": "plaintext"})
+    assert "base_url" not in llm.to_persisted()
 
 
 def test_create_subscription_llm_from_config_preserves_non_auth_options(

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1737,6 +1737,36 @@ def test_llm_create_agent_resolves_subscription_llm(monkeypatch) -> None:
     assert agent.llm.is_subscription is True
 
 
+def test_llm_from_persisted_rehydrates_subscription_runtime(monkeypatch) -> None:
+    from openhands.sdk.llm.auth import openai
+
+    runtime_llm = LLM(model="openai/gpt-5.2-codex", auth_type="subscription")
+    runtime_llm._is_subscription = True
+
+    def fake_create_subscription_llm_from_config(llm: LLM) -> LLM:
+        assert llm.auth_type == "subscription"
+        assert llm.subscription_vendor == "openai"
+        return runtime_llm
+
+    monkeypatch.setattr(
+        openai,
+        "create_subscription_llm_from_config",
+        fake_create_subscription_llm_from_config,
+    )
+
+    loaded = LLM.from_persisted(
+        {
+            "model": "gpt-5.2-codex",
+            "auth_type": "subscription",
+            "subscription_vendor": "openai",
+            "schema_version": 1,
+        }
+    )
+
+    assert loaded is runtime_llm
+    assert loaded.is_subscription is True
+
+
 def test_openai_subscription_create_llm_serializes_subscription_auth(
     monkeypatch,
 ) -> None:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1767,6 +1767,90 @@ def test_llm_from_persisted_rehydrates_subscription_runtime(monkeypatch) -> None
     assert loaded.is_subscription is True
 
 
+def test_llm_load_from_env_rehydrates_subscription_runtime(monkeypatch) -> None:
+    from openhands.sdk.llm.auth import openai
+
+    runtime_llm = LLM(model="openai/gpt-5.2-codex", auth_type="subscription")
+    runtime_llm._is_subscription = True
+
+    def fake_create_subscription_llm_from_config(llm: LLM) -> LLM:
+        assert llm.auth_type == "subscription"
+        assert llm.subscription_vendor == "openai"
+        assert llm.model == "gpt-5.2-codex"
+        return runtime_llm
+
+    monkeypatch.setenv("LLM_MODEL", "gpt-5.2-codex")
+    monkeypatch.setenv("LLM_AUTH_TYPE", "subscription")
+    monkeypatch.setenv("LLM_SUBSCRIPTION_VENDOR", "openai")
+    monkeypatch.setattr(
+        openai,
+        "create_subscription_llm_from_config",
+        fake_create_subscription_llm_from_config,
+    )
+
+    loaded = LLM.load_from_env()
+
+    assert loaded is runtime_llm
+    assert loaded.is_subscription is True
+
+
+def test_create_subscription_llm_from_config_preserves_runtime_llm(monkeypatch) -> None:
+    import openhands.sdk.llm.auth.openai as openai_auth
+
+    class UnexpectedAuth:
+        def __init__(self, *args, **kwargs):
+            raise AssertionError("runtime subscription LLM should not be rehydrated")
+
+    monkeypatch.setattr(openai_auth, "OpenAISubscriptionAuth", UnexpectedAuth)
+    runtime_llm = LLM(
+        model="openai/gpt-5.2-codex",
+        auth_type="subscription",
+        subscription_vendor="openai",
+    )
+    runtime_llm._is_subscription = True
+
+    assert openai_auth.create_subscription_llm_from_config(runtime_llm) is runtime_llm
+
+
+@pytest.mark.asyncio
+async def test_async_subscription_api_key_uses_async_refresh(monkeypatch) -> None:
+    import openhands.sdk.llm.auth.openai as openai_auth
+    from openhands.sdk.llm.auth.credentials import OAuthCredentials
+
+    credentials = OAuthCredentials(
+        vendor="openai",
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=4_102_444_800_000,
+    )
+
+    class FakeAuth:
+        def __init__(self, credential_store=None):
+            self.credential_store = credential_store
+
+        async def refresh_if_needed(self):
+            return credentials
+
+        def refresh_if_needed_sync(self):
+            raise AssertionError("async transport must not sync-refresh credentials")
+
+        def extract_chatgpt_account_id(self, refreshed_credentials):
+            assert refreshed_credentials is credentials
+            return "account-id"
+
+    monkeypatch.setattr(openai_auth, "OpenAISubscriptionAuth", FakeAuth)
+    llm = LLM(
+        model="openai/gpt-5.2-codex",
+        auth_type="subscription",
+        subscription_vendor="openai",
+    )
+    llm._is_subscription = True
+
+    assert await llm._aget_litellm_api_key_value() == "access-token"
+    assert llm.extra_headers is not None
+    assert llm.extra_headers["chatgpt-account-id"] == "account-id"
+
+
 def test_openai_subscription_create_llm_serializes_subscription_auth(
     monkeypatch,
 ) -> None:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1688,3 +1688,50 @@ def test_acp_agent_reports_no_openhands_capabilities() -> None:
     assert agent.supports_openhands_mcp is False
     assert agent.supports_condenser is False
     assert agent.agent_kind == "acp"
+
+
+def test_llm_subscription_fields_roundtrip() -> None:
+    settings = validate_agent_settings(
+        {
+            "llm": {
+                "model": "gpt-5.2-codex",
+                "auth_type": "subscription",
+                "subscription_vendor": "openai",
+            }
+        }
+    )
+
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert settings.llm.auth_type == "subscription"
+    assert settings.llm.subscription_vendor == "openai"
+    dumped = settings.model_dump(mode="json", exclude_none=True)
+    assert dumped["llm"]["auth_type"] == "subscription"
+    assert dumped["llm"]["subscription_vendor"] == "openai"
+    assert "api_key" not in dumped["llm"]
+
+
+def test_llm_create_agent_resolves_subscription_llm(monkeypatch) -> None:
+    from openhands.sdk.llm.auth import openai
+
+    original_llm = LLM(
+        model="gpt-5.2-codex",
+        auth_type="subscription",
+        subscription_vendor="openai",
+    )
+    runtime_llm = LLM(model="openai/gpt-5.2-codex")
+    runtime_llm._is_subscription = True
+
+    def fake_create_subscription_llm_from_config(llm: LLM) -> LLM:
+        assert llm is original_llm
+        return runtime_llm
+
+    monkeypatch.setattr(
+        openai,
+        "create_subscription_llm_from_config",
+        fake_create_subscription_llm_from_config,
+    )
+
+    agent = OpenHandsAgentSettings(llm=original_llm).create_agent()
+
+    assert agent.llm is runtime_llm
+    assert agent.llm.is_subscription is True


### PR DESCRIPTION
## Summary
- add safe OpenAI subscription status, device-code start/poll, logout, and model endpoints to agent-server
- add serializable LLM auth mode fields and resolve subscription-backed LLM configs at runtime without exposing OAuth tokens
- cover endpoint token-redaction behavior and subscription settings round-tripping in tests

## Tests
- uv run ruff check openhands-sdk/openhands/sdk/llm/llm.py openhands-sdk/openhands/sdk/llm/auth/openai.py openhands-sdk/openhands/sdk/llm/auth/__init__.py openhands-sdk/openhands/sdk/settings/model.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-agent-server/openhands/agent_server/llm_router.py tests/agent_server/test_llm_router.py tests/sdk/test_settings.py
- uv run pytest tests/agent_server/test_llm_router.py tests/sdk/test_settings.py -q

This PR was created by an AI agent (OpenHands) on behalf of the user.











<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9fe0f27-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9fe0f27-python \
  ghcr.io/openhands/agent-server:9fe0f27-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9fe0f27-golang-amd64
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-golang-amd64
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-golang-amd64
ghcr.io/openhands/agent-server:9fe0f27-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9fe0f27-golang-arm64
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-golang-arm64
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-golang-arm64
ghcr.io/openhands/agent-server:9fe0f27-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9fe0f27-java-amd64
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-java-amd64
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-java-amd64
ghcr.io/openhands/agent-server:9fe0f27-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9fe0f27-java-arm64
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-java-arm64
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-java-arm64
ghcr.io/openhands/agent-server:9fe0f27-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9fe0f27-python-amd64
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-python-amd64
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-python-amd64
ghcr.io/openhands/agent-server:9fe0f27-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9fe0f27-python-arm64
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-python-arm64
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-python-arm64
ghcr.io/openhands/agent-server:9fe0f27-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9fe0f27-golang
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-golang
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-golang
ghcr.io/openhands/agent-server:9fe0f27-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9fe0f27-java
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-java
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-java
ghcr.io/openhands/agent-server:9fe0f27-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9fe0f27-python
ghcr.io/openhands/agent-server:9fe0f2796b908b33c56aac37b21f03dc1e0eb89d-python
ghcr.io/openhands/agent-server:add-llm-subscription-endpoints-python
ghcr.io/openhands/agent-server:9fe0f27-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9fe0f27-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9fe0f27-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Issue

Fixes #3484

_This PR description update was created by an AI agent (OpenHands) on behalf of Graham Neubig._
