### PR TITLE
feat(acp): add available_models / default_model to ACP provider registry

### DIFF
--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -51,6 +51,7 @@ from openhands.sdk.plugin import Plugin
 from openhands.sdk.settings import (
     ACP_PROVIDERS,
     ACPAgentSettings,
+    ACPModelOption,
     ACPProviderInfo,
     AgentSettingsBase,
     AgentSettingsConfig,
@@ -192,6 +193,7 @@ __all__ = [
     "VerificationSettings",
     "ACP_PROVIDERS",
     "ACPAgentSettings",
+    "ACPModelOption",
     "ACPProviderInfo",
     "AgentSettingsBase",
     "AgentSettingsConfig",

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any
 
 from .acp_providers import (
     ACP_PROVIDERS,
+    ACPModelOption,
     ACPProviderInfo,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
@@ -74,6 +75,7 @@ _MODEL_EXPORTS = {
 
 __all__ = [
     "ACP_PROVIDERS",
+    "ACPModelOption",
     "ACPProviderInfo",
     "build_session_model_meta",
     "AGENT_SETTINGS_SCHEMA_VERSION",

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -13,10 +13,15 @@ Each record captures the static properties that are known at configuration time
                             used by ``ACPAgent`` to auto-detect mode / protocol
 - ``supports_set_session_model``  whether to use the ``set_session_model``
                                   protocol call (vs ``_meta``) for model selection
+- ``session_meta_key``      top-level ``_meta`` key for model selection (or ``None``)
+- ``available_models``      curated list of selectable models for the provider's
+                            model picker (``acp_model`` candidates)
+- ``default_model``         model preselected when none is configured (or ``None``)
 
 Callers outside the SDK (e.g. ``openhands-agent-server``, the ``OpenHands``
-frontend) can import :data:`ACP_PROVIDERS` and :func:`get_acp_provider` instead
-of maintaining their own copies of this metadata.
+frontend, and the ``@openhands/typescript-client`` mirror) can import
+:data:`ACP_PROVIDERS` and :func:`get_acp_provider` instead of maintaining their
+own copies of this metadata.
 """
 
 from __future__ import annotations
@@ -25,6 +30,17 @@ from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
 from typing import Any
+
+
+@dataclass(frozen=True)
+class ACPModelOption:
+    """One selectable model for a built-in ACP provider's model picker."""
+
+    id: str
+    """Exact model identifier sent to the ACP server as ``acp_model``."""
+
+    label: str
+    """Human-readable label shown in the model picker (e.g. ``"Claude Opus 4.7"``)."""
 
 
 @dataclass(frozen=True)
@@ -91,6 +107,92 @@ class ACPProviderInfo:
     - ``None``         — codex-acp, gemini-cli
     """
 
+    available_models: tuple[ACPModelOption, ...] = field(default=(), compare=False)
+    """Curated list of models surfaced in this provider's ``acp_model`` picker.
+
+    These mirror the runtime picker values for each built-in harness, but are
+    suggestions — not authoritative access checks. A user can still configure a
+    custom ``acp_model`` the list does not contain, and actual availability
+    depends on the account's plan tier. Empty for providers without a curated
+    list (e.g. forward-compatible entries).
+    """
+
+    default_model: str | None = None
+    """Model ID preselected when no ``acp_model`` is configured, or ``None``.
+
+    When set, it must be one of the :attr:`available_models` ids. ``None`` lets
+    the ACP server pick its own default.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Curated ``acp_model`` candidate lists for the built-in providers.
+#
+# These are suggestions for the model picker, mirroring each harness's own
+# runtime ``/model`` options. They are not authoritative access checks —
+# availability ultimately depends on the user's plan tier, and a custom
+# ``acp_model`` outside these lists is always allowed.
+# ---------------------------------------------------------------------------
+
+# Canonical model IDs the Claude Code CLI accepts. ``opus[1m]`` / ``sonnet[1m]``
+# are the SDK-documented version-agnostic 1M-context aliases (so they auto-track
+# the newest 1M-capable model — keep their labels version-less to match).
+# ``opusplan`` routes planning to Opus and execution to Sonnet.
+_CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="claude-opus-4-7", label="Claude Opus 4.7"),
+    ACPModelOption(id="claude-opus-4-6", label="Claude Opus 4.6"),
+    ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),
+    ACPModelOption(id="claude-opus-4-5", label="Claude Opus 4.5"),
+    ACPModelOption(id="claude-opus-4-1-20250805", label="Claude Opus 4.1"),
+    ACPModelOption(id="claude-sonnet-4-6", label="Claude Sonnet 4.6"),
+    ACPModelOption(id="sonnet[1m]", label="Claude Sonnet (1M)"),
+    ACPModelOption(id="claude-sonnet-4-5", label="Claude Sonnet 4.5"),
+    ACPModelOption(id="claude-haiku-4-5", label="Claude Haiku 4.5"),
+    ACPModelOption(id="opusplan", label="Opus (plan) + Sonnet (execute)"),
+)
+
+# Model IDs accepted by ``@zed-industries/codex-acp``, mirroring the Codex CLI's
+# ``/model`` picker. Format is ``<base-model>/<effort>`` where the trailing tier
+# (``low``/``medium``/``high``/``xhigh``) hints the reasoning effort for the turn.
+_CODEX_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="gpt-5.5/low", label="GPT-5.5 (low)"),
+    ACPModelOption(id="gpt-5.5/medium", label="GPT-5.5 (medium)"),
+    ACPModelOption(id="gpt-5.5/high", label="GPT-5.5 (high)"),
+    ACPModelOption(id="gpt-5.5/xhigh", label="GPT-5.5 (xhigh)"),
+    ACPModelOption(id="gpt-5.4/low", label="GPT-5.4 (low)"),
+    ACPModelOption(id="gpt-5.4/medium", label="GPT-5.4 (medium)"),
+    ACPModelOption(id="gpt-5.4/high", label="GPT-5.4 (high)"),
+    ACPModelOption(id="gpt-5.4/xhigh", label="GPT-5.4 (xhigh)"),
+    ACPModelOption(id="gpt-5.4-mini/low", label="GPT-5.4 Mini (low)"),
+    ACPModelOption(id="gpt-5.4-mini/medium", label="GPT-5.4 Mini (medium)"),
+    ACPModelOption(id="gpt-5.4-mini/high", label="GPT-5.4 Mini (high)"),
+    ACPModelOption(id="gpt-5.4-mini/xhigh", label="GPT-5.4 Mini (xhigh)"),
+    ACPModelOption(id="gpt-5.3-codex/low", label="GPT-5.3 Codex (low)"),
+    ACPModelOption(id="gpt-5.3-codex/medium", label="GPT-5.3 Codex (medium)"),
+    ACPModelOption(id="gpt-5.3-codex/high", label="GPT-5.3 Codex (high)"),
+    ACPModelOption(id="gpt-5.3-codex/xhigh", label="GPT-5.3 Codex (xhigh)"),
+    ACPModelOption(id="gpt-5.2/low", label="GPT-5.2 (low)"),
+    ACPModelOption(id="gpt-5.2/medium", label="GPT-5.2 (medium)"),
+    ACPModelOption(id="gpt-5.2/high", label="GPT-5.2 (high)"),
+    ACPModelOption(id="gpt-5.2/xhigh", label="GPT-5.2 (xhigh)"),
+)
+
+# Model IDs accepted by ``@google/gemini-cli --acp``. The ``auto-gemini-*``
+# entries delegate version selection to the CLI's router; the explicit
+# ``gemini-3.1-*`` / ``gemini-2.5-*`` entries pin to a specific snapshot.
+_GEMINI_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="auto-gemini-3", label="Auto (Gemini 3)"),
+    ACPModelOption(id="auto-gemini-2.5", label="Auto (Gemini 2.5)"),
+    ACPModelOption(id="gemini-3.1-pro-preview", label="Gemini 3.1 Pro (preview)"),
+    ACPModelOption(id="gemini-3-flash-preview", label="Gemini 3 Flash (preview)"),
+    ACPModelOption(
+        id="gemini-3.1-flash-lite-preview", label="Gemini 3.1 Flash Lite (preview)"
+    ),
+    ACPModelOption(id="gemini-2.5-pro", label="Gemini 2.5 Pro"),
+    ACPModelOption(id="gemini-2.5-flash", label="Gemini 2.5 Flash"),
+    ACPModelOption(id="gemini-2.5-flash-lite", label="Gemini 2.5 Flash Lite"),
+)
+
 
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
     {
@@ -104,6 +206,8 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             agent_name_patterns=("claude-agent",),
             supports_set_session_model=False,
             session_meta_key="claudeCode",
+            available_models=_CLAUDE_MODELS,
+            default_model="claude-opus-4-7",
         ),
         "codex": ACPProviderInfo(
             key="codex",
@@ -115,6 +219,8 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             agent_name_patterns=("codex-acp",),
             supports_set_session_model=True,
             session_meta_key=None,
+            available_models=_CODEX_MODELS,
+            default_model="gpt-5.5/medium",
         ),
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
@@ -126,6 +232,8 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             agent_name_patterns=("gemini-cli",),
             supports_set_session_model=True,
             session_meta_key=None,
+            available_models=_GEMINI_MODELS,
+            default_model="gemini-2.5-pro",
         ),
     }
 )

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -233,7 +233,12 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             supports_set_session_model=True,
             session_meta_key=None,
             available_models=_GEMINI_MODELS,
-            default_model="gemini-2.5-pro",
+            # Match the Gemini CLI's own no-model-configured default
+            # (``DEFAULT_GEMINI_MODEL_AUTO``), i.e. the auto-router — not a
+            # manually-pinned snapshot. Pinning ``gemini-2.5-pro`` here would
+            # make downstream clients persist a value that bypasses the CLI's
+            # auto-routing.
+            default_model="auto-gemini-2.5",
         ),
     }
 )

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -64,8 +64,8 @@ class TestACPProviderInfo:
         assert "gemini-cli" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.session_meta_key is None
-        assert info.default_model == "gemini-2.5-pro"
-        assert any(m.id == "gemini-2.5-pro" for m in info.available_models)
+        assert info.default_model == "auto-gemini-2.5"
+        assert any(m.id == "auto-gemini-2.5" for m in info.available_models)
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -8,6 +8,7 @@ import pytest
 
 from openhands.sdk.settings.acp_providers import (
     ACP_PROVIDERS,
+    ACPModelOption,
     ACPProviderInfo,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
@@ -35,6 +36,8 @@ class TestACPProviderInfo:
         assert "claude-agent" in info.agent_name_patterns
         assert info.supports_set_session_model is False
         assert info.session_meta_key == "claudeCode"
+        assert info.default_model == "claude-opus-4-7"
+        assert any(m.id == "claude-opus-4-7" for m in info.available_models)
 
     def test_codex_metadata(self):
         info = ACP_PROVIDERS["codex"]
@@ -47,6 +50,8 @@ class TestACPProviderInfo:
         assert "codex-acp" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.session_meta_key is None
+        assert info.default_model == "gpt-5.5/medium"
+        assert any(m.id == "gpt-5.5/medium" for m in info.available_models)
 
     def test_gemini_cli_metadata(self):
         info = ACP_PROVIDERS["gemini-cli"]
@@ -59,6 +64,8 @@ class TestACPProviderInfo:
         assert "gemini-cli" in info.agent_name_patterns
         assert info.supports_set_session_model is True
         assert info.session_meta_key is None
+        assert info.default_model == "gemini-2.5-pro"
+        assert any(m.id == "gemini-2.5-pro" for m in info.available_models)
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
@@ -152,6 +159,40 @@ class TestProviderRegistryConsistency:
                 assert detected.key == key, (
                     f"pattern {pattern!r} matched {detected.key!r}, expected {key!r}"
                 )
+
+
+class TestProviderModelLists:
+    """Verify the curated ``available_models`` / ``default_model`` fields."""
+
+    def test_every_builtin_provider_has_available_models(self):
+        for key, info in ACP_PROVIDERS.items():
+            assert info.available_models, f"{key}: available_models must not be empty"
+
+    def test_available_models_entries_are_model_options(self):
+        for info in ACP_PROVIDERS.values():
+            for option in info.available_models:
+                assert isinstance(option, ACPModelOption)
+                assert option.id, "model option id must not be empty"
+                assert option.label, "model option label must not be empty"
+
+    def test_model_ids_unique_within_provider(self):
+        for key, info in ACP_PROVIDERS.items():
+            ids = [m.id for m in info.available_models]
+            assert len(ids) == len(set(ids)), f"{key}: duplicate model ids"
+
+    def test_default_model_is_one_of_available_models(self):
+        for key, info in ACP_PROVIDERS.items():
+            if info.default_model is None:
+                continue
+            ids = {m.id for m in info.available_models}
+            assert info.default_model in ids, (
+                f"{key}: default_model {info.default_model!r} not in available_models"
+            )
+
+    def test_model_option_is_frozen(self):
+        option = ACP_PROVIDERS["claude-code"].available_models[0]
+        with pytest.raises((AttributeError, TypeError)):
+            option.id = "mutated"  # type: ignore[misc]
 
 
 class TestBuildSessionModelMeta:


### PR DESCRIPTION
## Summary

Adds curated **model-picker** data to the built-in ACP provider registry so downstream consumers — `openhands-agent-server`, the OpenHands frontend, and the `@openhands/typescript-client` mirror — can source ACP model options from the SDK instead of each maintaining their own hardcoded copy.

This is the source-of-truth half of the plan to de-duplicate ACP model lists currently hardcoded in agent-canvas (`agent-canvas#730` hardcodes them in TS; this moves them upstream).

## Changes

- New frozen `ACPModelOption(id, label)` dataclass.
- `ACPProviderInfo` gains two fields:
  - `available_models: tuple[ACPModelOption, ...]` (defaults to `()`, `compare=False`)
  - `default_model: str | None`
- Seeded the three built-in providers with their runtime `/model` picker options:
  - **Claude Code** — 10 entries, default `claude-opus-4-7`
  - **Codex** — 20 entries (`<model>/<effort>`), default `gpt-5.5/medium`
  - **Gemini CLI** — 8 entries, default `auto-gemini-2.5`
- Exported `ACPModelOption` from `openhands.sdk.settings` and the top-level `openhands.sdk` package.

The lists mirror each harness's own picker; they are **suggestions, not access checks** — a custom `acp_model` is always allowed, and real availability depends on the account's plan tier.

## Tests

- New `TestProviderModelLists` enforces the key invariant: **`default_model` is always one of `available_models`**, plus non-empty / unique-ids / frozen checks.
- Per-provider metadata tests extended with `default_model` + membership assertions.
- `uv run pytest tests/sdk/settings/test_acp_providers.py` → **32 passed**; `ruff check` + `ruff format --check` clean.

## Downstream / ordering

`@openhands/typescript-client`'s drift check (`scripts/check-acp-drift.py`) pins `openhands-sdk @ main`, so its mirror PR (OpenHands/typescript-client#TBD) stays red until **this PR merges to main** — then it goes green automatically. Merge order: this → typescript-client → agent-canvas pin bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:31ae53a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-31ae53a-python \
  ghcr.io/openhands/agent-server:31ae53a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:31ae53a-golang-amd64
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-provider-models-golang-amd64
ghcr.io/openhands/agent-server:31ae53a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:31ae53a-golang-arm64
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-provider-models-golang-arm64
ghcr.io/openhands/agent-server:31ae53a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:31ae53a-java-amd64
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-java-amd64
ghcr.io/openhands/agent-server:feat-acp-provider-models-java-amd64
ghcr.io/openhands/agent-server:31ae53a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:31ae53a-java-arm64
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-java-arm64
ghcr.io/openhands/agent-server:feat-acp-provider-models-java-arm64
ghcr.io/openhands/agent-server:31ae53a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:31ae53a-python-amd64
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-python-amd64
ghcr.io/openhands/agent-server:feat-acp-provider-models-python-amd64
ghcr.io/openhands/agent-server:31ae53a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:31ae53a-python-arm64
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-python-arm64
ghcr.io/openhands/agent-server:feat-acp-provider-models-python-arm64
ghcr.io/openhands/agent-server:31ae53a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:31ae53a-golang
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-golang
ghcr.io/openhands/agent-server:feat-acp-provider-models-golang
ghcr.io/openhands/agent-server:31ae53a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:31ae53a-java
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-java
ghcr.io/openhands/agent-server:feat-acp-provider-models-java
ghcr.io/openhands/agent-server:31ae53a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:31ae53a-python
ghcr.io/openhands/agent-server:31ae53ae0a1785d0ba45283b0df0042865344c79-python
ghcr.io/openhands/agent-server:feat-acp-provider-models-python
ghcr.io/openhands/agent-server:31ae53a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `31ae53a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `31ae53a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->