### PR TITLE
fix(sdk): snapshot LLM metrics via Metrics.get_snapshot() (Q2 of #3341)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -105,7 +105,7 @@ from openhands.sdk.llm.streaming import (
 )
 from openhands.sdk.llm.utils.image_resize import maybe_resize_messages_for_provider
 from openhands.sdk.llm.utils.litellm_provider import infer_litellm_provider
-from openhands.sdk.llm.utils.metrics import Metrics, MetricsSnapshot
+from openhands.sdk.llm.utils.metrics import Metrics
 from openhands.sdk.llm.utils.model_features import get_features
 from openhands.sdk.llm.utils.retry_mixin import RetryMixin
 from openhands.sdk.llm.utils.telemetry import Telemetry
@@ -757,15 +757,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     # Shared helpers for completion / acompletion / responses / aresponses
     # =========================================================================
 
-    def _current_metrics_snapshot(self) -> MetricsSnapshot:
-        """Snapshot current LLM metrics for an :class:`LLMResponse`."""
-        return MetricsSnapshot(
-            model_name=self.metrics.model_name,
-            accumulated_cost=self.metrics.accumulated_cost,
-            max_budget_per_task=self.metrics.max_budget_per_task,
-            accumulated_token_usage=self.metrics.accumulated_token_usage,
-        )
-
     def _make_retry_decorator(
         self,
     ) -> Callable[[Callable[..., Any]], Callable[..., Any]]:
@@ -785,7 +776,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         message = Message.from_llm_chat_message(first_choice["message"])
         return LLMResponse(
             message=message,
-            metrics=self._current_metrics_snapshot(),
+            metrics=self.metrics.get_snapshot(),
             raw_response=resp,
         )
 
@@ -795,7 +786,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         message = Message.from_llm_responses_output(output_seq)
         return LLMResponse(
             message=message,
-            metrics=self._current_metrics_snapshot(),
+            metrics=self.metrics.get_snapshot(),
             raw_response=resp,
         )
 


### PR DESCRIPTION
## What

Q2 of #3341. Every `LLMResponse` carries a `MetricsSnapshot`. It was hand-built and passed the live `accumulated_token_usage` **by reference**, so the "snapshot" aliased mutable LLM state instead of capturing it. This snapshots via the canonical `Metrics.get_snapshot()` directly in the two `LLMResponse` builders (`_build_completion_result`, `_build_responses_result`):

```python
return LLMResponse(
    message=message,
    metrics=self.metrics.get_snapshot(),
    raw_response=resp,
)
```

## Why this is good

1. **It makes the snapshot an actual snapshot.** `get_snapshot()` `deepcopy`s `accumulated_token_usage`; the hand-built version aliased the live object, so a returned snapshot could change after the fact. This is observable, not theoretical: `ACPAgent` mutates that object in place (`acp_agent.py:736` — `...accumulated_token_usage.model = self.acp_model`), which would retroactively rewrite the `model` of any `LLMResponse` snapshot already handed out.

2. **Single source of truth.** `get_snapshot()` is the canonical snapshot method and is already what `ConversationStats` uses (`conversation_stats.py:51`). The hand-built copy duplicated its field list and would silently drift — and re-introduce the aliasing — if `MetricsSnapshot` ever gains a field.

3. **No needless indirection.** The interim `_current_metrics_snapshot()` wrapper added nothing once its body was a one-line delegation (no logic, no extra typing, only 2 call sites, unreferenced by tests), so it's dropped in favour of calling `get_snapshot()` directly. `MetricsSnapshot` is no longer imported in `llm.py`.

## Why it's a small diff

The issue originally listed four hand-built `MetricsSnapshot(...)` sites (`llm.py:907/1032/1256/1450`). #3355 / #3356 already consolidated all four into one helper while fixing the async error path, so this PR finishes Q2 by removing that helper and snapshotting directly.

## Testing
- `ruff format --check` and `ruff check` clean on the changed file
- 141 targeted tests pass: `test_llm_metrics`, `test_llm_completion`, `test_llm_fallback`, `test_llm`, `test_stats_update_event_snapshot`


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9fe1960-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9fe1960-python \
  ghcr.io/openhands/agent-server:9fe1960-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9fe1960-golang-amd64
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-golang-amd64
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-golang-amd64
ghcr.io/openhands/agent-server:9fe1960-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9fe1960-golang-arm64
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-golang-arm64
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-golang-arm64
ghcr.io/openhands/agent-server:9fe1960-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9fe1960-java-amd64
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-java-amd64
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-java-amd64
ghcr.io/openhands/agent-server:9fe1960-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9fe1960-java-arm64
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-java-arm64
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-java-arm64
ghcr.io/openhands/agent-server:9fe1960-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9fe1960-python-amd64
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-python-amd64
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-python-amd64
ghcr.io/openhands/agent-server:9fe1960-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9fe1960-python-arm64
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-python-arm64
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-python-arm64
ghcr.io/openhands/agent-server:9fe1960-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9fe1960-golang
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-golang
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-golang
ghcr.io/openhands/agent-server:9fe1960-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9fe1960-java
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-java
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-java
ghcr.io/openhands/agent-server:9fe1960-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9fe1960-python
ghcr.io/openhands/agent-server:9fe1960a7c107190e4ed075cb0d440dc77ee5c29-python
ghcr.io/openhands/agent-server:fix-reuse-metrics-get-snapshot-python
ghcr.io/openhands/agent-server:9fe1960-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9fe1960-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9fe1960-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->