### PR TITLE
fix(llm): skip legacy thinking block for claude-opus-4-8

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -3,7 +3,22 @@ from __future__ import annotations
 from typing import Any
 
 from openhands.sdk.llm.options.common import apply_defaults_if_absent
-from openhands.sdk.llm.utils.model_features import get_features
+from openhands.sdk.llm.utils.model_features import get_features, model_matches
+
+
+# Models that are listed in EXTENDED_THINKING_MODELS for the side effect of
+# stripping `temperature`/`top_p` (which Anthropic reasoning models reject),
+# but that do NOT accept the legacy
+# ``thinking: {"type": "enabled", "budget_tokens": N}`` block.
+#
+# claude-opus-4-8 uses Anthropic's newer adaptive reasoning schema
+# (``thinking: {"type": "adaptive"}`` + ``output_config.effort``) and returns
+# a 400 ``"thinking.type.enabled" is not supported for this model`` if we send
+# the legacy block. Until the SDK builds the new schema, just skip emitting
+# the legacy block for these models; temp/top_p stripping still runs below.
+_MODELS_WITHOUT_LEGACY_THINKING_BLOCK: list[str] = [
+    "claude-opus-4-8",
+]
 
 
 def select_chat_options(
@@ -56,7 +71,14 @@ def select_chat_options(
 
     # Extended thinking models
     if get_features(llm.model).supports_extended_thinking:
-        if llm.extended_thinking_budget and max_output_tokens:
+        skip_legacy_thinking_block = model_matches(
+            llm.model, _MODELS_WITHOUT_LEGACY_THINKING_BLOCK
+        )
+        if (
+            not skip_legacy_thinking_block
+            and llm.extended_thinking_budget
+            and max_output_tokens
+        ):
             # Anthropic throws errors if thinking budget equals or exceeds max output
             # tokens -- force the thinking budget lower if there's a conflict
             budget_tokens = min(

--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -96,7 +96,10 @@ EXTENDED_THINKING_MODELS: list[str] = [
     # Opus 4.8 is a reasoning model: Anthropic rejects requests with
     # `temperature`/`top_p` ("`temperature` is deprecated for this model"),
     # so it must go through the extended-thinking path which strips those
-    # params and enables the thinking budget header.
+    # params. Opus 4.8 uses the newer adaptive reasoning schema
+    # (`thinking.type=adaptive` + `output_config.effort`) rather than the
+    # legacy `thinking.type=enabled` block, so chat_options.py omits the
+    # legacy block for this model via `_MODELS_WITHOUT_LEGACY_THINKING_BLOCK`.
     "claude-opus-4-8",
 ]
 

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -152,8 +152,9 @@ def test_claude_opus_4_8_strips_temp_and_top_p():
 
     Anthropic rejects requests to Claude Opus 4.8 with `temperature`/`top_p`:
     ``"`temperature` is deprecated for this model."``. Routing the model
-    through the extended-thinking path strips both params (and enables the
-    thinking budget header) so requests succeed.
+    through the extended-thinking path strips both params so requests
+    succeed. (The legacy thinking block is deliberately NOT emitted for
+    opus-4-8 -- see test_claude_opus_4_8_skips_legacy_thinking_block.)
     """
     llm = DummyLLM(
         model="litellm_proxy/anthropic/claude-opus-4-8",
@@ -164,6 +165,53 @@ def test_claude_opus_4_8_strips_temp_and_top_p():
 
     assert "temperature" not in out
     assert "top_p" not in out
+
+
+def test_claude_opus_4_8_skips_legacy_thinking_block():
+    """claude-opus-4-8 must not be sent the legacy ``thinking.type=enabled``
+    block. Anthropic rejects it with:
+    ``"thinking.type.enabled" is not supported for this model. Use
+    "thinking.type.adaptive" and "output_config.effort" to control thinking
+    behavior.`` Until the SDK builds that newer schema, the legacy block (and
+    the ``interleaved-thinking-2025-05-14`` beta header that goes with it)
+    must be omitted, even when ``extended_thinking_budget`` is set.
+
+    Sibling models in EXTENDED_THINKING_MODELS (e.g. sonnet-4-5/4-6) still
+    accept the legacy block, so this test also pins that those models are
+    NOT affected by the opus-4-8 skip.
+    """
+    # opus-4-8: thinking block + beta header must be omitted, even with a
+    # configured budget.
+    opus = DummyLLM(
+        model="litellm_proxy/anthropic/claude-opus-4-8",
+        max_output_tokens=8192,
+        extended_thinking_budget=4096,
+    )
+    out = select_chat_options(opus, user_kwargs={}, has_tools=True)
+
+    assert "thinking" not in out
+    assert "anthropic-beta" not in (out.get("extra_headers") or {})
+    # The whole point of routing opus-4-8 through this path is to strip
+    # temperature/top_p; make sure that side effect still happens.
+    assert "temperature" not in out
+    assert "top_p" not in out
+
+    # sonnet-4-5 still gets the legacy thinking block; the opus-4-8 skip
+    # must not regress other extended-thinking models.
+    sonnet = DummyLLM(
+        model="claude-sonnet-4-5",
+        max_output_tokens=8192,
+        extended_thinking_budget=4096,
+    )
+    sonnet_out = select_chat_options(sonnet, user_kwargs={}, has_tools=True)
+
+    assert sonnet_out.get("thinking") == {
+        "type": "enabled",
+        "budget_tokens": 4096,
+    }
+    assert (sonnet_out.get("extra_headers") or {}).get(
+        "anthropic-beta"
+    ) == "interleaved-thinking-2025-05-14"
 
 
 def test_extended_thinking_budget_clamped_below_max_tokens():


### PR DESCRIPTION
## Problem

Anthropic's API for `claude-opus-4-8` no longer accepts the legacy `thinking.type=enabled` + `budget_tokens` block that the SDK emits for every model in `EXTENDED_THINKING_MODELS`. Every call against `litellm_proxy/anthropic/claude-opus-4-8` errors with:

```
invalid_request_error: "thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
request_id: req_011CbX18CQeQxYJ99w7nUorj
```

Observed in production via SWE‑bench eval runs:

| Eval run | Outcome |
|---|---|
| `26608744731` (smoke) | ✅ — old proxy litellm silently dropped the unknown params |
| `26618647016` (smoke, post‑proxy‑upgrade) | ❌ — `litellm.UnsupportedParamsError` upfront |
| [`26641824100`](https://openhands-eval-monitor.vercel.app/?run=swebench%2Flitellm_proxy-anthropic-claude-opus-4-8%2F26641824100%2F) (smoke, after reverting [OpenHands/benchmarks#729](https://github.com/OpenHands/benchmarks/pull/729)) | ❌ — proxy forwards, Anthropic rejects `thinking.type.enabled` |

All instances landed in `output_errors.jsonl` with `patch_len=0`, which the eval-monitor dashboard reports as "0% Critic 1 acceptance" — the critic never actually evaluated anything; the LLM call itself failed.

## Root cause

`claude-opus-4-8` was added to `EXTENDED_THINKING_MODELS` in #3427 so it would inherit that branch's stripping of `temperature` / `top_p` (which Anthropic now rejects for reasoning models). The intended payload was the side effect of being in that list; the unintended side effect was that the same code path also emits:

```python
out["thinking"] = {"type": "enabled", "budget_tokens": N}
out["extra_headers"] = {"anthropic-beta": "interleaved-thinking-2025-05-14", ...}
```

That block is correct for `claude-sonnet-4-5/4-6` and `claude-haiku-4-5`. It is **not** correct for `claude-opus-4-8`, which is a newer reasoning model expecting the adaptive schema (`thinking.type=adaptive` + `output_config.effort`).

## Fix

Minimal: in `chat_options.py`, omit the legacy thinking block (and the interleaved‑thinking beta header) for any model in a new small allow‑list:

```python
_MODELS_WITHOUT_LEGACY_THINKING_BLOCK: list[str] = [
    "claude-opus-4-8",
]
```

The `temperature` / `top_p` stripping that follows in the same branch — the original reason opus‑4‑8 was added to `EXTENDED_THINKING_MODELS` — is preserved. Other extended‑thinking models are untouched.

Future Anthropic reasoning models that ship with the same constraint can be added to that list in one line. When the SDK is updated to build the new adaptive schema, opus‑4‑8 should be moved off this allow‑list and onto that new path.

## Tests

- New `test_claude_opus_4_8_skips_legacy_thinking_block`:
  - opus‑4‑8 with `extended_thinking_budget=4096`, `max_output_tokens=8192` → no `thinking` key, no `anthropic-beta` header, `temperature` and `top_p` still stripped.
  - sonnet‑4‑5 with the same inputs → `thinking == {"type": "enabled", "budget_tokens": 4096}` and `anthropic-beta == "interleaved-thinking-2025-05-14"`, locking in that the opus‑4‑8 skip does not regress other extended‑thinking models.
- Existing `test_claude_opus_4_8_strips_temp_and_top_p` and the thinking‑budget‑clamp tests continue to pass (`167 passed` locally on `tests/sdk/llm/test_chat_options.py` + `tests/sdk/llm/test_model_features.py`).

## Caveats / follow‑ups

- This is a stop‑gap. The proper fix is to teach `chat_options.py` to build Anthropic's new adaptive schema (`thinking: {"type": "adaptive"}` + `output_config: {"effort": llm.reasoning_effort}`) for reasoning models, and route opus‑4‑8 through that. Tracking that as a follow‑up rather than expanding this PR's scope.
- The companion benchmarks revert is [OpenHands/benchmarks#729](https://github.com/OpenHands/benchmarks/pull/729), which restored the proxy‑side litellm pin so the SDK's payload is forwarded to Anthropic unmodified (without that, the proxy itself errors on `reasoning_effort` / `thinking` before Anthropic ever sees the request).
- Eval‑monitor UX (not in this PR): when `output.jsonl == 0` and `output_errors.jsonl > 0`, the dashboard should surface "all completed instances errored" rather than "0% critic acceptance" — the current label sent us down the wrong rabbit hole during this investigation.

---

_This PR was opened by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6ef33fe1-c3f5-4ed4-8c5e-5e56bd30ea8d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:828144c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-828144c-python \
  ghcr.io/openhands/agent-server:828144c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:828144c-golang-amd64
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-golang-amd64
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-golang-amd64
ghcr.io/openhands/agent-server:828144c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:828144c-golang-arm64
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-golang-arm64
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-golang-arm64
ghcr.io/openhands/agent-server:828144c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:828144c-java-amd64
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-java-amd64
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-java-amd64
ghcr.io/openhands/agent-server:828144c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:828144c-java-arm64
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-java-arm64
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-java-arm64
ghcr.io/openhands/agent-server:828144c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:828144c-python-amd64
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-python-amd64
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-python-amd64
ghcr.io/openhands/agent-server:828144c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:828144c-python-arm64
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-python-arm64
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-python-arm64
ghcr.io/openhands/agent-server:828144c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:828144c-golang
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-golang
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-golang
ghcr.io/openhands/agent-server:828144c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:828144c-java
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-java
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-java
ghcr.io/openhands/agent-server:828144c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:828144c-python
ghcr.io/openhands/agent-server:828144ca28b57e4b56d05b7f62d9ab735705978d-python
ghcr.io/openhands/agent-server:fix-opus-4-8-skip-legacy-thinking-block-python
ghcr.io/openhands/agent-server:828144c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `828144c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `828144c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->