### PR TITLE
fix(agent-server): route sync-only agents through sync run() instead of threaded astep (B5)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -740,8 +740,9 @@ class EventService:
         immediately.  When possible, the conversation is driven via its native
         ``arun()`` coroutine so LLM I/O does not tie up a thread-pool worker.
         For conversations that do not expose ``arun()`` (e.g., custom
-        subclasses), the synchronous ``run()`` is executed in the thread pool as
-        before.
+        subclasses) or whose agent only implements sync ``step()`` (no
+        ``astep()`` override, e.g. ACPAgent), the synchronous ``run()`` is
+        executed in the thread pool as before.
 
         Raises:
             ValueError: If the service is inactive or conversation is already running.
@@ -773,19 +774,23 @@ class EventService:
                     # loop is free during LLM I/O.  Fall back to thread-pool
                     # execution for backward compatibility.
                     #
-                    # Both guards are required:
+                    # All guards are required:
                     #  • iscoroutinefunction – filters out non-async objects
                     #    (e.g. MagicMock in tests).
-                    #  • override check – BaseConversation defines a default
-                    #    ``async def arun()`` that delegates to sync ``run()``,
-                    #    so iscoroutinefunction alone is always True for real
-                    #    subclasses.  We detect an *actual* override to avoid
-                    #    running a sync-only subclass on the event loop.
+                    #  • conversation override – BaseConversation's default
+                    #    ``arun()`` delegates to sync ``run()``, so we require an
+                    #    *actual* override to avoid running a sync-only subclass
+                    #    on the event loop.
+                    #  • agent override – ``LocalConversation`` always overrides
+                    #    ``arun()``, but an agent without an ``astep()`` override
+                    #    (e.g. ACPAgent) runs sync ``step()`` in a worker thread;
+                    #    route it through sync ``run()`` instead.
                     arun = getattr(conversation, "arun", None)
                     has_native_arun = (
                         arun is not None
                         and asyncio.iscoroutinefunction(arun)
                         and type(conversation).arun is not BaseConversation.arun
+                        and type(conversation.agent).astep is not AgentBase.astep
                     )
                     if has_native_arun:
                         await conversation.arun()

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -741,8 +741,8 @@ class EventService:
         ``arun()`` coroutine so LLM I/O does not tie up a thread-pool worker.
         For conversations that do not expose ``arun()`` (e.g., custom
         subclasses) or whose agent only implements sync ``step()`` (no
-        ``astep()`` override, e.g. ACPAgent), the synchronous ``run()`` is
-        executed in the thread pool as before.
+        ``astep()`` override), the synchronous ``run()`` is executed
+        in the thread pool as before.
 
         Raises:
             ValueError: If the service is inactive or conversation is already running.
@@ -783,8 +783,8 @@ class EventService:
                     #    on the event loop.
                     #  • agent override – ``LocalConversation`` always overrides
                     #    ``arun()``, but an agent without an ``astep()`` override
-                    #    (e.g. ACPAgent) runs sync ``step()`` in a worker thread;
-                    #    route it through sync ``run()`` instead.
+                    #    runs sync ``step()`` in a worker thread; route it
+                    #    through sync ``run()`` instead.
                     arun = getattr(conversation, "arun", None)
                     has_native_arun = (
                         arun is not None

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -2270,10 +2270,10 @@ class TestEventServiceClose:
         """EventService.run() must use the thread-pool executor when the
         agent only implements sync step() (no astep() override), even if the
         conversation overrides arun().  ``LocalConversation`` always overrides
-        arun(), so the conversation-level guard alone would route ACP/custom
-        agents through the native async path, running their sync step() in a
-        worker thread while arun() holds the state lock on the event-loop
-        thread (B5)."""
+        arun(), so the conversation-level guard alone would route sync-only
+        custom agents through the native async path, running their sync
+        step() in a worker thread while arun() holds the state lock on the
+        event-loop thread (B5)."""
         from openhands.sdk.conversation.base import BaseConversation
 
         run_called = False

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -22,7 +22,7 @@ from openhands.agent_server.models import (
     StoredConversation,
 )
 from openhands.agent_server.pub_sub import Subscriber
-from openhands.sdk import LLM, Agent, Conversation, Message
+from openhands.sdk import LLM, Agent, AgentBase, Conversation, Message
 from openhands.sdk.conversation.fifo_lock import FIFOLock
 from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
@@ -2024,6 +2024,17 @@ class TestSearchEventsBlockedByRunLoop:
         )
 
 
+class _SyncOnlyAgent(AgentBase):
+    """Agent that only implements sync step() (no astep override).
+
+    Defined at module level (not inside a test) because ``AgentBase`` is a
+    discriminated-union member and local classes cannot be registered.
+    """
+
+    def step(self, conversation, on_event, on_token=None):
+        pass
+
+
 class TestEventServiceClose:
     """Tests for EventService.close() awaiting conversation teardown."""
 
@@ -2253,6 +2264,65 @@ class TestEventServiceClose:
         assert run_thread_id is not None, "run() was never called"
         assert run_thread_id != event_loop_thread, (
             "run() executed on the event loop thread — expected thread-pool"
+        )
+
+    async def test_run_uses_executor_for_sync_only_agent(self, event_service):
+        """EventService.run() must use the thread-pool executor when the
+        agent only implements sync step() (no astep() override), even if the
+        conversation overrides arun().  ``LocalConversation`` always overrides
+        arun(), so the conversation-level guard alone would route ACP/custom
+        agents through the native async path, running their sync step() in a
+        worker thread while arun() holds the state lock on the event-loop
+        thread (B5)."""
+        from openhands.sdk.conversation.base import BaseConversation
+
+        run_called = False
+        arun_called = False
+        agent = _SyncOnlyAgent(llm=LLM(model="gpt-4o", usage_id="sync-only"))
+
+        # Stand-in conversation that overrides arun() (like LocalConversation)
+        # but wraps a sync-only agent.  Only the dispatch-relevant members are
+        # implemented.
+        class AsyncConvSyncAgent:
+            def __init__(self):
+                self.agent = agent
+
+            async def arun(self):
+                nonlocal arun_called
+                arun_called = True
+
+            def run(self):
+                nonlocal run_called
+                run_called = True
+
+        conv = AsyncConvSyncAgent()
+        event_service._conversation = conv  # type: ignore[assignment]
+
+        # Sanity: conversation overrides arun() but the agent inherits the
+        # default astep(), so the native async path must NOT be taken.
+        assert type(conv).arun is not BaseConversation.arun
+        assert type(conv.agent).astep is AgentBase.astep
+
+        with (
+            patch.object(
+                type(event_service),
+                "_get_execution_status",
+                new_callable=AsyncMock,
+                return_value=ConversationExecutionStatus.PAUSED,
+            ),
+            patch.object(
+                type(event_service),
+                "_publish_state_update",
+                new_callable=AsyncMock,
+            ),
+        ):
+            await event_service.run()
+            # Give the background task a moment to execute
+            await asyncio.sleep(0.3)
+
+        assert run_called, "sync run() was never called"
+        assert not arun_called, (
+            "arun() was used for a sync-only agent — expected sync run()"
         )
 
 


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

EventService.run() selected the native async path (arun()) based solely on whether the conversation overrides BaseConversation.arun. Since LocalConversation always overrides arun(), every server run took the async path, including agents that only implement sync step() and inherit the default AgentBase.astep, which ships step() to a worker thread via run_in_executor.

The result: for ACPAgent and other custom AgentBase subclasses, sync step() (and its callbacks) ran on a worker thread while arun() held the state lock on the event-loop thread — silently changing the threading/ordering model those agents were written and tested against. This is item B5 from the async-LLM follow-up tracker (#3341).

This is not a deadlock (step() never re-acquires the state lock), but it is a behavioral change that can surface as hard-to-reproduce ordering/threading issues for ACP and custom agents.

The fix is to gate the async path on the agent's capability as well as the conversation's:

- Added type(conversation.agent).astep is not AgentBase.astep to the has_native_arun guard.
  
Agents that genuinely override astep (e.g. Agent) keep the native async path; agents that only implement sync step() fall back to running run() in the thread pool as before. The guard short-circuits before reaching conversation.agent, so the existing MagicMock-based tests are unaffected.

## Issue Number
#3341 

## How to Test

- Added test_run_uses_executor_for_sync_only_agent: a conversation that overrides arun() but wraps a sync-only agent must dispatch through sync run(), not arun(). Verified it fails without the guard and passes with it.
- Full tests/agent_server/test_event_service.py suite passes (84 tests); pyright/ruff clean.
- The test's sync-only agent is defined at module level because AgentBase is a discriminated-union member and locally-defined subclasses cannot be registered.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c643a77-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c643a77-python \
  ghcr.io/openhands/agent-server:c643a77-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c643a77-golang-amd64
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-golang-amd64
ghcr.io/openhands/agent-server:vasco-b5-golang-amd64
ghcr.io/openhands/agent-server:c643a77-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c643a77-golang-arm64
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-golang-arm64
ghcr.io/openhands/agent-server:vasco-b5-golang-arm64
ghcr.io/openhands/agent-server:c643a77-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c643a77-java-amd64
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-java-amd64
ghcr.io/openhands/agent-server:vasco-b5-java-amd64
ghcr.io/openhands/agent-server:c643a77-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c643a77-java-arm64
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-java-arm64
ghcr.io/openhands/agent-server:vasco-b5-java-arm64
ghcr.io/openhands/agent-server:c643a77-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c643a77-python-amd64
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-python-amd64
ghcr.io/openhands/agent-server:vasco-b5-python-amd64
ghcr.io/openhands/agent-server:c643a77-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c643a77-python-arm64
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-python-arm64
ghcr.io/openhands/agent-server:vasco-b5-python-arm64
ghcr.io/openhands/agent-server:c643a77-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c643a77-golang
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-golang
ghcr.io/openhands/agent-server:vasco-b5-golang
ghcr.io/openhands/agent-server:c643a77-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c643a77-java
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-java
ghcr.io/openhands/agent-server:vasco-b5-java
ghcr.io/openhands/agent-server:c643a77-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c643a77-python
ghcr.io/openhands/agent-server:c643a770a3f1de966b9686b11d56f0c7d47d128f-python
ghcr.io/openhands/agent-server:vasco-b5-python
ghcr.io/openhands/agent-server:c643a77-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c643a77-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c643a77-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->