### PR TITLE
feat(profiles): persist ACP AgentProfiles alongside legacy LLM profiles

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -510,10 +510,16 @@ async def activate_profile(
                 }
             else:
                 llm = profile_store.load(name, cipher=cipher)
+                # ``agent_kind: "openhands"`` flips the kind back when the
+                # current settings are ACP — without it the ``{"llm": ...}``
+                # diff would deep-merge into the ACP settings and stay ``acp``,
+                # leaving an OpenHands profile unable to take effect. Validated
+                # as OpenHandsAgentSettings, the leftover acp_* keys are ignored.
                 agent_diff = {
+                    "agent_kind": "openhands",
                     "llm": llm.model_dump(
                         mode="json", context={"expose_secrets": "plaintext"}
-                    )
+                    ),
                 }
     except FileNotFoundError:
         raise HTTPException(

--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -2,7 +2,7 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Annotated, Any
+from typing import Annotated, Any, Literal
 
 from fastapi import APIRouter, HTTPException, Path, Request, status
 from pydantic import BaseModel, Field, SecretStr
@@ -26,6 +26,7 @@ from openhands.sdk.llm.llm_profile_store import (
     ProfileLimitExceeded,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.settings import ACPAgentSettings, validate_agent_settings
 
 
 logger = get_logger(__name__)
@@ -42,8 +43,24 @@ ProfileName = Annotated[
 
 class ProfileInfo(BaseModel):
     name: str
+    kind: Literal["openhands", "acp"] = Field(
+        default="openhands",
+        description=(
+            "AgentProfile kind. ``openhands`` profiles carry an LLM config; "
+            "``acp`` profiles launch an ACP subprocess (see ``acp_server`` / "
+            "``acp_model``). Legacy LLM profiles default to ``openhands``."
+        ),
+    )
     model: str | None = None
     base_url: str | None = None
+    acp_server: str | None = Field(
+        default=None,
+        description="ACP backend key for ``acp`` profiles (else null).",
+    )
+    acp_model: str | None = Field(
+        default=None,
+        description="Configured ACP model for ``acp`` profiles (else null).",
+    )
     api_key_set: bool = False
 
 
@@ -66,10 +83,29 @@ class ProfileMutationResponse(BaseModel):
 
 
 class SaveProfileRequest(BaseModel):
-    llm: LLM
+    """Save an AgentProfile.
+
+    Provide exactly one of:
+
+    - ``llm`` — the legacy LLM-only payload, saved as an ``openhands`` profile.
+      Kept for backward compatibility with existing clients.
+    - ``agent_settings`` — a full AgentSettings payload (``agent_kind`` +
+      fields). ``acp`` settings are saved as an ACP profile; ``openhands`` /
+      ``llm`` settings persist their ``llm`` (profiles remain LLM-only for the
+      OpenHands kind for now).
+    """
+
+    llm: LLM | None = None
+    agent_settings: dict[str, Any] | None = Field(
+        default=None,
+        description=(
+            "Full AgentSettings payload (discriminated by ``agent_kind``). "
+            "Use this to save ACP profiles. Mutually exclusive with ``llm``."
+        ),
+    )
     include_secrets: bool = Field(
         default=True,
-        description="Whether to persist the API key with the profile.",
+        description="Whether to persist secrets (API key / acp_env) with the profile.",
     )
 
 
@@ -103,6 +139,17 @@ def _has_api_key(llm: LLM) -> bool:
     if not isinstance(llm.api_key, SecretStr):
         return False
     return bool(llm.api_key.get_secret_value().strip())
+
+
+def _acp_has_secret(acp: ACPAgentSettings) -> bool:
+    """Whether an ACP profile carries credentials (acp_env or bookkeeping llm).
+
+    ``acp_env`` is the ACP subprocess's real auth surface (e.g.
+    ``ANTHROPIC_API_KEY``); a non-empty value there counts as "secret set".
+    """
+    if any(isinstance(v, str) and v.strip() for v in acp.acp_env.values()):
+        return True
+    return _has_api_key(acp.llm)
 
 
 def _model_to_profile_name(model: str) -> str:
@@ -217,17 +264,34 @@ async def get_profile(request: Request, name: ProfileName) -> ProfileDetailRespo
     store = LLMProfileStore()
     try:
         with _store_errors():
-            llm = store.load(name, cipher=cipher)
+            kind = store.profile_kind(name)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Profile '{name}' not found",
         )
 
+    if kind == "acp":
+        with _store_errors():
+            acp = store.load_acp(name, cipher=cipher)
+        if expose_mode:
+            context = build_expose_context(expose_mode, cipher)
+            with translate_missing_cipher():
+                config: dict[str, Any] = acp.model_dump(mode="json", context=context)
+        else:
+            # No context → the model's secret serializers mask llm secrets and
+            # acp_env values, so nothing sensitive leaks.
+            config = acp.model_dump(mode="json")
+        return ProfileDetailResponse(
+            name=name, config=config, api_key_set=_acp_has_secret(acp)
+        )
+
+    with _store_errors():
+        llm = store.load(name, cipher=cipher)
     if expose_mode:
         context = build_expose_context(expose_mode, cipher)
         with translate_missing_cipher():
-            config: dict[str, Any] = llm.model_dump(mode="json", context=context)
+            config = llm.model_dump(mode="json", context=context)
     else:
         config = llm.model_dump(mode="json")
         config["api_key"] = None
@@ -247,27 +311,75 @@ async def save_profile(
     name: ProfileName,
     body: SaveProfileRequest,
 ) -> ProfileMutationResponse:
-    """Save an LLM configuration as a named profile.
+    """Save an AgentProfile (LLM or ACP) as a named profile.
 
-    Overwrites an existing profile of the same name. Returns 409 if creating
-    a new profile would exceed ``MAX_PROFILES``.
+    Accepts either the legacy ``llm`` payload (saved as an ``openhands``
+    profile) or a full ``agent_settings`` payload (``acp`` settings are saved
+    as an ACP profile). Overwrites an existing profile of the same name.
+    Returns 409 if creating a new profile would exceed ``MAX_PROFILES``.
 
     When ``OH_SECRET_KEY`` is configured, secrets are encrypted at rest.
     Clients can submit cipher-encrypted secrets which will be decrypted
     server-side before re-encrypting with the storage cipher.
     """
+    if (body.llm is None) == (body.agent_settings is None):
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail="Provide exactly one of `llm` or `agent_settings`.",
+        )
+
     cipher = get_cipher(request)
-    llm = decrypt_incoming_llm_secrets(body.llm, cipher) if cipher else body.llm
     store = LLMProfileStore()
     try:
         with _store_errors():
-            store.save(
-                name,
-                llm,
-                include_secrets=body.include_secrets,
-                cipher=cipher,
-                max_profiles=MAX_PROFILES,
-            )
+            if body.agent_settings is not None:
+                # New AgentProfile path. Validate with the cipher in context so
+                # client-encrypted secrets (llm.api_key, acp_env values) are
+                # decrypted before re-encryption at rest.
+                try:
+                    settings = validate_agent_settings(
+                        body.agent_settings,
+                        context={"cipher": cipher} if cipher else None,
+                    )
+                except Exception as e:
+                    # type(e).__name__ only — Pydantic errors may echo secrets.
+                    raise HTTPException(
+                        status_code=status.HTTP_400_BAD_REQUEST,
+                        detail=f"Invalid agent_settings payload: {type(e).__name__}",
+                    )
+                if isinstance(settings, ACPAgentSettings):
+                    store.save_acp(
+                        name,
+                        settings,
+                        include_secrets=body.include_secrets,
+                        cipher=cipher,
+                        max_profiles=MAX_PROFILES,
+                    )
+                else:
+                    # OpenHands AgentProfile: persist its LLM (profiles remain
+                    # LLM-only for the OpenHands kind for now).
+                    store.save(
+                        name,
+                        settings.llm,
+                        include_secrets=body.include_secrets,
+                        cipher=cipher,
+                        max_profiles=MAX_PROFILES,
+                    )
+            else:
+                # Legacy LLM-only payload.
+                assert body.llm is not None  # guaranteed by SaveProfileRequest
+                llm = (
+                    decrypt_incoming_llm_secrets(body.llm, cipher)
+                    if cipher
+                    else body.llm
+                )
+                store.save(
+                    name,
+                    llm,
+                    include_secrets=body.include_secrets,
+                    cipher=cipher,
+                    max_profiles=MAX_PROFILES,
+                )
     except ProfileLimitExceeded:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,
@@ -356,11 +468,14 @@ class ActivateProfileResponse(BaseModel):
 async def activate_profile(
     request: Request, name: ProfileName
 ) -> ActivateProfileResponse:
-    """Activate a saved LLM profile.
+    """Activate a saved AgentProfile.
 
     This endpoint:
-    1. Loads the named profile's LLM configuration
-    2. Applies it to the current agent settings (updates ``agent_settings.llm``)
+    1. Loads the named profile (LLM or ACP)
+    2. Applies it to the current agent settings — for an ``openhands`` profile
+       this updates ``agent_settings.llm``; for an ``acp`` profile it flips
+       ``agent_kind`` to ``acp`` and applies the ACP launch fields
+       (server/model/command/args/env)
     3. Records the profile name as the active profile for frontend tracking
 
     Returns 404 if the profile does not exist.
@@ -371,26 +486,48 @@ async def activate_profile(
     cipher = get_cipher(request)
     config = get_config(request)
 
-    # Load the profile
+    # Load the profile (kind-aware)
     profile_store = LLMProfileStore()
     try:
         with _store_errors():
-            llm = profile_store.load(name, cipher=cipher)
+            kind = profile_store.profile_kind(name)
+            if kind == "acp":
+                acp = profile_store.load_acp(name, cipher=cipher)
+                # Build the agent_settings diff from the saved ACP fields. Drop
+                # ``llm`` so it doesn't deep-merge into the current bookkeeping
+                # LLM, and drop ``schema_version`` / ``agent_context`` which the
+                # union validator fills in. The remaining ``agent_kind: "acp"``
+                # + acp_* fields flip the kind and apply the full launch config
+                # (including acp_env credentials). Leftover OpenHands-only keys
+                # from the current settings are ignored by ACPAgentSettings.
+                acp_dump = acp.model_dump(
+                    mode="json", context={"expose_secrets": "plaintext"}
+                )
+                agent_diff = {
+                    k: v
+                    for k, v in acp_dump.items()
+                    if k not in ("llm", "schema_version", "agent_context")
+                }
+            else:
+                llm = profile_store.load(name, cipher=cipher)
+                agent_diff = {
+                    "llm": llm.model_dump(
+                        mode="json", context={"expose_secrets": "plaintext"}
+                    )
+                }
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Profile '{name}' not found",
         )
 
-    # Apply the LLM config to settings and record active profile
+    # Apply the config to settings and record active profile
     settings_store = get_settings_store(config)
 
     def apply_profile(settings: PersistedSettings) -> PersistedSettings:
-        # Update the LLM configuration
-        llm_dict = llm.model_dump(mode="json", context={"expose_secrets": "plaintext"})
         settings.update(
             {
-                "agent_settings_diff": {"llm": llm_dict},
+                "agent_settings_diff": agent_diff,
                 "active_profile": name,
             }
         )

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -18,7 +18,28 @@ from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 if TYPE_CHECKING:
     from openhands.sdk.llm.llm import LLM
+    from openhands.sdk.settings.model import ACPAgentSettings
     from openhands.sdk.utils.cipher import Cipher
+
+
+def _build_save_context(include_secrets: bool, cipher: Cipher | None) -> dict[str, Any]:
+    """Pydantic serialization context for persisting a profile.
+
+    When ``include_secrets`` is set, secrets are encrypted at rest if a
+    ``cipher`` is available, else written in plaintext. When it is unset, an
+    empty context masks secrets via the model serializers. Shared by
+    :meth:`LLMProfileStore.save` and :meth:`LLMProfileStore.save_acp` so both
+    paths handle secrets identically.
+    """
+    context: dict[str, Any] = {}
+    if include_secrets:
+        if cipher:
+            context["cipher"] = cipher
+            context["expose_secrets"] = "encrypted"
+        else:
+            context["expose_secrets"] = True
+    return context
+
 
 _DEFAULT_PROFILE_DIR: Final[Path] = Path.home() / ".openhands" / "profiles"
 _LOCK_TIMEOUT_SECONDS: Final[float] = 30.0
@@ -126,6 +147,56 @@ class LLMProfileStore:
             ProfileLimitExceeded: If ``max_profiles`` would be exceeded.
             TimeoutError: If the lock cannot be acquired.
         """
+        context = _build_save_context(include_secrets, cipher)
+        profile_json = json.dumps(llm.to_persisted(context=context), indent=2)
+        self._persist_profile_json(name, profile_json, max_profiles=max_profiles)
+
+    def save_acp(
+        self,
+        name: str,
+        acp_settings: ACPAgentSettings,
+        include_secrets: bool = False,
+        *,
+        cipher: Cipher | None = None,
+        max_profiles: int | None = None,
+    ) -> None:
+        """Save an ACP AgentProfile to the profile directory.
+
+        ACP counterpart to :meth:`save`. The on-disk JSON carries
+        ``agent_kind: "acp"`` so :meth:`profile_kind` and :meth:`list_summaries`
+        can tell it apart from a legacy bare-LLM (OpenHands) profile, and
+        :meth:`load` rejects it (an ACP profile is not an :class:`LLM`).
+
+        ``acp_env`` values and the bookkeeping ``llm`` secrets are encrypted at
+        rest when ``cipher`` is provided, mirroring :meth:`save`.
+
+        Args:
+            name: Name of the profile to save.
+            acp_settings: The ACP agent settings to persist.
+            include_secrets: Whether to persist ``acp_env`` / ``llm`` secrets.
+            cipher: Optional cipher for at-rest encryption of secrets.
+            max_profiles: Optional cap on the number of profiles.
+
+        Raises:
+            ProfileLimitExceeded: If ``max_profiles`` would be exceeded.
+            TimeoutError: If the lock cannot be acquired.
+        """
+        context = _build_save_context(include_secrets, cipher)
+        profile_json = json.dumps(
+            acp_settings.model_dump(mode="json", exclude_none=True, context=context),
+            indent=2,
+        )
+        self._persist_profile_json(name, profile_json, max_profiles=max_profiles)
+
+    def _persist_profile_json(
+        self, name: str, profile_json: str, *, max_profiles: int | None
+    ) -> None:
+        """Atomically write ``profile_json`` to ``<name>.json`` under the lock.
+
+        Shared by :meth:`save` (LLM profiles) and :meth:`save_acp` (ACP
+        profiles) so the profile-limit check and atomic temp-file replace live
+        in exactly one place.
+        """
         profile_path = self._get_profile_path(name)
 
         with self._acquire_lock():
@@ -147,15 +218,6 @@ class LLMProfileStore:
                     f"[Profile Store] Profile `{name}` already exists. Overwriting."
                 )
 
-            context: dict[str, Any] = {}
-            if include_secrets:
-                if cipher:
-                    context["cipher"] = cipher
-                    context["expose_secrets"] = "encrypted"
-                else:
-                    context["expose_secrets"] = True
-
-            profile_json = json.dumps(llm.to_persisted(context=context), indent=2)
             with tempfile.NamedTemporaryFile(
                 mode="w", dir=self.base_dir, suffix=".tmp", delete=False
             ) as tmp:
@@ -207,6 +269,70 @@ class LLMProfileStore:
 
             logger.info(f"[Profile Store] Loaded profile `{name}` from {profile_path}")
             return llm_instance
+
+    def profile_kind(self, name: str) -> str:
+        """Return the AgentProfile kind for a saved profile.
+
+        Reads the JSON directly (no model instantiation). A file without an
+        ``agent_kind`` (legacy bare-LLM profile) or with ``"openhands"`` /
+        ``"llm"`` reports ``"openhands"``; ``"acp"`` reports ``"acp"``. Callers
+        use this to pick :meth:`load` vs :meth:`load_acp`.
+
+        Raises:
+            FileNotFoundError: If the profile does not exist.
+            ValueError: If the profile file cannot be read/parsed.
+        """
+        profile_path = self._get_profile_path(name)
+        with self._acquire_lock():
+            if not profile_path.exists():
+                raise FileNotFoundError(f"Profile `{name}` not found")
+            try:
+                data = json.loads(profile_path.read_text())
+            except (OSError, json.JSONDecodeError) as e:
+                raise ValueError(f"Failed to read profile `{name}`: {e}") from e
+        kind = data.get("agent_kind") if isinstance(data, dict) else None
+        return "acp" if kind == "acp" else "openhands"
+
+    def load_acp(self, name: str, *, cipher: Cipher | None = None) -> ACPAgentSettings:
+        """Load an ACP AgentProfile (:class:`ACPAgentSettings`) by name.
+
+        ACP counterpart to :meth:`load`. Validates through
+        :func:`validate_agent_settings` so ``acp_env`` / ``llm`` secrets are
+        decrypted when ``cipher`` is provided.
+
+        Raises:
+            FileNotFoundError: If the profile does not exist.
+            ValueError: If the file is corrupted or is not an ACP profile.
+            TimeoutError: If the lock cannot be acquired.
+        """
+        from openhands.sdk.settings.model import (
+            ACPAgentSettings,
+            validate_agent_settings,
+        )
+
+        profile_path = self._get_profile_path(name)
+
+        with self._acquire_lock():
+            if not profile_path.exists():
+                existing = [p.name for p in self.base_dir.glob("*.json")]
+                raise FileNotFoundError(
+                    f"Profile `{name}` not found. "
+                    f"Available profiles: {', '.join(existing) or 'none'}"
+                )
+            try:
+                data = json.loads(profile_path.read_text())
+                context: dict[str, Any] | None = {"cipher": cipher} if cipher else None
+                settings = validate_agent_settings(data, context=context)
+            except Exception as e:
+                raise ValueError(f"Failed to load profile `{name}`: {e}") from e
+
+        if not isinstance(settings, ACPAgentSettings):
+            raise ValueError(
+                f"Profile `{name}` is not an ACP profile "
+                f"(agent_kind={getattr(settings, 'agent_kind', 'openhands')!r})"
+            )
+        logger.info(f"[Profile Store] Loaded ACP profile `{name}` from {profile_path}")
+        return settings
 
     def delete(self, name: str) -> None:
         """Delete an existing profile.
@@ -277,18 +403,53 @@ class LLMProfileStore:
                         f"[Profile Store] Skipping non-dict profile {name!r}"
                     )
                     continue
-                api_key = data.get("api_key")
-                api_key_set = (
-                    isinstance(api_key, str)
-                    and bool(api_key.strip())
-                    and api_key != REDACTED_SECRET_VALUE
-                )
-                summaries.append(
-                    {
-                        "name": name,
-                        "model": data.get("model"),
-                        "base_url": data.get("base_url"),
-                        "api_key_set": api_key_set,
-                    }
-                )
+                if data.get("agent_kind") == "acp":
+                    summaries.append(_acp_summary(name, data))
+                else:
+                    summaries.append(_llm_summary(name, data))
         return summaries
+
+
+def _is_set_secret(value: Any) -> bool:
+    """True when a serialized secret carries a real (non-redacted) value."""
+    return (
+        isinstance(value, str)
+        and bool(value.strip())
+        and value != REDACTED_SECRET_VALUE
+    )
+
+
+def _llm_summary(name: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Summary for a legacy bare-LLM (OpenHands) profile file."""
+    return {
+        "name": name,
+        "kind": "openhands",
+        "model": data.get("model"),
+        "base_url": data.get("base_url"),
+        "acp_server": None,
+        "acp_model": None,
+        "api_key_set": _is_set_secret(data.get("api_key")),
+    }
+
+
+def _acp_summary(name: str, data: dict[str, Any]) -> dict[str, Any]:
+    """Summary for an ACP profile file.
+
+    ``model`` mirrors ``acp_model`` so chip/label consumers that read ``model``
+    still show something. ``api_key_set`` reflects whether the profile carries
+    credentials in ``acp_env`` (the ACP subprocess's real auth surface).
+    """
+    acp_env = data.get("acp_env")
+    api_key_set = isinstance(acp_env, dict) and any(
+        _is_set_secret(v) for v in acp_env.values()
+    )
+    acp_model = data.get("acp_model")
+    return {
+        "name": name,
+        "kind": "acp",
+        "model": acp_model,
+        "base_url": None,
+        "acp_server": data.get("acp_server"),
+        "acp_model": acp_model,
+        "api_key_set": api_key_set,
+    }

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1318,3 +1318,26 @@ def test_acp_profile_cipher_roundtrip(client_with_cipher):
     assert (
         settings["agent_settings"]["acp_env"]["ANTHROPIC_API_KEY"] == "sk-secret-value"
     )
+
+
+def test_activate_openhands_profile_flips_kind_back_from_acp(client):
+    """Activating an OpenHands profile must reset agent_kind from acp."""
+    # Start with an ACP default.
+    client.post(
+        "/api/profiles/acp-default",
+        json={"agent_settings": _acp_agent_settings_payload()},
+    )
+    client.post("/api/profiles/acp-default/activate")
+    assert client.get("/api/settings").json()["agent_settings"]["agent_kind"] == "acp"
+
+    # Now activate an OpenHands (LLM) profile — kind must flip back.
+    client.post(
+        "/api/profiles/oh-llm",
+        json={"llm": {"model": "openai/gpt-4o"}},
+    )
+    resp = client.post("/api/profiles/oh-llm/activate")
+    assert resp.status_code == 200
+
+    agent_settings = client.get("/api/settings").json()["agent_settings"]
+    assert agent_settings["agent_kind"] == "openhands"
+    assert agent_settings["llm"]["model"] == "openai/gpt-4o"

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1197,3 +1197,124 @@ def test_auto_created_profile_persists(client, store):
     assert loaded.temperature == 0.7
     assert loaded.api_key is not None
     assert loaded.api_key.get_secret_value() == "sk-persist-test"
+
+
+# ── ACP AgentProfiles ────────────────────────────────────────────────────────
+
+
+def _acp_agent_settings_payload() -> dict:
+    return {
+        "agent_kind": "acp",
+        "acp_server": "claude-code",
+        "acp_model": "claude-opus-4-7",
+        "acp_command": ["npx", "-y", "@anthropic-ai/claude-code-acp"],
+        "acp_args": [],
+        "acp_env": {"ANTHROPIC_API_KEY": "sk-secret-value"},
+    }
+
+
+def test_save_acp_profile_and_list(client):
+    """POST agent_settings (acp) saves an ACP profile surfaced with kind=acp."""
+    resp = client.post(
+        "/api/profiles/local-claude",
+        json={"agent_settings": _acp_agent_settings_payload()},
+    )
+    assert resp.status_code == 201
+
+    listing = client.get("/api/profiles").json()
+    by_name = {p["name"]: p for p in listing["profiles"]}
+    acp = by_name["local-claude"]
+    assert acp["kind"] == "acp"
+    assert acp["acp_server"] == "claude-code"
+    assert acp["acp_model"] == "claude-opus-4-7"
+    assert acp["model"] == "claude-opus-4-7"
+
+
+def test_get_acp_profile_masks_secret(client):
+    """GET (no expose header) returns the ACP config with acp_env masked."""
+    client.post(
+        "/api/profiles/local-claude",
+        json={"agent_settings": _acp_agent_settings_payload()},
+    )
+    resp = client.get("/api/profiles/local-claude")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["config"]["agent_kind"] == "acp"
+    assert "sk-secret-value" not in str(body["config"])
+    assert body["api_key_set"] is True
+
+
+def test_activate_acp_profile_flips_agent_kind(client):
+    """Activating an ACP profile flips agent_kind and applies ACP fields."""
+    client.post(
+        "/api/profiles/local-claude",
+        json={"agent_settings": _acp_agent_settings_payload()},
+    )
+    activate = client.post("/api/profiles/local-claude/activate")
+    assert activate.status_code == 200
+
+    listing = client.get("/api/profiles").json()
+    assert listing["active_profile"] == "local-claude"
+
+    settings = client.get("/api/settings").json()
+    agent_settings = settings["agent_settings"]
+    assert agent_settings["agent_kind"] == "acp"
+    assert agent_settings["acp_server"] == "claude-code"
+    assert agent_settings["acp_model"] == "claude-opus-4-7"
+
+
+def test_save_profile_rejects_both_payloads(client):
+    """Providing both `llm` and `agent_settings` is a 422."""
+    resp = client.post(
+        "/api/profiles/both",
+        json={
+            "llm": {"model": "gpt-4o"},
+            "agent_settings": _acp_agent_settings_payload(),
+        },
+    )
+    assert resp.status_code == 422
+
+
+def test_save_openhands_via_agent_settings(client):
+    """An openhands agent_settings payload persists as an LLM (openhands) profile."""
+    resp = client.post(
+        "/api/profiles/oh",
+        json={
+            "agent_settings": {
+                "agent_kind": "openhands",
+                "llm": {"model": "openai/gpt-4o"},
+            }
+        },
+    )
+    assert resp.status_code == 201
+
+    listing = client.get("/api/profiles").json()
+    by_name = {p["name"]: p for p in listing["profiles"]}
+    assert by_name["oh"]["kind"] == "openhands"
+    assert by_name["oh"]["model"] == "openai/gpt-4o"
+
+
+def test_acp_profile_cipher_roundtrip(client_with_cipher):
+    """With a cipher configured, an ACP profile's acp_env secret is encrypted at
+    rest and recoverable plaintext for activation, never leaked in masked GETs."""
+    save = client_with_cipher.post(
+        "/api/profiles/sealed",
+        json={"agent_settings": _acp_agent_settings_payload()},
+    )
+    assert save.status_code == 201
+
+    # Masked GET (no expose header) must not leak the plaintext secret.
+    masked = client_with_cipher.get("/api/profiles/sealed").json()
+    assert "sk-secret-value" not in str(masked["config"])
+    assert masked["api_key_set"] is True
+
+    # Activation applies the decrypted acp_env to settings.
+    activate = client_with_cipher.post("/api/profiles/sealed/activate")
+    assert activate.status_code == 200
+    settings = client_with_cipher.get(
+        "/api/settings", headers={"X-Expose-Secrets": "plaintext"}
+    ).json()
+    assert settings["agent_settings"]["agent_kind"] == "acp"
+    assert (
+        settings["agent_settings"]["acp_env"]["ANTHROPIC_API_KEY"] == "sk-secret-value"
+    )

--- a/tests/sdk/llm/test_llm_profile_store.py
+++ b/tests/sdk/llm/test_llm_profile_store.py
@@ -669,3 +669,85 @@ def test_multiple_profiles(profile_store: LLMProfileStore) -> None:
     profile_store.delete("gpt4")
     assert len(profile_store.list()) == 2
     assert "gpt4.json" not in profile_store.list()
+
+
+# ── ACP AgentProfiles ────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def sample_acp_settings():
+    """A sample ACPAgentSettings for testing ACP profile persistence."""
+    from openhands.sdk.settings import ACPAgentSettings
+
+    return ACPAgentSettings(
+        acp_server="claude-code",
+        acp_model="claude-opus-4-7",
+        acp_command=["npx", "-y", "@anthropic-ai/claude-code-acp"],
+        acp_args=[],
+        acp_env={"ANTHROPIC_API_KEY": "sk-secret-value"},
+    )
+
+
+def test_save_and_load_acp_profile(profile_store, sample_acp_settings):
+    """save_acp persists an ACP profile that load_acp round-trips."""
+    profile_store.save_acp("local-codex", sample_acp_settings, include_secrets=True)
+
+    assert profile_store.profile_kind("local-codex") == "acp"
+
+    loaded = profile_store.load_acp("local-codex")
+    assert loaded.agent_kind == "acp"
+    assert loaded.acp_server == "claude-code"
+    assert loaded.acp_model == "claude-opus-4-7"
+    assert loaded.acp_command == ["npx", "-y", "@anthropic-ai/claude-code-acp"]
+    assert loaded.acp_env["ANTHROPIC_API_KEY"] == "sk-secret-value"
+
+
+def test_acp_profile_kind_for_legacy_llm(profile_store, sample_llm):
+    """A legacy bare-LLM profile reports kind 'openhands'."""
+    profile_store.save("legacy", sample_llm)
+    assert profile_store.profile_kind("legacy") == "openhands"
+
+
+def test_load_rejects_acp_profile(profile_store, sample_acp_settings):
+    """The LLM load() path raises on an ACP profile rather than mis-parsing it."""
+    profile_store.save_acp("acp-only", sample_acp_settings)
+    with pytest.raises(ValueError):
+        profile_store.load("acp-only")
+
+
+def test_load_acp_rejects_llm_profile(profile_store, sample_llm):
+    """load_acp raises on an OpenHands (bare-LLM) profile."""
+    profile_store.save("oh", sample_llm)
+    with pytest.raises(ValueError):
+        profile_store.load_acp("oh")
+
+
+def test_list_summaries_includes_kind_and_acp_fields(
+    profile_store, sample_llm, sample_acp_settings
+):
+    """list_summaries tags each profile with kind + ACP summary fields."""
+    profile_store.save("oh", sample_llm)
+    profile_store.save_acp("acp", sample_acp_settings, include_secrets=True)
+
+    by_name = {s["name"]: s for s in profile_store.list_summaries()}
+
+    assert by_name["oh"]["kind"] == "openhands"
+    assert by_name["oh"]["model"] == sample_llm.model
+    assert by_name["oh"]["acp_server"] is None
+
+    acp = by_name["acp"]
+    assert acp["kind"] == "acp"
+    assert acp["acp_server"] == "claude-code"
+    assert acp["acp_model"] == "claude-opus-4-7"
+    # model mirrors acp_model so chip consumers reading `model` still render.
+    assert acp["model"] == "claude-opus-4-7"
+    # acp_env carries a credential, so api_key_set is reported.
+    assert acp["api_key_set"] is True
+
+
+def test_acp_profile_without_secrets_masks_env(profile_store, sample_acp_settings):
+    """include_secrets=False must not write the acp_env secret to disk."""
+    profile_store.save_acp("masked", sample_acp_settings, include_secrets=False)
+
+    raw = json.loads((profile_store.base_dir / "masked.json").read_text())
+    assert "sk-secret-value" not in json.dumps(raw)


### PR DESCRIPTION
## What

Backend half of [agent-canvas#669](https://github.com/OpenHands/agent-canvas/issues/2206) — reframe the user-facing concept around a kind-discriminated **AgentProfile**. Today `/api/profiles` only persists LLM configs; this lets a profile also be an **ACP profile** (provider / model / command / args / env), which the agent-canvas in-conversation runtime-compatibility picker needs in order to offer ACP→ACP live switches and to grey out cross-kind profiles with a reason.

Scope is deliberately bounded to **ACP profiles + legacy compatibility** (per the issue's "ACP profile" data-model direction). OpenHands profiles remain LLM-only for now; condenser / MCP / verification / conversation-settings snapshots are out of scope.

## Store (`LLMProfileStore`)

- `save_acp()` / `load_acp()` persist and round-trip an `ACPAgentSettings`. `acp_env` values and the bookkeeping `llm` secrets are encrypted at rest when a cipher is configured, reusing the existing `AgentSettings` secret serializers / validators.
- `profile_kind()` reports `"openhands"` | `"acp"` by peeking `agent_kind`.
- `list_summaries()` tags each profile with `kind`, and for ACP adds `acp_server` / `acp_model` (`model` mirrors `acp_model` so chip consumers still render).
- **Backward compatible:** OpenHands profiles stay bare-LLM files and `load() -> LLM` is unchanged, so existing runtime callers (`switch_profile`, fallback strategy, subagents) keep working. `load()` raises on an ACP profile instead of mis-parsing it.

## Router (`/api/profiles`)

- `ProfileInfo` gains `kind` / `acp_server` / `acp_model`.
- `SaveProfileRequest` accepts **either** the legacy `llm` payload (saved as `openhands`) **or** a full `agent_settings` payload (`acp` saved as an ACP profile); exactly one is required.
- `GET` and `activate` are kind-aware. Activating an ACP profile flips `agent_kind` to `acp` and applies the saved launch fields (including `acp_env` credentials); client-encrypted secrets are decrypted via the cipher context.

## Tests

`tests/sdk/llm/test_llm_profile_store.py` and `tests/agent_server/test_profiles_router.py` cover save/load/list/kind, legacy compat, GET masking, ACP activate flipping `agent_kind`, the exactly-one-payload guard, and an end-to-end **cipher round-trip** (encrypted at rest, masked on GET, decrypted on activate). All existing profile tests still pass; `ruff` + `pyright` pre-commit hooks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ddef396-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ddef396-python \
  ghcr.io/openhands/agent-server:ddef396-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ddef396-golang-amd64
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-golang-amd64
ghcr.io/openhands/agent-server:ddef396-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ddef396-golang-arm64
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-golang-arm64
ghcr.io/openhands/agent-server:ddef396-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ddef396-java-amd64
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-java-amd64
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-java-amd64
ghcr.io/openhands/agent-server:ddef396-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ddef396-java-arm64
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-java-arm64
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-java-arm64
ghcr.io/openhands/agent-server:ddef396-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ddef396-python-amd64
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-python-amd64
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-python-amd64
ghcr.io/openhands/agent-server:ddef396-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ddef396-python-arm64
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-python-arm64
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-python-arm64
ghcr.io/openhands/agent-server:ddef396-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ddef396-golang
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-golang
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-golang
ghcr.io/openhands/agent-server:ddef396-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ddef396-java
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-java
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-java
ghcr.io/openhands/agent-server:ddef396-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ddef396-python
ghcr.io/openhands/agent-server:ddef396f5ce5a0fc31ddcbb8bc3751f77349dfe0-python
ghcr.io/openhands/agent-server:feat-acp-agent-profiles-python
ghcr.io/openhands/agent-server:ddef396-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ddef396-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ddef396-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->