### PR TITLE
feat(agent-server): dedicated CRUD endpoints for ACP env-vars

### DIFF
--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -469,6 +469,12 @@ async def upsert_acp_env_var(
     server-side mutation is an unconditional dict assignment under the
     store's file lock.
 
+    Encryption-at-rest is conditional on a configured cipher
+    (``OH_SECRET_KEY``): keyed deployments persist Fernet ciphertext, while
+    a keyless local server writes plaintext to ``settings.json`` — identical
+    to the ``/api/settings/secrets`` endpoints and every other secret-bearing
+    field.
+
     Raises:
         HTTPException: 422 if name format is invalid, 409 if the active
         agent isn't ACP, 500 on file I/O failures.

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -19,6 +19,9 @@ from openhands.agent_server.persistence import (
 from openhands.agent_server.persistence.models import SettingsUpdatePayload
 from openhands.sdk.logger import get_logger
 from openhands.sdk.settings import (
+    AcpEnvVarItem,
+    AcpEnvVarsListResponse,
+    AcpEnvVarUpsertRequest,
     ConversationSettings,
     SecretCreateRequest,
     SecretItemResponse,
@@ -28,6 +31,7 @@ from openhands.sdk.settings import (
     SettingsUpdateRequest,
     export_agent_settings_schema,
 )
+from openhands.sdk.settings.model import ACPAgentSettings
 
 
 logger = get_logger(__name__)
@@ -41,6 +45,8 @@ logger = get_logger(__name__)
 SETTINGS_PATH = ""  # -> /api/settings
 SECRETS_PATH = "/secrets"  # -> /api/settings/secrets
 SECRET_VALUE_PATH = "/secrets/{name}"  # -> /api/settings/secrets/{name}
+ACP_ENV_PATH = "/agent-env"  # -> /api/settings/agent-env
+ACP_ENV_VALUE_PATH = "/agent-env/{name}"  # -> /api/settings/agent-env/{name}
 
 settings_router = APIRouter(prefix="/settings", tags=["Settings"])
 
@@ -383,5 +389,173 @@ async def delete_secret(request: Request, name: str) -> dict[str, bool]:
     logger.info(
         "Secret deleted",
         extra={"secret_name": name, "client_host": client_host},
+    )
+    return {"deleted": True}
+
+
+# ── ACP env-var CRUD Endpoints ───────────────────────────────────────────
+#
+# ``acp_env`` is a ``dict[str, str]`` field on ``ACPAgentSettings`` that
+# injects environment variables into the ACP subprocess at spawn time.
+# Mirrors the secrets API so single-key adds and deletes don't have to
+# thread through ``PATCH /api/settings``'s deep-merge (which has no
+# "unset" primitive). Storage stays inside ``agent_settings`` — only the
+# wire-level mutation shape is different.
+
+
+def _require_acp_agent_settings(
+    settings: PersistedSettings,
+) -> ACPAgentSettings:
+    """Return ``settings.agent_settings`` if it's an ACP variant, else 409.
+
+    The ``acp_env`` field only exists on the ACP discriminated-union
+    variant. Mutating it when the active agent is OpenHands would either
+    be silently dropped on save (the union picks the OpenHands schema) or
+    fail validation — the dedicated 409 is clearer.
+    """
+    agent_settings = settings.agent_settings
+    if not isinstance(agent_settings, ACPAgentSettings):
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail=(
+                "ACP env-vars are only available when ``agent_settings.agent_kind`` "
+                "is ``'acp'``. Switch to an ACP agent before managing env-vars."
+            ),
+        )
+    return agent_settings
+
+
+@settings_router.get(ACP_ENV_PATH, response_model=AcpEnvVarsListResponse)
+async def list_acp_env_vars(request: Request) -> AcpEnvVarsListResponse:
+    """List the names of every ACP env-var configured for this agent.
+
+    Values are intentionally not surfaced — callers that need to round-trip
+    a plaintext value should use ``GET /api/settings`` with an
+    ``X-Expose-Secrets`` header, since that path already understands the
+    cipher and serialization context.
+
+    Returns an empty list when the active agent isn't ACP; the GUI treats
+    the absence of variables and the absence of an ACP agent the same way
+    (the env-vars panel is only rendered on the ACP branch).
+    """
+    config = get_config(request)
+    store = get_settings_store(config)
+    settings = store.load() or PersistedSettings()
+
+    client_host = request.client.host if request.client else "unknown"
+    agent_settings = settings.agent_settings
+    if not isinstance(agent_settings, ACPAgentSettings):
+        logger.info(
+            "ACP env-vars list accessed (non-ACP agent)",
+            extra={"client_host": client_host, "env_var_count": 0},
+        )
+        return AcpEnvVarsListResponse(env_vars=[])
+
+    names = sorted(agent_settings.acp_env.keys())
+    logger.info(
+        "ACP env-vars list accessed",
+        extra={"client_host": client_host, "env_var_count": len(names)},
+    )
+    return AcpEnvVarsListResponse(
+        env_vars=[AcpEnvVarItem(name=name) for name in names]
+    )
+
+
+@settings_router.put(ACP_ENV_PATH, response_model=AcpEnvVarItem)
+async def upsert_acp_env_var(
+    request: Request, body: AcpEnvVarUpsertRequest
+) -> AcpEnvVarItem:
+    """Create or replace an ACP env-var.
+
+    Same shape is used for first-time adds and value rotations — the
+    server-side mutation is an unconditional dict assignment under the
+    store's file lock.
+
+    Raises:
+        HTTPException: 422 if name format is invalid, 409 if the active
+        agent isn't ACP, 500 on file I/O failures.
+    """
+    _validate_secret_name(body.name)
+
+    config = get_config(request)
+    store = get_settings_store(config)
+    client_host = request.client.host if request.client else "unknown"
+
+    def apply(settings: PersistedSettings) -> PersistedSettings:
+        agent_settings = _require_acp_agent_settings(settings)
+        # ``acp_env: dict[str, str]`` — assign a fresh dict so Pydantic
+        # treats this as an explicit field set (no in-place mutation
+        # subtleties around model validation on re-save).
+        agent_settings.acp_env = {
+            **agent_settings.acp_env,
+            body.name: body.value.get_secret_value(),
+        }
+        return settings
+
+    try:
+        store.update(apply)
+    except HTTPException:
+        raise
+    except RuntimeError as e:
+        logger.error(f"ACP env-var upsert blocked: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Settings file is corrupted or encrypted with a different key",
+        )
+    except (OSError, PermissionError):
+        # exc_info omitted to keep secret values out of tracebacks.
+        logger.error("Failed to upsert ACP env-var - file I/O error")
+        raise HTTPException(status_code=500, detail="Failed to save settings")
+
+    logger.info(
+        "ACP env-var upserted",
+        extra={"env_var_name": body.name, "client_host": client_host},
+    )
+    return AcpEnvVarItem(name=body.name)
+
+
+@settings_router.delete(ACP_ENV_VALUE_PATH)
+async def delete_acp_env_var(request: Request, name: str) -> dict[str, bool]:
+    """Delete a single ACP env-var by name.
+
+    Raises:
+        HTTPException: 422 if name format is invalid, 404 if the var
+        doesn't exist, 409 if the active agent isn't ACP, 500 on file
+        I/O failures.
+    """
+    _validate_secret_name(name)
+
+    config = get_config(request)
+    store = get_settings_store(config)
+    client_host = request.client.host if request.client else "unknown"
+
+    def apply(settings: PersistedSettings) -> PersistedSettings:
+        agent_settings = _require_acp_agent_settings(settings)
+        if name not in agent_settings.acp_env:
+            # Generic 404 message — symmetric with the secrets endpoints,
+            # which avoid leaking which exact names exist.
+            raise HTTPException(status_code=404, detail="ACP env-var not found")
+        agent_settings.acp_env = {
+            k: v for k, v in agent_settings.acp_env.items() if k != name
+        }
+        return settings
+
+    try:
+        store.update(apply)
+    except HTTPException:
+        raise
+    except RuntimeError as e:
+        logger.error(f"ACP env-var delete blocked: {e}")
+        raise HTTPException(
+            status_code=500,
+            detail="Settings file is corrupted or encrypted with a different key",
+        )
+    except (OSError, PermissionError):
+        logger.error("Failed to delete ACP env-var - file I/O error")
+        raise HTTPException(status_code=500, detail="Failed to save settings")
+
+    logger.info(
+        "ACP env-var deleted",
+        extra={"env_var_name": name, "client_host": client_host},
     )
     return {"deleted": True}

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -456,9 +456,7 @@ async def list_acp_env_vars(request: Request) -> AcpEnvVarsListResponse:
         "ACP env-vars list accessed",
         extra={"client_host": client_host, "env_var_count": len(names)},
     )
-    return AcpEnvVarsListResponse(
-        env_vars=[AcpEnvVarItem(name=name) for name in names]
-    )
+    return AcpEnvVarsListResponse(env_vars=[AcpEnvVarItem(name=name) for name in names])
 
 
 @settings_router.put(ACP_ENV_PATH, response_model=AcpEnvVarItem)

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -11,6 +11,9 @@ from .acp_providers import (
     get_acp_provider,
 )
 from .api_models import (
+    AcpEnvVarItem,
+    AcpEnvVarsListResponse,
+    AcpEnvVarUpsertRequest,
     SecretCreateRequest,
     SecretItemResponse,
     SecretsListResponse,
@@ -80,6 +83,9 @@ __all__ = [
     "AGENT_SETTINGS_SCHEMA_VERSION",
     "CONVERSATION_SETTINGS_SCHEMA_VERSION",
     "ACPAgentSettings",
+    "AcpEnvVarItem",
+    "AcpEnvVarsListResponse",
+    "AcpEnvVarUpsertRequest",
     "AgentKind",
     "AgentSettingsBase",
     "AgentSettingsConfig",

--- a/openhands-sdk/openhands/sdk/settings/api_models.py
+++ b/openhands-sdk/openhands/sdk/settings/api_models.py
@@ -138,14 +138,21 @@ class SecretCreateRequest(BaseModel):
 # These models mirror the secrets API shape on purpose: clients that already
 # know how to talk to ``/api/settings/secrets`` can lift the same hook code
 # almost verbatim.
+#
+# Encryption-at-rest is inherited from the existing ``ACPAgentSettings``
+# ``acp_env`` serializer and is therefore conditional on a configured cipher
+# (``OH_SECRET_KEY``), exactly like every other secret-bearing field. On a
+# keyless local server values persist as plaintext in ``settings.json`` — same
+# as the ``/api/settings/secrets`` endpoints; it is not a guarantee this CRUD
+# surface adds on its own.
 
 
 class AcpEnvVarItem(BaseModel):
     """One ACP env-var entry, without its value.
 
     Returned in list responses and from upsert. Values are intentionally
-    not surfaced — the dedicated ``GET /agent-env/{name}`` endpoint exists
-    if a backend client needs to round-trip the plaintext value.
+    not surfaced — use ``GET /api/settings`` with the ``X-Expose-Secrets``
+    header if a backend client needs to round-trip the plaintext value.
     """
 
     name: str

--- a/openhands-sdk/openhands/sdk/settings/api_models.py
+++ b/openhands-sdk/openhands/sdk/settings/api_models.py
@@ -124,3 +124,45 @@ class SecretCreateRequest(BaseModel):
     name: str
     value: SecretStr
     description: str | None = None
+
+
+# ── ACP env-var API Models ─────────────────────────────────────────────────
+#
+# ``acp_env`` is a ``dict[str, str]`` field on ``ACPAgentSettings`` that maps
+# environment variable names to values injected into the ACP subprocess at
+# spawn time. It is conceptually a small, agent-scoped secret store — and is
+# best managed through a dedicated CRUD surface so that single-key adds and
+# deletes don't have to thread through ``PATCH /api/settings``'s deep-merge
+# semantics, which have no "unset" primitive.
+#
+# These models mirror the secrets API shape on purpose: clients that already
+# know how to talk to ``/api/settings/secrets`` can lift the same hook code
+# almost verbatim.
+
+
+class AcpEnvVarItem(BaseModel):
+    """One ACP env-var entry, without its value.
+
+    Returned in list responses and from upsert. Values are intentionally
+    not surfaced — the dedicated ``GET /agent-env/{name}`` endpoint exists
+    if a backend client needs to round-trip the plaintext value.
+    """
+
+    name: str
+
+
+class AcpEnvVarsListResponse(BaseModel):
+    """Response model for GET /api/settings/agent-env."""
+
+    env_vars: list[AcpEnvVarItem]
+
+
+class AcpEnvVarUpsertRequest(BaseModel):
+    """Request model for PUT /api/settings/agent-env.
+
+    Creates or replaces the value bound to ``name``. The same shape is
+    used for both first-time adds and value rotations.
+    """
+
+    name: str
+    value: SecretStr

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -1044,6 +1044,7 @@ def test_upsert_acp_env_var_invalid_name_returns_422(client_with_settings):
 
 
 def test_delete_acp_env_var_invalid_name_returns_422(client_with_settings):
+    """Invalid names are rejected on the DELETE path too (SECRET_NAME_PATTERN)."""
     response = client_with_settings.delete("/api/settings/agent-env/1bad-name")
     assert response.status_code == 422
 
@@ -1059,5 +1060,7 @@ def test_upsert_acp_env_var_on_non_acp_agent_returns_409(client_with_settings):
 
 
 def test_delete_acp_env_var_on_non_acp_agent_returns_409(client_with_settings):
+    """The default OpenHands agent has no acp_env field — the DELETE path fails
+    loudly with 409 rather than silently coercing into the OpenHands schema."""
     response = client_with_settings.delete("/api/settings/agent-env/ANTHROPIC_API_KEY")
     assert response.status_code == 409

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -905,3 +905,163 @@ def test_delete_secret_corrupted_file_returns_500(
     response = client_with_settings.delete("/api/settings/secrets/MY_SECRET")
 
     assert response.status_code == 500
+
+
+# ── ACP env-var CRUD tests ──────────────────────────────────────────────
+
+
+def _seed_acp_agent_settings(
+    client_with_settings, *, acp_env: dict[str, str] | None = None
+) -> None:
+    """Switch the persisted agent to an ACP agent for env-var tests."""
+    diff: dict[str, object] = {
+        "agent_kind": "acp",
+        "acp_server": "claude-code",
+        "acp_command": [],
+    }
+    if acp_env is not None:
+        diff["acp_env"] = acp_env
+    response = client_with_settings.patch(
+        "/api/settings", json={"agent_settings_diff": diff}
+    )
+    assert response.status_code == 200, response.text
+
+
+def test_list_acp_env_vars_empty(client_with_settings):
+    """GET /agent-env on an ACP agent with no env vars returns an empty list."""
+    _seed_acp_agent_settings(client_with_settings)
+    response = client_with_settings.get("/api/settings/agent-env")
+    assert response.status_code == 200
+    assert response.json() == {"env_vars": []}
+
+
+def test_list_acp_env_vars_non_acp_returns_empty(client_with_settings):
+    """GET /agent-env on a non-ACP agent returns an empty list (not 409).
+
+    The UI may poll this endpoint regardless of agent kind; a 409 here would
+    surface as an error toast even when the env-vars panel is hidden.
+    """
+    response = client_with_settings.get("/api/settings/agent-env")
+    assert response.status_code == 200
+    assert response.json() == {"env_vars": []}
+
+
+def test_upsert_acp_env_var_creates_then_lists(client_with_settings):
+    """PUT /agent-env creates an entry; GET lists it (names only)."""
+    _seed_acp_agent_settings(client_with_settings)
+
+    create = client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "ANTHROPIC_API_KEY", "value": "sk-ant"},
+    )
+    assert create.status_code == 200, create.text
+    assert create.json() == {"name": "ANTHROPIC_API_KEY"}
+    # Response shape excludes the value.
+    assert "value" not in create.json()
+
+    listing = client_with_settings.get("/api/settings/agent-env")
+    assert listing.status_code == 200
+    assert listing.json() == {"env_vars": [{"name": "ANTHROPIC_API_KEY"}]}
+
+
+def test_upsert_acp_env_var_replaces_existing_value(
+    client_with_settings, temp_persistence_dir, secret_key
+):
+    """A second PUT with the same name overwrites the value on disk."""
+    _seed_acp_agent_settings(client_with_settings)
+    cipher = Cipher(secret_key)
+
+    client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "ANTHROPIC_API_KEY", "value": "sk-original"},
+    )
+    client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "ANTHROPIC_API_KEY", "value": "sk-rotated"},
+    )
+
+    # Verify via the store that the value on disk is the rotated one.
+    store = FileSettingsStore(persistence_dir=temp_persistence_dir, cipher=cipher)
+    settings = store.load()
+    assert settings is not None
+    assert isinstance(settings.agent_settings, ACPAgentSettings)
+    assert settings.agent_settings.acp_env == {"ANTHROPIC_API_KEY": "sk-rotated"}
+
+
+def test_upsert_acp_env_var_persists_encrypted_on_disk(
+    client_with_settings, temp_persistence_dir
+):
+    """The value must be encrypted at rest (Fernet ciphertext, not plaintext)."""
+    _seed_acp_agent_settings(client_with_settings)
+    client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "ANTHROPIC_API_KEY", "value": "sk-roundtrip"},
+    )
+
+    on_disk_text = (temp_persistence_dir / "settings.json").read_text()
+    assert "sk-roundtrip" not in on_disk_text
+    on_disk = json.loads(on_disk_text)
+    stored = on_disk["agent_settings"]["acp_env"]["ANTHROPIC_API_KEY"]
+    assert stored.startswith("gAAAA")
+
+
+def test_delete_acp_env_var_removes_key(client_with_settings):
+    """DELETE removes the key; subsequent list shows siblings only."""
+    _seed_acp_agent_settings(client_with_settings)
+    client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "KEEP_ME", "value": "x"},
+    )
+    client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "DROP_ME", "value": "y"},
+    )
+
+    response = client_with_settings.delete("/api/settings/agent-env/DROP_ME")
+    assert response.status_code == 200
+    assert response.json() == {"deleted": True}
+
+    listing = client_with_settings.get("/api/settings/agent-env")
+    assert listing.status_code == 200
+    assert listing.json() == {"env_vars": [{"name": "KEEP_ME"}]}
+
+
+def test_delete_acp_env_var_missing_returns_404(client_with_settings):
+    """DELETE on a name that isn't there returns 404, not a 200 no-op."""
+    _seed_acp_agent_settings(client_with_settings)
+    response = client_with_settings.delete("/api/settings/agent-env/NOPE")
+    assert response.status_code == 404
+
+
+def test_upsert_acp_env_var_invalid_name_returns_422(client_with_settings):
+    """Names that don't match SECRET_NAME_PATTERN are rejected at the boundary."""
+    _seed_acp_agent_settings(client_with_settings)
+    response = client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "1bad-name", "value": "x"},
+    )
+    assert response.status_code == 422
+
+
+def test_delete_acp_env_var_invalid_name_returns_422(client_with_settings):
+    response = client_with_settings.delete(
+        "/api/settings/agent-env/1bad-name"
+    )
+    assert response.status_code == 422
+
+
+def test_upsert_acp_env_var_on_non_acp_agent_returns_409(client_with_settings):
+    """The default OpenHands agent has no acp_env field — fail loudly, don't
+    silently coerce into the OpenHands schema where the field would vanish."""
+    response = client_with_settings.put(
+        "/api/settings/agent-env",
+        json={"name": "ANTHROPIC_API_KEY", "value": "sk-x"},
+    )
+    assert response.status_code == 409
+
+
+def test_delete_acp_env_var_on_non_acp_agent_returns_409(client_with_settings):
+    response = client_with_settings.delete(
+        "/api/settings/agent-env/ANTHROPIC_API_KEY"
+    )
+    assert response.status_code == 409

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -1044,9 +1044,7 @@ def test_upsert_acp_env_var_invalid_name_returns_422(client_with_settings):
 
 
 def test_delete_acp_env_var_invalid_name_returns_422(client_with_settings):
-    response = client_with_settings.delete(
-        "/api/settings/agent-env/1bad-name"
-    )
+    response = client_with_settings.delete("/api/settings/agent-env/1bad-name")
     assert response.status_code == 422
 
 
@@ -1061,7 +1059,5 @@ def test_upsert_acp_env_var_on_non_acp_agent_returns_409(client_with_settings):
 
 
 def test_delete_acp_env_var_on_non_acp_agent_returns_409(client_with_settings):
-    response = client_with_settings.delete(
-        "/api/settings/agent-env/ANTHROPIC_API_KEY"
-    )
+    response = client_with_settings.delete("/api/settings/agent-env/ANTHROPIC_API_KEY")
     assert response.status_code == 409


### PR DESCRIPTION
Supersedes #3418.

## Problem

`acp_env` lives on `ACPAgentSettings` as a `dict[str, str]`. Until now its only mutation surface was `PATCH /api/settings`'s deep-merge, which can ADD or OVERWRITE a key but has no primitive for REMOVE — the overlay cannot subtract from the base. A frontend wanting to delete a single env-var had no clean wire shape: the GET response redacts values, so it can't round-trip the full map back with one key omitted, and the deep-merge would preserve the unmentioned key anyway.

#3418 worked around this by overloading PATCH with a `null`-means-delete sentinel. That was 12 lines but architecturally inconsistent — the existing `/api/settings/secrets` endpoints solved the identical problem the right way years ago, with dedicated CRUD methods.

## Fix

Mirror the established `/api/settings/secrets` pattern with a small, dedicated CRUD surface that mutates the dict directly:

```
GET    /api/settings/agent-env             list names (values redacted)
PUT    /api/settings/agent-env             upsert {name, value}
DELETE /api/settings/agent-env/{name}      delete
```

## Wire-level mechanics

- All three mutate `settings.agent_settings.acp_env` under the store's file lock (`FileSettingsStore.update`), matching the existing `PATCH /api/settings` concurrency guarantees.
- Name validation reuses `SECRET_NAME_PATTERN` so the rules line up with the Secrets endpoints.
- Values are persisted via the existing `_serialize_acp_env` / `_decrypt_acp_env_values` round-trip. Encryption-at-rest is conditional on a configured cipher (`OH_SECRET_KEY`): keyed deployments persist Fernet ciphertext, a keyless local server writes plaintext — identical to `/api/settings/secrets` and every other secret-bearing field (this endpoint adds no weaker and no stronger guarantee).
- **GET on a non-ACP agent returns `{"env_vars": []}` (not 409)** so the GUI's polling on the agent settings page doesn't surface spurious errors when the user hasn't picked an ACP agent yet.
- **PUT/DELETE on a non-ACP agent returns 409** — silently coercing into the OpenHands schema would drop the field on next save with no diagnostic.

## Test plan

`uv run pytest tests/agent_server/test_settings_router.py` — 42 passed.

New tests (11):
- `test_list_acp_env_vars_empty` — ACP agent, no vars.
- `test_list_acp_env_vars_non_acp_returns_empty` — non-ACP agent returns `{env_vars: []}`, not 409.
- `test_upsert_acp_env_var_creates_then_lists` — create → list shows it.
- `test_upsert_acp_env_var_replaces_existing_value` — second PUT rotates the value (verified via store).
- `test_upsert_acp_env_var_persists_encrypted_on_disk` — Fernet ciphertext on disk, no plaintext leak.
- `test_delete_acp_env_var_removes_key` — delete works; siblings survive.
- `test_delete_acp_env_var_missing_returns_404` — symmetric with secrets endpoints.
- `test_upsert_acp_env_var_invalid_name_returns_422` — `SECRET_NAME_PATTERN` violations.
- `test_delete_acp_env_var_invalid_name_returns_422` — same on the DELETE path.
- `test_upsert_acp_env_var_on_non_acp_agent_returns_409` — surfaces the kind mismatch.
- `test_delete_acp_env_var_on_non_acp_agent_returns_409` — same on the DELETE path.

## Frontend dependency

agent-canvas#874 swaps the `acp_env`-shaped `PATCH /api/settings` calls in its env-var UI for the three endpoints above.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7d7ffc0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7d7ffc0-python \
  ghcr.io/openhands/agent-server:7d7ffc0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7d7ffc0-golang-amd64
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-golang-amd64
ghcr.io/openhands/agent-server:7d7ffc0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7d7ffc0-golang-arm64
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-golang-arm64
ghcr.io/openhands/agent-server:7d7ffc0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7d7ffc0-java-amd64
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-java-amd64
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-java-amd64
ghcr.io/openhands/agent-server:7d7ffc0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7d7ffc0-java-arm64
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-java-arm64
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-java-arm64
ghcr.io/openhands/agent-server:7d7ffc0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7d7ffc0-python-amd64
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-python-amd64
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-python-amd64
ghcr.io/openhands/agent-server:7d7ffc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7d7ffc0-python-arm64
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-python-arm64
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-python-arm64
ghcr.io/openhands/agent-server:7d7ffc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7d7ffc0-golang
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-golang
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-golang
ghcr.io/openhands/agent-server:7d7ffc0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7d7ffc0-java
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-java
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-java
ghcr.io/openhands/agent-server:7d7ffc0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7d7ffc0-python
ghcr.io/openhands/agent-server:7d7ffc07a8295e46b49ed210995a34e748ee471b-python
ghcr.io/openhands/agent-server:feat-acp-env-crud-endpoints-python
ghcr.io/openhands/agent-server:7d7ffc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7d7ffc0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7d7ffc0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
