### PR TITLE
Revert removal of ToolDefinition.acall

### DIFF
--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -1,3 +1,4 @@
+import asyncio
 import re
 import threading
 from abc import ABC, abstractmethod
@@ -387,6 +388,21 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
             raise TypeError(
                 "Output must be dict or BaseModel when no output schema is defined"
             )
+
+    async def acall(
+        self, action: ActionT, conversation: "LocalConversation | None" = None
+    ) -> Observation:
+        """Run this tool asynchronously when called directly.
+
+        The default implementation runs :meth:`__call__` in a thread via the
+        event loop's executor, so callers can await a single tool invocation
+        without blocking the event loop.
+
+        The SDK's internal async dispatch path does not call this hook; it
+        dispatches through :meth:`__call__` directly from its own executor.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, self, action, conversation)
 
     def to_mcp_tool(
         self,


### PR DESCRIPTION
## Summary

- Reverts #3456 / commit `88b43b44dabcc76d9fcf3c5f9438e28a734c009f`
- Restores `ToolDefinition.acall` and its `asyncio` import
- Clarifies the restored `acall` docstring so users know it is a direct-call async wrapper, not the SDK internal async dispatch hook
- Fixes the Griffe Python API breakage workflow caused by removing a public SDK method before the deprecation runway

## Compatibility intent

This PR is an urgent compatibility restore for the released SDK surface. It does not decide whether `acall` should be deprecated again; if we still want eventual removal, that should happen in a follow-up with the standard deprecation metadata/runtime warning and the required 5-minor-release runway.

## Validation

- `uv run pre-commit run --files openhands-sdk/openhands/sdk/tool/tool.py`
- `ACP_VERSION_CHECK_BASE_REF=main SDK_API_BREAKAGE_REPORT_PATH=/tmp/sdk-api-breakage-report.json uv run python .github/scripts/check_sdk_api_breakage.py`

_This PR was created by an AI agent (OpenHands) on behalf of the requester._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/75ee4c28-d469-4b0c-b82f-810a2425df63)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8420c1d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8420c1d-python \
  ghcr.io/openhands/agent-server:8420c1d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8420c1d-golang-amd64
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-golang-amd64
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-golang-amd64
ghcr.io/openhands/agent-server:8420c1d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8420c1d-golang-arm64
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-golang-arm64
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-golang-arm64
ghcr.io/openhands/agent-server:8420c1d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8420c1d-java-amd64
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-java-amd64
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-java-amd64
ghcr.io/openhands/agent-server:8420c1d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8420c1d-java-arm64
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-java-arm64
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-java-arm64
ghcr.io/openhands/agent-server:8420c1d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8420c1d-python-amd64
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-python-amd64
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-python-amd64
ghcr.io/openhands/agent-server:8420c1d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8420c1d-python-arm64
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-python-arm64
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-python-arm64
ghcr.io/openhands/agent-server:8420c1d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8420c1d-golang
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-golang
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-golang
ghcr.io/openhands/agent-server:8420c1d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8420c1d-java
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-java
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-java
ghcr.io/openhands/agent-server:8420c1d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8420c1d-python
ghcr.io/openhands/agent-server:8420c1d0b7493b9dc678512071ecd6c46209fd51-python
ghcr.io/openhands/agent-server:revert-tool-acall-api-breakage-python
ghcr.io/openhands/agent-server:8420c1d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8420c1d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8420c1d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->