### PR TITLE
fix(api-breakage): recognize the `_DEPRECATED_SDK_EXPORTS` registry as a deprecation source

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -879,12 +879,25 @@ def _load_prev_from_pypi(
         return None
 
 
+# Names of module-level data registries that declare deprecated public
+# re-exports as ``{name: {"deprecated_in": ..., "removed_in": ...}}`` and are
+# consumed by a module-level ``__getattr__``. The SDK uses this form for renamed
+# export aliases (e.g. ``LLMAgentSettings``) that deliberately are NOT
+# ``@deprecated``-decorated on the class itself (the class stays a live internal
+# union member) and whose ``warn_deprecated`` feature name is a dynamic f-string.
+# Such deprecations are invisible to the decorator/call scans below, so we read
+# the registry as a third deprecation source.
+_DEPRECATED_EXPORT_REGISTRY_NAMES = frozenset({"_DEPRECATED_SDK_EXPORTS"})
+
+
 def _find_deprecated_symbols(source_root: Path) -> DeprecatedSymbols:
     """Scan source files for symbols marked with the SDK deprecation helpers.
 
-    Detects two forms:
+    Detects three forms:
     - ``@deprecated(...)`` decorator on a class/function/method
     - ``warn_deprecated('SomeFeature', ...)`` call
+    - entries in a ``_DEPRECATED_SDK_EXPORTS``-style registry dict mapping an
+      export name to ``{"deprecated_in": ..., "removed_in": ...}``
 
     Returns:
         DeprecatedSymbols(top_level=..., qualified=..., metadata=...)
@@ -975,6 +988,40 @@ def _find_deprecated_symbols(source_root: Path) -> DeprecatedSymbols:
 
             self.generic_visit(node)
 
+        def visit_AnnAssign(self, node: ast.AnnAssign) -> None:  # noqa: N802
+            self._record_export_registry(node.target, node.value)
+            self.generic_visit(node)
+
+        def visit_Assign(self, node: ast.Assign) -> None:  # noqa: N802
+            for target in node.targets:
+                self._record_export_registry(target, node.value)
+            self.generic_visit(node)
+
+        def _record_export_registry(
+            self, target: ast.expr, value: ast.expr | None
+        ) -> None:
+            """Record exports declared deprecated via a registry dict literal."""
+            if not (
+                isinstance(target, ast.Name)
+                and target.id in _DEPRECATED_EXPORT_REGISTRY_NAMES
+            ):
+                return
+            if not isinstance(value, ast.Dict):
+                return
+            for key_node, val_node in zip(value.keys, value.values):
+                if key_node is None:
+                    continue
+                export = _extract_string_literal(key_node)
+                if export is None or not isinstance(val_node, ast.Dict):
+                    continue
+                metadata = DeprecationMetadata(
+                    deprecated_in=_extract_dict_string_value(val_node, "deprecated_in"),
+                    removed_in=_extract_dict_string_value(val_node, "removed_in"),
+                )
+                self.top_level.add(export)
+                self.qualified.add(export)
+                self.metadata[export] = metadata
+
     top_level: set[str] = set()
     qualified: set[str] = set()
     metadata: dict[str, DeprecationMetadata] = {}
@@ -1004,6 +1051,19 @@ def _extract_string_literal(node: ast.AST) -> str | None:
     """Return the string value if *node* is a simple string literal."""
     if isinstance(node, ast.Constant) and isinstance(node.value, str):
         return node.value
+    return None
+
+
+def _extract_dict_string_value(node: ast.Dict, key: str) -> str | None:
+    """Return the string value for *key* in an ``ast.Dict`` literal, if present."""
+    for k, v in zip(node.keys, node.values):
+        if (
+            isinstance(k, ast.Constant)
+            and k.value == key
+            and isinstance(v, ast.Constant)
+            and isinstance(v.value, str)
+        ):
+            return v.value
     return None
 
 

--- a/tests/cross/test_check_sdk_api_breakage.py
+++ b/tests/cross/test_check_sdk_api_breakage.py
@@ -198,6 +198,50 @@ def test_removal_with_warn_deprecated_is_not_undeprecated(tmp_path):
     assert undeprecated == 0
 
 
+def test_find_deprecated_symbols_reads_export_registry(tmp_path):
+    """``_DEPRECATED_SDK_EXPORTS`` registry entries are recognized as deprecated
+    top-level symbols (the SDK's data-driven mechanism for renamed import
+    aliases such as ``LLMAgentSettings``)."""
+    src = tmp_path / "openhands" / "sdk"
+    src.mkdir(parents=True)
+    (src / "__init__.py").write_text(
+        "_DEPRECATED_SDK_EXPORTS: dict[str, dict[str, str]] = {\n"
+        "    'LLMAgentSettings': {'deprecated_in': '1.19.0',"
+        " 'removed_in': '1.24.0'},\n"
+        "}\n"
+    )
+
+    found = _find_deprecated_symbols(tmp_path)
+
+    assert "LLMAgentSettings" in found.top_level
+    assert found.metadata["LLMAgentSettings"].deprecated_in == "1.19.0"
+    assert found.metadata["LLMAgentSettings"].removed_in == "1.24.0"
+
+
+def test_removal_via_export_registry_is_not_undeprecated(tmp_path):
+    """An export deprecated only through the ``_DEPRECATED_SDK_EXPORTS`` registry
+    dict can be removed on schedule without being flagged as an undeprecated
+    removal -- the registry is the only place its deprecation is statically
+    visible (no ``@deprecated`` decorator; f-string ``warn_deprecated`` name)."""
+    old_pkg = _write_pkg_init(tmp_path, "old", ["Foo", "Bar"])
+    old_init = old_pkg / "__init__.py"
+    old_init.write_text(
+        old_init.read_text()
+        + "\n_DEPRECATED_SDK_EXPORTS: dict[str, dict[str, str]] = {\n"
+        + "    'Bar': {'deprecated_in': '1.0', 'removed_in': '2.0'},\n"
+        + "}\n"
+    )
+    _write_pkg_init(tmp_path, "new", ["Foo"])
+
+    old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])
+    new_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "new")])
+
+    total_breaks, undeprecated = _prod._compute_breakages(old_root, new_root, _SDK_CFG)
+
+    assert total_breaks == 1
+    assert undeprecated == 0
+
+
 def test_removed_public_method_requires_deprecation(tmp_path):
     old_pkg = _write_pkg_init(tmp_path, "old", ["Foo"])
     new_pkg = _write_pkg_init(tmp_path, "new", ["Foo"])


### PR DESCRIPTION
## Why

The SDK API-breakage gate (`.github/scripts/check_sdk_api_breakage.py`) only sanctions removing a public `__all__` export when it can **statically** find that the symbol was deprecated in the baseline release — via a `@deprecated(...)` decorator or a `warn_deprecated("LiteralName", ...)` call.

But the SDK has a **second** deprecation mechanism the checker was never taught about: the `_DEPRECATED_SDK_EXPORTS` registry dict in `openhands/sdk/__init__.py` (consumed by a module-level `__getattr__`). It's used for renamed re-export aliases that:
- deliberately are **not** `@deprecated`-decorated on the class itself (the class stays a live internal member — e.g. it's still part of a discriminated union), and
- emit their warning through `warn_deprecated(f"Importing {name!r} …")` — a **dynamic f-string** feature name the AST scan can't read.

So an export deprecated *only* through this registry is invisible to the gate and gets reported as **"Removed '<name>' without prior deprecation"**, blocking its scheduled removal even though it carried the full deprecation runway.

This is not hypothetical: `LLMAgentSettings` (deprecated `1.19.0`, `removed_in: 1.24.0`) is exactly this case. Its removal is currently blocked purely because the checker can't see a deprecation that *is* present in the baseline — just expressed via the registry rather than a decorator/literal call.

## What

Teach `_find_deprecated_symbols` to also parse module-level `_DEPRECATED_SDK_EXPORTS` dict literals (`name -> {"deprecated_in": ..., "removed_in": ...}`) as a **third** deprecation source, alongside the existing decorator and `warn_deprecated("literal")` forms.

This only **adds** a recognized deprecation source, so it can never mask a real breakage — it can only sanction removals that were genuinely deprecated via the registry.

## Verification

- New unit test (`test_find_deprecated_symbols_reads_export_registry`) and end-to-end `_compute_breakages` test (`test_removal_via_export_registry_is_not_undeprecated`); full checker suite passes (53 tests).
- Verified live against the published `1.23.1` baseline: with this change, removing `LLMAgentSettings` is reported as a `::notice` ("Removed previously-deprecated symbol … after its scheduled removal version") instead of an `::error`, and the check exits 0.

## Context

Split out of the `v1.24.0` release work so the release PR stays scoped to its version bump + feature changes. Once this merges, the deferred `LLMAgentSettings` removal becomes a clean follow-up.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cb1dc53-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cb1dc53-python \
  ghcr.io/openhands/agent-server:cb1dc53-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cb1dc53-golang-amd64
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-golang-amd64
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-golang-amd64
ghcr.io/openhands/agent-server:cb1dc53-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cb1dc53-golang-arm64
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-golang-arm64
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-golang-arm64
ghcr.io/openhands/agent-server:cb1dc53-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cb1dc53-java-amd64
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-java-amd64
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-java-amd64
ghcr.io/openhands/agent-server:cb1dc53-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cb1dc53-java-arm64
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-java-arm64
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-java-arm64
ghcr.io/openhands/agent-server:cb1dc53-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cb1dc53-python-amd64
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-python-amd64
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-python-amd64
ghcr.io/openhands/agent-server:cb1dc53-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cb1dc53-python-arm64
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-python-arm64
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-python-arm64
ghcr.io/openhands/agent-server:cb1dc53-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cb1dc53-golang
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-golang
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-golang
ghcr.io/openhands/agent-server:cb1dc53-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:cb1dc53-java
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-java
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-java
ghcr.io/openhands/agent-server:cb1dc53-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:cb1dc53-python
ghcr.io/openhands/agent-server:cb1dc534ccc9b109b805c36f69dbbff80969d836-python
ghcr.io/openhands/agent-server:fix-apibreak-registry-deprecations-python
ghcr.io/openhands/agent-server:cb1dc53-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cb1dc53-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cb1dc53-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->