### PR TITLE
fix(sdk): add missing @observe spans on async agent/conversation paths

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -681,6 +681,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                     response_type=response_type,
                 )
 
+    @observe(name="agent.astep", ignore_inputs=["state", "on_event"])
     async def astep(
         self,
         conversation: LocalConversation,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1056,6 +1056,7 @@ class LocalConversation(BaseConversation):
         finally:
             self._cancel_token = None
 
+    @observe(name="conversation.arun")
     async def arun(self) -> None:
         """Async variant of :meth:`run`.
 

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -8,6 +8,9 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
+from openhands.sdk.agent.agent import Agent
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+
 
 @pytest.fixture(autouse=True)
 def _reset_observability_cache():
@@ -524,3 +527,18 @@ def test_deprecated_shims_emit_warnings():
             lam.SpanManager().start_active_span("conversation")
         with pytest.warns(DeprecationWarning, match="SpanManager.end_active_span"):
             lam.SpanManager().end_active_span()
+
+
+def test_async_agent_and_conversation_paths_are_observed():
+    """The async twins must be ``@observe``-wrapped like their sync versions.
+
+    Regression test for the async-parity gap (issue #3449): ``Agent.astep`` and
+    ``LocalConversation.arun`` lost the tracing decorators their sync twins
+    (``Agent.step`` / ``LocalConversation.run``) carry. The ``observe`` wrapper
+    renames the underlying code object to ``async_wrapper``/``sync_wrapper``, so
+    its presence is detectable via ``__code__.co_name``.
+    """
+    assert Agent.step.__code__.co_name == "sync_wrapper"
+    assert Agent.astep.__code__.co_name == "async_wrapper"
+    assert LocalConversation.run.__code__.co_name == "sync_wrapper"
+    assert LocalConversation.arun.__code__.co_name == "async_wrapper"


### PR DESCRIPTION
<!-- AI/LLM agents: This PR was created by an AI agent (OpenHands). -->

- [x] A human has tested these changes.

---

## Why

The async LLM path added in #3284 did not carry over the `@observe` tracing decorators from its sync twins. Two spans that exist on the sync path are absent on the async path:

| Sync (traced) | Async (NOT traced) |
|---|---|
| `Agent.step` → `@observe(name="agent.step")` | `Agent.astep` → no decorator |
| `LocalConversation.run` → `@observe(name="conversation.run")` | `LocalConversation.arun` → no decorator |

This matters in production because the agent server drives `LocalConversation` through `arun()`/`astep()` by default, so real server runs emit traces missing both the per-conversation envelope and the per-step spans. `ACPAgent` decorates **both** colors (`acp_agent.step` and `acp_agent.astep`), confirming async observability was intended — the base async methods were simply missed when copied from the sync ones.

Observability-only — **no correctness/behavior impact** (no data loss, no crash). See #3449.

## Summary

- `Agent.astep` → `@observe(name="agent.astep", ignore_inputs=["state", "on_event"])`
- `LocalConversation.arun` → `@observe(name="conversation.arun")`

Distinct span names (`agent.astep` / `conversation.arun`) are used so sync and async runs are distinguishable in traces. Low risk: the `observe` wrapper already branches on `inspect.iscoroutinefunction`, so it traces coroutine functions while preserving their async-ness for callers that introspect (e.g. `run_async`). No signature or behavior change.

## How to Test

A regression test asserts all four methods are `@observe`-wrapped (the wrapper renames the underlying code object to `sync_wrapper`/`async_wrapper`):

```bash
uv run pytest tests/sdk/observability/test_laminar.py -q   # 33 passed
```

Pre-commit (ruff, pyright, pycodestyle, import rules) passes on all changed files.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

Closes #3449


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f7063e8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f7063e8-python \
  ghcr.io/openhands/agent-server:f7063e8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f7063e8-golang-amd64
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-golang-amd64
ghcr.io/openhands/agent-server:f7063e8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f7063e8-golang-arm64
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-golang-arm64
ghcr.io/openhands/agent-server:f7063e8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f7063e8-java-amd64
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-java-amd64
ghcr.io/openhands/agent-server:f7063e8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f7063e8-java-arm64
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-java-arm64
ghcr.io/openhands/agent-server:f7063e8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f7063e8-python-amd64
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-python-amd64
ghcr.io/openhands/agent-server:f7063e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f7063e8-python-arm64
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-python-arm64
ghcr.io/openhands/agent-server:f7063e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f7063e8-golang
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-golang
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-golang
ghcr.io/openhands/agent-server:f7063e8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f7063e8-java
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-java
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-java
ghcr.io/openhands/agent-server:f7063e8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f7063e8-python
ghcr.io/openhands/agent-server:f7063e83da3033096009f8d058a95857438967ca-python
ghcr.io/openhands/agent-server:vasco-fix-async-observe-spans-python
ghcr.io/openhands/agent-server:f7063e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f7063e8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f7063e8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->