### PR TITLE
chore(sdk): remove dead Tool.acall method (Q1 of #3341)

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -1,4 +1,3 @@
-import asyncio
 import re
 import threading
 from abc import ABC, abstractmethod
@@ -388,22 +387,6 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
             raise TypeError(
                 "Output must be dict or BaseModel when no output schema is defined"
             )
-
-    async def acall(
-        self, action: ActionT, conversation: "LocalConversation | None" = None
-    ) -> Observation:
-        """Async tool execution.
-
-        The default implementation runs :meth:`__call__` in a thread via
-        :func:`asyncio.loop.run_in_executor` so that blocking tool I/O
-        (subprocess management, filesystem operations, etc.) does not
-        starve the event loop.
-
-        Tools with native async implementations (e.g. HTTP-based tools)
-        can override this method to avoid the thread-pool overhead.
-        """
-        loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(None, self, action, conversation)
 
     def to_mcp_tool(
         self,


### PR DESCRIPTION
- [x] A human has tested these changes.

  ---

  ## Why

  `ToolDefinition.acall` (`tool.py`) was added by #3284 but is **dead code and a
  false affordance**:

  - Zero callers anywhere in the repo (code or tests).
  - The async execution path never dispatches to it. `aexecute_batch` →
    `_arun_safe` → `loop.run_in_executor(None, _run_safe, …)` → `tool_runner` →
    `_execute_action_event` → `tool(action, conversation)` (the **sync**
    `__call__`). The thread-wrapping is deliberate so `ResourceLockManager`'s
    threading locks are acquired off the event-loop thread.
  - Its docstring invites tool authors to "override this method to avoid the
    thread-pool overhead," but overriding it does nothing — the framework still
    runs `__call__` in a thread. A method that silently ignores overrides is
    worse than no method.

  This is the remaining `Tool.acall` item under Q1 of #3341 (the
  `_return_metrics` and title-helper items were handled by #3432 and #3447).

  ## Summary

  - Remove the unused `ToolDefinition.acall` method from `tool.py`.
  - Remove the now-unused `import asyncio` (`acall` was its only consumer).

  ## Issue Number

  Q1 of #3341
  
  ## How to Test

  Pure dead-code removal — no runtime behavior changes (nothing dispatched to
  `acall`). Verified with:

  - `uv run ruff check openhands-sdk/openhands/sdk/tool/tool.py` → All checks passed
  - Import smoke test → `hasattr(ToolDefinition, "acall")` is now `False`
  - `uv run pytest tests/sdk/tool/ -q` → 148 passed
  - `uv run pytest tests/sdk/ -q -k "parallel or aexecute or arun or async"` →
    188 passed (exercises the async/parallel execution path that was claimed to
    never call `acall`)

  ## Type
  
  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Docs / chore

  ## Notes

  If native-async tool dispatch is wanted later (e.g. so MCP tools `await`
  their executor directly instead of the current thread → `__call__` →
  `call_async_from_sync` → `await` sandwich), it should be reintroduced **wired
  up** — i.e. have the async path dispatch to a native-async override with an
  async-aware locking branch — rather than left as an unused method. See the
  Option B discussion and Q3/Q5 in #3341.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9819db1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9819db1-python \
  ghcr.io/openhands/agent-server:9819db1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9819db1-golang-amd64
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-golang-amd64
ghcr.io/openhands/agent-server:vasco-refactor-atool-golang-amd64
ghcr.io/openhands/agent-server:9819db1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9819db1-golang-arm64
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-golang-arm64
ghcr.io/openhands/agent-server:vasco-refactor-atool-golang-arm64
ghcr.io/openhands/agent-server:9819db1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9819db1-java-amd64
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-java-amd64
ghcr.io/openhands/agent-server:vasco-refactor-atool-java-amd64
ghcr.io/openhands/agent-server:9819db1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9819db1-java-arm64
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-java-arm64
ghcr.io/openhands/agent-server:vasco-refactor-atool-java-arm64
ghcr.io/openhands/agent-server:9819db1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9819db1-python-amd64
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-python-amd64
ghcr.io/openhands/agent-server:vasco-refactor-atool-python-amd64
ghcr.io/openhands/agent-server:9819db1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9819db1-python-arm64
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-python-arm64
ghcr.io/openhands/agent-server:vasco-refactor-atool-python-arm64
ghcr.io/openhands/agent-server:9819db1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9819db1-golang
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-golang
ghcr.io/openhands/agent-server:vasco-refactor-atool-golang
ghcr.io/openhands/agent-server:9819db1-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9819db1-java
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-java
ghcr.io/openhands/agent-server:vasco-refactor-atool-java
ghcr.io/openhands/agent-server:9819db1-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9819db1-python
ghcr.io/openhands/agent-server:9819db1cdec328baccce5dbbdd6d5950b6492ce7-python
ghcr.io/openhands/agent-server:vasco-refactor-atool-python
ghcr.io/openhands/agent-server:9819db1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9819db1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9819db1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->