### PR TITLE
feat(acp): materialise reserved file-content auth secrets (Codex auth.json, Gemini Vertex SA)

### DIFF
--- a/openhands-sdk/openhands/sdk/__init__.py
+++ b/openhands-sdk/openhands/sdk/__init__.py
@@ -50,6 +50,7 @@ from openhands.sdk.plugin import Plugin
 from openhands.sdk.settings import (
     ACP_PROVIDERS,
     ACPAgentSettings,
+    ACPFileSecretSpec,
     ACPModelOption,
     ACPProviderInfo,
     AgentSettingsBase,
@@ -159,6 +160,7 @@ __all__ = [
     "VerificationSettings",
     "ACP_PROVIDERS",
     "ACPAgentSettings",
+    "ACPFileSecretSpec",
     "ACPModelOption",
     "ACPProviderInfo",
     "AgentSettingsBase",

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1582,6 +1582,11 @@ class ACPAgent(AgentBase):
                 # permissions the user chose.
                 if not pinned:
                     directory.chmod(0o700)
+                    # Also clamp the shared SDK-owned `acp/` parent, which
+                    # parents=True may have created under the process umask
+                    # (e.g. 0o755); the leaf chmod above only covers <subdir>.
+                    # Stop at `acp/` — its parent is the persistence layer's.
+                    directory.parent.chmod(0o700)
                 if target.is_file() and target.stat().st_size > 0:
                     # Seed-if-absent: keep the (possibly CLI-refreshed) contents,
                     # but still clamp perms — a pre-existing credential file may

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -268,13 +268,16 @@ def _select_auth_method(
 def _write_secret_file(path: Path, value: str) -> None:
     """Write ``value`` to ``path`` as a ``0600`` file.
 
-    Opens with mode ``0600`` so the bytes never exist with wider permissions,
-    then re-chmods defensively in case the file pre-existed with looser perms.
+    ``os.open`` creates a *new* file at ``0600``, but ``O_CREAT`` does not
+    narrow an existing file's mode. So ``fchmod`` the raw fd to ``0600`` before
+    any bytes land — clamping the mode while we still hold the fd guarantees the
+    secret content never exists with wider permissions even when the file
+    pre-existed (e.g. a ``0644`` empty file from another tool).
     """
     fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    os.fchmod(fd, 0o600)
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(value)
-    path.chmod(0o600)
 
 
 def _extract_session_models(
@@ -1572,9 +1575,18 @@ class ACPAgent(AgentBase):
                 target = directory / spec.filename
             try:
                 directory.mkdir(mode=0o700, parents=True, exist_ok=True)
-                # Tighten in case the dir pre-existed or umask widened the mode.
-                directory.chmod(0o700)
+                # Tighten the SDK-owned per-conversation dir in case it
+                # pre-existed or umask widened mkdir's mode. Skip for an
+                # externally-pinned acp_env dir (e.g. a deliberately
+                # group-readable shared mount) so we don't silently narrow
+                # permissions the user chose.
+                if not pinned:
+                    directory.chmod(0o700)
                 if target.is_file() and target.stat().st_size > 0:
+                    # Seed-if-absent: keep the (possibly CLI-refreshed) contents,
+                    # but still clamp perms — a pre-existing credential file may
+                    # be world-readable (e.g. 0644 from another tool/restore).
+                    target.chmod(0o600)
                     logger.info(
                         "ACP file-secret %r already present at %s; preserving "
                         "(seed-if-absent)",

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -70,6 +70,7 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
 from openhands.sdk.secret import SecretSource
 from openhands.sdk.settings.acp_providers import (
+    ACP_FILE_SECRETS_BY_NAME,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
 )
@@ -210,6 +211,21 @@ _CHATGPT_AUTH_PATH = Path(".codex") / "auth.json"
 _GEMINI_OAUTH_PATH = Path(".gemini") / "oauth_creds.json"
 
 
+def _codex_auth_file(env: dict[str, str]) -> Path:
+    """Path to Codex's ChatGPT-subscription ``auth.json``, honoring ``CODEX_HOME``.
+
+    Codex reads ``$CODEX_HOME/auth.json`` when ``CODEX_HOME`` is set — which the
+    SDK does after materialising a relocated, per-conversation ``auth.json``
+    (see :meth:`ACPAgent._materialise_file_secrets`) — and ``~/.codex/auth.json``
+    otherwise. Detection must follow the same relocation or a materialised
+    subscription token is never recognised (issue #1020).
+    """
+    codex_home = env.get("CODEX_HOME")
+    if codex_home:
+        return Path(codex_home) / "auth.json"
+    return Path.home() / _CHATGPT_AUTH_PATH
+
+
 def _select_auth_method(
     auth_methods: list[Any],
     env: dict[str, str],
@@ -219,21 +235,26 @@ def _select_auth_method(
     Returns the ``id`` of the first matching method, or ``None`` if no
     supported credential source is available (the server may not require auth).
 
-    Subscription / OAuth logins (whose cached credential file is present) are
-    checked first so they take precedence over explicit API keys, which serve
-    as the fallback:
+    File-backed subscription / SA logins are checked first so they take
+    precedence over explicit API keys, which serve as the fallback:
 
-    - ``chatgpt`` (codex-acp) — ``~/.codex/auth.json``
+    - ``chatgpt`` (codex-acp) — ``$CODEX_HOME/auth.json`` or ``~/.codex/auth.json``
+    - ``vertex-ai`` (gemini-cli) — service-account JSON at
+      ``GOOGLE_APPLICATION_CREDENTIALS`` (the deployable Gemini path; preferred
+      over personal OAuth, which is host-bound and undeployable)
     - ``oauth-personal`` (gemini-cli) — ``~/.gemini/oauth_creds.json``
 
-    In a server image these files are absent (no interactive login), so the
-    API-key fallback (e.g. ``GEMINI_API_KEY``) is used instead.
+    In a server image the interactive-login files are absent, so the API-key
+    fallback (e.g. ``GEMINI_API_KEY``) is used instead.
     """
     method_ids = {m.id for m in auth_methods}
-    # Prefer subscription / OAuth logins when their cached credential file is
-    # present.
-    if "chatgpt" in method_ids and (Path.home() / _CHATGPT_AUTH_PATH).is_file():
+    # Prefer file-backed subscription / service-account logins when their
+    # credential file is present.
+    if "chatgpt" in method_ids and _codex_auth_file(env).is_file():
         return "chatgpt"
+    gac = env.get("GOOGLE_APPLICATION_CREDENTIALS")
+    if "vertex-ai" in method_ids and gac and Path(gac).is_file():
+        return "vertex-ai"
     if "oauth-personal" in method_ids and (Path.home() / _GEMINI_OAUTH_PATH).is_file():
         return "oauth-personal"
     # Fall back to explicit API key env vars.
@@ -241,6 +262,39 @@ def _select_auth_method(
         if method_id in method_ids and env_var in env:
             return method_id
     return None
+
+
+def _write_secret_file(path: Path, value: str) -> None:
+    """Write ``value`` to ``path`` as a ``0600`` file.
+
+    Opens with mode ``0600`` so the bytes never exist with wider permissions,
+    then re-chmods defensively in case the file pre-existed with looser perms.
+    """
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w", encoding="utf-8") as f:
+        f.write(value)
+    path.chmod(0o600)
+
+
+def _present_acp_file_secret_names(
+    state: ConversationState,
+    agent_context: AgentContext | None,
+) -> set[str]:
+    """Reserved file-content secret names supplied for this conversation.
+
+    A name counts as present if it appears in either credential channel
+    (``state.secret_registry`` or ``agent_context.secrets``) and maps to a
+    built-in provider's ``file_secrets``. These names are materialised to disk
+    and therefore excluded from the plain env-var injection and the
+    ``<CUSTOM_SECRETS>`` advertisement (their values are file blobs, not env
+    vars the subprocess can reference by name).
+    """
+    if not ACP_FILE_SECRETS_BY_NAME:
+        return set()
+    present = set(state.secret_registry.secret_sources)
+    if agent_context and agent_context.secrets:
+        present |= set(agent_context.secrets)
+    return present & set(ACP_FILE_SECRETS_BY_NAME)
 
 
 def _extract_session_models(
@@ -1382,9 +1436,32 @@ class ACPAgent(AgentBase):
         would silently drop the advertisement, leaving the agent ignorant of
         secrets that are nonetheless about to land in its env via
         ``_start_acp_server``.
+
+        Reserved file-content secrets (Codex ``auth.json``, Gemini Vertex SA —
+        see :meth:`_materialise_file_secrets`) are dropped from the
+        advertisement: their values are written to disk, not injected as env
+        vars, so advertising them as available env vars would mislead the agent.
         """
         secret_infos = state.secret_registry.get_secret_infos()
-        if self.agent_context is None:
+        agent_context = self.agent_context
+        file_secret_names = _present_acp_file_secret_names(state, agent_context)
+        if file_secret_names:
+            secret_infos = [
+                info
+                for info in secret_infos
+                if info.get("name") not in file_secret_names
+            ]
+            if agent_context is not None and agent_context.secrets:
+                agent_context = agent_context.model_copy(
+                    update={
+                        "secrets": {
+                            name: secret
+                            for name, secret in agent_context.secrets.items()
+                            if name not in file_secret_names
+                        }
+                    }
+                )
+        if agent_context is None:
             # No caller-supplied context. Only synthesize an empty one for the
             # renderer if we actually have a registry-secret advertisement to
             # emit — otherwise return None so we don't start injecting other
@@ -1396,9 +1473,129 @@ class ACPAgent(AgentBase):
             return AgentContext(current_datetime=None).to_acp_prompt_context(
                 additional_secret_infos=secret_infos
             )
-        return self.agent_context.to_acp_prompt_context(
-            additional_secret_infos=secret_infos
-        )
+        return agent_context.to_acp_prompt_context(additional_secret_infos=secret_infos)
+
+    def _read_conversation_secret(
+        self, state: ConversationState, name: str
+    ) -> str | None:
+        """Read a secret value from the canonical channel, then the drain.
+
+        Prefers ``state.secret_registry`` — the canonical channel, where
+        ``create_request`` lifts ``agent_context.secrets`` on the Python /
+        OpenHands-cloud path and where ``StartConversationRequest.secrets``
+        land — and falls back to ``agent_context.secrets`` for topologies that
+        do not call ``create_request`` (notably canvas-local). See #1022.
+        """
+        if name in state.secret_registry.secret_sources:
+            value = state.secret_registry.get_secret_value(name)
+            if value:
+                return value
+        if self.agent_context and self.agent_context.secrets:
+            secret = self.agent_context.secrets.get(name)
+            if secret is not None:
+                return (
+                    secret.get_value()
+                    if isinstance(secret, SecretSource)
+                    else str(secret)
+                )
+        return None
+
+    def _acp_file_secret_dir(self, state: ConversationState, provider_key: str) -> Path:
+        """Durable per-conversation directory for one provider's credential files.
+
+        ``<persistence_dir>/acp/{provider}`` — the same per-conversation tree the
+        regular agent persists ``base_state.json`` / events to, so a token the
+        CLI refreshes on disk survives a pod recycle (``/workspace`` persists
+        across pause/resume; see #1018/#1019). Falls back to a per-conversation
+        directory under the workspace when the conversation is not persisted
+        (e.g. in-memory tests) — still seed-if-absent, still no
+        ``TemporaryDirectory``. Returned absolute so the subprocess (which
+        inherits the agent-server's cwd) resolves it unambiguously.
+        """
+        if state.persistence_dir:
+            root = Path(state.persistence_dir) / "acp" / provider_key
+        else:
+            root = (
+                Path(state.workspace.working_dir) / ".openhands" / "acp" / provider_key
+            )
+        return Path(os.path.abspath(root))
+
+    def _materialise_file_secrets(
+        self, state: ConversationState, env: dict[str, str]
+    ) -> None:
+        """Seed reserved file-content credentials onto disk and point the CLI at them.
+
+        For each reserved secret present in either credential channel (see
+        :meth:`_read_conversation_secret`), write its value to the provider's
+        durable per-conversation directory (:meth:`_acp_file_secret_dir`) and
+        set the controlling env var (``CODEX_HOME`` /
+        ``GOOGLE_APPLICATION_CREDENTIALS``) unless the caller pinned it via
+        ``acp_env``.
+
+        Seed-if-absent: a non-empty existing file is preserved, never clobbered
+        — so a token the CLI rewrites on refresh (Codex) survives a recycle, and
+        a stale pasted blob can't overwrite the live one. Files are ``0600`` in
+        ``0700`` directories. The blob secret itself is not exported as an env
+        var (callers exclude it via :func:`_present_acp_file_secret_names`); only
+        the path env var is set.
+
+        If the caller pinned the data-dir env var via the (deprecated)
+        ``acp_env``, the credential is seeded *where that pin points* so the file
+        and env stay consistent — and ``acp_env`` keeps its precedence over the
+        env var.
+        """
+        for name, (provider_key, spec) in ACP_FILE_SECRETS_BY_NAME.items():
+            value = self._read_conversation_secret(state, name)
+            if not value:
+                continue
+            # Seed where the data-dir env var will actually point: an explicit
+            # acp_env pin (which wins in env precedence) overrides the default
+            # per-conversation root, so honor it as the write target too.
+            pinned = self.acp_env.get(spec.env_var)
+            if pinned and spec.env_points_to == "dir":
+                directory = Path(pinned)
+                target = directory / spec.filename
+            elif pinned:  # env_points_to == "file"
+                target = Path(pinned)
+                directory = target.parent
+            else:
+                directory = self._acp_file_secret_dir(state, provider_key)
+                target = directory / spec.filename
+            try:
+                directory.mkdir(mode=0o700, parents=True, exist_ok=True)
+                # Tighten in case the dir pre-existed or umask widened the mode.
+                directory.chmod(0o700)
+                if target.is_file() and target.stat().st_size > 0:
+                    logger.info(
+                        "ACP file-secret %r already present at %s; preserving "
+                        "(seed-if-absent)",
+                        name,
+                        target,
+                    )
+                else:
+                    _write_secret_file(target, value)
+                    logger.info("Materialised ACP file-secret %r -> %s", name, target)
+            except OSError:
+                logger.exception(
+                    "Failed to materialise ACP file-secret %r under %s",
+                    name,
+                    directory,
+                )
+                continue
+            # acp_env (applied last in _start_acp_server) keeps precedence; only
+            # set the env var here when the caller did not pin it.
+            if spec.env_var not in self.acp_env:
+                env[spec.env_var] = str(
+                    directory if spec.env_points_to == "dir" else target
+                )
+            for companion in spec.warn_if_unset:
+                if not env.get(companion) and companion not in self.acp_env:
+                    logger.warning(
+                        "ACP file-secret %r materialised but %s is unset; the "
+                        "provider may fail to authenticate until it is configured",
+                        name,
+                        companion,
+                    )
 
     def _start_acp_server(self, state: ConversationState) -> None:
         """Start the ACP subprocess and initialize the session."""
@@ -1441,6 +1638,11 @@ class ACPAgent(AgentBase):
                     "StartConversationRequest.secrets) instead."
                 ),
             )
+        # Reserved file-content credential secrets (Codex auth.json, Gemini
+        # Vertex SA — see _materialise_file_secrets) are written to disk, not
+        # injected as env vars, so exclude their (large blob) names from the
+        # plain env-injection below; materialisation sets only the path env var.
+        file_secret_names = _present_acp_file_secret_names(state, self.agent_context)
         # agent_context.secrets drain (lower precedence than the registry).
         # Skip keys a higher tier will set — acp_env (applied last) and the
         # registry (applied next) — to avoid a wasted SecretSource.get_value()
@@ -1448,7 +1650,11 @@ class ACPAgent(AgentBase):
         registry_names = set(state.secret_registry.secret_sources)
         if self.agent_context and self.agent_context.secrets:
             for name, secret in self.agent_context.secrets.items():
-                if name in self.acp_env or name in registry_names:
+                if (
+                    name in self.acp_env
+                    or name in registry_names
+                    or name in file_secret_names
+                ):
                     continue
                 value = (
                     secret.get_value()
@@ -1460,11 +1666,16 @@ class ACPAgent(AgentBase):
         # state.secret_registry overrides the drain and ambient os.environ. Skip
         # keys acp_env will set (avoids a redundant LookupSecret.get_value()).
         for name in state.secret_registry.secret_sources:
-            if name in self.acp_env:
+            if name in self.acp_env or name in file_secret_names:
                 continue
             value = state.secret_registry.get_secret_value(name)
             if value:
                 env[name] = value
+        # Materialise reserved file-content secrets to disk and point their
+        # data-dir env vars (CODEX_HOME / GOOGLE_APPLICATION_CREDENTIALS) at the
+        # written files. Done before acp_env so an explicit acp_env override of
+        # those vars still wins.
+        self._materialise_file_secrets(state, env)
         # acp_env (deprecated) has highest precedence.
         env.update(self.acp_env)
         # Strip CLAUDECODE so nested Claude Code instances don't refuse to start

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -70,8 +70,9 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
 from openhands.sdk.secret import SecretSource
 from openhands.sdk.settings.acp_providers import (
-    ACP_FILE_SECRETS_BY_NAME,
+    ACPFileSecretSpec,
     build_session_model_meta,
+    default_acp_file_secrets,
     detect_acp_provider_by_agent_name,
 )
 from openhands.sdk.tool import Tool  # noqa: TC002
@@ -274,27 +275,6 @@ def _write_secret_file(path: Path, value: str) -> None:
     with os.fdopen(fd, "w", encoding="utf-8") as f:
         f.write(value)
     path.chmod(0o600)
-
-
-def _present_acp_file_secret_names(
-    state: ConversationState,
-    agent_context: AgentContext | None,
-) -> set[str]:
-    """Reserved file-content secret names supplied for this conversation.
-
-    A name counts as present if it appears in either credential channel
-    (``state.secret_registry`` or ``agent_context.secrets``) and maps to a
-    built-in provider's ``file_secrets``. These names are materialised to disk
-    and therefore excluded from the plain env-var injection and the
-    ``<CUSTOM_SECRETS>`` advertisement (their values are file blobs, not env
-    vars the subprocess can reference by name).
-    """
-    if not ACP_FILE_SECRETS_BY_NAME:
-        return set()
-    present = set(state.secret_registry.secret_sources)
-    if agent_context and agent_context.secrets:
-        present |= set(agent_context.secrets)
-    return present & set(ACP_FILE_SECRETS_BY_NAME)
 
 
 def _extract_session_models(
@@ -1001,6 +981,18 @@ class ACPAgent(AgentBase):
             "If None, the server picks its default."
         ),
     )
+    acp_file_secrets: list[ACPFileSecretSpec] = Field(
+        default_factory=lambda: list(default_acp_file_secrets()),
+        description=(
+            "Reserved 'file-content' credential secrets to materialise to disk "
+            "before launching the subprocess (e.g. Codex auth.json, Gemini "
+            "Vertex SA JSON). The SDK owns the mechanism (write the file in the "
+            "runtime pod, set the env var, seed-if-absent); these specs are the "
+            "policy. Defaults to the built-in supported providers; a downstream "
+            "application may override or extend this to support other ACP "
+            "servers with different file-auth schemes."
+        ),
+    )
 
     def model_post_init(self, __context: object) -> None:
         super().model_post_init(__context)
@@ -1444,7 +1436,7 @@ class ACPAgent(AgentBase):
         """
         secret_infos = state.secret_registry.get_secret_infos()
         agent_context = self.agent_context
-        file_secret_names = _present_acp_file_secret_names(state, agent_context)
+        file_secret_names = self._present_file_secret_names(state)
         if file_secret_names:
             secret_infos = [
                 info
@@ -1500,10 +1492,28 @@ class ACPAgent(AgentBase):
                 )
         return None
 
-    def _acp_file_secret_dir(self, state: ConversationState, provider_key: str) -> Path:
-        """Durable per-conversation directory for one provider's credential files.
+    def _present_file_secret_names(self, state: ConversationState) -> set[str]:
+        """Reserved file-content secret names supplied for this conversation.
 
-        ``<persistence_dir>/acp/{provider}`` — the same per-conversation tree the
+        A name counts as present if it is configured in
+        :attr:`acp_file_secrets` *and* appears in either credential channel
+        (``state.secret_registry`` or ``agent_context.secrets``). These names
+        are materialised to disk and therefore excluded from the plain env-var
+        injection and the ``<CUSTOM_SECRETS>`` advertisement (their values are
+        file blobs, not env vars the subprocess can reference by name).
+        """
+        configured = {spec.secret_name for spec in self.acp_file_secrets}
+        if not configured:
+            return set()
+        present = set(state.secret_registry.secret_sources)
+        if self.agent_context and self.agent_context.secrets:
+            present |= set(self.agent_context.secrets)
+        return present & configured
+
+    def _acp_file_secret_dir(self, state: ConversationState, subdir: str) -> Path:
+        """Durable per-conversation directory for a credential file.
+
+        ``<persistence_dir>/acp/{subdir}`` — the same per-conversation tree the
         regular agent persists ``base_state.json`` / events to, so a token the
         CLI refreshes on disk survives a pod recycle (``/workspace`` persists
         across pause/resume; see #1018/#1019). Falls back to a per-conversation
@@ -1513,11 +1523,9 @@ class ACPAgent(AgentBase):
         inherits the agent-server's cwd) resolves it unambiguously.
         """
         if state.persistence_dir:
-            root = Path(state.persistence_dir) / "acp" / provider_key
+            root = Path(state.persistence_dir) / "acp" / subdir
         else:
-            root = (
-                Path(state.workspace.working_dir) / ".openhands" / "acp" / provider_key
-            )
+            root = Path(state.workspace.working_dir) / ".openhands" / "acp" / subdir
         return Path(os.path.abspath(root))
 
     def _materialise_file_secrets(
@@ -1525,18 +1533,18 @@ class ACPAgent(AgentBase):
     ) -> None:
         """Seed reserved file-content credentials onto disk and point the CLI at them.
 
-        For each reserved secret present in either credential channel (see
-        :meth:`_read_conversation_secret`), write its value to the provider's
-        durable per-conversation directory (:meth:`_acp_file_secret_dir`) and
-        set the controlling env var (``CODEX_HOME`` /
-        ``GOOGLE_APPLICATION_CREDENTIALS``) unless the caller pinned it via
-        ``acp_env``.
+        For each spec in :attr:`acp_file_secrets` whose secret is present in
+        either credential channel (see :meth:`_read_conversation_secret`), write
+        its value to the spec's durable per-conversation directory
+        (:meth:`_acp_file_secret_dir`) and set the controlling env var
+        (``CODEX_HOME`` / ``GOOGLE_APPLICATION_CREDENTIALS``) unless the caller
+        pinned it via ``acp_env``.
 
         Seed-if-absent: a non-empty existing file is preserved, never clobbered
         — so a token the CLI rewrites on refresh (Codex) survives a recycle, and
         a stale pasted blob can't overwrite the live one. Files are ``0600`` in
         ``0700`` directories. The blob secret itself is not exported as an env
-        var (callers exclude it via :func:`_present_acp_file_secret_names`); only
+        var (callers exclude it via :meth:`_present_file_secret_names`); only
         the path env var is set.
 
         If the caller pinned the data-dir env var via the (deprecated)
@@ -1544,7 +1552,8 @@ class ACPAgent(AgentBase):
         and env stay consistent — and ``acp_env`` keeps its precedence over the
         env var.
         """
-        for name, (provider_key, spec) in ACP_FILE_SECRETS_BY_NAME.items():
+        for spec in self.acp_file_secrets:
+            name = spec.secret_name
             value = self._read_conversation_secret(state, name)
             if not value:
                 continue
@@ -1559,7 +1568,7 @@ class ACPAgent(AgentBase):
                 target = Path(pinned)
                 directory = target.parent
             else:
-                directory = self._acp_file_secret_dir(state, provider_key)
+                directory = self._acp_file_secret_dir(state, spec.subdir)
                 target = directory / spec.filename
             try:
                 directory.mkdir(mode=0o700, parents=True, exist_ok=True)
@@ -1642,7 +1651,7 @@ class ACPAgent(AgentBase):
         # Vertex SA — see _materialise_file_secrets) are written to disk, not
         # injected as env vars, so exclude their (large blob) names from the
         # plain env-injection below; materialisation sets only the path env var.
-        file_secret_names = _present_acp_file_secret_names(state, self.agent_context)
+        file_secret_names = self._present_file_secret_names(state)
         # agent_context.secrets drain (lower precedence than the registry).
         # Skip keys a higher tier will set — acp_env (applied last) and the
         # registry (applied next) — to avoid a wasted SecretSource.get_value()

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1597,12 +1597,18 @@ class ACPAgent(AgentBase):
                     _write_secret_file(target, value)
                     logger.info("Materialised ACP file-secret %r -> %s", name, target)
             except OSError:
+                # Fail fast rather than swallowing: if the credential the caller
+                # supplied can't be written (read-only/full workspace mount, etc.)
+                # its data-dir env var would never be set and the subprocess would
+                # fail at auth time with a cryptic CLI error and no SDK breadcrumb.
+                # Re-raising lets init_state surface a typed ConversationErrorEvent
+                # (ACPInitError) that names the materialisation failure.
                 logger.exception(
                     "Failed to materialise ACP file-secret %r under %s",
                     name,
                     directory,
                 )
-                continue
+                raise
             # acp_env (applied last in _start_acp_server) keeps precedence; only
             # set the env var here when the caller did not pin it.
             if spec.env_var not in self.acp_env:

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .acp_providers import (
+    ACP_FILE_SECRETS_BY_NAME,
     ACP_PROVIDERS,
+    ACPFileSecretSpec,
     ACPModelOption,
     ACPProviderInfo,
     build_session_model_meta,
@@ -73,7 +75,9 @@ _MODEL_EXPORTS = {
 }
 
 __all__ = [
+    "ACP_FILE_SECRETS_BY_NAME",
     "ACP_PROVIDERS",
+    "ACPFileSecretSpec",
     "ACPModelOption",
     "ACPProviderInfo",
     "build_session_model_meta",

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -3,12 +3,12 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from .acp_providers import (
-    ACP_FILE_SECRETS_BY_NAME,
     ACP_PROVIDERS,
     ACPFileSecretSpec,
     ACPModelOption,
     ACPProviderInfo,
     build_session_model_meta,
+    default_acp_file_secrets,
     detect_acp_provider_by_agent_name,
     get_acp_provider,
 )
@@ -75,12 +75,12 @@ _MODEL_EXPORTS = {
 }
 
 __all__ = [
-    "ACP_FILE_SECRETS_BY_NAME",
     "ACP_PROVIDERS",
     "ACPFileSecretSpec",
     "ACPModelOption",
     "ACPProviderInfo",
     "build_session_model_meta",
+    "default_acp_file_secrets",
     "AGENT_SETTINGS_SCHEMA_VERSION",
     "CONVERSATION_SETTINGS_SCHEMA_VERSION",
     "ACPAgentSettings",

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -35,8 +35,11 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import dataclass, field
+from pathlib import PurePosixPath
 from types import MappingProxyType
 from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 @dataclass(frozen=True)
@@ -50,8 +53,7 @@ class ACPModelOption:
     """Human-readable label shown in the model picker (e.g. ``"Claude Opus 4.7"``)."""
 
 
-@dataclass(frozen=True)
-class ACPFileSecretSpec:
+class ACPFileSecretSpec(BaseModel):
     """Declarative mapping from a reserved "file-content" secret to a credential
     file the ACP subprocess authenticates from.
 
@@ -66,18 +68,32 @@ class ACPFileSecretSpec:
     Materialisation is keyed off :attr:`secret_name` (not the launch command),
     so a custom or aliased ``acp_command`` still works as long as the reserved
     secret is supplied.
+
+    The SDK owns the *mechanism* (writing the file in the runtime pod, setting
+    the env var, seed-if-absent, permissions); the *policy* — which secrets map
+    to which files for which CLIs — lives in these specs. Built-in defaults
+    cover the supported providers, but downstream applications can override
+    :attr:`~openhands.sdk.agent.ACPAgent.acp_file_secrets` to support other ACP
+    servers with different file-auth schemes without an SDK change.
     """
 
-    secret_name: str
+    model_config = ConfigDict(frozen=True)
+
+    secret_name: str = Field(min_length=1)
     """Reserved secret whose value is the credential file's contents (looked up
     in ``state.secret_registry`` / ``agent_context.secrets``)."""
 
-    filename: str
-    """Basename of the materialised file, written under the per-conversation
-    ``<conversations>/{id.hex}/acp/{provider}/`` directory."""
+    filename: str = Field(min_length=1)
+    """Basename of the materialised file (e.g. ``auth.json``)."""
 
-    env_var: str
+    env_var: str = Field(min_length=1)
     """Env var the CLI reads to locate the materialised credential."""
+
+    subdir: str = Field(min_length=1)
+    """Folder under the per-conversation ``<conversations>/{id.hex}/acp/`` root
+    where the file is written — the provider key for built-ins (``codex`` /
+    ``gemini-cli``), or any stable folder name for a custom spec. Keeps
+    concurrent providers' credential files isolated within one sandbox."""
 
     env_points_to: Literal["dir", "file"] = "file"
     """Whether :attr:`env_var` is set to the file's parent *directory* (Codex's
@@ -88,6 +104,23 @@ class ACPFileSecretSpec:
     """Companion env vars to warn about when this secret is materialised but
     they are missing (e.g. ``GOOGLE_CLOUD_PROJECT`` / ``GOOGLE_CLOUD_LOCATION``
     for Vertex AI). Advisory only — materialisation still proceeds."""
+
+    @field_validator("filename")
+    @classmethod
+    def _validate_filename(cls, value: str) -> str:
+        """``filename`` must be a bare basename, never a path or traversal."""
+        if "/" in value or "\\" in value or value in (".", ".."):
+            raise ValueError("filename must be a bare basename, not a path")
+        return value
+
+    @field_validator("subdir")
+    @classmethod
+    def _validate_subdir(cls, value: str) -> str:
+        """``subdir`` must be a relative path with no traversal or root escape."""
+        path = PurePosixPath(value)
+        if path.is_absolute() or ".." in path.parts:
+            raise ValueError("subdir must be a relative path without '..' segments")
+        return value
 
 
 @dataclass(frozen=True)
@@ -299,6 +332,7 @@ _CODEX_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
         secret_name="CODEX_AUTH_JSON",
         filename="auth.json",
         env_var="CODEX_HOME",
+        subdir="codex",
         env_points_to="dir",
     ),
 )
@@ -307,6 +341,7 @@ _GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
         secret_name="GOOGLE_APPLICATION_CREDENTIALS_JSON",
         filename="gcloud-credentials.json",
         env_var="GOOGLE_APPLICATION_CREDENTIALS",
+        subdir="gemini-cli",
         env_points_to="file",
         warn_if_unset=("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"),
     ),
@@ -373,21 +408,16 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
 """Read-only registry of built-in ACP providers keyed by ``acp_server`` value."""
 
 
-ACP_FILE_SECRETS_BY_NAME: Mapping[str, tuple[str, ACPFileSecretSpec]] = (
-    MappingProxyType(
-        {
-            spec.secret_name: (key, spec)
-            for key, info in ACP_PROVIDERS.items()
-            for spec in info.file_secrets
-        }
-    )
-)
-"""Reserved file-content secret name → ``(provider_key, spec)``.
+def default_acp_file_secrets() -> tuple[ACPFileSecretSpec, ...]:
+    """Built-in file-content credential specs across all supported providers.
 
-Aggregates :attr:`ACPProviderInfo.file_secrets` across the built-in providers so
-materialisation can be driven by the reserved secret name alone — independent of
-which ``acp_command`` is configured.
-"""
+    The union of every :attr:`ACPProviderInfo.file_secrets` (Codex ``auth.json``,
+    Gemini Vertex SA). Used as the default for
+    :attr:`~openhands.sdk.agent.ACPAgent.acp_file_secrets`, which a downstream
+    application may override or extend to support other ACP servers without an
+    SDK change.
+    """
+    return tuple(spec for info in ACP_PROVIDERS.values() for spec in info.file_secrets)
 
 
 def get_acp_provider(key: str) -> ACPProviderInfo | None:

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -21,6 +21,9 @@ Each record captures the static properties that are known at configuration time
 - ``available_models``      curated list of selectable models for the provider's
                             model picker (``acp_model`` candidates)
 - ``default_model``         model preselected when none is configured (or ``None``)
+- ``file_secrets``          reserved "file-content" credential secrets the
+                            provider authenticates from (Codex ``auth.json``,
+                            Gemini Vertex SA JSON); see :class:`ACPFileSecretSpec`
 
 Callers outside the SDK (e.g. ``openhands-agent-server``, the ``OpenHands``
 frontend, and the ``@openhands/typescript-client`` mirror) can import
@@ -33,7 +36,7 @@ from __future__ import annotations
 from collections.abc import Mapping
 from dataclasses import dataclass, field
 from types import MappingProxyType
-from typing import Any
+from typing import Any, Literal
 
 
 @dataclass(frozen=True)
@@ -45,6 +48,46 @@ class ACPModelOption:
 
     label: str
     """Human-readable label shown in the model picker (e.g. ``"Claude Opus 4.7"``)."""
+
+
+@dataclass(frozen=True)
+class ACPFileSecretSpec:
+    """Declarative mapping from a reserved "file-content" secret to a credential
+    file the ACP subprocess authenticates from.
+
+    Some providers read their credential from a *file on disk* rather than an
+    env var: Codex reads ``$CODEX_HOME/auth.json``; Gemini (Vertex AI) reads a
+    service-account JSON pointed at by ``GOOGLE_APPLICATION_CREDENTIALS``. The
+    user supplies that credential as a pasted blob — a reserved secret named
+    :attr:`secret_name` — and :class:`~openhands.sdk.agent.ACPAgent` materialises
+    it to :attr:`filename` under the conversation's durable per-conversation root
+    (seed-if-absent), then sets :attr:`env_var` so the CLI can find it.
+
+    Materialisation is keyed off :attr:`secret_name` (not the launch command),
+    so a custom or aliased ``acp_command`` still works as long as the reserved
+    secret is supplied.
+    """
+
+    secret_name: str
+    """Reserved secret whose value is the credential file's contents (looked up
+    in ``state.secret_registry`` / ``agent_context.secrets``)."""
+
+    filename: str
+    """Basename of the materialised file, written under the per-conversation
+    ``<conversations>/{id.hex}/acp/{provider}/`` directory."""
+
+    env_var: str
+    """Env var the CLI reads to locate the materialised credential."""
+
+    env_points_to: Literal["dir", "file"] = "file"
+    """Whether :attr:`env_var` is set to the file's parent *directory* (Codex's
+    ``CODEX_HOME``) or to the *file* path itself (Gemini's
+    ``GOOGLE_APPLICATION_CREDENTIALS``)."""
+
+    warn_if_unset: tuple[str, ...] = ()
+    """Companion env vars to warn about when this secret is materialised but
+    they are missing (e.g. ``GOOGLE_CLOUD_PROJECT`` / ``GOOGLE_CLOUD_LOCATION``
+    for Vertex AI). Advisory only — materialisation still proceeds."""
 
 
 @dataclass(frozen=True)
@@ -162,6 +205,16 @@ class ACPProviderInfo:
     signature break; the built-in providers set it explicitly.
     """
 
+    file_secrets: tuple[ACPFileSecretSpec, ...] = field(default=(), compare=False)
+    """Reserved file-content credential secrets this provider authenticates from.
+
+    Each entry maps a reserved secret name to the on-disk file (and the env var
+    pointing at it) that :class:`~openhands.sdk.agent.ACPAgent` materialises
+    before launching the subprocess. Empty for providers that authenticate
+    purely via env vars (e.g. Claude Code). Defaults to ``()`` so external
+    callers constructing this dataclass positionally keep working.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Curated ``acp_model`` candidate lists for the built-in providers.
@@ -232,6 +285,34 @@ _GEMINI_MODELS: tuple[ACPModelOption, ...] = (
 )
 
 
+# ---------------------------------------------------------------------------
+# Reserved file-content credential secrets for the built-in providers.
+#
+# Codex's ChatGPT-subscription ``auth.json`` relocates with ``CODEX_HOME`` (and
+# is rewritten in place on token refresh, so it must live on durable, writable
+# storage). Gemini's Vertex AI service-account JSON is pointed at directly by
+# ``GOOGLE_APPLICATION_CREDENTIALS``; Vertex also needs a project/location, so
+# warn when those are unset.
+# ---------------------------------------------------------------------------
+_CODEX_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
+    ACPFileSecretSpec(
+        secret_name="CODEX_AUTH_JSON",
+        filename="auth.json",
+        env_var="CODEX_HOME",
+        env_points_to="dir",
+    ),
+)
+_GEMINI_FILE_SECRETS: tuple[ACPFileSecretSpec, ...] = (
+    ACPFileSecretSpec(
+        secret_name="GOOGLE_APPLICATION_CREDENTIALS_JSON",
+        filename="gcloud-credentials.json",
+        env_var="GOOGLE_APPLICATION_CREDENTIALS",
+        env_points_to="file",
+        warn_if_unset=("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION"),
+    ),
+)
+
+
 ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
     {
         "claude-code": ACPProviderInfo(
@@ -265,6 +346,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             session_meta_key=None,
             available_models=_CODEX_MODELS,
             default_model="gpt-5.5/medium",
+            file_secrets=_CODEX_FILE_SECRETS,
         ),
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
@@ -284,10 +366,28 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # make downstream clients persist a value that bypasses the CLI's
             # auto-routing.
             default_model="auto-gemini-2.5",
+            file_secrets=_GEMINI_FILE_SECRETS,
         ),
     }
 )
 """Read-only registry of built-in ACP providers keyed by ``acp_server`` value."""
+
+
+ACP_FILE_SECRETS_BY_NAME: Mapping[str, tuple[str, ACPFileSecretSpec]] = (
+    MappingProxyType(
+        {
+            spec.secret_name: (key, spec)
+            for key, info in ACP_PROVIDERS.items()
+            for spec in info.file_secrets
+        }
+    )
+)
+"""Reserved file-content secret name → ``(provider_key, spec)``.
+
+Aggregates :attr:`ACPProviderInfo.file_secrets` across the built-in providers so
+materialisation can be driven by the reserved secret name alone — independent of
+which ``acp_command`` is configured.
+"""
 
 
 def get_acp_provider(key: str) -> ACPProviderInfo | None:

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -116,10 +116,14 @@ class ACPFileSecretSpec(BaseModel):
     @field_validator("subdir")
     @classmethod
     def _validate_subdir(cls, value: str) -> str:
-        """``subdir`` must be a relative path with no traversal or root escape."""
+        """``subdir`` must be a real relative folder (no traversal, root escape,
+        or the ``.`` identity path that would drop the credential straight into
+        the shared ``acp/`` root where two specs could collide)."""
         path = PurePosixPath(value)
-        if path.is_absolute() or ".." in path.parts:
-            raise ValueError("subdir must be a relative path without '..' segments")
+        if path.is_absolute() or ".." in path.parts or value.strip() in ("", "."):
+            raise ValueError(
+                "subdir must be a non-empty relative path without '.'/'..' segments"
+            )
         return value
 
 

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -51,7 +51,12 @@ from openhands.sdk.utils.pydantic_secrets import (
 from openhands.sdk.utils.redact import sanitize_dict
 from openhands.sdk.workspace import LocalWorkspace
 
-from .acp_providers import ACPProviderInfo, get_acp_provider
+from .acp_providers import (
+    ACPFileSecretSpec,
+    ACPProviderInfo,
+    default_acp_file_secrets,
+    get_acp_provider,
+)
 from .metadata import (
     SETTINGS_METADATA_KEY,
     SETTINGS_SECTION_METADATA_KEY,
@@ -1092,6 +1097,27 @@ class ACPAgentSettings(AgentSettingsBase):
             ).model_dump(),
         },
     )
+    acp_file_secrets: list[ACPFileSecretSpec] = Field(
+        default_factory=lambda: list(default_acp_file_secrets()),
+        description=(
+            "Reserved 'file-content' credential secrets the SDK materialises to "
+            "disk before launching the ACP subprocess (e.g. Codex auth.json, "
+            "Gemini Vertex SA JSON). Defaults to the built-in supported "
+            "providers; override to support other ACP servers with different "
+            "file-auth schemes."
+        ),
+        json_schema_extra={
+            SETTINGS_METADATA_KEY: SettingsFieldMetadata(
+                label="ACP file-content credential secrets",
+                prominence=SettingProminence.MINOR,
+            ).model_dump(),
+            SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
+                key="acp",
+                label="ACP (Agent Client Protocol)",
+                variant="acp",
+            ).model_dump(),
+        },
+    )
     llm: LLM = Field(
         default_factory=_default_llm_settings,
         description=(
@@ -1286,6 +1312,7 @@ class ACPAgentSettings(AgentSettingsBase):
             acp_model=self.acp_model,
             acp_session_mode=self.acp_session_mode,
             acp_prompt_timeout=self.acp_prompt_timeout,
+            acp_file_secrets=list(self.acp_file_secrets),
             agent_context=agent_context,
         )
 

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1097,6 +1097,10 @@ class ACPAgentSettings(AgentSettingsBase):
             ).model_dump(),
         },
     )
+    # Programmatic / downstream-facing knob, deliberately NOT surfaced in the
+    # settings-form UI (no SETTINGS_METADATA_KEY): it's a list of structured
+    # specs a downstream application supplies in code to support other ACP CLIs,
+    # not an end-user field. The built-in providers work via the default.
     acp_file_secrets: list[ACPFileSecretSpec] = Field(
         default_factory=lambda: list(default_acp_file_secrets()),
         description=(
@@ -1106,17 +1110,6 @@ class ACPAgentSettings(AgentSettingsBase):
             "providers; override to support other ACP servers with different "
             "file-auth schemes."
         ),
-        json_schema_extra={
-            SETTINGS_METADATA_KEY: SettingsFieldMetadata(
-                label="ACP file-content credential secrets",
-                prominence=SettingProminence.MINOR,
-            ).model_dump(),
-            SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
-                key="acp",
-                label="ACP (Agent Client Protocol)",
-                variant="acp",
-            ).model_dump(),
-        },
     )
     llm: LLM = Field(
         default_factory=_default_llm_settings,

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -27,7 +27,6 @@ from openhands.sdk.agent.acp_agent import (
     _image_url_to_acp_block,
     _maybe_set_session_model,
     _OpenHandsACPBridge,
-    _present_acp_file_secret_names,
     _reapply_session_model_on_resume,
     _select_auth_method,
     _serialize_tool_content,
@@ -6743,6 +6742,7 @@ class TestACPFileSecretMaterialisation:
     def test_present_file_secret_names_helper(self, tmp_path):
         from openhands.sdk.secret import StaticSecret
 
+        agent = _make_agent()
         state = self._state(tmp_path)
         state.secret_registry.update_secrets(
             {
@@ -6750,7 +6750,7 @@ class TestACPFileSecretMaterialisation:
                 "PLAIN_TOKEN": StaticSecret(value=SecretStr("t")),
             }
         )
-        assert _present_acp_file_secret_names(state, None) == {"CODEX_AUTH_JSON"}
+        assert agent._present_file_secret_names(state) == {"CODEX_AUTH_JSON"}
 
     def test_blob_excluded_from_custom_secrets_advertisement(self, tmp_path):
         """The <CUSTOM_SECRETS> advertisement lists plain secrets but not the
@@ -6777,3 +6777,63 @@ class TestACPFileSecretMaterialisation:
         assert suffix is not None
         assert "PLAIN_TOKEN" in suffix.text
         assert "CODEX_AUTH_JSON" not in suffix.text
+
+    def test_downstream_can_override_specs_with_custom_provider(self, tmp_path):
+        """A downstream app supplies its own ACPFileSecretSpec for a custom CLI;
+        the SDK mechanism materialises it without any registry change."""
+        from openhands.sdk import ACPFileSecretSpec
+        from openhands.sdk.secret import StaticSecret
+
+        custom = ACPFileSecretSpec(
+            secret_name="MYCLI_TOKEN_JSON",
+            filename="token.json",
+            env_var="MYCLI_HOME",
+            subdir="mycli",
+            env_points_to="dir",
+        )
+        agent = _make_agent(acp_file_secrets=[custom])
+        state = self._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {"MYCLI_TOKEN_JSON": StaticSecret(value=SecretStr('{"t": 1}'))}
+        )
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        home = Path(env["MYCLI_HOME"])
+        assert home == Path(persist) / "acp" / "mycli"
+        assert (home / "token.json").read_text(encoding="utf-8") == '{"t": 1}'
+        assert "MYCLI_TOKEN_JSON" not in env
+        # The built-in Codex/Gemini specs were replaced, so their secrets would
+        # NOT be materialised by this agent.
+        assert agent._present_file_secret_names(state) == {"MYCLI_TOKEN_JSON"}
+
+    def test_empty_specs_disables_materialisation(self, tmp_path):
+        """With acp_file_secrets=[], a CODEX_AUTH_JSON secret is treated as an
+        ordinary env var (no file written, no CODEX_HOME) — downstream opt-out."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(acp_file_secrets=[])
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("blob"))}
+        )
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        assert "CODEX_HOME" not in env
+        # Not configured as a file-secret, so it flows through as a plain env var.
+        assert env.get("CODEX_AUTH_JSON") == "blob"
+
+    def test_settings_pass_file_secrets_through_create_agent(self):
+        """ACPAgentSettings defaults to the built-in specs and forwards them to
+        the constructed ACPAgent."""
+        from openhands.sdk.settings.acp_providers import default_acp_file_secrets
+        from openhands.sdk.settings.model import ACPAgentSettings
+
+        settings = ACPAgentSettings(acp_server="codex")
+        agent = settings.create_agent()
+        names = {s.secret_name for s in agent.acp_file_secrets}
+        assert "CODEX_AUTH_JSON" in names
+        assert {s.secret_name for s in agent.acp_file_secrets} == {
+            s.secret_name for s in default_acp_file_secrets()
+        }

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6615,9 +6615,10 @@ class TestACPFileSecretMaterialisation:
         assert codex_home == Path(persist) / "acp" / "codex"
         auth_file = codex_home / "auth.json"
         assert auth_file.read_text(encoding="utf-8") == '{"tokens": "x"}'
-        # 0600 file inside a 0700 dir.
+        # 0600 file inside a 0700 dir, and the shared acp/ parent is 0700 too.
         assert auth_file.stat().st_mode & 0o777 == 0o600
         assert codex_home.stat().st_mode & 0o777 == 0o700
+        assert codex_home.parent.stat().st_mode & 0o777 == 0o700
         # The blob is not exported as an env var.
         assert "CODEX_AUTH_JSON" not in env
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6642,7 +6642,9 @@ class TestACPFileSecretMaterialisation:
         gac = Path(env["GOOGLE_APPLICATION_CREDENTIALS"])
         assert gac == Path(persist) / "acp" / "gemini-cli" / "gcloud-credentials.json"
         assert gac.read_text(encoding="utf-8") == '{"type": "service_account"}'
+        # 0600 file inside a 0700 dir (symmetry with the Codex test).
         assert gac.stat().st_mode & 0o777 == 0o600
+        assert gac.parent.stat().st_mode & 0o777 == 0o700
         assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
 
     def test_seed_if_absent_does_not_clobber_existing_file(self, tmp_path):

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6654,11 +6654,12 @@ class TestACPFileSecretMaterialisation:
         state = self._state(tmp_path)
         persist = state.persistence_dir
         assert persist is not None
-        # Pre-seed a "refreshed" auth.json at the target path.
+        # Pre-seed a "refreshed" auth.json with deliberately wide (0644) perms.
         codex_home = Path(persist) / "acp" / "codex"
         codex_home.mkdir(parents=True)
         refreshed = codex_home / "auth.json"
         refreshed.write_text('{"refreshed": true}', encoding="utf-8")
+        refreshed.chmod(0o644)
 
         state.secret_registry.update_secrets(
             {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"stale": true}'))}
@@ -6666,7 +6667,11 @@ class TestACPFileSecretMaterialisation:
         env = self._run_start(agent, state, conn=self._make_conn())
 
         assert Path(env["CODEX_HOME"]) == codex_home
+        # Contents preserved (not clobbered by the stale paste)...
         assert refreshed.read_text(encoding="utf-8") == '{"refreshed": true}'
+        # ...but perms are still clamped to 0600 (regression: QA found a
+        # preserved 0644 file staying world-readable).
+        assert refreshed.stat().st_mode & 0o777 == 0o600
 
     def test_reads_from_agent_context_secrets_drain(self, tmp_path):
         """The reserved secret can arrive via agent_context.secrets (canvas-local
@@ -6692,6 +6697,9 @@ class TestACPFileSecretMaterialisation:
         from openhands.sdk.secret import StaticSecret
 
         pinned = tmp_path / "pinned_codex"
+        # Pre-create the pinned dir with deliberately wide (0755) perms.
+        pinned.mkdir()
+        pinned.chmod(0o755)
         agent = _make_agent(acp_env={"CODEX_HOME": str(pinned)})
         state = self._state(tmp_path)
         state.secret_registry.update_secrets(
@@ -6702,6 +6710,10 @@ class TestACPFileSecretMaterialisation:
         assert env["CODEX_HOME"] == str(pinned)
         # The credential lands under the pinned dir, not the conversation root.
         assert (pinned / "auth.json").read_text(encoding="utf-8") == '{"k": 1}'
+        # The pinned dir's user-chosen perms are NOT silently narrowed...
+        assert pinned.stat().st_mode & 0o777 == 0o755
+        # ...but the credential file itself is still 0600.
+        assert (pinned / "auth.json").stat().st_mode & 0o777 == 0o600
 
     def test_fallback_root_when_not_persisted(self, tmp_path):
         """With no persistence_dir, the file lands under the workspace tree —

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6741,6 +6741,25 @@ class TestACPFileSecretMaterialisation:
         env = self._run_start(agent, state, conn=self._make_conn())
         assert "CODEX_HOME" not in env
 
+    def test_materialisation_oserror_fails_fast(self, tmp_path):
+        """If the credential can't be written (e.g. read-only mount), the error
+        propagates out of _start_acp_server (so init_state surfaces a typed
+        ConversationErrorEvent) instead of being swallowed and leaving the CLI
+        to fail at auth time with no SDK breadcrumb."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
+        )
+        with patch(
+            "openhands.sdk.agent.acp_agent._write_secret_file",
+            side_effect=OSError("[Errno 30] Read-only file system"),
+        ):
+            with pytest.raises(OSError, match="Read-only file system"):
+                self._run_start(agent, state, conn=self._make_conn())
+
     def test_vertex_warns_when_project_unset(self, tmp_path, caplog):
         from openhands.sdk.secret import StaticSecret
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -8,6 +8,7 @@ import threading
 import uuid
 from base64 import urlsafe_b64encode
 from concurrent.futures import Future
+from pathlib import Path
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -19,12 +20,14 @@ from pydantic import SecretStr
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _classify_acp_init_error,
+    _codex_auth_file,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
     _image_url_to_acp_block,
     _maybe_set_session_model,
     _OpenHandsACPBridge,
+    _present_acp_file_secret_names,
     _reapply_session_model_on_resume,
     _select_auth_method,
     _serialize_tool_content,
@@ -4039,6 +4042,91 @@ class TestSelectAuthMethod:
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, env) is None
 
+    # -- CODEX_HOME-aware chatgpt detection (issue #1020) ------------------
+
+    def test_chatgpt_detected_under_relocated_codex_home(self, tmp_path):
+        """chatgpt is selected when auth.json lives under a relocated CODEX_HOME,
+        even though ~/.codex/auth.json does not exist."""
+        codex_home = tmp_path / "conv" / "acp" / "codex"
+        codex_home.mkdir(parents=True)
+        (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+        methods = [self._make_auth_method("chatgpt")]
+        empty_home = tmp_path / "home"
+        empty_home.mkdir()
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=empty_home):
+            assert (
+                _select_auth_method(methods, {"CODEX_HOME": str(codex_home)})
+                == "chatgpt"
+            )
+
+    def test_codex_home_without_auth_file_falls_back(self, tmp_path):
+        """A CODEX_HOME without auth.json is not detected as chatgpt; it falls
+        back to the API key when offered."""
+        codex_home = tmp_path / "empty_codex_home"
+        codex_home.mkdir()
+        methods = [
+            self._make_auth_method("chatgpt"),
+            self._make_auth_method("openai-api-key"),
+        ]
+        env = {"CODEX_HOME": str(codex_home), "OPENAI_API_KEY": "sk-test"}
+        empty_home = tmp_path / "home"
+        empty_home.mkdir()
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=empty_home):
+            assert _select_auth_method(methods, env) == "openai-api-key"
+
+    def test_codex_auth_file_honors_codex_home(self, tmp_path):
+        """_codex_auth_file points at $CODEX_HOME/auth.json when set, else
+        ~/.codex/auth.json."""
+        home = tmp_path / "home"
+        home.mkdir()
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=home):
+            assert _codex_auth_file({}) == home / ".codex" / "auth.json"
+        ch = tmp_path / "ch"
+        assert _codex_auth_file({"CODEX_HOME": str(ch)}) == ch / "auth.json"
+
+    # -- Gemini Vertex AI service-account detection (issue #1020) ----------
+
+    def test_vertex_ai_selected_when_credentials_file_present(self, tmp_path):
+        """vertex-ai is selected when GOOGLE_APPLICATION_CREDENTIALS points at an
+        existing service-account JSON."""
+        sa = tmp_path / "gcloud-credentials.json"
+        sa.write_text("{}", encoding="utf-8")
+        methods = [
+            self._make_auth_method("vertex-ai"),
+            self._make_auth_method("oauth-personal"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        env = {"GOOGLE_APPLICATION_CREDENTIALS": str(sa), "GEMINI_API_KEY": "g"}
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, env) == "vertex-ai"
+
+    def test_vertex_ai_preferred_over_personal_oauth(self, tmp_path):
+        """The materialised Vertex SA (deployable) wins over a host-bound
+        personal OAuth login file."""
+        sa = tmp_path / "sa.json"
+        sa.write_text("{}", encoding="utf-8")
+        gem_dir = tmp_path / ".gemini"
+        gem_dir.mkdir()
+        (gem_dir / "oauth_creds.json").write_text("{}", encoding="utf-8")
+        methods = [
+            self._make_auth_method("vertex-ai"),
+            self._make_auth_method("oauth-personal"),
+        ]
+        env = {"GOOGLE_APPLICATION_CREDENTIALS": str(sa)}
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, env) == "vertex-ai"
+
+    def test_vertex_ai_offered_but_no_credentials_file(self, tmp_path):
+        """vertex-ai offered but GOOGLE_APPLICATION_CREDENTIALS missing/empty ->
+        falls through to the API-key fallback."""
+        methods = [
+            self._make_auth_method("vertex-ai"),
+            self._make_auth_method("gemini-api-key"),
+        ]
+        env = {"GEMINI_API_KEY": "g"}
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
+            assert _select_auth_method(methods, env) == "gemini-api-key"
+
 
 # ---------------------------------------------------------------------------
 # ACP model overrides
@@ -6410,3 +6498,282 @@ class TestACPAgentSupportsRuntimeModelSwitch:
         agent._session_id = "sess-1"
         agent._agent_name = "locked-down-provider"
         assert agent.supports_runtime_model_switch is False
+
+
+# ---------------------------------------------------------------------------
+# Reserved file-content secret materialisation (issue #1020)
+# ---------------------------------------------------------------------------
+
+
+class TestACPFileSecretMaterialisation:
+    """Codex auth.json / Gemini Vertex SA JSON materialise to the durable
+    per-conversation root, with the right data-dir env var, seed-if-absent.
+    """
+
+    @staticmethod
+    def _make_conn(*, agent_name: str = "codex-acp", auth_method: str | None = None):
+        conn = MagicMock()
+        init_response = MagicMock()
+        init_response.agent_info = MagicMock()
+        init_response.agent_info.name = agent_name
+        init_response.agent_info.version = "1.0"
+        init_response.auth_methods = [MagicMock(id=auth_method)] if auth_method else []
+        # MagicMock(id=...) doesn't set .id; assign explicitly.
+        for m in init_response.auth_methods:
+            m.id = auth_method
+        conn.initialize = AsyncMock(return_value=init_response)
+        new_response = MagicMock()
+        new_response.session_id = "sess-new"
+        new_response.models = None
+        conn.new_session = AsyncMock(return_value=new_response)
+        conn.load_session = AsyncMock(return_value=MagicMock())
+        conn.set_session_mode = AsyncMock()
+        conn.set_session_model = AsyncMock()
+        conn.authenticate = AsyncMock()
+        conn.close = AsyncMock()
+        return conn
+
+    @staticmethod
+    def _run_start(agent, state, *, conn):
+        """Run the real _start_acp_server with transport mocked; return the env
+        dict handed to the subprocess."""
+        from contextlib import ExitStack
+
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        captured: dict[str, Any] = {}
+        mock_process = MagicMock()
+        mock_process.stdin = MagicMock()
+        mock_process.stdout = MagicMock()
+
+        async def _fake_exec(*_args, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return mock_process
+
+        async def _fake_filter(_src, _dst):
+            return None
+
+        agent._executor = AsyncExecutor()
+        with ExitStack() as stack:
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.create_subprocess_exec",
+                    new=_fake_exec,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.ClientSideConnection",
+                    return_value=conn,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent._filter_jsonrpc_lines",
+                    new=_fake_filter,
+                )
+            )
+            stack.enter_context(
+                patch(
+                    "openhands.sdk.agent.acp_agent.asyncio.StreamReader",
+                    return_value=MagicMock(),
+                )
+            )
+            agent._start_acp_server(state)
+        return captured["env"]
+
+    @staticmethod
+    def _state(tmp_path, *, persisted: bool = True):
+        from openhands.sdk.agent.acp_agent import ACPAgent
+
+        agent = ACPAgent(acp_command=["codex-acp"])
+        workspace = LocalWorkspace(working_dir=str(tmp_path / "ws"))
+        (tmp_path / "ws").mkdir()
+        persistence_dir = (
+            str(tmp_path / "conversations" / uuid.uuid4().hex) if persisted else None
+        )
+        state = ConversationState.create(
+            id=uuid.uuid4(),
+            agent=agent,
+            workspace=workspace,
+            persistence_dir=persistence_dir,
+        )
+        return state
+
+    def test_codex_auth_json_materialises_to_conversation_root(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"tokens": "x"}'))}
+        )
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        codex_home = Path(env["CODEX_HOME"])
+        assert codex_home == Path(persist) / "acp" / "codex"
+        auth_file = codex_home / "auth.json"
+        assert auth_file.read_text(encoding="utf-8") == '{"tokens": "x"}'
+        # 0600 file inside a 0700 dir.
+        assert auth_file.stat().st_mode & 0o777 == 0o600
+        assert codex_home.stat().st_mode & 0o777 == 0o700
+        # The blob is not exported as an env var.
+        assert "CODEX_AUTH_JSON" not in env
+
+    def test_gemini_vertex_sa_materialises_and_points_at_file(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {
+                "GOOGLE_APPLICATION_CREDENTIALS_JSON": StaticSecret(
+                    value=SecretStr('{"type": "service_account"}')
+                )
+            }
+        )
+        env = self._run_start(
+            agent, state, conn=self._make_conn(agent_name="gemini-cli")
+        )
+
+        gac = Path(env["GOOGLE_APPLICATION_CREDENTIALS"])
+        assert gac == Path(persist) / "acp" / "gemini-cli" / "gcloud-credentials.json"
+        assert gac.read_text(encoding="utf-8") == '{"type": "service_account"}'
+        assert gac.stat().st_mode & 0o777 == 0o600
+        assert "GOOGLE_APPLICATION_CREDENTIALS_JSON" not in env
+
+    def test_seed_if_absent_does_not_clobber_existing_file(self, tmp_path):
+        """A non-empty existing credential file (e.g. a token the CLI refreshed)
+        is preserved; the stale pasted blob does not overwrite it."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        # Pre-seed a "refreshed" auth.json at the target path.
+        codex_home = Path(persist) / "acp" / "codex"
+        codex_home.mkdir(parents=True)
+        refreshed = codex_home / "auth.json"
+        refreshed.write_text('{"refreshed": true}', encoding="utf-8")
+
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"stale": true}'))}
+        )
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        assert Path(env["CODEX_HOME"]) == codex_home
+        assert refreshed.read_text(encoding="utf-8") == '{"refreshed": true}'
+
+    def test_reads_from_agent_context_secrets_drain(self, tmp_path):
+        """The reserved secret can arrive via agent_context.secrets (canvas-local
+        path) rather than the registry."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(
+            agent_context=AgentContext(
+                current_datetime=None,
+                secrets={"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"a": 1}'))},
+            ),
+        )
+        state = self._state(tmp_path)
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        auth_file = Path(env["CODEX_HOME"]) / "auth.json"
+        assert auth_file.read_text(encoding="utf-8") == '{"a": 1}'
+        assert "CODEX_AUTH_JSON" not in env
+
+    def test_acp_env_pin_wins_and_credential_seeds_where_it_points(self, tmp_path):
+        """An explicit acp_env[CODEX_HOME] keeps its precedence, and the
+        credential is seeded *there* so the file and env stay consistent."""
+        from openhands.sdk.secret import StaticSecret
+
+        pinned = tmp_path / "pinned_codex"
+        agent = _make_agent(acp_env={"CODEX_HOME": str(pinned)})
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"k": 1}'))}
+        )
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        assert env["CODEX_HOME"] == str(pinned)
+        # The credential lands under the pinned dir, not the conversation root.
+        assert (pinned / "auth.json").read_text(encoding="utf-8") == '{"k": 1}'
+
+    def test_fallback_root_when_not_persisted(self, tmp_path):
+        """With no persistence_dir, the file lands under the workspace tree —
+        still seed-if-absent, no TemporaryDirectory."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path, persisted=False)
+        assert state.persistence_dir is None
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}"))}
+        )
+        env = self._run_start(agent, state, conn=self._make_conn())
+
+        expected = Path(state.workspace.working_dir) / ".openhands" / "acp" / "codex"
+        assert Path(env["CODEX_HOME"]) == expected
+        assert (expected / "auth.json").is_file()
+
+    def test_no_file_secret_when_secret_absent(self, tmp_path):
+        """No reserved secret present -> no data-dir env var is set."""
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        env = self._run_start(agent, state, conn=self._make_conn())
+        assert "CODEX_HOME" not in env
+
+    def test_vertex_warns_when_project_unset(self, tmp_path, caplog):
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent()
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"GOOGLE_APPLICATION_CREDENTIALS_JSON": StaticSecret(value=SecretStr("{}"))}
+        )
+        with caplog.at_level("WARNING"):
+            self._run_start(agent, state, conn=self._make_conn(agent_name="gemini-cli"))
+        assert any("GOOGLE_CLOUD_PROJECT" in rec.message for rec in caplog.records)
+
+    def test_present_file_secret_names_helper(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {
+                "CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}")),
+                "PLAIN_TOKEN": StaticSecret(value=SecretStr("t")),
+            }
+        )
+        assert _present_acp_file_secret_names(state, None) == {"CODEX_AUTH_JSON"}
+
+    def test_blob_excluded_from_custom_secrets_advertisement(self, tmp_path):
+        """The <CUSTOM_SECRETS> advertisement lists plain secrets but not the
+        file-content blob (it's not an env var the agent can reference)."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = _make_agent(
+            agent_context=AgentContext(current_datetime=None),
+        )
+        state = self._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {
+                "CODEX_AUTH_JSON": StaticSecret(value=SecretStr("{}")),
+                "PLAIN_TOKEN": StaticSecret(
+                    value=SecretStr("t"), description="A plain token"
+                ),
+            }
+        )
+        events: list = []
+        with patch("openhands.sdk.agent.acp_agent.ACPAgent._start_acp_server"):
+            agent.init_state(state, on_event=events.append)
+
+        suffix = events[0].dynamic_context
+        assert suffix is not None
+        assert "PLAIN_TOKEN" in suffix.text
+        assert "CODEX_AUTH_JSON" not in suffix.text

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -261,7 +261,9 @@ class TestACPFileSecrets:
             "CODEX_AUTH_JSON",
             "GOOGLE_APPLICATION_CREDENTIALS_JSON",
         }
-        # The union is exactly the providers' file_secrets concatenated.
+        # Deterministic concatenation in ACP_PROVIDERS registration order
+        # (codex before gemini-cli) — downstream callers can rely on a stable
+        # ordering of the built-in specs.
         assert specs == (
             ACP_PROVIDERS["codex"].file_secrets
             + ACP_PROVIDERS["gemini-cli"].file_secrets

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -238,6 +238,7 @@ class TestACPFileSecrets:
         assert spec.secret_name == "CODEX_AUTH_JSON"
         assert spec.filename == "auth.json"
         assert spec.env_var == "CODEX_HOME"
+        assert spec.subdir == "codex"
         assert spec.env_points_to == "dir"
 
     def test_gemini_vertex_sa_spec(self):
@@ -247,26 +248,56 @@ class TestACPFileSecrets:
         assert spec.secret_name == "GOOGLE_APPLICATION_CREDENTIALS_JSON"
         assert spec.filename == "gcloud-credentials.json"
         assert spec.env_var == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert spec.subdir == "gemini-cli"
         assert spec.env_points_to == "file"
         # Vertex needs a project + location alongside the SA JSON.
         assert spec.warn_if_unset == ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
 
-    def test_file_secrets_by_name_aggregates_all_providers(self):
-        from openhands.sdk.settings.acp_providers import ACP_FILE_SECRETS_BY_NAME
+    def test_default_acp_file_secrets_aggregates_all_providers(self):
+        from openhands.sdk.settings.acp_providers import default_acp_file_secrets
 
-        assert set(ACP_FILE_SECRETS_BY_NAME) == {
+        specs = default_acp_file_secrets()
+        assert {s.secret_name for s in specs} == {
             "CODEX_AUTH_JSON",
             "GOOGLE_APPLICATION_CREDENTIALS_JSON",
         }
-        provider_key, spec = ACP_FILE_SECRETS_BY_NAME["CODEX_AUTH_JSON"]
-        assert provider_key == "codex"
-        assert spec is ACP_PROVIDERS["codex"].file_secrets[0]
+        # The union is exactly the providers' file_secrets concatenated.
+        assert specs == (
+            ACP_PROVIDERS["codex"].file_secrets
+            + ACP_PROVIDERS["gemini-cli"].file_secrets
+        )
 
     def test_file_secret_spec_is_frozen(self):
-        import dataclasses
+        from pydantic import ValidationError
 
         from openhands.sdk.settings.acp_providers import ACPFileSecretSpec
 
-        spec = ACPFileSecretSpec(secret_name="X", filename="x.json", env_var="X_HOME")
-        with pytest.raises(dataclasses.FrozenInstanceError):
+        spec = ACPFileSecretSpec(
+            secret_name="X", filename="x.json", env_var="X_HOME", subdir="x"
+        )
+        with pytest.raises(ValidationError):
             spec.secret_name = "Y"  # type: ignore[misc]
+
+    def test_file_secret_spec_rejects_path_traversal(self):
+        from pydantic import ValidationError
+
+        from openhands.sdk.settings.acp_providers import ACPFileSecretSpec
+
+        # filename must be a bare basename.
+        with pytest.raises(ValidationError):
+            ACPFileSecretSpec(
+                secret_name="X", filename="../escape.json", env_var="X", subdir="x"
+            )
+        with pytest.raises(ValidationError):
+            ACPFileSecretSpec(
+                secret_name="X", filename="a/b.json", env_var="X", subdir="x"
+            )
+        # subdir must not escape the acp root.
+        with pytest.raises(ValidationError):
+            ACPFileSecretSpec(
+                secret_name="X", filename="x.json", env_var="X", subdir="../up"
+            )
+        with pytest.raises(ValidationError):
+            ACPFileSecretSpec(
+                secret_name="X", filename="x.json", env_var="X", subdir="/abs"
+            )

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -221,3 +221,52 @@ class TestBuildSessionModelMeta:
     def test_unknown_agent_returns_empty(self):
         result = build_session_model_meta("unknown-agent", "some-model")
         assert result == {}
+
+
+class TestACPFileSecrets:
+    """The registry declares reserved file-content credential secrets for the
+    providers that authenticate from a file on disk (issue #1020)."""
+
+    def test_claude_code_has_no_file_secrets(self):
+        # Claude Code authenticates via env vars (token / API key) only.
+        assert ACP_PROVIDERS["claude-code"].file_secrets == ()
+
+    def test_codex_auth_json_spec(self):
+        specs = ACP_PROVIDERS["codex"].file_secrets
+        assert len(specs) == 1
+        spec = specs[0]
+        assert spec.secret_name == "CODEX_AUTH_JSON"
+        assert spec.filename == "auth.json"
+        assert spec.env_var == "CODEX_HOME"
+        assert spec.env_points_to == "dir"
+
+    def test_gemini_vertex_sa_spec(self):
+        specs = ACP_PROVIDERS["gemini-cli"].file_secrets
+        assert len(specs) == 1
+        spec = specs[0]
+        assert spec.secret_name == "GOOGLE_APPLICATION_CREDENTIALS_JSON"
+        assert spec.filename == "gcloud-credentials.json"
+        assert spec.env_var == "GOOGLE_APPLICATION_CREDENTIALS"
+        assert spec.env_points_to == "file"
+        # Vertex needs a project + location alongside the SA JSON.
+        assert spec.warn_if_unset == ("GOOGLE_CLOUD_PROJECT", "GOOGLE_CLOUD_LOCATION")
+
+    def test_file_secrets_by_name_aggregates_all_providers(self):
+        from openhands.sdk.settings.acp_providers import ACP_FILE_SECRETS_BY_NAME
+
+        assert set(ACP_FILE_SECRETS_BY_NAME) == {
+            "CODEX_AUTH_JSON",
+            "GOOGLE_APPLICATION_CREDENTIALS_JSON",
+        }
+        provider_key, spec = ACP_FILE_SECRETS_BY_NAME["CODEX_AUTH_JSON"]
+        assert provider_key == "codex"
+        assert spec is ACP_PROVIDERS["codex"].file_secrets[0]
+
+    def test_file_secret_spec_is_frozen(self):
+        import dataclasses
+
+        from openhands.sdk.settings.acp_providers import ACPFileSecretSpec
+
+        spec = ACPFileSecretSpec(secret_name="X", filename="x.json", env_var="X_HOME")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            spec.secret_name = "Y"  # type: ignore[misc]

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -303,3 +303,9 @@ class TestACPFileSecrets:
             ACPFileSecretSpec(
                 secret_name="X", filename="x.json", env_var="X", subdir="/abs"
             )
+        # "." / whitespace would drop the file straight into the shared acp/ root.
+        for bad in (".", "  ", " . "):
+            with pytest.raises(ValidationError):
+                ACPFileSecretSpec(
+                    secret_name="X", filename="x.json", env_var="X", subdir=bad
+                )


### PR DESCRIPTION
## What

Implements [agent-canvas#1020](https://github.com/OpenHands/agent-canvas/issues/2115) (part of the [ACP-on-Cloud epic OpenHands/OpenHands#15746](https://github.com/OpenHands/OpenHands/issues/15746)).

Some ACP providers authenticate from a **file on disk** rather than an env var: Codex reads `$CODEX_HOME/auth.json`; Gemini (Vertex AI) reads a service-account JSON at `GOOGLE_APPLICATION_CREDENTIALS`. The user supplies the credential as a pasted blob (a reserved *file-content* secret); the SDK **materialises it to the file path the CLI expects**, in the runtime pod, before the subprocess is spawned.

Builds on [#3464 (#1022)](https://github.com/OpenHands/agent-canvas/issues/2113) — provider creds ride `state.secret_registry`.

## Design — mechanism (SDK) vs policy (overridable data)

Per the [#1020 discussion](https://github.com/OpenHands/agent-canvas/issues/2115), this separates the two concerns so the SDK owns the *mechanism* (which must run in-pod) while the *policy* is overridable data a downstream app can supply without an SDK release:

- **`ACPFileSecretSpec`** (frozen, exported) — declarative `secret_name → filename + subdir + env_var(+points-to dir/file)` mapping, with path-traversal validation. This is the *policy*.
- **`ACPAgent.acp_file_secrets`** / **`ACPAgentSettings.acp_file_secrets`** (forwarded via `create_agent`) — the configurable list of specs. **`default_acp_file_secrets()`** supplies built-in **convenience defaults** for the supported providers (Codex / Gemini Vertex); a downstream app may **override or extend** them to support another file-auth ACP server with no SDK change, or pass `[]` to opt out entirely.
  - **Codex:** `CODEX_AUTH_JSON` → `auth.json`, env `CODEX_HOME=<dir>`.
  - **Gemini (Vertex):** `GOOGLE_APPLICATION_CREDENTIALS_JSON` → `gcloud-credentials.json`, env `GOOGLE_APPLICATION_CREDENTIALS=<file>`; warns if `GOOGLE_CLOUD_PROJECT` / `GOOGLE_CLOUD_LOCATION` are unset.

Why the engine stays SDK-side: in cloud the CLI runs in a remote runtime pod and the credential arrives only as a transmitted secret — the downstream app (canvas browser / OpenHands backend) has no filesystem access to the pod, and a read-only K8s projected-secret mount can't replace it (Codex rewrites `auth.json` on refresh). Materialising into a writable, durable, per-conversation dir is the only thing that survives. It's also a **no-op locally**: it only acts when a reserved secret is present, otherwise detection falls back to the host login files unchanged.

## Implementation (`ACPAgent`)

For each configured spec whose secret is present:
- **Read** the value from `state.secret_registry` (canonical channel), falling back to `agent_context.secrets` (canvas-local drain) — `_read_conversation_secret`.
- **Seed** into the durable per-conversation root `<persistence_dir>/acp/{subdir}/` — the same tree the regular agent persists to — **seed-if-absent, no `TemporaryDirectory`, `0600` files in `0700` dirs** (incl. the shared `acp/` parent). So a token Codex rewrites on refresh survives a recycle, and a stale paste never clobbers the live one. Falls back under the workspace when unpersisted.
- **Point** the data-dir env var (`CODEX_HOME` / `GOOGLE_APPLICATION_CREDENTIALS`) at the materialised path; the blob is **excluded** from plain env injection and the `<CUSTOM_SECRETS>` advertisement. An explicit `acp_env` pin still wins, and the credential is seeded *where that pin points*.
- **Fail fast:** if the credential can't be written (read-only/full mount), the error propagates so `init_state` surfaces a typed `ConversationErrorEvent(ACPInitError)` instead of a cryptic downstream auth failure.
- **Detection:** `CODEX_HOME`-aware Codex `chatgpt` detection (was hardcoded to `~/.codex/auth.json`); prefer the gemini-cli `vertex-ai` method when the SA file is present.

## Tests

- Codex `auth.json` + Gemini Vertex SA materialise to the right per-conversation path; env vars point at them (dir vs file); `0600`/`0700` perms (file, leaf dir, and `acp/` parent); blob not injected / not advertised.
- Seed-if-absent: a pre-existing (refreshed) file is preserved *and* its perms clamped to `0600`.
- Reads from `agent_context.secrets` (drain) as well as the registry; `acp_env` pin wins and seeds where it points; workspace fallback when unpersisted.
- **Downstream override**: a custom provider spec materialises with no registry change; `acp_file_secrets=[]` opts out (blob flows through as a plain env var); settings pass-through.
- Materialisation `OSError` propagates (fail-fast); `ACPFileSecretSpec` rejects `..`/absolute/`.`/whitespace paths.
- `_select_auth_method`: `CODEX_HOME`-aware `chatgpt`; `vertex-ai` preferred when `GOOGLE_APPLICATION_CREDENTIALS` exists.

Validated end-to-end against the containerized agent-server image: Codex authenticates via the materialised `auth.json` → `CODEX_HOME` → `chatgpt`, and completes a real tool-using turn (Claude Code via the env-token path also green).

## Follow-ups (not this PR)
- Canvas / OpenHands cloud construction to pass explicit `acp_file_secrets` for the selected provider, with product-level coverage that the right Codex/Gemini specs are sent.
- Open design call ([#1020](https://github.com/OpenHands/agent-canvas/issues/2115)): keep the mechanism in `openhands-sdk` core vs. relocate to `openhands-agent-server` (both run in-pod). In core today because `ACPAgent` lives there and policy-as-data keeps core CLI-agnostic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:20333b3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-20333b3-python \
  ghcr.io/openhands/agent-server:20333b3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:20333b3-golang-amd64
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-golang-amd64
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-golang-amd64
ghcr.io/openhands/agent-server:20333b3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:20333b3-golang-arm64
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-golang-arm64
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-golang-arm64
ghcr.io/openhands/agent-server:20333b3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:20333b3-java-amd64
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-java-amd64
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-java-amd64
ghcr.io/openhands/agent-server:20333b3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:20333b3-java-arm64
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-java-arm64
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-java-arm64
ghcr.io/openhands/agent-server:20333b3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:20333b3-python-amd64
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-python-amd64
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-python-amd64
ghcr.io/openhands/agent-server:20333b3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:20333b3-python-arm64
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-python-arm64
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-python-arm64
ghcr.io/openhands/agent-server:20333b3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:20333b3-golang
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-golang
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-golang
ghcr.io/openhands/agent-server:20333b3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:20333b3-java
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-java
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-java
ghcr.io/openhands/agent-server:20333b3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:20333b3-python
ghcr.io/openhands/agent-server:20333b3dbd1698f9fc5a3853d44884d7a266ed0a-python
ghcr.io/openhands/agent-server:acp-materialise-file-secrets-python
ghcr.io/openhands/agent-server:20333b3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `20333b3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `20333b3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->