### PR TITLE
feat(sdk): deprecate no-op _return_metrics LLM param (Q1 of #3341)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -110,9 +110,21 @@ from openhands.sdk.llm.utils.model_features import get_features
 from openhands.sdk.llm.utils.retry_mixin import RetryMixin
 from openhands.sdk.llm.utils.telemetry import Telemetry
 from openhands.sdk.logger import ENV_LOG_DIR, get_logger
+from openhands.sdk.utils.deprecation import warn_deprecated
 
 
 logger = get_logger(__name__)
+
+# Shared message for the no-op ``_return_metrics`` deprecation (Q1 of #3341).
+# Metrics are always returned via ``LLMResponse.metrics``; the parameter has no
+# effect and is scheduled for removal after the standard 5-minor-release runway.
+# NOTE: ``deprecated_in`` / ``removed_in`` must be passed as string literals at
+# each call site — ``check_deprecations.py`` reads them via static AST analysis
+# and cannot resolve module-level constants.
+_RETURN_METRICS_DETAILS: Final[str] = (
+    "The _return_metrics parameter has no effect; metrics are always available "
+    "via LLMResponse.metrics. Stop passing it."
+)
 
 __all__ = ["LLM"]
 
@@ -1099,7 +1111,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         Args:
             messages: List of conversation messages.
             tools: Optional list of tools available to the model.
-            _return_metrics: Whether to return usage metrics.
+            _return_metrics: Deprecated and ignored; metrics are always returned
+                via ``LLMResponse.metrics``. Scheduled for removal in
+                ``1.29.0``.
             add_security_risk_prediction: Add security_risk field to tool schemas.
             on_token: Optional callback for streaming tokens.
             **kwargs: Additional arguments passed to the LLM API.
@@ -1123,6 +1137,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             print(response.content)
             ```
         """
+        if _return_metrics:
+            warn_deprecated(
+                "LLM.completion(_return_metrics=...)",
+                deprecated_in="1.24.0",
+                removed_in="1.29.0",
+                details=_RETURN_METRICS_DETAILS,
+            )
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
         if enable_streaming:
             if on_token is None:
@@ -1167,9 +1188,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 lambda fb: fb.completion(
                     messages,
                     tools,
-                    _return_metrics,
-                    add_security_risk_prediction,
-                    on_token,
+                    add_security_risk_prediction=add_security_risk_prediction,
+                    on_token=on_token,
                 ),
             )
 
@@ -1190,6 +1210,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         Uses ``litellm.acompletion`` under the hood, freeing the event loop
         while waiting for the LLM provider response.
         """
+        if _return_metrics:
+            warn_deprecated(
+                "LLM.acompletion(_return_metrics=...)",
+                deprecated_in="1.24.0",
+                removed_in="1.29.0",
+                details=_RETURN_METRICS_DETAILS,
+            )
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
         if enable_streaming:
             if on_token is None:
@@ -1237,9 +1264,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 lambda fb: fb.completion(
                     messages,
                     tools,
-                    _return_metrics,
-                    add_security_risk_prediction,
-                    _fb_token,
+                    add_security_risk_prediction=add_security_risk_prediction,
+                    on_token=_fb_token,
                 ),
             )
 
@@ -1266,7 +1292,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             tools: Optional list of tools available to the model
             include: Optional list of fields to include in response
             store: Whether to store the conversation
-            _return_metrics: Whether to return usage metrics
+            _return_metrics: Deprecated and ignored; metrics are always returned
+                via ``LLMResponse.metrics``. Scheduled for removal in ``1.29.0``.
             add_security_risk_prediction: Add security_risk field to tool schemas
             on_token: Optional callback for streaming deltas
             **kwargs: Additional arguments passed to the API
@@ -1275,6 +1302,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             Summary field is always added to tool schemas for transparency and
             explainability of agent actions.
         """
+        if _return_metrics:
+            warn_deprecated(
+                "LLM.responses(_return_metrics=...)",
+                deprecated_in="1.24.0",
+                removed_in="1.29.0",
+                details=_RETURN_METRICS_DETAILS,
+            )
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
         if user_enable_streaming:
             # We allow on_token to be None for subscription mode
@@ -1360,9 +1394,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     tools,
                     include,
                     store,
-                    _return_metrics,
-                    add_security_risk_prediction,
-                    on_token,
+                    add_security_risk_prediction=add_security_risk_prediction,
+                    on_token=on_token,
                 ),
             )
 
@@ -1385,6 +1418,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         Uses ``litellm.aresponses`` under the hood, freeing the event loop
         while waiting for the LLM provider response.
         """
+        if _return_metrics:
+            warn_deprecated(
+                "LLM.aresponses(_return_metrics=...)",
+                deprecated_in="1.24.0",
+                removed_in="1.29.0",
+                details=_RETURN_METRICS_DETAILS,
+            )
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
         if user_enable_streaming:
             # We allow on_token to be None for subscription mode
@@ -1474,9 +1514,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     tools,
                     include,
                     store,
-                    _return_metrics,
-                    add_security_risk_prediction,
-                    _fb_token,
+                    add_security_risk_prediction=add_security_risk_prediction,
+                    on_token=_fb_token,
                 ),
             )
 

--- a/openhands-sdk/openhands/sdk/llm/router/base.py
+++ b/openhands-sdk/openhands/sdk/llm/router/base.py
@@ -7,12 +7,13 @@ from pydantic import (
     model_validator,
 )
 
-from openhands.sdk.llm.llm import LLM
+from openhands.sdk.llm.llm import _RETURN_METRICS_DETAILS, LLM
 from openhands.sdk.llm.llm_response import LLMResponse
 from openhands.sdk.llm.message import Message
 from openhands.sdk.llm.streaming import TokenCallbackType
 from openhands.sdk.logger import get_logger
 from openhands.sdk.tool.tool import ToolDefinition
+from openhands.sdk.utils.deprecation import warn_deprecated
 
 
 logger = get_logger(__name__)
@@ -63,7 +64,8 @@ class RouterLLM(LLM):
         Args:
             messages: List of conversation messages
             tools: Optional list of tools available to the model
-            return_metrics: Whether to return usage metrics
+            return_metrics: Deprecated and ignored; metrics are always returned
+                via ``LLMResponse.metrics``. Scheduled for removal in ``1.29.0``.
             add_security_risk_prediction: Add security_risk field to tool schemas
             on_token: Optional callback for streaming tokens
             **kwargs: Additional arguments passed to the LLM API
@@ -72,17 +74,25 @@ class RouterLLM(LLM):
             Summary field is always added to tool schemas for transparency and
             explainability of agent actions.
         """
+        if return_metrics:
+            warn_deprecated(
+                "RouterLLM.completion(return_metrics=...)",
+                deprecated_in="1.24.0",
+                removed_in="1.29.0",
+                details=_RETURN_METRICS_DETAILS,
+            )
+
         # Select appropriate LLM
         selected_model = self.select_llm(messages)
         self.active_llm = self.llms_for_routing[selected_model]
 
         logger.info(f"RouterLLM routing to {selected_model}...")
 
-        # Delegate to selected LLM
+        # Delegate to selected LLM. ``return_metrics`` is intentionally not
+        # forwarded: it is a no-op and the warning above already fired.
         return self.active_llm.completion(
             messages=messages,
             tools=tools,
-            _return_metrics=return_metrics,
             add_security_risk_prediction=add_security_risk_prediction,
             on_token=on_token,
             **kwargs,

--- a/tests/sdk/llm/test_return_metrics_deprecation.py
+++ b/tests/sdk/llm/test_return_metrics_deprecation.py
@@ -1,0 +1,88 @@
+"""Deprecation of the no-op ``_return_metrics`` / ``return_metrics`` parameter.
+
+Tracks Q1 of #3341: the parameter has no effect (metrics are always returned
+via ``LLMResponse.metrics``) and is scheduled for removal in 1.29.0. Until then
+it stays in the public signatures and emits a ``DeprecationWarning`` only when a
+caller actually passes it.
+"""
+
+import warnings
+
+import pytest
+from litellm.types.utils import (
+    Choices,
+    Message as LiteLLMMessage,
+    ModelResponse,
+    Usage,
+)
+from pydantic import SecretStr
+
+from openhands.sdk.llm import LLM, Message, TextContent
+
+
+_MSGS = [Message(role="user", content=[TextContent(text="hi")])]
+
+
+def _mock_response(content: str = "ok", model: str = "gpt-4o") -> ModelResponse:
+    return ModelResponse(
+        id="resp-1",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(content=content, role="assistant"),
+            )
+        ],
+        created=1,
+        model=model,
+        object="chat.completion",
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+def _llm(model: str = "gpt-4o") -> LLM:
+    return LLM(model=model, api_key=SecretStr("k"), usage_id="test")
+
+
+def _has_return_metrics_warning(records) -> bool:
+    return any(
+        issubclass(r.category, DeprecationWarning)
+        and "_return_metrics" in str(r.message)
+        for r in records
+    )
+
+
+def test_return_metrics_emits_deprecation_warning(monkeypatch):
+    llm = _llm()
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm_completion", lambda **kw: _mock_response()
+    )
+
+    with pytest.warns(DeprecationWarning, match="_return_metrics"):
+        llm.completion(_MSGS, _return_metrics=True)
+
+
+def test_no_warning_when_not_passed(monkeypatch):
+    llm = _llm()
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm_completion", lambda **kw: _mock_response()
+    )
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        llm.completion(_MSGS)
+
+    assert not _has_return_metrics_warning(records)
+
+
+def test_no_warning_when_falsy(monkeypatch):
+    llm = _llm()
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.litellm_completion", lambda **kw: _mock_response()
+    )
+
+    with warnings.catch_warnings(record=True) as records:
+        warnings.simplefilter("always")
+        llm.completion(_MSGS, _return_metrics=False)
+
+    assert not _has_return_metrics_warning(records)


### PR DESCRIPTION
## Summary

Part of #3341 (Q1 — dead code). The `_return_metrics` parameter on `LLM.completion` / `acompletion` / `responses` / `aresponses` (and `return_metrics` on `RouterLLM.completion`) has **no effect**: metrics are always returned via `LLMResponse.metrics`. It dates back to #143 and was never read in any conditional in the repo's history; #3284 then propagated it into the async twins.

Originally this PR removed the parameter outright, but that breaks the SDK's **public API removal policy** (the `check_sdk_api_breakage.py` checker compares against the released PyPI baseline, which never deprecated it). Per maintainer discussion, this now follows the **normal deprecation runway** instead: keep the parameter as an ignored no-op, warn when it is passed, and remove it after the required 5 minor releases.

## Changes

- **Deprecate, don't remove.** `_return_metrics` / `return_metrics` stay in the public signatures (defaults and order unchanged → no structural API break). Each public method emits a `DeprecationWarning` via `warn_deprecated(...)` **only when the parameter is truthy**, with `deprecated_in="1.24.0"`, `removed_in="1.29.0"` (≥ 5 minor releases). Docstrings now mark the parameter deprecated.
- **Stop threading the no-op internally.** The fallback lambdas in `llm.py` and the `RouterLLM` delegation no longer forward the parameter (it's a no-op and avoids a double warning on the fallback path); trailing args are passed by keyword so positions stay correct.
- **Test:** `tests/sdk/llm/test_return_metrics_deprecation.py` asserts the warning fires when the param is passed and stays silent otherwise.

The actual deletion will land in a follow-up once the repo reaches `1.29.0`, at which point `check_deprecations.py` enforces the cleanup. Q1's `_return_metrics` item is therefore **deprecated here, removed later**.

## Verification

- `check_deprecations.py` recognizes the new entries (version literals are inlined so the static-AST checker can read them) and does not flag them against 1.24.0.
- Public signatures are byte-identical to the PyPI baseline → no structural break for `check_sdk_api_breakage.py`.
- pre-commit (ruff format/lint, pycodestyle, pyright, import rules) and `tests/sdk/llm/` (799 passed) are green.
