### PR TITLE
Add EVIDENCE_BASED_INFORMATION section to system prompt

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
+++ b/openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2
@@ -131,6 +131,16 @@ You have a browser for navigating pages and interacting with web UIs.
   - When possible, use more targeted approaches like finding the PID from a pidfile or using application-specific shutdown commands
 </PROCESS_MANAGEMENT>
 
+<EVIDENCE_BASED_INFORMATION>
+When providing field values or factual claims, always support them with official documentation and verifiable sources. For each field, provide:
+- **Field**: the field name
+- **Value**: the value you are assigning
+- **Quote**: the exact text from the source that supports this value
+- **Source**: the official link (URL) where the quote can be found
+
+Prefer primary sources such as official documentation, RFCs, API references, and source code over secondary sources like blog posts or forums. If no official source can be found, state that explicitly rather than fabricating a reference.
+</EVIDENCE_BASED_INFORMATION>
+
 {%- set _imp -%}
 {%- if model_family -%}
 {%- include "model_specific/" ~ model_family ~ ".j2" ignore missing -%}

--- a/tests/sdk/agent/test_system_prompt.py
+++ b/tests/sdk/agent/test_system_prompt.py
@@ -84,3 +84,18 @@ def test_system_prompt_none_survives_json_round_trip() -> None:
     restored = AgentBase.model_validate_json(agent_json)
     assert isinstance(restored, Agent)
     assert restored.system_prompt is None
+
+
+# --- evidence-based information section ---
+
+
+def test_default_system_prompt_contains_evidence_based_information() -> None:
+    """The default system prompt must include the EVIDENCE_BASED_INFORMATION section."""
+    agent = Agent(llm=_make_llm(), tools=[])
+    msg = agent.static_system_message
+    assert "<EVIDENCE_BASED_INFORMATION>" in msg
+    assert "</EVIDENCE_BASED_INFORMATION>" in msg
+    assert "**Field**" in msg
+    assert "**Value**" in msg
+    assert "**Quote**" in msg
+    assert "**Source**" in msg


### PR DESCRIPTION
## Summary

Adds an always-on `<EVIDENCE_BASED_INFORMATION>` section to the default system prompt (`system_prompt.j2`) that instructs the agent to back every field value or factual claim with official documentation and verifiable sources.

When providing field values, the agent will now be instructed to include:
- **Field**: the field name
- **Value**: the value being assigned
- **Quote**: the exact text from the source that supports this value
- **Source**: the official link (URL) where the quote can be found

## Changes

- **`openhands-sdk/openhands/sdk/agent/prompts/system_prompt.j2`**: Added `<EVIDENCE_BASED_INFORMATION>` section between `<PROCESS_MANAGEMENT>` and the model-specific includes block.
- **`tests/sdk/agent/test_system_prompt.py`**: Added `test_default_system_prompt_contains_evidence_based_information` to verify the section and its key fields appear in the rendered system prompt.

## Why system prompt (not a skill)

As discussed in the issue, this is core agent behavior that should always be active - not an optional skill that requires a trigger. When the agent provides factual information, it should always cite sources. The system prompt (`system_prompt.j2`) is the correct location for always-on instructions, not `AGENTS.md`.

Fixes OpenHands/extensions#157

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d081b534-7821-4737-a9fc-e8013e98dde9)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d97422d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d97422d-python \
  ghcr.io/openhands/agent-server:d97422d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d97422d-golang-amd64
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-golang-amd64
ghcr.io/openhands/agent-server:d97422d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d97422d-golang-arm64
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-golang-arm64
ghcr.io/openhands/agent-server:d97422d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d97422d-java-amd64
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-java-amd64
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-java-amd64
ghcr.io/openhands/agent-server:d97422d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d97422d-java-arm64
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-java-arm64
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-java-arm64
ghcr.io/openhands/agent-server:d97422d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d97422d-python-amd64
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-python-amd64
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-python-amd64
ghcr.io/openhands/agent-server:d97422d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d97422d-python-arm64
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-python-arm64
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-python-arm64
ghcr.io/openhands/agent-server:d97422d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d97422d-golang
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-golang
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-golang
ghcr.io/openhands/agent-server:d97422d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d97422d-java
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-java
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-java
ghcr.io/openhands/agent-server:d97422d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d97422d-python
ghcr.io/openhands/agent-server:d97422d8d7fa584f2923ce84959f100efc2a8286-python
ghcr.io/openhands/agent-server:openhands-add-evidence-based-information-to-system-prompt-python
ghcr.io/openhands/agent-server:d97422d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d97422d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d97422d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->