### PR TITLE
fix(sdk): use dedicated ThreadPoolExecutor per aexecute_batch (Q3 of #3341)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/parallel_executor.py
+++ b/openhands-sdk/openhands/sdk/agent/parallel_executor.py
@@ -110,11 +110,15 @@ class ParallelToolExecutor:
     ) -> list[list[Event]]:
         """Async variant of :meth:`execute_batch`.
 
-        Each tool call is dispatched to a thread pool worker via
-        :func:`asyncio.loop.run_in_executor` and scheduled
-        concurrently with :func:`asyncio.gather`.  A
-        :class:`asyncio.Semaphore` enforces the same concurrency
-        limit as the sync path's :class:`ThreadPoolExecutor`.
+        Each tool call is dispatched to a dedicated
+        :class:`~concurrent.futures.ThreadPoolExecutor` (sized to
+        ``max_workers``) via :func:`asyncio.loop.run_in_executor` and
+        scheduled concurrently with :func:`asyncio.gather`. The pool
+        itself bounds concurrency, matching the sync path's per-batch
+        :class:`ThreadPoolExecutor`; using a dedicated pool avoids
+        serializing on asyncio's shared default executor (small and
+        process-wide), which could throttle previously-parallel tool
+        calls when other ``run_in_executor`` users contend for it.
 
         The *tool_runner* is the same **synchronous** callable used by
         :meth:`execute_batch` (i.e. ``_execute_action_event``).
@@ -136,15 +140,24 @@ class ParallelToolExecutor:
                 for action in action_events
             ]
 
-        sem = asyncio.Semaphore(self._max_workers)
-
-        async def _limited(action: ActionEvent) -> list[Event]:
-            async with sem:
-                return await self._arun_safe(
-                    action, tool_runner, _resolve(action), cancel_token
+        with ThreadPoolExecutor(
+            max_workers=self._max_workers,
+            thread_name_prefix="aexecute_batch",
+        ) as pool:
+            return list(
+                await asyncio.gather(
+                    *[
+                        self._arun_safe(
+                            action,
+                            tool_runner,
+                            _resolve(action),
+                            cancel_token,
+                            pool,
+                        )
+                        for action in action_events
+                    ]
                 )
-
-        return list(await asyncio.gather(*[_limited(a) for a in action_events]))
+            )
 
     async def _arun_safe(
         self,
@@ -152,6 +165,7 @@ class ParallelToolExecutor:
         tool_runner: Callable[[ActionEvent], list[Event]],
         tool: ToolDefinition | None = None,
         cancel_token: CancellationToken | None = None,
+        executor: ThreadPoolExecutor | None = None,
     ) -> list[Event]:
         """Run :meth:`_run_safe` in a thread via ``run_in_executor``.
 
@@ -159,6 +173,12 @@ class ParallelToolExecutor:
         executes and ensures that ``ResourceLockManager``'s threading
         locks are acquired on the worker thread, not the event-loop
         thread.
+
+        When *executor* is ``None`` the asyncio default pool is used
+        (suitable for one-off / single-action calls); batch callers
+        should pass a dedicated pool so concurrent tool calls don't
+        contend with other ``run_in_executor`` users on the shared
+        default pool.
 
         If the asyncio task is cancelled while the thread is running
         (e.g. via ``conversation.interrupt()``), we call
@@ -170,7 +190,7 @@ class ParallelToolExecutor:
         """
         loop = asyncio.get_running_loop()
         fut = loop.run_in_executor(
-            None, self._run_safe, action, tool_runner, tool, cancel_token
+            executor, self._run_safe, action, tool_runner, tool, cancel_token
         )
         try:
             return await fut


### PR DESCRIPTION
## Summary

Addresses **Q3** in tracker #3341 — parallel-tool throughput regression on the async path.

`aexecute_batch` dispatched tool calls via `run_in_executor(None, ...)` and bounded concurrency with an `asyncio.Semaphore(max_workers)`. The default loop executor is small (`min(32, os.cpu_count()+4)`) and shared process-wide, so concurrent batches and other `run_in_executor` users (e.g. LLM transport) contended for the same workers. When `max_workers` exceeded the default pool size — or when the pool was simply busy — previously-parallel tool calls would serialize even though the semaphore allowed them through.

This PR mirrors the sync `execute_batch` path: each batch opens its own `ThreadPoolExecutor(max_workers)` via `with`, and `_arun_safe` now accepts an `executor` parameter and forwards it to `run_in_executor(executor, ...)`. The pool itself caps concurrency, so the `Semaphore` is dropped.

- Single-action / `max_workers == 1` fast path is unchanged (no point allocating a pool for one call; `_arun_safe`'s `executor` defaults to `None` → the loop default).
- Cancellation semantics, result ordering, and `ResourceLockManager` behavior are unchanged.

## Test plan

- [x] `pre-commit run --files openhands-sdk/openhands/sdk/agent/parallel_executor.py` — passes (ruff, pyright, deps, tool-registration).
- [x] `pytest tests/sdk/agent/test_parallel_executor.py tests/sdk/agent/test_parallel_executor_locking.py tests/sdk/agent/test_parallel_execution_integration.py` — 29/29 passing, including the existing ordering / concurrency-cap / nested-execution / cancellation cases.
- [ ] CI green.

Refs #3341.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6acb13d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6acb13d-python \
  ghcr.io/openhands/agent-server:6acb13d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6acb13d-golang-amd64
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-golang-amd64
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-golang-amd64
ghcr.io/openhands/agent-server:6acb13d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6acb13d-golang-arm64
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-golang-arm64
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-golang-arm64
ghcr.io/openhands/agent-server:6acb13d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6acb13d-java-amd64
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-java-amd64
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-java-amd64
ghcr.io/openhands/agent-server:6acb13d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6acb13d-java-arm64
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-java-arm64
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-java-arm64
ghcr.io/openhands/agent-server:6acb13d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6acb13d-python-amd64
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-python-amd64
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-python-amd64
ghcr.io/openhands/agent-server:6acb13d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6acb13d-python-arm64
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-python-arm64
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-python-arm64
ghcr.io/openhands/agent-server:6acb13d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6acb13d-golang
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-golang
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-golang
ghcr.io/openhands/agent-server:6acb13d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6acb13d-java
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-java
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-java
ghcr.io/openhands/agent-server:6acb13d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6acb13d-python
ghcr.io/openhands/agent-server:6acb13d01163dc00c8703b11f6444c7ae5e8e061-python
ghcr.io/openhands/agent-server:vasco-q3-dedicated-pool-aexecute-batch-python
ghcr.io/openhands/agent-server:6acb13d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6acb13d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6acb13d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->