### PR TITLE
fix: do not auto-recreate an LLM profile after deleting all profiles

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -165,9 +165,12 @@ async def list_profiles(request: Request) -> ProfileListResponse:
 
     active_profile = settings.active_profile
 
-    # Auto-create profile from existing LLM settings if no profiles exist
-    # but an API key is configured. Use the model name as the profile name.
-    if not summaries and settings.llm_api_key_is_set:
+    # Auto-create a profile from existing LLM settings only for a genuinely
+    # first-time user (no profiles AND no profile has ever been active). A set
+    # active_profile means the user has engaged with profiles before — e.g.
+    # activated one and then deleted everything — so we must NOT resurrect a
+    # profile from the LLM/API key still lingering in agent_settings.
+    if not summaries and active_profile is None and settings.llm_api_key_is_set:
         llm = settings.agent_settings.llm
         profile_name = _model_to_profile_name(llm.model or "default")
         try:

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1197,3 +1197,27 @@ def test_auto_created_profile_persists(client, store):
     assert loaded.temperature == 0.7
     assert loaded.api_key is not None
     assert loaded.api_key.get_secret_value() == "sk-persist-test"
+
+
+def test_list_profiles_no_auto_create_after_deleting_active_profile(client, store):
+    """Deleting all profiles must not auto-recreate one (regression).
+
+    Activating a profile copies its LLM (with API key) into agent_settings, so
+    after deleting every profile the lingering key would otherwise re-trigger
+    auto-creation. A previously-set active_profile must suppress that.
+    """
+    # Arrange: create and activate a profile (mirrors the GUI repro)
+    store.save(
+        "my-profile",
+        LLM(model="gpt-4o", api_key="sk-test"),
+        include_secrets=True,
+    )
+    client.post("/api/profiles/my-profile/activate")
+
+    # Act: delete the active profile, then list
+    client.delete("/api/profiles/my-profile")
+    response = client.get("/api/profiles")
+
+    # Assert: nothing is auto-recreated; the list stays empty
+    assert response.status_code == 200
+    assert response.json()["profiles"] == []


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Summary
On the **Settings → LLM** page, deleting every LLM profile does not leave the list empty. The backend immediately recreates a profile (e.g. `claude-sonnet-4-20250514`) and marks it active.

### Steps to reproduce
1. Run the GUI dev server (`npm run dev`) against a **Local** backend.
2. Open **Settings → LLM**.
3. Create two LLM profiles.
4. Set the first profile as **active**.
5. Delete both profiles.

### Expected behavior
- Both profiles are removed.
- No replacement profile is created.
- The list is allowed to remain empty ("No profiles saved yet").

### Actual behavior
- Both profiles are removed, **but** a new profile named after the active model is auto-created and re-activated.

### Root cause
`GET /api/profiles` (`list_profiles`) auto-creates a profile from `agent_settings.llm` whenever the profile store is empty **and** an API key is configured — an intended one-time migration for users who configured an LLM before profiles existed. It can't distinguish a first-time user from one who just deleted everything: activating a profile copies its API key into `agent_settings.llm`, and `delete` leaves that key in place, so the GUI's post-delete refetch re-triggers creation.

### Fix
Gate auto-creation on `active_profile is None`, so it only runs for a genuinely first-time user (one who has never activated or auto-created a profile). A user who has deleted their profiles has a non-null `active_profile`, so the list stays empty.

### Acceptance criteria
- [ ] Deleting all profiles leaves the list empty; no profile is recreated.
- [ ] A first-time user with a configured LLM + API key and no profiles still receives the one-time auto-created profile.
- [ ] Regression test added and green; existing profile tests unaffected.

## Summary

<!-- 1-3 bullets describing what changed. -->
Deleting all LLM profiles in **Settings → LLM** unexpectedly recreated a profile (e.g. `claude-sonnet-4-20250514`) instead of leaving the list empty. This is a backend issue — the GUI faithfully renders whatever `GET /api/profiles` returns.

### Root cause
`list_profiles` in `profiles_router.py` auto-creates a profile from `agent_settings.llm` when the store is empty and an API key is configured — a one-time migration convenience. It couldn't distinguish a first-time user from one who had just deleted everything:

- `activate_profile` copies the profile's LLM (**including the API key**) into `agent_settings.llm`.
- `delete_profile` removes the profile file but leaves that API key in place.
- The GUI refetches `GET /api/profiles` after delete → empty store + `llm_api_key_is_set` still true → a profile is recreated and re-activated.

### The change
One-line guard plus an explanatory comment in `list_profiles`:

```diff
-    if not summaries and settings.llm_api_key_is_set:
+    if not summaries and active_profile is None and settings.llm_api_key_is_set:
```

`active_profile` becomes non-null the moment a user activates or first auto-creates a profile, so it is a reliable "has engaged with profiles" signal. After deleting all profiles it is non-null, so auto-create is correctly skipped.

### Deliberately not changed
- `delete_profile` still does not clear `active_profile`. That retained pointer is exactly the signal that suppresses resurrection, and it's harmless — the list is empty and `active_profile` is display-only.
- `agent_settings.llm` is left intact so the agent keeps a usable LLM config.

> A heavier alternative — a persisted one-time-migration flag plus clearing `active_profile` on delete — was considered and rejected as out of proportion to the bug.

### Testing
- New regression test `test_list_profiles_no_auto_create_after_deleting_active_profile` (create → activate → delete → assert list empty). Verified **red before / green after** the fix.
- `tests/agent_server/test_profiles_router.py`: **77 passed** (including the 8 existing auto-create tests — preserved behavior unaffected).
- `ruff check` clean on changed files.
- Two unrelated tests in `tests/agent_server` (`test_autotitle_sets_title_on_first_user_message`, `test_post_events_http_error_with_retries`) fail/flake independently of this PR — verified by running them on a clean tree (stashing this change).

```bash
cd software-agent-sdk
uv run pytest tests/agent_server/test_profiles_router.py -q
```

### Files changed
- `openhands-agent-server/openhands/agent_server/profiles_router.py`
- `tests/agent_server/test_profiles_router.py`

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/2392

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

1. Clone the `agent-canvas` repository.

2. Start the development server:

   ```bash
   npm run dev
   ```

3. Open the **LLM Settings** page.

4. Create two LLM profiles.

5. Set the first profile as the active profile.

6. Delete both LLM profiles.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

https://github.com/user-attachments/assets/cd9d999d-565c-420f-a1a0-f3ed2b923912

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1244b2e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1244b2e-python \
  ghcr.io/openhands/agent-server:1244b2e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1244b2e-golang-amd64
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-2124-golang-amd64
ghcr.io/openhands/agent-server:1244b2e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1244b2e-golang-arm64
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-2124-golang-arm64
ghcr.io/openhands/agent-server:1244b2e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1244b2e-java-amd64
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-2124-java-amd64
ghcr.io/openhands/agent-server:1244b2e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1244b2e-java-arm64
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-2124-java-arm64
ghcr.io/openhands/agent-server:1244b2e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1244b2e-python-amd64
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-2124-python-amd64
ghcr.io/openhands/agent-server:1244b2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1244b2e-python-arm64
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-2124-python-arm64
ghcr.io/openhands/agent-server:1244b2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1244b2e-golang
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-golang
ghcr.io/openhands/agent-server:hieptl-app-2124-golang
ghcr.io/openhands/agent-server:1244b2e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1244b2e-java
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-java
ghcr.io/openhands/agent-server:hieptl-app-2124-java
ghcr.io/openhands/agent-server:1244b2e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1244b2e-python
ghcr.io/openhands/agent-server:1244b2e5b12cf3debb02342dfae7eb64ce078b40-python
ghcr.io/openhands/agent-server:hieptl-app-2124-python
ghcr.io/openhands/agent-server:1244b2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1244b2e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1244b2e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->