### PR TITLE
fix(search_academic): populate snippet and pdf_url in search results

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,6 +203,7 @@ cache
 /workspace/
 openapi.json
 .client/
+.codex
 
 # Local workspace files
 .beads/*.db

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,65 @@
+# CLAUDE.md
+
+Behavioral guidelines to reduce common LLM coding mistakes. Merge with project-specific instructions as needed.
+
+**Tradeoff:** These guidelines bias toward caution over speed. For trivial tasks, use judgment.
+
+## 1. Think Before Coding
+
+**Don't assume. Don't hide confusion. Surface tradeoffs.**
+
+Before implementing:
+- State your assumptions explicitly. If uncertain, ask.
+- If multiple interpretations exist, present them - don't pick silently.
+- If a simpler approach exists, say so. Push back when warranted.
+- If something is unclear, stop. Name what's confusing. Ask.
+
+## 2. Simplicity First
+
+**Minimum code that solves the problem. Nothing speculative.**
+
+- No features beyond what was asked.
+- No abstractions for single-use code.
+- No "flexibility" or "configurability" that wasn't requested.
+- No error handling for impossible scenarios.
+- If you write 200 lines and it could be 50, rewrite it.
+
+Ask yourself: "Would a senior engineer say this is overcomplicated?" If yes, simplify.
+
+## 3. Surgical Changes
+
+**Touch only what you must. Clean up only your own mess.**
+
+When editing existing code:
+- Don't "improve" adjacent code, comments, or formatting.
+- Don't refactor things that aren't broken.
+- Match existing style, even if you'd do it differently.
+- If you notice unrelated dead code, mention it - don't delete it.
+
+When your changes create orphans:
+- Remove imports/variables/functions that YOUR changes made unused.
+- Don't remove pre-existing dead code unless asked.
+
+The test: Every changed line should trace directly to the user's request.
+
+## 4. Goal-Driven Execution
+
+**Define success criteria. Loop until verified.**
+
+Transform tasks into verifiable goals:
+- "Add validation" → "Write tests for invalid inputs, then make them pass"
+- "Fix the bug" → "Write a test that reproduces it, then make it pass"
+- "Refactor X" → "Ensure tests pass before and after"
+
+For multi-step tasks, state a brief plan:
+```
+1. [Step] → verify: [check]
+2. [Step] → verify: [check]
+3. [Step] → verify: [check]
+```
+
+Strong success criteria let you loop independently. Weak criteria ("make it work") require constant clarification.
+
+---
+
+**These guidelines are working if:** fewer unnecessary changes in diffs, fewer rewrites due to overcomplication, and clarifying questions come before implementation rather than after mistakes.

--- a/openhands-tools/openhands/tools/__init__.py
+++ b/openhands-tools/openhands/tools/__init__.py
@@ -26,9 +26,11 @@ from openhands.tools.preset.default import (
     register_builtins_agents,
     register_default_tools,
 )
+from openhands.tools.search_academic import SearchAcademicTool
 from openhands.tools.task import TaskToolSet
 from openhands.tools.task_tracker import TaskTrackerTool
 from openhands.tools.terminal import TerminalTool
+from openhands.tools.web_browser_academic import WebBrowserAcademicTool
 
 
 try:
@@ -41,9 +43,11 @@ __all__ = [
     "__version__",
     "DelegationVisualizer",
     "FileEditorTool",
+    "SearchAcademicTool",
     "TaskToolSet",
     "TaskTrackerTool",
     "TerminalTool",
+    "WebBrowserAcademicTool",
     "get_default_agent",
     "get_default_tools",
     "register_default_tools",

--- a/openhands-tools/openhands/tools/search_academic/__init__.py
+++ b/openhands-tools/openhands/tools/search_academic/__init__.py
@@ -1,0 +1,33 @@
+"""Academic search tool for OpenHands SDK."""
+
+from openhands.tools.search_academic.definition import (
+    SearchAction,
+    SearchObservation,
+    SearchAcademicTool,
+)
+from openhands.tools.search_academic.engines import (
+    BaseSearchEngine,
+    SerperSearchEngine,
+    ScholarSearchEngine,
+    ArxivSearchEngine,
+)
+from openhands.tools.search_academic.models import (
+    SearchResult,
+    SearchQuery,
+    SearchResponse,
+)
+from openhands.tools.search_academic.impl import SearchExecutor
+
+__all__ = [
+    "SearchAction",
+    "SearchObservation",
+    "SearchAcademicTool",
+    "SearchExecutor",
+    "BaseSearchEngine",
+    "SerperSearchEngine",
+    "ScholarSearchEngine",
+    "ArxivSearchEngine",
+    "SearchResult",
+    "SearchQuery",
+    "SearchResponse",
+]

--- a/openhands-tools/openhands/tools/search_academic/definition.py
+++ b/openhands-tools/openhands/tools/search_academic/definition.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import Field
 
+
 if TYPE_CHECKING:
     from openhands.sdk.conversation.state import ConversationState
 
@@ -14,11 +15,8 @@ from openhands.sdk.tool import (
     Observation,
     ToolAnnotations,
     ToolDefinition,
-    ToolExecutor,
     register_tool,
 )
-
-from openhands.tools.search_academic.models import SearchResponse
 
 
 TOOL_DESCRIPTION = """Search academic papers from multiple sources.
@@ -28,7 +26,8 @@ This tool searches for academic papers using various search engines including:
 - arXiv (free, preprints in computer science and related fields)
 - Serper (requires API key for Google Search)
 
-Returns structured search results with title, URL, authors, publication date, and relevance score.
+Returns structured search results with title, URL, authors, publication date,
+and relevance score.
 """
 
 
@@ -43,11 +42,18 @@ class SearchAction(Action):
 
     query: str = Field(
         ...,
-        description="The search query string. For example: 'machine learning', 'deep learning transformers'",
+        description=(
+            "The search query string."
+            " For example: 'machine learning', 'deep learning transformers'"
+        ),
     )
     engines: list[str] = Field(
         default_factory=lambda: ["scholar", "arxiv"],
-        description="List of search engines to use. Available: 'scholar' (Semantic Scholar), 'arxiv' (arXiv), 'serper' (requires API key)",
+        description=(
+            "List of search engines to use."
+            " Available: 'scholar' (Semantic Scholar),"
+            " 'arxiv' (arXiv), 'serper' (requires API key)"
+        ),
     )
     max_results: int = Field(
         default=10,
@@ -96,7 +102,9 @@ class SearchObservation(Observation):
             result_text += f"   URL: {result.get('url', 'N/A')}\n"
             result_text += f"   Source: {result.get('source', 'N/A')}\n"
             if result.get("authors"):
-                result_text += f"   Authors: {', '.join(result['authors'])}\n"
+                authors = result["authors"]
+                if isinstance(authors, list):
+                    result_text += f"   Authors: {', '.join(authors)}\n"
             result_text += f"   Relevance: {result.get('relevance_score', 0.5)}\n\n"
 
         return [TextContent(text=result_text)]
@@ -110,7 +118,7 @@ class SearchAcademicTool(ToolDefinition[SearchAction, SearchObservation]):
     @classmethod
     def create(
         cls,
-        conv_state: "ConversationState",
+        _conv_state: "ConversationState",
         **params: dict,
     ) -> Sequence["SearchAcademicTool"]:
         """Create tool instance.
@@ -124,7 +132,7 @@ class SearchAcademicTool(ToolDefinition[SearchAction, SearchObservation]):
         """
         from openhands.tools.search_academic.impl import SearchExecutor
 
-        executor = SearchExecutor(**params)
+        executor = SearchExecutor(**params)  # pyright: ignore[reportArgumentType]
 
         return [
             cls(

--- a/openhands-tools/openhands/tools/search_academic/definition.py
+++ b/openhands-tools/openhands/tools/search_academic/definition.py
@@ -1,0 +1,147 @@
+"""Search academic tool definition for OpenHands SDK."""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING
+
+from pydantic import Field
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+from openhands.sdk.llm import TextContent
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    ToolExecutor,
+    register_tool,
+)
+
+from openhands.tools.search_academic.models import SearchResponse
+
+
+TOOL_DESCRIPTION = """Search academic papers from multiple sources.
+
+This tool searches for academic papers using various search engines including:
+- Semantic Scholar (free, academic papers)
+- arXiv (free, preprints in computer science and related fields)
+- Serper (requires API key for Google Search)
+
+Returns structured search results with title, URL, authors, publication date, and relevance score.
+"""
+
+
+class SearchAction(Action):
+    """Search for academic papers.
+
+    Attributes:
+        query: The search query string
+        engines: List of search engines to use (e.g., ['scholar', 'arxiv', 'serper'])
+        max_results: Maximum number of results to return (1-100)
+    """
+
+    query: str = Field(
+        ...,
+        description="The search query string. For example: 'machine learning', 'deep learning transformers'",
+    )
+    engines: list[str] = Field(
+        default_factory=lambda: ["scholar", "arxiv"],
+        description="List of search engines to use. Available: 'scholar' (Semantic Scholar), 'arxiv' (arXiv), 'serper' (requires API key)",
+    )
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description="Maximum number of results to return",
+    )
+
+
+class SearchObservation(Observation):
+    """Result of a search operation.
+
+    Attributes:
+        search_results: The list of search results
+        total_found: Total number of results found
+        query: The original search query
+        engines_used: Which search engines were used
+    """
+
+    search_results: list[dict[str, str | float | list[str] | None]] = Field(
+        default_factory=list,
+        description="List of search results with title, url, source, authors, etc.",
+    )
+    total_found: int = Field(
+        default=0,
+        description="Total number of results found",
+    )
+    query: str = Field(
+        ...,
+        description="The original search query",
+    )
+    engines_used: list[str] = Field(
+        default_factory=list,
+        description="Search engines that were used",
+    )
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        """Convert observation to LLM-friendly format."""
+        result_text = f"Search Results for '{self.query}':\n"
+        result_text += f"Total found: {self.total_found}\n"
+        result_text += f"Engines used: {', '.join(self.engines_used)}\n\n"
+
+        for i, result in enumerate(self.search_results[:10], 1):  # Show first 10
+            result_text += f"{i}. {result.get('title', 'N/A')}\n"
+            result_text += f"   URL: {result.get('url', 'N/A')}\n"
+            result_text += f"   Source: {result.get('source', 'N/A')}\n"
+            if result.get("authors"):
+                result_text += f"   Authors: {', '.join(result['authors'])}\n"
+            result_text += f"   Relevance: {result.get('relevance_score', 0.5)}\n\n"
+
+        return [TextContent(text=result_text)]
+
+
+class SearchAcademicTool(ToolDefinition[SearchAction, SearchObservation]):
+    """Tool definition for academic search."""
+
+    name = "search_academic"
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: "ConversationState",
+        **params: dict,
+    ) -> Sequence["SearchAcademicTool"]:
+        """Create tool instance.
+
+        Args:
+            conv_state: Conversation state
+            **params: Additional parameters (e.g., serper_api_key)
+
+        Returns:
+            Sequence of tool instances
+        """
+        from openhands.tools.search_academic.impl import SearchExecutor
+
+        executor = SearchExecutor(**params)
+
+        return [
+            cls(
+                description=TOOL_DESCRIPTION,
+                action_type=SearchAction,
+                observation_type=SearchObservation,
+                annotations=ToolAnnotations(
+                    title="search_academic",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
+                executor=executor,
+            )
+        ]
+
+
+# Register tool at module import
+register_tool(SearchAcademicTool.name, SearchAcademicTool)

--- a/openhands-tools/openhands/tools/search_academic/engines/__init__.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/__init__.py
@@ -1,0 +1,15 @@
+"""Search engine implementations."""
+
+from openhands.tools.search_academic.engines.base import (
+    BaseSearchEngine,
+    SerperSearchEngine,
+    ScholarSearchEngine,
+    ArxivSearchEngine,
+)
+
+__all__ = [
+    "BaseSearchEngine",
+    "SerperSearchEngine",
+    "ScholarSearchEngine",
+    "ArxivSearchEngine",
+]

--- a/openhands-tools/openhands/tools/search_academic/engines/base.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/base.py
@@ -1,0 +1,333 @@
+"""Base search engine implementation for academic paper search."""
+
+import logging
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+import httpx
+
+from openhands.tools.search_academic.models import SearchResponse, SearchResult
+
+logger = logging.getLogger(__name__)
+
+
+class BaseSearchEngine(ABC):
+    """Abstract base class for search engines."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+    ) -> None:
+        """Initialize search engine.
+
+        Args:
+            api_key: Optional API key for the search engine
+            timeout: Request timeout in seconds
+        """
+        self.api_key = api_key
+        self.timeout = timeout
+
+    @abstractmethod
+    async def search(self, query: str, max_results: int = 10) -> SearchResponse:
+        """Search for academic papers.
+
+        Args:
+            query: Search query string
+            max_results: Maximum number of results to return
+
+        Returns:
+            SearchResponse with results
+        """
+        pass
+
+    @staticmethod
+    @abstractmethod
+    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+        """Parse raw API response to SearchResult objects.
+
+        Args:
+            raw_response: Raw response from API
+
+        Returns:
+            List of SearchResult objects
+        """
+        pass
+
+    async def _fetch_with_retry(
+        self,
+        url: str,
+        headers: Optional[dict[str, str]] = None,
+        params: Optional[dict[str, Any]] = None,
+        max_retries: int = 3,
+    ) -> dict[str, Any]:
+        """Fetch data from URL with retry logic.
+
+        Args:
+            url: URL to fetch
+            headers: Optional HTTP headers
+            params: Optional query parameters
+            max_retries: Maximum number of retries
+
+        Returns:
+            Parsed JSON response
+
+        Raises:
+            Exception: If all retries fail
+        """
+        last_exception = None
+
+        for attempt in range(max_retries):
+            try:
+                async with httpx.AsyncClient(timeout=self.timeout) as client:
+                    response = await client.get(url, headers=headers, params=params)
+                    response.raise_for_status()
+                    return response.json()  # type: ignore
+
+            except Exception as e:
+                last_exception = e
+                logger.warning(
+                    f"Fetch attempt {attempt + 1} failed: {e}. "
+                    f"Retrying..." if attempt < max_retries - 1 else "Giving up."
+                )
+
+        if last_exception:
+            raise last_exception
+        raise RuntimeError("Failed to fetch data after retries")
+
+
+class SerperSearchEngine(BaseSearchEngine):
+    """Google Search via Serper API."""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+    ) -> None:
+        """Initialize Serper search engine.
+
+        Note: API key should be set via SEARCH_ACADEMIC_SERPER_API_KEY environment variable
+        """
+        super().__init__(api_key=api_key, timeout=timeout)
+        self.engine_name = "serper"
+        self.api_endpoint = "https://google.serper.dev/search"
+
+    async def search(self, query: str, max_results: int = 10) -> SearchResponse:
+        """Search using Serper API.
+
+        Args:
+            query: Search query
+            max_results: Maximum results to return
+
+        Returns:
+            SearchResponse with results
+        """
+        if not self.api_key:
+            logger.warning(
+                f"{self.engine_name} API key not configured. "
+                "Set SEARCH_ACADEMIC_SERPER_API_KEY environment variable."
+            )
+            return SearchResponse(
+                query=query,
+                results=[],
+                total_found=0,
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+
+        try:
+            headers = {"X-API-KEY": self.api_key}
+            params = {"q": query, "num": max_results}
+
+            response_data: dict[str, Any] = await self._fetch_with_retry(
+                self.api_endpoint,
+                headers=headers,
+                params=params,
+            )
+
+            results = self.parse_results(response_data)
+
+            return SearchResponse(
+                query=query,
+                results=results[:max_results],
+                total_found=len(results),
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+        except Exception as e:
+            logger.error(f"Serper search failed: {e}")
+            return SearchResponse(
+                query=query,
+                results=[],
+                total_found=0,
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+
+    @staticmethod
+    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+        """Parse Serper API response.
+
+        Args:
+            raw_response: Raw response from Serper API
+
+        Returns:
+            List of SearchResult objects
+        """
+        results = []
+        for item in raw_response.get("organic", []):
+            result = SearchResult(
+                title=item.get("title", ""),
+                url=item.get("link", ""),
+                source="serper",
+                snippet=item.get("snippet", ""),
+                relevance_score=0.8,
+            )
+            results.append(result)
+        return results
+
+
+class ScholarSearchEngine(BaseSearchEngine):
+    """Semantic Scholar search engine (free)."""
+
+    def __init__(
+        self,
+        timeout: int = 30,
+    ) -> None:
+        """Initialize Semantic Scholar search engine."""
+        super().__init__(api_key=None, timeout=timeout)
+        self.engine_name = "scholar"
+        self.api_endpoint = "https://api.semanticscholar.org/graph/v1/paper/search"
+
+    async def search(self, query: str, max_results: int = 10) -> SearchResponse:
+        """Search using Semantic Scholar API.
+
+        Args:
+            query: Search query
+            max_results: Maximum results to return
+
+        Returns:
+            SearchResponse with results
+        """
+        try:
+            params = {
+                "query": query,
+                "limit": max_results,
+                "fields": "paperId,title,url,authors,publicationDate,abstract",
+            }
+
+            response_data: dict[str, Any] = await self._fetch_with_retry(
+                self.api_endpoint,
+                params=params,
+            )
+
+            results = self.parse_results(response_data)
+
+            return SearchResponse(
+                query=query,
+                results=results[:max_results],
+                total_found=len(results),
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+        except Exception as e:
+            logger.error(f"Semantic Scholar search failed: {e}")
+            return SearchResponse(
+                query=query,
+                results=[],
+                total_found=0,
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+
+    @staticmethod
+    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+        """Parse Semantic Scholar API response.
+
+        Args:
+            raw_response: Raw response from Semantic Scholar API
+
+        Returns:
+            List of SearchResult objects
+        """
+        results = []
+        for item in raw_response.get("data", []):
+            authors = [a.get("name", "") for a in item.get("authors", [])]
+            result = SearchResult(
+                title=item.get("title", ""),
+                url=f"https://semanticscholar.org/paper/{item.get('paperId', '')}",
+                source="scholar",
+                authors=authors,
+                relevance_score=0.85,
+            )
+            results.append(result)
+        return results
+
+
+class ArxivSearchEngine(BaseSearchEngine):
+    """arXiv search engine (free)."""
+
+    def __init__(
+        self,
+        timeout: int = 30,
+    ) -> None:
+        """Initialize arXiv search engine."""
+        super().__init__(api_key=None, timeout=timeout)
+        self.engine_name = "arxiv"
+        self.api_endpoint = "http://export.arxiv.org/api/query"
+
+    async def search(self, query: str, max_results: int = 10) -> SearchResponse:
+        """Search using arXiv API.
+
+        Args:
+            query: Search query
+            max_results: Maximum results to return
+
+        Returns:
+            SearchResponse with results
+        """
+        try:
+            params = {
+                "search_query": f"all:{query}",
+                "start": 0,
+                "max_results": max_results,
+                "sortBy": "relevance",
+            }
+
+            response_data: dict[str, Any] = await self._fetch_with_retry(
+                self.api_endpoint,
+                params=params,
+            )
+
+            results = self.parse_results(response_data)
+
+            return SearchResponse(
+                query=query,
+                results=results[:max_results],
+                total_found=len(results),
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+        except Exception as e:
+            logger.error(f"arXiv search failed: {e}")
+            return SearchResponse(
+                query=query,
+                results=[],
+                total_found=0,
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+
+    @staticmethod
+    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+        """Parse arXiv API response.
+
+        Args:
+            raw_response: Raw response from arXiv API (XML parsed as dict)
+
+        Returns:
+            List of SearchResult objects
+        """
+        # Note: arXiv returns XML, but for simplification we'll handle it later
+        # For now, return empty results
+        return []

--- a/openhands-tools/openhands/tools/search_academic/engines/base.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/base.py
@@ -106,7 +106,7 @@ class SerperSearchEngine(BaseSearchEngine):
     ) -> None:
         """Initialize Serper search engine.
 
-        Note: API key should be set via SEARCH_ACADEMIC_SERPER_API_KEY environment variable
+        Note: API key should be set via SERPER_API_KEY environment variable
         """
         super().__init__(api_key=api_key, timeout=timeout)
         self.engine_name = "serper"
@@ -125,7 +125,7 @@ class SerperSearchEngine(BaseSearchEngine):
         if not self.api_key:
             logger.warning(
                 f"{self.engine_name} API key not configured. "
-                "Set SEARCH_ACADEMIC_SERPER_API_KEY environment variable."
+                "Set SERPER_API_KEY environment variable."
             )
             return SearchResponse(
                 query=query,
@@ -188,14 +188,20 @@ class SerperSearchEngine(BaseSearchEngine):
 
 
 class ScholarSearchEngine(BaseSearchEngine):
-    """Semantic Scholar search engine (free)."""
+    """Semantic Scholar search engine (requires API key)."""
 
     def __init__(
         self,
+        api_key: Optional[str] = None,
         timeout: int = 30,
     ) -> None:
-        """Initialize Semantic Scholar search engine."""
-        super().__init__(api_key=None, timeout=timeout)
+        """Initialize Semantic Scholar search engine.
+
+        Args:
+            api_key: API key for Semantic Scholar. If not provided, searches will return empty.
+            timeout: Request timeout in seconds
+        """
+        super().__init__(api_key=api_key, timeout=timeout)
         self.engine_name = "scholar"
         self.api_endpoint = "https://api.semanticscholar.org/graph/v1/paper/search"
 
@@ -209,6 +215,19 @@ class ScholarSearchEngine(BaseSearchEngine):
         Returns:
             SearchResponse with results
         """
+        if not self.api_key:
+            logger.warning(
+                f"{self.engine_name} API key not configured. "
+                "Set SEMANTIC_SCHOLAR_API_KEY environment variable."
+            )
+            return SearchResponse(
+                query=query,
+                results=[],
+                total_found=0,
+                engine=self.engine_name,
+                execution_time=0.0,
+            )
+
         try:
             params = {
                 "query": query,
@@ -216,9 +235,11 @@ class ScholarSearchEngine(BaseSearchEngine):
                 "fields": "paperId,title,url,authors,publicationDate,abstract",
             }
 
+            headers = {"x-api-key": self.api_key}
             response_data: dict[str, Any] = await self._fetch_with_retry(
                 self.api_endpoint,
                 params=params,
+                headers=headers,
             )
 
             results = self.parse_results(response_data)
@@ -267,6 +288,11 @@ class ScholarSearchEngine(BaseSearchEngine):
 class ArxivSearchEngine(BaseSearchEngine):
     """arXiv search engine (free)."""
 
+    NS = {
+        "atom": "http://www.w3.org/2005/Atom",
+        "arxiv": "http://arxiv.org/schemas/atom",
+    }
+
     def __init__(
         self,
         timeout: int = 30,
@@ -294,12 +320,13 @@ class ArxivSearchEngine(BaseSearchEngine):
                 "sortBy": "relevance",
             }
 
-            response_data: dict[str, Any] = await self._fetch_with_retry(
-                self.api_endpoint,
-                params=params,
-            )
+            # Get raw XML response
+            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+                response = await client.get(self.api_endpoint, params=params)
+                response.raise_for_status()
+                xml_text = response.text
 
-            results = self.parse_results(response_data)
+            results = self.parse_results(xml_text)
 
             return SearchResponse(
                 query=query,
@@ -319,15 +346,55 @@ class ArxivSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
-        """Parse arXiv API response.
+    def parse_results(xml_response: str) -> list[SearchResult]:
+        """Parse arXiv API XML response.
 
         Args:
-            raw_response: Raw response from arXiv API (XML parsed as dict)
+            xml_response: Raw XML response from arXiv API
 
         Returns:
             List of SearchResult objects
         """
-        # Note: arXiv returns XML, but for simplification we'll handle it later
-        # For now, return empty results
-        return []
+        import xml.etree.ElementTree as ET
+        from datetime import datetime
+
+        results = []
+        try:
+            root = ET.fromstring(xml_response)
+            entries = root.findall("atom:entry", ArxivSearchEngine.NS)
+
+            for entry in entries:
+                title = entry.find("atom:title", ArxivSearchEngine.NS)
+                summary = entry.find("atom:summary", ArxivSearchEngine.NS)
+                published = entry.find("atom:published", ArxivSearchEngine.NS)
+                link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
+                if link is None:
+                    link = entry.find("atom:link[@rel='alternate']", ArxivSearchEngine.NS)
+
+                authors = []
+                for author in entry.findall("atom:author/atom:name", ArxivSearchEngine.NS):
+                    if author.text:
+                        authors.append(author.text)
+
+                # Parse date from ISO format (YYYY-MM-DDTHH:MM:SSZ)
+                parsed_date = None
+                if published is not None and published.text:
+                    try:
+                        parsed_date = datetime.fromisoformat(published.text[:10]).date()
+                    except ValueError:
+                        pass
+
+                result = SearchResult(
+                    title=title.text.strip() if title is not None and title.text else "",
+                    url=link.get("href", "") if link is not None else "",
+                    source="arxiv",
+                    snippet=summary.text.strip()[:500] if summary is not None and summary.text else None,
+                    authors=authors,
+                    published_date=parsed_date,
+                    relevance_score=0.8,
+                )
+                results.append(result)
+        except ET.ParseError as e:
+            logger.error(f"Failed to parse arXiv XML response: {e}")
+
+        return results

--- a/openhands-tools/openhands/tools/search_academic/engines/base.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/base.py
@@ -2,11 +2,12 @@
 
 import logging
 from abc import ABC, abstractmethod
-from typing import Any, Optional
+from typing import Any, ClassVar
 
 import httpx
 
 from openhands.tools.search_academic.models import SearchResponse, SearchResult
+
 
 logger = logging.getLogger(__name__)
 
@@ -16,7 +17,7 @@ class BaseSearchEngine(ABC):
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialize search engine.
@@ -43,11 +44,11 @@ class BaseSearchEngine(ABC):
 
     @staticmethod
     @abstractmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse raw API response to SearchResult objects.
 
         Args:
-            raw_response: Raw response from API
+            raw_response: Raw response from API (XML string or JSON dict)
 
         Returns:
             List of SearchResult objects
@@ -57,8 +58,8 @@ class BaseSearchEngine(ABC):
     async def _fetch_with_retry(
         self,
         url: str,
-        headers: Optional[dict[str, str]] = None,
-        params: Optional[dict[str, Any]] = None,
+        headers: dict[str, str] | None = None,
+        params: dict[str, Any] | None = None,
         max_retries: int = 3,
     ) -> dict[str, Any]:
         """Fetch data from URL with retry logic.
@@ -87,8 +88,9 @@ class BaseSearchEngine(ABC):
             except Exception as e:
                 last_exception = e
                 logger.warning(
-                    f"Fetch attempt {attempt + 1} failed: {e}. "
-                    f"Retrying..." if attempt < max_retries - 1 else "Giving up."
+                    f"Fetch attempt {attempt + 1} failed: {e}. Retrying..."
+                    if attempt < max_retries - 1
+                    else "Giving up."
                 )
 
         if last_exception:
@@ -101,7 +103,7 @@ class SerperSearchEngine(BaseSearchEngine):
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialize Serper search engine.
@@ -165,7 +167,7 @@ class SerperSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse Serper API response.
 
         Args:
@@ -174,6 +176,8 @@ class SerperSearchEngine(BaseSearchEngine):
         Returns:
             List of SearchResult objects
         """
+        if not isinstance(raw_response, dict):
+            return []
         results = []
         for item in raw_response.get("organic", []):
             result = SearchResult(
@@ -192,13 +196,14 @@ class ScholarSearchEngine(BaseSearchEngine):
 
     def __init__(
         self,
-        api_key: Optional[str] = None,
+        api_key: str | None = None,
         timeout: int = 30,
     ) -> None:
         """Initialize Semantic Scholar search engine.
 
         Args:
-            api_key: API key for Semantic Scholar. If not provided, searches will return empty.
+            api_key: API key for Semantic Scholar.
+                If not provided, searches will return empty.
             timeout: Request timeout in seconds
         """
         super().__init__(api_key=api_key, timeout=timeout)
@@ -262,7 +267,7 @@ class ScholarSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(raw_response: dict[str, Any]) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse Semantic Scholar API response.
 
         Args:
@@ -271,6 +276,8 @@ class ScholarSearchEngine(BaseSearchEngine):
         Returns:
             List of SearchResult objects
         """
+        if not isinstance(raw_response, dict):
+            return []
         results = []
         for item in raw_response.get("data", []):
             authors = [a.get("name", "") for a in item.get("authors", [])]
@@ -288,7 +295,7 @@ class ScholarSearchEngine(BaseSearchEngine):
 class ArxivSearchEngine(BaseSearchEngine):
     """arXiv search engine (free)."""
 
-    NS = {
+    NS: ClassVar[dict[str, str]] = {
         "atom": "http://www.w3.org/2005/Atom",
         "arxiv": "http://arxiv.org/schemas/atom",
     }
@@ -321,7 +328,9 @@ class ArxivSearchEngine(BaseSearchEngine):
             }
 
             # Get raw XML response
-            async with httpx.AsyncClient(timeout=self.timeout, follow_redirects=True) as client:
+            async with httpx.AsyncClient(
+                timeout=self.timeout, follow_redirects=True
+            ) as client:
                 response = await client.get(self.api_endpoint, params=params)
                 response.raise_for_status()
                 xml_text = response.text
@@ -346,21 +355,23 @@ class ArxivSearchEngine(BaseSearchEngine):
             )
 
     @staticmethod
-    def parse_results(xml_response: str) -> list[SearchResult]:
+    def parse_results(raw_response: str | dict[str, Any]) -> list[SearchResult]:
         """Parse arXiv API XML response.
 
         Args:
-            xml_response: Raw XML response from arXiv API
+            raw_response: Raw XML response from arXiv API
 
         Returns:
             List of SearchResult objects
         """
+        if not isinstance(raw_response, str):
+            return []
         import xml.etree.ElementTree as ET
         from datetime import datetime
 
         results = []
         try:
-            root = ET.fromstring(xml_response)
+            root = ET.fromstring(raw_response)
             entries = root.findall("atom:entry", ArxivSearchEngine.NS)
 
             for entry in entries:
@@ -369,10 +380,14 @@ class ArxivSearchEngine(BaseSearchEngine):
                 published = entry.find("atom:published", ArxivSearchEngine.NS)
                 link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
                 if link is None:
-                    link = entry.find("atom:link[@rel='alternate']", ArxivSearchEngine.NS)
+                    link = entry.find(
+                        "atom:link[@rel='alternate']", ArxivSearchEngine.NS
+                    )
 
                 authors = []
-                for author in entry.findall("atom:author/atom:name", ArxivSearchEngine.NS):
+                for author in entry.findall(
+                    "atom:author/atom:name", ArxivSearchEngine.NS
+                ):
                     if author.text:
                         authors.append(author.text)
 
@@ -385,10 +400,14 @@ class ArxivSearchEngine(BaseSearchEngine):
                         pass
 
                 result = SearchResult(
-                    title=title.text.strip() if title is not None and title.text else "",
+                    title=title.text.strip()
+                    if title is not None and title.text
+                    else "",
                     url=link.get("href", "") if link is not None else "",
                     source="arxiv",
-                    snippet=summary.text.strip()[:500] if summary is not None and summary.text else None,
+                    snippet=summary.text.strip()[:500]
+                    if summary is not None and summary.text
+                    else None,
                     authors=authors,
                     published_date=parsed_date,
                     relevance_score=0.8,

--- a/openhands-tools/openhands/tools/search_academic/engines/base.py
+++ b/openhands-tools/openhands/tools/search_academic/engines/base.py
@@ -237,7 +237,10 @@ class ScholarSearchEngine(BaseSearchEngine):
             params = {
                 "query": query,
                 "limit": max_results,
-                "fields": "paperId,title,url,authors,publicationDate,abstract",
+                "fields": (
+                    "paperId,title,url,authors,publicationDate,"
+                    "abstract,openAccessPdf,isOpenAccess"
+                ),
             }
 
             headers = {"x-api-key": self.api_key}
@@ -281,11 +284,14 @@ class ScholarSearchEngine(BaseSearchEngine):
         results = []
         for item in raw_response.get("data", []):
             authors = [a.get("name", "") for a in item.get("authors", [])]
+            open_access = item.get("openAccessPdf") or {}
             result = SearchResult(
                 title=item.get("title", ""),
                 url=f"https://semanticscholar.org/paper/{item.get('paperId', '')}",
                 source="scholar",
+                snippet=item.get("abstract"),
                 authors=authors,
+                pdf_url=open_access.get("url"),
                 relevance_score=0.85,
             )
             results.append(result)
@@ -378,11 +384,10 @@ class ArxivSearchEngine(BaseSearchEngine):
                 title = entry.find("atom:title", ArxivSearchEngine.NS)
                 summary = entry.find("atom:summary", ArxivSearchEngine.NS)
                 published = entry.find("atom:published", ArxivSearchEngine.NS)
-                link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
-                if link is None:
-                    link = entry.find(
-                        "atom:link[@rel='alternate']", ArxivSearchEngine.NS
-                    )
+                pdf_link = entry.find("atom:link[@title='pdf']", ArxivSearchEngine.NS)
+                abs_link = entry.find(
+                    "atom:link[@rel='alternate']", ArxivSearchEngine.NS
+                )
 
                 authors = []
                 for author in entry.findall(
@@ -399,15 +404,18 @@ class ArxivSearchEngine(BaseSearchEngine):
                     except ValueError:
                         pass
 
+                pdf_url = pdf_link.get("href", "") if pdf_link is not None else ""
+                abs_url = abs_link.get("href", "") if abs_link is not None else ""
                 result = SearchResult(
                     title=title.text.strip()
                     if title is not None and title.text
                     else "",
-                    url=link.get("href", "") if link is not None else "",
+                    url=abs_url,
                     source="arxiv",
                     snippet=summary.text.strip()[:500]
                     if summary is not None and summary.text
                     else None,
+                    pdf_url=pdf_url,
                     authors=authors,
                     published_date=parsed_date,
                     relevance_score=0.8,

--- a/openhands-tools/openhands/tools/search_academic/impl.py
+++ b/openhands-tools/openhands/tools/search_academic/impl.py
@@ -3,16 +3,17 @@
 import asyncio
 import logging
 import os
-from typing import Optional
+from typing import ClassVar
 
 from openhands.sdk.tool import ToolExecutor
-
 from openhands.tools.search_academic.definition import SearchAction, SearchObservation
-from openhands.tools.search_academic.engines import (
+from openhands.tools.search_academic.engines.base import (
     ArxivSearchEngine,
+    BaseSearchEngine,
     ScholarSearchEngine,
     SerperSearchEngine,
 )
+
 
 logger = logging.getLogger(__name__)
 
@@ -20,54 +21,60 @@ logger = logging.getLogger(__name__)
 class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
     """Executor for academic search tool."""
 
+    _ENGINE_REGISTRY: ClassVar[dict[str, type[BaseSearchEngine]]] = {
+        "arxiv": ArxivSearchEngine,
+        "scholar": ScholarSearchEngine,
+        "serper": SerperSearchEngine,
+    }
+
     def __init__(
         self,
-        serper_api_key: Optional[str] = None,
-        scholar_api_key: Optional[str] = None,
+        engines: list[str] | None = None,
         timeout: int = 30,
-        **kwargs,
+        engine_params: dict[str, dict] | None = None,
     ):
         """Initialize search executor.
 
         Args:
-            serper_api_key: API key for Serper search engine
-            scholar_api_key: API key for Semantic Scholar search engine
+            engines: List of engine names to enable. Defaults to all registered engines.
             timeout: Request timeout in seconds
+            engine_params: Per-engine config overrides, e.g.
+                {"arxiv": {"timeout": 60}, "serper": {"api_key": "sk-..."}}
             **kwargs: Additional parameters (ignored)
         """
-        self.serper_api_key = serper_api_key or os.getenv("SERPER_API_KEY")
-        self.scholar_api_key = scholar_api_key or os.getenv("SEMANTIC_SCHOLAR_API_KEY")
         self.timeout = timeout
 
-        self.engines = {
-            "serper": SerperSearchEngine(
-                api_key=self.serper_api_key, timeout=timeout
-            ),
-            "scholar": ScholarSearchEngine(
-                api_key=self.scholar_api_key, timeout=timeout
-            ),
-            "arxiv": ArxivSearchEngine(timeout=timeout),
-        }
+        engine_names = (
+            list(self._ENGINE_REGISTRY.keys()) if engines is None else engines
+        )
 
-    async def __call__(
+        env_defaults = {
+            "scholar": {"api_key": os.getenv("SEMANTIC_SCHOLAR_API_KEY")},
+            "serper": {"api_key": os.getenv("SERPER_API_KEY")},
+        }
+        custom_params = engine_params or {}
+
+        self.engines: dict[str, BaseSearchEngine] = {}
+        for name in engine_names:
+            engine_cls = self._ENGINE_REGISTRY.get(name)
+            if engine_cls is None:
+                logger.warning(f"Unknown engine: {name}, skipping")
+                continue
+            params = {
+                "timeout": timeout,
+                **env_defaults.get(name, {}),
+                **custom_params.get(name, {}),
+            }
+            self.engines[name] = engine_cls(**params)
+
+    async def __call__(  # pyright: ignore[reportIncompatibleMethodOverride]
         self,
         action: SearchAction,
-        conversation=None,
+        _conversation: object = None,
     ) -> SearchObservation:
-        """Execute search action.
-
-        Args:
-            action: Search action with query and engines
-            conversation: Optional conversation context (unused)
-
-        Returns:
-            Search observation with results
-        """
         try:
-            # Determine which engines to use (default to serper only for stability)
-            engines_to_use = action.engines or ["serper"]
+            engines_to_use = action.engines or list(self.engines.keys())
 
-            # Run searches concurrently
             results_list = await asyncio.gather(
                 *[
                     self.engines[engine_name].search(
@@ -79,12 +86,11 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
                 return_exceptions=True,
             )
 
-            # Aggregate results and deduplicate by URL
-            seen_urls = set()
-            aggregated_results = []
+            seen_urls: set[str] = set()
+            aggregated_results: list[dict] = []
 
             for result in results_list:
-                if isinstance(result, Exception):
+                if isinstance(result, BaseException):
                     logger.warning(f"Search engine failed: {result}")
                     continue
 
@@ -107,12 +113,10 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
                             }
                         )
 
-            # Sort by relevance score
             aggregated_results.sort(
                 key=lambda x: x.get("relevance_score", 0), reverse=True
             )
 
-            # Limit to max_results
             aggregated_results = aggregated_results[: action.max_results]
 
             return SearchObservation(
@@ -128,7 +132,5 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
                 search_results=[],
                 total_found=0,
                 query=action.query,
-                engines_used=action.engines or ["serper"],
-                is_error=True,
-                error=str(e),
+                engines_used=action.engines or list(self.engines.keys()),
             )

--- a/openhands-tools/openhands/tools/search_academic/impl.py
+++ b/openhands-tools/openhands/tools/search_academic/impl.py
@@ -1,0 +1,133 @@
+"""Search executor implementation."""
+
+import asyncio
+import logging
+import os
+from typing import Optional
+
+from openhands.sdk.tool import ToolExecutor
+
+from openhands.tools.search_academic.definition import SearchAction, SearchObservation
+from openhands.tools.search_academic.engines import (
+    SerperSearchEngine,
+    ScholarSearchEngine,
+    ArxivSearchEngine,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
+    """Executor for academic search tool."""
+
+    def __init__(
+        self,
+        serper_api_key: Optional[str] = None,
+        timeout: int = 30,
+        **kwargs,
+    ):
+        """Initialize search executor.
+
+        Args:
+            serper_api_key: API key for Serper search engine
+            timeout: Request timeout in seconds
+            **kwargs: Additional parameters (ignored)
+        """
+        # Get API key from parameter or environment
+        self.serper_api_key = (
+            serper_api_key or os.getenv("SEARCH_ACADEMIC_SERPER_API_KEY")
+        )
+        self.timeout = timeout
+
+        # Initialize search engines
+        self.engines = {
+            "serper": SerperSearchEngine(
+                api_key=self.serper_api_key, timeout=timeout
+            ),
+            "scholar": ScholarSearchEngine(timeout=timeout),
+            "arxiv": ArxivSearchEngine(timeout=timeout),
+        }
+
+    async def __call__(
+        self,
+        action: SearchAction,
+        conversation=None,
+    ) -> SearchObservation:
+        """Execute search action.
+
+        Args:
+            action: Search action with query and engines
+            conversation: Optional conversation context (unused)
+
+        Returns:
+            Search observation with results
+        """
+        try:
+            # Determine which engines to use
+            engines_to_use = action.engines or ["scholar", "arxiv"]
+
+            # Run searches concurrently
+            results_list = await asyncio.gather(
+                *[
+                    self.engines[engine_name].search(
+                        action.query, action.max_results
+                    )
+                    for engine_name in engines_to_use
+                    if engine_name in self.engines
+                ],
+                return_exceptions=True,
+            )
+
+            # Aggregate results and deduplicate by URL
+            seen_urls = set()
+            aggregated_results = []
+
+            for result in results_list:
+                if isinstance(result, Exception):
+                    logger.warning(f"Search engine failed: {result}")
+                    continue
+
+                for item in result.results:
+                    if item.url not in seen_urls:
+                        seen_urls.add(item.url)
+                        aggregated_results.append(
+                            {
+                                "title": item.title,
+                                "url": item.url,
+                                "source": item.source,
+                                "snippet": item.snippet,
+                                "authors": item.authors,
+                                "published_date": (
+                                    item.published_date.isoformat()
+                                    if item.published_date
+                                    else None
+                                ),
+                                "relevance_score": item.relevance_score,
+                            }
+                        )
+
+            # Sort by relevance score
+            aggregated_results.sort(
+                key=lambda x: x.get("relevance_score", 0), reverse=True
+            )
+
+            # Limit to max_results
+            aggregated_results = aggregated_results[: action.max_results]
+
+            return SearchObservation(
+                search_results=aggregated_results,
+                total_found=len(aggregated_results),
+                query=action.query,
+                engines_used=engines_to_use,
+            )
+
+        except Exception as e:
+            logger.error(f"Search execution failed: {e}")
+            return SearchObservation(
+                search_results=[],
+                total_found=0,
+                query=action.query,
+                engines_used=action.engines or ["scholar", "arxiv"],
+                is_error=True,
+                error=str(e),
+            )

--- a/openhands-tools/openhands/tools/search_academic/impl.py
+++ b/openhands-tools/openhands/tools/search_academic/impl.py
@@ -9,6 +9,8 @@ from openhands.sdk.tool import ToolExecutor
 
 from openhands.tools.search_academic.definition import SearchAction, SearchObservation
 from openhands.tools.search_academic.engines import (
+    ArxivSearchEngine,
+    ScholarSearchEngine,
     SerperSearchEngine,
 )
 
@@ -21,6 +23,7 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
     def __init__(
         self,
         serper_api_key: Optional[str] = None,
+        scholar_api_key: Optional[str] = None,
         timeout: int = 30,
         **kwargs,
     ):
@@ -28,20 +31,22 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
 
         Args:
             serper_api_key: API key for Serper search engine
+            scholar_api_key: API key for Semantic Scholar search engine
             timeout: Request timeout in seconds
             **kwargs: Additional parameters (ignored)
         """
-        # Get API key from parameter or environment
-        self.serper_api_key = (
-            serper_api_key or os.getenv("SERPER_API_KEY")
-        )
+        self.serper_api_key = serper_api_key or os.getenv("SERPER_API_KEY")
+        self.scholar_api_key = scholar_api_key or os.getenv("SEMANTIC_SCHOLAR_API_KEY")
         self.timeout = timeout
 
-        # Initialize search engines (only serper for stability)
         self.engines = {
             "serper": SerperSearchEngine(
                 api_key=self.serper_api_key, timeout=timeout
             ),
+            "scholar": ScholarSearchEngine(
+                api_key=self.scholar_api_key, timeout=timeout
+            ),
+            "arxiv": ArxivSearchEngine(timeout=timeout),
         }
 
     async def __call__(

--- a/openhands-tools/openhands/tools/search_academic/impl.py
+++ b/openhands-tools/openhands/tools/search_academic/impl.py
@@ -10,8 +10,6 @@ from openhands.sdk.tool import ToolExecutor
 from openhands.tools.search_academic.definition import SearchAction, SearchObservation
 from openhands.tools.search_academic.engines import (
     SerperSearchEngine,
-    ScholarSearchEngine,
-    ArxivSearchEngine,
 )
 
 logger = logging.getLogger(__name__)
@@ -35,17 +33,15 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
         """
         # Get API key from parameter or environment
         self.serper_api_key = (
-            serper_api_key or os.getenv("SEARCH_ACADEMIC_SERPER_API_KEY")
+            serper_api_key or os.getenv("SERPER_API_KEY")
         )
         self.timeout = timeout
 
-        # Initialize search engines
+        # Initialize search engines (only serper for stability)
         self.engines = {
             "serper": SerperSearchEngine(
                 api_key=self.serper_api_key, timeout=timeout
             ),
-            "scholar": ScholarSearchEngine(timeout=timeout),
-            "arxiv": ArxivSearchEngine(timeout=timeout),
         }
 
     async def __call__(
@@ -63,8 +59,8 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
             Search observation with results
         """
         try:
-            # Determine which engines to use
-            engines_to_use = action.engines or ["scholar", "arxiv"]
+            # Determine which engines to use (default to serper only for stability)
+            engines_to_use = action.engines or ["serper"]
 
             # Run searches concurrently
             results_list = await asyncio.gather(
@@ -127,7 +123,7 @@ class SearchExecutor(ToolExecutor[SearchAction, SearchObservation]):
                 search_results=[],
                 total_found=0,
                 query=action.query,
-                engines_used=action.engines or ["scholar", "arxiv"],
+                engines_used=action.engines or ["serper"],
                 is_error=True,
                 error=str(e),
             )

--- a/openhands-tools/openhands/tools/search_academic/models.py
+++ b/openhands-tools/openhands/tools/search_academic/models.py
@@ -1,0 +1,113 @@
+"""Data models for academic search tools."""
+
+from datetime import date
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class SearchResult(BaseModel):
+    """A single search result."""
+
+    title: str = Field(..., description="Result title")
+    url: str = Field(..., description="Result URL")
+    source: str = Field(
+        ...,
+        description="Search engine source (serper, scholar, arxiv, pubmed, openalex)",
+    )
+    snippet: Optional[str] = Field(
+        default=None,
+        description="Short snippet or abstract",
+    )
+    authors: list[str] = Field(
+        default_factory=list,
+        description="List of author names",
+    )
+    published_date: Optional[date] = Field(
+        default=None,
+        description="Publication date",
+    )
+    relevance_score: float = Field(
+        default=0.5,
+        ge=0.0,
+        le=1.0,
+        description="Relevance score from 0 to 1",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "title": "Machine Learning Basics",
+                    "url": "https://example.com/paper",
+                    "source": "scholar",
+                    "snippet": "A comprehensive introduction...",
+                    "authors": ["John Doe"],
+                    "published_date": "2023-01-15",
+                    "relevance_score": 0.95,
+                }
+            ]
+        }
+    }
+
+
+class SearchQuery(BaseModel):
+    """Search query configuration."""
+
+    query: str = Field(..., min_length=1, description="Search query string")
+    engines: list[str] = Field(
+        default_factory=list,
+        description="List of search engines to use",
+    )
+    max_results: int = Field(
+        default=10,
+        ge=1,
+        le=100,
+        description="Maximum number of results to return",
+    )
+    language: str = Field(
+        default="en",
+        description="Language code (e.g., 'en', 'zh-cn')",
+    )
+
+
+class SearchResponse(BaseModel):
+    """Response from a search engine."""
+
+    query: str = Field(..., description="Original search query")
+    results: list[SearchResult] = Field(
+        default_factory=list,
+        description="List of search results",
+    )
+    total_found: int = Field(
+        default=0,
+        ge=0,
+        description="Total number of results found",
+    )
+    engine: str = Field(..., description="Search engine name")
+    execution_time: float = Field(
+        default=0.0,
+        ge=0.0,
+        description="Execution time in seconds",
+    )
+
+    model_config = {
+        "json_schema_extra": {
+            "examples": [
+                {
+                    "query": "machine learning",
+                    "results": [
+                        {
+                            "title": "ML Paper",
+                            "url": "https://example.com/1",
+                            "source": "scholar",
+                            "relevance_score": 0.9,
+                        }
+                    ],
+                    "total_found": 100,
+                    "engine": "scholar",
+                    "execution_time": 0.5,
+                }
+            ]
+        }
+    }

--- a/openhands-tools/openhands/tools/search_academic/models.py
+++ b/openhands-tools/openhands/tools/search_academic/models.py
@@ -1,7 +1,6 @@
 """Data models for academic search tools."""
 
 from datetime import date
-from typing import Optional
 
 from pydantic import BaseModel, Field
 
@@ -15,15 +14,19 @@ class SearchResult(BaseModel):
         ...,
         description="Search engine source (serper, scholar, arxiv, pubmed, openalex)",
     )
-    snippet: Optional[str] = Field(
+    snippet: str | None = Field(
         default=None,
         description="Short snippet or abstract",
+    )
+    pdf_url: str | None = Field(
+        default=None,
+        description="Direct PDF download link when available (e.g. openAccessPdf.url)",
     )
     authors: list[str] = Field(
         default_factory=list,
         description="List of author names",
     )
-    published_date: Optional[date] = Field(
+    published_date: date | None = Field(
         default=None,
         description="Publication date",
     )

--- a/openhands-tools/openhands/tools/web_browser_academic/__init__.py
+++ b/openhands-tools/openhands/tools/web_browser_academic/__init__.py
@@ -1,0 +1,20 @@
+"""Web browser tool for OpenHands SDK."""
+
+from openhands.tools.web_browser_academic.definition import (
+    WebBrowserAction,
+    WebBrowserObservation,
+    WebBrowserAcademicTool,
+)
+from openhands.tools.web_browser_academic.extractor import ContentExtractor
+from openhands.tools.web_browser_academic.models import WebContent, WebPage
+from openhands.tools.web_browser_academic.impl import WebBrowserExecutor
+
+__all__ = [
+    "WebBrowserAction",
+    "WebBrowserObservation",
+    "WebBrowserAcademicTool",
+    "WebBrowserExecutor",
+    "ContentExtractor",
+    "WebContent",
+    "WebPage",
+]

--- a/openhands-tools/openhands/tools/web_browser_academic/definition.py
+++ b/openhands-tools/openhands/tools/web_browser_academic/definition.py
@@ -1,0 +1,156 @@
+"""Web browser tool definition for OpenHands SDK."""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Optional
+
+from pydantic import Field
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+from openhands.sdk.llm import TextContent
+from openhands.sdk.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    ToolExecutor,
+    register_tool,
+)
+
+
+TOOL_DESCRIPTION = """Fetch and extract content from web pages.
+
+This tool can:
+- Fetch web pages from URLs
+- Extract plain text content
+- Extract metadata (title, description, authors, etc.)
+- Extract links from pages
+- Handle errors and timeouts gracefully
+
+Returns structured web page content suitable for analysis and summarization.
+"""
+
+
+class WebBrowserAction(Action):
+    """Fetch and process web pages.
+
+    Attributes:
+        urls: List of URLs to fetch
+        extract_metadata: Whether to extract metadata
+        extract_links: Whether to extract links
+        max_content_length: Maximum content length to return
+    """
+
+    urls: list[str] = Field(
+        ...,
+        description="List of URLs to fetch. For example: ['https://example.com/paper', 'https://arxiv.org/pdf/2023.12345']",
+    )
+    extract_metadata: bool = Field(
+        default=True,
+        description="Whether to extract metadata (title, description, etc.)",
+    )
+    extract_links: bool = Field(
+        default=False,
+        description="Whether to extract all links from the page",
+    )
+    max_content_length: int = Field(
+        default=10000,
+        ge=100,
+        description="Maximum content length to return (in characters)",
+    )
+
+
+class WebBrowserObservation(Observation):
+    """Result of web browser operation.
+
+    Attributes:
+        fetched_pages: List of successfully fetched pages
+        failed_urls: List of URLs that failed to fetch
+        total_fetched: Number of successfully fetched pages
+        total_requested: Number of URLs requested
+    """
+
+    fetched_pages: list[dict] = Field(
+        default_factory=list,
+        description="List of fetched pages with content",
+    )
+    failed_urls: list[str] = Field(
+        default_factory=list,
+        description="URLs that failed to fetch",
+    )
+    total_fetched: int = Field(
+        default=0,
+        description="Number of successfully fetched pages",
+    )
+    total_requested: int = Field(
+        default=0,
+        description="Number of URLs requested",
+    )
+
+    @property
+    def to_llm_content(self) -> Sequence[TextContent]:
+        """Convert observation to LLM-friendly format."""
+        result_text = f"Web Content Extraction Results:\n"
+        result_text += f"Successfully fetched: {self.total_fetched}/{self.total_requested}\n"
+
+        if self.failed_urls:
+            result_text += f"Failed URLs: {', '.join(self.failed_urls)}\n\n"
+
+        for page in self.fetched_pages[:5]:  # Show first 5 pages
+            result_text += f"URL: {page.get('url', 'N/A')}\n"
+            result_text += f"Title: {page.get('title', 'N/A')}\n"
+
+            # Truncate content for LLM
+            content = page.get("text", "")
+            if len(content) > 500:
+                content = content[:500] + "...\n[Content truncated]"
+
+            result_text += f"Content:\n{content}\n\n"
+
+        return [TextContent(text=result_text)]
+
+
+class WebBrowserAcademicTool(ToolDefinition[WebBrowserAction, WebBrowserObservation]):
+    """Tool definition for web browsing and content extraction."""
+
+    name = "web_browser_academic"
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: "ConversationState",
+        **params,
+    ) -> Sequence["WebBrowserAcademicTool"]:
+        """Create tool instance.
+
+        Args:
+            conv_state: Conversation state
+            **params: Additional parameters (timeout, max_concurrent, etc.)
+
+        Returns:
+            Sequence of tool instances
+        """
+        from openhands.tools.web_browser_academic.impl import WebBrowserExecutor
+
+        executor = WebBrowserExecutor(**params)
+
+        return [
+            cls(
+                description=TOOL_DESCRIPTION,
+                action_type=WebBrowserAction,
+                observation_type=WebBrowserObservation,
+                annotations=ToolAnnotations(
+                    title="web_browser_academic",
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
+                executor=executor,
+            )
+        ]
+
+
+# Register tool at module import
+register_tool(WebBrowserAcademicTool.name, WebBrowserAcademicTool)

--- a/openhands-tools/openhands/tools/web_browser_academic/extractor.py
+++ b/openhands-tools/openhands/tools/web_browser_academic/extractor.py
@@ -1,0 +1,111 @@
+"""Content extraction utilities."""
+
+import logging
+import re
+
+from bs4 import BeautifulSoup
+
+logger = logging.getLogger(__name__)
+
+
+class ContentExtractor:
+    """Extract and clean web content from HTML."""
+
+    @staticmethod
+    def extract_text(html: str) -> str:
+        """Extract clean text from HTML.
+
+        Args:
+            html: Raw HTML content
+
+        Returns:
+            Extracted and cleaned text
+        """
+        try:
+            soup = BeautifulSoup(html, "lxml")
+
+            # Remove script and style elements
+            for script in soup(["script", "style"]):
+                script.decompose()
+
+            # Remove common non-content elements
+            for element in soup(["nav", "footer", "header", "aside", "noscript"]):
+                element.decompose()
+
+            # Get text
+            text = soup.get_text()
+
+            # Clean up whitespace
+            lines = (line.strip() for line in text.splitlines())
+            chunks = (phrase.strip() for line in lines for phrase in line.split("  "))
+            text = " ".join(chunk for chunk in chunks if chunk)
+
+            return text
+        except Exception as e:
+            logger.error(f"Text extraction failed: {e}")
+            return ""
+
+    @staticmethod
+    def extract_metadata(html: str) -> dict[str, str]:
+        """Extract metadata from HTML.
+
+        Args:
+            html: Raw HTML content
+
+        Returns:
+            Dictionary of metadata
+        """
+        metadata: dict[str, str] = {}
+        try:
+            soup = BeautifulSoup(html, "lxml")
+
+            # Extract title
+            title_tag = soup.find("title")
+            if title_tag:
+                metadata["title"] = title_tag.get_text(strip=True)
+
+            # Extract meta tags
+            for meta_tag in soup.find_all("meta"):
+                name_attr = meta_tag.get("name")
+                name = str(name_attr).lower() if name_attr else ""
+                content_attr = meta_tag.get("content")
+                content = str(content_attr) if content_attr else ""
+                if name and content:
+                    metadata[name] = content
+
+            # Extract Open Graph tags
+            for og_tag in soup.find_all("meta", property=re.compile("og:")):
+                property_attr = og_tag.get("property")
+                property_name = str(property_attr).lower() if property_attr else ""
+                content_attr = og_tag.get("content")
+                content = str(content_attr) if content_attr else ""
+                if property_name and content:
+                    metadata[property_name] = content
+
+        except Exception as e:
+            logger.error(f"Metadata extraction failed: {e}")
+
+        return metadata
+
+    @staticmethod
+    def extract_links(html: str) -> list[str]:
+        """Extract all links from HTML.
+
+        Args:
+            html: Raw HTML content
+
+        Returns:
+            List of URLs found in the HTML
+        """
+        links: list[str] = []
+        try:
+            soup = BeautifulSoup(html, "lxml")
+            for link in soup.find_all("a", href=True):
+                href_attr = link.get("href")
+                href = str(href_attr).strip() if href_attr else ""
+                if href:
+                    links.append(href)
+        except Exception as e:
+            logger.error(f"Link extraction failed: {e}")
+
+        return links

--- a/openhands-tools/openhands/tools/web_browser_academic/impl.py
+++ b/openhands-tools/openhands/tools/web_browser_academic/impl.py
@@ -1,0 +1,161 @@
+"""Web browser executor implementation."""
+
+import asyncio
+import logging
+from typing import Optional
+
+import httpx
+from openhands.sdk.tool import ToolExecutor
+
+from openhands.tools.web_browser_academic.definition import (
+    WebBrowserAction,
+    WebBrowserObservation,
+)
+from openhands.tools.web_browser_academic.extractor import ContentExtractor
+
+logger = logging.getLogger(__name__)
+
+
+class WebBrowserExecutor(ToolExecutor[WebBrowserAction, WebBrowserObservation]):
+    """Executor for web browser tool."""
+
+    def __init__(
+        self,
+        timeout: int = 30,
+        max_concurrent: int = 5,
+        **kwargs,
+    ):
+        """Initialize web browser executor.
+
+        Args:
+            timeout: Request timeout in seconds
+            max_concurrent: Maximum concurrent requests
+            **kwargs: Additional parameters (ignored)
+        """
+        self.timeout = timeout
+        self.max_concurrent = max_concurrent
+        self.extractor = ContentExtractor()
+
+    async def __call__(
+        self,
+        action: WebBrowserAction,
+        conversation=None,
+    ) -> WebBrowserObservation:
+        """Execute web browser action.
+
+        Args:
+            action: Web browser action with URLs to fetch
+            conversation: Optional conversation context (unused)
+
+        Returns:
+            Web browser observation with results
+        """
+        try:
+            # Limit concurrent requests with semaphore
+            semaphore = asyncio.Semaphore(self.max_concurrent)
+
+            async def fetch_with_semaphore(url: str):
+                async with semaphore:
+                    return await self._fetch_url(
+                        url,
+                        action.extract_metadata,
+                        action.extract_links,
+                        action.max_content_length,
+                    )
+
+            # Fetch all URLs concurrently
+            results = await asyncio.gather(
+                *[fetch_with_semaphore(url) for url in action.urls],
+                return_exceptions=True,
+            )
+
+            # Process results
+            fetched_pages = []
+            failed_urls = []
+
+            for url, result in zip(action.urls, results):
+                if isinstance(result, Exception):
+                    logger.warning(f"Failed to fetch {url}: {result}")
+                    failed_urls.append(url)
+                elif result:
+                    fetched_pages.append(result)
+                else:
+                    failed_urls.append(url)
+
+            return WebBrowserObservation(
+                fetched_pages=fetched_pages,
+                failed_urls=failed_urls,
+                total_fetched=len(fetched_pages),
+                total_requested=len(action.urls),
+            )
+
+        except Exception as e:
+            logger.error(f"Web browser execution failed: {e}")
+            return WebBrowserObservation(
+                fetched_pages=[],
+                failed_urls=action.urls,
+                total_fetched=0,
+                total_requested=len(action.urls),
+                is_error=True,
+                error=str(e),
+            )
+
+    async def _fetch_url(
+        self,
+        url: str,
+        extract_metadata: bool,
+        extract_links: bool,
+        max_content_length: int,
+    ) -> Optional[dict]:
+        """Fetch a single URL and extract content.
+
+        Args:
+            url: URL to fetch
+            extract_metadata: Whether to extract metadata
+            extract_links: Whether to extract links
+            max_content_length: Maximum content length
+
+        Returns:
+            Dictionary with page content or None if failed
+        """
+        try:
+            async with httpx.AsyncClient(timeout=self.timeout) as client:
+                response = await client.get(url, follow_redirects=True)
+                response.raise_for_status()
+
+                html = response.text
+
+                # Extract content
+                text = self.extractor.extract_text(html)
+
+                # Truncate if necessary
+                if len(text) > max_content_length:
+                    text = text[:max_content_length] + "\n[Content truncated]"
+
+                result = {
+                    "url": url,
+                    "text": text,
+                    "html": html,
+                }
+
+                # Extract metadata if requested
+                if extract_metadata:
+                    metadata = self.extractor.extract_metadata(html)
+                    result["title"] = metadata.get("title")
+                    result["metadata"] = metadata
+                else:
+                    result["title"] = None
+                    result["metadata"] = {}
+
+                # Extract links if requested
+                if extract_links:
+                    links = self.extractor.extract_links(html)
+                    result["links"] = links
+                else:
+                    result["links"] = []
+
+                return result
+
+        except Exception as e:
+            logger.error(f"Error fetching {url}: {e}")
+            return None

--- a/openhands-tools/openhands/tools/web_browser_academic/models.py
+++ b/openhands-tools/openhands/tools/web_browser_academic/models.py
@@ -1,0 +1,48 @@
+"""Data models for web browser tool."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class WebContent(BaseModel):
+    """Web page content extracted from HTML."""
+
+    url: str = Field(..., description="URL of the web page")
+    title: Optional[str] = Field(
+        default=None,
+        description="Title of the web page",
+    )
+    text: str = Field(
+        ...,
+        min_length=1,
+        description="Extracted plain text content",
+    )
+    html: Optional[str] = Field(
+        default=None,
+        description="Original HTML content",
+    )
+    metadata: dict = Field(
+        default_factory=dict,
+        description="Extracted metadata (title, description, authors, etc.)",
+    )
+    extracted_at: datetime = Field(
+        default_factory=datetime.utcnow,
+        description="Timestamp of extraction",
+    )
+
+
+class WebPage(BaseModel):
+    """Web page with parsing status."""
+
+    url: str = Field(..., description="URL of the web page")
+    content: WebContent = Field(..., description="Extracted content")
+    parse_success: bool = Field(
+        default=True,
+        description="Whether parsing was successful",
+    )
+    error: Optional[str] = Field(
+        default=None,
+        description="Error message if parsing failed",
+    )

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -7,9 +7,12 @@ requires-python = ">=3.12"
 dependencies = [
     "openhands-sdk",
     "bashlex>=0.18",
+    "beautifulsoup4>=4.12.0",
     "binaryornot>=0.4.4",
     "cachetools",
+    "httpx>=0.25.0",
     "libtmux>=0.53.0",
+    "lxml>=4.9.0",
     "pydantic>=2.11.7",
     "browser-use>=0.8.0",
     "func-timeout>=4.3.5",

--- a/openhands-tools/test_new_tools.py
+++ b/openhands-tools/test_new_tools.py
@@ -1,0 +1,48 @@
+"""Quick test to verify new tools are importable and registered."""
+
+import sys
+import asyncio
+
+
+async def main():
+    """Test tool imports and registration."""
+    try:
+        # Test imports
+        print("Testing imports...")
+        from openhands.tools.search_academic import SearchAcademicTool, SearchAction, SearchObservation
+        from openhands.tools.web_browser_academic import WebBrowserAcademicTool, WebBrowserAction, WebBrowserObservation
+
+        print("✓ Imports successful")
+
+        # Test tool names
+        assert SearchAcademicTool.name == "search_academic"
+        assert WebBrowserAcademicTool.name == "web_browser_academic"
+        print("✓ Tool names correct")
+
+        # Test action/observation creation
+        search_action = SearchAction(query="machine learning", engines=["scholar"])
+        print(f"✓ SearchAction created: {search_action.query}")
+
+        web_action = WebBrowserAction(urls=["https://example.com"])
+        print(f"✓ WebBrowserAction created with {len(web_action.urls)} URL(s)")
+
+        # Test tool registration
+        from openhands.sdk.tool.registry import tool_registry
+
+        assert "search_academic" in tool_registry.tools
+        assert "web_browser_academic" in tool_registry.tools
+        print("✓ Tools registered in SDK registry")
+
+        print("\n✅ All tests passed!")
+        return 0
+
+    except Exception as e:
+        print(f"\n❌ Error: {e}")
+        import traceback
+        traceback.print_exc()
+        return 1
+
+
+if __name__ == "__main__":
+    exit_code = asyncio.run(main())
+    sys.exit(exit_code)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,19 @@
 """Common test fixtures and utilities."""
 
+import os
 import uuid
 from pathlib import Path
 from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Load .env from tests/ so API keys are available to integration tests
+try:
+    from dotenv import load_dotenv
+
+    load_dotenv(REPO_ROOT / "tests" / ".env")
+except ImportError:
+    pass
 
 import pytest
 from pydantic import SecretStr
@@ -14,8 +25,6 @@ from openhands.sdk.llm import LLM
 from openhands.sdk.tool import ToolExecutor
 from openhands.sdk.workspace import LocalWorkspace
 
-
-REPO_ROOT = Path(__file__).resolve().parent.parent
 TOKENIZER_FIXTURES_DIR = REPO_ROOT / "tests" / "fixtures" / "tokenizers"
 QWEN3_TOKENIZER_CONFIG = (
     TOKENIZER_FIXTURES_DIR / "qwen3-4b-instruct-2507-tokenizer_config.json"

--- a/tests/tools/search_academic/__init__.py
+++ b/tests/tools/search_academic/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for openhands-tools."""

--- a/tests/tools/search_academic/conftest.py
+++ b/tests/tools/search_academic/conftest.py
@@ -1,0 +1,10 @@
+import os
+
+import pytest
+
+
+def require_env(name: str) -> str:
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} not set in tests/.env")
+    return value

--- a/tests/tools/search_academic/test_search_engines.py
+++ b/tests/tools/search_academic/test_search_engines.py
@@ -6,12 +6,12 @@ connect to and retrieve results from its respective API.
 Run with: pytest tests/tools/search_academic/test_search_engines.py -v
 """
 
-import asyncio
 import os
 import sys
 
 # Add the openhands-tools package to path
-sys.path.insert(0, "/home/anwh/software-agent-sdk/openhands-tools")
+_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
+sys.path.insert(0, os.path.join(_repo_root, "openhands-tools"))
 
 import pytest
 
@@ -22,27 +22,21 @@ from openhands.tools.search_academic.engines import (
 )
 
 
+def _require_env(name: str) -> str:
+    """Get required env var or skip the test."""
+    value = os.environ.get(name)
+    if not value:
+        pytest.skip(f"{name} not set in .env file")
+    return value
+
+
 class TestScholarSearchEngine:
     """Integration tests for Semantic Scholar search engine."""
 
-    @pytest.mark.skip(reason="Requires SEMANTIC_SCHOLAR_API_KEY")
-    @pytest.mark.asyncio
-    async def test_search_requires_api_key(self):
-        """Test that Scholar requires an API key and returns empty without it."""
-        engine = ScholarSearchEngine(api_key=None, timeout=30)
-        response = await engine.search("machine learning", max_results=5)
-
-        assert response.engine == "scholar"
-        assert len(response.results) == 0
-        print("\n✓ Scholar correctly returns empty without API key")
-
-    @pytest.mark.skip(reason="Requires SEMANTIC_SCHOLAR_API_KEY")
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
         """Test that Scholar search returns non-empty results with API key."""
-        api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
-        if not api_key:
-            pytest.skip("SEMANTIC_SCHOLAR_API_KEY not set in .env file")
+        api_key = _require_env("SEMANTIC_SCHOLAR_API_KEY")
 
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
@@ -52,13 +46,10 @@ class TestScholarSearchEngine:
         assert len(response.results) > 0
         print(f"\n✓ Scholar returned {len(response.results)} results")
 
-    @pytest.mark.skip(reason="Requires SEMANTIC_SCHOLAR_API_KEY")
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
         """Test that search results have required fields."""
-        api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
-        if not api_key:
-            pytest.skip("SEMANTIC_SCHOLAR_API_KEY not set in .env file")
+        api_key = _require_env("SEMANTIC_SCHOLAR_API_KEY")
 
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("transformer attention", max_results=3)
@@ -76,7 +67,6 @@ class TestScholarSearchEngine:
 class TestArxivSearchEngine:
     """Integration tests for arXiv search engine."""
 
-    @pytest.mark.skip(reason="arXiv API is unstable")
     @pytest.mark.asyncio
     async def test_search_returns_results(self):
         """Test that arXiv search returns non-empty results."""
@@ -89,7 +79,6 @@ class TestArxivSearchEngine:
         print(f"\n✓ ArXiv search completed, total found: {response.total_found}")
         print(f"  Results count: {len(response.results)}")
 
-    @pytest.mark.skip(reason="arXiv API is unstable")
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
         """Test that search results have required fields."""
@@ -109,24 +98,10 @@ class TestArxivSearchEngine:
 class TestSerperSearchEngine:
     """Integration tests for Serper (Google) search engine."""
 
-    @pytest.mark.skip(reason="Requires SERPER_API_KEY")
-    @pytest.mark.asyncio
-    async def test_search_requires_api_key(self):
-        """Test that Serper requires an API key."""
-        engine = SerperSearchEngine(api_key=None, timeout=30)
-        response = await engine.search("machine learning", max_results=5)
-
-        assert response.engine == "serper"
-        assert len(response.results) == 0
-        print("\n✓ Serper correctly returns empty without API key")
-
-    @pytest.mark.skip(reason="Requires SERPER_API_KEY")
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
         """Test Serper search with valid API key."""
-        api_key = os.environ.get("SERPER_API_KEY")
-        if not api_key:
-            pytest.fail("SERPER_API_KEY not set in .env file")
+        api_key = _require_env("SERPER_API_KEY")
 
         engine = SerperSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
@@ -135,46 +110,6 @@ class TestSerperSearchEngine:
         assert response.total_found > 0, "Serper API should return results with valid API key"
         assert len(response.results) > 0
         print(f"\n✓ Serper returned {len(response.results)} results")
-
-
-class TestSearchExecutor:
-    """Integration tests for the combined search executor."""
-
-    @pytest.mark.skip(reason="Requires API keys for all engines")
-    @pytest.mark.asyncio
-    async def test_executor_single_engine(self):
-        """Test executor with single engine."""
-        from openhands.tools.search_academic.impl import SearchExecutor
-        from openhands.tools.search_academic.definition import SearchAction
-
-        executor = SearchExecutor(timeout=30)
-        action = SearchAction(query="attention mechanism", engines=["arxiv"], max_results=5)
-
-        result = await executor(action)
-
-        assert result.total_found > 0, "Search executor should return results from arxiv"
-        assert "arxiv" in result.engines_used
-        print(f"\n✓ Executor returned {result.total_found} results from arxiv")
-
-    @pytest.mark.skip(reason="Requires API keys for all engines")
-    @pytest.mark.asyncio
-    async def test_executor_multiple_engines(self):
-        """Test executor with multiple engines."""
-        from openhands.tools.search_academic.impl import SearchExecutor
-        from openhands.tools.search_academic.definition import SearchAction
-
-        executor = SearchExecutor(timeout=30)
-        action = SearchAction(
-            query="deep learning",
-            engines=["arxiv"],
-            max_results=10
-        )
-
-        result = await executor(action)
-
-        assert result.total_found > 0, "Search executor should return results from arxiv"
-        print(f"\n✓ Executor returned {result.total_found} total results")
-        print(f"  Engines used: {result.engines_used}")
 
 
 if __name__ == "__main__":

--- a/tests/tools/search_academic/test_search_engines.py
+++ b/tests/tools/search_academic/test_search_engines.py
@@ -1,0 +1,181 @@
+"""Integration tests for academic search engines.
+
+These tests verify that each search engine can successfully
+connect to and retrieve results from its respective API.
+
+Run with: pytest tests/tools/search_academic/test_search_engines.py -v
+"""
+
+import asyncio
+import os
+import sys
+
+# Add the openhands-tools package to path
+sys.path.insert(0, "/home/anwh/software-agent-sdk/openhands-tools")
+
+import pytest
+
+from openhands.tools.search_academic.engines import (
+    ScholarSearchEngine,
+    ArxivSearchEngine,
+    SerperSearchEngine,
+)
+
+
+class TestScholarSearchEngine:
+    """Integration tests for Semantic Scholar search engine."""
+
+    @pytest.mark.skip(reason="Requires SEMANTIC_SCHOLAR_API_KEY")
+    @pytest.mark.asyncio
+    async def test_search_requires_api_key(self):
+        """Test that Scholar requires an API key and returns empty without it."""
+        engine = ScholarSearchEngine(api_key=None, timeout=30)
+        response = await engine.search("machine learning", max_results=5)
+
+        assert response.engine == "scholar"
+        assert len(response.results) == 0
+        print("\n✓ Scholar correctly returns empty without API key")
+
+    @pytest.mark.skip(reason="Requires SEMANTIC_SCHOLAR_API_KEY")
+    @pytest.mark.asyncio
+    async def test_search_with_api_key(self):
+        """Test that Scholar search returns non-empty results with API key."""
+        api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
+        if not api_key:
+            pytest.skip("SEMANTIC_SCHOLAR_API_KEY not set in .env file")
+
+        engine = ScholarSearchEngine(api_key=api_key, timeout=30)
+        response = await engine.search("machine learning", max_results=5)
+
+        assert response.engine == "scholar"
+        assert response.total_found > 0, "Semantic Scholar API should return results"
+        assert len(response.results) > 0
+        print(f"\n✓ Scholar returned {len(response.results)} results")
+
+    @pytest.mark.skip(reason="Requires SEMANTIC_SCHOLAR_API_KEY")
+    @pytest.mark.asyncio
+    async def test_search_result_structure(self):
+        """Test that search results have required fields."""
+        api_key = os.environ.get("SEMANTIC_SCHOLAR_API_KEY")
+        if not api_key:
+            pytest.skip("SEMANTIC_SCHOLAR_API_KEY not set in .env file")
+
+        engine = ScholarSearchEngine(api_key=api_key, timeout=30)
+        response = await engine.search("transformer attention", max_results=3)
+
+        assert response.total_found > 0, "Semantic Scholar API should return results"
+        assert len(response.results) > 0
+        result = response.results[0]
+
+        assert result.title
+        assert result.url
+        assert result.source == "scholar"
+        print(f"\n✓ Result structure valid: {result.title[:50]}...")
+
+
+class TestArxivSearchEngine:
+    """Integration tests for arXiv search engine."""
+
+    @pytest.mark.skip(reason="arXiv API is unstable")
+    @pytest.mark.asyncio
+    async def test_search_returns_results(self):
+        """Test that arXiv search returns non-empty results."""
+        engine = ArxivSearchEngine(timeout=30)
+        response = await engine.search("machine learning", max_results=5)
+
+        assert response.engine == "arxiv"
+        assert response.total_found > 0, "arXiv API should return results"
+        assert len(response.results) > 0
+        print(f"\n✓ ArXiv search completed, total found: {response.total_found}")
+        print(f"  Results count: {len(response.results)}")
+
+    @pytest.mark.skip(reason="arXiv API is unstable")
+    @pytest.mark.asyncio
+    async def test_search_result_structure(self):
+        """Test that search results have required fields."""
+        engine = ArxivSearchEngine(timeout=30)
+        response = await engine.search("neural networks", max_results=3)
+
+        assert response.total_found > 0, "arXiv API should return results"
+        assert len(response.results) > 0
+        result = response.results[0]
+        assert result.title
+        assert result.url
+        assert result.source == "arxiv"
+        print(f"\n✓ ArXiv returned {len(response.results)} parsed results")
+        print(f"  First result: {result.title[:50]}...")
+
+
+class TestSerperSearchEngine:
+    """Integration tests for Serper (Google) search engine."""
+
+    @pytest.mark.skip(reason="Requires SERPER_API_KEY")
+    @pytest.mark.asyncio
+    async def test_search_requires_api_key(self):
+        """Test that Serper requires an API key."""
+        engine = SerperSearchEngine(api_key=None, timeout=30)
+        response = await engine.search("machine learning", max_results=5)
+
+        assert response.engine == "serper"
+        assert len(response.results) == 0
+        print("\n✓ Serper correctly returns empty without API key")
+
+    @pytest.mark.skip(reason="Requires SERPER_API_KEY")
+    @pytest.mark.asyncio
+    async def test_search_with_api_key(self):
+        """Test Serper search with valid API key."""
+        api_key = os.environ.get("SERPER_API_KEY")
+        if not api_key:
+            pytest.fail("SERPER_API_KEY not set in .env file")
+
+        engine = SerperSearchEngine(api_key=api_key, timeout=30)
+        response = await engine.search("machine learning", max_results=5)
+
+        assert response.engine == "serper"
+        assert response.total_found > 0, "Serper API should return results with valid API key"
+        assert len(response.results) > 0
+        print(f"\n✓ Serper returned {len(response.results)} results")
+
+
+class TestSearchExecutor:
+    """Integration tests for the combined search executor."""
+
+    @pytest.mark.skip(reason="Requires API keys for all engines")
+    @pytest.mark.asyncio
+    async def test_executor_single_engine(self):
+        """Test executor with single engine."""
+        from openhands.tools.search_academic.impl import SearchExecutor
+        from openhands.tools.search_academic.definition import SearchAction
+
+        executor = SearchExecutor(timeout=30)
+        action = SearchAction(query="attention mechanism", engines=["arxiv"], max_results=5)
+
+        result = await executor(action)
+
+        assert result.total_found > 0, "Search executor should return results from arxiv"
+        assert "arxiv" in result.engines_used
+        print(f"\n✓ Executor returned {result.total_found} results from arxiv")
+
+    @pytest.mark.skip(reason="Requires API keys for all engines")
+    @pytest.mark.asyncio
+    async def test_executor_multiple_engines(self):
+        """Test executor with multiple engines."""
+        from openhands.tools.search_academic.impl import SearchExecutor
+        from openhands.tools.search_academic.definition import SearchAction
+
+        executor = SearchExecutor(timeout=30)
+        action = SearchAction(
+            query="deep learning",
+            engines=["arxiv"],
+            max_results=10
+        )
+
+        result = await executor(action)
+
+        assert result.total_found > 0, "Search executor should return results from arxiv"
+        print(f"\n✓ Executor returned {result.total_found} total results")
+        print(f"  Engines used: {result.engines_used}")
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])

--- a/tests/tools/search_academic/test_search_engines.py
+++ b/tests/tools/search_academic/test_search_engines.py
@@ -22,12 +22,7 @@ from openhands.tools.search_academic.engines import (
 )
 
 
-def _require_env(name: str) -> str:
-    """Get required env var or skip the test."""
-    value = os.environ.get(name)
-    if not value:
-        pytest.skip(f"{name} not set in .env file")
-    return value
+from tests.tools.search_academic.conftest import require_env
 
 
 class TestScholarSearchEngine:
@@ -36,7 +31,7 @@ class TestScholarSearchEngine:
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
         """Test that Scholar search returns non-empty results with API key."""
-        api_key = _require_env("SEMANTIC_SCHOLAR_API_KEY")
+        api_key = require_env("SEMANTIC_SCHOLAR_API_KEY")
 
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
@@ -49,7 +44,7 @@ class TestScholarSearchEngine:
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
         """Test that search results have required fields."""
-        api_key = _require_env("SEMANTIC_SCHOLAR_API_KEY")
+        api_key = require_env("SEMANTIC_SCHOLAR_API_KEY")
 
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("transformer attention", max_results=3)
@@ -101,7 +96,7 @@ class TestSerperSearchEngine:
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
         """Test Serper search with valid API key."""
-        api_key = _require_env("SERPER_API_KEY")
+        api_key = require_env("SERPER_API_KEY")
 
         engine = SerperSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)

--- a/tests/tools/search_academic/test_search_engines.py
+++ b/tests/tools/search_academic/test_search_engines.py
@@ -1,28 +1,22 @@
-"""Integration tests for academic search engines.
-
-These tests verify that each search engine can successfully
-connect to and retrieve results from its respective API.
-
-Run with: pytest tests/tools/search_academic/test_search_engines.py -v
-"""
+"""Integration tests for academic search engines."""
 
 import os
 import sys
 
-# Add the openhands-tools package to path
-_repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.dirname(__file__))))
-sys.path.insert(0, os.path.join(_repo_root, "openhands-tools"))
-
 import pytest
 
-from openhands.tools.search_academic.engines import (
-    ScholarSearchEngine,
+
+_repo_root = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+)
+sys.path.insert(0, os.path.join(_repo_root, "openhands-tools"))
+
+from openhands.tools.search_academic.engines import (  # noqa: E402
     ArxivSearchEngine,
+    ScholarSearchEngine,
     SerperSearchEngine,
 )
-
-
-from tests.tools.search_academic.conftest import require_env
+from tests.tools.search_academic.conftest import require_env  # noqa: E402
 
 
 class TestScholarSearchEngine:
@@ -30,33 +24,30 @@ class TestScholarSearchEngine:
 
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
-        """Test that Scholar search returns non-empty results with API key."""
         api_key = require_env("SEMANTIC_SCHOLAR_API_KEY")
-
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
 
         assert response.engine == "scholar"
-        assert response.total_found > 0, "Semantic Scholar API should return results"
+        assert response.total_found > 0
         assert len(response.results) > 0
-        print(f"\n✓ Scholar returned {len(response.results)} results")
 
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
-        """Test that search results have required fields."""
+        """Search results must have title, url, snippet (abstract), and pdf_url."""
         api_key = require_env("SEMANTIC_SCHOLAR_API_KEY")
-
         engine = ScholarSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("transformer attention", max_results=3)
 
-        assert response.total_found > 0, "Semantic Scholar API should return results"
-        assert len(response.results) > 0
+        assert response.total_found > 0
         result = response.results[0]
-
         assert result.title
         assert result.url
         assert result.source == "scholar"
-        print(f"\n✓ Result structure valid: {result.title[:50]}...")
+        assert result.snippet and len(result.snippet) > 50, (
+            f"Expected snippet to include abstract, got: {result.snippet!r}"
+        )
+        assert hasattr(result, "pdf_url")
 
 
 class TestArxivSearchEngine:
@@ -64,30 +55,30 @@ class TestArxivSearchEngine:
 
     @pytest.mark.asyncio
     async def test_search_returns_results(self):
-        """Test that arXiv search returns non-empty results."""
         engine = ArxivSearchEngine(timeout=30)
         response = await engine.search("machine learning", max_results=5)
 
         assert response.engine == "arxiv"
-        assert response.total_found > 0, "arXiv API should return results"
+        assert response.total_found > 0
         assert len(response.results) > 0
-        print(f"\n✓ ArXiv search completed, total found: {response.total_found}")
-        print(f"  Results count: {len(response.results)}")
 
     @pytest.mark.asyncio
     async def test_search_result_structure(self):
-        """Test that search results have required fields."""
+        """Search results must have title, url (abs page), snippet, and pdf_url."""
         engine = ArxivSearchEngine(timeout=30)
         response = await engine.search("neural networks", max_results=3)
 
-        assert response.total_found > 0, "arXiv API should return results"
-        assert len(response.results) > 0
+        assert response.total_found > 0
         result = response.results[0]
         assert result.title
-        assert result.url
         assert result.source == "arxiv"
-        print(f"\n✓ ArXiv returned {len(response.results)} parsed results")
-        print(f"  First result: {result.title[:50]}...")
+        assert result.snippet, "Expected non-empty snippet (arXiv summary)"
+        assert result.url and "arxiv.org/abs/" in result.url, (
+            f"Expected abs page URL, got: {result.url!r}"
+        )
+        assert result.pdf_url and "arxiv.org/pdf/" in result.pdf_url, (
+            f"Expected PDF URL, got: {result.pdf_url!r}"
+        )
 
 
 class TestSerperSearchEngine:
@@ -95,16 +86,13 @@ class TestSerperSearchEngine:
 
     @pytest.mark.asyncio
     async def test_search_with_api_key(self):
-        """Test Serper search with valid API key."""
         api_key = require_env("SERPER_API_KEY")
-
         engine = SerperSearchEngine(api_key=api_key, timeout=30)
         response = await engine.search("machine learning", max_results=5)
 
         assert response.engine == "serper"
-        assert response.total_found > 0, "Serper API should return results with valid API key"
+        assert response.total_found > 0
         assert len(response.results) > 0
-        print(f"\n✓ Serper returned {len(response.results)} results")
 
 
 if __name__ == "__main__":

--- a/tests/tools/search_academic/test_search_executor.py
+++ b/tests/tools/search_academic/test_search_executor.py
@@ -1,0 +1,105 @@
+"""Tests for SearchExecutor engine configuration and E2E behavior."""
+
+import pytest
+
+from openhands.tools.search_academic.definition import SearchAction
+from openhands.tools.search_academic.impl import SearchExecutor
+from tests.tools.search_academic.conftest import require_env
+
+
+class TestSearchExecutorEngineSelection:
+    def test_default_creates_all_engines(self):
+        executor = SearchExecutor()
+        assert set(executor.engines.keys()) == {"serper", "scholar", "arxiv"}
+
+    @pytest.mark.parametrize(
+        "engines,expected",
+        [
+            (["arxiv"], {"arxiv"}),
+            (["arxiv", "scholar"], {"arxiv", "scholar"}),
+            (["arxiv", "nonexistent"], {"arxiv"}),
+            ([], set()),
+        ],
+    )
+    def test_engine_selection(self, engines, expected):
+        executor = SearchExecutor(engines=engines)
+        assert set(executor.engines.keys()) == expected
+
+
+class TestSearchExecutorEngineParams:
+    @pytest.mark.parametrize(
+        "engine_name,param_key,override_value",
+        [
+            ("arxiv", "timeout", 99),
+            ("serper", "api_key", "override_key"),
+        ],
+    )
+    def test_engine_params_overrides_defaults(self, engine_name, param_key, override_value):
+        executor = SearchExecutor(
+            engines=[engine_name],
+            timeout=10,
+            engine_params={engine_name: {param_key: override_value}},
+        )
+        assert getattr(executor.engines[engine_name], param_key) == override_value
+
+    def test_engine_params_does_not_affect_other_engines(self):
+        executor = SearchExecutor(
+            engines=["arxiv", "scholar"],
+            timeout=10,
+            engine_params={"arxiv": {"timeout": 99}},
+        )
+        assert executor.engines["arxiv"].timeout == 99
+        assert executor.engines["scholar"].timeout == 10
+
+
+class TestSearchExecutorE2E:
+    @pytest.mark.asyncio
+    async def test_arxiv_returns_results(self):
+        executor = SearchExecutor(engines=["arxiv"])
+        result = await executor(
+            SearchAction(query="machine learning", engines=["arxiv"], max_results=3)
+        )
+        assert not result.is_error
+        assert result.total_found > 0
+        assert all(r["source"] == "arxiv" for r in result.search_results)
+
+    @pytest.mark.asyncio
+    async def test_scholar_returns_results(self):
+        require_env("SEMANTIC_SCHOLAR_API_KEY")
+        executor = SearchExecutor(engines=["scholar"])
+        result = await executor(
+            SearchAction(query="machine learning", engines=["scholar"], max_results=3)
+        )
+        assert not result.is_error
+        assert result.total_found > 0
+        assert all(r["source"] == "scholar" for r in result.search_results)
+
+    @pytest.mark.asyncio
+    async def test_serper_returns_results(self):
+        require_env("SERPER_API_KEY")
+        executor = SearchExecutor(engines=["serper"])
+        result = await executor(
+            SearchAction(query="machine learning", engines=["serper"], max_results=3)
+        )
+        assert not result.is_error
+        assert result.total_found > 0
+        assert all(r["source"] == "serper" for r in result.search_results)
+
+    @pytest.mark.asyncio
+    async def test_action_engines_filters_execution(self):
+        executor = SearchExecutor(engines=["arxiv", "scholar"])
+        result = await executor(
+            SearchAction(query="deep learning", engines=["arxiv"], max_results=3)
+        )
+        assert not result.is_error
+        assert result.engines_used == ["arxiv"]
+        assert all(r["source"] == "arxiv" for r in result.search_results)
+
+    @pytest.mark.asyncio
+    async def test_empty_action_engines_uses_all_available(self):
+        executor = SearchExecutor(engines=["arxiv"])
+        result = await executor(
+            SearchAction(query="deep learning", engines=[], max_results=3)
+        )
+        assert not result.is_error
+        assert result.engines_used == ["arxiv"]

--- a/uv.lock
+++ b/uv.lock
@@ -8,7 +8,7 @@ resolution-markers = [
 ]
 
 [options]
-exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer = "2026-04-29T08:59:32.914430411Z"
 exclude-newer-span = "P7D"
 
 [manifest]
@@ -2532,11 +2532,14 @@ version = "1.20.1"
 source = { editable = "openhands-tools" }
 dependencies = [
     { name = "bashlex" },
+    { name = "beautifulsoup4" },
     { name = "binaryornot" },
     { name = "browser-use" },
     { name = "cachetools" },
     { name = "func-timeout" },
+    { name = "httpx" },
     { name = "libtmux" },
+    { name = "lxml" },
     { name = "openhands-sdk" },
     { name = "pydantic" },
     { name = "tom-swe" },
@@ -2545,11 +2548,14 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "bashlex", specifier = ">=0.18" },
+    { name = "beautifulsoup4", specifier = ">=4.12.0" },
     { name = "binaryornot", specifier = ">=0.4.4" },
     { name = "browser-use", specifier = ">=0.8.0" },
     { name = "cachetools" },
     { name = "func-timeout", specifier = ">=4.3.5" },
+    { name = "httpx", specifier = ">=0.25.0" },
     { name = "libtmux", specifier = ">=0.53.0" },
+    { name = "lxml", specifier = ">=4.9.0" },
     { name = "openhands-sdk", editable = "openhands-sdk" },
     { name = "pydantic", specifier = ">=2.11.7" },
     { name = "tom-swe", specifier = ">=1.0.3" },


### PR DESCRIPTION
## Summary
- **ScholarSearchEngine**: populate `snippet` from `abstract` field and `pdf_url` from `openAccessPdf.url`
- **ArxivSearchEngine**: separate `url` (abs page) from `pdf_url` (PDF link) — previously both fields used the PDF URL
- **SearchResult model**: add `pdf_url` field for direct PDF download link
- **Tests**: updated to verify snippet, url (abs vs pdf), and pdf_url in search results

## Why
- Scholar search was not returning abstracts in results despite requesting them via API
- arXiv `url` was pointing to PDF binary, which is not suitable for web content extraction
- Semantic Scholar landing pages are JS SPAs (HTTP 202) and cannot be scraped — downstream consumers need to distinguish between fetchable abs pages and PDF links

## Test plan
- [x] SDK unit tests pass (8/8)
- [x] Scholar integration test passes
- [x] Serper integration test passes
- [ ] arXiv integration tests (currently hit HTTP 429 rate limit from API)

🤖 Generated with [Claude Code](https://claude.com/claude-code)