### PR TITLE
ci: use MiniMax M2.7 in integration default matrix

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -50,7 +50,7 @@ on:
 env:
     N_PROCESSES: 4 # Global configuration for number of parallel processes for evaluation
     # Default models for scheduled/label-triggered runs (subset of models from resolve_model_config.py)
-    DEFAULT_MODEL_IDS: gpt-5.5,deepseek-v4-flash,kimi-k2.6,gemini-3.1-pro
+    DEFAULT_MODEL_IDS: gpt-5.5,deepseek-v4-flash,minimax-m2.7,gemini-3.1-pro
 
 jobs:
     setup-matrix:


### PR DESCRIPTION
## Summary
- Replace `kimi-k2.6` with `minimax-m2.7` in the integration workflow default model matrix.
- Keep the rest of the default model set unchanged.

## Validation
- `uv run pre-commit run --files .github/workflows/integration-runner.yml`

This PR was created by an AI agent (OpenHands) on behalf of the maintainer.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5203b93a-5f70-49b8-bddb-a39d6f9dd28c)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9e27789-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9e27789-python \
  ghcr.io/openhands/agent-server:9e27789-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9e27789-golang-amd64
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-golang-amd64
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-golang-amd64
ghcr.io/openhands/agent-server:9e27789-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9e27789-golang-arm64
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-golang-arm64
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-golang-arm64
ghcr.io/openhands/agent-server:9e27789-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9e27789-java-amd64
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-java-amd64
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-java-amd64
ghcr.io/openhands/agent-server:9e27789-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9e27789-java-arm64
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-java-arm64
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-java-arm64
ghcr.io/openhands/agent-server:9e27789-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9e27789-python-amd64
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-python-amd64
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-python-amd64
ghcr.io/openhands/agent-server:9e27789-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9e27789-python-arm64
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-python-arm64
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-python-arm64
ghcr.io/openhands/agent-server:9e27789-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9e27789-golang
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-golang
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-golang
ghcr.io/openhands/agent-server:9e27789-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9e27789-java
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-java
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-java
ghcr.io/openhands/agent-server:9e27789-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9e27789-python
ghcr.io/openhands/agent-server:9e27789bbf3601ecb67ba697e35544e5446a121d-python
ghcr.io/openhands/agent-server:replace-kimi-with-minimax-m27-python
ghcr.io/openhands/agent-server:9e27789-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9e27789-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9e27789-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->