### PR TITLE
refactor(acp): dedup tool-call progress at the source (O(n²)→O(1))

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -640,13 +640,22 @@ class _OpenHandsACPBridge:
             }
             self.accumulated_tool_calls.append(entry)
             logger.debug("ACP tool call start: %s", update.tool_call_id)
+            # Emit one early "started" event — the action half of the
+            # action->observation pair. (If the server reports a terminal
+            # status on the very first notification, this single event is
+            # also the observation; the matching terminal-transition guard
+            # below then suppresses any redundant re-emission.)
             self._emit_tool_call_event(entry)
             self._maybe_signal_activity()
         elif isinstance(update, ToolCallProgress):
-            # Find the existing tool call entry and merge updates
+            # Find the existing tool call entry and merge updates. Track the
+            # status seen *before* this frame so we can detect the single
+            # transition into a terminal state.
             target: dict[str, Any] | None = None
+            prev_status: str | None = None
             for tc in self.accumulated_tool_calls:
                 if tc["tool_call_id"] == update.tool_call_id:
+                    prev_status = tc.get("status")
                     if update.title is not None:
                         tc["title"] = update.title
                     if update.kind is not None:
@@ -662,7 +671,19 @@ class _OpenHandsACPBridge:
                     target = tc
                     break
             logger.debug("ACP tool call progress: %s", update.tool_call_id)
-            if target is not None:
+            # Persist exactly one terminal event per tool call. Intermediate
+            # progress frames each carry the *full cumulative* output; emitting
+            # one per frame is O(n^2) storage + WebSocket relay (the bug this
+            # method fixes). We accumulate them into ``target`` silently and
+            # emit only on the first transition into a terminal status, so the
+            # terminal event still carries the complete final output. This is
+            # the observation half of the action->observation pair.
+            became_terminal = (
+                target is not None
+                and target.get("status") in _TERMINAL_TOOL_CALL_STATUSES
+                and prev_status not in _TERMINAL_TOOL_CALL_STATUSES
+            )
+            if target is not None and became_terminal:
                 self._emit_tool_call_event(target)
             self._maybe_signal_activity()
         else:
@@ -1658,6 +1679,28 @@ class ACPAgent(AgentBase):
                     exc_info=True,
                 )
 
+    def _flush_inflight_tool_calls_as_completed(self) -> None:
+        """Emit a terminal ``completed`` ACPToolCallEvent for every accumulated
+        tool call still sitting at a non-terminal status.
+
+        The prompt returned successfully, so a tool card the server opened but
+        never closed (it sent ``ToolCallStart`` but no terminal
+        ``ToolCallProgress``) is treated as completed. Since we now persist
+        exactly one early ``started`` event and one terminal event per call,
+        this guarantees the action->observation pairing holds for *every*
+        call — without it, a server that omits the closing frame would leave
+        the early ``started`` event as the last word, and the relaxed canvas
+        render gate would show that card spinning forever. Reuses
+        ``_emit_tool_call_event`` so truncation and error-swallowing match the
+        live terminal path. No-op once every call is already terminal (the
+        common case, since ``conn.prompt`` only returns after its tools run).
+        """
+        for tc in self._client.accumulated_tool_calls:
+            if tc.get("status") in _TERMINAL_TOOL_CALL_STATUSES:
+                continue
+            tc["status"] = "completed"
+            self._client._emit_tool_call_event(tc)
+
     async def _arequest_session_cancel(self) -> None:
         """Async variant of _request_session_cancel that waits for cancel send."""
         if self._conn is None or self._executor is None or self._session_id is None:
@@ -1895,10 +1938,13 @@ class ACPAgent(AgentBase):
             usage_update=usage_update,
         )
 
-        # ACPToolCallEvents were already emitted live from
-        # _OpenHandsACPBridge.session_update as each ToolCallStart /
-        # ToolCallProgress notification arrived — no end-of-turn fan-out
-        # here. FinishAction closes out the turn below.
+        # Tool cards were already streamed live from
+        # _OpenHandsACPBridge.session_update: one early ``started`` event per
+        # ToolCallStart and one terminal event per call. Close out any card the
+        # server opened but never terminated so every ``started`` has its
+        # matching terminal observation before the turn's FinishAction lands.
+        self._flush_inflight_tool_calls_as_completed()
+
         response_text = "".join(self._client.accumulated_text)
         thought_text = "".join(self._client.accumulated_thoughts)
         if not response_text:

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -346,10 +346,14 @@ class RemoteEventsList(EventsListBase):
 
     def _add_event_unsafe(self, event: Event) -> None:
         """Add event to cache without acquiring lock (caller must hold lock)."""
-        # ACP streaming emits one ACPToolCallEvent per ToolCallProgress, each
-        # carrying the full cumulative stdout so far — O(n²) memory growth.
-        # Deduplicate by tool_call_id: replace the existing entry in-place so
-        # only the latest (most complete) snapshot is kept.
+        # ACP emits two ACPToolCallEvents per call — an early ``started`` event
+        # and one terminal (``completed`` / ``failed``) event — the
+        # action->observation pair for a tool call. Merge by tool_call_id:
+        # replace the ``started`` entry in-place with the terminal one so a
+        # single card updates from running to its result, mirroring how an
+        # ObservationEvent supersedes its ActionEvent. (The source no longer
+        # fans out one frame per cumulative-output ToolCallProgress, so this is
+        # an O(1) two-event merge, not an O(n²) dedup.)
         if isinstance(event, ACPToolCallEvent):
             existing_id = self._acp_tool_call_id_to_event_id.get(event.tool_call_id)
             if existing_id is not None:

--- a/openhands-sdk/openhands/sdk/event/resume_transcript.py
+++ b/openhands-sdk/openhands/sdk/event/resume_transcript.py
@@ -211,9 +211,13 @@ def _render_tool_event(event: ACPToolCallEvent, max_chars: int) -> str | None:
 def _terminal_tool_indices(events: Sequence[Event]) -> set[int]:
     """Indices of the terminal ACPToolCallEvent for each *streaming sequence*.
 
-    ACP streams ``pending → … → completed`` events for a single tool call
-    consecutively; only the last event in that run carries the final I/O.
-    We keep that last event and drop the earlier intermediates.
+    ACP emits an early ``started`` event and one terminal
+    (``completed`` / ``failed``) event for a single tool call consecutively;
+    only the terminal event carries the final I/O. We keep that terminal event
+    and drop the earlier ``started`` one. (This also tolerates legacy logs
+    persisted before the source collapse, where a ``pending → … → completed``
+    run held several intermediates — keeping the last still picks the
+    terminal frame.)
 
     Critically, dedup is scoped to **contiguous runs separated by
     MessageEvents**, not to the entire history. ACP providers (e.g. Codex)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -848,6 +848,210 @@ class TestOpenHandsACPClient:
 
 
 # ---------------------------------------------------------------------------
+# Tool-call event emission (started + terminal, no per-progress fan-out)
+# ---------------------------------------------------------------------------
+
+
+def _mk_tool_start(
+    tool_call_id: str = "tc-1",
+    *,
+    title: str = "git status",
+    kind: str = "execute",
+    status: str = "in_progress",
+    raw_input: Any | None = None,
+    raw_output: Any | None = None,
+    content: Any | None = None,
+) -> Any:
+    from acp.schema import ToolCallStart
+
+    start = MagicMock(spec=ToolCallStart)
+    start.tool_call_id = tool_call_id
+    start.title = title
+    start.kind = kind
+    start.status = status
+    start.raw_input = raw_input
+    start.raw_output = raw_output
+    start.content = content
+    return start
+
+
+def _mk_tool_progress(
+    tool_call_id: str = "tc-1",
+    *,
+    title: str | None = None,
+    kind: str | None = None,
+    status: str | None = None,
+    raw_input: Any | None = None,
+    raw_output: Any | None = None,
+    content: Any | None = None,
+) -> Any:
+    from acp.schema import ToolCallProgress
+
+    progress = MagicMock(spec=ToolCallProgress)
+    progress.tool_call_id = tool_call_id
+    progress.title = title
+    progress.kind = kind
+    progress.status = status
+    progress.raw_input = raw_input
+    progress.raw_output = raw_output
+    progress.content = content
+    return progress
+
+
+class TestACPToolCallProgressCollapse:
+    """The bridge persists exactly one ``started`` + one terminal event.
+
+    Each ``ToolCallProgress`` carries the *full cumulative* output, so emitting
+    one event per frame is O(n^2) storage + WebSocket relay. The bridge instead
+    streams one early ``started`` event and one terminal (``completed`` /
+    ``failed``) event per ``tool_call_id`` — the action->observation pair —
+    while silently accumulating the intermediate frames so the terminal event
+    still carries the final output.
+    """
+
+    @pytest.mark.asyncio
+    async def test_tool_call_start_emits_started_event(self) -> None:
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+
+        await client.session_update("s1", _mk_tool_start(status="in_progress"))
+
+        assert len(events) == 1
+        assert isinstance(events[0], ACPToolCallEvent)
+        assert events[0].tool_call_id == "tc-1"
+        assert events[0].status == "in_progress"
+        assert events[0].is_error is False
+
+    @pytest.mark.asyncio
+    async def test_intermediate_progress_frames_are_not_emitted(self) -> None:
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+
+        await client.session_update("s1", _mk_tool_start(status="in_progress"))
+        # Several non-terminal progress frames with growing cumulative output.
+        for chunk in ("a", "ab", "abc"):
+            await client.session_update(
+                "s1", _mk_tool_progress(status="in_progress", raw_output=chunk)
+            )
+
+        # Only the started event was persisted — the intermediate frames are
+        # accumulated silently (this is the O(n^2)->O(1) collapse).
+        assert len(events) == 1
+        assert events[0].status == "in_progress"
+
+    @pytest.mark.asyncio
+    async def test_full_lifecycle_emits_exactly_two_events(self) -> None:
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+
+        await client.session_update("s1", _mk_tool_start(status="pending"))
+        await client.session_update(
+            "s1", _mk_tool_progress(status="in_progress", raw_output="partial")
+        )
+        await client.session_update(
+            "s1", _mk_tool_progress(status="completed", raw_output="partial-final")
+        )
+
+        assert len(events) == 2
+        started, terminal = events
+        assert started.status == "pending"
+        assert terminal.status == "completed"
+        # Terminal event carries the final cumulative output.
+        assert terminal.raw_output == "partial-final"
+        assert terminal.is_error is False
+
+    @pytest.mark.asyncio
+    async def test_failed_terminal_sets_is_error(self) -> None:
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+
+        await client.session_update("s1", _mk_tool_start(status="in_progress"))
+        await client.session_update(
+            "s1", _mk_tool_progress(status="failed", raw_output="boom")
+        )
+
+        assert len(events) == 2
+        assert events[-1].status == "failed"
+        assert events[-1].is_error is True
+
+    @pytest.mark.asyncio
+    async def test_single_shot_completed_start_emits_once(self) -> None:
+        """A ToolCallStart that is already terminal is the only event."""
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+
+        await client.session_update(
+            "s1", _mk_tool_start(status="completed", raw_output="done")
+        )
+
+        assert len(events) == 1
+        assert events[0].status == "completed"
+
+    @pytest.mark.asyncio
+    async def test_redundant_terminal_progress_does_not_double_emit(self) -> None:
+        """Only the first transition into a terminal status emits."""
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+
+        await client.session_update("s1", _mk_tool_start(status="in_progress"))
+        await client.session_update("s1", _mk_tool_progress(status="completed"))
+        # A trailing duplicate terminal frame must not produce a third event.
+        await client.session_update("s1", _mk_tool_progress(status="completed"))
+
+        assert len(events) == 2
+        assert [e.status for e in events] == ["in_progress", "completed"]
+
+    def test_finalize_flush_completes_orphaned_tool_calls(self) -> None:
+        """A card the server opened but never closed is flushed to completed."""
+        agent = _make_agent()
+        client = _OpenHandsACPBridge()
+        events: list[Any] = []
+        client.on_event = events.append
+        agent._client = client
+
+        # One still-running call and one already-terminal call.
+        client.accumulated_tool_calls.append(
+            {
+                "tool_call_id": "live-1",
+                "title": "long task",
+                "tool_kind": "execute",
+                "status": "in_progress",
+                "raw_input": None,
+                "raw_output": "partial output",
+                "content": None,
+            }
+        )
+        client.accumulated_tool_calls.append(
+            {
+                "tool_call_id": "done-1",
+                "title": "quick task",
+                "tool_kind": "read",
+                "status": "completed",
+                "raw_input": None,
+                "raw_output": "ok",
+                "content": None,
+            }
+        )
+
+        agent._flush_inflight_tool_calls_as_completed()
+
+        # Only the non-terminal call is flushed (the terminal one is untouched).
+        assert len(events) == 1
+        assert events[0].tool_call_id == "live-1"
+        assert events[0].status == "completed"
+        assert events[0].is_error is False
+        assert events[0].raw_output == "partial output"
+        # The accumulator entry is now terminal so it won't be flushed again.
+        assert client.accumulated_tool_calls[0]["status"] == "completed"
+
+
+# ---------------------------------------------------------------------------
 # Activity heartbeat
 # ---------------------------------------------------------------------------
 

--- a/tests/sdk/event/test_resume_transcript.py
+++ b/tests/sdk/event/test_resume_transcript.py
@@ -144,6 +144,24 @@ class TestRenderResumeTranscript:
         assert "(completed)" in out
         assert "ok" in out
 
+    def test_started_then_terminal_renders_only_terminal(self) -> None:
+        # The source now persists exactly two events per call: an early
+        # ``started`` (in_progress) event and one terminal event. The transcript
+        # must keep only the terminal one — it carries the final I/O.
+        started = _tool("tc-1", title="bash", status="in_progress", raw_input={"c": 1})
+        terminal = _tool(
+            "tc-1",
+            title="bash",
+            status="completed",
+            raw_input={"c": 1},
+            raw_output="final output",
+        )
+        out = render_resume_transcript([started, terminal])
+        assert out is not None
+        assert out.count("[TOOL USE: bash]") == 1
+        assert "(completed)" in out
+        assert "final output" in out
+
     def test_cross_session_same_id_both_render(self) -> None:
         # ACP providers like Codex reset tool_call_id counters each session.
         # A user message between two events with the same id means they come


### PR DESCRIPTION
## Problem

ACP persisted **every** `ToolCallProgress` emission, each carrying the **full cumulative output** (`acp_agent.py` `session_update`; `_default_callback` persists each one). For a chatty tool call that is **O(n²)** storage + WebSocket relay — and on cloud the proxy relays *and* persists every cumulative frame across the network, the single biggest relay/storage cost. The regular agent persists exactly one Action + one Observation per tool call, with no per-progress fan-out.

Part of OpenHands/agent-canvas#2110 (epic OpenHands/OpenHands#15746). Implements pre-cloud refactor **P1-1**.

## Change

Collapse ACP onto the regular agent's action→observation model. The bridge now persists **exactly two events per `tool_call_id`**:

- one early **`started`** event (the *action*) on `ToolCallStart`, and
- one **terminal** `completed`/`failed` event (the *observation*) on the first transition into a terminal status.

Intermediate `ToolCallProgress` frames are accumulated silently (so the terminal event still carries the final, complete output) but **not** emitted — this is the O(n²)→O(1) collapse. `_finalize_successful_turn` flushes any tool call the server opened but never closed to `completed`, so **every `started` has a matching terminal observation** (no orphaned "running" cards).

### Downstream merges: kept, not deleted

The original issue suggested deleting the three downstream `tool_call_id` dedups. Those dedups serve a second purpose beyond papering over O(n²): they **merge a tool call's lifecycle events into one card** — exactly the analog of an `ObservationEvent` superseding its `ActionEvent`. With the source now emitting a `started` + `terminal` pair (not N cumulative frames), deleting them would render **two** cards per call. So they are **retained but become trivial O(1) two-event merges**; their comments are updated to describe the new semantics:

- `RemoteConversation._add_event_unsafe`
- `resume_transcript._terminal_tool_indices`

(The canvas `handle-event-for-ui` merge + the should-render gate are handled in the paired agent-canvas PR.)

## Tests

- New `TestACPToolCallProgressCollapse`: started emits once; intermediate progress frames do **not** emit; full lifecycle emits exactly two events; the terminal event carries the final cumulative output; single-shot terminal `ToolCallStart` emits once; redundant terminal frames don't double-emit; the finalize flush completes orphaned calls.
- New `resume_transcript` test asserting a `started`→`terminal` pair renders only the terminal frame (terminal-event semantics).
- Full affected suites green: `tests/sdk/agent/test_acp_agent.py`, `tests/sdk/agent/test_acp_dedup_and_truncation.py`, `tests/sdk/event/test_resume_transcript.py` (342 passed); `ruff check` + `ruff format` clean.

## Pairs with

agent-canvas PR (relaxes the should-render gate to render the running `started` card): _link added in a comment below._

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:04c6dc0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-04c6dc0-python \
  ghcr.io/openhands/agent-server:04c6dc0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:04c6dc0-golang-amd64
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-golang-amd64
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-golang-amd64
ghcr.io/openhands/agent-server:04c6dc0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:04c6dc0-golang-arm64
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-golang-arm64
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-golang-arm64
ghcr.io/openhands/agent-server:04c6dc0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:04c6dc0-java-amd64
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-java-amd64
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-java-amd64
ghcr.io/openhands/agent-server:04c6dc0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:04c6dc0-java-arm64
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-java-arm64
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-java-arm64
ghcr.io/openhands/agent-server:04c6dc0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:04c6dc0-python-amd64
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-python-amd64
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-python-amd64
ghcr.io/openhands/agent-server:04c6dc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:04c6dc0-python-arm64
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-python-arm64
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-python-arm64
ghcr.io/openhands/agent-server:04c6dc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:04c6dc0-golang
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-golang
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-golang
ghcr.io/openhands/agent-server:04c6dc0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:04c6dc0-java
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-java
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-java
ghcr.io/openhands/agent-server:04c6dc0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:04c6dc0-python
ghcr.io/openhands/agent-server:04c6dc083193adcaf2744ff52db92bd6dbb008e6-python
ghcr.io/openhands/agent-server:acp-progress-dedup-at-source-python
ghcr.io/openhands/agent-server:04c6dc0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `04c6dc0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `04c6dc0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->