### PR TITLE
feat: use X-Session-API-Key header for automation completion callbacks

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -55,7 +55,8 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
 
     Supports optional completion callbacks on exit via environment variables:
       - ``AUTOMATION_CALLBACK_URL`` — URL to POST completion status to
-      - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
+      - ``AUTOMATION_CALLBACK_API_KEY`` — API key for callback auth (optional,
+        sent via ``X-Session-API-Key`` header)
       - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
 
     Example:
@@ -283,7 +284,8 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
 
         Reads configuration from environment variables:
           - ``AUTOMATION_CALLBACK_URL`` — URL to POST completion status to
-          - ``AUTOMATION_CALLBACK_API_KEY`` — Bearer token for callback auth (optional)
+          - ``AUTOMATION_CALLBACK_API_KEY`` — API key for callback auth (optional,
+            sent via ``X-Session-API-Key`` header)
           - ``AUTOMATION_RUN_ID`` — Run ID to include in callback payload (optional)
 
         Includes ``conversation_id`` in the payload if one was registered via
@@ -314,7 +316,7 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         try:
             headers: dict[str, str] = {}
             if callback_api_key:
-                headers["Authorization"] = f"Bearer {callback_api_key}"
+                headers["X-Session-API-Key"] = callback_api_key
             with httpx.Client(timeout=10.0) as cb_client:
                 resp = cb_client.post(callback_url, json=payload, headers=headers)
                 logger.info(f"Completion callback sent ({status}): {resp.status_code}")

--- a/openhands-workspace/openhands/workspace/cloud/workspace.py
+++ b/openhands-workspace/openhands/workspace/cloud/workspace.py
@@ -877,7 +877,7 @@ class OpenHandsCloudWorkspace(RemoteWorkspace):
             payload["conversation_id"] = self._conversation_id
 
         try:
-            headers = {"Authorization": f"Bearer {self.cloud_api_key}"}
+            headers = {"X-Session-API-Key": self.cloud_api_key}
             with httpx.Client(timeout=10.0) as cb_client:
                 resp = cb_client.post(callback_url, json=payload, headers=headers)
                 logger.info(f"Completion callback sent ({status}): {resp.status_code}")

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -1073,7 +1073,7 @@ def test_send_completion_callback_on_success(monkeypatch):
         assert payload["status"] == "COMPLETED"
         assert payload["run_id"] == "run-42"
         assert "error" not in payload
-        assert headers["Authorization"] == "Bearer test-api-key"
+        assert headers["X-Session-API-Key"] == "test-api-key"
 
 
 def test_send_completion_callback_on_failure(monkeypatch):
@@ -1131,7 +1131,7 @@ def test_send_completion_callback_swallows_errors(monkeypatch):
 
 
 def test_send_completion_callback_without_api_key(monkeypatch):
-    """Test _send_completion_callback sends without Authorization when no key."""
+    """Test _send_completion_callback sends without X-Session-API-Key when no key."""
     monkeypatch.setenv("AUTOMATION_CALLBACK_URL", "https://svc.test/complete")
     monkeypatch.delenv("AUTOMATION_CALLBACK_API_KEY", raising=False)
 
@@ -1150,7 +1150,7 @@ def test_send_completion_callback_without_api_key(monkeypatch):
         workspace._send_completion_callback(None, None)
 
         headers = mock_client.post.call_args.kwargs["headers"]
-        assert "Authorization" not in headers
+        assert "X-Session-API-Key" not in headers
 
 
 def test_send_completion_callback_includes_conversation_id(monkeypatch):


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

Reverse proxies like ngrok sometimes strip `Authorization` headers, causing automation completion callbacks to fail authentication. The `X-Session-API-Key` header is more reliably preserved through proxies and is already the convention used by agent servers for authentication.

## Summary

- Replace `Authorization: Bearer` header with `X-Session-API-Key` header when sending automation completion callbacks from `RemoteWorkspace` and `OpenHandsCloudWorkspace`
- Update related docstrings to reflect the new header convention
- Update tests to assert on `X-Session-API-Key` instead of `Authorization: Bearer`

## How to Test

The automation service's `auth.py` (`_extract_api_key()`) already accepts both `Authorization: Bearer` AND `X-Session-API-Key` headers, so this is backward compatible.

Run the callback-related tests:
```bash
uv run pytest tests/sdk/workspace/remote/test_remote_workspace.py -k "callback" -v
uv run pytest tests/workspace/test_cloud_workspace.py -k "callback" -v
uv run pytest tests/workspace/test_api_remote_workspace.py -k "callback" -v
```

All 14 callback tests pass:
```
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_on_success PASSED
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_on_failure PASSED
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_no_op_without_url PASSED
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_swallows_errors PASSED
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_without_api_key PASSED
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_includes_conversation_id PASSED
tests/sdk/workspace/remote/test_remote_workspace.py::test_send_completion_callback_omits_conversation_id_when_not_registered PASSED
tests/workspace/test_cloud_workspace.py::test_callback_on_successful_exit PASSED
tests/workspace/test_cloud_workspace.py::test_callback_on_exception_exit PASSED
tests/workspace/test_cloud_workspace.py::test_no_callback_when_url_not_set PASSED
tests/workspace/test_cloud_workspace.py::test_callback_failure_does_not_raise PASSED
tests/workspace/test_cloud_workspace.py::test_callback_includes_conversation_id_when_registered PASSED
tests/workspace/test_cloud_workspace.py::test_callback_omits_conversation_id_when_not_registered PASSED
tests/workspace/test_api_remote_workspace.py::test_api_remote_workspace_exit_sends_callback PASSED
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The receiving side (automation service `auth.py`) already supports both `Authorization: Bearer` and `X-Session-API-Key` headers, so this change is backward compatible — no changes needed in the automation repo.
- This is motivated by VM-based automation server backends where ngrok or similar tunneling tools drop `Authorization` headers. `X-Session-API-Key` is more consistent with how agent servers handle authentication.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/718abaef-7edd-4aec-a2ae-c4c285c5ac79)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a007252-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a007252-python \
  ghcr.io/openhands/agent-server:a007252-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a007252-golang-amd64
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-golang-amd64
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-golang-amd64
ghcr.io/openhands/agent-server:a007252-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a007252-golang-arm64
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-golang-arm64
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-golang-arm64
ghcr.io/openhands/agent-server:a007252-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a007252-java-amd64
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-java-amd64
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-java-amd64
ghcr.io/openhands/agent-server:a007252-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a007252-java-arm64
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-java-arm64
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-java-arm64
ghcr.io/openhands/agent-server:a007252-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a007252-python-amd64
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-python-amd64
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-python-amd64
ghcr.io/openhands/agent-server:a007252-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a007252-python-arm64
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-python-arm64
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-python-arm64
ghcr.io/openhands/agent-server:a007252-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a007252-golang
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-golang
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-golang
ghcr.io/openhands/agent-server:a007252-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a007252-java
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-java
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-java
ghcr.io/openhands/agent-server:a007252-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a007252-python
ghcr.io/openhands/agent-server:a007252f9822eed28dd8c2d9bce10a4b4d61f80c-python
ghcr.io/openhands/agent-server:feat-callback-x-session-api-key-python
ghcr.io/openhands/agent-server:a007252-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a007252-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a007252-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->