### PR TITLE
fix(acp): select gemini-cli 'oauth-personal' auth from cached creds

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -175,6 +175,10 @@ _AUTH_METHOD_ENV_MAP: dict[str, str] = {
     "gemini-api-key": "GEMINI_API_KEY",
 }
 _CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
+# Gemini CLI personal (Google OAuth) login, cached by ``gemini login`` /
+# ``gemini --acp``. Its presence lets us select the server's ``oauth-personal``
+# auth method without an API key (mirrors the ChatGPT subscription path).
+_GEMINI_OAUTH_PATH = Path(".gemini") / "oauth_creds.json"
 
 
 def _select_auth_method(
@@ -186,15 +190,23 @@ def _select_auth_method(
     Returns the ``id`` of the first matching method, or ``None`` if no
     supported credential source is available (the server may not require auth).
 
-    ChatGPT subscription login (device-code flow stored in
-    ``~/.codex/auth.json``) is checked first so it takes precedence over
-    explicit API keys, which serve as the fallback.
+    Subscription / OAuth logins (whose cached credential file is present) are
+    checked first so they take precedence over explicit API keys, which serve
+    as the fallback:
+
+    - ``chatgpt`` (codex-acp) — ``~/.codex/auth.json``
+    - ``oauth-personal`` (gemini-cli) — ``~/.gemini/oauth_creds.json``
+
+    In a server image these files are absent (no interactive login), so the
+    API-key fallback (e.g. ``GEMINI_API_KEY``) is used instead.
     """
     method_ids = {m.id for m in auth_methods}
-    # Prefer ChatGPT subscription login when the auth file is present.
-    if "chatgpt" in method_ids:
-        if (Path.home() / _CHATGPT_AUTH_PATH).is_file():
-            return "chatgpt"
+    # Prefer subscription / OAuth logins when their cached credential file is
+    # present.
+    if "chatgpt" in method_ids and (Path.home() / _CHATGPT_AUTH_PATH).is_file():
+        return "chatgpt"
+    if "oauth-personal" in method_ids and (Path.home() / _GEMINI_OAUTH_PATH).is_file():
+        return "oauth-personal"
     # Fall back to explicit API key env vars.
     for method_id, env_var in _AUTH_METHOD_ENV_MAP.items():
         if method_id in method_ids and env_var in env:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -3161,6 +3161,54 @@ class TestSelectAuthMethod:
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, {}) == "chatgpt"
 
+    def test_gemini_oauth_personal_when_creds_file_present(self, tmp_path):
+        """gemini-cli's OAuth login is selected when ~/.gemini/oauth_creds.json
+        exists, with no GEMINI_API_KEY needed."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        gem_dir = tmp_path / ".gemini"
+        gem_dir.mkdir()
+        (gem_dir / "oauth_creds.json").write_text("{}", encoding="utf-8")
+
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, {}) == "oauth-personal"
+
+    def test_gemini_oauth_preferred_over_api_key(self, tmp_path):
+        """OAuth login takes precedence over GEMINI_API_KEY (mirrors chatgpt)."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        gem_dir = tmp_path / ".gemini"
+        gem_dir.mkdir()
+        (gem_dir / "oauth_creds.json").write_text("{}", encoding="utf-8")
+
+        env = {"GEMINI_API_KEY": "g-test"}
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, env) == "oauth-personal"
+
+    def test_gemini_api_key_fallback_when_no_oauth_file(self, tmp_path):
+        """Falls back to GEMINI_API_KEY when oauth-personal is offered but the
+        creds file is absent (e.g. in a server image)."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        env = {"GEMINI_API_KEY": "g-test"}
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, env) == "gemini-api-key"
+
+    def test_gemini_oauth_offered_but_no_creds_no_key(self, tmp_path):
+        """oauth-personal offered, no creds file and no API key -> None."""
+        methods = [
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, {}) is None
+
     def test_empty_auth_methods(self):
         assert _select_auth_method([], {}) is None
 


### PR DESCRIPTION
## Problem

`_select_auth_method` special-cases codex-acp's `chatgpt` subscription login (checks `~/.codex/auth.json`) but had **no handling for gemini-cli's `oauth-personal`** method. So a `gemini-cli` logged in via Google OAuth (i.e. `~/.gemini/oauth_creds.json` present, no `GEMINI_API_KEY`) never received an `authenticate()` call — the SDK logged `"ACP server offers auth methods ['oauth-personal', 'gemini-api-key', ...] but no matching env var is set"` and **session creation failed with a JSON-RPC `-32603`** even though valid cached credentials existed.

## Fix

Mirror the `chatgpt` path: when the server offers `oauth-personal` and `~/.gemini/oauth_creds.json` exists, select it. Precedence matches the established design (OAuth/subscription login is preferred over an explicit API key, exactly like `chatgpt` over `OPENAI_API_KEY`).

```python
if "chatgpt" in method_ids and (Path.home() / _CHATGPT_AUTH_PATH).is_file():
    return "chatgpt"
if "oauth-personal" in method_ids and (Path.home() / _GEMINI_OAUTH_PATH).is_file():
    return "oauth-personal"
# ... GEMINI_API_KEY fallback unchanged
```

**Server images are unaffected:** there's no interactive OAuth login there, so `oauth_creds.json` is absent and the `GEMINI_API_KEY` fallback is used exactly as before. This only fixes local/dev usage of an OAuth-logged-in gemini-cli.

## Validation

- **Unit** (`TestSelectAuthMethod`, 4 new cases): creds-file present → `oauth-personal`; preferred over `GEMINI_API_KEY`; falls back to the key when the creds file is absent; `None` when neither is available. Full `tests/sdk/agent/test_acp_agent.py`: **192 passed**.
- **Real end-to-end** against the pinned `@google/gemini-cli@0.38.0` (the version in the agent-server Dockerfile): the SDK now logs `Authenticating with ACP method: oauth-personal`, with zero "no matching env var" warnings, and creates a working session with no API key. Before this change the same setup failed at session creation with `-32603`.

## Context

Independent of OpenHands/software-agent-sdk#3390 (runtime `switch_acp_model`). Surfaced while validating ACP model switching for OpenHands/agent-canvas#2176 — this auth gap was the actual reason gemini-cli was effectively "untested": the SDK couldn't even establish a gemini session under OAuth auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7cfdf96-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7cfdf96-python \
  ghcr.io/openhands/agent-server:7cfdf96-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7cfdf96-golang-amd64
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-golang-amd64
ghcr.io/openhands/agent-server:7cfdf96-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7cfdf96-golang-arm64
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-golang-arm64
ghcr.io/openhands/agent-server:7cfdf96-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7cfdf96-java-amd64
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-java-amd64
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-java-amd64
ghcr.io/openhands/agent-server:7cfdf96-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7cfdf96-java-arm64
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-java-arm64
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-java-arm64
ghcr.io/openhands/agent-server:7cfdf96-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7cfdf96-python-amd64
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-python-amd64
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-python-amd64
ghcr.io/openhands/agent-server:7cfdf96-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7cfdf96-python-arm64
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-python-arm64
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-python-arm64
ghcr.io/openhands/agent-server:7cfdf96-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7cfdf96-golang
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-golang
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-golang
ghcr.io/openhands/agent-server:7cfdf96-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7cfdf96-java
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-java
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-java
ghcr.io/openhands/agent-server:7cfdf96-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7cfdf96-python
ghcr.io/openhands/agent-server:7cfdf967e1dd11acfd3292e3fb4376cb06f4b619-python
ghcr.io/openhands/agent-server:fix-acp-gemini-oauth-auth-python
ghcr.io/openhands/agent-server:7cfdf96-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7cfdf96-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7cfdf96-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->