### PR TITLE
feat(agent-server): delete ACP env-vars via PATCH null

### DIFF
--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -53,6 +53,45 @@ def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]
     return result
 
 
+def _apply_acp_env_deletes(
+    agent_update: dict[str, Any], agent_base: dict[str, Any]
+) -> dict[str, Any]:
+    """Honour ``acp_env: {KEY: None}`` as ``"delete KEY"`` in a PATCH diff.
+
+    Plain ``_deep_merge`` has no "unset" semantic for dict-value entries:
+    a null overlay value would survive the merge and then fail validation
+    against ``ACPAgentSettings.acp_env: dict[str, str]``. Frontends need a
+    PATCH-shaped way to remove a single env-var without round-tripping
+    the entire map, so this pre-processing step:
+
+      1. Strips ``None``-valued keys from ``agent_update["acp_env"]`` so
+         only positive add/replace entries remain to merge.
+      2. Strips the same keys from ``agent_base["acp_env"]`` so the
+         deletion sticks after the merge.
+
+    Returns the (possibly rewritten) ``agent_update`` mapping. ``agent_base``
+    is mutated in place when deletions apply.
+    """
+    env_diff = agent_update.get("acp_env")
+    if not isinstance(env_diff, dict):
+        return agent_update
+
+    delete_keys = [k for k, v in env_diff.items() if v is None]
+    if not delete_keys:
+        return agent_update
+
+    positive_env_diff = {k: v for k, v in env_diff.items() if v is not None}
+    rewritten = {**agent_update, "acp_env": positive_env_diff}
+
+    base_env = agent_base.get("acp_env")
+    if isinstance(base_env, dict):
+        agent_base["acp_env"] = {
+            k: v for k, v in base_env.items() if k not in delete_keys
+        }
+
+    return rewritten
+
+
 PERSISTED_SETTINGS_SCHEMA_VERSION = 1
 
 
@@ -132,12 +171,11 @@ class PersistedSettings(BaseModel):
 
         try:
             if isinstance(agent_update, dict):
-                agent_merged = _deep_merge(
-                    self.agent_settings.model_dump(
-                        mode="json", context={"expose_secrets": "plaintext"}
-                    ),
-                    agent_update,
+                agent_base = self.agent_settings.model_dump(
+                    mode="json", context={"expose_secrets": "plaintext"}
                 )
+                agent_update = _apply_acp_env_deletes(agent_update, agent_base)
+                agent_merged = _deep_merge(agent_base, agent_update)
                 try:
                     new_agent = validate_agent_settings(agent_merged)
                 except Exception as e:

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -538,6 +538,105 @@ def test_patch_settings_empty_payload_returns_400(client_with_settings):
     assert "At least one of" in response.json()["detail"]
 
 
+def test_patch_settings_acp_env_null_value_deletes_key(client_with_settings):
+    """PATCH ``agent_settings_diff.acp_env: {K: null}`` removes that key.
+
+    The deep-merge has no "unset" semantic for dict-value entries, so the
+    router pre-processes null-valued ``acp_env`` entries as deletions
+    before the merge. Sibling keys must survive untouched, and the
+    deleted key must not reappear on a subsequent GET.
+    """
+    # Seed two env vars on an ACP agent.
+    seed = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "acp",
+                "acp_server": "claude-code",
+                "acp_command": [],
+                "acp_env": {
+                    "ANTHROPIC_API_KEY": "sk-keep",
+                    "OPENAI_API_KEY": "sk-drop",
+                },
+            }
+        },
+    )
+    assert seed.status_code == 200, seed.text
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": {"OPENAI_API_KEY": None}}},
+    )
+    assert response.status_code == 200, response.text
+
+    get_response = client_with_settings.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    )
+    assert get_response.status_code == 200
+    env = get_response.json()["agent_settings"]["acp_env"]
+    assert env == {"ANTHROPIC_API_KEY": "sk-keep"}
+
+
+def test_patch_settings_acp_env_null_value_on_missing_key_is_a_noop(
+    client_with_settings,
+):
+    """Deleting a key that isn't there must not 422 — it's a no-op."""
+    client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "acp",
+                "acp_server": "claude-code",
+                "acp_command": [],
+                "acp_env": {"ANTHROPIC_API_KEY": "sk-keep"},
+            }
+        },
+    )
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": {"NOPE": None}}},
+    )
+    assert response.status_code == 200, response.text
+
+    get_response = client_with_settings.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    )
+    env = get_response.json()["agent_settings"]["acp_env"]
+    assert env == {"ANTHROPIC_API_KEY": "sk-keep"}
+
+
+def test_patch_settings_acp_env_mixed_add_and_delete(client_with_settings):
+    """One PATCH can both add a new key and delete an existing key."""
+    client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "acp",
+                "acp_server": "claude-code",
+                "acp_command": [],
+                "acp_env": {"OLD_KEY": "old-value"},
+            }
+        },
+    )
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "acp_env": {"OLD_KEY": None, "NEW_KEY": "new-value"}
+            }
+        },
+    )
+    assert response.status_code == 200, response.text
+
+    get_response = client_with_settings.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    )
+    env = get_response.json()["agent_settings"]["acp_env"]
+    assert env == {"NEW_KEY": "new-value"}
+
+
 def test_patch_settings_deep_merges(client_with_settings):
     """PATCH /api/settings deep-merges with existing settings."""
     # First update: set model


### PR DESCRIPTION
## Problem

PATCH `/api/settings` deep-merges `agent_settings_diff`. The merge has no "unset" semantic for inner dict-value entries — so frontends that want to remove a single `acp_env` key currently have to round-trip the whole map. But `acp_env` values are redacted on GET, so the UI doesn't have them to send back. Result: no way for a UI to delete a single env var without losing siblings.

## Fix

Pre-process the diff in `PersistedSettings.update`. Any `agent_settings_diff.acp_env` entry whose value is `None` is treated as "delete this key" — stripped from both the overlay and the base before the merge, so the key is absent from the merged dict and validation against `dict[str, str]` succeeds.

Sibling `acp_env` keys, scalar fields, and other settings are unaffected — only the `acp_env` sub-object honours the null-delete convention.

```python
# Add new key, delete existing key, in one PATCH:
PATCH /api/settings
{
  "agent_settings_diff": {
    "acp_env": {
      "ANTHROPIC_API_KEY": "sk-new",
      "OPENAI_API_KEY": null
    }
  }
}
```

## Test plan

`uv run pytest tests/agent_server/test_settings_router.py` — 34 passed.

New tests:
- `test_patch_settings_acp_env_null_value_deletes_key` — null deletes, siblings survive.
- `test_patch_settings_acp_env_null_value_on_missing_key_is_a_noop` — null on a missing key is a no-op (no 422).
- `test_patch_settings_acp_env_mixed_add_and_delete` — one PATCH can add and delete in the same call.

## Frontend dependency

agent-canvas#874 uses this to wire up the Delete button on the agent-settings env-var editor. That PR will be amended to match the global Secrets UX (list + Add + Delete) and depends on this landing.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5906776-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5906776-python \
  ghcr.io/openhands/agent-server:5906776-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5906776-golang-amd64
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-golang-amd64
ghcr.io/openhands/agent-server:5906776-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5906776-golang-arm64
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-golang-arm64
ghcr.io/openhands/agent-server:5906776-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5906776-java-amd64
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-java-amd64
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-java-amd64
ghcr.io/openhands/agent-server:5906776-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5906776-java-arm64
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-java-arm64
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-java-arm64
ghcr.io/openhands/agent-server:5906776-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5906776-python-amd64
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-python-amd64
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-python-amd64
ghcr.io/openhands/agent-server:5906776-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5906776-python-arm64
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-python-arm64
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-python-arm64
ghcr.io/openhands/agent-server:5906776-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5906776-golang
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-golang
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-golang
ghcr.io/openhands/agent-server:5906776-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5906776-java
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-java
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-java
ghcr.io/openhands/agent-server:5906776-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5906776-python
ghcr.io/openhands/agent-server:59067768609afb840d280f442397187c4c06455f-python
ghcr.io/openhands/agent-server:feat-acp-env-delete-via-null-python
ghcr.io/openhands/agent-server:5906776-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5906776-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5906776-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->