### PR TITLE
Gate switch_llm tool on enable flag only, not local profile presence

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -743,8 +743,8 @@ class OpenHandsAgentSettings(AgentSettingsBase):
     enable_switch_llm_tool: bool = Field(
         default=True,
         description=(
-            "Enable the built-in switch_llm tool when saved LLM profiles are "
-            "available. The tool is omitted when no profiles exist."
+            "Enable the built-in switch_llm tool for switching between saved "
+            "LLM profiles."
         ),
         json_schema_extra={
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
@@ -860,7 +860,6 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         """
         from openhands.sdk.agent import Agent
         from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, SwitchLLMTool
-        from openhands.sdk.tool.builtins.switch_llm import has_llm_profiles
 
         # Bypass ``_serialize_mcp_config``: MCP servers need real env/headers.
         mcp_config = (
@@ -869,7 +868,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             else {}
         )
         include_default_tools = [tool.__name__ for tool in BUILT_IN_TOOLS]
-        if self.enable_switch_llm_tool and has_llm_profiles():
+        if self.enable_switch_llm_tool:
             include_default_tools.append(SwitchLLMTool.__name__)
 
         return Agent(

--- a/openhands-sdk/openhands/sdk/tool/builtins/switch_llm.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/switch_llm.py
@@ -88,10 +88,6 @@ def get_llm_profile_names() -> list[str]:
     return [summary["name"] for summary in LLMProfileStore().list_summaries()]
 
 
-def has_llm_profiles() -> bool:
-    return bool(get_llm_profile_names())
-
-
 def _format_profiles(profile_names: Sequence[str]) -> str:
     if not profile_names:
         return "- No saved LLM profiles are currently available."

--- a/tests/sdk/tool/test_switch_llm.py
+++ b/tests/sdk/tool/test_switch_llm.py
@@ -79,16 +79,16 @@ def test_agent_settings_omits_switch_llm_tool_when_disabled(profile_store):
     assert "switch_llm" not in agent.tools_map
 
 
-def test_agent_settings_omits_switch_llm_tool_without_profiles(empty_profile_store):
+def test_agent_settings_includes_switch_llm_tool_without_profiles(empty_profile_store):
     agent = OpenHandsAgentSettings(
         llm=_make_llm("default-model", "default")
     ).create_agent()
 
-    assert "SwitchLLMTool" not in agent.include_default_tools
+    assert "SwitchLLMTool" in agent.include_default_tools
 
     conversation = LocalConversation(agent=agent, workspace=Path.cwd())
     conversation._ensure_agent_ready()
-    assert "switch_llm" not in agent.tools_map
+    assert "switch_llm" in agent.tools_map
 
 
 def test_switch_llm_tool_switches_conversation_profile(profile_store):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [x] A human has tested these changes.

---

## Why

`SwitchLLMTool` is only added by `create_agent()` when `has_llm_profiles()` finds profiles on the **local** filesystem (`Path.home() / ".openhands" / "profiles"`). On SaaS this check runs inside the **app-server** process, but the profiles the tool needs are saved in the **sandbox/agent-server** process under `/home/openhands/.openhands/profiles`. So profiles can be saved perfectly fine in the sandbox, yet `create_agent()` looks at the app-server's local filesystem, sees nothing, and decides not to add the tool.

The switching mechanism itself already works: tool execution calls `conversation.switch_profile(...)`, and `LLMProfileStore()` reads from the sandbox filesystem where the profiles live (there `/home/openhands` matches `Path.home()`). The only problem is the gating check running in the wrong process.

## Summary

- Gate `SwitchLLMTool` solely on the `enable_switch_llm_tool` flag in `create_agent()`; drop the `has_llm_profiles()` filesystem check.
- Remove the now-unused `has_llm_profiles()` helper.
- Update the field description and the test that asserted the tool is omitted when no local profiles exist.

## Issue Number

## How to Test

```
uv run pytest tests/sdk/tool/test_switch_llm.py tests/sdk/test_settings.py
```

All 66 tests pass, and `pre-commit` (ruff format/lint, pycodestyle, pyright, import rules, tool registration) passes on the changed files.

The full SaaS app-server ↔ sandbox split cannot be reproduced from this checkout, so a human should confirm on SaaS / Agent Canvas that, with the setting enabled and profiles saved in the sandbox, `switch_llm` is now offered to the agent.

## Video/Screenshots

N/A

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Implements option 1 from the discussion: rely only on the enable/disable button and remove the directory check. The alternative (require ≥ 2 saved profiles) was considered but rejected — SaaS and Agent Canvas always have at least one profile saved, and the gating belongs with the flag rather than a process-local filesystem probe.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:715a018-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-715a018-python \
  ghcr.io/openhands/agent-server:715a018-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:715a018-golang-amd64
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-golang-amd64
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-golang-amd64
ghcr.io/openhands/agent-server:715a018-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:715a018-golang-arm64
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-golang-arm64
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-golang-arm64
ghcr.io/openhands/agent-server:715a018-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:715a018-java-amd64
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-java-amd64
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-java-amd64
ghcr.io/openhands/agent-server:715a018-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:715a018-java-arm64
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-java-arm64
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-java-arm64
ghcr.io/openhands/agent-server:715a018-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:715a018-python-amd64
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-python-amd64
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-python-amd64
ghcr.io/openhands/agent-server:715a018-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:715a018-python-arm64
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-python-arm64
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-python-arm64
ghcr.io/openhands/agent-server:715a018-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:715a018-golang
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-golang
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-golang
ghcr.io/openhands/agent-server:715a018-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:715a018-java
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-java
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-java
ghcr.io/openhands/agent-server:715a018-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:715a018-python
ghcr.io/openhands/agent-server:715a01865af18a44833f98c727c21b33ea2f274d-python
ghcr.io/openhands/agent-server:switch-llm-tool-drop-profile-check-python
ghcr.io/openhands/agent-server:715a018-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `715a018-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `715a018-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->