### PR TITLE
fix(sdk): dedupe LLMs by usage_id in _ensure_agent_ready registration loop

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -629,12 +629,17 @@ class LocalConversation(BaseConversation):
             # Initialize agent with complete configuration
             self.agent.init_state(self._state, on_event=self._on_event)
 
-            # Register LLMs in the registry (still holding lock)
+            # Register LLMs in the registry (still holding lock).
+            # `registered` is updated after each add so that duplicate usage_ids
+            # within the same batch are silently skipped (first-write-wins),
+            # preventing a ValueError when e.g. agent and condenser LLMs were
+            # both serialised with usage_id="default".
             self.llm_registry.subscribe(self._state.stats.register_llm)
             registered = set(self.llm_registry.list_usage_ids())
             for llm in list(self.agent.get_all_llms()):
                 if llm.usage_id not in registered:
                     self.llm_registry.add(llm)
+                    registered.add(llm.usage_id)
 
             self._agent_ready = True
 

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -5,6 +5,7 @@ from pydantic import SecretStr
 
 from openhands.sdk import LLM, LocalConversation
 from openhands.sdk.agent import Agent
+from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.llm import llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.testing import TestLLM
@@ -252,3 +253,28 @@ def test_switch_profile_delegates_to_switch_llm(profile_store, monkeypatch):
     assert len(seen) == 1
     assert seen[0].usage_id == "profile:fast"
     assert seen[0].model == "fast-model"
+
+
+def test_duplicate_usage_ids_in_registration_loop_are_silently_deduped(tmp_path):
+    """Regression: if agent LLM and condenser LLM both carry the same
+    usage_id (as happens when a conversation is deserialised from a
+    base_state.json written before #3368), _ensure_agent_ready() must
+    NOT raise ValueError.  The first-write-wins contract means only
+    the agent LLM entry is registered; the condenser duplicate is
+    silently skipped.
+    """
+    # Simulate the broken persisted state: condenser inherits the agent LLM's usage_id
+    agent_llm = LLM(
+        model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="default"
+    )
+    condenser_llm = agent_llm.model_copy()  # inherits usage_id="default"
+    condenser = LLMSummarizingCondenser(llm=condenser_llm, max_size=100, keep_first=2)
+    agent = Agent(llm=agent_llm, condenser=condenser, tools=[])
+
+    conv = LocalConversation(agent=agent, workspace=tmp_path)
+
+    # Must not raise ValueError("Usage ID 'default' already exists in registry")
+    conv._ensure_agent_ready()
+
+    # First-write-wins: only one entry under the shared usage_id
+    assert conv.llm_registry.list_usage_ids().count("default") == 1


### PR DESCRIPTION
## Summary

Fixes the secondary bug described in OpenHands/agent-canvas#2175.

The `registered` snapshot in `_ensure_agent_ready()` was taken **once** before the loop and never updated inside it. When two LLMs share the same `usage_id` (e.g. both `"default"`, as in conversations persisted before SDK OpenHands/OpenHands#3368), both pass the `if usage_id not in registered` guard and the second `llm_registry.add()` throws:

```
ValueError: Usage ID 'default' already exists in registry  →  500
```

## Root cause

```python
# Before
registered = set(self.llm_registry.list_usage_ids())
for llm in list(self.agent.get_all_llms()):
    if llm.usage_id not in registered:
        self.llm_registry.add(llm)       # ← registered never updated
```

`registered` is a one-time snapshot so duplicate `usage_id`s within the same batch are not caught — the second `add()` always raises.

## Fix

Update `registered` after each successful `add()` so the loop provides **first-write-wins deduplication** within the batch:

```python
registered = set(self.llm_registry.list_usage_ids())
for llm in list(self.agent.get_all_llms()):
    if llm.usage_id not in registered:
        self.llm_registry.add(llm)
        registered.add(llm.usage_id)    # ← keeps snapshot current
```

## Why this is needed even after OpenHands/OpenHands#3368

OpenHands/OpenHands#3368 fixed `build_condenser()` to assign `usage_id="condenser"` going forward, but conversations whose `base_state.json` was written _before_ that fix still have `condenser.llm.usage_id = "default"` baked in. Those conversations keep 500-ing on load until this defence-in-depth guard is in place.

## Testing

Added `test_duplicate_usage_ids_in_registration_loop_are_silently_deduped` in `tests/sdk/conversation/test_switch_model.py`: creates an agent + condenser whose LLMs both carry `usage_id="default"`, calls `_ensure_agent_ready()`, and asserts no `ValueError` is raised and only one registry entry exists.

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:52d4dd2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-52d4dd2-python \
  ghcr.io/openhands/agent-server:52d4dd2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:52d4dd2-golang-amd64
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-golang-amd64
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-golang-amd64
ghcr.io/openhands/agent-server:52d4dd2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:52d4dd2-golang-arm64
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-golang-arm64
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-golang-arm64
ghcr.io/openhands/agent-server:52d4dd2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:52d4dd2-java-amd64
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-java-amd64
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-java-amd64
ghcr.io/openhands/agent-server:52d4dd2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:52d4dd2-java-arm64
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-java-arm64
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-java-arm64
ghcr.io/openhands/agent-server:52d4dd2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:52d4dd2-python-amd64
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-python-amd64
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-python-amd64
ghcr.io/openhands/agent-server:52d4dd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:52d4dd2-python-arm64
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-python-arm64
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-python-arm64
ghcr.io/openhands/agent-server:52d4dd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:52d4dd2-golang
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-golang
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-golang
ghcr.io/openhands/agent-server:52d4dd2-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:52d4dd2-java
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-java
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-java
ghcr.io/openhands/agent-server:52d4dd2-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:52d4dd2-python
ghcr.io/openhands/agent-server:52d4dd25a2632305dd19830467727d59b60e0394-python
ghcr.io/openhands/agent-server:fix-llm-registry-dedup-by-usage-id-python
ghcr.io/openhands/agent-server:52d4dd2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `52d4dd2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `52d4dd2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->