### PR TITLE
Add MiniMax M3 model configuration

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -234,6 +234,16 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # https://www.minimax.io/models/text/m3
+    "minimax-m3": {
+        "id": "minimax-m3",
+        "display_name": "MiniMax M3",
+        "llm_config": {
+            "model": "litellm_proxy/minimax/MiniMax-M3",
+            "temperature": 1.0,
+            "top_p": 0.95,
+        },
+    },
     "deepseek-v3.2-reasoner": {
         "id": "deepseek-v3.2-reasoner",
         "display_name": "DeepSeek V3.2 Reasoner",

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -234,7 +234,6 @@ MODELS = {
             "top_p": 0.95,
         },
     },
-    # https://www.minimax.io/models/text/m3
     "minimax-m3": {
         "id": "minimax-m3",
         "display_name": "MiniMax M3",

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -692,3 +692,14 @@ def test_claude_opus_4_8_config():
     assert model["id"] == "claude-opus-4-8"
     assert model["display_name"] == "Claude Opus 4.8"
     assert model["llm_config"]["model"] == "litellm_proxy/anthropic/claude-opus-4-8"
+
+
+def test_minimax_m3_config():
+    """Test that minimax-m3 has correct configuration."""
+    model = MODELS["minimax-m3"]
+
+    assert model["id"] == "minimax-m3"
+    assert model["display_name"] == "MiniMax M3"
+    assert model["llm_config"]["model"] == "litellm_proxy/minimax/MiniMax-M3"
+    assert model["llm_config"]["temperature"] == 1.0
+    assert model["llm_config"]["top_p"] == 0.95


### PR DESCRIPTION
## Summary
Adds the `minimax-m3` model to `resolve_model_config.py`, following the workflow described in `.github/run-eval/ADDINGMODEL.md`.

Reference: https://www.minimax.io/models/text/m3

## Changes
- Added `minimax-m3` entry to the `MODELS` dictionary in `.github/run-eval/resolve_model_config.py`
- Added `test_minimax_m3_config()` test function in `tests/cross/test_resolve_model_config.py`

## Configuration
- Model ID: `minimax-m3`
- Provider: MiniMax (via litellm_proxy)
- LiteLLM model: `litellm_proxy/minimax/MiniMax-M3`
- Temperature: `1.0` — MiniMax frontier reasoning models (M2.5, M2.7) use `1.0`; M3 follows the same pattern
- top_p: `0.95` — matches the M2.5/M2.7 reasoning configuration

Per the issue request, **this model is intentionally not added to `verified_models.py` yet**.

## Integration Test Results
Will be triggered separately on this PR via the integration-runner workflow.

Fixes #3459

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d1250d12-5454-4345-bf83-674b154d47d6)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d7f1bed-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d7f1bed-python \
  ghcr.io/openhands/agent-server:d7f1bed-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d7f1bed-golang-amd64
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-golang-amd64
ghcr.io/openhands/agent-server:d7f1bed-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d7f1bed-golang-arm64
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-golang-arm64
ghcr.io/openhands/agent-server:d7f1bed-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d7f1bed-java-amd64
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-java-amd64
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-java-amd64
ghcr.io/openhands/agent-server:d7f1bed-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d7f1bed-java-arm64
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-java-arm64
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-java-arm64
ghcr.io/openhands/agent-server:d7f1bed-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d7f1bed-python-amd64
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-python-amd64
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-python-amd64
ghcr.io/openhands/agent-server:d7f1bed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d7f1bed-python-arm64
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-python-arm64
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-python-arm64
ghcr.io/openhands/agent-server:d7f1bed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d7f1bed-golang
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-golang
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-golang
ghcr.io/openhands/agent-server:d7f1bed-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d7f1bed-java
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-java
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-java
ghcr.io/openhands/agent-server:d7f1bed-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d7f1bed-python
ghcr.io/openhands/agent-server:d7f1bed3520bc1ed39564154b3dea3f2c73a19ae-python
ghcr.io/openhands/agent-server:openhands-add-minimax-m3-python
ghcr.io/openhands/agent-server:d7f1bed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d7f1bed-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d7f1bed-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->