### PR TITLE
fix(sdk): override RemoteConversation.interrupt() to POST /interrupt (B4 of #3341)

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1230,6 +1230,13 @@ class RemoteConversation(BaseConversation):
             f"{self._conversation_action_base_path}/{self._id}/pause",
         )
 
+    def interrupt(self) -> None:
+        _send_request(
+            self._client,
+            "POST",
+            f"{self._conversation_action_base_path}/{self._id}/interrupt",
+        )
+
     def update_secrets(self, secrets: Mapping[str, SecretValue]) -> None:
         from openhands.sdk.secret.secrets import SecretSource
 

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -1088,6 +1088,32 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_remote_conversation_interrupt(self, mock_ws_client):
+        """interrupt() must POST to /interrupt, not degrade to /pause."""
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+
+        mock_ws_instance = Mock()
+        mock_ws_client.return_value = mock_ws_instance
+
+        conversation = RemoteConversation(agent=self.agent, workspace=self.workspace)
+        conversation.interrupt()
+
+        posts = [
+            call[0][1]
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "POST"
+        ]
+        assert any(
+            f"/api/conversations/{conversation_id}/interrupt" in url for url in posts
+        ), "Should have made a POST call to interrupt endpoint"
+        assert not any(
+            f"/api/conversations/{conversation_id}/pause" in url for url in posts
+        ), "interrupt() must not degrade to the pause endpoint"
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_remote_conversation_update_secrets(self, mock_ws_client):
         """Test updating secrets."""
         # Setup mocks


### PR DESCRIPTION
## What

Addresses B4 of #3341. `RemoteConversation` didn't override `interrupt()`, so it inherited `BaseConversation.interrupt()`, whose default falls back to `pause()`. A remote caller invoking `interrupt()` therefore got **pause** semantics — wait for the in-flight LLM request to finish — from a method named `interrupt()`.

The server already exposes `POST /conversations/{id}/interrupt` (`conversation_router.py:219`), so this adds the missing override, mirroring `pause()`:

```python
def interrupt(self) -> None:
    _send_request(
        self._client,
        "POST",
        f"{self._conversation_action_base_path}/{self._id}/interrupt",
    )
```

## Test

`test_remote_conversation_interrupt` asserts the call POSTs to `/interrupt` and **not** to `/pause` — i.e. it no longer silently degrades to the inherited fallback.

## Verification
- `ruff format --check` and `ruff check` clean
- full `test_remote_conversation.py` suite passes (32 tests)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:30e52a4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-30e52a4-python \
  ghcr.io/openhands/agent-server:30e52a4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:30e52a4-golang-amd64
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-golang-amd64
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-golang-amd64
ghcr.io/openhands/agent-server:30e52a4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:30e52a4-golang-arm64
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-golang-arm64
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-golang-arm64
ghcr.io/openhands/agent-server:30e52a4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:30e52a4-java-amd64
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-java-amd64
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-java-amd64
ghcr.io/openhands/agent-server:30e52a4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:30e52a4-java-arm64
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-java-arm64
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-java-arm64
ghcr.io/openhands/agent-server:30e52a4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:30e52a4-python-amd64
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-python-amd64
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-python-amd64
ghcr.io/openhands/agent-server:30e52a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:30e52a4-python-arm64
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-python-arm64
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-python-arm64
ghcr.io/openhands/agent-server:30e52a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:30e52a4-golang
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-golang
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-golang
ghcr.io/openhands/agent-server:30e52a4-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:30e52a4-java
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-java
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-java
ghcr.io/openhands/agent-server:30e52a4-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:30e52a4-python
ghcr.io/openhands/agent-server:30e52a4bf7567936e4ba5593482cfca7f53e7dc0-python
ghcr.io/openhands/agent-server:fix-remote-conversation-interrupt-python
ghcr.io/openhands/agent-server:30e52a4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `30e52a4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `30e52a4-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->