### PR TITLE
fix(acp): surface structured errors on ACP spawn/auth/init failure

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -386,6 +386,23 @@ class EventService:
         loop = asyncio.get_running_loop()
         return await loop.run_in_executor(None, self._get_execution_status_sync)
 
+    def _mark_error_status_sync(self) -> None:
+        """Force the conversation into ERROR status (idempotent backstop).
+
+        Called when a run task raised before the conversation could set its own
+        ERROR status — e.g. an exception in ``init_state``, which executes
+        outside ``run()``/``arun()``'s try-block (via ``_ensure_agent_ready()``).
+        Without this, the run's finally would publish a stale non-error status
+        (IDLE/RUNNING) and the failure would look like a clean stop. No-op once
+        the status is already ERROR. Best-effort: never raises (the caller is an
+        error handler).
+        """
+        if not self._conversation:
+            return
+        with self._conversation._state as state:
+            if state.execution_status != ConversationExecutionStatus.ERROR:
+                state.execution_status = ConversationExecutionStatus.ERROR
+
     def _create_state_update_event_sync(self) -> ConversationStateUpdateEvent:
         if not self._conversation:
             raise ValueError("inactive_service")
@@ -893,6 +910,13 @@ class EventService:
                         await loop.run_in_executor(self._run_executor, conversation.run)
                 except Exception:
                     logger.exception("Error during conversation run")
+                    # Backstop: a run that raised before reaching its own error
+                    # handling (e.g. an ACP cold-start failure in init_state,
+                    # which runs outside run()/arun()'s try-block) can leave the
+                    # status at IDLE/RUNNING. Force ERROR so the finally's
+                    # _publish_state_update() surfaces the failure instead of a
+                    # misleading non-error state.
+                    await loop.run_in_executor(None, self._mark_error_status_sync)
                 finally:
                     # Wait for all pending events to be published via
                     # AsyncCallbackWrapper before publishing the final state update.

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -487,6 +487,34 @@ async def _filter_jsonrpc_lines(source: Any, dest: Any) -> None:
         dest.feed_eof()
 
 
+def _classify_acp_init_error(exc: BaseException) -> str:
+    """Map a cold-start failure to a structured ``ConversationErrorEvent`` code.
+
+    ACP's spawn + auth + ``session/new`` runs in :meth:`ACPAgent.init_state`,
+    which ``LocalConversation.run()``/``arun()`` invoke *before* their try-block
+    (via ``_ensure_agent_ready()``).  These cold-start failures — far more common
+    on cloud than locally — therefore bypass the run loop's error emission, so
+    ``init_state`` surfaces them itself.  The code tells clients *which* failure
+    occurred so they can react (e.g. prompt re-auth vs. report a missing binary):
+
+    - ``ACPAuthRequired``: the ACP server reported a JSON-RPC auth-required error
+      (code ``-32000``) from ``authenticate``/``new_session`` — missing, expired,
+      or rejected credentials.  The most actionable cloud failure, so it gets its
+      own code.
+    - ``ACPSpawnError``: the subprocess could not be launched — the CLI binary is
+      missing or not executable (``FileNotFoundError`` / ``PermissionError`` from
+      ``create_subprocess_exec``).
+    - ``ACPInitError``: anything else during the protocol handshake or session
+      creation (timeouts, transport drops, unexpected protocol errors, cwd
+      mismatch surfaced by the server).
+    """
+    if isinstance(exc, ACPRequestError) and getattr(exc, "code", None) == -32000:
+        return "ACPAuthRequired"
+    if isinstance(exc, (FileNotFoundError, PermissionError)):
+        return "ACPSpawnError"
+    return "ACPInitError"
+
+
 class _OpenHandsACPBridge:
     """Bridge between OpenHands and ACP that accumulates session updates.
 
@@ -1197,6 +1225,28 @@ class ACPAgent(AgentBase):
         except Exception as e:
             logger.error("Failed to start ACP server: %s", e)
             self._cleanup()
+            # init_state runs *outside* run()/arun()'s try-block (it is reached
+            # via _ensure_agent_ready() before the loop starts), so a cold-start
+            # failure — bad/expired auth, missing CLI binary, cwd mismatch — would
+            # otherwise bypass error emission and reach the client as a generic
+            # "remote conversation ended with error".  Emit a typed
+            # ConversationErrorEvent and flip the status to ERROR here, mirroring
+            # what the regular Agent (and ACPAgent.astep) do from inside the run
+            # loop, so clients render their existing error banner instead.
+            # Best-effort: surfacing the error must never mask the original
+            # exception, which still propagates to preserve the existing
+            # cleanup/re-raise contract that run()/arun() rely on.
+            try:
+                state.execution_status = ConversationExecutionStatus.ERROR
+                on_event(
+                    ConversationErrorEvent(
+                        source="agent",
+                        code=_classify_acp_init_error(e),
+                        detail=str(e)[:500],
+                    )
+                )
+            except Exception:
+                logger.exception("Failed to surface ACP init error to client")
             raise
 
         # A successful resume keeps the prior id; cwd mismatch and load_session

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1152,6 +1152,59 @@ class TestEventServiceSendMessage:
         conversation.run.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_run_exception_forces_error_status(self, event_service):
+        """A run that raises before setting its own ERROR status (e.g. an ACP
+        cold-start failure in init_state, which runs outside run()/arun()'s
+        try-block) must be flipped to ERROR so the finally's state publish
+        surfaces the failure instead of a stale IDLE/RUNNING status (issue
+        #1024)."""
+        conversation = MagicMock()
+        state = MagicMock()
+        # Status never advanced past IDLE because the failure happened in
+        # _ensure_agent_ready() before the run loop set RUNNING.
+        state.execution_status = ConversationExecutionStatus.IDLE
+        state.__enter__ = MagicMock(return_value=state)
+        state.__exit__ = MagicMock(return_value=None)
+        conversation.state = state
+        conversation._state = state
+        conversation.send_message = MagicMock()
+        conversation.run = MagicMock(side_effect=RuntimeError("init failed"))
+
+        event_service._conversation = conversation
+        event_service._publish_state_update = AsyncMock()
+
+        await event_service.send_message(Message(role="user", content=[]), run=True)
+        assert event_service._run_task is not None
+        await event_service._run_task
+
+        assert state.execution_status == ConversationExecutionStatus.ERROR
+        # The final state update is still published after the flip.
+        event_service._publish_state_update.assert_awaited()
+
+    @pytest.mark.asyncio
+    async def test_run_exception_preserves_existing_error_status(self, event_service):
+        """When the run already set ERROR (the regular Agent path), the backstop
+        is a no-op — it must not clobber a status the run already owns."""
+        conversation = MagicMock()
+        state = MagicMock()
+        state.execution_status = ConversationExecutionStatus.ERROR
+        state.__enter__ = MagicMock(return_value=state)
+        state.__exit__ = MagicMock(return_value=None)
+        conversation.state = state
+        conversation._state = state
+        conversation.send_message = MagicMock()
+        conversation.run = MagicMock(side_effect=RuntimeError("boom"))
+
+        event_service._conversation = conversation
+        event_service._publish_state_update = AsyncMock()
+
+        await event_service.send_message(Message(role="user", content=[]), run=True)
+        assert event_service._run_task is not None
+        await event_service._run_task
+
+        assert state.execution_status == ConversationExecutionStatus.ERROR
+
+    @pytest.mark.asyncio
     async def test_send_message_with_different_message_types(self, event_service):
         """Test send_message with different message types."""
         # Mock conversation

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -18,6 +18,7 @@ from pydantic import SecretStr
 
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
+    _classify_acp_init_error,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
@@ -766,6 +767,120 @@ class TestACPAgentInitState:
 
         assert events[0].dynamic_context is not None
         assert "REGISTRY_TOKEN" in events[0].dynamic_context.text
+
+    # -- Cold-start error surfacing (issue #1024) --------------------------
+
+    def _init_state_failure(self, tmp_path, exc: BaseException):
+        """Run init_state with ``_start_acp_server`` raising ``exc``.
+
+        Returns ``(state, events, raised)`` where ``raised`` is the exception
+        that escaped init_state (asserted to be the original ``exc``).
+        """
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        events: list = []
+        with patch(
+            "openhands.sdk.agent.acp_agent.ACPAgent._start_acp_server",
+            side_effect=exc,
+        ):
+            with pytest.raises(type(exc)) as excinfo:
+                agent.init_state(state, on_event=events.append)
+        assert excinfo.value is exc, "original exception must propagate unchanged"
+        return state, events
+
+    def test_init_state_surfaces_auth_required(self, tmp_path):
+        """An auth-required protocol error becomes a typed ACPAuthRequired event
+        with ERROR status — instead of bypassing emission and reaching the
+        client as a generic "remote conversation ended with error"."""
+        exc = ACPRequestError(-32000, "Authentication required")
+        state, events = self._init_state_failure(tmp_path, exc)
+
+        errors = [e for e in events if isinstance(e, ConversationErrorEvent)]
+        assert len(errors) == 1
+        assert errors[0].source == "agent"
+        assert errors[0].code == "ACPAuthRequired"
+        assert "Authentication required" in errors[0].detail
+        assert state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_init_state_surfaces_spawn_error(self, tmp_path):
+        """A missing/unexecutable CLI binary (FileNotFoundError /
+        PermissionError from create_subprocess_exec) becomes ACPSpawnError."""
+        for exc in (
+            FileNotFoundError("no such file: claude-agent-acp"),
+            PermissionError("permission denied"),
+        ):
+            state, events = self._init_state_failure(tmp_path, exc)
+            errors = [e for e in events if isinstance(e, ConversationErrorEvent)]
+            assert len(errors) == 1
+            assert errors[0].code == "ACPSpawnError"
+            assert state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_init_state_surfaces_generic_init_error(self, tmp_path):
+        """Any other handshake/session failure falls back to ACPInitError."""
+        exc = RuntimeError("protocol handshake timed out")
+        state, events = self._init_state_failure(tmp_path, exc)
+
+        errors = [e for e in events if isinstance(e, ConversationErrorEvent)]
+        assert len(errors) == 1
+        assert errors[0].code == "ACPInitError"
+        assert "protocol handshake timed out" in errors[0].detail
+        assert state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_init_state_truncates_long_detail(self, tmp_path):
+        """detail is capped at 500 chars, matching the run-loop error path."""
+        exc = RuntimeError("x" * 1000)
+        _state, events = self._init_state_failure(tmp_path, exc)
+        errors = [e for e in events if isinstance(e, ConversationErrorEvent)]
+        assert len(errors[0].detail) == 500
+
+    def test_init_state_reraises_even_if_emission_fails(self, tmp_path):
+        """A failure while surfacing the error must never mask the original
+        exception — the re-raise contract run()/arun() rely on is preserved."""
+        agent = _make_agent()
+        state = _make_state(tmp_path)
+        exc = RuntimeError("boom")
+
+        def _explode(_event):
+            raise ValueError("on_event is broken")
+
+        with patch(
+            "openhands.sdk.agent.acp_agent.ACPAgent._start_acp_server",
+            side_effect=exc,
+        ):
+            with pytest.raises(RuntimeError, match="boom") as excinfo:
+                agent.init_state(state, on_event=_explode)
+        assert excinfo.value is exc
+
+
+# ---------------------------------------------------------------------------
+# _classify_acp_init_error
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyACPInitError:
+    def test_auth_required_code(self):
+        exc = ACPRequestError(-32000, "Authentication required")
+        assert _classify_acp_init_error(exc) == "ACPAuthRequired"
+
+    def test_other_request_error_is_init_error(self):
+        # A protocol error that isn't auth-required (e.g. internal error) is a
+        # generic init failure, not an auth failure.
+        exc = ACPRequestError(-32603, "Internal error")
+        assert _classify_acp_init_error(exc) == "ACPInitError"
+
+    def test_file_not_found_is_spawn_error(self):
+        assert _classify_acp_init_error(FileNotFoundError()) == "ACPSpawnError"
+
+    def test_permission_error_is_spawn_error(self):
+        assert _classify_acp_init_error(PermissionError()) == "ACPSpawnError"
+
+    def test_broken_pipe_is_init_error(self):
+        # A transport drop during the handshake is an OSError subclass but not a
+        # spawn failure — it must classify as ACPInitError, not ACPSpawnError.
+        assert _classify_acp_init_error(BrokenPipeError()) == "ACPInitError"
+
+    def test_generic_exception_is_init_error(self):
+        assert _classify_acp_init_error(RuntimeError("x")) == "ACPInitError"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

ACP's spawn + auth + `session/new` runs in `ACPAgent.init_state`, which `LocalConversation.run()`/`arun()` invoke via `_ensure_agent_ready()` **before** their `try`-block (`local_conversation.py:937` / `:1096`, before the try at `:950` / `:1126`). So cold-start failures — bad/expired auth, missing CLI binary, cwd mismatch (all far more common on cloud than locally) — bypass the run loop's error emission and surface to the client as a generic *"remote conversation ended with error"* (`remote_conversation.py`).

The regular agent never raises in init; its failures occur inside `run()` and emit a typed `ConversationErrorEvent` (`local_conversation.py:1055-1066`), which canvas already renders as a banner. `ACPAgent.astep` does the same via `_emit_turn_error`. ACP init was the one path that didn't.

## Change

**`acp_agent.py` — `init_state`'s `except` around `_start_acp_server`:** before re-raising, emit a typed `ConversationErrorEvent(source='agent', code=…, detail=str(e)[:500])` and set `execution_status = ERROR`. A new `_classify_acp_init_error` helper maps the failure to a code:

| Failure | Code |
|---|---|
| ACP auth-required (JSON-RPC `-32000`) from `authenticate`/`new_session` | `ACPAuthRequired` |
| `FileNotFoundError` / `PermissionError` from `create_subprocess_exec` (missing/unexecutable CLI binary) | `ACPSpawnError` |
| anything else (handshake timeout, transport drop, server-side cwd mismatch, …) | `ACPInitError` |

Surfacing is **best-effort** — wrapped so it can never mask the original exception, which still propagates to preserve the existing `_cleanup()` + re-raise contract `run()`/`arun()` rely on.

**`event_service.py` — `_run_and_publish` backstop (the issue's optional item):** when a run raises before setting its own ERROR status, force `execution_status = ERROR` (idempotent) so the `finally`'s `_publish_state_update()` surfaces the failure instead of a stale `IDLE`/`RUNNING` state. No-op when the run already set ERROR (regular Agent path).

No frontend change needed: canvas's `isDisplayableErrorEvent` already renders any `ConversationErrorEvent` as a banner regardless of `source`, and `source='agent'` is the same value `astep` already emits.

## Tests

- `TestClassifyACPInitError` — all three codes + that an `ACPRequestError` with a non-auth code and a transport `BrokenPipeError` (OSError subclass, but not a spawn failure) both classify as `ACPInitError`.
- `TestACPAgentInitState` — auth/spawn/generic failures each emit the right typed event with `source='agent'`, set ERROR status, truncate detail to 500 chars, and re-raise the **original** exception even when `on_event` itself throws.
- `test_event_service.py` — a run that raises with status still `IDLE` is flipped to `ERROR` (and state is still published); an already-`ERROR` status is left untouched.

356 passing across both affected test files; `ruff check`, `ruff format --check`, and `pyright` all clean.

Zero-dependency, purely additive — does not touch the happy path. Implements pre-cloud refactor **P0-3**. Part of OpenHands/OpenHands#15746.

Closes OpenHands/agent-canvas#2111

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e7a3bbb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e7a3bbb-python \
  ghcr.io/openhands/agent-server:e7a3bbb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e7a3bbb-golang-amd64
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-golang-amd64
ghcr.io/openhands/agent-server:e7a3bbb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e7a3bbb-golang-arm64
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-golang-arm64
ghcr.io/openhands/agent-server:e7a3bbb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e7a3bbb-java-amd64
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-java-amd64
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-java-amd64
ghcr.io/openhands/agent-server:e7a3bbb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e7a3bbb-java-arm64
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-java-arm64
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-java-arm64
ghcr.io/openhands/agent-server:e7a3bbb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e7a3bbb-python-amd64
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-python-amd64
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-python-amd64
ghcr.io/openhands/agent-server:e7a3bbb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e7a3bbb-python-arm64
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-python-arm64
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-python-arm64
ghcr.io/openhands/agent-server:e7a3bbb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e7a3bbb-golang
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-golang
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-golang
ghcr.io/openhands/agent-server:e7a3bbb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e7a3bbb-java
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-java
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-java
ghcr.io/openhands/agent-server:e7a3bbb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e7a3bbb-python
ghcr.io/openhands/agent-server:e7a3bbb24fd85174ee670423bec92f81ad460fcd-python
ghcr.io/openhands/agent-server:fix-acp-surface-init-errors-python
ghcr.io/openhands/agent-server:e7a3bbb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e7a3bbb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e7a3bbb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->