### PR TITLE
fix(security): pin ACP npx launchers to reviewed versions (closes #3357)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_router_acp.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router_acp.py
@@ -50,7 +50,13 @@ START_ACP_CONVERSATION_EXAMPLES = [
         ),
     ).model_dump(exclude_defaults=True, mode="json"),
     StartACPConversationRequest(
-        agent=ACPAgent(acp_command=["npx", "-y", "claude-agent-acp"]),
+        agent=ACPAgent(
+            acp_command=[
+                "npx",
+                "-y",
+                "@agentclientprotocol/claude-agent-acp@0.30.0",
+            ]
+        ),
         workspace=LocalWorkspace(working_dir="workspace/project"),
         initial_message=SendMessageRequest(
             role="user",

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -383,12 +383,29 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
 )
 
 
+# Pinned npm versions for the built-in ACP launchers. Keep in sync with the
+# `npm install -g` line in
+# openhands-agent-server/openhands/agent_server/docker/Dockerfile — a bump must
+# edit both. The pin constrains the native (no pre-installed binary) path, where
+# the bare `npx -y <pkg>` would otherwise resolve npm `latest` at launch under a
+# permission-disabling session mode. In the image the binary rewrite in
+# `ACPAgentSettings.resolve_acp_command` runs the pinned `binary_name` instead,
+# so the `@version` suffix is a no-op there.
+CLAUDE_AGENT_ACP_VERSION = "0.30.0"
+CODEX_ACP_VERSION = "0.15.0"
+GEMINI_CLI_VERSION = "0.38.0"
+
+
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
     {
         "claude-code": ACPProviderInfo(
             key="claude-code",
             display_name="Claude Code",
-            default_command=("npx", "-y", "@agentclientprotocol/claude-agent-acp"),
+            default_command=(
+                "npx",
+                "-y",
+                f"@agentclientprotocol/claude-agent-acp@{CLAUDE_AGENT_ACP_VERSION}",
+            ),
             api_key_env_var="ANTHROPIC_API_KEY",
             base_url_env_var="ANTHROPIC_BASE_URL",
             default_session_mode="bypassPermissions",
@@ -408,7 +425,11 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "codex": ACPProviderInfo(
             key="codex",
             display_name="Codex",
-            default_command=("npx", "-y", "@zed-industries/codex-acp"),
+            default_command=(
+                "npx",
+                "-y",
+                f"@zed-industries/codex-acp@{CODEX_ACP_VERSION}",
+            ),
             api_key_env_var="OPENAI_API_KEY",
             base_url_env_var="OPENAI_BASE_URL",
             default_session_mode="full-access",
@@ -425,7 +446,12 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
             display_name="Gemini CLI",
-            default_command=("npx", "-y", "@google/gemini-cli", "--acp"),
+            default_command=(
+                "npx",
+                "-y",
+                f"@google/gemini-cli@{GEMINI_CLI_VERSION}",
+                "--acp",
+            ),
             api_key_env_var="GEMINI_API_KEY",
             base_url_env_var="GEMINI_BASE_URL",
             default_session_mode="yolo",

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1541,6 +1541,19 @@ class ACPAgentSettings(AgentSettingsBase):
         package, *extra_args = rest
         return package, extra_args
 
+    @staticmethod
+    def _npm_package_name(package: str) -> str:
+        """Strip any ``@version`` specifier from an npm package spec.
+
+        ``@scope/pkg@1.2.3`` → ``@scope/pkg``; ``pkg@1.2.3`` → ``pkg``; an
+        unversioned spec is returned unchanged. The version separator is the
+        ``@`` *after* the name — for scoped specs that is the second ``@`` (the
+        first introduces the scope), so a leading ``@`` is skipped.
+        """
+        start = 1 if package.startswith("@") else 0
+        at = package.find("@", start)
+        return package[:at] if at != -1 else package
+
     def _prefer_pinned_binary(self, command: list[str]) -> list[str]:
         """Swap an ``npx -y <pkg>`` command for the provider's pinned binary.
 
@@ -1551,6 +1564,12 @@ class ACPAgentSettings(AgentSettingsBase):
         downloading npm-latest. Returned unchanged otherwise: no pinned binary
         (custom server), a non-matching/non-npx command, or the binary not on
         ``PATH`` (local dev).
+
+        Package matching ignores any ``@version`` suffix: the registry default
+        is version-pinned (so the native fallback can't drift to npm ``latest``),
+        but a client may still send the bare or a differently-pinned package
+        name. In the image the pinned binary stands in for the provider's package
+        regardless of the requested version, so the rewrite compares names only.
         """
         info = get_acp_provider(self.acp_server)
         if info is None or info.binary_name is None:
@@ -1563,7 +1582,10 @@ class ACPAgentSettings(AgentSettingsBase):
 
         default_pkg, _ = default_parsed
         actual_pkg, extra = actual_parsed
-        if actual_pkg != default_pkg or shutil.which(info.binary_name) is None:
+        same_package = self._npm_package_name(actual_pkg) == self._npm_package_name(
+            default_pkg
+        )
+        if not same_package or shutil.which(info.binary_name) is None:
             return command
 
         return [info.binary_name, *extra]

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -771,7 +771,7 @@ def test_acp_create_agent_uses_server_default_command(
     assert agent.acp_command == [
         "npx",
         "-y",
-        "@agentclientprotocol/claude-agent-acp",
+        "@agentclientprotocol/claude-agent-acp@0.30.0",
     ]
     assert agent.acp_model == "claude-opus-4-6"
 
@@ -887,16 +887,40 @@ def test_acp_resolve_command_rewrites_explicit_npx_command(
     assert settings.resolve_acp_command() == ["codex-acp", "--verbose"]
 
 
+def test_acp_resolve_command_rewrites_versioned_npx_to_pinned_binary(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(b') Matching is version-agnostic: an ``npx`` command for the provider's
+    package at *any* version (bare, the pinned default, or a drifted pin a client
+    sends) rewrites to the pinned binary on PATH — in the image we always stand
+    the reviewed binary in for the provider's package."""
+    monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
+    for pkg in (
+        "@zed-industries/codex-acp",
+        "@zed-industries/codex-acp@0.15.0",
+        "@zed-industries/codex-acp@0.11.1",
+    ):
+        settings = ACPAgentSettings(
+            acp_server="codex",
+            acp_command=["npx", "-y", pkg],
+        )
+        assert settings.resolve_acp_command() == ["codex-acp"], pkg
+
+
 def test_acp_resolve_command_keeps_npx_when_binary_absent(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """(c) Binary not on PATH (local dev) → the ``npx`` command is unchanged."""
+    """(c) Binary not on PATH (local dev) → the ``npx`` command is unchanged.
+
+    The default is version-pinned, so the native fallback launches the reviewed
+    version rather than npm ``latest``.
+    """
     monkeypatch.setattr(shutil, "which", lambda _: None)
     settings = ACPAgentSettings(acp_server="codex")
     assert settings.resolve_acp_command() == [
         "npx",
         "-y",
-        "@zed-industries/codex-acp",
+        "@zed-industries/codex-acp@0.15.0",
     ]
 
 


### PR DESCRIPTION
<!-- AI/LLM agents: do not edit the HUMAN section or the human-tested checkbox. -->

HUMAN:
pin ACP npx launchers to reviewed versions

- [x] A human has tested these changes.

AGENT:

Rebases and salvages #3399 onto current `main`, reconciled with the ACP
binary-rewrite design merged in #3490. Original work by @Sanjays2402
(co-authored on the commit); a maintainer pushed the reconciled version to
this same branch.

Changes vs. the original #3399:
- Pin versions now match `main`'s Dockerfile exactly (the single source of
  truth): `codex-acp@0.15.0` (was a stale `0.11.1`) and `gemini-cli@0.38.0`
  (was `0.39.1`). `claude-agent-acp@0.30.0` unchanged.
- Dropped the out-of-scope Dockerfile `gemini-cli` bump — the SDK pin tracks
  the Dockerfile, it does not change it.
- Reconciled with #3490: a version-pinned default would otherwise break the
  image-binary rewrite for an explicit *unpinned* `npx` command (canvas's
  fallback path), silently running npm-latest in the image. Fixed by matching
  the provider package by **name** (ignoring any `@version`) in
  `_prefer_pinned_binary`, so the pinned binary stands in regardless of the
  requested version. The native (no-binary) path keeps the pin.

Verification (clean worktree off `main`; `uv.lock` churn reverted):

```
ruff check / ruff format --check (4 changed files) ......... clean
pytest tests/sdk/test_settings.py tests/sdk/settings/ \
       tests/sdk/agent/test_acp_agent.py ................... 580 passed
pytest tests/agent_server/test_conversation_router_acp.py \
       tests/agent_server/test_openapi_discriminator.py \
       tests/cross/test_check_agent_server_rest_api_breakage.py \
       tests/cross/test_check_sdk_api_breakage.py ........... passed
```

Runtime check of `ACPAgentSettings.resolve_acp_command()`:

```
registry default_command (pinned):
  claude-code: ['npx','-y','@agentclientprotocol/claude-agent-acp@0.30.0']
  codex:       ['npx','-y','@zed-industries/codex-acp@0.15.0']
  gemini-cli:  ['npx','-y','@google/gemini-cli@0.38.0','--acp']

native fallback (no binary on PATH)   -> pinned npx command (as above)
image (binaries on PATH), default     -> ['claude-agent-acp'] / ['codex-acp'] / ['gemini','--acp']
image, explicit npx bare/pinned/drifted:
  npx @zed-industries/codex-acp        -> ['codex-acp']
  npx @zed-industries/codex-acp@0.15.0 -> ['codex-acp']
  npx @zed-industries/codex-acp@0.11.1 -> ['codex-acp']
```

The REST-API breakage cross-check passes, so the OpenAPI example change does
not alter the published schema.

---

## Why

Closes #3357.

The three built-in ACP providers in `openhands.sdk.settings.acp_providers`
launched with floating `npx -y <pkg>` commands. On the **native** launch path
(a host with no pre-installed ACP binary), the package version is resolved from
npm's `latest` at agent-launch time — after commit review and after the
`[tool.uv] exclude-newer` guardrail on the Python lock. Each provider also
defaults to a permission-disabling session mode (`bypassPermissions`,
`full-access`, `yolo`), so a poisoned or unexpectedly broken `latest` publish
would be fetched and executed under a high-trust mode on the next launch.

In the agent-server image these packages are pre-installed as PATH binaries and
#3490 already rewrites the `npx` command to the pinned binary, so the gap is
only the native fallback. Hardening, not a report of an active exploit.

## Summary

- Pin `default_command` for `claude-code`, `codex`, and `gemini-cli` in
  `acp_providers.py` via module-level constants matching the agent-server
  Dockerfile (the single source of truth):
  `@agentclientprotocol/claude-agent-acp@0.30.0`,
  `@zed-industries/codex-acp@0.15.0`, `@google/gemini-cli@0.38.0`.
- Reconcile with #3490: make `_prefer_pinned_binary` match the provider package
  by name (ignoring any `@version`) so the image-binary rewrite still fires for
  the pinned default and for any `npx` command a client sends (bare, pinned, or
  drifted); only the native fallback carries the pin. Adds
  `ACPAgentSettings._npm_package_name`.
- Fix the OpenAPI example in `conversation_router_acp.py` — previously
  `npx -y claude-agent-acp` (unscoped name, 404 on npm today, registerable by
  anyone → dependency-confusion footgun). Now the scoped, pinned default.
- Update the affected tests in `tests/sdk/test_settings.py` (default-command
  and native-fallback forms) and add a test asserting the version-agnostic
  rewrite to the pinned binary.

## Issue Number

Closes #3357

## How to Test

```bash
uv run pytest tests/sdk/test_settings.py tests/sdk/settings/test_acp_providers.py
```

Or by inspection:

```python
from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
for k, v in ACP_PROVIDERS.items():
    print(k, list(v.default_command))
# claude-code ['npx', '-y', '@agentclientprotocol/claude-agent-acp@0.30.0']
# codex       ['npx', '-y', '@zed-industries/codex-acp@0.15.0']
# gemini-cli  ['npx', '-y', '@google/gemini-cli@0.38.0', '--acp']
```

The SDK pins and the Dockerfile `npm install -g` line are now identical, so
build-time and native runtime versions cannot diverge.

## Video/Screenshots

N/A — no UI change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `default_command` is a tuple of `str`; only its contents changed. Callers
  building their own command via `ACPAgent(acp_command=[...])` are unaffected.
- Bumping a version requires editing both the constants block in
  `acp_providers.py` and the Dockerfile `npm install -g` line; a comment on the
  constants points at the Dockerfile to make that contract explicit.
- Follow-up (non-blocking, downstream): the `@openhands/typescript-client` ACP
  registry mirrors these defaults. It can be synced to the pinned forms for
  tidiness, but the name-based rewrite means the image launches the pinned
  binary even if the mirror temporarily lags.
