### PR TITLE
feat(acp): prompt-free auth-status probe + GET /acp/auth-status

### DIFF
--- a/openhands-agent-server/openhands/agent_server/acp_auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/acp_auth_router.py
@@ -1,0 +1,184 @@
+"""ACP authentication-status probe endpoint.
+
+``GET /acp/auth-status?server=<key>`` reports whether the chosen ACP provider's
+CLI is already authenticated — by a subscription login (Claude Pro/Max, ChatGPT,
+Google) *or* a pre-set API key — so the canvas onboarding can show a
+"✓ you're already logged in" banner instead of unconditionally asking for an
+API key.
+
+The browser cannot read the keychain or credential files, so detection must run
+server-side. We avoid sniffing credentials per-OS/topology and instead drive the
+ACP protocol handshake (``initialize`` + ``session/new``) via
+:meth:`ACPAgent.probe_auth`: the handshake only succeeds when the CLI can
+authenticate, and it sends no prompt, so it spends no model tokens. Because the
+probe runs *inside* the agent-server, it reports the truth for wherever the agent
+will actually run, with no topology knowledge needed.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from typing import Annotated, Literal, cast
+
+from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi.concurrency import run_in_threadpool
+from pydantic import BaseModel, Field
+
+from openhands.agent_server._secrets_exposure import get_config
+from openhands.agent_server.persistence import (
+    PersistedSettings,
+    get_secrets_store,
+    get_settings_store,
+)
+from openhands.sdk.agent.acp_agent import ACPAgent, ACPAuthProbeResult
+from openhands.sdk.logger import get_logger
+from openhands.sdk.settings import ACPAgentSettings
+from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
+from openhands.sdk.settings.model import ACPServerKind
+
+
+logger = get_logger(__name__)
+
+acp_auth_router = APIRouter(prefix="/acp", tags=["ACP Auth"])
+
+# Outcome categories the canvas onboarding maps directly onto its
+# ``useAcpAuthStatus`` hook:
+#   - authenticated   → "✓ already logged in" banner; API-key fields optional
+#   - unauthenticated → show the API-key fields (server reachable, not logged in)
+#   - unknown         → the probe could not run/complete; fall back to key fields
+ACPAuthStatusValue = Literal["authenticated", "unauthenticated", "unknown"]
+
+# Cap how much of a probe failure we echo back; these are transport/spawn errors
+# (e.g. a missing ``npx``), not user secrets, but we truncate defensively.
+_MAX_DETAIL_CHARS = 300
+
+
+class ACPAuthStatusResponse(BaseModel):
+    """Result of an ACP auth-status probe for one provider."""
+
+    server: str = Field(description="The ACP provider key that was probed.")
+    status: ACPAuthStatusValue = Field(
+        description=(
+            "'authenticated' (session/new succeeded ⇒ logged in by subscription "
+            "or API key), 'unauthenticated' (server reachable but not logged "
+            "in), or 'unknown' (the probe could not run/complete)."
+        )
+    )
+    auth_methods: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Auth method ids the server advertised at initialize. Informational "
+            "only — the menu of how to log in, not a logged-in signal."
+        ),
+    )
+    agent_name: str = Field(
+        default="", description="ACP server name reported by the handshake."
+    )
+    agent_version: str = Field(
+        default="", description="ACP server version reported by the handshake."
+    )
+    detail: str | None = Field(
+        default=None,
+        description="Populated only when status is 'unknown': why the probe failed.",
+    )
+
+
+def _resolve_acp_settings(server: str, settings: PersistedSettings) -> ACPAgentSettings:
+    """Resolve the ACPAgentSettings to probe ``server`` with.
+
+    Reuses the persisted agent settings when they already target ``server`` (so
+    a user's custom command / configured key are honored); otherwise falls back
+    to a fresh default for that provider.
+    """
+    persisted = settings.agent_settings
+    if isinstance(persisted, ACPAgentSettings) and persisted.acp_server == server:
+        return persisted
+    # ``server`` is validated against ACP_PROVIDERS before this is called, so it
+    # is always a concrete ACPServerKind (never the open-ended "custom").
+    return ACPAgentSettings(acp_server=cast(ACPServerKind, server))
+
+
+@acp_auth_router.get("/auth-status")
+async def get_acp_auth_status(
+    request: Request,
+    server: Annotated[
+        str,
+        Query(title="ACP provider key to probe (e.g. 'claude-code', 'codex')."),
+    ],
+) -> ACPAuthStatusResponse:
+    """Probe whether ``server``'s ACP CLI is already authenticated.
+
+    Resolves the launch command + environment for ``server`` from the registry,
+    the persisted agent settings, and any stored global secrets, then runs a
+    prompt-free :meth:`ACPAgent.probe_auth`. Always returns 200 with a ``status``
+    of ``authenticated`` / ``unauthenticated`` / ``unknown`` — the probe spinning
+    up a subprocess that fails is reported as ``unknown``, not an HTTP error.
+    """
+    if server not in ACP_PROVIDERS:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+            detail=(
+                f"Unknown ACP server {server!r}. Known providers: "
+                f"{', '.join(sorted(ACP_PROVIDERS))}."
+            ),
+        )
+
+    config = get_config(request)
+    settings = get_settings_store(config).load() or PersistedSettings()
+    acp_settings = _resolve_acp_settings(server, settings)
+
+    try:
+        command = acp_settings.resolve_acp_command()
+    except ValueError as e:
+        # Shouldn't happen for a registry provider, but stay honest if it does.
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        )
+
+    # Build the probe environment from stored global secrets (the onboarding-
+    # stored keys) overlaid with the provider-specific env derived from agent
+    # settings, so the settings take precedence — matching how a real
+    # conversation resolves its ACP subprocess environment.
+    env: dict[str, str] = {}
+    stored = get_secrets_store(config).load()
+    if stored is not None:
+        env.update(stored.get_env_vars())
+    env.update(acp_settings.resolve_acp_env())
+
+    client_host = request.client.host if request.client else "unknown"
+    logger.info(
+        "ACP auth-status probe requested",
+        extra={"acp_server": server, "client_host": client_host},
+    )
+
+    # ``session/new`` keys persistence by cwd; a throwaway directory keeps the
+    # probe from leaving session state in any real workspace.
+    try:
+        with tempfile.TemporaryDirectory(prefix="acp-auth-probe-") as cwd:
+            result: ACPAuthProbeResult = await run_in_threadpool(
+                ACPAgent.probe_auth, command, env=env, cwd=cwd
+            )
+    except Exception as e:
+        # Any failure to even run the handshake (subprocess won't start, the
+        # server hangs past the timeout, a protocol error other than
+        # auth_required) is reported as 'unknown' so the canvas falls back to
+        # the API-key fields rather than falsely claiming "not logged in".
+        logger.warning(
+            "ACP auth-status probe failed for %s: %s",
+            server,
+            e,
+            exc_info=True,
+        )
+        return ACPAuthStatusResponse(
+            server=server,
+            status="unknown",
+            detail=f"{type(e).__name__}: {e}"[:_MAX_DETAIL_CHARS],
+        )
+
+    return ACPAuthStatusResponse(
+        server=server,
+        status="authenticated" if result.authenticated else "unauthenticated",
+        auth_methods=result.auth_methods,
+        agent_name=result.agent_name,
+        agent_version=result.agent_version,
+    )

--- a/openhands-agent-server/openhands/agent_server/acp_auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/acp_auth_router.py
@@ -48,9 +48,14 @@ acp_auth_router = APIRouter(prefix="/acp", tags=["ACP Auth"])
 #   - unknown         → the probe could not run/complete; fall back to key fields
 ACPAuthStatusValue = Literal["authenticated", "unauthenticated", "unknown"]
 
-# Cap how much of a probe failure we echo back; these are transport/spawn errors
-# (e.g. a missing ``npx``), not user secrets, but we truncate defensively.
+# Cap how much of a probe failure we echo back. These are transport/spawn errors
+# (e.g. a missing ``npx``), not user secrets, but we both scrub known secret
+# values out of the message and truncate it defensively before surfacing it.
 _MAX_DETAIL_CHARS = 300
+
+# Only scrub env values at least this long, so redaction can't mangle a detail
+# string by blanking out short, non-secret tokens (e.g. "1", "true").
+_MIN_SECRET_LEN = 8
 
 
 class ACPAuthStatusResponse(BaseModel):
@@ -137,8 +142,11 @@ async def get_acp_auth_status(
 
     # Build the probe environment from stored global secrets (the onboarding-
     # stored keys) overlaid with the provider-specific env derived from agent
-    # settings, so the settings take precedence — matching how a real
-    # conversation resolves its ACP subprocess environment.
+    # settings, so the settings take precedence. Note: probe_auth lets every key
+    # here override the agent-server's own process env, whereas a real run
+    # applies registry/agent_context secrets fill-missing (process env wins) — so
+    # for a key defined in *both* a stored secret and the process env, the probe
+    # can authenticate with a different value than the conversation would.
     env: dict[str, str] = {}
     stored = get_secrets_store(config).load()
     if stored is not None:
@@ -169,10 +177,16 @@ async def get_acp_auth_status(
             e,
             exc_info=True,
         )
+        # Scrub any secret/env value the error string might have echoed (e.g. a
+        # provider rejecting a bad key by quoting it back) before truncating.
+        detail = f"{type(e).__name__}: {e}"
+        for value in env.values():
+            if value and len(value) >= _MIN_SECRET_LEN:
+                detail = detail.replace(value, "***")
         return ACPAuthStatusResponse(
             server=server,
             status="unknown",
-            detail=f"{type(e).__name__}: {e}"[:_MAX_DETAIL_CHARS],
+            detail=detail[:_MAX_DETAIL_CHARS],
         )
 
     return ACPAuthStatusResponse(

--- a/openhands-agent-server/openhands/agent_server/acp_auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/acp_auth_router.py
@@ -37,7 +37,10 @@ from openhands.sdk.agent.acp_agent import (
 )
 from openhands.sdk.logger import get_logger
 from openhands.sdk.settings import ACPAgentSettings
-from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
+from openhands.sdk.settings.acp_providers import (
+    ACP_CLI_AUTH_STATUS_ARGS,
+    ACP_PROVIDERS,
+)
 from openhands.sdk.settings.model import ACPServerKind
 
 
@@ -132,12 +135,17 @@ async def get_acp_auth_status(
             ),
         )
 
-    # Some providers (e.g. claude-agent-acp) accept ``session/new`` without
-    # validating credentials — auth is enforced later, at prompt time — so the
-    # handshake probe can't tell logged-in from logged-out and would
-    # false-positive. Report ``unknown`` for those instead of guessing; the
-    # canvas then shows the API-key fields rather than a misleading banner.
-    if not ACP_PROVIDERS[server].supports_auth_status_probe:
+    # Pick a detection strategy. Most providers (codex, gemini) are detected via
+    # the ACP handshake (``probe_auth``). Some — notably claude-agent-acp — accept
+    # ``session/new`` without validating credentials (auth is enforced later, at
+    # prompt time), so the handshake can't tell logged-in from logged-out; for
+    # those we fall back to the CLI's own ``auth status`` subcommand
+    # (``probe_cli_auth_status``) when one is registered. A provider with neither
+    # strategy reports ``unknown`` so the canvas shows the API-key fields rather
+    # than a misleading banner.
+    provider = ACP_PROVIDERS[server]
+    cli_status_args = ACP_CLI_AUTH_STATUS_ARGS.get(server)
+    if not provider.supports_auth_status_probe and cli_status_args is None:
         logger.info("ACP auth-status probe skipped (unsupported provider): %s", server)
         return ACPAuthStatusResponse(
             server=server,
@@ -179,25 +187,39 @@ async def get_acp_auth_status(
         extra={"acp_server": server, "client_host": client_host},
     )
 
-    # ``session/new`` keys persistence by cwd; a throwaway directory keeps the
-    # probe from leaving session state in any real workspace.
+    # Forward the SDK's probe timeout explicitly (single source of truth,
+    # env-overridable via ACP_AUTH_PROBE_TIMEOUT) so a slow/hung CLI can't pin a
+    # FastAPI threadpool worker past that ceiling.
     try:
-        with tempfile.TemporaryDirectory(prefix="acp-auth-probe-") as cwd:
-            # Forward the SDK's probe timeout explicitly (single source of
-            # truth, env-overridable via ACP_AUTH_PROBE_TIMEOUT) so a slow/hung
-            # CLI can't pin a FastAPI threadpool worker past that ceiling.
-            result: ACPAuthProbeResult = await run_in_threadpool(
-                ACPAgent.probe_auth,
+        if provider.supports_auth_status_probe:
+            # ``session/new`` keys persistence by cwd; a throwaway directory keeps
+            # the probe from leaving session state in any real workspace.
+            with tempfile.TemporaryDirectory(prefix="acp-auth-probe-") as cwd:
+                result: ACPAuthProbeResult = await run_in_threadpool(
+                    ACPAgent.probe_auth,
+                    command,
+                    env=env,
+                    cwd=cwd,
+                    timeout=_ACP_AUTH_PROBE_TIMEOUT,
+                )
+        else:
+            # Handshake can't classify this provider; use its CLI auth-status
+            # subcommand instead. ``cli_status_args`` is non-None here — the
+            # early return above filtered out providers with neither strategy.
+            assert cli_status_args is not None
+            result = await run_in_threadpool(
+                ACPAgent.probe_cli_auth_status,
                 command,
+                list(cli_status_args),
                 env=env,
-                cwd=cwd,
                 timeout=_ACP_AUTH_PROBE_TIMEOUT,
             )
     except Exception as e:
-        # Any failure to even run the handshake (subprocess won't start, the
-        # server hangs past the timeout, a protocol error other than
-        # auth_required) is reported as 'unknown' so the canvas falls back to
-        # the API-key fields rather than falsely claiming "not logged in".
+        # Any failure to even run the probe (subprocess won't start, the server
+        # hangs past the timeout, a protocol error other than auth_required, or
+        # unparseable auth-status output) is reported as 'unknown' so the canvas
+        # falls back to the API-key fields rather than falsely claiming
+        # "not logged in".
         logger.warning(
             "ACP auth-status probe failed for %s: %s",
             server,

--- a/openhands-agent-server/openhands/agent_server/acp_auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/acp_auth_router.py
@@ -17,6 +17,7 @@ will actually run, with no topology knowledge needed.
 
 from __future__ import annotations
 
+import os
 import tempfile
 from typing import Annotated, Literal, cast
 
@@ -56,6 +57,13 @@ _MAX_DETAIL_CHARS = 300
 # Only scrub env values at least this long, so redaction can't mangle a detail
 # string by blanking out short, non-secret tokens (e.g. "1", "true").
 _MIN_SECRET_LEN = 8
+
+# Hard ceiling for a single probe so a slow/hung ACP CLI can't pin a FastAPI
+# threadpool worker indefinitely. We forward this explicitly rather than relying
+# on probe_auth's default. 60s (overridable via ACP_AUTH_PROBE_TIMEOUT) is
+# deliberately generous: a cold ``npx -y`` first run downloads the CLI, and a
+# tighter cap would turn cold starts into false "unknown"s.
+_PROBE_TIMEOUT_SECONDS = float(os.environ.get("ACP_AUTH_PROBE_TIMEOUT", "60.0"))
 
 
 class ACPAuthStatusResponse(BaseModel):
@@ -164,7 +172,11 @@ async def get_acp_auth_status(
     try:
         with tempfile.TemporaryDirectory(prefix="acp-auth-probe-") as cwd:
             result: ACPAuthProbeResult = await run_in_threadpool(
-                ACPAgent.probe_auth, command, env=env, cwd=cwd
+                ACPAgent.probe_auth,
+                command,
+                env=env,
+                cwd=cwd,
+                timeout=_PROBE_TIMEOUT_SECONDS,
             )
     except Exception as e:
         # Any failure to even run the handshake (subprocess won't start, the

--- a/openhands-agent-server/openhands/agent_server/acp_auth_router.py
+++ b/openhands-agent-server/openhands/agent_server/acp_auth_router.py
@@ -17,7 +17,6 @@ will actually run, with no topology knowledge needed.
 
 from __future__ import annotations
 
-import os
 import tempfile
 from typing import Annotated, Literal, cast
 
@@ -31,7 +30,11 @@ from openhands.agent_server.persistence import (
     get_secrets_store,
     get_settings_store,
 )
-from openhands.sdk.agent.acp_agent import ACPAgent, ACPAuthProbeResult
+from openhands.sdk.agent.acp_agent import (
+    _ACP_AUTH_PROBE_TIMEOUT,
+    ACPAgent,
+    ACPAuthProbeResult,
+)
 from openhands.sdk.logger import get_logger
 from openhands.sdk.settings import ACPAgentSettings
 from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
@@ -57,13 +60,6 @@ _MAX_DETAIL_CHARS = 300
 # Only scrub env values at least this long, so redaction can't mangle a detail
 # string by blanking out short, non-secret tokens (e.g. "1", "true").
 _MIN_SECRET_LEN = 8
-
-# Hard ceiling for a single probe so a slow/hung ACP CLI can't pin a FastAPI
-# threadpool worker indefinitely. We forward this explicitly rather than relying
-# on probe_auth's default. 60s (overridable via ACP_AUTH_PROBE_TIMEOUT) is
-# deliberately generous: a cold ``npx -y`` first run downloads the CLI, and a
-# tighter cap would turn cold starts into false "unknown"s.
-_PROBE_TIMEOUT_SECONDS = float(os.environ.get("ACP_AUTH_PROBE_TIMEOUT", "60.0"))
 
 
 class ACPAuthStatusResponse(BaseModel):
@@ -136,6 +132,22 @@ async def get_acp_auth_status(
             ),
         )
 
+    # Some providers (e.g. claude-agent-acp) accept ``session/new`` without
+    # validating credentials — auth is enforced later, at prompt time — so the
+    # handshake probe can't tell logged-in from logged-out and would
+    # false-positive. Report ``unknown`` for those instead of guessing; the
+    # canvas then shows the API-key fields rather than a misleading banner.
+    if not ACP_PROVIDERS[server].supports_auth_status_probe:
+        logger.info("ACP auth-status probe skipped (unsupported provider): %s", server)
+        return ACPAuthStatusResponse(
+            server=server,
+            status="unknown",
+            detail=(
+                f"{server} does not report login state through the ACP handshake; "
+                "its credentials can't be probed server-side."
+            ),
+        )
+
     config = get_config(request)
     settings = get_settings_store(config).load() or PersistedSettings()
     acp_settings = _resolve_acp_settings(server, settings)
@@ -171,12 +183,15 @@ async def get_acp_auth_status(
     # probe from leaving session state in any real workspace.
     try:
         with tempfile.TemporaryDirectory(prefix="acp-auth-probe-") as cwd:
+            # Forward the SDK's probe timeout explicitly (single source of
+            # truth, env-overridable via ACP_AUTH_PROBE_TIMEOUT) so a slow/hung
+            # CLI can't pin a FastAPI threadpool worker past that ceiling.
             result: ACPAuthProbeResult = await run_in_threadpool(
                 ACPAgent.probe_auth,
                 command,
                 env=env,
                 cwd=cwd,
-                timeout=_PROBE_TIMEOUT_SECONDS,
+                timeout=_ACP_AUTH_PROBE_TIMEOUT,
             )
     except Exception as e:
         # Any failure to even run the handshake (subprocess won't start, the

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -15,6 +15,7 @@ from fastapi.responses import JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
 
+from openhands.agent_server.acp_auth_router import acp_auth_router
 from openhands.agent_server.auth_router import auth_router
 from openhands.agent_server.bash_router import bash_router
 from openhands.agent_server.bash_service import get_default_bash_event_service
@@ -301,6 +302,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(event_router)
     api_router.include_router(conversation_router)
     api_router.include_router(conversation_router_acp)
+    api_router.include_router(acp_auth_router)
     api_router.include_router(tool_router)
     api_router.include_router(bash_router)
     api_router.include_router(git_router)

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -45,6 +45,8 @@ from acp.schema import (
 )
 from acp.transports import default_environment
 from pydantic import (
+    BaseModel,
+    ConfigDict,
     Field,
     PrivateAttr,
     SecretStr,
@@ -125,6 +127,23 @@ _RETRIABLE_CONNECTION_ERRORS = (OSError, ConnectionError, BrokenPipeError, EOFEr
 #          upstream model 500s, and transient infrastructure errors.
 _RETRIABLE_SERVER_ERROR_CODES: frozenset[int] = frozenset({-32603})
 
+# JSON-RPC error code an ACP server returns from ``session/new`` when the
+# underlying CLI has no working credentials — ``RequestError.auth_required``
+# (acp.exceptions, code -32000, "Authentication required").  This is the one
+# error ``ACPAgent.probe_auth`` classifies as "not logged in" rather than a
+# failure: any other error means the probe could not determine login state.
+_ACP_AUTH_REQUIRED_CODE: int = -32000
+
+# Default hard cap (seconds) for ``ACPAgent.probe_auth``.  Generous because a
+# cold ``npx -y`` first run can take 10-30s to download the ACP CLI; deployed
+# images that pre-bake the CLI complete in a few seconds.
+_ACP_AUTH_PROBE_TIMEOUT: float = float(os.environ.get("ACP_AUTH_PROBE_TIMEOUT", "60.0"))
+
+# Cap (seconds) on the graceful connection-close during a probe teardown.
+# Bounded so a wedged ACP subprocess can't hang teardown — after this we fall
+# through to terminate()/kill() regardless.
+_ACP_TEARDOWN_TIMEOUT: float = 5.0
+
 
 # Maximum characters for ACP tool call content — matches MAX_CMD_OUTPUT_SIZE
 # used by the terminal tool and the default max_message_chars in LLM config.
@@ -143,6 +162,24 @@ MAX_ACP_CONTENT_CHARS: int = 30_000
 _ENV_CONFLICT_MAP: dict[str, frozenset[str]] = {
     "CLAUDE_CONFIG_DIR": frozenset({"ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL"}),
 }
+
+
+def _apply_env_conflict_rules(env: dict[str, str]) -> None:
+    """Strip env vars that would break the active auth mechanism, in place.
+
+    Drops ``CLAUDECODE`` so a nested Claude Code instance does not refuse to
+    start, then applies :data:`_ENV_CONFLICT_MAP` (e.g. removing
+    ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_BASE_URL`` when ``CLAUDE_CONFIG_DIR``
+    selects Claude Code's OAuth credential-file flow).  Shared by
+    :meth:`ACPAgent._start_acp_server` and :meth:`ACPAgent.probe_auth` so both
+    paths build the subprocess environment with identical rules.
+    """
+    env.pop("CLAUDECODE", None)
+    for dominant, conflicts in _ENV_CONFLICT_MAP.items():
+        if dominant in env:
+            for conflict in conflicts:
+                env.pop(conflict, None)
+
 
 # Limit for asyncio.StreamReader buffers used by the ACP subprocess pipes.
 # The default (64 KiB) is too small for session_update notifications that
@@ -806,6 +843,164 @@ class _OpenHandsACPBridge:
 
 
 # ---------------------------------------------------------------------------
+# Shared ACP handshake helpers (used by _start_acp_server and probe_auth)
+# ---------------------------------------------------------------------------
+
+
+async def _spawn_acp_connection(
+    client: _OpenHandsACPBridge,
+    command: str,
+    args: list[str],
+    env: dict[str, str],
+) -> tuple[Any, ClientSideConnection, asyncio.StreamReader]:
+    """Spawn the ACP subprocess and wrap it in a JSON-RPC connection.
+
+    Spawns ``command`` directly (rather than via the ACP helper) so a
+    filtering reader can drop the non-JSON-RPC lines some servers (e.g.
+    ``claude-code-acp`` v0.1.x) write to stdout. Returns the live
+    ``(process, connection, filtered_reader)`` triple; the **caller owns
+    teardown** (see :func:`_teardown_acp_connection`).
+    """
+    process = await asyncio.create_subprocess_exec(
+        command,
+        *args,
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        env=env,
+        limit=_STREAM_READER_LIMIT,
+    )
+    assert process.stdin is not None
+    assert process.stdout is not None
+
+    # Wrap subprocess stdout in a filtering reader that only forwards
+    # JSON-RPC lines (see _filter_jsonrpc_lines).
+    filtered_reader = asyncio.StreamReader(limit=_STREAM_READER_LIMIT)
+    asyncio.get_event_loop().create_task(
+        _filter_jsonrpc_lines(process.stdout, filtered_reader)
+    )
+
+    conn = ClientSideConnection(
+        client,
+        process.stdin,  # write to subprocess
+        filtered_reader,  # read filtered output
+    )
+    return process, conn, filtered_reader
+
+
+async def _acp_initialize(
+    conn: ClientSideConnection,
+    env: dict[str, str],
+) -> tuple[str, str, list[str]]:
+    """Run the ACP ``initialize`` handshake and authenticate if required.
+
+    Returns ``(agent_name, agent_version, auth_method_ids)`` discovered from
+    ``InitializeResponse``. Some servers (e.g. ``codex-acp``) require an
+    explicit ``authenticate`` call before session creation; the method is
+    auto-selected from the credentials present in ``env`` and the cached
+    subscription/OAuth files (see :func:`_select_auth_method`). When no method
+    matches, session creation may still succeed if the CLI has its own login.
+
+    Shared by :meth:`ACPAgent._start_acp_server` and
+    :meth:`ACPAgent.probe_auth`.
+    """
+    init_response = await conn.initialize(protocol_version=1)
+    agent_name = ""
+    agent_version = ""
+    if init_response.agent_info is not None:
+        agent_name = init_response.agent_info.name or ""
+        agent_version = init_response.agent_info.version or ""
+    logger.info(
+        "ACP server initialized: agent_name=%r, agent_version=%r",
+        agent_name,
+        agent_version,
+    )
+
+    auth_methods = init_response.auth_methods or []
+    if auth_methods:
+        method_id = _select_auth_method(auth_methods, env)
+        if method_id is not None:
+            logger.info("Authenticating with ACP method: %s", method_id)
+            auth_kwargs: dict[str, Any] = {}
+            # gemini-cli: pass gateway baseUrl to route API calls through the
+            # LiteLLM proxy. claude-agent-acp and codex-acp read their provider
+            # base URL from env vars directly.
+            if method_id == "gemini-api-key":
+                provider = detect_acp_provider_by_agent_name(agent_name)
+                base_url_var = (
+                    provider.base_url_env_var if provider is not None else None
+                )
+                if base_url_var:
+                    base_url = env.get(base_url_var)
+                    if base_url:
+                        auth_kwargs["gateway"] = {"baseUrl": base_url}
+            await conn.authenticate(method_id=method_id, **auth_kwargs)
+        else:
+            logger.warning(
+                "ACP server offers auth methods %s but no matching "
+                "env var is set — session creation may fail",
+                [m.id for m in auth_methods],
+            )
+    return agent_name, agent_version, [m.id for m in auth_methods]
+
+
+async def _teardown_acp_connection(conn: Any, process: Any) -> None:
+    """Best-effort teardown of a probe's ACP connection and subprocess.
+
+    Closes the JSON-RPC connection (bounded by :data:`_ACP_TEARDOWN_TIMEOUT` so
+    a wedged subprocess can't hang here), then terminates and kills the
+    subprocess. Every step is guarded so a failure in one does not skip the
+    others; used by :meth:`ACPAgent.probe_auth`, which owns a short-lived
+    connection rather than the instance-level resources
+    :meth:`ACPAgent._cleanup` manages.
+    """
+    try:
+        await asyncio.wait_for(conn.close(), timeout=_ACP_TEARDOWN_TIMEOUT)
+    except Exception:
+        logger.debug("Error closing probe ACP connection", exc_info=True)
+    if process is not None:
+        for stop in (process.terminate, process.kill):
+            try:
+                stop()
+            except Exception:
+                logger.debug("Error stopping probe ACP process", exc_info=True)
+
+
+class ACPAuthProbeResult(BaseModel):
+    """Result of a prompt-free ACP authentication probe.
+
+    Produced by :meth:`ACPAgent.probe_auth`. ``authenticated`` is the headline
+    signal: ``True`` when ``session/new`` succeeded (the CLI found working
+    credentials — a subscription login *or* an API key), ``False`` when the
+    server returned ``auth_required``. The remaining fields echo what the
+    ``initialize`` handshake reported, for display/diagnostics.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    authenticated: bool = Field(
+        description=(
+            "True when session/new succeeded ⇒ the ACP CLI is logged in "
+            "(by subscription or API key). False on an auth_required error."
+        )
+    )
+    auth_methods: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Auth method ids from initialize.authMethods. Informational only: "
+            "the menu of how to log in, not a reliable logged-in signal."
+        ),
+    )
+    agent_name: str = Field(
+        default="", description="ACP server name from InitializeResponse.agent_info."
+    )
+    agent_version: str = Field(
+        default="",
+        description="ACP server version from InitializeResponse.agent_info.",
+    )
+
+
+# ---------------------------------------------------------------------------
 # ACPAgent
 # ---------------------------------------------------------------------------
 
@@ -1356,16 +1551,10 @@ class ACPAgent(AgentBase):
                 )
                 if value:
                     env[name] = value
-        # Strip CLAUDECODE so nested Claude Code instances don't refuse to start
-        env.pop("CLAUDECODE", None)
-
-        # Strip env vars that conflict with an active auth mechanism.
-        # E.g. CLAUDE_CONFIG_DIR (OAuth credential file) conflicts with
-        # ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL (API-key + proxy auth).
-        for dominant, conflicts in _ENV_CONFLICT_MAP.items():
-            if dominant in env:
-                for conflict in conflicts:
-                    env.pop(conflict, None)
+        # Drop CLAUDECODE (nested Claude Code) and strip env vars that conflict
+        # with an active auth mechanism (e.g. CLAUDE_CONFIG_DIR's OAuth
+        # credential file vs ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL).
+        _apply_env_conflict_rules(env)
 
         command = self.acp_command[0]
         args = list(self.acp_command[1:]) + list(self.acp_args)
@@ -1396,33 +1585,11 @@ class ACPAgent(AgentBase):
         async def _init() -> tuple[
             str, str, str, str | None, list[ACPModelInfo] | None, bool
         ]:
-            # Spawn the subprocess directly so we can install a
-            # filtering reader that skips non-JSON-RPC lines some
-            # ACP servers (e.g. claude-code-acp v0.1.x) write to
-            # stdout.
-            process = await asyncio.create_subprocess_exec(
-                command,
-                *args,
-                stdin=asyncio.subprocess.PIPE,
-                stdout=asyncio.subprocess.PIPE,
-                stderr=asyncio.subprocess.PIPE,
-                env=env,
-                limit=_STREAM_READER_LIMIT,
-            )
-            assert process.stdin is not None
-            assert process.stdout is not None
-
-            # Wrap the subprocess stdout in a filtering reader that
-            # only passes lines starting with '{' (JSON-RPC messages).
-            filtered_reader = asyncio.StreamReader(limit=_STREAM_READER_LIMIT)
-            asyncio.get_event_loop().create_task(
-                _filter_jsonrpc_lines(process.stdout, filtered_reader)
-            )
-
-            conn = ClientSideConnection(
-                client,
-                process.stdin,  # write to subprocess
-                filtered_reader,  # read filtered output
+            # Spawn the subprocess and install a JSON-RPC filtering reader
+            # (some servers, e.g. claude-code-acp v0.1.x, write non-protocol
+            # lines to stdout).
+            process, conn, filtered_reader = await _spawn_acp_connection(
+                client, command, args, env
             )
 
             # Track the subprocess/connection on self as soon as they exist, so
@@ -1436,48 +1603,12 @@ class ACPAgent(AgentBase):
             self._conn = conn
             self._filtered_reader = filtered_reader
 
-            # Initialize the protocol and discover server identity
-            init_response = await conn.initialize(protocol_version=1)
-            agent_name = ""
-            agent_version = ""
-            if init_response.agent_info is not None:
-                agent_name = init_response.agent_info.name or ""
-                agent_version = init_response.agent_info.version or ""
-            logger.info(
-                "ACP server initialized: agent_name=%r, agent_version=%r",
-                agent_name,
-                agent_version,
+            # Initialize the protocol, discover server identity, and
+            # authenticate if the server requires it (auto-selected from the
+            # credentials available in env / cached subscription files).
+            agent_name, agent_version, _auth_method_ids = await _acp_initialize(
+                conn, env
             )
-
-            # Authenticate if the server requires it.  Some ACP servers
-            # (e.g. codex-acp) require an explicit authenticate call
-            # before session creation.  We auto-detect the method from
-            # the env vars that are available to the process.
-            auth_methods = init_response.auth_methods or []
-            if auth_methods:
-                method_id = _select_auth_method(auth_methods, env)
-                if method_id is not None:
-                    logger.info("Authenticating with ACP method: %s", method_id)
-                    auth_kwargs: dict[str, Any] = {}
-                    # gemini-cli: pass gateway baseUrl to route API calls
-                    # through LiteLLM proxy. claude-agent-acp and codex-acp
-                    # read their provider base URL from env vars directly.
-                    if method_id == "gemini-api-key":
-                        provider = detect_acp_provider_by_agent_name(agent_name)
-                        base_url_var = (
-                            provider.base_url_env_var if provider is not None else None
-                        )
-                        if base_url_var:
-                            base_url = env.get(base_url_var)
-                            if base_url:
-                                auth_kwargs["gateway"] = {"baseUrl": base_url}
-                    await conn.authenticate(method_id=method_id, **auth_kwargs)
-                else:
-                    logger.warning(
-                        "ACP server offers auth methods %s but no matching "
-                        "env var is set — session creation may fail",
-                        [m.id for m in auth_methods],
-                    )
 
             # Resume the prior ACP session if we have its id.  If the server
             # has forgotten it (state wiped, new host, etc.) fall through to
@@ -1592,6 +1723,123 @@ class ACPAgent(AgentBase):
             self._model_override_applied,
         ) = self._executor.run_async(_init)
         self._working_dir = working_dir
+
+    @staticmethod
+    def probe_auth(
+        command: list[str],
+        *,
+        args: list[str] | None = None,
+        env: dict[str, str] | None = None,
+        cwd: str | None = None,
+        timeout: float = _ACP_AUTH_PROBE_TIMEOUT,
+    ) -> ACPAuthProbeResult:
+        """Probe whether an ACP server is already authenticated — prompt-free.
+
+        Runs the same lightweight handshake as :meth:`_start_acp_server`
+        (spawn → ``initialize`` → best-effort ``authenticate`` → ``session/new``)
+        and then tears the subprocess down. **No prompt is sent, so no model
+        tokens are spent.** The reliable signal is the outcome of ``session/new``:
+
+        - it **succeeds** ⇒ the CLI found working credentials (a subscription
+          login *or* an API key) ⇒ ``authenticated=True``;
+        - it fails with ``auth_required`` (JSON-RPC ``-32000``) ⇒ not logged in
+          ⇒ ``authenticated=False``.
+
+        ``initialize.authMethods`` alone is *not* a reliable logged-in signal
+        (Claude omits it once authed; Gemini lists it even when authed), so it
+        is returned for display only.
+
+        This is the agent-server-side detection behind the ACP onboarding
+        "you're already logged in" banner: the browser can't read the keychain
+        or credential files, but the ACP CLI — running wherever the agent-server
+        runs — reports the truth through the protocol handshake, keeping the
+        caller OS- and topology-agnostic.
+
+        Args:
+            command: Full launch command for the ACP server, e.g. the output of
+                ``ACPAgentSettings.resolve_acp_command()``. ``command[0]`` is the
+                executable; the remainder are arguments.
+            args: Extra arguments appended after ``command[1:]`` (the ``acp_args``
+                equivalent).
+            env: Extra environment variables overlaid on the inherited process
+                environment (the ``acp_env`` equivalent — typically the provider
+                API key / base URL resolved from settings). The same
+                CLAUDECODE / auth-conflict stripping as ``_start_acp_server`` is
+                applied (see :func:`_apply_env_conflict_rules`).
+            cwd: Working directory for ``session/new``. Login state does not
+                depend on it, so a throwaway directory is fine; defaults to the
+                current process directory.
+            timeout: Hard cap in seconds for the whole probe.
+
+        Returns:
+            An :class:`ACPAuthProbeResult`.
+
+        Raises:
+            ValueError: if ``command`` is empty.
+            TimeoutError: if the probe exceeds ``timeout``.
+            Exception: any transport/protocol error other than ``auth_required``
+                (e.g. the subprocess failing to start) propagates — callers
+                should treat it as "unknown", not "not logged in".
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        if not command:
+            raise ValueError("probe_auth() requires a non-empty command")
+        executable = command[0]
+        full_args = list(command[1:]) + list(args or [])
+
+        # Mirror _start_acp_server's environment construction: inherit the
+        # process env, overlay the caller-supplied extras, then strip the
+        # CLAUDECODE / auth-conflicting vars so the probe authenticates exactly
+        # as a real conversation would.
+        full_env = default_environment()
+        full_env.update(os.environ)
+        full_env.update(env or {})
+        _apply_env_conflict_rules(full_env)
+
+        working_dir = cwd if cwd is not None else os.getcwd()
+
+        async def _handshake(conn: ClientSideConnection) -> ACPAuthProbeResult:
+            agent_name, agent_version, auth_method_ids = await _acp_initialize(
+                conn, full_env
+            )
+            authenticated = True
+            try:
+                await conn.new_session(cwd=working_dir, mcp_servers=[])
+            except ACPRequestError as e:
+                if e.code != _ACP_AUTH_REQUIRED_CODE:
+                    raise
+                authenticated = False
+                logger.info(
+                    "ACP auth probe: %s is not logged in (auth_required)",
+                    agent_name or executable,
+                )
+            return ACPAuthProbeResult(
+                authenticated=authenticated,
+                auth_methods=auth_method_ids,
+                agent_name=agent_name,
+                agent_version=agent_version,
+            )
+
+        async def _probe() -> ACPAuthProbeResult:
+            # Spawn first (fast, no hang risk), then bound the handshake with the
+            # timeout *inside* the coroutine so the teardown in ``finally`` is
+            # guaranteed to run on this same event loop before we hand control
+            # back — even on timeout — rather than leaking the subprocess.
+            client = _OpenHandsACPBridge()
+            process, conn, _reader = await _spawn_acp_connection(
+                client, executable, full_args, full_env
+            )
+            try:
+                return await asyncio.wait_for(_handshake(conn), timeout=timeout)
+            finally:
+                await _teardown_acp_connection(conn, process)
+
+        executor = AsyncExecutor()
+        try:
+            return executor.run_async(_probe)
+        finally:
+            executor.close()
 
     def _reset_client_for_turn(
         self,

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1800,8 +1800,10 @@ class ACPAgent(AgentBase):
         instead uses a different error code, or lets ``session/new`` succeed and
         only fails at first prompt, would be misreported (``unknown`` is the safe
         outcome the router falls back on; a false ``authenticated`` is the risky
-        one). Validated against the real ``claude-code`` CLI; ``codex`` and
-        ``gemini`` auth_required paths are covered by mock-transport tests only.
+        one). Confirmed against the real CLIs for ``claude-code`` and
+        ``gemini-cli`` 0.43.0 (logged-out ``session/new`` → ``-32000``, and the
+        logged-in path → success); ``codex``'s explicit-``authenticate`` →
+        ``-32000`` path is covered by tests against a simulated server.
 
         This is the agent-server-side detection behind the ACP onboarding
         "you're already logged in" banner: the browser can't read the keychain

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -852,14 +852,16 @@ async def _spawn_acp_connection(
     command: str,
     args: list[str],
     env: dict[str, str],
-) -> tuple[Any, ClientSideConnection, asyncio.StreamReader]:
+) -> tuple[Any, ClientSideConnection, asyncio.StreamReader, asyncio.Task[None]]:
     """Spawn the ACP subprocess and wrap it in a JSON-RPC connection.
 
     Spawns ``command`` directly (rather than via the ACP helper) so a
     filtering reader can drop the non-JSON-RPC lines some servers (e.g.
     ``claude-code-acp`` v0.1.x) write to stdout. Returns the live
-    ``(process, connection, filtered_reader)`` triple; the **caller owns
-    teardown** (see :func:`_teardown_acp_connection`).
+    ``(process, connection, filtered_reader, reader_task)`` tuple; the **caller
+    owns teardown** (see :func:`_teardown_acp_connection`), including cancelling
+    ``reader_task`` — otherwise a short-lived caller whose loop closes right
+    after (e.g. :meth:`ACPAgent.probe_auth`) leaks it as a destroyed-pending-task.
     """
     process = await asyncio.create_subprocess_exec(
         command,
@@ -876,7 +878,7 @@ async def _spawn_acp_connection(
     # Wrap subprocess stdout in a filtering reader that only forwards
     # JSON-RPC lines (see _filter_jsonrpc_lines).
     filtered_reader = asyncio.StreamReader(limit=_STREAM_READER_LIMIT)
-    asyncio.get_event_loop().create_task(
+    reader_task = asyncio.get_running_loop().create_task(
         _filter_jsonrpc_lines(process.stdout, filtered_reader)
     )
 
@@ -885,7 +887,7 @@ async def _spawn_acp_connection(
         process.stdin,  # write to subprocess
         filtered_reader,  # read filtered output
     )
-    return process, conn, filtered_reader
+    return process, conn, filtered_reader, reader_task
 
 
 async def _acp_initialize(
@@ -944,35 +946,54 @@ async def _acp_initialize(
     return agent_name, agent_version, [m.id for m in auth_methods]
 
 
-async def _teardown_acp_connection(conn: Any, process: Any) -> None:
+async def _teardown_acp_connection(
+    conn: Any, process: Any, reader_task: Any = None
+) -> None:
     """Best-effort teardown of a probe's ACP connection and subprocess.
 
-    Closes the JSON-RPC connection (bounded by :data:`_ACP_TEARDOWN_TIMEOUT` so
-    a wedged subprocess can't hang here), then terminates, kills, and reaps the
-    subprocess. Every step is guarded so a failure in one does not skip the
-    others; used by :meth:`ACPAgent.probe_auth`, which owns a short-lived
-    connection rather than the instance-level resources
+    Cancels the stdout filter task, closes the JSON-RPC connection (bounded by
+    :data:`_ACP_TEARDOWN_TIMEOUT` so a wedged subprocess can't hang here), then
+    gracefully terminates the subprocess (SIGTERM → reap → escalate to SIGKILL
+    only if it doesn't exit in time). Every step is guarded so a failure in one
+    does not skip the others; used by :meth:`ACPAgent.probe_auth`, which owns a
+    short-lived connection rather than the instance-level resources
     :meth:`ACPAgent._cleanup` manages.
     """
+    # Cancel the stdout filter task first. It only ends naturally on stdout EOF
+    # (which races with killing the subprocess); without cancelling, a caller
+    # whose event loop closes right after teardown (probe_auth) leaks it as a
+    # "Task was destroyed but it is pending" warning.
+    if reader_task is not None:
+        reader_task.cancel()
+        try:
+            await reader_task
+        except asyncio.CancelledError:
+            pass
+        except Exception:
+            logger.debug("Probe ACP reader task error on teardown", exc_info=True)
     try:
         await asyncio.wait_for(conn.close(), timeout=_ACP_TEARDOWN_TIMEOUT)
     except Exception:
         logger.debug("Error closing probe ACP connection", exc_info=True)
     if process is not None:
+        # SIGTERM, then reap (process.wait); only escalate to SIGKILL if it
+        # doesn't exit within the timeout. Reaping clears asyncio's child watcher
+        # so a standalone SDK/CLI caller (whose event loop closes right after
+        # probe_auth returns) doesn't see a "Loop ... that handles pid ... is
+        # closed" warning — the agent-server path avoids it only because its loop
+        # stays alive.
         for stop in (process.terminate, process.kill):
             try:
                 stop()
             except Exception:
                 logger.debug("Error stopping probe ACP process", exc_info=True)
-        # Reap the subprocess after signalling it. Without this, asyncio's child
-        # watcher still tracks the pid, so a standalone SDK/CLI caller (whose
-        # event loop closes right after probe_auth returns) sees a noisy
-        # "Loop ... that handles pid ... is closed" warning. The agent-server
-        # path avoids it only because its loop stays alive.
-        try:
-            await asyncio.wait_for(process.wait(), timeout=_ACP_TEARDOWN_TIMEOUT)
-        except Exception:
-            logger.debug("Probe ACP process did not exit cleanly", exc_info=True)
+            try:
+                await asyncio.wait_for(process.wait(), timeout=_ACP_TEARDOWN_TIMEOUT)
+                break  # exited; no need to escalate to SIGKILL
+            except Exception:
+                logger.debug(
+                    "Probe ACP process did not exit after signal", exc_info=True
+                )
 
 
 class ACPAuthProbeResult(BaseModel):
@@ -1597,7 +1618,10 @@ class ACPAgent(AgentBase):
             # Spawn the subprocess and install a JSON-RPC filtering reader
             # (some servers, e.g. claude-code-acp v0.1.x, write non-protocol
             # lines to stdout).
-            process, conn, filtered_reader = await _spawn_acp_connection(
+            # The reader task here lives on the instance's long-lived executor
+            # loop and ends on stdout EOF when _cleanup() terminates the
+            # subprocess, so (unlike the probe) it doesn't orphan; left untracked.
+            process, conn, filtered_reader, _reader_task = await _spawn_acp_connection(
                 client, command, args, env
             )
 
@@ -1745,18 +1769,27 @@ class ACPAgent(AgentBase):
         """Probe whether an ACP server is already authenticated — prompt-free.
 
         Runs the same lightweight handshake as :meth:`_start_acp_server`
-        (spawn → ``initialize`` → best-effort ``authenticate`` → ``session/new``)
-        and then tears the subprocess down. **No prompt is sent, so no model
-        tokens are spent.** The reliable signal is the outcome of ``session/new``:
+        (spawn → ``initialize`` → ``authenticate`` if the server asks for it →
+        ``session/new``) and then tears the subprocess down. **No prompt is
+        sent, so no model tokens are spent.** The signal is an ``auth_required``
+        (JSON-RPC ``-32000``) error from *either* the ``authenticate`` call or
+        ``session/new``:
 
-        - it **succeeds** ⇒ the CLI found working credentials (a subscription
+        - neither raises it ⇒ the CLI found working credentials (a subscription
           login *or* an API key) ⇒ ``authenticated=True``;
-        - it fails with ``auth_required`` (JSON-RPC ``-32000``) ⇒ not logged in
-          ⇒ ``authenticated=False``.
+        - either raises it ⇒ not logged in ⇒ ``authenticated=False``.
 
         ``initialize.authMethods`` alone is *not* a reliable logged-in signal
         (Claude omits it once authed; Gemini lists it even when authed), so it
         is returned for display only.
+
+        Reliability caveat: this assumes every supported CLI reports missing
+        credentials via the ``-32000`` ``auth_required`` code. A provider that
+        instead uses a different error code, or lets ``session/new`` succeed and
+        only fails at first prompt, would be misreported (``unknown`` is the safe
+        outcome the router falls back on; a false ``authenticated`` is the risky
+        one). Validated against the real ``claude-code`` CLI; ``codex`` and
+        ``gemini`` auth_required paths are covered by mock-transport tests only.
 
         This is the agent-server-side detection behind the ACP onboarding
         "you're already logged in" banner: the browser can't read the keychain
@@ -1799,8 +1832,14 @@ class ACPAgent(AgentBase):
 
         # Mirror _start_acp_server's environment construction: inherit the
         # process env, overlay the caller-supplied extras, then strip the
-        # CLAUDECODE / auth-conflicting vars so the probe authenticates exactly
-        # as a real conversation would.
+        # CLAUDECODE / auth-conflicting vars so the probe authenticates as a real
+        # conversation would. Caveat: here every key in ``env`` overrides
+        # os.environ. That matches _start_acp_server for ``acp_env``, but there
+        # secret-registry / agent_context secrets are applied *fill-missing*
+        # (os.environ wins). So if the caller folds stored secrets into ``env``
+        # and one shadows a process-env var of the same name (e.g.
+        # ANTHROPIC_API_KEY), the probe may authenticate with a different value
+        # than the real run — an edge case, but a real precedence divergence.
         full_env = default_environment()
         full_env.update(os.environ)
         full_env.update(env or {})
@@ -1809,11 +1848,19 @@ class ACPAgent(AgentBase):
         working_dir = cwd if cwd is not None else os.getcwd()
 
         async def _handshake(conn: ClientSideConnection) -> ACPAuthProbeResult:
-            agent_name, agent_version, auth_method_ids = await _acp_initialize(
-                conn, full_env
-            )
             authenticated = True
+            agent_name = ""
+            agent_version = ""
+            auth_method_ids: list[str] = []
+            # A single auth_required guard around the whole handshake: some
+            # servers (e.g. codex-acp) surface "not logged in" from the explicit
+            # ``authenticate`` call inside _acp_initialize rather than from
+            # ``session/new``. Catching it in either place classifies as
+            # unauthenticated instead of letting it bubble up to "unknown".
             try:
+                agent_name, agent_version, auth_method_ids = await _acp_initialize(
+                    conn, full_env
+                )
                 await conn.new_session(cwd=working_dir, mcp_servers=[])
             except ACPRequestError as e:
                 if e.code != _ACP_AUTH_REQUIRED_CODE:
@@ -1831,18 +1878,26 @@ class ACPAgent(AgentBase):
             )
 
         async def _probe() -> ACPAuthProbeResult:
-            # Spawn first (fast, no hang risk), then bound the handshake with the
-            # timeout *inside* the coroutine so the teardown in ``finally`` is
-            # guaranteed to run on this same event loop before we hand control
-            # back — even on timeout — rather than leaking the subprocess.
+            # Bound spawn + handshake under ``timeout`` together (a hung spawn
+            # shouldn't escape the cap), while guaranteeing teardown runs on this
+            # same event loop in ``finally`` — even on timeout — so the
+            # subprocess and reader task are never leaked.
             client = _OpenHandsACPBridge()
-            process, conn, _reader = await _spawn_acp_connection(
-                client, executable, full_args, full_env
-            )
+            process: Any = None
+            conn: Any = None
+            reader_task: Any = None
+
+            async def _spawn_and_handshake() -> ACPAuthProbeResult:
+                nonlocal process, conn, reader_task
+                process, conn, _reader, reader_task = await _spawn_acp_connection(
+                    client, executable, full_args, full_env
+                )
+                return await _handshake(conn)
+
             try:
-                return await asyncio.wait_for(_handshake(conn), timeout=timeout)
+                return await asyncio.wait_for(_spawn_and_handshake(), timeout=timeout)
             finally:
-                await _teardown_acp_connection(conn, process)
+                await _teardown_acp_connection(conn, process, reader_task)
 
         executor = AsyncExecutor()
         try:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -20,6 +20,7 @@ import asyncio
 import inspect
 import json
 import os
+import subprocess
 import threading
 import time
 import uuid
@@ -179,6 +180,29 @@ def _apply_env_conflict_rules(env: dict[str, str]) -> None:
         if dominant in env:
             for conflict in conflicts:
                 env.pop(conflict, None)
+
+
+def _parse_cli_auth_status(stdout: str) -> dict[str, Any]:
+    """Extract the JSON object printed by a CLI ``auth status --json`` command.
+
+    Used by :meth:`ACPAgent.probe_cli_auth_status`. Tolerates leading/trailing
+    noise (banners, log lines) the CLI may interleave on stdout by falling back
+    to the first ``{`` … last ``}`` slice. Raises ``ValueError`` if no JSON
+    object can be recovered — the caller treats that as "unknown".
+    """
+    text = stdout.strip()
+    try:
+        obj = json.loads(text)
+    except json.JSONDecodeError:
+        start, end = text.find("{"), text.rfind("}")
+        if start == -1 or end == -1 or end < start:
+            raise ValueError(
+                f"no JSON object in auth-status output: {text[:200]!r}"
+            ) from None
+        obj = json.loads(text[start : end + 1])
+    if not isinstance(obj, dict):
+        raise ValueError("auth-status output was not a JSON object")
+    return obj
 
 
 # Limit for asyncio.StreamReader buffers used by the ACP subprocess pipes.
@@ -1935,6 +1959,80 @@ class ACPAgent(AgentBase):
             return executor.run_async(_probe)
         finally:
             executor.close()
+
+    @staticmethod
+    def probe_cli_auth_status(
+        command: list[str],
+        status_args: list[str],
+        *,
+        env: dict[str, str] | None = None,
+        timeout: float = _ACP_AUTH_PROBE_TIMEOUT,
+    ) -> ACPAuthProbeResult:
+        """Probe login state via the CLI's own ``auth status`` subcommand.
+
+        A fallback for ACP servers whose protocol handshake can't report login
+        state — notably ``claude-agent-acp``, which accepts ``session/new``
+        without validating credentials (auth is enforced later, at prompt time),
+        so :meth:`probe_auth` would false-positive ``authenticated``. Instead of
+        the handshake, this runs ``command + status_args`` — e.g.
+        ``npx -y @agentclientprotocol/claude-agent-acp --cli auth status --json``
+        — and reads the ``loggedIn`` boolean from the JSON it prints.
+
+        The CLI resolves credentials from wherever it stores them (macOS
+        Keychain, ``~/.claude/.credentials.json``, …), so detection stays OS-
+        and topology-agnostic without the agent-server reading those stores
+        itself, and reflects wherever the agent-server runs. No prompt is sent ⇒
+        no model tokens are spent.
+
+        The subcommand may exit non-zero when logged out, so the result is taken
+        from the parsed ``loggedIn`` field, not the exit code. A command that
+        can't run, times out, or whose output has no boolean ``loggedIn`` raises
+        — callers should treat that as "unknown", not "not logged in".
+
+        Args:
+            command: The ACP server launch command (``command[0]`` executable).
+            status_args: Args appended to invoke the CLI's auth-status mode.
+            env: Extra environment overlaid on the inherited process env, with
+                the same conflict-stripping as :meth:`probe_auth`.
+            timeout: Hard cap in seconds for the subprocess.
+
+        Returns:
+            An :class:`ACPAuthProbeResult` (``authenticated`` from ``loggedIn``;
+            ``auth_methods`` carries the reported ``authMethod`` when present).
+        """
+        if not command:
+            raise ValueError("probe_cli_auth_status() requires a non-empty command")
+
+        # Mirror probe_auth's environment construction so the status check sees
+        # the same credentials a real conversation would.
+        full_env = default_environment()
+        full_env.update(os.environ)
+        full_env.update(env or {})
+        _apply_env_conflict_rules(full_env)
+
+        full_command = list(command) + list(status_args)
+        proc = subprocess.run(
+            full_command,
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            env=full_env,
+            check=False,
+        )
+        payload = _parse_cli_auth_status(proc.stdout)
+        logged_in = payload.get("loggedIn")
+        if not isinstance(logged_in, bool):
+            raise ValueError(
+                "auth-status output missing a boolean 'loggedIn' "
+                f"(exit={proc.returncode}, stdout={proc.stdout[:200]!r})"
+            )
+        auth_method = payload.get("authMethod")
+        return ACPAuthProbeResult(
+            authenticated=logged_in,
+            auth_methods=(
+                [auth_method] if isinstance(auth_method, str) and auth_method else []
+            ),
+        )
 
     def _reset_client_for_turn(
         self,

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -852,7 +852,12 @@ async def _spawn_acp_connection(
     command: str,
     args: list[str],
     env: dict[str, str],
-) -> tuple[Any, ClientSideConnection, asyncio.StreamReader, asyncio.Task[None]]:
+) -> tuple[
+    asyncio.subprocess.Process,
+    ClientSideConnection,
+    asyncio.StreamReader,
+    asyncio.Task[None],
+]:
     """Spawn the ACP subprocess and wrap it in a JSON-RPC connection.
 
     Spawns ``command`` directly (rather than via the ACP helper) so a
@@ -995,6 +1000,7 @@ async def _teardown_acp_connection(
         # probe_auth returns) doesn't see a "Loop ... that handles pid ... is
         # closed" warning — the agent-server path avoids it only because its loop
         # stays alive.
+        reaped = False
         for stop in (process.terminate, process.kill):
             try:
                 stop()
@@ -1002,11 +1008,21 @@ async def _teardown_acp_connection(
                 logger.debug("Error stopping probe ACP process", exc_info=True)
             try:
                 await asyncio.wait_for(process.wait(), timeout=_ACP_TEARDOWN_TIMEOUT)
+                reaped = True
                 break  # exited; no need to escalate to SIGKILL
             except Exception:
                 logger.debug(
                     "Probe ACP process did not exit after signal", exc_info=True
                 )
+        if not reaped:
+            # Both SIGTERM and SIGKILL failed to reap it (extremely rare on
+            # POSIX). Surface it: the subprocess may be orphaned and its pid
+            # leaked rather than silently abandoning it.
+            logger.warning(
+                "Probe ACP subprocess (pid=%s) did not exit after SIGTERM+SIGKILL; "
+                "it may be orphaned",
+                getattr(process, "pid", "?"),
+            )
 
 
 class ACPAuthProbeResult(BaseModel):
@@ -1795,15 +1811,17 @@ class ACPAgent(AgentBase):
         (Claude omits it once authed; Gemini lists it even when authed), so it
         is returned for display only.
 
-        Reliability caveat: this assumes every supported CLI reports missing
-        credentials via the ``-32000`` ``auth_required`` code. A provider that
-        instead uses a different error code, or lets ``session/new`` succeed and
-        only fails at first prompt, would be misreported (``unknown`` is the safe
-        outcome the router falls back on; a false ``authenticated`` is the risky
-        one). Confirmed against the real CLIs for ``claude-code`` and
-        ``gemini-cli`` 0.43.0 (logged-out ``session/new`` → ``-32000``, and the
-        logged-in path → success); ``codex``'s explicit-``authenticate`` →
-        ``-32000`` path is covered by tests against a simulated server.
+        Reliability caveat: this only works for CLIs that actually validate
+        credentials at ``session/new`` (or ``authenticate``) and report a
+        missing-credential failure via the ``-32000`` ``auth_required`` code.
+        Verified against the real ``codex-acp`` and ``gemini-cli`` CLIs
+        (logged-out → ``-32000``, logged-in → success). It does **not** hold for
+        ``claude-agent-acp``: that server accepts ``session/new`` without
+        checking auth (it's enforced later, at prompt time), so the probe would
+        false-positive ``authenticated`` for a logged-out user. Callers must not
+        probe such providers — the agent-server gates them out via
+        ``ACPProviderInfo.supports_auth_status_probe`` (``False`` for
+        claude-code) and returns ``unknown`` instead.
 
         This is the agent-server-side detection behind the ACP onboarding
         "you're already logged in" banner: the browser can't read the keychain
@@ -1862,10 +1880,6 @@ class ACPAgent(AgentBase):
         working_dir = cwd if cwd is not None else os.getcwd()
 
         async def _handshake(conn: ClientSideConnection) -> ACPAuthProbeResult:
-            authenticated = True
-            agent_name = ""
-            agent_version = ""
-            auth_method_ids: list[str] = []
             # Capture the initialize metadata first and *outside* the auth_required
             # guard, so the not-logged-in result still reports the agent
             # name/version and offered methods. A single guard then wraps both
@@ -1875,6 +1889,7 @@ class ACPAgent(AgentBase):
             # unauthenticated instead of letting it bubble up to "unknown".
             agent_name, agent_version, auth_methods = await _acp_initialize(conn)
             auth_method_ids = [m.id for m in auth_methods]
+            authenticated = True
             try:
                 await _acp_authenticate(conn, full_env, agent_name, auth_methods)
                 await conn.new_session(cwd=working_dir, mcp_servers=[])

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -948,7 +948,7 @@ async def _teardown_acp_connection(conn: Any, process: Any) -> None:
     """Best-effort teardown of a probe's ACP connection and subprocess.
 
     Closes the JSON-RPC connection (bounded by :data:`_ACP_TEARDOWN_TIMEOUT` so
-    a wedged subprocess can't hang here), then terminates and kills the
+    a wedged subprocess can't hang here), then terminates, kills, and reaps the
     subprocess. Every step is guarded so a failure in one does not skip the
     others; used by :meth:`ACPAgent.probe_auth`, which owns a short-lived
     connection rather than the instance-level resources
@@ -964,6 +964,15 @@ async def _teardown_acp_connection(conn: Any, process: Any) -> None:
                 stop()
             except Exception:
                 logger.debug("Error stopping probe ACP process", exc_info=True)
+        # Reap the subprocess after signalling it. Without this, asyncio's child
+        # watcher still tracks the pid, so a standalone SDK/CLI caller (whose
+        # event loop closes right after probe_auth returns) sees a noisy
+        # "Loop ... that handles pid ... is closed" warning. The agent-server
+        # path avoids it only because its loop stays alive.
+        try:
+            await asyncio.wait_for(process.wait(), timeout=_ACP_TEARDOWN_TIMEOUT)
+        except Exception:
+            logger.debug("Probe ACP process did not exit cleanly", exc_info=True)
 
 
 class ACPAuthProbeResult(BaseModel):

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -892,18 +892,16 @@ async def _spawn_acp_connection(
 
 async def _acp_initialize(
     conn: ClientSideConnection,
-    env: dict[str, str],
-) -> tuple[str, str, list[str]]:
-    """Run the ACP ``initialize`` handshake and authenticate if required.
+) -> tuple[str, str, list[Any]]:
+    """Run the ACP ``initialize`` handshake and report what the server advertised.
 
-    Returns ``(agent_name, agent_version, auth_method_ids)`` discovered from
-    ``InitializeResponse``. Some servers (e.g. ``codex-acp``) require an
-    explicit ``authenticate`` call before session creation; the method is
-    auto-selected from the credentials present in ``env`` and the cached
-    subscription/OAuth files (see :func:`_select_auth_method`). When no method
-    matches, session creation may still succeed if the CLI has its own login.
-
-    Shared by :meth:`ACPAgent._start_acp_server` and
+    Returns ``(agent_name, agent_version, auth_methods)`` from
+    ``InitializeResponse`` — the *raw* advertised auth-method objects, to be
+    passed to :func:`_acp_authenticate`. The metadata is captured here, before
+    any authenticate step, so a caller can preserve it even when a later
+    ``authenticate`` / ``session/new`` fails (see :meth:`ACPAgent.probe_auth`,
+    which still wants the agent name/version + offered methods on the
+    not-logged-in path). Shared by :meth:`ACPAgent._start_acp_server` and
     :meth:`ACPAgent.probe_auth`.
     """
     init_response = await conn.initialize(protocol_version=1)
@@ -917,33 +915,48 @@ async def _acp_initialize(
         agent_name,
         agent_version,
     )
+    return agent_name, agent_version, list(init_response.auth_methods or [])
 
-    auth_methods = init_response.auth_methods or []
-    if auth_methods:
-        method_id = _select_auth_method(auth_methods, env)
-        if method_id is not None:
-            logger.info("Authenticating with ACP method: %s", method_id)
-            auth_kwargs: dict[str, Any] = {}
-            # gemini-cli: pass gateway baseUrl to route API calls through the
-            # LiteLLM proxy. claude-agent-acp and codex-acp read their provider
-            # base URL from env vars directly.
-            if method_id == "gemini-api-key":
-                provider = detect_acp_provider_by_agent_name(agent_name)
-                base_url_var = (
-                    provider.base_url_env_var if provider is not None else None
-                )
-                if base_url_var:
-                    base_url = env.get(base_url_var)
-                    if base_url:
-                        auth_kwargs["gateway"] = {"baseUrl": base_url}
-            await conn.authenticate(method_id=method_id, **auth_kwargs)
-        else:
-            logger.warning(
-                "ACP server offers auth methods %s but no matching "
-                "env var is set — session creation may fail",
-                [m.id for m in auth_methods],
-            )
-    return agent_name, agent_version, [m.id for m in auth_methods]
+
+async def _acp_authenticate(
+    conn: ClientSideConnection,
+    env: dict[str, str],
+    agent_name: str,
+    auth_methods: list[Any],
+) -> None:
+    """Authenticate against the ACP server when it advertised auth methods.
+
+    Some servers (e.g. ``codex-acp``) require an explicit ``authenticate`` call
+    before session creation; the method is auto-selected from the credentials
+    present in ``env`` and the cached subscription/OAuth files (see
+    :func:`_select_auth_method`). When no method matches this is a no-op — session
+    creation may still succeed via the CLI's own login. Split out from
+    :func:`_acp_initialize` so callers capture the initialize metadata *before* an
+    auth failure here can discard it.
+    """
+    if not auth_methods:
+        return
+    method_id = _select_auth_method(auth_methods, env)
+    if method_id is None:
+        logger.warning(
+            "ACP server offers auth methods %s but no matching "
+            "env var is set — session creation may fail",
+            [m.id for m in auth_methods],
+        )
+        return
+    logger.info("Authenticating with ACP method: %s", method_id)
+    auth_kwargs: dict[str, Any] = {}
+    # gemini-cli: pass gateway baseUrl to route API calls through the LiteLLM
+    # proxy. claude-agent-acp and codex-acp read their provider base URL from
+    # env vars directly.
+    if method_id == "gemini-api-key":
+        provider = detect_acp_provider_by_agent_name(agent_name)
+        base_url_var = provider.base_url_env_var if provider is not None else None
+        if base_url_var:
+            base_url = env.get(base_url_var)
+            if base_url:
+                auth_kwargs["gateway"] = {"baseUrl": base_url}
+    await conn.authenticate(method_id=method_id, **auth_kwargs)
 
 
 async def _teardown_acp_connection(
@@ -1639,9 +1652,8 @@ class ACPAgent(AgentBase):
             # Initialize the protocol, discover server identity, and
             # authenticate if the server requires it (auto-selected from the
             # credentials available in env / cached subscription files).
-            agent_name, agent_version, _auth_method_ids = await _acp_initialize(
-                conn, env
-            )
+            agent_name, agent_version, _auth_methods = await _acp_initialize(conn)
+            await _acp_authenticate(conn, env, agent_name, _auth_methods)
 
             # Resume the prior ACP session if we have its id.  If the server
             # has forgotten it (state wiped, new host, etc.) fall through to
@@ -1852,15 +1864,17 @@ class ACPAgent(AgentBase):
             agent_name = ""
             agent_version = ""
             auth_method_ids: list[str] = []
-            # A single auth_required guard around the whole handshake: some
-            # servers (e.g. codex-acp) surface "not logged in" from the explicit
-            # ``authenticate`` call inside _acp_initialize rather than from
-            # ``session/new``. Catching it in either place classifies as
+            # Capture the initialize metadata first and *outside* the auth_required
+            # guard, so the not-logged-in result still reports the agent
+            # name/version and offered methods. A single guard then wraps both
+            # authenticate and session/new: some servers (e.g. codex-acp) surface
+            # "not logged in" from the explicit ``authenticate`` call rather than
+            # from ``session/new`` — catching it in either place classifies as
             # unauthenticated instead of letting it bubble up to "unknown".
+            agent_name, agent_version, auth_methods = await _acp_initialize(conn)
+            auth_method_ids = [m.id for m in auth_methods]
             try:
-                agent_name, agent_version, auth_method_ids = await _acp_initialize(
-                    conn, full_env
-                )
+                await _acp_authenticate(conn, full_env, agent_name, auth_methods)
                 await conn.new_session(cwd=working_dir, mcp_servers=[])
             except ACPRequestError as e:
                 if e.code != _ACP_AUTH_REQUIRED_CODE:

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -312,6 +312,22 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
 """Read-only registry of built-in ACP providers keyed by ``acp_server`` value."""
 
 
+# Per-provider CLI auth-status fallback for servers whose ACP handshake can't
+# report login state (``supports_auth_status_probe=False``). These args are
+# appended to the provider's launch command to invoke the CLI's own auth-status
+# subcommand, which prints JSON containing a ``loggedIn`` boolean
+# (see ``ACPAgent.probe_cli_auth_status``). For ``claude-agent-acp`` the ``--cli``
+# flag re-exposes the bundled Claude CLI's ``auth status`` so no separate
+# ``claude`` binary need be installed.
+#
+# Kept as a module constant rather than an ``ACPProviderInfo`` field so the
+# dataclass — and its exact mirror in typescript-client's ``acp-providers.json``
+# (enforced by the drift check) — stays unchanged.
+ACP_CLI_AUTH_STATUS_ARGS: dict[str, tuple[str, ...]] = {
+    "claude-code": ("--cli", "auth", "status", "--json"),
+}
+
+
 def get_acp_provider(key: str) -> ACPProviderInfo | None:
     """Return the :class:`ACPProviderInfo` for ``key``, or ``None`` if unknown."""
     return ACP_PROVIDERS.get(key)

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -162,6 +162,24 @@ class ACPProviderInfo:
     signature break; the built-in providers set it explicitly.
     """
 
+    supports_auth_status_probe: bool = True
+    """``True`` if this provider's login state can be detected via the ACP
+    handshake behind ``GET /acp/auth-status`` (see ``ACPAgent.probe_auth``).
+
+    The probe infers login from ``session/new``: an ``auth_required`` (-32000)
+    error ⇒ not logged in, success ⇒ logged in. That only holds for servers
+    that actually validate credentials at session-creation time (codex-acp,
+    gemini-cli — both return -32000 when logged out, verified against the real
+    CLIs).
+
+    ``False`` for ``claude-agent-acp``: it does **not** gate auth at
+    ``session/new`` (the call always succeeds and auth is enforced later, at
+    prompt time), so a probe would false-positive ``authenticated`` for a
+    logged-out user. The endpoint returns ``unknown`` for such providers instead
+    of guessing. Detecting Claude login needs an out-of-band credential check
+    (env / ``~/.claude`` / keychain) — tracked separately, not done here.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Curated ``acp_model`` candidate lists for the built-in providers.
@@ -251,6 +269,10 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             session_meta_key="claudeCode",
             available_models=_CLAUDE_MODELS,
             default_model="claude-opus-4-7",
+            # claude-agent-acp accepts session/new without validating creds
+            # (auth is enforced at prompt time), so the auth-status probe would
+            # false-positive — the endpoint returns "unknown" for it instead.
+            supports_auth_status_probe=False,
         ),
         "codex": ACPProviderInfo(
             key="codex",

--- a/tests/agent_server/test_acp_auth_router.py
+++ b/tests/agent_server/test_acp_auth_router.py
@@ -1,0 +1,194 @@
+"""Tests for the ACP auth-status probe router (GET /acp/auth-status)."""
+
+import os
+import tempfile
+from base64 import urlsafe_b64encode
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from fastapi.testclient import TestClient
+from pydantic import SecretStr
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+from openhands.agent_server.persistence import (
+    PersistedSettings,
+    get_secrets_store,
+    get_settings_store,
+    reset_stores,
+)
+from openhands.sdk.agent.acp_agent import ACPAuthProbeResult
+from openhands.sdk.settings import ACPAgentSettings
+from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
+
+
+PROBE_PATH = "openhands.agent_server.acp_auth_router.ACPAgent.probe_auth"
+
+
+@pytest.fixture
+def temp_persistence_dir():
+    """Isolated persistence dir + fresh store singletons per test."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        reset_stores()
+        old_val = os.environ.get("OH_PERSISTENCE_DIR")
+        os.environ["OH_PERSISTENCE_DIR"] = tmpdir
+        yield Path(tmpdir)
+        reset_stores()
+        if old_val is not None:
+            os.environ["OH_PERSISTENCE_DIR"] = old_val
+        else:
+            os.environ.pop("OH_PERSISTENCE_DIR", None)
+
+
+@pytest.fixture
+def config(temp_persistence_dir):
+    return Config(
+        static_files_path=None,
+        session_api_keys=[],
+        secret_key=SecretStr(urlsafe_b64encode(b"a" * 32).decode("ascii")),
+    )
+
+
+@pytest.fixture
+def client(config):
+    return TestClient(create_app(config))
+
+
+def _result(
+    *,
+    authenticated: bool = True,
+    auth_methods: list[str] | None = None,
+    agent_name: str = "",
+    agent_version: str = "",
+) -> ACPAuthProbeResult:
+    return ACPAuthProbeResult(
+        authenticated=authenticated,
+        auth_methods=auth_methods or [],
+        agent_name=agent_name,
+        agent_version=agent_version,
+    )
+
+
+def test_unknown_server_returns_422(client):
+    response = client.get("/api/acp/auth-status", params={"server": "bogus"})
+    assert response.status_code == 422
+    assert "bogus" in response.json()["detail"]
+
+
+def test_missing_server_param_returns_422(client):
+    # ``server`` is a required query parameter.
+    response = client.get("/api/acp/auth-status")
+    assert response.status_code == 422
+
+
+def test_authenticated_status(client):
+    probe_result = _result(
+        authenticated=True,
+        auth_methods=["chatgpt", "openai-api-key"],
+        agent_name="codex-acp",
+        agent_version="2.0",
+    )
+    with patch(PROBE_PATH, return_value=probe_result) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["server"] == "codex"
+    assert body["status"] == "authenticated"
+    assert body["auth_methods"] == ["chatgpt", "openai-api-key"]
+    assert body["agent_name"] == "codex-acp"
+    assert body["agent_version"] == "2.0"
+    assert body["detail"] is None
+    mock_probe.assert_called_once()
+
+
+def test_unauthenticated_status(client):
+    with patch(PROBE_PATH, return_value=_result(authenticated=False)):
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "unauthenticated"
+    assert body["detail"] is None
+
+
+def test_unknown_status_on_probe_error(client):
+    with patch(PROBE_PATH, side_effect=RuntimeError("npx not found")):
+        response = client.get("/api/acp/auth-status", params={"server": "gemini-cli"})
+
+    # The probe failing to run is reported as 'unknown', not an HTTP error, so
+    # the canvas gracefully falls back to the API-key fields.
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "unknown"
+    assert "RuntimeError" in body["detail"]
+    assert "npx not found" in body["detail"]
+
+
+def test_unknown_status_on_timeout(client):
+    with patch(PROBE_PATH, side_effect=TimeoutError()):
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+    assert response.status_code == 200
+    assert response.json()["status"] == "unknown"
+
+
+def test_resolves_default_command_for_server(client):
+    # With no ACP settings persisted, the command comes from the registry
+    # default for the requested provider.
+    with patch(PROBE_PATH, return_value=_result()) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    command = mock_probe.call_args.args[0]
+    assert command == list(ACP_PROVIDERS["claude-code"].default_command)
+
+
+def test_uses_persisted_acp_command_override(client, config):
+    # A persisted ACPAgentSettings whose acp_server matches the probe is reused,
+    # so a user's custom launch command is honored.
+    get_settings_store(config).save(
+        PersistedSettings(
+            agent_settings=ACPAgentSettings(
+                acp_server="claude-code",
+                acp_command=["my-claude-acp", "--flag"],
+            )
+        )
+    )
+    with patch(PROBE_PATH, return_value=_result()) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    assert mock_probe.call_args.args[0] == ["my-claude-acp", "--flag"]
+
+
+def test_includes_stored_secrets_in_probe_env(client, config):
+    # Global secrets stored during onboarding are folded into the probe env so
+    # the handshake authenticates exactly as a real conversation would.
+    get_secrets_store(config).set_secret(name="ANTHROPIC_API_KEY", value="sk-stored")
+
+    with patch(PROBE_PATH, return_value=_result()) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    env = mock_probe.call_args.kwargs["env"]
+    assert env["ANTHROPIC_API_KEY"] == "sk-stored"
+
+
+def test_settings_env_overrides_stored_secret(client, config):
+    # When both a stored secret and the agent-settings provider env supply the
+    # same var, the settings value wins (matches real conversation precedence).
+    get_secrets_store(config).set_secret(name="ANTHROPIC_API_KEY", value="sk-secret")
+    get_settings_store(config).save(
+        PersistedSettings(
+            agent_settings=ACPAgentSettings(
+                acp_server="claude-code",
+                acp_env={"ANTHROPIC_API_KEY": "sk-settings"},
+            )
+        )
+    )
+    with patch(PROBE_PATH, return_value=_result()) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    assert mock_probe.call_args.kwargs["env"]["ANTHROPIC_API_KEY"] == "sk-settings"

--- a/tests/agent_server/test_acp_auth_router.py
+++ b/tests/agent_server/test_acp_auth_router.py
@@ -144,6 +144,18 @@ def test_resolves_default_command_for_server(client):
     assert command == list(ACP_PROVIDERS["claude-code"].default_command)
 
 
+def test_forwards_explicit_probe_timeout(client):
+    # The router caps each probe explicitly so a hung CLI can't pin a threadpool
+    # worker for longer than the configured ceiling.
+    from openhands.agent_server.acp_auth_router import _PROBE_TIMEOUT_SECONDS
+
+    with patch(PROBE_PATH, return_value=_result()) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    assert mock_probe.call_args.kwargs["timeout"] == _PROBE_TIMEOUT_SECONDS
+
+
 def test_uses_persisted_acp_command_override(client, config):
     # A persisted ACPAgentSettings whose acp_server matches the probe is reused,
     # so a user's custom launch command is honored.

--- a/tests/agent_server/test_acp_auth_router.py
+++ b/tests/agent_server/test_acp_auth_router.py
@@ -105,7 +105,7 @@ def test_authenticated_status(client):
 
 def test_unauthenticated_status(client):
     with patch(PROBE_PATH, return_value=_result(authenticated=False)):
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
     body = response.json()
@@ -128,32 +128,47 @@ def test_unknown_status_on_probe_error(client):
 
 def test_unknown_status_on_timeout(client):
     with patch(PROBE_PATH, side_effect=TimeoutError()):
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
     assert response.status_code == 200
     assert response.json()["status"] == "unknown"
+
+
+def test_claude_code_returns_unknown_without_probing(client):
+    # claude-agent-acp doesn't validate auth at session/new, so the protocol
+    # probe would false-positive. The router must short-circuit to 'unknown'
+    # WITHOUT spawning a probe.
+    with patch(PROBE_PATH) as mock_probe:
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["server"] == "claude-code"
+    assert body["status"] == "unknown"
+    assert body["detail"]  # explains why it can't be probed
+    mock_probe.assert_not_called()
 
 
 def test_resolves_default_command_for_server(client):
     # With no ACP settings persisted, the command comes from the registry
     # default for the requested provider.
     with patch(PROBE_PATH, return_value=_result()) as mock_probe:
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
     command = mock_probe.call_args.args[0]
-    assert command == list(ACP_PROVIDERS["claude-code"].default_command)
+    assert command == list(ACP_PROVIDERS["codex"].default_command)
 
 
 def test_forwards_explicit_probe_timeout(client):
     # The router caps each probe explicitly so a hung CLI can't pin a threadpool
     # worker for longer than the configured ceiling.
-    from openhands.agent_server.acp_auth_router import _PROBE_TIMEOUT_SECONDS
+    from openhands.sdk.agent.acp_agent import _ACP_AUTH_PROBE_TIMEOUT
 
     with patch(PROBE_PATH, return_value=_result()) as mock_probe:
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
-    assert mock_probe.call_args.kwargs["timeout"] == _PROBE_TIMEOUT_SECONDS
+    assert mock_probe.call_args.kwargs["timeout"] == _ACP_AUTH_PROBE_TIMEOUT
 
 
 def test_uses_persisted_acp_command_override(client, config):
@@ -162,61 +177,61 @@ def test_uses_persisted_acp_command_override(client, config):
     get_settings_store(config).save(
         PersistedSettings(
             agent_settings=ACPAgentSettings(
-                acp_server="claude-code",
-                acp_command=["my-claude-acp", "--flag"],
+                acp_server="codex",
+                acp_command=["my-codex-acp", "--flag"],
             )
         )
     )
     with patch(PROBE_PATH, return_value=_result()) as mock_probe:
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
-    assert mock_probe.call_args.args[0] == ["my-claude-acp", "--flag"]
+    assert mock_probe.call_args.args[0] == ["my-codex-acp", "--flag"]
 
 
 def test_includes_stored_secrets_in_probe_env(client, config):
     # Global secrets stored during onboarding are folded into the probe env so
     # the handshake authenticates exactly as a real conversation would.
-    get_secrets_store(config).set_secret(name="ANTHROPIC_API_KEY", value="sk-stored")
+    get_secrets_store(config).set_secret(name="OPENAI_API_KEY", value="sk-stored")
 
     with patch(PROBE_PATH, return_value=_result()) as mock_probe:
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
     env = mock_probe.call_args.kwargs["env"]
-    assert env["ANTHROPIC_API_KEY"] == "sk-stored"
+    assert env["OPENAI_API_KEY"] == "sk-stored"
 
 
 def test_settings_env_overrides_stored_secret(client, config):
     # When both a stored secret and the agent-settings provider env supply the
     # same var, the settings value wins (matches real conversation precedence).
-    get_secrets_store(config).set_secret(name="ANTHROPIC_API_KEY", value="sk-secret")
+    get_secrets_store(config).set_secret(name="OPENAI_API_KEY", value="sk-secret")
     get_settings_store(config).save(
         PersistedSettings(
             agent_settings=ACPAgentSettings(
-                acp_server="claude-code",
-                acp_env={"ANTHROPIC_API_KEY": "sk-settings"},
+                acp_server="codex",
+                acp_env={"OPENAI_API_KEY": "sk-settings"},
             )
         )
     )
     with patch(PROBE_PATH, return_value=_result()) as mock_probe:
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
-    assert mock_probe.call_args.kwargs["env"]["ANTHROPIC_API_KEY"] == "sk-settings"
+    assert mock_probe.call_args.kwargs["env"]["OPENAI_API_KEY"] == "sk-settings"
 
 
 def test_unknown_detail_scrubs_stored_secret(client, config):
     # If a provider error echoes a stored secret value, the 'unknown' detail
     # surfaced to the UI must redact it, not pass it through.
     get_secrets_store(config).set_secret(
-        name="ANTHROPIC_API_KEY", value="sk-supersecret-123"
+        name="OPENAI_API_KEY", value="sk-supersecret-123"
     )
     with patch(
         PROBE_PATH,
         side_effect=RuntimeError("rejected key sk-supersecret-123"),
     ):
-        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+        response = client.get("/api/acp/auth-status", params={"server": "codex"})
 
     assert response.status_code == 200
     body = response.json()

--- a/tests/agent_server/test_acp_auth_router.py
+++ b/tests/agent_server/test_acp_auth_router.py
@@ -192,3 +192,22 @@ def test_settings_env_overrides_stored_secret(client, config):
 
     assert response.status_code == 200
     assert mock_probe.call_args.kwargs["env"]["ANTHROPIC_API_KEY"] == "sk-settings"
+
+
+def test_unknown_detail_scrubs_stored_secret(client, config):
+    # If a provider error echoes a stored secret value, the 'unknown' detail
+    # surfaced to the UI must redact it, not pass it through.
+    get_secrets_store(config).set_secret(
+        name="ANTHROPIC_API_KEY", value="sk-supersecret-123"
+    )
+    with patch(
+        PROBE_PATH,
+        side_effect=RuntimeError("rejected key sk-supersecret-123"),
+    ):
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["status"] == "unknown"
+    assert "sk-supersecret-123" not in body["detail"]
+    assert "***" in body["detail"]

--- a/tests/agent_server/test_acp_auth_router.py
+++ b/tests/agent_server/test_acp_auth_router.py
@@ -20,10 +20,14 @@ from openhands.agent_server.persistence import (
 )
 from openhands.sdk.agent.acp_agent import ACPAuthProbeResult
 from openhands.sdk.settings import ACPAgentSettings
-from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
+from openhands.sdk.settings.acp_providers import (
+    ACP_CLI_AUTH_STATUS_ARGS,
+    ACP_PROVIDERS,
+)
 
 
 PROBE_PATH = "openhands.agent_server.acp_auth_router.ACPAgent.probe_auth"
+CLI_PROBE_PATH = "openhands.agent_server.acp_auth_router.ACPAgent.probe_cli_auth_status"
 
 
 @pytest.fixture
@@ -133,19 +137,70 @@ def test_unknown_status_on_timeout(client):
     assert response.json()["status"] == "unknown"
 
 
-def test_claude_code_returns_unknown_without_probing(client):
-    # claude-agent-acp doesn't validate auth at session/new, so the protocol
-    # probe would false-positive. The router must short-circuit to 'unknown'
-    # WITHOUT spawning a probe.
-    with patch(PROBE_PATH) as mock_probe:
+def test_claude_code_authenticated_via_cli_status(client):
+    # claude-agent-acp can't be classified by the handshake (it accepts
+    # session/new unauthenticated), so the router uses the CLI auth-status
+    # fallback — and must NOT call the handshake probe.
+    cli_result = _result(authenticated=True, auth_methods=["claude.ai"])
+    with (
+        patch(PROBE_PATH) as handshake,
+        patch(CLI_PROBE_PATH, return_value=cli_result) as cli,
+    ):
         response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
 
     assert response.status_code == 200
     body = response.json()
     assert body["server"] == "claude-code"
+    assert body["status"] == "authenticated"
+    assert body["auth_methods"] == ["claude.ai"]
+    handshake.assert_not_called()
+    # Invoked with the registry command + the claude CLI auth-status args.
+    cli.assert_called_once()
+    assert cli.call_args.args[0] == list(ACP_PROVIDERS["claude-code"].default_command)
+    assert cli.call_args.args[1] == list(ACP_CLI_AUTH_STATUS_ARGS["claude-code"])
+
+
+def test_claude_code_unauthenticated_via_cli_status(client):
+    with (
+        patch(PROBE_PATH),
+        patch(CLI_PROBE_PATH, return_value=_result(authenticated=False)),
+    ):
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "unauthenticated"
+
+
+def test_claude_code_cli_status_error_returns_unknown(client):
+    # If the CLI status command can't run / parse, fall back to 'unknown' so the
+    # canvas shows the API-key fields rather than falsely claiming "not logged in".
+    with (
+        patch(PROBE_PATH),
+        patch(CLI_PROBE_PATH, side_effect=RuntimeError("npx not found")),
+    ):
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "unknown"
+
+
+def test_provider_with_no_strategy_returns_unknown(client):
+    # A provider that neither supports the handshake nor has a CLI fallback
+    # short-circuits to 'unknown' without spawning anything. Simulate by clearing
+    # the CLI fallback for claude (whose handshake is already unsupported).
+    with (
+        patch("openhands.agent_server.acp_auth_router.ACP_CLI_AUTH_STATUS_ARGS", {}),
+        patch(PROBE_PATH) as handshake,
+        patch(CLI_PROBE_PATH) as cli,
+    ):
+        response = client.get("/api/acp/auth-status", params={"server": "claude-code"})
+
+    assert response.status_code == 200
+    body = response.json()
     assert body["status"] == "unknown"
     assert body["detail"]  # explains why it can't be probed
-    mock_probe.assert_not_called()
+    handshake.assert_not_called()
+    cli.assert_not_called()
 
 
 def test_resolves_default_command_for_server(client):

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -17,7 +17,10 @@ from acp.schema import PromptResponse
 from pydantic import SecretStr
 
 from openhands.sdk.agent.acp_agent import (
+    _ACP_AUTH_REQUIRED_CODE,
     ACPAgent,
+    ACPAuthProbeResult,
+    _apply_env_conflict_rules,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
@@ -5977,3 +5980,215 @@ class TestACPAgentSupportsRuntimeModelSwitch:
         agent._session_id = "sess-1"
         agent._agent_name = "locked-down-provider"
         assert agent.supports_runtime_model_switch is False
+
+
+def _auth_method(method_id: str) -> MagicMock:
+    """Build a minimal ACP AuthMethod stand-in exposing ``.id``."""
+    m = MagicMock()
+    m.id = method_id
+    return m
+
+
+class TestApplyEnvConflictRules:
+    """``_apply_env_conflict_rules`` drops CLAUDECODE and auth-conflict vars."""
+
+    def test_drops_claudecode(self):
+        env = {"CLAUDECODE": "1", "KEEP": "v"}
+        _apply_env_conflict_rules(env)
+        assert env == {"KEEP": "v"}
+
+    def test_strips_anthropic_vars_under_claude_config_dir(self):
+        env = {
+            "CLAUDE_CONFIG_DIR": "/home/u/.claude",
+            "ANTHROPIC_API_KEY": "sk-x",
+            "ANTHROPIC_BASE_URL": "https://proxy",
+            "OTHER": "ok",
+        }
+        _apply_env_conflict_rules(env)
+        assert env == {"CLAUDE_CONFIG_DIR": "/home/u/.claude", "OTHER": "ok"}
+
+    def test_keeps_anthropic_vars_without_dominant(self):
+        env = {"ANTHROPIC_API_KEY": "sk-x", "ANTHROPIC_BASE_URL": "https://proxy"}
+        _apply_env_conflict_rules(env)
+        assert env == {
+            "ANTHROPIC_API_KEY": "sk-x",
+            "ANTHROPIC_BASE_URL": "https://proxy",
+        }
+
+
+class TestACPProbeAuth:
+    """``ACPAgent.probe_auth`` runs a prompt-free initialize + session/new probe.
+
+    The transport layer (subprocess, JSON-RPC reader, connection) is mocked so
+    the test exercises the classification + teardown logic without spawning a
+    real ACP server — mirroring ``TestACPSessionIdPersistence``.
+    """
+
+    @staticmethod
+    def _transport_patches(conn):
+        """Stack the transport-layer mocks so probe_auth runs without a real
+        subprocess. Returns ``(ExitStack, mock_process)``.
+        """
+        from contextlib import ExitStack
+
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+
+        async def _fake_create_subprocess_exec(*_args, **_kwargs):
+            return mock_process
+
+        async def _fake_filter(_src, _dst):
+            return None
+
+        stack = ExitStack()
+        stack.enter_context(
+            patch(
+                "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                new=_fake_create_subprocess_exec,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                return_value=conn,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                new=_fake_filter,
+            )
+        )
+        stack.enter_context(
+            patch(
+                "openhands.sdk.agent.acp_agent.asyncio.StreamReader",
+                return_value=MagicMock(),
+            )
+        )
+        return stack, mock_process
+
+    @staticmethod
+    def _make_conn(
+        *,
+        new_session_exc: Exception | None = None,
+        auth_methods: list | None = None,
+        agent_name: str = "codex-acp",
+        agent_version: str = "2.0",
+    ):
+        conn = MagicMock()
+
+        init_response = MagicMock()
+        init_response.agent_info = MagicMock()
+        init_response.agent_info.name = agent_name
+        init_response.agent_info.version = agent_version
+        init_response.auth_methods = auth_methods or []
+        conn.initialize = AsyncMock(return_value=init_response)
+
+        conn.authenticate = AsyncMock()
+        if new_session_exc is not None:
+            conn.new_session = AsyncMock(side_effect=new_session_exc)
+        else:
+            new_response = MagicMock()
+            new_response.session_id = "probe-sess"
+            conn.new_session = AsyncMock(return_value=new_response)
+        conn.close = AsyncMock()
+        return conn
+
+    def test_empty_command_raises(self):
+        with pytest.raises(ValueError, match="non-empty command"):
+            ACPAgent.probe_auth([])
+
+    def test_authenticated_when_new_session_succeeds(self, tmp_path):
+        conn = self._make_conn()
+        stack, proc = self._transport_patches(conn)
+        with stack:
+            result = ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path))
+
+        assert isinstance(result, ACPAuthProbeResult)
+        assert result.authenticated is True
+        assert result.agent_name == "codex-acp"
+        assert result.agent_version == "2.0"
+        conn.initialize.assert_awaited_once()
+        conn.new_session.assert_awaited_once()
+        # session/new is called with the probe cwd; no prompt is ever sent.
+        _, kwargs = conn.new_session.call_args
+        assert kwargs["cwd"] == str(tmp_path)
+        # Teardown always runs.
+        conn.close.assert_awaited_once()
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+
+    def test_unauthenticated_on_auth_required(self, tmp_path):
+        conn = self._make_conn(
+            new_session_exc=ACPRequestError(
+                _ACP_AUTH_REQUIRED_CODE, "Authentication required"
+            )
+        )
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            result = ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path))
+
+        assert result.authenticated is False
+        # The probe still tears the subprocess down on the not-logged-in path.
+        conn.close.assert_awaited_once()
+
+    def test_non_auth_request_error_propagates(self, tmp_path):
+        conn = self._make_conn(
+            new_session_exc=ACPRequestError(-32603, "Internal error")
+        )
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            with pytest.raises(ACPRequestError):
+                ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path))
+        # Teardown runs even when the error propagates.
+        conn.close.assert_awaited_once()
+
+    def test_subprocess_spawn_failure_propagates(self, tmp_path):
+        # If even the connection can't be established, the error must propagate
+        # so the caller (endpoint) can report "unknown" rather than guess.
+        conn = self._make_conn()
+        conn.initialize = AsyncMock(side_effect=BrokenPipeError("no pipe"))
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            with pytest.raises(BrokenPipeError):
+                ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path))
+
+    def test_authenticates_when_method_credentials_present(self, tmp_path):
+        # An offered API-key method whose env var is supplied gets an explicit
+        # authenticate() call before session/new (mirrors _start_acp_server).
+        conn = self._make_conn(auth_methods=[_auth_method("openai-api-key")])
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            result = ACPAgent.probe_auth(
+                ["echo", "test"],
+                env={"OPENAI_API_KEY": "sk-test"},
+                cwd=str(tmp_path),
+            )
+        conn.authenticate.assert_awaited_once()
+        assert result.auth_methods == ["openai-api-key"]
+        assert result.authenticated is True
+
+    def test_no_authenticate_when_no_method_matches(self, tmp_path):
+        # Auth methods offered but no matching credential → skip authenticate;
+        # session/new may still succeed via the CLI's own cached login.
+        conn = self._make_conn(auth_methods=[_auth_method("openai-api-key")])
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            result = ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path))
+        conn.authenticate.assert_not_awaited()
+        assert result.auth_methods == ["openai-api-key"]
+        assert result.authenticated is True
+
+    def test_timeout_raises(self, tmp_path):
+        # A handshake that never completes is capped by the timeout.
+        conn = self._make_conn()
+
+        async def _never(*_a, **_k):
+            await asyncio.sleep(10)
+
+        conn.initialize = _never
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            with pytest.raises(TimeoutError):
+                ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path), timeout=0.2)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
+import subprocess
 import threading
 import uuid
 from base64 import urlsafe_b64encode
 from concurrent.futures import Future
-from typing import Any
+from typing import Any, ClassVar
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -6227,6 +6228,116 @@ class TestACPProbeAuth:
         with stack:
             with pytest.raises(TimeoutError):
                 ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path), timeout=0.2)
+
+
+class TestACPProbeCliAuthStatus:
+    """``ACPAgent.probe_cli_auth_status`` reads ``loggedIn`` from a CLI's
+    ``auth status --json`` output for providers the handshake can't classify
+    (e.g. claude-agent-acp). ``subprocess.run`` is mocked — no real CLI is run.
+    """
+
+    _CMD: ClassVar[list[str]] = ["npx", "-y", "@agentclientprotocol/claude-agent-acp"]
+    _ARGS: ClassVar[list[str]] = ["--cli", "auth", "status", "--json"]
+
+    @staticmethod
+    def _completed(stdout: str, returncode: int = 0):
+        proc = MagicMock()
+        proc.stdout = stdout
+        proc.stderr = ""
+        proc.returncode = returncode
+        return proc
+
+    def test_empty_command_raises(self):
+        with pytest.raises(ValueError, match="non-empty command"):
+            ACPAgent.probe_cli_auth_status([], self._ARGS)
+
+    def test_authenticated_when_logged_in(self):
+        payload = {
+            "loggedIn": True,
+            "authMethod": "claude.ai",
+            "subscriptionType": "max",
+        }
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            return_value=self._completed(json.dumps(payload)),
+        ) as run:
+            result = ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS)
+
+        assert isinstance(result, ACPAuthProbeResult)
+        assert result.authenticated is True
+        # ``authMethod`` is surfaced via auth_methods for display.
+        assert result.auth_methods == ["claude.ai"]
+        # The status args are appended to the launch command.
+        assert run.call_args.args[0] == self._CMD + self._ARGS
+
+    def test_unauthenticated_even_when_exit_nonzero(self):
+        # Logged out: the CLI may exit non-zero, but ``loggedIn: false`` is the
+        # signal — classify as unauthenticated, not unknown.
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            return_value=self._completed(json.dumps({"loggedIn": False}), returncode=1),
+        ):
+            result = ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS)
+
+        assert result.authenticated is False
+        assert result.auth_methods == []
+
+    def test_missing_logged_in_raises(self):
+        # No boolean ``loggedIn`` ⇒ can't determine ⇒ raise (caller → unknown).
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            return_value=self._completed(json.dumps({"authMethod": "claude.ai"})),
+        ):
+            with pytest.raises(ValueError, match="loggedIn"):
+                ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS)
+
+    def test_unparseable_output_raises(self):
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            return_value=self._completed("command not found: npx"),
+        ):
+            with pytest.raises(ValueError, match="no JSON object"):
+                ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS)
+
+    def test_tolerates_surrounding_noise(self):
+        # A banner/log line around the JSON object is recovered via the
+        # first-{ … last-} slice.
+        noisy = 'starting…\n{"loggedIn": true}\nbye\n'
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            return_value=self._completed(noisy),
+        ):
+            result = ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS)
+        assert result.authenticated is True
+
+    def test_timeout_propagates(self):
+        # A hung CLI raises TimeoutExpired, which must propagate so the caller
+        # reports "unknown" rather than "not logged in".
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=self._CMD, timeout=1.0),
+        ):
+            with pytest.raises(subprocess.TimeoutExpired):
+                ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS, timeout=1.0)
+
+    def test_env_conflict_rules_applied(self):
+        # The same env stripping as probe_auth: CLAUDECODE removed, and
+        # ANTHROPIC_API_KEY removed when CLAUDE_CONFIG_DIR selects the OAuth flow.
+        env = {
+            "CLAUDECODE": "1",
+            "CLAUDE_CONFIG_DIR": "/tmp/claude",
+            "ANTHROPIC_API_KEY": "sk-should-be-stripped",
+        }
+        with patch(
+            "openhands.sdk.agent.acp_agent.subprocess.run",
+            return_value=self._completed(json.dumps({"loggedIn": True})),
+        ) as run:
+            ACPAgent.probe_cli_auth_status(self._CMD, self._ARGS, env=env)
+
+        passed_env = run.call_args.kwargs["env"]
+        assert "CLAUDECODE" not in passed_env
+        assert "ANTHROPIC_API_KEY" not in passed_env
+        assert passed_env["CLAUDE_CONFIG_DIR"] == "/tmp/claude"
 
 
 class TestTeardownACPConnection:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6161,6 +6161,8 @@ class TestACPProbeAuth:
         with stack:
             with pytest.raises(BrokenPipeError):
                 ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path))
+        # Teardown still runs on the spawn/initialize failure path.
+        conn.close.assert_awaited_once()
 
     def test_authenticates_when_method_credentials_present(self, tmp_path):
         # An offered API-key method whose env var is supplied gets an explicit
@@ -6207,6 +6209,11 @@ class TestACPProbeAuth:
         # session/new is never reached once authenticate reports auth_required.
         conn.new_session.assert_not_awaited()
         conn.close.assert_awaited_once()
+        # Metadata discovered at initialize must survive the auth failure — the
+        # not-logged-in result still reports the agent identity + offered methods.
+        assert result.agent_name == "codex-acp"
+        assert result.agent_version == "2.0"
+        assert result.auth_methods == ["openai-api-key"]
 
     def test_timeout_raises(self, tmp_path):
         # A handshake that never completes is capped by the timeout.

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6034,6 +6034,9 @@ class TestACPProbeAuth:
         mock_process = MagicMock()
         mock_process.stdin = MagicMock()
         mock_process.stdout = MagicMock()
+        # ``_teardown_acp_connection`` awaits ``process.wait()`` to reap the
+        # subprocess; give the mock an awaitable so that path runs.
+        mock_process.wait = AsyncMock(return_value=0)
 
         async def _fake_create_subprocess_exec(*_args, **_kwargs):
             return mock_process
@@ -6114,10 +6117,13 @@ class TestACPProbeAuth:
         # session/new is called with the probe cwd; no prompt is ever sent.
         _, kwargs = conn.new_session.call_args
         assert kwargs["cwd"] == str(tmp_path)
-        # Teardown always runs.
+        # Teardown always runs, and the subprocess is reaped (process.wait)
+        # so a standalone caller's event loop doesn't log a child-watcher
+        # warning at shutdown.
         conn.close.assert_awaited_once()
         proc.terminate.assert_called_once()
         proc.kill.assert_called_once()
+        proc.wait.assert_awaited()
 
     def test_unauthenticated_on_auth_required(self, tmp_path):
         conn = self._make_conn(

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -30,6 +30,7 @@ from openhands.sdk.agent.acp_agent import (
     _reapply_session_model_on_resume,
     _select_auth_method,
     _serialize_tool_content,
+    _teardown_acp_connection,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
@@ -6117,13 +6118,14 @@ class TestACPProbeAuth:
         # session/new is called with the probe cwd; no prompt is ever sent.
         _, kwargs = conn.new_session.call_args
         assert kwargs["cwd"] == str(tmp_path)
-        # Teardown always runs, and the subprocess is reaped (process.wait)
-        # so a standalone caller's event loop doesn't log a child-watcher
-        # warning at shutdown.
+        # Teardown always runs and reaps the subprocess (process.wait) so a
+        # standalone caller's event loop doesn't log a child-watcher warning at
+        # shutdown. SIGTERM reaps the (mock) process here, so it never escalates
+        # to SIGKILL.
         conn.close.assert_awaited_once()
         proc.terminate.assert_called_once()
-        proc.kill.assert_called_once()
         proc.wait.assert_awaited()
+        proc.kill.assert_not_called()
 
     def test_unauthenticated_on_auth_required(self, tmp_path):
         conn = self._make_conn(
@@ -6186,6 +6188,26 @@ class TestACPProbeAuth:
         assert result.auth_methods == ["openai-api-key"]
         assert result.authenticated is True
 
+    def test_authenticate_failure_is_unauthenticated_not_unknown(self, tmp_path):
+        # codex-acp-style: auth_required surfaces from the explicit authenticate()
+        # call (before session/new). It must classify as unauthenticated, not
+        # propagate to the caller as "unknown".
+        conn = self._make_conn(auth_methods=[_auth_method("openai-api-key")])
+        conn.authenticate = AsyncMock(
+            side_effect=ACPRequestError(_ACP_AUTH_REQUIRED_CODE, "login required")
+        )
+        stack, _proc = self._transport_patches(conn)
+        with stack:
+            result = ACPAgent.probe_auth(
+                ["echo", "test"],
+                env={"OPENAI_API_KEY": "sk-test"},
+                cwd=str(tmp_path),
+            )
+        assert result.authenticated is False
+        # session/new is never reached once authenticate reports auth_required.
+        conn.new_session.assert_not_awaited()
+        conn.close.assert_awaited_once()
+
     def test_timeout_raises(self, tmp_path):
         # A handshake that never completes is capped by the timeout.
         conn = self._make_conn()
@@ -6198,3 +6220,50 @@ class TestACPProbeAuth:
         with stack:
             with pytest.raises(TimeoutError):
                 ACPAgent.probe_auth(["echo", "test"], cwd=str(tmp_path), timeout=0.2)
+
+
+class TestTeardownACPConnection:
+    """Unit tests for ``_teardown_acp_connection`` reaping + task cleanup."""
+
+    @pytest.mark.asyncio
+    async def test_terminate_reaps_without_escalating_to_kill(self):
+        conn = MagicMock()
+        conn.close = AsyncMock()
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)  # exits on SIGTERM
+
+        await _teardown_acp_connection(conn, proc)
+
+        proc.terminate.assert_called_once()
+        proc.wait.assert_awaited_once()
+        proc.kill.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_escalates_to_kill_when_terminate_does_not_reap(self):
+        conn = MagicMock()
+        conn.close = AsyncMock()
+        proc = MagicMock()
+        # First reap (after SIGTERM) times out; second (after SIGKILL) succeeds.
+        proc.wait = AsyncMock(side_effect=[TimeoutError(), 0])
+
+        await _teardown_acp_connection(conn, proc)
+
+        proc.terminate.assert_called_once()
+        proc.kill.assert_called_once()
+        assert proc.wait.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_reader_task_is_cancelled(self):
+        conn = MagicMock()
+        conn.close = AsyncMock()
+        proc = MagicMock()
+        proc.wait = AsyncMock(return_value=0)
+
+        async def _never_ends():
+            await asyncio.sleep(3600)
+
+        reader_task = asyncio.ensure_future(_never_ends())
+
+        await _teardown_acp_connection(conn, proc, reader_task)
+
+        assert reader_task.cancelled()

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -42,6 +42,17 @@ class TestACPProviderInfo:
         assert info.session_meta_key == "claudeCode"
         assert info.default_model == "claude-opus-4-7"
         assert any(m.id == "claude-opus-4-7" for m in info.available_models)
+        # claude-agent-acp doesn't gate auth at session/new, so the auth-status
+        # probe can't detect its login state — it's opted out.
+        assert info.supports_auth_status_probe is False
+
+    def test_auth_status_probe_support(self):
+        # Only providers whose session/new actually validates credentials
+        # (codex, gemini — both return -32000 when logged out) can be probed;
+        # claude-agent-acp accepts the session regardless, so it opts out.
+        assert ACP_PROVIDERS["claude-code"].supports_auth_status_probe is False
+        assert ACP_PROVIDERS["codex"].supports_auth_status_probe is True
+        assert ACP_PROVIDERS["gemini-cli"].supports_auth_status_probe is True
 
     def test_codex_metadata(self):
         info = ACP_PROVIDERS["codex"]


### PR DESCRIPTION
## Summary

Phase 1 **SDK side** of OpenHands/agent-canvas#2400 — server-side detection of an existing ACP subscription/login so onboarding can show "✓ you're already logged in" instead of unconditionally asking for an API key.

Detection rides the **ACP protocol handshake** rather than sniffing credentials per-OS/topology (keychain vs `~/.codex/auth.json` vs `~/.gemini/oauth_creds.json`, across local/docker/cloud). The reliable signal:

> `session/new` succeeds ⇒ authenticated (by whatever the CLI found — subscription *or* API key); it fails with `auth_required` (JSON-RPC `-32000`) when not logged in.

No prompt is sent, so **no model tokens are spent**. Because the probe runs *inside the agent-server*, it reports the truth for wherever the agent will actually run — the canvas + server stay OS/topology-agnostic.

```
Canvas onboarding (ACP credentials step)
   │  GET /acp/auth-status?server=claude-code        ← NEW thin endpoint
   ▼
agent-server (openhands-agent-server)
   │  ACPAgent.probe_auth(command, env, cwd)         ← NEW: factored out of
   ▼                                                    _start_acp_server()
ACP subprocess  →  initialize + session/new + teardown
   → { authenticated, auth_methods, agent_info }
```

## Changes

### `openhands-sdk`
- Factored the subprocess **spawn** + **initialize/authenticate** handshake out of `_start_acp_server` into shared module-level helpers (`_spawn_acp_connection`, `_acp_initialize`, `_apply_env_conflict_rules`) — `_start_acp_server` now calls them, so both paths build the env and authenticate identically.
- **`ACPAgent.probe_auth(command, *, args, env, cwd, timeout)`** — spawn → `initialize` → best-effort `authenticate` → `session/new` → classify success vs `auth_required` → tear down. Returns `ACPAuthProbeResult(authenticated, auth_methods, agent_name, agent_version)`. The handshake is timeout-bounded and teardown is guaranteed on the same event loop (with a bounded connection close), so a wedged subprocess can't leak.

### `openhands-agent-server`
- **`GET /acp/auth-status?server=<key>`** (`acp_auth_router`) — resolves the launch command + env for a provider key from `ACP_PROVIDERS` + persisted agent settings + stored global secrets, runs `probe_auth` in a threadpool, and returns `{ server, status, auth_methods, agent_name, agent_version, detail }` where `status ∈ {authenticated, unauthenticated, unknown}`.
  - Unknown provider → `422`.
  - A probe that can't run (subprocess won't start, timeout, non-`auth_required` error) → `status: "unknown"` with `200`, so the canvas falls back to the API-key fields rather than falsely claiming "not logged in".
  - `status` maps 1:1 onto the canvas `useAcpAuthStatus` hook, so Phase 1 can swap its body to this endpoint without touching the banner UI.

## Tests
- `TestACPProbeAuth` — authenticated, `auth_required`→unauthenticated, non-auth errors propagate, spawn failure propagates, conditional authenticate, timeout; transport mocked (no real subprocess), mirroring `TestACPSessionIdPersistence`.
- `test_acp_auth_router` — authenticated/unauthenticated/unknown(error & timeout), `422` for unknown/missing server, command resolution from registry + persisted override, and stored-secret → probe-env folding with settings precedence.
- Full existing `test_acp_agent.py` suite stays green, verifying the `_start_acp_server` refactor.

## Cross-repo follow-up (not in this PR)
SDK release → bump the server pin / `@openhands/typescript-client` in agent-canvas → swap the Phase 0 throwaway-conversation probe in `useAcpAuthStatus` for this endpoint. The canvas Phase 0 UI (banner + optional key fields) already exists behind that hook.

Refs OpenHands/agent-canvas#2400

🤖 Generated with [Claude Code](https://claude.com/claude-code)







<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a7b7945-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a7b7945-python \
  ghcr.io/openhands/agent-server:a7b7945-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a7b7945-golang-amd64
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-golang-amd64
ghcr.io/openhands/agent-server:a7b7945-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a7b7945-golang-arm64
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-golang-arm64
ghcr.io/openhands/agent-server:a7b7945-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a7b7945-java-amd64
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-java-amd64
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-java-amd64
ghcr.io/openhands/agent-server:a7b7945-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a7b7945-java-arm64
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-java-arm64
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-java-arm64
ghcr.io/openhands/agent-server:a7b7945-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a7b7945-python-amd64
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-python-amd64
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-python-amd64
ghcr.io/openhands/agent-server:a7b7945-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a7b7945-python-arm64
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-python-arm64
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-python-arm64
ghcr.io/openhands/agent-server:a7b7945-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a7b7945-golang
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-golang
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-golang
ghcr.io/openhands/agent-server:a7b7945-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a7b7945-java
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-java
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-java
ghcr.io/openhands/agent-server:a7b7945-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a7b7945-python
ghcr.io/openhands/agent-server:a7b7945ec4bdaa7206079eb00d3532e6604bd577-python
ghcr.io/openhands/agent-server:feat-acp-auth-status-probe-python
ghcr.io/openhands/agent-server:a7b7945-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a7b7945-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a7b7945-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->