### PR TITLE
feat(sdk): forward MCP servers to the ACP subprocess

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -35,9 +35,14 @@ from acp.schema import (
     AgentMessageChunk,
     AgentThoughtChunk,
     AllowedOutcome,
+    EnvVariable,
+    HttpHeader,
+    HttpMcpServer,
     ImageContentBlock,
+    McpServerStdio,
     PromptResponse,
     RequestPermissionResponse,
+    SseMcpServer,
     TextContentBlock,
     ToolCallProgress,
     ToolCallStart,
@@ -280,6 +285,108 @@ def _extract_session_models(
         info for info in (ACPModelInfo.from_protocol(m) for m in raw) if info.model_id
     ]
     return current, available
+
+
+# The ACP MCP server union accepted by new_session() / load_session().
+_ACPMcpServer = HttpMcpServer | SseMcpServer | McpServerStdio
+
+
+def _mcp_config_to_acp_servers(
+    mcp_config: dict[str, Any],
+    mcp_capabilities: Any,
+) -> list[_ACPMcpServer]:
+    """Translate an OpenHands ``mcp_config`` dict into ACP MCP server objects.
+
+    Reads the standard ``{"mcpServers": {name: {...}}}`` shape (the same shape
+    :attr:`AgentBase.mcp_config` carries for the built-in Agent) and returns the
+    list to pass to ``new_session()`` / ``load_session()`` so the ACP
+    subprocess connects to those servers itself.  Unlike the built-in Agent
+    these are *not* turned into in-process OpenHands MCP tools
+    (:attr:`ACPAgent.supports_openhands_mcp` stays ``False``) — the ACP server
+    owns the MCP connection and exposes the tools through its own turn.
+
+    Each entry maps by transport:
+
+    - ``command`` present → :class:`McpServerStdio` (always forwarded; the
+      protocol gates only the remote transports behind a capability flag).
+    - ``url`` present, transport ``sse`` → :class:`SseMcpServer`, forwarded only
+      when the server advertises ``mcp_capabilities.sse``.
+    - ``url`` present, any other / absent transport → :class:`HttpMcpServer`
+      (covers ``http`` and ``streamable-http``), forwarded only when the server
+      advertises ``mcp_capabilities.http``.
+
+    A remote server whose transport the ACP server does not advertise is dropped
+    with a warning rather than failing init — one misconfigured server should
+    not sink the whole conversation.  ``env`` / ``headers`` maps are converted
+    to the protocol's ``[{name, value}]`` list form; their values were already
+    decrypted by :class:`AgentBase`'s ``mcp_config`` validator.
+    """
+    servers = mcp_config.get("mcpServers")
+    if not isinstance(servers, dict):
+        return []
+    http_ok = bool(getattr(mcp_capabilities, "http", False))
+    sse_ok = bool(getattr(mcp_capabilities, "sse", False))
+    result: list[_ACPMcpServer] = []
+    for name, spec in servers.items():
+        if not isinstance(spec, dict):
+            logger.warning("Skipping malformed ACP MCP server %r", name)
+            continue
+        command = spec.get("command")
+        url = spec.get("url")
+        if command:
+            env = [
+                EnvVariable(name=str(k), value=str(v))
+                for k, v in (spec.get("env") or {}).items()
+            ]
+            result.append(
+                McpServerStdio(
+                    name=str(name),
+                    command=str(command),
+                    args=[str(a) for a in (spec.get("args") or [])],
+                    env=env,
+                )
+            )
+        elif url:
+            headers = [
+                HttpHeader(name=str(k), value=str(v))
+                for k, v in (spec.get("headers") or {}).items()
+            ]
+            transport = str(spec.get("transport") or "http").lower()
+            if transport == "sse":
+                if not sse_ok:
+                    logger.warning(
+                        "ACP server does not advertise SSE MCP support; "
+                        "dropping MCP server %r (%s)",
+                        name,
+                        url,
+                    )
+                    continue
+                result.append(
+                    SseMcpServer(
+                        type="sse", name=str(name), url=str(url), headers=headers
+                    )
+                )
+            else:
+                if not http_ok:
+                    logger.warning(
+                        "ACP server does not advertise HTTP MCP support; "
+                        "dropping MCP server %r (%s)",
+                        name,
+                        url,
+                    )
+                    continue
+                result.append(
+                    HttpMcpServer(
+                        type="http", name=str(name), url=str(url), headers=headers
+                    )
+                )
+        else:
+            logger.warning(
+                "Skipping ACP MCP server %r: needs a 'command' (stdio) or "
+                "'url' (http/sse)",
+                name,
+            )
+    return result
 
 
 async def _maybe_set_session_model(
@@ -1049,7 +1156,14 @@ class ACPAgent(AgentBase):
 
     @property
     def supports_openhands_mcp(self) -> bool:
-        """``False`` — MCP configuration is owned by the ACP subprocess."""
+        """``False`` — OpenHands does not create in-process MCP *tools* here.
+
+        This stays ``False`` even though ``mcp_config`` is honored: any
+        configured MCP servers are forwarded to the ACP subprocess at session
+        creation (see :func:`_mcp_config_to_acp_servers`) rather than connected
+        in-process. The ACP server owns the MCP connection and surfaces the
+        tools through its own turn.
+        """
         return False
 
     @property
@@ -1145,17 +1259,14 @@ class ACPAgent(AgentBase):
         """Spawn the ACP server and initialize a session."""
         # Validate unsupported execution features. agent_context is allowed
         # because it contributes prompt-only extensions to user messages; ACP
-        # server tools, MCP configuration, and context-window management remain
-        # owned by the server.
+        # server tools and context-window management remain owned by the server.
+        # mcp_config IS supported: its servers are forwarded to the subprocess at
+        # session creation (see _mcp_config_to_acp_servers) rather than turned
+        # into in-process OpenHands MCP tools.
         if self.tools:
             raise NotImplementedError(
                 "ACPAgent does not support custom tools; "
                 "the ACP server manages its own tools"
-            )
-        if self.mcp_config:
-            raise NotImplementedError(
-                "ACPAgent does not support mcp_config; "
-                "configure MCP on the ACP server instead"
             )
         if self.condenser is not None:
             raise NotImplementedError(
@@ -1449,6 +1560,25 @@ class ACPAgent(AgentBase):
                 agent_version,
             )
 
+            # Translate any configured MCP servers into ACP protocol objects,
+            # gating remote (http/sse) transports on what this server advertised
+            # in its initialize response. The same list is passed to both
+            # new_session and load_session: load_session does not persist the
+            # prior MCP set server-side, so a resume must re-send it or the
+            # restored session would silently lose its MCP servers.
+            mcp_caps = (
+                init_response.agent_capabilities.mcp_capabilities
+                if init_response.agent_capabilities is not None
+                else None
+            )
+            acp_mcp_servers = _mcp_config_to_acp_servers(self.mcp_config, mcp_caps)
+            if acp_mcp_servers:
+                logger.info(
+                    "Forwarding %d MCP server(s) to ACP session: %s",
+                    len(acp_mcp_servers),
+                    [s.name for s in acp_mcp_servers],
+                )
+
             # Authenticate if the server requires it.  Some ACP servers
             # (e.g. codex-acp) require an explicit authenticate call
             # before session creation.  We auto-detect the method from
@@ -1496,7 +1626,7 @@ class ACPAgent(AgentBase):
                     load_response = await conn.load_session(
                         cwd=working_dir,
                         session_id=prior_session_id,
-                        mcp_servers=[],
+                        mcp_servers=acp_mcp_servers,
                     )
                     session_id = prior_session_id
                     reported_model_id, available_models = _extract_session_models(
@@ -1526,7 +1656,11 @@ class ACPAgent(AgentBase):
                 # _meta dict in the JSON-RPC request — do NOT wrap in _meta=
                 # (that double-nests).
                 session_meta = build_session_model_meta(agent_name, self.acp_model)
-                response = await conn.new_session(cwd=working_dir, **session_meta)
+                response = await conn.new_session(
+                    cwd=working_dir,
+                    mcp_servers=acp_mcp_servers,
+                    **session_meta,
+                )
                 session_id = response.session_id
                 reported_model_id, available_models = _extract_session_models(response)
                 # Initial-selection protocol call for providers that use it

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -351,30 +351,25 @@ def _mcp_config_to_acp_servers(
                 HttpHeader(name=str(k), value=str(v))
                 for k, v in (spec.get("headers") or {}).items()
             ]
-            transport = str(spec.get("transport") or "http").lower()
-            if transport == "sse":
-                if not sse_ok:
-                    logger.warning(
-                        "ACP server does not advertise SSE MCP support; "
-                        "dropping MCP server %r (%s)",
-                        name,
-                        url,
-                    )
-                    continue
+            is_sse = str(spec.get("transport") or "http").lower() == "sse"
+            if not (sse_ok if is_sse else http_ok):
+                logger.warning(
+                    "ACP server does not advertise %s MCP support; "
+                    "dropping MCP server %r (%s)",
+                    "SSE" if is_sse else "HTTP",
+                    name,
+                    url,
+                )
+                continue
+            # Construct each transport explicitly so the ``type`` literal stays
+            # narrow (the union's two arms require distinct ``Literal``s).
+            if is_sse:
                 result.append(
                     SseMcpServer(
                         type="sse", name=str(name), url=str(url), headers=headers
                     )
                 )
             else:
-                if not http_ok:
-                    logger.warning(
-                        "ACP server does not advertise HTTP MCP support; "
-                        "dropping MCP server %r (%s)",
-                        name,
-                        url,
-                    )
-                    continue
                 result.append(
                     HttpMcpServer(
                         type="http", name=str(name), url=str(url), headers=headers

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1085,6 +1085,75 @@ class ACPAgentSettings(AgentSettingsBase):
             ).model_dump(),
         },
     )
+    mcp_config: MCPConfig | None = Field(
+        default=None,
+        description=(
+            "MCP servers to make available to the ACP subprocess. Unlike the "
+            "OpenHands agent — where these become in-process MCP tools — the "
+            "servers are forwarded to the ACP server at session creation and it "
+            "owns the connection. Remote (http/sse) servers are only forwarded "
+            "when the ACP server advertises support for that transport; stdio "
+            "servers (which run inside the runtime) are always forwarded."
+        ),
+        json_schema_extra={
+            SETTINGS_METADATA_KEY: SettingsFieldMetadata(
+                label="MCP configuration",
+                prominence=SettingProminence.MINOR,
+                variant="acp",
+            ).model_dump(),
+        },
+    )
+
+    @field_validator("mcp_config", mode="before")
+    @classmethod
+    def _normalize_empty_mcp_config(cls, value: Any) -> Any:
+        if value in (None, {}):
+            return None
+        return value
+
+    @field_validator("mcp_config", mode="before")
+    @classmethod
+    def _decrypt_mcp_secret_values(cls, value: Any, info: ValidationInfo) -> Any:
+        """Decrypt MCP ``env`` / ``headers`` values when a cipher is in
+        context (the on-disk load path). Mirrors the OpenHands settings
+        variant; both reuse the shared module-level helpers.
+        """
+        if not isinstance(value, dict):
+            return value
+        cipher: Cipher | None = info.context.get("cipher") if info.context else None
+        if cipher is None:
+            return value
+        return _walk_mcp_secret_values(
+            value, lambda v: _decrypt_mcp_value_or_keep(cipher, v)
+        )
+
+    @field_serializer("mcp_config")
+    def _serialize_mcp_config(
+        self, value: MCPConfig | None, info: SerializationInfo
+    ) -> dict[str, Any]:
+        if value is None:
+            return {}
+        dumped = value.model_dump(exclude_none=True, exclude_defaults=True)
+        ctx = info.context or {}
+        mode = resolve_expose_mode(ctx)
+
+        if mode == "plaintext":
+            return dumped
+
+        if mode == "encrypted":
+            cipher: Cipher | None = ctx.get("cipher")
+            if cipher is None:
+                raise MissingCipherError(
+                    "Cannot encrypt MCP env/headers: no cipher configured. "
+                    "Set OH_SECRET_KEY environment variable."
+                )
+            # cipher.encrypt returns None only for None input; SecretStr(v) never is.
+            return _walk_mcp_secret_values(
+                dumped, lambda v: cast(str, cipher.encrypt(SecretStr(v)))
+            )
+
+        return sanitize_dict(dumped)
+
     llm: LLM = Field(
         default_factory=_default_llm_settings,
         description=(
@@ -1211,6 +1280,14 @@ class ACPAgentSettings(AgentSettingsBase):
         """
         from openhands.sdk.agent import ACPAgent
 
+        # Bypass ``_serialize_mcp_config``: the subprocess needs real
+        # env/headers, not the masked/encrypted on-disk form.
+        mcp_config = (
+            self.mcp_config.model_dump(exclude_none=True, exclude_defaults=True)
+            if self.mcp_config is not None
+            else {}
+        )
+
         return ACPAgent(
             llm=self.llm,
             acp_command=self.resolve_acp_command(),
@@ -1220,6 +1297,7 @@ class ACPAgentSettings(AgentSettingsBase):
             acp_session_mode=self.acp_session_mode,
             acp_prompt_timeout=self.acp_prompt_timeout,
             agent_context=self.agent_context,
+            mcp_config=mcp_config,
         )
 
 

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -103,6 +103,67 @@ def _decrypt_mcp_value_or_keep(cipher: Cipher, value: str) -> str:
     return decrypt_str_with_cipher_or_keep(cipher, value, description="MCP env/headers")
 
 
+# ---------------------------------------------------------------------------
+# Shared ``mcp_config`` field (de)serialization, used verbatim by every
+# settings variant that exposes an ``mcp_config: MCPConfig | None`` field
+# (``OpenHandsAgentSettings`` and ``ACPAgentSettings``). Kept here as plain
+# functions so the per-class ``@field_validator`` / ``@field_serializer``
+# stubs — which pydantic requires to live on each model — stay one-liners and
+# the encrypt/decrypt logic has a single source of truth.
+# ---------------------------------------------------------------------------
+
+
+def normalize_empty_mcp_config(value: Any) -> Any:
+    """Coerce an empty/absent ``mcp_config`` to ``None`` (else pass through)."""
+    return None if value in (None, {}) else value
+
+
+def decrypt_mcp_config_secrets(value: Any, info: ValidationInfo) -> Any:
+    """Decrypt MCP ``env`` / ``headers`` values when a cipher is in context.
+
+    The on-disk load path. Values that aren't valid Fernet tokens pass through
+    as plaintext (e.g. migrating from a build that wrote them unencrypted).
+    Mirrors :func:`serialize_mcp_config`'s per-value encryption.
+    """
+    if not isinstance(value, dict):
+        return value
+    cipher: Cipher | None = info.context.get("cipher") if info.context else None
+    if cipher is None:
+        return value
+    return _walk_mcp_secret_values(
+        value, lambda v: _decrypt_mcp_value_or_keep(cipher, v)
+    )
+
+
+def serialize_mcp_config(
+    value: MCPConfig | None, info: SerializationInfo
+) -> dict[str, Any]:
+    """Serialize an ``mcp_config`` field, masking/encrypting env+headers per
+    the active expose mode (``plaintext`` / ``encrypted`` / redacted)."""
+    if value is None:
+        return {}
+    dumped = value.model_dump(exclude_none=True, exclude_defaults=True)
+    ctx = info.context or {}
+    mode = resolve_expose_mode(ctx)
+
+    if mode == "plaintext":
+        return dumped
+
+    if mode == "encrypted":
+        cipher: Cipher | None = ctx.get("cipher")
+        if cipher is None:
+            raise MissingCipherError(
+                "Cannot encrypt MCP env/headers: no cipher configured. "
+                "Set OH_SECRET_KEY environment variable."
+            )
+        # cipher.encrypt returns None only for None input; SecretStr(v) never is.
+        return _walk_mcp_secret_values(
+            dumped, lambda v: cast(str, cipher.encrypt(SecretStr(v)))
+        )
+
+    return sanitize_dict(dumped)
+
+
 SettingsValueType = Literal[
     "string",
     "integer",
@@ -776,59 +837,23 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         },
     )
 
+    # ``mcp_config`` (de)serialization is shared with ACPAgentSettings via the
+    # module-level helpers — these stubs just bind them to the field.
     @field_validator("mcp_config", mode="before")
     @classmethod
     def _normalize_empty_mcp_config(cls, value: Any) -> Any:
-        if value in (None, {}):
-            return None
-        return value
+        return normalize_empty_mcp_config(value)
 
     @field_validator("mcp_config", mode="before")
     @classmethod
     def _decrypt_mcp_secret_values(cls, value: Any, info: ValidationInfo) -> Any:
-        """Decrypt MCP ``env`` / ``headers`` values when a cipher is in
-        context (the on-disk load path). Mirrors ``_serialize_mcp_config``'s
-        per-value encryption.
-
-        Values that aren't valid Fernet tokens are passed through as
-        plaintext (e.g. when migrating from a build that wrote env/headers
-        unencrypted to disk).
-        """
-        if not isinstance(value, dict):
-            return value
-        cipher: Cipher | None = info.context.get("cipher") if info.context else None
-        if cipher is None:
-            return value
-        return _walk_mcp_secret_values(
-            value, lambda v: _decrypt_mcp_value_or_keep(cipher, v)
-        )
+        return decrypt_mcp_config_secrets(value, info)
 
     @field_serializer("mcp_config")
     def _serialize_mcp_config(
         self, value: MCPConfig | None, info: SerializationInfo
     ) -> dict[str, Any]:
-        if value is None:
-            return {}
-        dumped = value.model_dump(exclude_none=True, exclude_defaults=True)
-        ctx = info.context or {}
-        mode = resolve_expose_mode(ctx)
-
-        if mode == "plaintext":
-            return dumped
-
-        if mode == "encrypted":
-            cipher: Cipher | None = ctx.get("cipher")
-            if cipher is None:
-                raise MissingCipherError(
-                    "Cannot encrypt MCP env/headers: no cipher configured. "
-                    "Set OH_SECRET_KEY environment variable."
-                )
-            # cipher.encrypt returns None only for None input; SecretStr(v) never is.
-            return _walk_mcp_secret_values(
-                dumped, lambda v: cast(str, cipher.encrypt(SecretStr(v)))
-            )
-
-        return sanitize_dict(dumped)
+        return serialize_mcp_config(value, info)
 
     def create_agent(self) -> Agent:
         """Build an :class:`Agent` purely from these settings.
@@ -1104,55 +1129,22 @@ class ACPAgentSettings(AgentSettingsBase):
         },
     )
 
+    # Same shared ``mcp_config`` (de)serialization as OpenHandsAgentSettings.
     @field_validator("mcp_config", mode="before")
     @classmethod
     def _normalize_empty_mcp_config(cls, value: Any) -> Any:
-        if value in (None, {}):
-            return None
-        return value
+        return normalize_empty_mcp_config(value)
 
     @field_validator("mcp_config", mode="before")
     @classmethod
     def _decrypt_mcp_secret_values(cls, value: Any, info: ValidationInfo) -> Any:
-        """Decrypt MCP ``env`` / ``headers`` values when a cipher is in
-        context (the on-disk load path). Mirrors the OpenHands settings
-        variant; both reuse the shared module-level helpers.
-        """
-        if not isinstance(value, dict):
-            return value
-        cipher: Cipher | None = info.context.get("cipher") if info.context else None
-        if cipher is None:
-            return value
-        return _walk_mcp_secret_values(
-            value, lambda v: _decrypt_mcp_value_or_keep(cipher, v)
-        )
+        return decrypt_mcp_config_secrets(value, info)
 
     @field_serializer("mcp_config")
     def _serialize_mcp_config(
         self, value: MCPConfig | None, info: SerializationInfo
     ) -> dict[str, Any]:
-        if value is None:
-            return {}
-        dumped = value.model_dump(exclude_none=True, exclude_defaults=True)
-        ctx = info.context or {}
-        mode = resolve_expose_mode(ctx)
-
-        if mode == "plaintext":
-            return dumped
-
-        if mode == "encrypted":
-            cipher: Cipher | None = ctx.get("cipher")
-            if cipher is None:
-                raise MissingCipherError(
-                    "Cannot encrypt MCP env/headers: no cipher configured. "
-                    "Set OH_SECRET_KEY environment variable."
-                )
-            # cipher.encrypt returns None only for None input; SecretStr(v) never is.
-            return _walk_mcp_secret_values(
-                dumped, lambda v: cast(str, cipher.encrypt(SecretStr(v)))
-            )
-
-        return sanitize_dict(dumped)
+        return serialize_mcp_config(value, info)
 
     llm: LLM = Field(
         default_factory=_default_llm_settings,

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -7492,4 +7492,3 @@ class TestACPStepMasksPersistedTurn:
         )
         assert "supersecret" not in finish.action.message
         assert finish.action.message == "the value is <secret-hidden> now"
-

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -23,6 +23,7 @@ from openhands.sdk.agent.acp_agent import (
     _extract_token_usage,
     _image_url_to_acp_block,
     _maybe_set_session_model,
+    _mcp_config_to_acp_servers,
     _OpenHandsACPBridge,
     _reapply_session_model_on_resume,
     _select_auth_method,
@@ -372,13 +373,20 @@ class TestACPAgentValidation:
             agent.init_state(state, on_event=events.append)
         return events
 
-    def test_rejects_mcp_config(self, tmp_path):
+    def test_allows_mcp_config(self, tmp_path):
+        """mcp_config is forwarded to the ACP subprocess, not rejected.
+
+        The servers are translated and passed to new_session/load_session
+        (see test_acp_mcp.py); here we just assert init_state no longer raises.
+        """
         agent = ACPAgent(
             acp_command=["echo"],
             mcp_config={"mcpServers": {"test": {"command": "echo"}}},
         )
-        with pytest.raises(NotImplementedError, match="mcp_config"):
-            self._init_with_patches(agent, tmp_path)
+        # Should not raise; supports_openhands_mcp stays False (no in-process
+        # tools — the ACP server owns the connection).
+        self._init_with_patches(agent, tmp_path)
+        assert agent.supports_openhands_mcp is False
 
     def test_allows_agent_context_for_prompt_extensions(self, tmp_path):
         agent = ACPAgent(
@@ -5977,3 +5985,154 @@ class TestACPAgentSupportsRuntimeModelSwitch:
         agent._session_id = "sess-1"
         agent._agent_name = "locked-down-provider"
         assert agent.supports_runtime_model_switch is False
+
+
+# ---------------------------------------------------------------------------
+# MCP forwarding
+# ---------------------------------------------------------------------------
+
+
+class TestMcpConfigToAcpServers:
+    """Unit tests for the mcp_config -> ACP server translation + gating."""
+
+    @staticmethod
+    def _caps(http: bool, sse: bool):
+        from acp.schema import McpCapabilities
+
+        return McpCapabilities(http=http, sse=sse)
+
+    def test_stdio_always_forwarded(self):
+        from acp.schema import McpServerStdio
+
+        cfg = {
+            "mcpServers": {
+                "fetch": {
+                    "command": "uvx",
+                    "args": ["mcp-server-fetch"],
+                    "env": {"API_KEY": "x"},
+                }
+            }
+        }
+        # Even with no advertised remote capabilities, stdio is forwarded.
+        out = _mcp_config_to_acp_servers(cfg, self._caps(http=False, sse=False))
+        assert len(out) == 1
+        srv = out[0]
+        assert isinstance(srv, McpServerStdio)
+        assert srv.name == "fetch"
+        assert srv.command == "uvx"
+        assert srv.args == ["mcp-server-fetch"]
+        assert [(e.name, e.value) for e in srv.env] == [("API_KEY", "x")]
+
+    def test_http_gated_on_capability(self):
+        from acp.schema import HttpMcpServer
+
+        cfg = {
+            "mcpServers": {
+                "remote": {
+                    "url": "https://h/mcp",
+                    "headers": {"Authorization": "Bearer y"},
+                }
+            }
+        }
+        # Dropped when the server doesn't advertise http.
+        assert _mcp_config_to_acp_servers(cfg, self._caps(http=False, sse=False)) == []
+        # Forwarded when advertised.
+        out = _mcp_config_to_acp_servers(cfg, self._caps(http=True, sse=False))
+        assert len(out) == 1
+        assert isinstance(out[0], HttpMcpServer)
+        assert out[0].type == "http"
+        assert out[0].url == "https://h/mcp"
+        assert [(h.name, h.value) for h in out[0].headers] == [
+            ("Authorization", "Bearer y")
+        ]
+
+    def test_sse_gated_on_capability(self):
+        from acp.schema import SseMcpServer
+
+        cfg = {"mcpServers": {"s": {"url": "https://s/sse", "transport": "sse"}}}
+        assert _mcp_config_to_acp_servers(cfg, self._caps(http=True, sse=False)) == []
+        out = _mcp_config_to_acp_servers(cfg, self._caps(http=True, sse=True))
+        assert len(out) == 1
+        assert isinstance(out[0], SseMcpServer)
+        assert out[0].type == "sse"
+
+    def test_streamable_http_maps_to_http(self):
+        from acp.schema import HttpMcpServer
+
+        cfg = {
+            "mcpServers": {
+                "s": {"url": "https://h/mcp", "transport": "streamable-http"}
+            }
+        }
+        out = _mcp_config_to_acp_servers(cfg, self._caps(http=True, sse=True))
+        assert len(out) == 1
+        assert isinstance(out[0], HttpMcpServer)
+
+    def test_empty_and_malformed_configs(self):
+        caps = self._caps(http=True, sse=True)
+        assert _mcp_config_to_acp_servers({}, caps) == []
+        assert _mcp_config_to_acp_servers({"mcpServers": {}}, caps) == []
+        # Not a dict -> skipped, no crash.
+        assert _mcp_config_to_acp_servers({"mcpServers": {"bad": 123}}, caps) == []
+        # No command and no url -> skipped.
+        assert _mcp_config_to_acp_servers({"mcpServers": {"x": {}}}, caps) == []
+
+    def test_none_capabilities_drops_remote_keeps_stdio(self):
+        from acp.schema import McpServerStdio
+
+        cfg = {
+            "mcpServers": {
+                "fetch": {"command": "echo"},
+                "remote": {"url": "https://h/mcp"},
+            }
+        }
+        out = _mcp_config_to_acp_servers(cfg, None)
+        assert [type(s).__name__ for s in out] == [McpServerStdio.__name__]
+
+
+class TestACPMcpForwarding:
+    """The translated servers reach new_session AND load_session (resume)."""
+
+    @staticmethod
+    def _conn_with_caps(*, http=True, sse=True, load_exc=None):
+        conn = TestACPSessionIdPersistence._make_conn(load_exc=load_exc)
+        conn.initialize.return_value.agent_capabilities.mcp_capabilities = (
+            TestMcpConfigToAcpServers._caps(http=http, sse=sse)
+        )
+        return conn
+
+    def test_new_session_receives_mcp_servers(self, tmp_path):
+        agent = _make_agent(mcp_config={"mcpServers": {"fetch": {"command": "echo"}}})
+        state = _make_state(tmp_path)
+        conn = self._conn_with_caps()
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.new_session.assert_awaited_once()
+        servers = conn.new_session.call_args.kwargs["mcp_servers"]
+        assert [s.name for s in servers] == ["fetch"]
+
+    def test_resume_load_session_receives_mcp_servers(self, tmp_path):
+        """The key correctness point: resume must re-pass MCP servers, since
+        load_session does not persist them server-side."""
+        agent = _make_agent(mcp_config={"mcpServers": {"fetch": {"command": "echo"}}})
+        state = _make_state(tmp_path)
+        state.agent_state = {**state.agent_state, "acp_session_id": "stored-sess"}
+        conn = self._conn_with_caps()
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.load_session.assert_awaited_once()
+        servers = conn.load_session.call_args.kwargs["mcp_servers"]
+        assert [s.name for s in servers] == ["fetch"]
+        conn.new_session.assert_not_awaited()
+
+    def test_no_mcp_config_forwards_empty_list(self, tmp_path):
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        conn = self._conn_with_caps()
+
+        TestACPSessionIdPersistence._patched_start_acp_server(agent, state, conn=conn)
+
+        conn.new_session.assert_awaited_once()
+        assert conn.new_session.call_args.kwargs["mcp_servers"] == []

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -145,6 +145,13 @@ def test_acp_agent_settings_export_schema_has_acp_section() -> None:
     assert acp_fields["acp_model"].prominence is SettingProminence.CRITICAL
     assert acp_fields["acp_command"].prominence is SettingProminence.MINOR
 
+    # mcp_config is exposed as a single object field (matching the OpenHands
+    # variant) rather than being expanded into nested per-server fields. The
+    # servers are forwarded to the ACP subprocess at session creation.
+    general_fields = {f.key: f for f in sections["general"].fields}
+    assert "mcp_config" in general_fields
+    assert general_fields["mcp_config"].prominence is SettingProminence.MINOR
+
 
 def test_conversation_settings_export_schema_groups_sections() -> None:
     schema = ConversationSettings.export_schema()


### PR DESCRIPTION
## What

Enables ACP agents (Claude Code / Codex / Gemini CLI / custom) to use **MCP servers**. Previously they couldn't: `ACPAgent.init_state()` raised `NotImplementedError` on any `mcp_config`, and session creation hardcoded `mcp_servers=[]`.

The block was entirely on our side — the ACP protocol and all three built-in servers already support MCP (claude-agent-acp: stdio+http+sse; codex-acp: stdio+http; gemini-cli: native).

## How

Reuse the existing `mcp_config` field rather than inventing a new one — `ACPAgent` already inherits `mcp_config` **and its env/headers secret-encryption** from `AgentBase`.

- New `_mcp_config_to_acp_servers()` translates the standard `{"mcpServers": {...}}` shape into ACP `McpServerStdio` / `HttpMcpServer` / `SseMcpServer` objects.
- Remote (http/sse) transports are **gated on the server's advertised `mcp_capabilities`** (from the initialize response); a transport the server doesn't support is dropped with a warning rather than failing init. **stdio is always forwarded.**
- The translated list is passed to **both** `new_session` and `load_session` — resume must re-pass it, since `load_session` does not persist the MCP set server-side (verified against claude-agent-acp).
- `supports_openhands_mcp` stays `False`: these servers become the ACP subprocess's own MCP connection, **not** in-process OpenHands MCP tools (`init_state` fully overrides `_initialize`, so `create_mcp_tools` is never reached).
- `ACPAgentSettings` gains `mcp_config: MCPConfig | None`, rendered as a single object field and threaded through `create_agent()`.

## Refactor (no behavior change)

- The `mcp_config` normalize/decrypt/serialize logic was byte-identical between `OpenHandsAgentSettings` and `ACPAgentSettings`, so it's now extracted into shared module-level helpers (`normalize_empty_mcp_config` / `decrypt_mcp_config_secrets` / `serialize_mcp_config`) — a single source of truth for the security-sensitive env/headers encryption; both classes bind them via one-line field stubs.
- Collapsed the duplicated capability-gate + warning in `_mcp_config_to_acp_servers`' remote branch (stdio path unchanged).
- Net −13 lines; full settings + ACP suites, agent-server settings router, and API-breakage check stay green.

## Validation (real API calls, local auth)

Exercised the full path against **all three real ACP harnesses over both transports**, confirming the MCP tool was actually invoked (via the subprocess's real tool call + the server's `Echo: <token>` response — not just reply text):

| Harness | stdio | http (streamable) |
|---|---|---|
| Claude Code | ✅ | ✅ |
| Codex | ✅ | ✅ |
| Gemini CLI | ✅ | ✅ |

MCP server = `@modelcontextprotocol/server-everything`; the http runs exercise the capability-gated remote branch end-to-end. (Gemini in `default` session mode routes the MCP call through the auto-approved permission path, so it surfaces as a subprocess tool call + `Echo:` output rather than a standalone tool-call event — confirmed reproducibly.)

## Notes / constraints

- **No runtime add** — MCP binds at session creation; changing config restarts the (cwd-keyed) session, unlike the live model-switch feature.
- **stdio binaries** (`npx`/`uvx`) must exist in the runtime image; remote http/sse needs none.
- The failing **`Python API`** check is **inherited from #3456** (the `acall` removal on `main` with no version bump) — it hits every PR branched after it (e.g. #3457) and needs a release-time minor-version bump, not a change here.

## Tests

- `TestMcpConfigToAcpServers` — translation + capability gating (stdio always, http/sse gated, streamable-http→http, malformed/empty skip, `None` caps).
- `TestACPMcpForwarding` — servers reach `new_session` and (the key case) re-reach `load_session` on resume; no-config forwards `[]`.
- Replaced `test_rejects_mcp_config` with `test_allows_mcp_config`.
- Settings round-trip + schema (`mcp_config` exposed as a single field).

Full suite green (`tests/sdk/agent`, `tests/sdk/settings`, `tests/sdk/test_settings.py`, agent-server settings router, SDK API-breakage check). ruff + pyright clean.

Part of OpenHands/OpenHands#15745. Paired with typescript-client + agent-canvas PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5e2f028-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5e2f028-python \
  ghcr.io/openhands/agent-server:5e2f028-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5e2f028-golang-amd64
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-mcp-golang-amd64
ghcr.io/openhands/agent-server:5e2f028-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5e2f028-golang-arm64
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-mcp-golang-arm64
ghcr.io/openhands/agent-server:5e2f028-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5e2f028-java-amd64
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-java-amd64
ghcr.io/openhands/agent-server:feat-acp-mcp-java-amd64
ghcr.io/openhands/agent-server:5e2f028-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5e2f028-java-arm64
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-java-arm64
ghcr.io/openhands/agent-server:feat-acp-mcp-java-arm64
ghcr.io/openhands/agent-server:5e2f028-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5e2f028-python-amd64
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-python-amd64
ghcr.io/openhands/agent-server:feat-acp-mcp-python-amd64
ghcr.io/openhands/agent-server:5e2f028-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5e2f028-python-arm64
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-python-arm64
ghcr.io/openhands/agent-server:feat-acp-mcp-python-arm64
ghcr.io/openhands/agent-server:5e2f028-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5e2f028-golang
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-golang
ghcr.io/openhands/agent-server:feat-acp-mcp-golang
ghcr.io/openhands/agent-server:5e2f028-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5e2f028-java
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-java
ghcr.io/openhands/agent-server:feat-acp-mcp-java
ghcr.io/openhands/agent-server:5e2f028-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5e2f028-python
ghcr.io/openhands/agent-server:5e2f0288c8e8769bb3bf97274273dff1876c59ed-python
ghcr.io/openhands/agent-server:feat-acp-mcp-python
ghcr.io/openhands/agent-server:5e2f028-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5e2f028-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5e2f028-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

