### PR TITLE
fix(acp): trust gemini workspace so autonomous (yolo) mode works

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -119,7 +119,16 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
             display_name="Gemini CLI",
-            default_command=("npx", "-y", "@google/gemini-cli", "--acp"),
+            # --skip-trust trusts the workspace so gemini-cli allows the
+            # "yolo" default_session_mode below; without it, set_session_mode
+            # fails (-32603) in untrusted folders, blocking autonomous runs.
+            default_command=(
+                "npx",
+                "-y",
+                "@google/gemini-cli",
+                "--acp",
+                "--skip-trust",
+            ),
             api_key_env_var="GEMINI_API_KEY",
             base_url_env_var="GEMINI_BASE_URL",
             default_session_mode="yolo",

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -53,6 +53,9 @@ class TestACPProviderInfo:
         assert info.key == "gemini-cli"
         assert info.display_name == "Gemini CLI"
         assert "--acp" in info.default_command
+        # gemini refuses "yolo" in an untrusted folder; --skip-trust trusts the
+        # workspace so the autonomous default_session_mode below can be set.
+        assert "--skip-trust" in info.default_command
         assert info.api_key_env_var == "GEMINI_API_KEY"
         assert info.base_url_env_var == "GEMINI_BASE_URL"
         assert info.default_session_mode == "yolo"


### PR DESCRIPTION
## Problem
Gemini ACP can't start in autonomous mode. The provider's `default_session_mode` is `yolo`, but gemini-cli refuses `yolo`/`autoEdit` in an **untrusted** folder (`setApprovalMode()` throws *"Cannot enable privileged approval modes in an untrusted folder"*), surfaced over ACP as a generic `-32603 Internal error`. The only untrusted-safe mode is `default`, which prompts on every action.

## Fix
Add `--skip-trust` to gemini's `default_command` — trusts the workspace for the session so `set_session_mode("yolo")` succeeds. Same no-prompt posture as claude (`bypassPermissions`) / codex (`full-access`). (Trusting the workspace also lets gemini load its `.gemini/` config — same trade-off the others already make.)

## Verified (gemini-cli 0.43.0)
With `--skip-trust`, all modes set OK; without it, `yolo`/`autoEdit` fail with `-32603`. End-to-end: ACP session now inits in `yolo` via the shipped default command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:628e08b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-628e08b-python \
  ghcr.io/openhands/agent-server:628e08b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:628e08b-golang-amd64
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-golang-amd64
ghcr.io/openhands/agent-server:628e08b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:628e08b-golang-arm64
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-golang-arm64
ghcr.io/openhands/agent-server:628e08b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:628e08b-java-amd64
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-java-amd64
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-java-amd64
ghcr.io/openhands/agent-server:628e08b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:628e08b-java-arm64
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-java-arm64
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-java-arm64
ghcr.io/openhands/agent-server:628e08b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:628e08b-python-amd64
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-python-amd64
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-python-amd64
ghcr.io/openhands/agent-server:628e08b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:628e08b-python-arm64
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-python-arm64
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-python-arm64
ghcr.io/openhands/agent-server:628e08b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:628e08b-golang
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-golang
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-golang
ghcr.io/openhands/agent-server:628e08b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:628e08b-java
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-java
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-java
ghcr.io/openhands/agent-server:628e08b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:628e08b-python
ghcr.io/openhands/agent-server:628e08bb1f4dc5eb187f0c926c20937b2701b71a-python
ghcr.io/openhands/agent-server:fix-acp-gemini-yolo-trust-python
ghcr.io/openhands/agent-server:628e08b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `628e08b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `628e08b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->