### PR TITLE
feat(acp): type acp_env values as SecretStr to mask secrets in memory

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -77,6 +77,7 @@ from openhands.sdk.tool import Tool  # noqa: TC002
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishObservation
 from openhands.sdk.utils import maybe_truncate
 from openhands.sdk.utils.pydantic_secrets import (
+    SecretEnvValue,
     serialize_secret,
     validate_secret_dict,
 )
@@ -830,7 +831,7 @@ class ACPAgent(AgentBase):
         default_factory=list,
         description="Additional arguments for the ACP server command",
     )
-    acp_env: dict[str, str] = Field(
+    acp_env: dict[str, SecretEnvValue] = Field(
         default_factory=dict,
         description="Additional environment variables for the ACP server process",
     )
@@ -864,9 +865,9 @@ class ACPAgent(AgentBase):
         return validate_secret_dict(value, info, description="ACP env")
 
     @field_serializer("acp_env", when_used="always")
-    def _serialize_acp_env(self, value: dict[str, str], info):
+    def _serialize_acp_env(self, value: dict[str, SecretStr], info):
         """Mask ``acp_env`` values via :func:`serialize_secret`."""
-        return {k: serialize_secret(SecretStr(v), info) for k, v in value.items()}
+        return {k: serialize_secret(v, info) for k, v in value.items()}
 
     acp_session_mode: str | None = Field(
         default=None,
@@ -1338,7 +1339,7 @@ class ACPAgent(AgentBase):
         # because LookupSecret can make an HTTP request.
         env = default_environment()
         env.update(os.environ)
-        env.update(self.acp_env)
+        env.update({k: v.get_secret_value() for k, v in self.acp_env.items()})
         for name in state.secret_registry.secret_sources:
             if name in env:
                 continue

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -42,6 +42,7 @@ from openhands.sdk.tool import Tool
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.utils.pydantic_secrets import (
     MissingCipherError,
+    SecretEnvValue,
     decrypt_str_with_cipher_or_keep,
     resolve_expose_mode,
     serialize_secret,
@@ -997,7 +998,7 @@ class ACPAgentSettings(AgentSettingsBase):
             ).model_dump(),
         },
     )
-    acp_env: dict[str, str] = Field(
+    acp_env: dict[str, SecretEnvValue] = Field(
         default_factory=dict,
         description="Extra environment variables passed to the ACP subprocess.",
         json_schema_extra={
@@ -1027,9 +1028,9 @@ class ACPAgentSettings(AgentSettingsBase):
         return validate_secret_dict(value, info, description="ACP env")
 
     @field_serializer("acp_env", when_used="always")
-    def _serialize_acp_env(self, value: dict[str, str], info):
+    def _serialize_acp_env(self, value: dict[str, SecretStr], info):
         """Mask ``acp_env`` values via :func:`serialize_secret`."""
-        return {k: serialize_secret(SecretStr(v), info) for k, v in value.items()}
+        return {k: serialize_secret(v, info) for k, v in value.items()}
 
     acp_model: str | None = Field(
         default=None,
@@ -1163,7 +1164,7 @@ class ACPAgentSettings(AgentSettingsBase):
 
         return env
 
-    def resolve_acp_env(self) -> dict[str, str]:
+    def resolve_acp_env(self) -> dict[str, SecretStr]:
         """Return the effective ACP subprocess environment.
 
         Explicit :attr:`acp_env` entries override provider-derived env vars.
@@ -1174,9 +1175,13 @@ class ACPAgentSettings(AgentSettingsBase):
         priority:
 
         ``acp_env > provider env > secret_registry > agent_context.secrets``.
+
+        Values are :class:`~pydantic.SecretStr` so they stay masked in memory
+        until the subprocess is spawned; provider-derived plaintext entries are
+        wrapped to match.
         """
         return {
-            **self.resolve_provider_env(),
+            **{k: SecretStr(v) for k, v in self.resolve_provider_env().items()},
             **dict(self.acp_env),
         }
 

--- a/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
+++ b/openhands-sdk/openhands/sdk/utils/pydantic_secrets.py
@@ -1,13 +1,27 @@
 import logging
 from collections.abc import Mapping
-from typing import Any, Literal, overload
+from typing import Annotated, Any, Literal, overload
 
-from pydantic import SecretStr, ValidationInfo
+from pydantic import SecretStr, ValidationInfo, WithJsonSchema
 
 from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
 
 
 REDACTED_SECRET_VALUE = "**********"
+
+# A ``SecretStr`` for use as the *value type* of a dict-of-string secret map
+# (e.g. ``acp_env``). It masks the value in memory — ``repr``, logs, and
+# tracebacks show ``**********`` instead of the plaintext — while a
+# ``field_serializer`` still emits a plain string on the wire (redacted,
+# encrypted, or exposed per context).
+#
+# ``WithJsonSchema({"type": "string"})`` pins the JSON/OpenAPI schema to a
+# plain ``string`` instead of ``SecretStr``'s default ``format: password,
+# writeOnly: true`` shape. That default would drop the field from *response*
+# schemas (writeOnly) and is a breaking REST change; it's also inaccurate
+# here, since the value really is returned as a (masked) string. Validation
+# is unaffected — plain strings are still coerced to ``SecretStr``.
+SecretEnvValue = Annotated[SecretStr, WithJsonSchema({"type": "string"})]
 
 # Type for expose_secrets context value
 ExposeSecretsMode = Literal["encrypted", "plaintext"] | bool

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -745,7 +745,9 @@ def test_start_conversation_accepts_acp_agent_settings(
         assert request.agent.kind == "ACPAgent"
         assert request.agent.acp_command == ["echo", "settings"]
         assert request.agent.acp_args == ["--verbose"]
-        assert request.agent.acp_env == {"OPENAI_API_KEY": "sk-acp-env"}
+        assert {
+            k: v.get_secret_value() for k, v in request.agent.acp_env.items()
+        } == {"OPENAI_API_KEY": "sk-acp-env"}
         assert request.agent.acp_model == "acp-test-model"
         assert request.agent.acp_session_mode == "bypassPermissions"
         assert request.agent.acp_prompt_timeout == 123.0

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -745,9 +745,9 @@ def test_start_conversation_accepts_acp_agent_settings(
         assert request.agent.kind == "ACPAgent"
         assert request.agent.acp_command == ["echo", "settings"]
         assert request.agent.acp_args == ["--verbose"]
-        assert {
-            k: v.get_secret_value() for k, v in request.agent.acp_env.items()
-        } == {"OPENAI_API_KEY": "sk-acp-env"}
+        assert {k: v.get_secret_value() for k, v in request.agent.acp_env.items()} == {
+            "OPENAI_API_KEY": "sk-acp-env"
+        }
         assert request.agent.acp_model == "acp-test-model"
         assert request.agent.acp_session_mode == "bypassPermissions"
         assert request.agent.acp_prompt_timeout == 123.0

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -301,7 +301,10 @@ def test_get_settings_migrates_acp_settings_and_resaves_encrypted_env(
     assert loaded.agent_settings.agent_kind == "acp"
     assert loaded.agent_settings.acp_command == ["echo", "settings"]
     assert loaded.agent_settings.acp_args == ["--verbose"]
-    assert loaded.agent_settings.acp_env == {"OPENAI_API_KEY": "sk-acp-env"}
+    assert (
+        loaded.agent_settings.acp_env["OPENAI_API_KEY"].get_secret_value()
+        == "sk-acp-env"
+    )
     assert loaded.agent_settings.acp_model == "acp-test-model"
     assert loaded.agent_settings.acp_session_mode == "bypassPermissions"
     assert loaded.agent_settings.acp_prompt_timeout == 123.0
@@ -335,7 +338,10 @@ def test_get_settings_migrates_acp_settings_and_resaves_encrypted_env(
     assert reloaded is not None
     assert isinstance(reloaded.agent_settings, ACPAgentSettings)
 
-    assert reloaded.agent_settings.acp_env == {"OPENAI_API_KEY": "sk-acp-env"}
+    assert (
+        reloaded.agent_settings.acp_env["OPENAI_API_KEY"].get_secret_value()
+        == "sk-acp-env"
+    )
     assert reloaded.conversation_settings.max_iterations == 88
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -55,6 +55,11 @@ from openhands.sdk.workspace.local import LocalWorkspace
 # ---------------------------------------------------------------------------
 
 
+def _secret_env(values: dict[str, str]) -> dict[str, SecretStr]:
+    """Wrap plaintext env values as ``SecretStr`` for ``acp_env`` construction."""
+    return {k: SecretStr(v) for k, v in values.items()}
+
+
 def _make_agent(**kwargs) -> ACPAgent:
     return ACPAgent(acp_command=["echo", "test"], **kwargs)
 
@@ -167,7 +172,7 @@ class TestACPAgentSerialization:
         agent = ACPAgent(
             acp_command=["npx", "-y", "claude-agent-acp"],
             acp_args=["--verbose"],
-            acp_env={"FOO": "bar"},
+            acp_env=_secret_env({"FOO": "bar"}),
         )
         # ``acp_env`` is redacted by default, so a value-preserving round-trip
         # requires expose_secrets=True (same contract as ``LLM.api_key``).
@@ -187,15 +192,22 @@ class TestACPAgentSerialization:
         """
         agent = ACPAgent(
             acp_command=["echo", "test"],
-            acp_env={
-                "OPENAI_API_KEY": "sk-real-secret-do-not-leak",
-                "GEMINI_API_KEY": "sk-other-secret",
-                "GEMINI_BASE_URL": "https://llm-proxy.example/",
-            },
+            acp_env=_secret_env(
+                {
+                    "OPENAI_API_KEY": "sk-real-secret-do-not-leak",
+                    "GEMINI_API_KEY": "sk-other-secret",
+                    "GEMINI_BASE_URL": "https://llm-proxy.example/",
+                }
+            ),
         )
 
-        # In-memory state still holds the real values — only serialization masks.
-        assert agent.acp_env["OPENAI_API_KEY"] == "sk-real-secret-do-not-leak"
+        # In-memory state still holds the real values (as SecretStr) — only
+        # serialization masks. repr/str must not leak them.
+        assert (
+            agent.acp_env["OPENAI_API_KEY"].get_secret_value()
+            == "sk-real-secret-do-not-leak"
+        )
+        assert "sk-real-secret-do-not-leak" not in repr(agent)
 
         # model_dump returns SecretStr objects — real values are hidden.
         dumped = agent.model_dump()
@@ -216,7 +228,7 @@ class TestACPAgentSerialization:
             "OPENAI_API_KEY": "sk-real-secret",
             "BASE_URL": "https://llm-proxy.example/",
         }
-        agent = ACPAgent(acp_command=["echo", "test"], acp_env=dict(secrets))
+        agent = ACPAgent(acp_command=["echo", "test"], acp_env=_secret_env(secrets))
 
         dumped = agent.model_dump(context={"expose_secrets": True})
         assert dumped["acp_env"] == secrets
@@ -225,7 +237,7 @@ class TestACPAgentSerialization:
         json_blob = agent.model_dump_json(context={"expose_secrets": True})
         restored = AgentBase.model_validate_json(json_blob)
         assert isinstance(restored, ACPAgent)
-        assert restored.acp_env == secrets
+        assert {k: v.get_secret_value() for k, v in restored.acp_env.items()} == secrets
 
     def test_acp_env_serializer_does_not_mutate_in_memory_state(self):
         """Serialization must not mutate ``self.acp_env`` — the runtime path
@@ -233,14 +245,14 @@ class TestACPAgentSerialization:
         subprocess environment.
         """
         original = {"OPENAI_API_KEY": "sk-real-secret"}
-        agent = ACPAgent(acp_command=["echo", "test"], acp_env=dict(original))
+        agent = ACPAgent(acp_command=["echo", "test"], acp_env=_secret_env(original))
 
         # Multiple dumps in different modes must leave the live dict alone.
         agent.model_dump()
         agent.model_dump_json()
         agent.model_dump(context={"expose_secrets": True})
 
-        assert agent.acp_env == original
+        assert {k: v.get_secret_value() for k, v in agent.acp_env.items()} == original
 
     def test_deserialization_from_dict(self):
         data = {
@@ -285,7 +297,7 @@ class TestACPAgentSerialization:
 
         restored = AgentBase.model_validate(data, context={"cipher": cipher})
         assert isinstance(restored, ACPAgent)
-        assert restored.acp_env == {
+        assert {k: v.get_secret_value() for k, v in restored.acp_env.items()} == {
             "ANTHROPIC_API_KEY": "sk-real",
             "ANTHROPIC_BASE_URL": "https://api.example.com",
         }
@@ -310,7 +322,8 @@ class TestACPAgentSerialization:
         }
         restored = AgentBase.model_validate(data)
         assert isinstance(restored, ACPAgent)
-        assert restored.acp_env == {"ANTHROPIC_API_KEY": encrypted}
+        # No cipher: ciphertext survives verbatim (just wrapped in SecretStr).
+        assert restored.acp_env["ANTHROPIC_API_KEY"].get_secret_value() == encrypted
 
     def test_acp_env_plaintext_passes_through_with_cipher(self):
         """First writes from clients that never went through the encryption
@@ -324,7 +337,7 @@ class TestACPAgentSerialization:
         }
         restored = AgentBase.model_validate(data, context={"cipher": cipher})
         assert isinstance(restored, ACPAgent)
-        assert restored.acp_env == {"FOO": "plaintext-value"}
+        assert restored.acp_env["FOO"].get_secret_value() == "plaintext-value"
 
     def test_acp_env_undecryptable_ciphertext_passes_through_with_warning(self, caplog):
         """Cipher mismatch / corruption shouldn't crash agent construction.
@@ -346,7 +359,7 @@ class TestACPAgentSerialization:
         with caplog.at_level("WARNING"):
             restored = AgentBase.model_validate(data, context={"cipher": cipher})
         assert isinstance(restored, ACPAgent)
-        assert restored.acp_env == {"BUSTED": bogus}
+        assert restored.acp_env["BUSTED"].get_secret_value() == bogus
         assert any("could not be decrypted" in r.message for r in caplog.records)
 
 

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -645,10 +645,13 @@ def test_acp_resolve_acp_env_explicit_entries_override_provider_env() -> None:
     settings = ACPAgentSettings(
         acp_server="claude-code",
         llm=LLM(model="claude-opus-4-6", api_key=SecretStr("sk-ui-key")),
-        acp_env={"ANTHROPIC_API_KEY": "sk-explicit-override"},
+        acp_env={"ANTHROPIC_API_KEY": SecretStr("sk-explicit-override")},
     )
 
-    assert settings.resolve_acp_env() == {"ANTHROPIC_API_KEY": "sk-explicit-override"}
+    resolved = settings.resolve_acp_env()
+    assert {k: v.get_secret_value() for k, v in resolved.items()} == {
+        "ANTHROPIC_API_KEY": "sk-explicit-override"
+    }
 
 
 def test_acp_create_agent_passes_resolved_env_and_agent_context() -> None:
@@ -661,7 +664,9 @@ def test_acp_create_agent_passes_resolved_env_and_agent_context() -> None:
 
     agent = settings.create_agent()
 
-    assert agent.acp_env == {"OPENAI_API_KEY": "sk-openai"}
+    assert {k: v.get_secret_value() for k, v in agent.acp_env.items()} == {
+        "OPENAI_API_KEY": "sk-openai"
+    }
     assert agent.agent_context == context
 
 
@@ -758,10 +763,11 @@ def test_conversation_settings_agent_settings_field_accepts_both_variants() -> N
 def test_acp_agent_settings_acp_env_redacted_by_default() -> None:
     settings = ACPAgentSettings(
         acp_command=["echo", "test"],
-        acp_env={"OPENAI_API_KEY": "sk-real-secret"},
+        acp_env={"OPENAI_API_KEY": SecretStr("sk-real-secret")},
     )
 
-    assert settings.acp_env["OPENAI_API_KEY"] == "sk-real-secret"
+    assert settings.acp_env["OPENAI_API_KEY"].get_secret_value() == "sk-real-secret"
+    assert "sk-real-secret" not in repr(settings)
     assert "sk-real-secret" not in settings.model_dump_json()
     assert settings.model_dump(mode="json")["acp_env"] == {
         "OPENAI_API_KEY": "**********"
@@ -782,7 +788,7 @@ def test_acp_agent_settings_acp_env_encrypts_with_cipher() -> None:
 
     settings = ACPAgentSettings(
         acp_command=["echo", "test"],
-        acp_env={"OPENAI_API_KEY": "sk-real-secret"},
+        acp_env={"OPENAI_API_KEY": SecretStr("sk-real-secret")},
     )
     cipher = Cipher(secret_key="test-encryption-key")
 
@@ -793,13 +799,16 @@ def test_acp_agent_settings_acp_env_encrypts_with_cipher() -> None:
     assert "sk-real-secret" not in json.dumps(dumped)
 
     restored = ACPAgentSettings.model_validate(dumped, context={"cipher": cipher})
-    assert restored.acp_env == {"OPENAI_API_KEY": "sk-real-secret"}
+    assert restored.acp_env["OPENAI_API_KEY"].get_secret_value() == "sk-real-secret"
 
     restored_from_persisted = validate_agent_settings(
         dumped, context={"cipher": cipher}
     )
     assert isinstance(restored_from_persisted, ACPAgentSettings)
-    assert restored_from_persisted.acp_env == {"OPENAI_API_KEY": "sk-real-secret"}
+    assert (
+        restored_from_persisted.acp_env["OPENAI_API_KEY"].get_secret_value()
+        == "sk-real-secret"
+    )
 
     legacy_plaintext = ACPAgentSettings.model_validate(
         {
@@ -808,7 +817,10 @@ def test_acp_agent_settings_acp_env_encrypts_with_cipher() -> None:
         },
         context={"cipher": cipher},
     )
-    assert legacy_plaintext.acp_env == {"OPENAI_API_KEY": "sk-legacy-plaintext"}
+    assert (
+        legacy_plaintext.acp_env["OPENAI_API_KEY"].get_secret_value()
+        == "sk-legacy-plaintext"
+    )
 
 
 def test_openhands_agent_settings_mcp_config_redacts_env_and_headers() -> None:


### PR DESCRIPTION
Closes #3430.

## Problem

`ACPAgent.acp_env` and `ACPAgentSettings.acp_env` were typed `dict[str, str]`. Masking happened **only at serialization time** (the `field_serializer` wraps each value in `SecretStr` on the way out), so the in-memory values were plaintext and leaked through paths that bypass the serializer:

- `repr(agent)` / `print(agent)` — pydantic renders the raw dict values
- `logger.info(f"...{agent.acp_env}")` or any direct log of the dict
- exception **tracebacks** that capture the model

Every other secret scalar in the SDK (`LLM.api_key`, `StaticSecret.value`, …) is `SecretStr`; `acp_env` was the odd one out.

## Fix

Type the values as `SecretStr` so they're masked in memory. A shared alias keeps the wire/OpenAPI schema unchanged:

```python
# pydantic_secrets.py
SecretEnvValue = Annotated[SecretStr, WithJsonSchema({"type": "string"})]
```

`WithJsonSchema({"type": "string"})` pins the JSON/OpenAPI schema to a plain `string` instead of `SecretStr`'s default `format: password, writeOnly: true`. That default would drop the field from **response** schemas (writeOnly) — a breaking REST change — and is also inaccurate here, since the value *is* returned (as a masked/encrypted string).

- `ACPAgent.acp_env` / `ACPAgentSettings.acp_env` → `dict[str, SecretEnvValue]`
- serializers drop the now-redundant `SecretStr(v)` wrap
- subprocess-spawn site unwraps via `.get_secret_value()`
- `resolve_acp_env()` returns `dict[str, SecretStr]` (wraps provider-derived env)
- decryption validators unchanged — the shared `validate_secret_dict` helper passes `SecretStr` through and coerces decrypted `str` → `SecretStr`

## No REST breakage (verified locally)

The generated agent-server OpenAPI for both `acp_env`-bearing schemas (`ACPAgent-Input`/`-Output`) is byte-identical to `main`:

```
acp_env -> {"additionalProperties": {"type": "string"}, ...}   # no writeOnly, no password format
```

`Python API` / `REST API (OpenAPI)` breakage checks should stay green.

## Tradeoff to be aware of

Because `dict` is invariant in its value type, constructing with a `dict[str, str]` literal no longer type-checks (`dict[str,str]` ⊄ `dict[str,SecretStr]`) — **runtime still coerces** via the before-validator. Callers either pass `SecretStr` values or go through `create_agent()` / `model_validate`. The OpenHands app builds the runtime agent via `create_agent()` (covered by `resolve_acp_env`); any *direct* `ACPAgent(acp_env=...)` construction there should wrap values in `SecretStr` (runtime works regardless). This is the inherent cost of in-memory masking for a dict field.

## Test plan

`uv run pytest` over acp_agent / settings / settings_router / remote-request-logging / validation-sanitization / pydantic_secrets / agent_context — **433 passed**. Added `repr()`-masking assertions to the redaction tests; existing cipher round-trip / plaintext-passthrough / undecryptable-warning tests updated to unwrap `SecretStr`.





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f0271ea-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f0271ea-python \
  ghcr.io/openhands/agent-server:f0271ea-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f0271ea-golang-amd64
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-golang-amd64
ghcr.io/openhands/agent-server:f0271ea-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f0271ea-golang-arm64
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-golang-arm64
ghcr.io/openhands/agent-server:f0271ea-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f0271ea-java-amd64
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-java-amd64
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-java-amd64
ghcr.io/openhands/agent-server:f0271ea-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f0271ea-java-arm64
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-java-arm64
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-java-arm64
ghcr.io/openhands/agent-server:f0271ea-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f0271ea-python-amd64
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-python-amd64
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-python-amd64
ghcr.io/openhands/agent-server:f0271ea-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f0271ea-python-arm64
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-python-arm64
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-python-arm64
ghcr.io/openhands/agent-server:f0271ea-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f0271ea-golang
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-golang
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-golang
ghcr.io/openhands/agent-server:f0271ea-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f0271ea-java
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-java
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-java
ghcr.io/openhands/agent-server:f0271ea-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f0271ea-python
ghcr.io/openhands/agent-server:f0271ea1231b97ec12aa3d06ef5f53ee621ac61f-python
ghcr.io/openhands/agent-server:feat-acp-env-secretstr-python
ghcr.io/openhands/agent-server:f0271ea-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f0271ea-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f0271ea-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->