### PR TITLE
test(stress): bump concurrent conversations wall_time_factor to 4.0

### DIFF
--- a/tests/agent_server/stress/budgets.py
+++ b/tests/agent_server/stress/budgets.py
@@ -52,8 +52,9 @@ class ConversationListingBudget:
 class ConcurrentConversationsBudget:
     n_conversations: int = 16
     per_call_latency_s: float = 0.1
-    # Concurrent wall < single-conversation wall × this.
-    wall_time_factor: float = 2.5
+    # Concurrent wall < single-conversation wall × this. 4.0 (vs serial
+    # estimate of n=16) leaves slack for shared CI runners.
+    wall_time_factor: float = 4.0
     # RSS delta (peak - baseline) must be < baseline × this. With factor=2.0,
     # peak is allowed up to 3× baseline.
     rss_growth_factor: float = 2.0


### PR DESCRIPTION
## Summary

`test_concurrent_conversations_isolated_and_fast` is flaky on shared CI runners. The `concurrent_wall / ref_wall` ratio routinely lands between 2.5 and 3.0:

- [run 26638695661](https://github.com/OpenHands/software-agent-sdk/actions/runs/26638695661/job/78509155993?pr=3432): 0.34 / 0.13 ≈ 2.6
- [run 26640443770](https://github.com/OpenHands/software-agent-sdk/actions/runs/26640443770/job/78511751182) (an earlier attempt at this fix, which bumped `per_call_latency_s` to 0.4s): 1.25 / 0.45 ≈ 2.8

So the absolute jitter wasn't the problem — the ratio itself sits above 2.5 on shared runners. Raising `wall_time_factor` 2.5 → 4.0 absorbs that variance.

A real global-lock regression would push the ratio toward `n=16` (the serial estimate), so 4.0 still catches the bug class the test is meant to catch.

## Change

`tests/agent_server/stress/budgets.py`: `ConcurrentConversationsBudget.wall_time_factor` 2.5 → 4.0. No production code touched.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1db3394-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1db3394-python \
  ghcr.io/openhands/agent-server:1db3394-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1db3394-golang-amd64
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-golang-amd64
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-golang-amd64
ghcr.io/openhands/agent-server:1db3394-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1db3394-golang-arm64
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-golang-arm64
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-golang-arm64
ghcr.io/openhands/agent-server:1db3394-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1db3394-java-amd64
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-java-amd64
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-java-amd64
ghcr.io/openhands/agent-server:1db3394-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1db3394-java-arm64
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-java-arm64
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-java-arm64
ghcr.io/openhands/agent-server:1db3394-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1db3394-python-amd64
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-python-amd64
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-python-amd64
ghcr.io/openhands/agent-server:1db3394-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1db3394-python-arm64
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-python-arm64
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-python-arm64
ghcr.io/openhands/agent-server:1db3394-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1db3394-golang
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-golang
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-golang
ghcr.io/openhands/agent-server:1db3394-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1db3394-java
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-java
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-java
ghcr.io/openhands/agent-server:1db3394-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1db3394-python
ghcr.io/openhands/agent-server:1db33946f6b547c26d2707380ae30e2cb7f605fe-python
ghcr.io/openhands/agent-server:fix-concurrent-conversations-flaky-budget-python
ghcr.io/openhands/agent-server:1db3394-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1db3394-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1db3394-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->