### PR TITLE
feat(agent-server): RFC 7386 merge-patch unset for PATCH /api/settings

### DIFF
--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -32,7 +32,14 @@ from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secr
 
 
 class SettingsUpdatePayload(TypedDict, total=False):
-    """Typed payload for PersistedSettings.update() method."""
+    """Typed payload for PersistedSettings.update() method.
+
+    The ``*_diff`` dicts are applied with JSON Merge Patch (RFC 7386)
+    semantics via :func:`_deep_merge`: nested objects merge recursively, and
+    a ``None`` value deletes that key (the "unset" primitive). This means a
+    single map entry can be removed by sending ``{"acp_env": {"NAME": None}}``
+    rather than re-sending the whole map.
+    """
 
     agent_settings_diff: dict[str, Any]
     conversation_settings_diff: dict[str, Any]
@@ -40,13 +47,30 @@ class SettingsUpdatePayload(TypedDict, total=False):
 
 
 def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
-    """Recursively merge overlay dict into base dict.
+    """Recursively merge ``overlay`` into ``base`` with JSON Merge Patch
+    (RFC 7386) semantics.
 
-    For nested dicts, merges recursively. For other types, overlay wins.
+    - Nested dicts are merged recursively.
+    - A ``None`` value in the overlay **removes** that key from the result —
+      this is the "unset" primitive a plain deep-merge lacks. It lets a
+      ``PATCH /api/settings`` diff delete a single map entry (e.g. one
+      ``acp_env`` / MCP ``env`` key) without having to round-trip and
+      re-send the whole redacted map.
+    - For any other scalar/list value, the overlay wins.
+
+    Deleting a key falls the field back to its model default on the next
+    validation pass (e.g. ``acp_env`` -> ``{}``). Note: because ``None``
+    means "remove", a client cannot use this path to *set* a field to a
+    literal ``null``; nothing in the settings models relies on that.
     """
     result = dict(base)
     for key, value in overlay.items():
-        if key in result and isinstance(result[key], dict) and isinstance(value, dict):
+        if value is None:
+            # RFC 7386: a null member removes the target key (no-op if absent).
+            result.pop(key, None)
+        elif (
+            key in result and isinstance(result[key], dict) and isinstance(value, dict)
+        ):
             result[key] = _deep_merge(result[key], value)
         else:
             result[key] = value

--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -34,11 +34,12 @@ from openhands.sdk.utils.pydantic_secrets import serialize_secret, validate_secr
 class SettingsUpdatePayload(TypedDict, total=False):
     """Typed payload for PersistedSettings.update() method.
 
-    The ``*_diff`` dicts are applied with JSON Merge Patch (RFC 7386)
-    semantics via :func:`_deep_merge`: nested objects merge recursively, and
-    a ``None`` value deletes that key (the "unset" primitive). This means a
-    single map entry can be removed by sending ``{"acp_env": {"NAME": None}}``
-    rather than re-sending the whole map.
+    The ``*_diff`` dicts are deep-merged via :func:`_deep_merge`: nested
+    objects merge recursively, and a ``None`` value *inside a nested map*
+    deletes that entry (the "unset" primitive) — e.g. send
+    ``{"acp_env": {"NAME": None}}`` to drop one env-var without re-sending the
+    whole map. A ``None`` on a top-level *field* is not treated as delete; it
+    flows to validation as before.
     """
 
     agent_settings_diff: dict[str, Any]
@@ -46,33 +47,45 @@ class SettingsUpdatePayload(TypedDict, total=False):
     active_profile: str | None
 
 
-def _deep_merge(base: dict[str, Any], overlay: dict[str, Any]) -> dict[str, Any]:
-    """Recursively merge ``overlay`` into ``base`` with JSON Merge Patch
-    (RFC 7386) semantics.
+def _deep_merge(
+    base: dict[str, Any],
+    overlay: dict[str, Any],
+    *,
+    unset_nulls: bool = False,
+) -> dict[str, Any]:
+    """Recursively merge ``overlay`` into ``base``.
 
     - Nested dicts are merged recursively.
-    - A ``None`` value in the overlay **removes** that key from the result —
-      this is the "unset" primitive a plain deep-merge lacks. It lets a
-      ``PATCH /api/settings`` diff delete a single map entry (e.g. one
-      ``acp_env`` / MCP ``env`` key) without having to round-trip and
-      re-send the whole redacted map.
+    - **Inside a nested map** a ``None`` value **removes** that key — the
+      "unset" primitive a plain deep-merge lacks. It lets a
+      ``PATCH /api/settings`` diff delete a single map entry (one
+      ``acp_env`` / MCP ``env`` key) without round-tripping the whole map::
+
+          {"agent_settings_diff": {"acp_env": {"STALE_KEY": null}}}
+
+    - **At the top level** (a settings *field* like ``confirmation_mode`` or
+      ``acp_env`` itself) a ``None`` is left as-is and flows to model
+      validation — exactly as before this primitive existed. So a stray
+      ``{"confirmation_mode": null}`` still fails loudly (422) instead of
+      silently resetting a field to its default. This scoping is deliberate:
+      ``unset`` is for *entries within* a map, not for nulling whole fields.
     - For any other scalar/list value, the overlay wins.
 
-    Deleting a key falls the field back to its model default on the next
-    validation pass (e.g. ``acp_env`` -> ``{}``). Note: because ``None``
-    means "remove", a client cannot use this path to *set* a field to a
-    literal ``null``; nothing in the settings models relies on that.
+    ``unset_nulls`` is ``False`` for the top-level call and ``True`` for every
+    recursive (nested) call — that's what draws the field-vs-entry line above.
     """
     result = dict(base)
     for key, value in overlay.items():
-        if value is None:
-            # RFC 7386: a null member removes the target key (no-op if absent).
+        if value is None and unset_nulls:
+            # Nested map entry: a null member removes the key (no-op if absent).
             result.pop(key, None)
         elif (
             key in result and isinstance(result[key], dict) and isinstance(value, dict)
         ):
-            result[key] = _deep_merge(result[key], value)
+            result[key] = _deep_merge(result[key], value, unset_nulls=True)
         else:
+            # Top-level null (unset_nulls=False) falls here: set as-is and let
+            # model validation decide (preserves pre-existing behavior).
             result[key] = value
     return result
 

--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -73,6 +73,13 @@ def _deep_merge(
 
     ``unset_nulls`` is ``False`` for the top-level call and ``True`` for every
     recursive (nested) call — that's what draws the field-vs-entry line above.
+
+    Corner case: a key **absent from** ``base`` whose overlay value is a dict
+    is assigned wholesale (no recursion), so any ``null`` entries inside that
+    dict are stored as-is rather than treated as deletes. This is intentional
+    — you can't delete an entry from a map that doesn't exist yet — but it
+    means "initialize a new map and unset a key within it" in one diff won't
+    strip the null; downstream validation handles the resulting value.
     """
     result = dict(base)
     for key, value in overlay.items():

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -170,21 +170,22 @@ async def update_settings(
     """Update settings with partial changes.
 
     Accepts ``agent_settings_diff`` and/or ``conversation_settings_diff``
-    for incremental updates. Diffs are applied with JSON Merge Patch
-    (RFC 7386) semantics: nested objects merge recursively, and a ``null``
-    value **deletes** that key.
-
-    The ``null``-deletes rule is the "unset" primitive that lets a client
-    remove a single map entry without round-tripping the whole map. For
-    example, to drop one ACP env-var::
+    for incremental updates. Diffs are deep-merged; nested objects merge
+    recursively, and a ``null`` value **inside a nested map deletes that
+    entry** — the "unset" primitive that lets a client remove a single map
+    key without round-tripping the whole map. To drop one ACP env-var::
 
         PATCH /api/settings
         {"agent_settings_diff": {"acp_env": {"STALE_KEY": null}}}
 
-    and to remove one MCP server's header::
+    or to remove one MCP server's header::
 
         {"agent_settings_diff":
             {"mcp_config": {"mcpServers": {"svc": {"headers": {"X-Old": null}}}}}}
+
+    A ``null`` on a top-level *field* (e.g. ``{"confirmation_mode": null}``)
+    is **not** an unset — it flows to model validation as before, so it still
+    fails loudly rather than silently resetting the field to its default.
 
     Uses file locking to prevent concurrent updates from overwriting each other.
 

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -170,7 +170,21 @@ async def update_settings(
     """Update settings with partial changes.
 
     Accepts ``agent_settings_diff`` and/or ``conversation_settings_diff``
-    for incremental updates. Values are deep-merged with existing settings.
+    for incremental updates. Diffs are applied with JSON Merge Patch
+    (RFC 7386) semantics: nested objects merge recursively, and a ``null``
+    value **deletes** that key.
+
+    The ``null``-deletes rule is the "unset" primitive that lets a client
+    remove a single map entry without round-tripping the whole map. For
+    example, to drop one ACP env-var::
+
+        PATCH /api/settings
+        {"agent_settings_diff": {"acp_env": {"STALE_KEY": null}}}
+
+    and to remove one MCP server's header::
+
+        {"agent_settings_diff":
+            {"mcp_config": {"mcpServers": {"svc": {"headers": {"X-Old": null}}}}}}
 
     Uses file locking to prevent concurrent updates from overwriting each other.
 

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -561,16 +561,18 @@ def test_patch_settings_deep_merges(client_with_settings):
 # ── JSON Merge Patch (RFC 7386) unset semantics ─────────────────────────
 
 
-def test_deep_merge_null_deletes_key():
-    """A ``None`` overlay value removes the key (the unset primitive)."""
+def test_deep_merge_top_level_null_is_set_not_delete():
+    """A ``None`` on a top-level *field* is left as-is (set), NOT deleted —
+    so it flows to validation and fails loudly instead of silently resetting
+    the field to its default."""
     from openhands.agent_server.persistence.models import _deep_merge
 
-    merged = _deep_merge({"KEEP": "a", "DROP": "b"}, {"DROP": None})
-    assert merged == {"KEEP": "a"}
+    merged = _deep_merge({"confirmation_mode": True}, {"confirmation_mode": None})
+    assert merged == {"confirmation_mode": None}
 
 
-def test_deep_merge_null_deletes_nested_key():
-    """``None`` removes a key inside a nested object; siblings survive."""
+def test_deep_merge_nested_null_deletes_entry():
+    """A ``None`` *inside a nested map* removes that entry; siblings survive."""
     from openhands.agent_server.persistence.models import _deep_merge
 
     merged = _deep_merge(
@@ -580,16 +582,16 @@ def test_deep_merge_null_deletes_nested_key():
     assert merged == {"acp_env": {"KEEP": "a"}}
 
 
-def test_deep_merge_null_on_absent_key_is_noop():
-    """Deleting a key that isn't present is a no-op (RFC 7386), not an error."""
+def test_deep_merge_nested_null_on_absent_key_is_noop():
+    """Unsetting a nested key that isn't present is a no-op, not an error."""
     from openhands.agent_server.persistence.models import _deep_merge
 
-    merged = _deep_merge({"KEEP": "a"}, {"MISSING": None})
-    assert merged == {"KEEP": "a"}
+    merged = _deep_merge({"acp_env": {"KEEP": "a"}}, {"acp_env": {"MISSING": None}})
+    assert merged == {"acp_env": {"KEEP": "a"}}
 
 
 def test_deep_merge_non_null_still_wins():
-    """Regression: non-null values still set/overwrite as before."""
+    """Regression: non-null values still set/overwrite and merge as before."""
     from openhands.agent_server.persistence.models import _deep_merge
 
     merged = _deep_merge({"a": 1, "b": {"x": 1}}, {"a": 2, "b": {"y": 2}})
@@ -649,6 +651,35 @@ def test_patch_settings_unset_then_add_acp_env_key(
     )
     assert response.status_code == 200
     assert set(response.json()["agent_settings"]["acp_env"]) == {"OLD", "NEW"}
+
+
+def test_patch_settings_null_on_acp_env_field_itself_is_rejected(
+    client_with_settings, temp_persistence_dir
+):
+    """A ``null`` on the ``acp_env`` *field* (not an entry) is not an unset —
+    it flows to validation. ``acp_env`` is a non-optional dict, so it 422s
+    rather than wiping the map; clients clear a map by sending ``{}``."""
+    _seed_acp_settings(temp_persistence_dir, {"KEEP_ME": "keep"})
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": None}},
+    )
+    assert response.status_code == 422
+    # The pre-existing value is untouched (atomic validate-then-apply).
+    after = client_with_settings.get("/api/settings").json()
+    assert set(after["agent_settings"]["acp_env"]) == {"KEEP_ME"}
+
+
+def test_patch_settings_null_on_scalar_field_fails_loudly(client_with_settings):
+    """Regression guard against the silent-reset footgun: ``null`` on a
+    non-optional scalar like ``confirmation_mode`` is rejected (422), not
+    silently reverted to its (unsafe) default."""
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"conversation_settings_diff": {"confirmation_mode": None}},
+    )
+    assert response.status_code == 422
 
 
 # ── Secrets CRUD tests ──────────────────────────────────────────────────

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -558,6 +558,99 @@ def test_patch_settings_deep_merges(client_with_settings):
     assert body["llm_api_key_is_set"] is True
 
 
+# ── JSON Merge Patch (RFC 7386) unset semantics ─────────────────────────
+
+
+def test_deep_merge_null_deletes_key():
+    """A ``None`` overlay value removes the key (the unset primitive)."""
+    from openhands.agent_server.persistence.models import _deep_merge
+
+    merged = _deep_merge({"KEEP": "a", "DROP": "b"}, {"DROP": None})
+    assert merged == {"KEEP": "a"}
+
+
+def test_deep_merge_null_deletes_nested_key():
+    """``None`` removes a key inside a nested object; siblings survive."""
+    from openhands.agent_server.persistence.models import _deep_merge
+
+    merged = _deep_merge(
+        {"acp_env": {"KEEP": "a", "DROP": "b"}},
+        {"acp_env": {"DROP": None}},
+    )
+    assert merged == {"acp_env": {"KEEP": "a"}}
+
+
+def test_deep_merge_null_on_absent_key_is_noop():
+    """Deleting a key that isn't present is a no-op (RFC 7386), not an error."""
+    from openhands.agent_server.persistence.models import _deep_merge
+
+    merged = _deep_merge({"KEEP": "a"}, {"MISSING": None})
+    assert merged == {"KEEP": "a"}
+
+
+def test_deep_merge_non_null_still_wins():
+    """Regression: non-null values still set/overwrite as before."""
+    from openhands.agent_server.persistence.models import _deep_merge
+
+    merged = _deep_merge({"a": 1, "b": {"x": 1}}, {"a": 2, "b": {"y": 2}})
+    assert merged == {"a": 2, "b": {"x": 1, "y": 2}}
+
+
+def _seed_acp_settings(persistence_dir: Path, acp_env: dict[str, str]) -> None:
+    """Write a settings.json with an active ACP agent carrying ``acp_env``."""
+    acp = ACPAgentSettings(acp_command=["echo", "hi"], acp_env=acp_env)
+    persisted = PersistedSettings(agent_settings=acp)
+    payload = persisted.model_dump(mode="json", context={"expose_secrets": "plaintext"})
+    _write_settings_file(persistence_dir, payload)
+
+
+def test_patch_settings_unset_deletes_acp_env_key(
+    client_with_settings, temp_persistence_dir
+):
+    """PATCH with a ``null`` map value deletes a single ``acp_env`` entry —
+    the motivating case for the general merge-patch unset (supersedes the
+    need for a dedicated per-field DELETE endpoint)."""
+    _seed_acp_settings(temp_persistence_dir, {"KEEP_ME": "keep", "DROP_ME": "drop"})
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": {"DROP_ME": None}}},
+    )
+    assert response.status_code == 200
+
+    acp_env = response.json()["agent_settings"]["acp_env"]
+    assert "KEEP_ME" in acp_env
+    assert "DROP_ME" not in acp_env
+
+
+def test_patch_settings_unset_absent_acp_env_key_is_noop(
+    client_with_settings, temp_persistence_dir
+):
+    """Unsetting a key that isn't present succeeds and changes nothing."""
+    _seed_acp_settings(temp_persistence_dir, {"KEEP_ME": "keep"})
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": {"NEVER_SET": None}}},
+    )
+    assert response.status_code == 200
+    assert set(response.json()["agent_settings"]["acp_env"]) == {"KEEP_ME"}
+
+
+def test_patch_settings_unset_then_add_acp_env_key(
+    client_with_settings, temp_persistence_dir
+):
+    """Add and delete coexist in one diff: set one key, drop another."""
+    _seed_acp_settings(temp_persistence_dir, {"OLD": "x", "DROP_ME": "y"})
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": {"NEW": "z", "DROP_ME": None}}},
+    )
+    assert response.status_code == 200
+    assert set(response.json()["agent_settings"]["acp_env"]) == {"OLD", "NEW"}
+
+
 # ── Secrets CRUD tests ──────────────────────────────────────────────────
 
 

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -16,6 +16,7 @@ from openhands.agent_server.persistence import (
     PersistedSettings,
     reset_stores,
 )
+from openhands.agent_server.persistence.models import _deep_merge
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
     CONVERSATION_SETTINGS_SCHEMA_VERSION,
@@ -565,16 +566,12 @@ def test_deep_merge_top_level_null_is_set_not_delete():
     """A ``None`` on a top-level *field* is left as-is (set), NOT deleted —
     so it flows to validation and fails loudly instead of silently resetting
     the field to its default."""
-    from openhands.agent_server.persistence.models import _deep_merge
-
     merged = _deep_merge({"confirmation_mode": True}, {"confirmation_mode": None})
     assert merged == {"confirmation_mode": None}
 
 
 def test_deep_merge_nested_null_deletes_entry():
     """A ``None`` *inside a nested map* removes that entry; siblings survive."""
-    from openhands.agent_server.persistence.models import _deep_merge
-
     merged = _deep_merge(
         {"acp_env": {"KEEP": "a", "DROP": "b"}},
         {"acp_env": {"DROP": None}},
@@ -584,16 +581,21 @@ def test_deep_merge_nested_null_deletes_entry():
 
 def test_deep_merge_nested_null_on_absent_key_is_noop():
     """Unsetting a nested key that isn't present is a no-op, not an error."""
-    from openhands.agent_server.persistence.models import _deep_merge
-
     merged = _deep_merge({"acp_env": {"KEEP": "a"}}, {"acp_env": {"MISSING": None}})
     assert merged == {"acp_env": {"KEEP": "a"}}
 
 
+def test_deep_merge_new_map_embedded_null_stored_as_is():
+    """Corner case (documented in ``_deep_merge``): when the nested map itself
+    doesn't exist in base yet, the overlay dict is assigned wholesale — null
+    entries inside are NOT treated as deletes (can't delete from a map that
+    doesn't exist yet). Pins the guarantee against a future refactor."""
+    merged = _deep_merge({}, {"new_map": {"KEY": None}})
+    assert merged == {"new_map": {"KEY": None}}
+
+
 def test_deep_merge_non_null_still_wins():
     """Regression: non-null values still set/overwrite and merge as before."""
-    from openhands.agent_server.persistence.models import _deep_merge
-
     merged = _deep_merge({"a": 1, "b": {"x": 1}}, {"a": 2, "b": {"y": 2}})
     assert merged == {"a": 2, "b": {"x": 1, "y": 2}}
 


### PR DESCRIPTION
## Problem

`PATCH /api/settings` deep-merges diffs into the persisted settings, but the merge has **no "unset" primitive**: an overlay can add or overwrite a map key, but it cannot remove one. Because the `GET` response redacts secret values, a client also can't round-trip the full map back with one key omitted. So there was no clean way to delete a single entry from a `dict[str, str]` setting (the original motivation for the ACP env-var work, #3418/#3420).

## Fix

Give `_deep_merge` an "unset" primitive: a `null` value **inside a nested map deletes that entry** (the borrowed-from-RFC-7386 part). The scope is deliberate — `null` is treated as delete **only for entries within a map**, not for top-level settings *fields* (see Semantics below).

```jsonc
// delete one ACP env-var
PATCH /api/settings
{"agent_settings_diff": {"acp_env": {"STALE_KEY": null}}}

// delete one MCP server header
{"agent_settings_diff":
  {"mcp_config": {"mcpServers": {"svc": {"headers": {"X-Old": null}}}}}}
```

One change, and the unset primitive works for **every** map-valued setting — `acp_env`, MCP `env`/`headers`, and any future field — with no new endpoints and no discriminated-union awareness leaking into the URL space.

## Why this instead of dedicated CRUD endpoints (#3420)

The limitation #3420 worked around is generic ("a deep-merge can't delete a key"), but its fix is specific: a bespoke 3-endpoint sub-resource for one field on one agent-settings variant. That pattern grows O(endpoints) per map field and couples the REST surface to a union variant (`/agent-env` only valid when `agent_kind == 'acp'`, hence the 409s and the GET-returns-empty asymmetry).

RFC 7386 solves the root cause once, for all fields, using the existing `PATCH /api/settings` surface clients already speak. It supersedes the **motivation** for #3420's dedicated endpoints. I've left #3420 untouched — maintainers can decide whether to retire those endpoints in favor of this; this PR doesn't depend on or conflict with it (no shared files).

## Semantics / safety

- **Nested map entry** (`{"acp_env": {"KEY": null}}`): `null` deletes the entry; **no-op if absent**, not an error. This is the motivating case.
- **Top-level field** (`{"acp_env": null}` or `{"confirmation_mode": null}`): `null` is **not** an unset — it's left as-is and flows to model validation, exactly as before this primitive existed. Since these fields are non-optional, that means a **422**, not a silent reset to the field's default. This scoping is deliberate: it avoids a footgun where a stray top-level `null` would silently revert a setting (e.g. disabling `confirmation_mode` by reverting it to its `False` default). Clear a whole map by sending `{}`, not `null`.
- Because top-level `null` keeps its pre-PR meaning, the only behavior change is "nested map entries gain delete" — top-level `null` is byte-for-byte identical to `main`. Spot-checked callers (agent-canvas) don't rely on nested `null`-to-set; they rebuild full maps today (the very round-trip this removes).
- `active_profile`'s "None clears it" path is a top-level payload key handled **outside** the merge — unchanged.
- Atomicity unchanged: the merged dict is still fully validated before any mutation.

## Test plan

`uv run pytest tests/agent_server/test_settings_router.py tests/agent_server/test_profiles_router.py` — 116 passed.

New tests:
- `_deep_merge` units: top-level `null` is set-not-deleted; nested `null` deletes; nested no-op on absent key; non-null still wins/merges.
- PATCH integration: delete one `acp_env` entry, no-op on absent nested key, add-and-delete in one diff; top-level `{"acp_env": null}` → 422 (value untouched); `{"confirmation_mode": null}` → 422 (silent-reset regression guard).




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a62ceb0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a62ceb0-python \
  ghcr.io/openhands/agent-server:a62ceb0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a62ceb0-golang-amd64
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-golang-amd64
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-golang-amd64
ghcr.io/openhands/agent-server:a62ceb0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a62ceb0-golang-arm64
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-golang-arm64
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-golang-arm64
ghcr.io/openhands/agent-server:a62ceb0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a62ceb0-java-amd64
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-java-amd64
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-java-amd64
ghcr.io/openhands/agent-server:a62ceb0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a62ceb0-java-arm64
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-java-arm64
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-java-arm64
ghcr.io/openhands/agent-server:a62ceb0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a62ceb0-python-amd64
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-python-amd64
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-python-amd64
ghcr.io/openhands/agent-server:a62ceb0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a62ceb0-python-arm64
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-python-arm64
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-python-arm64
ghcr.io/openhands/agent-server:a62ceb0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a62ceb0-golang
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-golang
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-golang
ghcr.io/openhands/agent-server:a62ceb0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a62ceb0-java
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-java
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-java
ghcr.io/openhands/agent-server:a62ceb0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a62ceb0-python
ghcr.io/openhands/agent-server:a62ceb0448e4d60ca5742d9ba8638efe5eaea5a3-python
ghcr.io/openhands/agent-server:feat-settings-merge-patch-unset-python
ghcr.io/openhands/agent-server:a62ceb0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a62ceb0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a62ceb0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
