### PR TITLE
fix(release-binaries): use macos-15-intel and make publishing resilient

### DIFF
--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -63,8 +63,8 @@ You can monitor the progress in the [Actions tab](https://github.com/OpenHands/s
 In parallel with the PyPI workflow, **release-binaries.yml** also fires on `release: published`.
 It also runs on every push to `main` as ongoing smoke coverage. It:
 
-- ✅ Builds the agent-server PyInstaller binary on a 4-runner matrix
-  (linux x86_64/arm64, macOS x86_64/arm64) and smoke-tests each
+- ✅ Builds the agent-server PyInstaller binary on a 5-runner matrix
+  (linux x86_64/arm64, macOS x86_64/arm64, windows x86_64) and smoke-tests each
 - ✅ Generates a combined `SHA256SUMS` and attaches all artifacts to the GitHub
   release as `agent-server-<version>-<os>-<arch>` on release/manual runs
 - ✅ Verifies that the multi-arch Docker manifest
@@ -82,7 +82,7 @@ release version and the binaries are uploaded to the GitHub release.
 
 | Stage | Runtime (typical) | Runners |
 |---|---|---|
-| Binary builds (4-way matrix, parallel) | ~10–15 min on Linux, ~12–18 min on macOS | `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-13`, `macos-14` |
+| Binary builds (5-way matrix, parallel) | ~10–15 min on Linux, ~12–18 min on macOS | `ubuntu-24.04`, `ubuntu-24.04-arm`, `macos-15-intel`, `macos-14`, `windows-2022` |
 | `publish-binaries` (download + checksum + upload) | ~1–2 min | `ubuntu-24.04` |
 | `docker-smoke-test` (6-way matrix, parallel) | Up to 45 min (mostly polling for the docker images) | `ubuntu-24.04` for amd64, `ubuntu-24.04-arm` for arm64 |
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -78,7 +78,9 @@ jobs:
                     - runner: ubuntu-24.04-arm
                       os_label: linux
                       arch: arm64
-                    - runner: macos-13
+                    # macos-13 (Intel) was retired by GitHub on 2025-12-04;
+                    # macos-15-intel is the last x86_64 macOS image (until ~2027).
+                    - runner: macos-15-intel
                       os_label: macos
                       arch: x86_64
                     - runner: macos-14
@@ -183,7 +185,11 @@ jobs:
     publish-binaries:
         name: Publish binaries + SHA256SUMS
         needs: [resolve-tag, build-binary]
-        if: github.event_name != 'push'
+        # always() so one dead/failed build leg (e.g. a retired runner that
+        # queues until timeout) can't skip publishing the binaries that did
+        # build. download-artifact's `pattern: binary-*` uploads whatever set
+        # succeeded; if nothing built the checksum step fails the job loudly.
+        if: ${{ always() && github.event_name != 'push' }}
         runs-on: ubuntu-24.04
         steps:
             - name: Download binary artifacts


### PR DESCRIPTION
- [x] A human has tested these changes.

## Why

`release-binaries.yml` builds the agent-server PyInstaller binaries but **never attaches them to releases** — every release since v1.22.0 (through v1.24.0) shipped with **0 binary assets**.

Root cause: GitHub **retired the `macos-13` (Intel/x86_64) runner on 2025-12-04**. A `runs-on:` label with no matching runner doesn't error — it queues until the 24h max and is auto-cancelled. Because `publish-binaries` is gated on the full build matrix with no status-check function in its `if:`, an implicit `success()` gate applies, so the cancelled macOS leg **skips publishing entirely**, discarding the 4 binaries that did build (they survive only as 7-day workflow artifacts).

Fixes #3439.

## Summary

- **Replace the retired `macos-13` runner with `macos-15-intel`** — the last GitHub-hosted x86_64 macOS image (available until ~2027). This keeps Intel macOS coverage and gets the leg a runner again, instead of dropping macOS x86_64. The PyInstaller spec uses `target_arch=None`, so the binary's architecture follows the runner.
- **Gate `publish-binaries` on `${{ always() && github.event_name != 'push' }}`** so a single dead/failed/cancelled build leg can no longer block publishing the rest. `download-artifact`'s `pattern: binary-*` uploads whatever set succeeded; if *nothing* built, the checksum step fails the job loudly (no silent empty release).
- Update `README-RELEASE.md` runner table (it's a 5-way matrix incl. `windows-2022`, and listed the retired `macos-13`).

## Issue Number

Closes #3439

## How to Test

The full path is best verified by dispatching the workflow against an existing tag, which **also backfills the missing binaries** for that release (`gh release upload --clobber`):

```bash
gh workflow run release-binaries.yml \
  --ref vasco/fix-release-binaries-macos13 \
  -f release_tag=v1.24.0

# then confirm assets now exist (was 0 before):
gh release view v1.24.0 --repo OpenHands/software-agent-sdk \
  --json assets -q '.assets[].name'
```

Expected after the fix: the `macos-15-intel` leg gets a runner in seconds (no 24h queue), all 5 build legs + smoke tests pass, `publish-binaries` runs, and `agent-server-1.24.0-macos-x86_64` + the other 4 binaries + `SHA256SUMS` appear on the release.

Reproduction of the bug (before this PR): the v1.24.0 release run shows the `macos-13` leg cancelled at exactly 24h with `runner_name: ""` / `steps: []`, `publish-binaries` skipped, and `gh release view v1.24.0 --json assets` returning `[]`. Same pattern on every release v1.22.0–v1.24.0.

Static check: `actionlint .github/workflows/release-binaries.yml` validates the YAML and the new `if:` expression. Pre-commit (`Format YAML files`) passes locally.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- `macos-15-intel` (and `macos-26-intel`) are GitHub's only remaining x86_64 macOS images; Intel macOS sunsets ~Fall 2027. When that leg eventually retires too, the `always()` gate means the other binaries still publish instead of re-introducing this exact bug — graceful degradation rather than a hard release block.
- Trade-off of `always()`: if a future leg *fails*, publishing proceeds with a partial set (a `SHA256SUMS` covering only the arches that built). This matches the "publish whatever built" intent; a hard completeness check could be added later if all-or-nothing is preferred.
- No in-repo consumer depends on the macOS x86_64 asset (the runtime binary target uses the Linux binary baked into the Docker image), so this change is safe for downstream tooling.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e08ea30-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e08ea30-python \
  ghcr.io/openhands/agent-server:e08ea30-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e08ea30-golang-amd64
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-golang-amd64
ghcr.io/openhands/agent-server:e08ea30-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e08ea30-golang-arm64
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-golang-arm64
ghcr.io/openhands/agent-server:e08ea30-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e08ea30-java-amd64
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-java-amd64
ghcr.io/openhands/agent-server:e08ea30-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e08ea30-java-arm64
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-java-arm64
ghcr.io/openhands/agent-server:e08ea30-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e08ea30-python-amd64
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-python-amd64
ghcr.io/openhands/agent-server:e08ea30-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e08ea30-python-arm64
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-python-arm64
ghcr.io/openhands/agent-server:e08ea30-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e08ea30-golang
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-golang
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-golang
ghcr.io/openhands/agent-server:e08ea30-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e08ea30-java
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-java
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-java
ghcr.io/openhands/agent-server:e08ea30-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e08ea30-python
ghcr.io/openhands/agent-server:e08ea308a03dba2f6c54e93c4bf95049318b0bd4-python
ghcr.io/openhands/agent-server:vasco-fix-release-binaries-macos13-python
ghcr.io/openhands/agent-server:e08ea30-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e08ea30-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e08ea30-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->