### PR TITLE
Fix nemotron-3-ultra-550b-a55b LiteLLM proxy model name

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -334,7 +334,7 @@ MODELS = {
         "id": "nemotron-3-ultra-550b-a55b",
         "display_name": "NVIDIA Nemotron-3 Ultra 550B",
         "llm_config": {
-            "model": "litellm_proxy/nvidia/nemotron-3-ultra-550b-a55b",
+            "model": "litellm_proxy/nemotron-3-ultra-550b-a55b",
             "temperature": 1.0,
             "top_p": 0.95,
         },

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -667,10 +667,7 @@ def test_nemotron_3_ultra_550b_a55b_config():
 
     assert model["id"] == "nemotron-3-ultra-550b-a55b"
     assert model["display_name"] == "NVIDIA Nemotron-3 Ultra 550B"
-    assert (
-        model["llm_config"]["model"]
-        == "litellm_proxy/nemotron-3-ultra-550b-a55b"
-    )
+    assert model["llm_config"]["model"] == "litellm_proxy/nemotron-3-ultra-550b-a55b"
     assert model["llm_config"]["temperature"] == 1.0
     assert model["llm_config"]["top_p"] == 0.95
 

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -669,7 +669,7 @@ def test_nemotron_3_ultra_550b_a55b_config():
     assert model["display_name"] == "NVIDIA Nemotron-3 Ultra 550B"
     assert (
         model["llm_config"]["model"]
-        == "litellm_proxy/nvidia/nemotron-3-ultra-550b-a55b"
+        == "litellm_proxy/nemotron-3-ultra-550b-a55b"
     )
     assert model["llm_config"]["temperature"] == 1.0
     assert model["llm_config"]["top_p"] == 0.95


### PR DESCRIPTION
## What

Drops the stray `nvidia/` prefix from the LiteLLM proxy model string for `nemotron-3-ultra-550b-a55b` in `.github/run-eval/resolve_model_config.py` (and its cross test).

```diff
-            "model": "litellm_proxy/nvidia/nemotron-3-ultra-550b-a55b",
+            "model": "litellm_proxy/nemotron-3-ultra-550b-a55b",
```

## Why

The eval LiteLLM proxy registers this model under the alias **`nemotron-3-ultra-550b-a55b`** (no prefix). See [`All-Hands-AI/infra` `k8s/evaluation/litellm.yaml` line 603](https://github.com/All-Hands-AI/infra/blob/main/k8s/evaluation/litellm.yaml#L602):

```yaml
# NVIDIA Nemotron-3 Ultra 550B A55B via NVIDIA Integrate
- model_name: "nemotron-3-ultra-550b-a55b"
  litellm_params:
    model: "openai/private/nvidia/nemotron-3-ultra-550b-a55b"
    api_base: https://integrate.api.nvidia.com/v1
    ...
```

It has never been registered with a `nvidia/` prefix (introduced in infra PR [#1225](https://github.com/All-Hands-AI/infra/pull/1225), 2026-05-13). The SDK entry was added in #3251 (2026-06-01) with the `nvidia/` prefix, which means the preflight call has been failing since merge:

```
litellm.BadRequestError: Error code: 400 -
  You passed in model=nvidia/nemotron-3-ultra-550b-a55b.
  There are no healthy deployments for this model
```

(LiteLLM uses the same "no healthy deployments" error when no `model_name` matches.)

Reproduced just now via `run-eval.yml` workflow run [26829955741](https://github.com/OpenHands/software-agent-sdk/actions/runs/26829955741) — the `Resolve model configurations and verify availability` step is what aborts the run before dispatch.

## Follow-up (not in this PR)

`nemotron-3-super-120b-a12b` has a similar shape of bug — the SDK sends `litellm_proxy/nvidia/nemotron-3-super-120b-a12b`, but the proxy only registers `nemotron-super-3-120b` (different slug + different upstream: AWS Bedrock Converse vs. NVIDIA Integrate). Fixing it cleanly requires deciding whether to (a) realign the slug or (b) keep the SDK key and route to the Bedrock alias, and how that should relate to the existing `converse-nemotron-super-3-120b` entry. Leaving that for a separate PR.

---
_This PR was created by an AI agent (OpenHands) on behalf of @rbren / xingyaoww (whichever of you triggered the failed eval run)._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bb9762a5-7142-4e50-89c5-75ef71f6e7d4)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:219cf87-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-219cf87-python \
  ghcr.io/openhands/agent-server:219cf87-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:219cf87-golang-amd64
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-golang-amd64
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-golang-amd64
ghcr.io/openhands/agent-server:219cf87-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:219cf87-golang-arm64
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-golang-arm64
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-golang-arm64
ghcr.io/openhands/agent-server:219cf87-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:219cf87-java-amd64
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-java-amd64
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-java-amd64
ghcr.io/openhands/agent-server:219cf87-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:219cf87-java-arm64
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-java-arm64
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-java-arm64
ghcr.io/openhands/agent-server:219cf87-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:219cf87-python-amd64
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-python-amd64
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-python-amd64
ghcr.io/openhands/agent-server:219cf87-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:219cf87-python-arm64
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-python-arm64
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-python-arm64
ghcr.io/openhands/agent-server:219cf87-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:219cf87-golang
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-golang
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-golang
ghcr.io/openhands/agent-server:219cf87-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:219cf87-java
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-java
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-java
ghcr.io/openhands/agent-server:219cf87-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:219cf87-python
ghcr.io/openhands/agent-server:219cf87979269d10f43f20b61ad3786c938e818b-python
ghcr.io/openhands/agent-server:fix-nemotron-ultra-proxy-name-python
ghcr.io/openhands/agent-server:219cf87-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `219cf87-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `219cf87-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->