### PR TITLE
feat: send x-litellm-session-id header for conversation-level routing affinity

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -732,7 +732,6 @@ class LocalConversation(BaseConversation):
         Note: if a caller passes ``extra_headers`` as a kwarg directly to
         ``completion()``, ``select_chat_options`` skips ``llm.extra_headers``
         entirely — the same limitation that affects OpenRouter headers.
-        Worth fixing in ``select_chat_options`` but out of scope here.
         """
         existing = llm.extra_headers or {}
         if "x-litellm-session-id" not in existing:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -700,20 +700,11 @@ class LocalConversation(BaseConversation):
             # both serialised with usage_id="default".
             self.llm_registry.subscribe(self._state.stats.register_llm)
             registered = set(self.llm_registry.list_usage_ids())
-            session_id = str(self._state.id)
             for llm in list(self.agent.get_all_llms()):
                 if llm.usage_id not in registered:
                     self.llm_registry.add(llm)
                     registered.add(llm.usage_id)
-                # Inject session ID for LiteLLM session affinity routing.
-                # Ensures all LLM calls in this conversation carry the same
-                # x-litellm-session-id header so the proxy pins to one deployment.
-                existing = llm.extra_headers or {}
-                if "x-litellm-session-id" not in existing:
-                    llm.extra_headers = {
-                        "x-litellm-session-id": session_id,
-                        **existing,
-                    }
+                self._pin_session_affinity_header(llm)
 
             self._agent_ready = True
 
@@ -735,6 +726,21 @@ class LocalConversation(BaseConversation):
         if self.agent.llm._prompt_cache_key is None:
             self.agent.llm._prompt_cache_key = str(self._state.id)
 
+    def _pin_session_affinity_header(self, llm: LLM) -> None:
+        """Ensure *llm* carries ``x-litellm-session-id`` for routing affinity.
+
+        Note: if a caller passes ``extra_headers`` as a kwarg directly to
+        ``completion()``, ``select_chat_options`` skips ``llm.extra_headers``
+        entirely — the same limitation that affects OpenRouter headers.
+        Worth fixing in ``select_chat_options`` but out of scope here.
+        """
+        existing = llm.extra_headers or {}
+        if "x-litellm-session-id" not in existing:
+            llm.extra_headers = {
+                "x-litellm-session-id": str(self._state.id),
+                **existing,
+            }
+
     def switch_llm(self, llm: LLM) -> None:
         """Swap the agent's LLM to the given object.
 
@@ -755,6 +761,7 @@ class LocalConversation(BaseConversation):
             self.agent = self.agent.model_copy(update={"llm": new_llm})
             self._state.agent = self.agent
             self._pin_prompt_cache_key()
+            self._pin_session_affinity_header(new_llm)
 
     def switch_profile(self, profile_name: str) -> None:
         """Switch the agent's LLM to a profile loaded from disk.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -700,10 +700,20 @@ class LocalConversation(BaseConversation):
             # both serialised with usage_id="default".
             self.llm_registry.subscribe(self._state.stats.register_llm)
             registered = set(self.llm_registry.list_usage_ids())
+            session_id = str(self._state.id)
             for llm in list(self.agent.get_all_llms()):
                 if llm.usage_id not in registered:
                     self.llm_registry.add(llm)
                     registered.add(llm.usage_id)
+                # Inject session ID for LiteLLM session affinity routing.
+                # Ensures all LLM calls in this conversation carry the same
+                # x-litellm-session-id header so the proxy pins to one deployment.
+                existing = llm.extra_headers or {}
+                if "x-litellm-session-id" not in existing:
+                    llm.extra_headers = {
+                        "x-litellm-session-id": session_id,
+                        **existing,
+                    }
 
             self._agent_ready = True
 


### PR DESCRIPTION
## Summary

Every LLM in a conversation now sends `x-litellm-session-id: <conversation_id>` on all requests. When the LiteLLM proxy has `session_affinity` enabled in its router settings, this pins all requests within a conversation to the same upstream deployment.

## Motivation

LiteLLM supports weighted load balancing across multiple deployments of the same model (e.g., spreading traffic across providers or regions). Without session affinity, each request is independently routed by weight, so a single conversation can bounce between deployments mid-stream. This breaks KV prefix caching (the new deployment has a cold cache for the conversation's history) and can cause subtle behavior differences if deployments run different versions or quantizations.

With this header, the proxy caches the routing decision per session ID. The first request picks a deployment by weight; all subsequent requests in the same conversation stick to it. Conversations still distribute across deployments probabilistically — it's just stable per-conversation rather than per-request.

## Implementation

Injected in `_ensure_plugins_loaded()` alongside the existing LLM registry loop, following the same pattern as `_pin_prompt_cache_key()` (which already uses `conversation_id` to shard OpenAI prefix caches). User-supplied `extra_headers` are preserved and win on conflict. The `not in existing` guard prevents double-injection.

## No-op when unused

If the LiteLLM proxy doesn't have `session_affinity` enabled, the header is ignored — no behavioral change.

---
*This PR was created by an AI agent (OpenHands) on behalf of @CalvinSmith.*


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9c6449c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9c6449c-python \
  ghcr.io/openhands/agent-server:9c6449c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9c6449c-golang-amd64
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-golang-amd64
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-golang-amd64
ghcr.io/openhands/agent-server:9c6449c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9c6449c-golang-arm64
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-golang-arm64
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-golang-arm64
ghcr.io/openhands/agent-server:9c6449c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9c6449c-java-amd64
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-java-amd64
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-java-amd64
ghcr.io/openhands/agent-server:9c6449c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9c6449c-java-arm64
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-java-arm64
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-java-arm64
ghcr.io/openhands/agent-server:9c6449c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9c6449c-python-amd64
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-python-amd64
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-python-amd64
ghcr.io/openhands/agent-server:9c6449c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9c6449c-python-arm64
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-python-arm64
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-python-arm64
ghcr.io/openhands/agent-server:9c6449c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9c6449c-golang
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-golang
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-golang
ghcr.io/openhands/agent-server:9c6449c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9c6449c-java
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-java
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-java
ghcr.io/openhands/agent-server:9c6449c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9c6449c-python
ghcr.io/openhands/agent-server:9c6449cc46490c99add4a3613501fa0a60927616-python
ghcr.io/openhands/agent-server:csmith-litellm-session-affinity-python
ghcr.io/openhands/agent-server:9c6449c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9c6449c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9c6449c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->