### PR TITLE
fix(sdk): detect malformed tool-call history errors

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
@@ -44,6 +44,8 @@ MALFORMED_HISTORY_PATTERNS: list[str] = [
         "each `tool_result` block must have a corresponding `tool_use` block "
         "in the previous message"
     ),
+    # Moonshot / Kimi variant
+    "must be followed by tool messages responding to each 'tool_call_id'",
 ]
 
 

--- a/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
@@ -33,6 +33,8 @@ LONG_PROMPT_PATTERNS: list[str] = [
 # into condensation-based recovery.
 MALFORMED_HISTORY_PATTERNS: list[str] = [
     "tool_use ids were found without `tool_result` blocks immediately after",
+    # Anthropic backtick variant
+    "`tool_use` ids were found without `tool_result` blocks immediately after",
     (
         "each `tool_use` block must have a corresponding `tool_result` block "
         "in the next message"

--- a/tests/sdk/llm/test_exception_classifier.py
+++ b/tests/sdk/llm/test_exception_classifier.py
@@ -72,6 +72,34 @@ def test_looks_like_malformed_conversation_history_error_positive():
     assert is_context_window_exceeded(malformed_history_error) is False
 
 
+def test_looks_like_malformed_conversation_history_error_moonshot():
+    error = BadRequestError(
+        (
+            "an assistant message with 'tool_calls' must be followed by tool "
+            "messages responding to each 'tool_call_id'"
+        ),
+        MODEL,
+        PROVIDER,
+    )
+
+    assert looks_like_malformed_conversation_history_error(error) is True
+    assert is_context_window_exceeded(error) is False
+
+
+def test_looks_like_malformed_conversation_history_error_anthropic_first_sentence():
+    error = BadRequestError(
+        (
+            "messages.134: `tool_use` ids were found without `tool_result` "
+            "blocks immediately after: toolu_01Aye4s5HrR2uXwXFYgtQi4H."
+        ),
+        MODEL,
+        PROVIDER,
+    )
+
+    assert looks_like_malformed_conversation_history_error(error) is True
+    assert is_context_window_exceeded(error) is False
+
+
 def test_is_context_window_exceeded_negative():
     assert (
         is_context_window_exceeded(BadRequestError("irrelevant", MODEL, PROVIDER))


### PR DESCRIPTION
## Summary

Two fixes to malformed tool-call history detection in `classifier.py`:

1. **Moonshot/Kimi variant (#3369)** — Moonshot/Kimi reports malformed history with provider-specific wording that detection did not recognize:

   > an assistant message with 'tool_calls' must be followed by tool messages responding to each 'tool_call_id'

   Because this phrasing was not in `MALFORMED_HISTORY_PATTERNS`, the error surfaced as a generic `LLMBadRequestError` and stopped the conversation instead of routing into the existing condensation-based recovery.

2. **Anthropic backtick variant (#3384)** — the existing pattern `tool_use ids were found without ...` omitted the backticks around `tool_use`, so it never matched Anthropic's actual wording (`` `tool_use` ids were found without ... ``). That entry was effectively dead code. Added the backtick variant alongside it so the first sentence of the Anthropic error is matched too (the second sentence was already covered).

## Issues

- Closes #3369
- Related to #3384 (the second sentence of the Anthropic error was already matched, so recovery already applied; this hardens detection by also matching the first sentence. Note #3384 also involves a misconfigured fallback chain and an unrelated `MissingStyle` TUI rendering bug, neither addressed here.)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:74da5d9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-74da5d9-python \
  ghcr.io/openhands/agent-server:74da5d9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:74da5d9-golang-amd64
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-golang-amd64
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-golang-amd64
ghcr.io/openhands/agent-server:74da5d9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:74da5d9-golang-arm64
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-golang-arm64
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-golang-arm64
ghcr.io/openhands/agent-server:74da5d9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:74da5d9-java-amd64
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-java-amd64
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-java-amd64
ghcr.io/openhands/agent-server:74da5d9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:74da5d9-java-arm64
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-java-arm64
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-java-arm64
ghcr.io/openhands/agent-server:74da5d9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:74da5d9-python-amd64
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-python-amd64
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-python-amd64
ghcr.io/openhands/agent-server:74da5d9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:74da5d9-python-arm64
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-python-arm64
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-python-arm64
ghcr.io/openhands/agent-server:74da5d9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:74da5d9-golang
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-golang
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-golang
ghcr.io/openhands/agent-server:74da5d9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:74da5d9-java
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-java
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-java
ghcr.io/openhands/agent-server:74da5d9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:74da5d9-python
ghcr.io/openhands/agent-server:74da5d9d2ddf7770873123f0d9831bf61421f7c9-python
ghcr.io/openhands/agent-server:fix-moonshot-malformed-history-detection-python
ghcr.io/openhands/agent-server:74da5d9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `74da5d9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `74da5d9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->