### PR TITLE
Remove amber-vector-3542 from resolve model config

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -356,14 +356,6 @@ MODELS = {
             "top_p": 0.95,
         },
     },
-    "amber-vector-3542": {
-        "id": "amber-vector-3542",
-        "display_name": "Amber Vector 3542",
-        "llm_config": {
-            "model": "litellm_proxy/amber-vector-3542",
-            "temperature": 0.0,
-        },
-    },
 }
 
 

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -675,16 +675,6 @@ def test_nemotron_3_ultra_550b_a55b_config():
     assert model["llm_config"]["top_p"] == 0.95
 
 
-def test_amber_vector_3542_config():
-    """Test that amber-vector-3542 has correct configuration."""
-    model = MODELS["amber-vector-3542"]
-
-    assert model["id"] == "amber-vector-3542"
-    assert model["display_name"] == "Amber Vector 3542"
-    assert model["llm_config"]["model"] == "litellm_proxy/amber-vector-3542"
-    assert model["llm_config"]["temperature"] == 0.0
-
-
 def test_claude_opus_4_8_config():
     """Test that claude-opus-4-8 has correct configuration."""
     model = MODELS["claude-opus-4-8"]


### PR DESCRIPTION
Fixes #3470

## Summary

Removes the `amber-vector-3542` entry from the eval `resolve_model_config.py` model registry. It was a stealth model that is no longer available, so keeping it in the config could cause confusion or eval failures.

## Changes

- `.github/run-eval/resolve_model_config.py`: removed the `amber-vector-3542` entry from `MODELS`.
- `tests/cross/test_resolve_model_config.py`: removed `test_amber_vector_3542_config` which validated the now-deleted entry.

## Verification

`uv run pytest tests/cross/test_resolve_model_config.py` → 38 passed.
`uv run pre-commit run --files .github/run-eval/resolve_model_config.py tests/cross/test_resolve_model_config.py` → all hooks pass (ruff, pyright, etc.).

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/beed5738-0b69-4c49-9970-9cc07b684930)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0249cc6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0249cc6-python \
  ghcr.io/openhands/agent-server:0249cc6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0249cc6-golang-amd64
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-golang-amd64
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-golang-amd64
ghcr.io/openhands/agent-server:0249cc6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0249cc6-golang-arm64
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-golang-arm64
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-golang-arm64
ghcr.io/openhands/agent-server:0249cc6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0249cc6-java-amd64
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-java-amd64
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-java-amd64
ghcr.io/openhands/agent-server:0249cc6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0249cc6-java-arm64
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-java-arm64
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-java-arm64
ghcr.io/openhands/agent-server:0249cc6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0249cc6-python-amd64
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-python-amd64
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-python-amd64
ghcr.io/openhands/agent-server:0249cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0249cc6-python-arm64
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-python-arm64
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-python-arm64
ghcr.io/openhands/agent-server:0249cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0249cc6-golang
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-golang
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-golang
ghcr.io/openhands/agent-server:0249cc6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0249cc6-java
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-java
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-java
ghcr.io/openhands/agent-server:0249cc6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0249cc6-python
ghcr.io/openhands/agent-server:0249cc68ec8b2194ec559b1a2d1a71d63e61a85e-python
ghcr.io/openhands/agent-server:openhands-remove-amber-vector-3542-python
ghcr.io/openhands/agent-server:0249cc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0249cc6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0249cc6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->