### PR TITLE
fix(sdk): count tools for condenser token limits

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/utils.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/utils.py
@@ -1,6 +1,7 @@
 from collections.abc import Sequence
 
 from openhands.sdk.event.base import LLMConvertibleEvent
+from openhands.sdk.event.llm_convertible.system import SystemPromptEvent
 from openhands.sdk.llm import LLM
 
 
@@ -35,6 +36,16 @@ def get_total_token_count(
         >>> print(f"Total tokens: {token_count}")
     """
     messages = LLMConvertibleEvent.events_to_messages(list(events))
+    tools = next(
+        (event.tools for event in events if isinstance(event, SystemPromptEvent)),
+        None,
+    )
+    if tools:
+        return llm.get_token_count(
+            messages,
+            tools=tools,
+            add_security_risk_prediction=True,
+        )
     return llm.get_token_count(messages)
 
 

--- a/openhands-sdk/openhands/sdk/context/condenser/utils.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/utils.py
@@ -13,7 +13,9 @@ def get_total_token_count(
 
     This function converts the events to LLM messages and uses the provided LLM
     to count the total number of tokens. This is useful for understanding how many
-    tokens a sequence of events will consume in the context window.
+    tokens a sequence of events will consume in the context window. A view is
+    expected to have one system prompt event; if multiple are present, only the
+    first system prompt's tools are included.
 
     Args:
         events: List of LLM convertible events to count tokens for

--- a/openhands-sdk/openhands/sdk/context/condenser/utils.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/utils.py
@@ -40,13 +40,12 @@ def get_total_token_count(
         (event.tools for event in events if isinstance(event, SystemPromptEvent)),
         None,
     )
-    if tools:
-        return llm.get_token_count(
-            messages,
-            tools=tools,
-            add_security_risk_prediction=True,
-        )
-    return llm.get_token_count(messages)
+    return llm.get_token_count(
+        messages,
+        tools=tools or None,
+        # Security-risk tokens are always included in real tool requests.
+        add_security_risk_prediction=bool(tools),
+    )
 
 
 def get_shortest_prefix_above_token_count(

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2009,16 +2009,38 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             return transform_for_subscription(system_chunks, input_items)
         return instructions, input_items
 
-    def get_token_count(self, messages: list[Message]) -> int:
+    def get_token_count(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        add_security_risk_prediction: bool = False,
+    ) -> int:
         logger.debug(
             "Message objects now include serialized tool calls in token counting"
         )
         formatted_messages = self.format_messages_for_llm(messages)
+        cc_tools = [
+            tool.to_openai_tool(
+                add_security_risk_prediction=add_security_risk_prediction,
+            )
+            for tool in tools or []
+        ]
+        use_mock_tools = self.should_mock_tool_calls(cc_tools)
+        if use_mock_tools:
+            formatted_messages, _ = self.pre_request_prompt_mock(
+                formatted_messages,
+                cc_tools,
+                {},
+                include_security_params=add_security_risk_prediction,
+            )
+            cc_tools = []
+
         try:
             return int(
                 token_counter(
                     model=self.model,
                     messages=formatted_messages,
+                    tools=cc_tools or None,
                     custom_tokenizer=self._tokenizer,
                 )
             )

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2027,10 +2027,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         ]
         use_mock_tools = self.should_mock_tool_calls(cc_tools)
         if use_mock_tools:
+            tool_call_state: dict[str, Any] = {}
             formatted_messages, _ = self.pre_request_prompt_mock(
                 formatted_messages,
                 cc_tools,
-                {},
+                tool_call_state,
                 include_security_params=add_security_risk_prediction,
             )
             cc_tools = []

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -300,7 +300,7 @@ def test_condense_with_token_limit_exceeded(mock_llm: LLM) -> None:
     agent_llm.model = "gpt-4"
 
     # Mock get_token_count to return predictable values based on message content length
-    def mock_token_count(messages):
+    def mock_token_count(messages, **_kwargs):
         # Simple heuristic: count characters in all text content
         # Each character = 0.25 tokens (roughly 4 chars per token)
         total_chars = 0
@@ -398,7 +398,7 @@ def test_condense_with_request_and_tokens_reasons(mock_llm: LLM) -> None:
     agent_llm.model = "gpt-4"
 
     # Mock get_token_count to return predictable values
-    def mock_token_count(messages):
+    def mock_token_count(messages, **_kwargs):
         total_chars = 0
         for msg in messages:
             for content in msg.content:
@@ -445,7 +445,7 @@ def test_condense_with_events_and_tokens_reasons(mock_llm: LLM) -> None:
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
 
-    def mock_token_count(messages):
+    def mock_token_count(messages, **_kwargs):
         total_chars = 0
         for msg in messages:
             for content in msg.content:
@@ -491,7 +491,7 @@ def test_condense_with_all_three_reasons(mock_llm: LLM) -> None:
     agent_llm = MagicMock(spec=LLM)
     agent_llm.model = "gpt-4"
 
-    def mock_token_count(messages):
+    def mock_token_count(messages, **_kwargs):
         total_chars = 0
         for msg in messages:
             for content in msg.content:

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -310,7 +310,7 @@ def test_condense_with_token_limit_exceeded(mock_llm: LLM) -> None:
                     total_chars += len(content.text)
         return total_chars // 4
 
-    agent_llm.get_token_count.side_effect = mock_token_count
+    cast(MagicMock, agent_llm.get_token_count).side_effect = mock_token_count
 
     # Create events that exceed token limit
     # Each event has 40 chars = 10 tokens
@@ -406,7 +406,7 @@ def test_condense_with_request_and_tokens_reasons(mock_llm: LLM) -> None:
                     total_chars += len(content.text)
         return total_chars // 4
 
-    agent_llm.get_token_count.side_effect = mock_token_count
+    cast(MagicMock, agent_llm.get_token_count).side_effect = mock_token_count
 
     # Create 20 events with 40 chars each = 10 tokens each = 200 total tokens
     # This exceeds max_tokens of 100 (triggers TOKENS)
@@ -453,7 +453,7 @@ def test_condense_with_events_and_tokens_reasons(mock_llm: LLM) -> None:
                     total_chars += len(content.text)
         return total_chars // 4
 
-    agent_llm.get_token_count.side_effect = mock_token_count
+    cast(MagicMock, agent_llm.get_token_count).side_effect = mock_token_count
 
     # Create 20 events (exceeds max_size of 15) with 40 chars each
     # 20 events * 10 tokens = 200 tokens (exceeds max_tokens of 100)
@@ -499,7 +499,7 @@ def test_condense_with_all_three_reasons(mock_llm: LLM) -> None:
                     total_chars += len(content.text)
         return total_chars // 4
 
-    agent_llm.get_token_count.side_effect = mock_token_count
+    cast(MagicMock, agent_llm.get_token_count).side_effect = mock_token_count
 
     # Create 20 events (exceeds max_size of 15) with 40 chars each
     # 20 events * 10 tokens = 200 tokens (exceeds max_tokens of 100)

--- a/tests/sdk/context/condenser/test_utils.py
+++ b/tests/sdk/context/condenser/test_utils.py
@@ -1,3 +1,4 @@
+from typing import cast
 from unittest.mock import MagicMock
 
 import pytest
@@ -8,7 +9,10 @@ from openhands.sdk.context.condenser.utils import (
     get_total_token_count,
 )
 from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.event.llm_convertible.system import SystemPromptEvent
 from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.tool.builtins.finish import FinishTool
 
 
 def message_event(content: str) -> MessageEvent:
@@ -77,6 +81,27 @@ class TestGetTotalTokenCount:
         call_args = mock_llm.get_token_count.call_args[0][0]  # type: ignore
         assert isinstance(call_args, list)
         assert all(isinstance(msg, Message) for msg in call_args)
+
+    def test_system_prompt_tools_are_counted(self, mock_llm: LLM):
+        """Test that agent tool schemas are included in token counting."""
+        tools = cast(list[ToolDefinition], list(FinishTool.create()))
+        events = [
+            SystemPromptEvent(
+                source="agent",
+                system_prompt=TextContent(text="system"),
+                tools=tools,
+            ),
+            message_event("Test"),
+        ]
+
+        mock_llm.get_token_count.side_effect = None  # type: ignore
+        mock_llm.get_token_count.return_value = 7  # type: ignore
+
+        assert get_total_token_count(events, mock_llm) == 7
+
+        kwargs = mock_llm.get_token_count.call_args.kwargs  # type: ignore
+        assert kwargs["tools"] == tools
+        assert kwargs["add_security_risk_prediction"] is True
 
 
 class TestGetShortestPrefixAboveTokenCount:

--- a/tests/sdk/context/condenser/test_utils.py
+++ b/tests/sdk/context/condenser/test_utils.py
@@ -103,6 +103,26 @@ class TestGetTotalTokenCount:
         assert kwargs["tools"] == tools
         assert kwargs["add_security_risk_prediction"] is True
 
+    def test_system_prompt_empty_tools_are_not_counted(self, mock_llm: LLM):
+        """Test that empty tool lists do not add tool schema tokens."""
+        events = [
+            SystemPromptEvent(
+                source="agent",
+                system_prompt=TextContent(text="system"),
+                tools=[],
+            ),
+            message_event("Test"),
+        ]
+
+        mock_llm.get_token_count.side_effect = None  # type: ignore
+        mock_llm.get_token_count.return_value = 3  # type: ignore
+
+        assert get_total_token_count(events, mock_llm) == 3
+
+        kwargs = mock_llm.get_token_count.call_args.kwargs  # type: ignore
+        assert kwargs["tools"] is None
+        assert kwargs["add_security_risk_prediction"] is False
+
 
 class TestGetShortestPrefixAboveTokenCount:
     """Tests for get_shortest_prefix_above_token_count function."""

--- a/tests/sdk/context/condenser/test_utils.py
+++ b/tests/sdk/context/condenser/test_utils.py
@@ -30,7 +30,7 @@ def mock_llm() -> LLM:
     mock_llm.model = "test-model"
 
     # Mock get_token_count to return predictable values based on message content length
-    def mock_token_count(messages):
+    def mock_token_count(messages, **_kwargs):
         # Simple heuristic: count characters in all text content
         # Each character = 0.25 tokens (roughly 4 chars per token)
         total_chars = 0

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -340,6 +340,38 @@ def test_llm_token_counting_includes_tools(mock_token_counter, default_llm):
     assert "message" in kwargs["tools"][0]["function"]["parameters"]["properties"]
 
 
+@patch("openhands.sdk.llm.llm.token_counter")
+def test_llm_token_counting_mocks_tools_for_non_native_models(mock_token_counter):
+    """Test token counting prompt-mocks tools when native tool calling is disabled."""
+    mock_token_counter.return_value = 456
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        usage_id="non-native-token-count-llm",
+        native_tool_calling=False,
+        caching_prompt=False,
+    )
+    messages = [
+        Message(role="system", content=[TextContent(text="System prompt")]),
+        Message(role="user", content=[TextContent(text="Hello")]),
+    ]
+
+    token_count = llm.get_token_count(
+        messages,
+        tools=list(FinishTool.create()),
+        add_security_risk_prediction=True,
+    )
+
+    assert token_count == 456
+    _, kwargs = mock_token_counter.call_args
+    assert kwargs["tools"] is None
+    formatted_messages = kwargs["messages"]
+    system_text = formatted_messages[0]["content"][0]["text"]
+    assert "You have access to the following functions" in system_text
+    assert "---- BEGIN FUNCTION #1: finish ----" in system_text
+    assert "<parameter=security_risk>LOW</parameter>" in system_text
+
+
 @patch("openhands.sdk.llm.llm.litellm_completion")
 def test_llm_forwards_extra_headers_to_litellm(mock_completion):
     mock_response = create_mock_litellm_response("ok")

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -335,7 +335,7 @@ def test_llm_token_counting_includes_tools(mock_token_counter, default_llm):
 
     assert token_count == 123
     _, kwargs = mock_token_counter.call_args
-    assert kwargs["tools"]
+    assert len(kwargs["tools"]) == 1
     assert kwargs["tools"][0]["function"]["name"] == "finish"
     assert "message" in kwargs["tools"][0]["function"]["parameters"]["properties"]
 

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -15,6 +15,7 @@ from openhands.sdk.llm.exceptions import LLMNoResponseError
 from openhands.sdk.llm.options.responses_options import select_responses_options
 from openhands.sdk.llm.utils.metrics import Metrics, TokenUsage
 from openhands.sdk.llm.utils.telemetry import Telemetry
+from openhands.sdk.tool.builtins.finish import FinishTool
 
 # Import common test utilities
 from tests.conftest import create_mock_litellm_response
@@ -317,6 +318,26 @@ def test_llm_token_counting(default_llm):
     token_count = llm.get_token_count(messages)
     assert isinstance(token_count, int)
     assert token_count >= 0
+
+
+@patch("openhands.sdk.llm.llm.token_counter")
+def test_llm_token_counting_includes_tools(mock_token_counter, default_llm):
+    """Test LLM token counting forwards tool schemas to LiteLLM."""
+    mock_token_counter.return_value = 123
+    messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    tools = list(FinishTool.create())
+
+    token_count = default_llm.get_token_count(
+        messages,
+        tools=tools,
+        add_security_risk_prediction=True,
+    )
+
+    assert token_count == 123
+    _, kwargs = mock_token_counter.call_args
+    assert kwargs["tools"]
+    assert kwargs["tools"][0]["function"]["name"] == "finish"
+    assert "message" in kwargs["tools"][0]["function"]["parameters"]["properties"]
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")


### PR DESCRIPTION
## Summary

- Count agent tool schemas when `LLMSummarizingCondenser(max_tokens=...)` evaluates the current agent prompt size.
- Extend `LLM.get_token_count(...)` with optional `tools` and `add_security_risk_prediction` parameters so token counting mirrors the chat-completion request shape.
- For non-native tool-calling models, count the prompt-mocked tool instructions instead of passing native tools to LiteLLM.
- Add regression coverage for condenser utility token counting and direct LLM tool-schema forwarding.

## Why

The token-based condenser trigger previously counted only converted message history. Agent steps send messages plus tool schemas, so large tool schemas could make the real request exceed the configured token budget before condensation triggered.

This PR keeps the existing condenser semantics: `agent_llm` is still used for agent prompt token counting, and the condenser's configured `llm` is still used for summary generation.

## Tests

- `uv run pytest tests/sdk/context/condenser/test_llm_summarizing_condenser.py tests/sdk/context/condenser/test_utils.py -q`
- `uv run pytest tests/sdk/llm/test_llm.py -q -k 'token_counting'`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py openhands-sdk/openhands/sdk/context/condenser/utils.py openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/context/condenser/test_llm_summarizing_condenser.py tests/sdk/context/condenser/test_utils.py tests/sdk/llm/test_llm.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._






<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:daec90e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-daec90e-python \
  ghcr.io/openhands/agent-server:daec90e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:daec90e-golang-amd64
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-golang-amd64
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-golang-amd64
ghcr.io/openhands/agent-server:daec90e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:daec90e-golang-arm64
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-golang-arm64
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-golang-arm64
ghcr.io/openhands/agent-server:daec90e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:daec90e-java-amd64
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-java-amd64
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-java-amd64
ghcr.io/openhands/agent-server:daec90e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:daec90e-java-arm64
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-java-arm64
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-java-arm64
ghcr.io/openhands/agent-server:daec90e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:daec90e-python-amd64
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-python-amd64
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-python-amd64
ghcr.io/openhands/agent-server:daec90e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:daec90e-python-arm64
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-python-arm64
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-python-arm64
ghcr.io/openhands/agent-server:daec90e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:daec90e-golang
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-golang
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-golang
ghcr.io/openhands/agent-server:daec90e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:daec90e-java
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-java
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-java
ghcr.io/openhands/agent-server:daec90e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:daec90e-python
ghcr.io/openhands/agent-server:daec90ee8d9187a1c0aae6de232cb45a9dbbaea9-python
ghcr.io/openhands/agent-server:fix-condenser-token-tool-count-python
ghcr.io/openhands/agent-server:daec90e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `daec90e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `daec90e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->