### PR TITLE
fix(sdk): make default current_datetime timezone-aware

### DIFF
--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -128,13 +128,16 @@ class AgentContext(BaseModel):
         json_schema_extra={"acp_compatible": True},
     )
     current_datetime: datetime | str | None = Field(
-        default_factory=datetime.now,
+        # Timezone-aware local "now" so the value injected into the system prompt
+        # carries a UTC offset instead of an ambiguous naive local time (#3438).
+        default_factory=lambda: datetime.now().astimezone(),
         description=(
             "Current date and time information to provide to the agent. "
             "Can be a datetime object (which will be formatted as ISO 8601) "
             "or a pre-formatted string. When provided, this information is "
             "included in the system prompt to give the agent awareness of "
-            "the current time context. Defaults to the current datetime."
+            "the current time context. Defaults to the current "
+            "(timezone-aware) datetime."
         ),
         json_schema_extra={"acp_compatible": True},
     )

--- a/tests/sdk/context/test_agent_context.py
+++ b/tests/sdk/context/test_agent_context.py
@@ -988,6 +988,13 @@ templates.",
         # local time) so the datetime injected into the system prompt is
         # unambiguous.
         assert context.current_datetime.tzinfo is not None
+        # The bug surfaced in the rendered value injected into the prompt, not
+        # just the field: get_formatted_datetime() must carry a UTC offset.
+        formatted = context.get_formatted_datetime()
+        assert formatted is not None
+        assert "+" in formatted or "-" in formatted.split("T", 1)[1], (
+            f"formatted datetime should carry a UTC offset, got {formatted!r}"
+        )
         # Verify it's approximately the current time (within 1 second)
         assert before <= context.current_datetime <= after + timedelta(seconds=1)
 

--- a/tests/sdk/context/test_agent_context.py
+++ b/tests/sdk/context/test_agent_context.py
@@ -974,16 +974,20 @@ templates.",
         assert result is None
 
     def test_agent_context_default_datetime(self):
-        """Test that AgentContext defaults to current datetime."""
+        """Test that AgentContext defaults to the current timezone-aware datetime."""
         from datetime import datetime, timedelta
 
-        before = datetime.now()
+        before = datetime.now().astimezone()
         context = AgentContext()
-        after = datetime.now()
+        after = datetime.now().astimezone()
 
         # Verify current_datetime is set and is a datetime object
         assert context.current_datetime is not None
         assert isinstance(context.current_datetime, datetime)
+        # Regression for #3438: the default must be timezone-aware (not naive
+        # local time) so the datetime injected into the system prompt is
+        # unambiguous.
+        assert context.current_datetime.tzinfo is not None
         # Verify it's approximately the current time (within 1 second)
         assert before <= context.current_datetime <= after + timedelta(seconds=1)
 


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

`AgentContext.current_datetime` injects a "current time" into the system prompt (the `<CURRENT_DATETIME>` block). Its default was `Field(default_factory=datetime.now)`, and `datetime.now()` with no argument returns **naive local time**, so `get_formatted_datetime()` emitted e.g. `2026-05-31T02:29:57.162025` with **no UTC offset**. The agent is handed an ambiguous time it can't resolve to an actual instant. (See #3438.)

## Summary

- Default `current_datetime` is now timezone-aware local time (`datetime.now().astimezone()`), so the value injected into the system prompt carries a UTC offset (e.g. `2026-05-31T02:37:24-06:00`) instead of a naive timestamp.
- User-supplied `current_datetime` values (datetime or string) are untouched — `get_formatted_datetime()` still returns them as-is (existing contract preserved).
- Updated `test_agent_context_default_datetime` to assert the default is timezone-aware (regression guard).

## Issue Number

Addresses #3438 (the timezone-ambiguity half — not using "Fixes" on purpose; see Notes).

## How to Test

Reproduce on `main` (before the fix), then confirm after:

```bash
uv run python -c "from openhands.sdk.context.agent_context import AgentContext as A; \
c=A(); print(c.current_datetime.tzinfo, '|', c.get_formatted_datetime())"
```

Rendered system-prompt block, before vs after:

```
# before (main):  naive, no offset
<CURRENT_DATETIME>
The current date and time is: 2026-05-31T02:29:57.162025
</CURRENT_DATETIME>

# after (this PR): timezone-aware, has offset
<CURRENT_DATETIME>
The current date and time is: 2026-05-31T02:37:24.994238-06:00
</CURRENT_DATETIME>
```

A user-supplied naive datetime still renders unchanged (`2024-03-15T14:30:00`).

```bash
uv run pytest tests/sdk/context/                      # 276 passed
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/context/agent_context.py \
  tests/sdk/context/test_agent_context.py             # ruff + pyright + deps: pass
```

## Type

- [x] Bug fix

## Notes

- **Scope:** #3438 also reports the datetime being *frozen* at `AgentContext` construction (stale in long conversations). That's intentionally out of scope here — regenerating it per turn would change the system prompt every turn and defeat prompt caching, so whether/how to refresh it is a design tradeoff for maintainers. This PR resolves only the timezone ambiguity, hence "Addresses" rather than "Fixes" so the stale aspect stays tracked.
- Chose `datetime.now().astimezone()` (local time + offset, minimal change to the displayed value) over forcing UTC; happy to switch to `datetime.now(timezone.utc)` if you'd prefer canonical UTC.
