### PR TITLE
refactor(llm): dedupe _transport_call/_atransport_call twins (#3341 Q5.iii)

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1554,15 +1554,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         return api_key_value
 
-    def _transport_call(
-        self,
-        *,
-        messages: list[dict[str, Any]],
-        enable_streaming: bool = False,
-        on_token: TokenCallbackType | None = None,
-        **kwargs,
-    ) -> ModelResponse:
-        # litellm.modify_params is GLOBAL; guard it for thread-safety
+    @contextmanager
+    def _transport_ctx(self):
+        """Guard a litellm transport call.
+
+        ``litellm.modify_params`` is GLOBAL, so it is guarded for thread-safety,
+        and the noisy provider/litellm warnings are filtered out for the call.
+        """
         with self._litellm_modify_params_ctx(self.modify_params):
             with warnings.catch_warnings():
                 warnings.filterwarnings(
@@ -1575,51 +1573,68 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 )
                 warnings.filterwarnings(
                     "ignore",
-                    message=r"There is no current event loop",
+                    message="There is no current event loop",
                     category=DeprecationWarning,
                 )
-                warnings.filterwarnings(
-                    "ignore",
-                    category=UserWarning,
-                )
+                warnings.filterwarnings("ignore", category=UserWarning)
                 warnings.filterwarnings(
                     "ignore",
                     category=DeprecationWarning,
                     message="Accessing the 'model_fields' attribute.*",
                 )
-                api_key_value = self._get_litellm_api_key_value()
+                yield
 
-                # When streaming, request usage in the final chunk so that
-                # detailed token breakdowns (prompt_tokens_details with
-                # cached_tokens, etc.) are not silently discarded by
-                # litellm's streaming handler.
-                if enable_streaming:
-                    kwargs.setdefault("stream_options", {"include_usage": True})
+    def _prepare_transport_kwargs(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        enable_streaming: bool,
+        **kwargs,
+    ) -> dict[str, Any]:
+        """Build the keyword arguments for a litellm (a)completion call."""
+        # When streaming, request usage in the final chunk so that detailed
+        # token breakdowns (prompt_tokens_details with cached_tokens, etc.) are
+        # not silently discarded by litellm's streaming handler.
+        if enable_streaming:
+            kwargs.setdefault("stream_options", {"include_usage": True})
+        return dict(
+            model=self.model,
+            api_key=self._get_litellm_api_key_value(),
+            api_base=self.base_url,
+            api_version=self.api_version,
+            timeout=self.timeout,
+            drop_params=self.drop_params,
+            seed=self.seed,
+            messages=messages,
+            **{**self._aws_kwargs(), **kwargs},
+        )
 
-                # Some providers need renames handled in _normalize_call_kwargs.
-                ret = litellm_completion(
-                    model=self.model,
-                    api_key=api_key_value,
-                    api_base=self.base_url,
-                    api_version=self.api_version,
-                    timeout=self.timeout,
-                    drop_params=self.drop_params,
-                    seed=self.seed,
-                    messages=messages,
-                    **{**self._aws_kwargs(), **kwargs},
+    def _transport_call(
+        self,
+        *,
+        messages: list[dict[str, Any]],
+        enable_streaming: bool = False,
+        on_token: TokenCallbackType | None = None,
+        **kwargs,
+    ) -> ModelResponse:
+        with self._transport_ctx():
+            ret = litellm_completion(
+                **self._prepare_transport_kwargs(
+                    messages=messages, enable_streaming=enable_streaming, **kwargs
                 )
-                if enable_streaming and on_token is not None:
-                    assert isinstance(ret, CustomStreamWrapper)
-                    chunks = []
-                    for chunk in ret:
-                        on_token(chunk)
-                        chunks.append(chunk)
-                    ret = litellm.stream_chunk_builder(chunks, messages=messages)
+            )
+            if enable_streaming and on_token is not None:
+                assert isinstance(ret, CustomStreamWrapper)
+                chunks: list[ModelResponseStream] = []
+                for chunk in ret:
+                    on_token(chunk)
+                    chunks.append(chunk)
+                ret = litellm.stream_chunk_builder(chunks, messages=messages)
 
-                assert isinstance(ret, ModelResponse), (
-                    f"Expected ModelResponse, got {type(ret)}"
-                )
-                return ret
+            assert isinstance(ret, ModelResponse), (
+                f"Expected ModelResponse, got {type(ret)}"
+            )
+            return ret
 
     async def _atransport_call(
         self,
@@ -1630,55 +1645,24 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         **kwargs,
     ) -> ModelResponse:
         """Async variant of :meth:`_transport_call`."""
-        with self._litellm_modify_params_ctx(self.modify_params):
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", category=DeprecationWarning, module="httpx.*"
+        with self._transport_ctx():
+            ret = await litellm_acompletion(
+                **self._prepare_transport_kwargs(
+                    messages=messages, enable_streaming=enable_streaming, **kwargs
                 )
-                warnings.filterwarnings(
-                    "ignore",
-                    message=r".*content=.*upload.*",
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings(
-                    "ignore",
-                    message=r"There is no current event loop",
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings("ignore", category=UserWarning)
-                warnings.filterwarnings(
-                    "ignore",
-                    category=DeprecationWarning,
-                    message="Accessing the 'model_fields' attribute.*",
-                )
-                api_key_value = self._get_litellm_api_key_value()
+            )
+            if enable_streaming and on_token is not None:
+                assert isinstance(ret, CustomStreamWrapper)
+                chunks: list[ModelResponseStream] = []
+                async for chunk in ret:
+                    await _invoke_token_callback(on_token, chunk)
+                    chunks.append(chunk)
+                ret = litellm.stream_chunk_builder(chunks, messages=messages)
 
-                if enable_streaming:
-                    kwargs.setdefault("stream_options", {"include_usage": True})
-
-                ret = await litellm_acompletion(
-                    model=self.model,
-                    api_key=api_key_value,
-                    api_base=self.base_url,
-                    api_version=self.api_version,
-                    timeout=self.timeout,
-                    drop_params=self.drop_params,
-                    seed=self.seed,
-                    messages=messages,
-                    **{**self._aws_kwargs(), **kwargs},
-                )
-                if enable_streaming and on_token is not None:
-                    assert isinstance(ret, CustomStreamWrapper)
-                    chunks = []
-                    async for chunk in ret:
-                        await _invoke_token_callback(on_token, chunk)
-                        chunks.append(chunk)
-                    ret = litellm.stream_chunk_builder(chunks, messages=messages)
-
-                assert isinstance(ret, ModelResponse), (
-                    f"Expected ModelResponse, got {type(ret)}"
-                )
-                return ret
+            assert isinstance(ret, ModelResponse), (
+                f"Expected ModelResponse, got {type(ret)}"
+            )
+            return ret
 
     @contextmanager
     def _litellm_modify_params_ctx(self, flag: bool):


### PR DESCRIPTION
- [x] A human has tested these changes.

## Summary
Addresses #3341 Q5.iii. The sync/async _transport_call/_atransport_call were ~95% identical. Extracts the shared prelude into two private helpers:

  - _transport_ctx() — context manager guarding the global litellm.modify_params and the warning filters.
  - _prepare_transport_kwargs(...) — builds the litellm (a)completion kwargs (api key, stream_options, model/base/timeout/…).

  Each method now contains only its irreducible difference: litellm_completion vs await litellm_acompletion and the sync vs async stream-drain loop. Also annotates the chunk buffers as list[ModelResponseStream] and drops a stale
  comment.

  Behavior-preserving — no public signature change; net -16 lines.

## Issue Number
#3341


## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a56be70-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a56be70-python \
  ghcr.io/openhands/agent-server:a56be70-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a56be70-golang-amd64
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-golang-amd64
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-golang-amd64
ghcr.io/openhands/agent-server:a56be70-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a56be70-golang-arm64
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-golang-arm64
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-golang-arm64
ghcr.io/openhands/agent-server:a56be70-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a56be70-java-amd64
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-java-amd64
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-java-amd64
ghcr.io/openhands/agent-server:a56be70-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a56be70-java-arm64
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-java-arm64
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-java-arm64
ghcr.io/openhands/agent-server:a56be70-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a56be70-python-amd64
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-python-amd64
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-python-amd64
ghcr.io/openhands/agent-server:a56be70-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a56be70-python-arm64
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-python-arm64
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-python-arm64
ghcr.io/openhands/agent-server:a56be70-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a56be70-golang
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-golang
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-golang
ghcr.io/openhands/agent-server:a56be70-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a56be70-java
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-java
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-java
ghcr.io/openhands/agent-server:a56be70-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a56be70-python
ghcr.io/openhands/agent-server:a56be7021d4f58a556ea24ef1ea61edb3c05b4f1-python
ghcr.io/openhands/agent-server:vasco-refactor-transport-call-python
ghcr.io/openhands/agent-server:a56be70-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a56be70-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a56be70-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->