### PR TITLE
docs(run-eval): guide reviewer/QA bot to not block on transient 'Invalid model name' preflight

### DIFF
--- a/.agents/skills/custom-codereview-guide.md
+++ b/.agents/skills/custom-codereview-guide.md
@@ -105,6 +105,36 @@ Examples:
 - A PR adding documentation notes to docstrings clarifying method behavior (e.g., security considerations, bypass behaviors)
 - A PR changing CI runners or fixing workflow infrastructure issues (e.g., standardizing runner types to fix path inconsistencies)
 
+### Special rule: live preflight failures for newly-added models
+
+PRs that only add an entry to `.github/run-eval/resolve_model_config.py` (and
+the matching test in `tests/cross/test_resolve_model_config.py`) interact with
+the LiteLLM proxy at `LLM_BASE_URL` (default
+`https://llm-proxy.eval.all-hands.dev`). Provisioning a new model name on that
+proxy is done **out-of-band**, not in the PR.
+
+A live preflight call that returns
+`Invalid model name passed in model=<provider>/<name>` for a model the PR is
+introducing is therefore **not** evidence that the PR is broken — it is most
+likely transient proxy-provisioning lag.
+
+When reviewing or QA-ing such a PR:
+
+- Do **not** post `❌ QA Report: FAIL` purely because the live preflight
+  rejected the new model name.
+- Do **not** open or re-open a 🔴 Critical inline thread on the new model
+  entry purely on the basis of `Invalid model name` from the live proxy.
+- Treat any of the following as authoritative validation instead:
+  1. A successful integration-runner workflow run for this PR.
+  2. A run for this model on
+     [openhands-eval-monitor.vercel.app](https://openhands-eval-monitor.vercel.app/).
+  3. The author's explicit confirmation (e.g. screenshot) that the model is
+     reachable via the proxy.
+
+Real preflight blockers still apply (parameter conflicts on Claude, bad
+`litellm_extra_body`, unit-test failures, regressions on existing models —
+see `.github/run-eval/AGENTS.md` "What still IS a real preflight blocker").
+
 ### When to COMMENT
 
 Use COMMENT when you have feedback or concerns:

--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -339,6 +339,29 @@ Fixes #[issue-number]
 
 **Reference**: #2137, #2193
 
+### Preflight Check: "Invalid model name" for a newly-added model
+**Cause**: The local preflight in `resolve_model_config.py` performs a *live*
+`litellm.completion(...)` against the LiteLLM proxy at `LLM_BASE_URL` (default
+`https://llm-proxy.eval.all-hands.dev`). Registering a new model name on that
+proxy is done **out-of-band** by infra/maintainers — it is not part of this PR.
+So immediately after adding a new entry, the proxy may not yet know the model
+name and respond with `Invalid model name passed in model=<provider>/<name>`.
+
+**This is not a bug in the PR** — it is a transient proxy-provisioning lag.
+
+**What to do**:
+- Author: keep the PR open, link evidence that the model works (see Step 7 — the
+  integration-runner workflow run and/or the
+  [eval monitor](https://openhands-eval-monitor.vercel.app/) run for this model
+  are the authoritative checks).
+- Reviewers / QA bot: do **not** block the PR on this specific failure. Treat
+  successful integration-runner results or an eval monitor link as authoritative
+  validation, and re-run the local preflight only after the proxy has been
+  updated. See the "Reviewing model PRs" section in
+  [`AGENTS.md`](./AGENTS.md) for the full review-side rule.
+
+**Reference**: #3472
+
 ### Vision Tests Fail
 **Cause**: LiteLLM reports vision support but model doesn't actually support it
 

--- a/.github/run-eval/AGENTS.md
+++ b/.github/run-eval/AGENTS.md
@@ -47,6 +47,68 @@ If you must update:
 2. Test thoroughly before and after the change
 3. Run integration tests to verify no regressions
 
+## Reviewing Model PRs (Reviewers / QA bot)
+
+When reviewing a PR that adds an entry to `resolve_model_config.py` (or the
+matching test in `tests/cross/test_resolve_model_config.py`), apply the
+following rules. They apply equally to human reviewers and to automated
+review / QA agents.
+
+### The local preflight check is NOT authoritative for new models
+
+`resolve_model_config.py` ends with a live `litellm.completion(...)` call
+against the LiteLLM proxy at `LLM_BASE_URL` (default
+`https://llm-proxy.eval.all-hands.dev`). Registering a brand-new model name on
+that proxy is done **out-of-band** by infra/maintainers, not in the PR. So a
+local run like:
+
+```bash
+MODEL_IDS="brand-new-model" uv run python .github/run-eval/resolve_model_config.py
+```
+
+can legitimately fail with `Invalid model name passed in model=<provider>/<name>`
+**even when the PR itself is correct**. The failure simply means the proxy has
+not been provisioned with the new model yet — it does **not** mean the PR is
+broken.
+
+**Do not** mark such a PR as failing preflight on this basis, and do not post
+"❌ QA Report: FAIL" purely because the live preflight rejected the new model
+name. Re-running the same command on every new commit will keep producing the
+same false negative until proxy provisioning catches up.
+
+### What IS authoritative for new model PRs
+
+For PRs adding a new model, treat the following as authoritative validation:
+
+1. The **integration-runner workflow** (`.github/workflows/integration-runner.yml`)
+   run for this PR, surfaced in the PR description / comments as a GitHub
+   Actions run URL.
+2. A run for this model on the
+   [eval monitor](https://openhands-eval-monitor.vercel.app/) (e.g. a SWE-bench
+   or other benchmark run that exercises the same model identifier end-to-end).
+3. The PR author's explicit confirmation (e.g. screenshot) that the model is
+   reachable via the proxy.
+
+If at least one of (1)–(3) is present and looks healthy, the live preflight
+result against the eval proxy can be ignored as a transient
+proxy-provisioning lag. See the
+"Preflight Check: 'Invalid model name' for a newly-added model" entry in
+[`ADDINGMODEL.md`](./ADDINGMODEL.md) for the author-side counterpart.
+
+### What still IS a real preflight blocker
+
+Don't conflate the lag above with real configuration problems. The following
+preflight failures **are** PR-blocking and should still be flagged:
+
+- `Cannot specify both temperature and top_p` for Claude models
+  (configuration error in the PR — see ADDINGMODEL.md).
+- Bad request errors caused by parameter shapes the PR introduced
+  (e.g. an unsupported `reasoning_effort` or `litellm_extra_body` value).
+- The PR fails the **unit test** in
+  `tests/cross/test_resolve_model_config.py` (independent of any proxy).
+- The PR breaks resolution of *existing* models (`MODEL_IDS=<existing-model>`
+  used to succeed and now fails) — that is a real regression.
+
 ## Directory Purpose
 
 This directory bridges model definitions with the evaluation system:


### PR DESCRIPTION
## Summary

Fixes #3472.

The reviewer/QA bot has been repeatedly marking model-config PRs (e.g. #3460) as **failing preflight** even when the model is running fine end-to-end on the
[eval monitor](https://openhands-eval-monitor.vercel.app/) and the
integration-runner workflow is green. The user (@juanmichelini) asked whether
the bot is doing something wrong and whether an md file should be updated to
guide it.

## Root cause

`.github/run-eval/resolve_model_config.py` ends with a live
`litellm.completion(...)` call against the LiteLLM proxy at `LLM_BASE_URL`
(default `https://llm-proxy.eval.all-hands.dev`). Registering a brand-new model
name on that proxy is done **out-of-band** by infra/maintainers — it is not
part of the PR. So immediately after adding a new entry to the SDK-side
`MODELS` dictionary, a local run of the resolver can legitimately respond with
`Invalid model name passed in model=<provider>/<name>` until the proxy
configuration catches up.

The PR itself is correct in that window; the QA bot, however, was treating
this transient proxy-provisioning lag as a hard fail (`❌ QA Report: FAIL` and
🔴 Critical inline threads on the new model entry), and re-running the same
preflight on every new commit produced the same false negative until the
proxy was updated.

This is documentation-only — no code, behavior, or test changes — so per the
contributing guidelines no new tests were added.

## Changes

Three guidance docs are updated so both human reviewers and the automated
reviewer/QA bot apply the right rule next time:

1. **`.github/run-eval/ADDINGMODEL.md`** — adds a new "Preflight Check:
   'Invalid model name' for a newly-added model" entry under **Common Issues**,
   pointing authors and reviewers at integration-runner results and the eval
   monitor as the authoritative validation, and at the matching section in
   `AGENTS.md` for the review-side rule.
2. **`.github/run-eval/AGENTS.md`** — adds a new **"Reviewing Model PRs
   (Reviewers / QA bot)"** section that:
   - States explicitly that the local preflight check is **not** authoritative
     for newly-added models.
   - Lists the three authoritative signals (integration-runner run, eval
     monitor run for this model, author confirmation/screenshot).
   - Calls out a "What still IS a real preflight blocker" list
     (`temperature`+`top_p` for Claude, bad `litellm_extra_body`, unit-test
     failures in `tests/cross/test_resolve_model_config.py`, regressions on
     existing models) so the bot is not blanket-disabled.
3. **`.agents/skills/custom-codereview-guide.md`** — adds a "Special rule:
   live preflight failures for newly-added models" subsection so the repo's
   custom code-review skill explicitly tells the bot not to post a failing
   QA report or open 🔴 Critical threads purely on the basis of a live
   `Invalid model name` response for the model the PR is introducing.

## Verification

- Pre-commit ran cleanly on the modified docs (all code hooks were correctly
  skipped because only markdown changed).
- No application code touched, so no new tests are required (per the
  contributing guidelines for documentation-only changes).
- Cross-checked the references against the actual script: the preflight call
  site is `run_preflight_check()` in `.github/run-eval/resolve_model_config.py`,
  default `LLM_BASE_URL` is `https://llm-proxy.eval.all-hands.dev`, and the
  unit-test file added in this directory's PRs is
  `tests/cross/test_resolve_model_config.py` (confirmed via `find tests
  -name test_resolve_model_config.py`).

Fixes #3472

---
_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._


@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6c30e996-187b-46e2-a18d-584c5423dc81)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e91cdcd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e91cdcd-python \
  ghcr.io/openhands/agent-server:e91cdcd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e91cdcd-golang-amd64
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-golang-amd64
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-golang-amd64
ghcr.io/openhands/agent-server:e91cdcd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e91cdcd-golang-arm64
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-golang-arm64
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-golang-arm64
ghcr.io/openhands/agent-server:e91cdcd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e91cdcd-java-amd64
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-java-amd64
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-java-amd64
ghcr.io/openhands/agent-server:e91cdcd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e91cdcd-java-arm64
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-java-arm64
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-java-arm64
ghcr.io/openhands/agent-server:e91cdcd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e91cdcd-python-amd64
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-python-amd64
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-python-amd64
ghcr.io/openhands/agent-server:e91cdcd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e91cdcd-python-arm64
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-python-arm64
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-python-arm64
ghcr.io/openhands/agent-server:e91cdcd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e91cdcd-golang
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-golang
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-golang
ghcr.io/openhands/agent-server:e91cdcd-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e91cdcd-java
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-java
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-java
ghcr.io/openhands/agent-server:e91cdcd-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e91cdcd-python
ghcr.io/openhands/agent-server:e91cdcd1a1dee5c65b1370cb98d285fc99cc7ae6-python
ghcr.io/openhands/agent-server:openhands-issue-3472-preflight-doc-guidance-python
ghcr.io/openhands/agent-server:e91cdcd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e91cdcd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e91cdcd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->