### PR TITLE
fix(mcp): auto-recover from fastmcp nesting-counter stuck state in MCPClient.connect()

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/client.py
+++ b/openhands-sdk/openhands/sdk/mcp/client.py
@@ -48,7 +48,23 @@ class MCPClient(AsyncMCPClient):
         return list(self._tools)
 
     async def connect(self) -> None:
-        """Establish connection to the MCP server."""
+        """Establish connection to the MCP server.
+
+        Automatically recovers from the fastmcp nesting-counter stuck state that
+        occurs when a background session task dies while the counter is non-zero
+        (e.g. after a server-side HTTP 500 or abrupt connection drop). Without
+        this recovery, fastmcp raises an internal ``RuntimeError`` ("nesting
+        counter should be 0 when starting new session, got N") and the client
+        becomes permanently unusable until the process restarts.
+        """
+        # fastmcp bug workaround: if the background session task has exited while
+        # the nesting counter is still non-zero, the client is in a stuck state
+        # where reconnection is impossible.  Force-closing via close() resets the
+        # counter through _disconnect(force=True) so a fresh session can start.
+        task = self._session_state.session_task
+        if task is not None and task.done() and self._session_state.nesting_counter != 0:
+            await self.close()
+
         try:
             await self.__aenter__()
         except RuntimeError as exc:

--- a/tests/sdk/mcp/test_mcp_session_persistence.py
+++ b/tests/sdk/mcp/test_mcp_session_persistence.py
@@ -3,6 +3,10 @@
 Verifies that MCP connections are reused across multiple tool calls,
 avoiding the overhead of reconnecting for each call.
 
+Also covers recovery from the fastmcp nesting-counter stuck state: when a
+background session task dies while nesting_counter > 0, MCPClient.connect()
+must auto-reset and reconnect rather than raising an internal RuntimeError.
+
 Related issue: https://github.com/OpenHands/software-agent-sdk/issues/1739
 """
 
@@ -13,8 +17,10 @@ import time
 
 import pytest
 from fastmcp import FastMCP
+from fastmcp.client.transports import StreamableHttpTransport
 
 from openhands.sdk.mcp import create_mcp_tools
+from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.tool import MCPToolExecutor
 
 
@@ -119,3 +125,114 @@ class TestSessionPersistence:
             action = tool.action_from_arguments({"message": "test"})
             result = executor(action)
             assert "test" in result.text
+
+
+class TestNestingCounterRecovery:
+    """Regression tests for the fastmcp nesting-counter stuck state.
+
+    fastmcp tracks re-entrant context-manager use with an integer
+    nesting_counter.  When a background session task dies unexpectedly
+    (server 500, connection drop, task cancellation) while the counter is
+    non-zero, fastmcp does NOT reset the counter.  Any subsequent attempt to
+    start a new session raises:
+
+        RuntimeError: Internal error: nesting counter should be 0
+                      when starting new session, got N
+
+    MCPClient.connect() works around this by detecting the stuck state and
+    force-closing before reconnecting.
+    """
+
+    # ── helpers ──────────────────────────────────────────────────────────────
+
+    @staticmethod
+    async def _kill_session(client: MCPClient) -> None:
+        """Cancel the background session task, mimicking a server-side failure."""
+        task = client._session_state.session_task
+        if task and not task.done():
+            task.cancel()
+            try:
+                await asyncio.wait_for(asyncio.shield(task), timeout=1.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+
+    @staticmethod
+    def _counter(client: MCPClient) -> int:
+        return client._session_state.nesting_counter
+
+    @staticmethod
+    def _task_done(client: MCPClient) -> bool:
+        task = client._session_state.session_task
+        return task is None or task.done()
+
+    # ── tests ─────────────────────────────────────────────────────────────
+
+    @pytest.mark.asyncio
+    async def test_connect_recovers_from_stuck_counter_at_1(
+        self, live_server: int
+    ) -> None:
+        """connect() after session death (counter=1) succeeds instead of raising."""
+        url = f"http://127.0.0.1:{live_server}/mcp"
+        client = MCPClient(StreamableHttpTransport(url))
+
+        await client.connect()
+        assert self._counter(client) == 1
+
+        await self._kill_session(client)
+        assert self._task_done(client)
+        assert self._counter(client) == 1  # stuck – the bug
+
+        # With the fix, connect() auto-recovers: no exception raised.
+        await client.connect()
+        assert self._counter(client) == 1
+        assert not self._task_done(client)
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_connect_recovers_from_stuck_counter_at_3(
+        self, live_server: int
+    ) -> None:
+        """connect() after session death with counter=3 matches the 'got 3' error."""
+        url = f"http://127.0.0.1:{live_server}/mcp"
+        client = MCPClient(StreamableHttpTransport(url))
+
+        # Simulate the reentrant pattern that produces counter=3.
+        await client.__aenter__()  # counter = 1
+        await client.__aenter__()  # counter = 2
+        await client.__aenter__()  # counter = 3
+        assert self._counter(client) == 3
+
+        await self._kill_session(client)
+        assert self._counter(client) == 3  # stuck
+
+        # connect() detects the stuck state, resets it, and reconnects cleanly.
+        await client.connect()
+        assert self._counter(client) == 1
+        assert not self._task_done(client)
+
+        # The server is actually reachable after recovery.
+        result = await client.call_tool("echo", {"message": "recovered"})
+        assert result is not None
+
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_connect_does_not_disturb_healthy_session(
+        self, live_server: int
+    ) -> None:
+        """connect() when the session is alive should increment counter normally."""
+        url = f"http://127.0.0.1:{live_server}/mcp"
+        client = MCPClient(StreamableHttpTransport(url))
+
+        await client.connect()
+        assert self._counter(client) == 1
+        assert not self._task_done(client)
+
+        # Reentrant connect on a live session must NOT trigger close().
+        await client.connect()
+        assert self._counter(client) == 2  # incremented, not reset
+        assert not self._task_done(client)
+
+        await client.close()
+        assert self._counter(client) == 0


### PR DESCRIPTION
## Problem

When a fastmcp background session task dies unexpectedly (server HTTP 500, connection drop, or task cancellation) while `nesting_counter > 0`, fastmcp does **not** reset the counter. Any subsequent call to `__aenter__` sees `need_to_start=True` with a non-zero counter and raises:

```
RuntimeError: Internal error: nesting counter should be 0 when starting new session, got N
```

This was observed in production as repeated `shttp_notion__*` tool failures after a single HTTP 500 from the integrations-hub context layer:

```
# First call:
Server error '500 Internal Server Error' for url 'https://openhands-context-layer.vercel.app/api/mcp'

# All subsequent calls on the same client:
Internal error: nesting counter should be 0 when starting new session, got 3
```

### Root cause (fastmcp ≤ 3.3.1, unreleased 3.4.0b1 main)

`_session_runner`'s `finally` block only ensures `ready_event` is set — it never touches `nesting_counter`. The counter accumulates through reentrant `__aenter__` calls during a session's lifetime. When the session task then dies, the counter freezes at whatever value it reached (3 in the production case), permanently blocking reconnection.

```python
# fastmcp/client/client.py – _connect()
if need_to_start:
    if self._session_state.nesting_counter != 0:
        raise RuntimeError(          # ← surfaces here after session death
            f"... nesting counter should be 0 ..., got {counter}"
        )
# ...
self._session_state.nesting_counter += 1   # incremented on every entry
```

The `_reset_session_state()` call added to `_context_manager`'s `finally` block in the main branch is called **without `full=True`**, so it resets `session` and `initialize_result` but **never** `nesting_counter`.

## Fix

Detect the stuck state in `MCPClient.connect()` — session task done, counter non-zero — and call `close()` before retrying. `close()` calls `_disconnect(force=True)` which resets the counter to 0, allowing a fresh session to start.

```python
# One condition, no string matching, no retry logic
task = self._session_state.session_task
if task is not None and task.done() and self._session_state.nesting_counter != 0:
    await self.close()
```

This makes `MCPClient.connect()` self-healing: a single call after a server failure reconnects cleanly without the caller needing to know about fastmcp internals.

## Tests

Three new tests in `TestNestingCounterRecovery` (added to `test_mcp_session_persistence.py`):

| Test | What it verifies |
|------|-----------------|
| `test_connect_recovers_from_stuck_counter_at_1` | Standard case: `connect()` once, session dies (counter=1), `connect()` auto-recovers |
| `test_connect_recovers_from_stuck_counter_at_3` | Exact production failure: counter=3 from reentrant use, `connect()` auto-recovers and tool calls succeed |
| `test_connect_does_not_disturb_healthy_session` | Safety: `connect()` on a live session still increments counter normally — the fix only fires when `session_task.done()` |

All 5 tests in the file pass (2 existing + 3 new).

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@xingyaoww can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d71c1853-2562-4035-a0ae-87a28142141e)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6f1e72c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6f1e72c-python \
  ghcr.io/openhands/agent-server:6f1e72c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6f1e72c-golang-amd64
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-golang-amd64
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-golang-amd64
ghcr.io/openhands/agent-server:6f1e72c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6f1e72c-golang-arm64
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-golang-arm64
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-golang-arm64
ghcr.io/openhands/agent-server:6f1e72c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6f1e72c-java-amd64
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-java-amd64
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-java-amd64
ghcr.io/openhands/agent-server:6f1e72c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6f1e72c-java-arm64
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-java-arm64
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-java-arm64
ghcr.io/openhands/agent-server:6f1e72c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6f1e72c-python-amd64
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-python-amd64
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-python-amd64
ghcr.io/openhands/agent-server:6f1e72c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6f1e72c-python-arm64
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-python-arm64
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-python-arm64
ghcr.io/openhands/agent-server:6f1e72c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6f1e72c-golang
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-golang
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-golang
ghcr.io/openhands/agent-server:6f1e72c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6f1e72c-java
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-java
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-java
ghcr.io/openhands/agent-server:6f1e72c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6f1e72c-python
ghcr.io/openhands/agent-server:6f1e72cfc782584f1baad28116dc4f5cb8df027c-python
ghcr.io/openhands/agent-server:fix-mcp-client-nesting-counter-recovery-python
ghcr.io/openhands/agent-server:6f1e72c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6f1e72c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6f1e72c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->