### PR TITLE
Add amber-vector-3542 model to resolve_model_config.py

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -337,6 +337,15 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    "amber-vector-3542": {
+        "id": "amber-vector-3542",
+        "display_name": "Amber Vector 3542",
+        "llm_config": {
+            "model": "litellm_proxy/amber-vector-3542",
+            "temperature": 0.0,
+            "reasoning_effort": "high",
+        },
+    },
 }
 
 

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -343,7 +343,6 @@ MODELS = {
         "llm_config": {
             "model": "litellm_proxy/amber-vector-3542",
             "temperature": 0.0,
-            "reasoning_effort": "high",
         },
     },
 }

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -669,4 +669,3 @@ def test_amber_vector_3542_config():
     assert model["display_name"] == "Amber Vector 3542"
     assert model["llm_config"]["model"] == "litellm_proxy/amber-vector-3542"
     assert model["llm_config"]["temperature"] == 0.0
-    assert model["llm_config"]["reasoning_effort"] == "high"

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -659,3 +659,14 @@ def test_deepseek_v4_flash_config():
     assert model["id"] == "deepseek-v4-flash"
     assert model["display_name"] == "DeepSeek V4 Flash"
     assert model["llm_config"]["model"] == "litellm_proxy/deepseek/deepseek-v4-flash"
+
+
+def test_amber_vector_3542_config():
+    """Test that amber-vector-3542 has correct configuration."""
+    model = MODELS["amber-vector-3542"]
+
+    assert model["id"] == "amber-vector-3542"
+    assert model["display_name"] == "Amber Vector 3542"
+    assert model["llm_config"]["model"] == "litellm_proxy/amber-vector-3542"
+    assert model["llm_config"]["temperature"] == 0.0
+    assert model["llm_config"]["reasoning_effort"] == "high"


### PR DESCRIPTION
## Summary
Adds the `amber-vector-3542` model to resolve_model_config.py.

## Changes
- Added amber-vector-3542 to MODELS dictionary in `.github/run-eval/resolve_model_config.py`
- Added `test_amber_vector_3542_config()` test function in `tests/cross/test_resolve_model_config.py`

## Configuration
- Model ID: amber-vector-3542
- Display Name: Amber Vector 3542
- Model path: `litellm_proxy/amber-vector-3542`
- Temperature: 0.0

## Integration Test Results
⏳ Integration tests running: https://github.com/OpenHands/software-agent-sdk/actions/runs/26431167029

Fixes #3386

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c642942-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c642942-python \
  ghcr.io/openhands/agent-server:c642942-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c642942-golang-amd64
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-golang-amd64
ghcr.io/openhands/agent-server:c642942-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c642942-golang-arm64
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-golang-arm64
ghcr.io/openhands/agent-server:c642942-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c642942-java-amd64
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-java-amd64
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-java-amd64
ghcr.io/openhands/agent-server:c642942-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c642942-java-arm64
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-java-arm64
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-java-arm64
ghcr.io/openhands/agent-server:c642942-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c642942-python-amd64
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-python-amd64
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-python-amd64
ghcr.io/openhands/agent-server:c642942-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c642942-python-arm64
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-python-arm64
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-python-arm64
ghcr.io/openhands/agent-server:c642942-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c642942-golang
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-golang
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-golang
ghcr.io/openhands/agent-server:c642942-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c642942-java
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-java
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-java
ghcr.io/openhands/agent-server:c642942-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c642942-python
ghcr.io/openhands/agent-server:c6429428b500bff15e7269f75598629cc6fa03c7-python
ghcr.io/openhands/agent-server:openhands-add-amber-vector-3542-python
ghcr.io/openhands/agent-server:c642942-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c642942-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c642942-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->