### PR TITLE
fix(sdk): assign condenser LLM usage id

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -890,6 +890,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         from openhands.sdk.context.condenser import LLMSummarizingCondenser
 
         condenser_llm = llm.model_copy(update={"usage_id": "condenser"})
+        condenser_llm.reset_metrics()
         return LLMSummarizingCondenser(
             llm=condenser_llm, max_size=self.condenser.max_size
         )

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -889,7 +889,10 @@ class OpenHandsAgentSettings(AgentSettingsBase):
 
         from openhands.sdk.context.condenser import LLMSummarizingCondenser
 
-        return LLMSummarizingCondenser(llm=llm, max_size=self.condenser.max_size)
+        condenser_llm = llm.model_copy(update={"usage_id": "condenser"})
+        return LLMSummarizingCondenser(
+            llm=condenser_llm, max_size=self.condenser.max_size
+        )
 
     def build_critic(self) -> CriticBase | None:
         """Create an :class:`APIBasedCritic` from these settings.

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -474,6 +474,7 @@ def test_llm_create_agent_serializes_typed_mcp_config_compactly() -> None:
 
 def test_llm_create_agent_builds_condenser_when_enabled() -> None:
     llm = LLM(model="test-model", usage_id="agent")
+    agent_metrics = llm.metrics
     settings = OpenHandsAgentSettings(
         llm=llm,
         condenser=CondenserSettings(enabled=True, max_size=100),
@@ -486,6 +487,7 @@ def test_llm_create_agent_builds_condenser_when_enabled() -> None:
     assert agent.condenser.llm is not llm
     assert agent.condenser.llm.model == llm.model
     assert agent.condenser.llm.usage_id == "condenser"
+    assert agent.condenser.llm.metrics is not agent_metrics
 
 
 def test_llm_create_agent_no_condenser_when_disabled() -> None:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -473,12 +473,19 @@ def test_llm_create_agent_serializes_typed_mcp_config_compactly() -> None:
 
 
 def test_llm_create_agent_builds_condenser_when_enabled() -> None:
+    llm = LLM(model="test-model", usage_id="agent")
     settings = OpenHandsAgentSettings(
+        llm=llm,
         condenser=CondenserSettings(enabled=True, max_size=100),
     )
     agent = settings.create_agent()
+
+    assert agent.llm is llm
     assert isinstance(agent.condenser, LLMSummarizingCondenser)
     assert agent.condenser.max_size == 100
+    assert agent.condenser.llm is not llm
+    assert agent.condenser.llm.model == llm.model
+    assert agent.condenser.llm.usage_id == "condenser"
 
 
 def test_llm_create_agent_no_condenser_when_disabled() -> None:


### PR DESCRIPTION
## Summary
- Copy the settings LLM when building the summarizing condenser
- Assign the condenser copy `usage_id="condenser"` so it does not collide with the agent LLM's `usage_id`
- Extend settings coverage to verify the condenser uses a copied LLM with the expected usage ID

Closes OpenHands/agent-canvas#2183.

## Tests
- `uv run pytest tests/sdk/test_settings.py -k condenser`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/settings/model.py tests/sdk/test_settings.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@neubig can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd2a650b-257a-4038-8cce-ce664be5586a)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:43032a6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-43032a6-python \
  ghcr.io/openhands/agent-server:43032a6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:43032a6-golang-amd64
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-golang-amd64
ghcr.io/openhands/agent-server:fix-condenser-usage-id-golang-amd64
ghcr.io/openhands/agent-server:43032a6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:43032a6-golang-arm64
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-golang-arm64
ghcr.io/openhands/agent-server:fix-condenser-usage-id-golang-arm64
ghcr.io/openhands/agent-server:43032a6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:43032a6-java-amd64
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-java-amd64
ghcr.io/openhands/agent-server:fix-condenser-usage-id-java-amd64
ghcr.io/openhands/agent-server:43032a6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:43032a6-java-arm64
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-java-arm64
ghcr.io/openhands/agent-server:fix-condenser-usage-id-java-arm64
ghcr.io/openhands/agent-server:43032a6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:43032a6-python-amd64
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-python-amd64
ghcr.io/openhands/agent-server:fix-condenser-usage-id-python-amd64
ghcr.io/openhands/agent-server:43032a6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:43032a6-python-arm64
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-python-arm64
ghcr.io/openhands/agent-server:fix-condenser-usage-id-python-arm64
ghcr.io/openhands/agent-server:43032a6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:43032a6-golang
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-golang
ghcr.io/openhands/agent-server:fix-condenser-usage-id-golang
ghcr.io/openhands/agent-server:43032a6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:43032a6-java
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-java
ghcr.io/openhands/agent-server:fix-condenser-usage-id-java
ghcr.io/openhands/agent-server:43032a6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:43032a6-python
ghcr.io/openhands/agent-server:43032a629660e7611e2cd62298de490853684723-python
ghcr.io/openhands/agent-server:fix-condenser-usage-id-python
ghcr.io/openhands/agent-server:43032a6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `43032a6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `43032a6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->