### PR TITLE
Add step-3.7-flash model configuration

### DIFF
--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -91,6 +91,49 @@ Add only if needed:
 - **`top_p: <value>`** - Nucleus sampling (cannot be used with `temperature` for Claude models)
 - **`litellm_extra_body: {...}`** - Provider-specific parameters (e.g., `{"enable_thinking": True}`)
 
+### Vision and Reasoning Capability Check
+
+Before finalizing the entry, explicitly check both capabilities against
+the **provider's official documentation** (don't rely only on LiteLLM):
+
+1. **Vision (multimodal input)**
+   - Does the model accept image / video input?
+   - Cross-check LiteLLM: in a Python shell, run
+     ```python
+     from litellm import supports_vision
+     supports_vision(model="<litellm_proxy_target_without_litellm_proxy_prefix>")
+     ```
+   - Decision matrix:
+     | Provider says | LiteLLM says | Action |
+     |---------------|--------------|--------|
+     | Vision ✅      | Vision ✅     | Do nothing — vision auto-enables. |
+     | Vision ❌      | Vision ✅     | Add `"disable_vision": True` (LiteLLM is wrong). |
+     | Vision ✅      | Vision ❌     | **Do not** add `disable_vision: True`. The SDK gates `vision_is_active()` on LiteLLM's `supports_vision()`, so images won't be sent until LiteLLM's metadata is updated upstream (`model_prices_and_context_window.json` in `BerriAI/litellm`). The vision integration test will be skipped, not failed — that's expected. |
+     | Vision ❌      | Vision ❌     | Do nothing. |
+   - Note the result in the PR description (e.g., "Vision: supported by provider; LiteLLM not yet aware — vision test will skip until LiteLLM is updated").
+
+2. **Reasoning (thinking / reasoning_effort)**
+   - Does the model expose adjustable reasoning levels or extended thinking?
+   - Cross-check LiteLLM:
+     ```python
+     from litellm import get_supported_openai_params
+     "reasoning_effort" in (get_supported_openai_params(
+         model="<litellm_target>", custom_llm_provider=None) or [])
+     ```
+   - Decision matrix:
+     | Provider style | LiteLLM `reasoning_effort` support | Action |
+     |----------------|-------------------------------------|--------|
+     | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Optionally pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
+     | OpenAI-style reasoning items | ❌ | **Do not** add `reasoning_effort` — `drop_params=True` will strip it before send. Leave the model at provider defaults; reasoning will still work, but you can't tune the level from `llm_config` until LiteLLM exposes the param. |
+     | Anthropic extended thinking (Claude Sonnet 4.5+, Haiku 4.5) | n/a | Add the model identifier to `EXTENDED_THINKING_MODELS` in `model_features.py` (see Step 2). |
+     | Non-reasoning model | n/a | Do nothing. |
+   - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort` for this model — leaving it unset; condenser thinking-block test will skip (expected for non-Anthropic reasoning models)").
+
+The integration runner correctly **skips** vision / extended-thinking tests
+when the SDK can't detect support. A skipped test for one of these reasons
+is **not** a failure of the PR and doesn't need to be fixed in the same PR;
+it usually means LiteLLM metadata needs to be updated upstream.
+
 ### Critical Rules
 
 1. Model ID must match dictionary key

--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -123,11 +123,11 @@ the **provider's official documentation** (don't rely only on LiteLLM):
    - Decision matrix:
      | Provider style | LiteLLM `reasoning_effort` support | Action |
      |----------------|-------------------------------------|--------|
-     | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Optionally pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
-     | OpenAI-style reasoning items | ❌ | **Do not** add `reasoning_effort` — `drop_params=True` will strip it before send. Leave the model at provider defaults; reasoning will still work, but you can't tune the level from `llm_config` until LiteLLM exposes the param. |
+     | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
+     | OpenAI-style reasoning items (OpenRouter native `reasoning` block) | ❌ | Pin via provider-specific passthrough: `"litellm_extra_body": {"reasoning": {"effort": "high"}}`. The top-level `reasoning_effort` would be dropped by `drop_params=True`, but `litellm_extra_body` is forwarded to the provider. Same pattern as `qwen3-max-thinking` (which uses `{"enable_thinking": True}`). |
      | Anthropic extended thinking (Claude Sonnet 4.5+, Haiku 4.5) | n/a | Add the model identifier to `EXTENDED_THINKING_MODELS` in `model_features.py` (see Step 2). |
      | Non-reasoning model | n/a | Do nothing. |
-   - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort` for this model — leaving it unset; condenser thinking-block test will skip (expected for non-Anthropic reasoning models)").
+   - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort`, so opting in via `litellm_extra_body`; condenser thinking-block test will skip — expected for non-Anthropic reasoning models").
 
 The integration runner correctly **skips** vision / extended-thinking tests
 when the SDK can't detect support. A skipped test for one of these reasons

--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -98,19 +98,36 @@ the **provider's official documentation** (don't rely only on LiteLLM):
 
 1. **Vision (multimodal input)**
    - Does the model accept image / video input?
-   - Cross-check LiteLLM: in a Python shell, run
+   - **Critical first check — proxy `model_name` alignment.** The eval
+     LiteLLM proxy stores capability metadata (`supports_vision`,
+     `supports_function_calling`, token limits, etc.) under each
+     `model_name` registered in its config. The SDK's lookup
+     (`_get_model_info_from_litellm_proxy`) does an **exact string match**
+     of `model.removeprefix("litellm_proxy/")` against the proxy's
+     `model_name`. If the strings don't match, `supports_vision` is
+     silently ignored and the SDK falls back to LiteLLM's static metadata.
+     So: **use the proxy's exact registered `model_name` in your
+     `llm_config["model"]`**, not a longer provider-prefixed alias, e.g.
+     prefer `litellm_proxy/step-3.7-flash` over
+     `litellm_proxy/openrouter/stepfun/step-3.7-flash` if the proxy entry
+     is registered as `step-3.7-flash`. Ask infra (or check the proxy
+     config) for the canonical `model_name` — and confirm `model_info`
+     has the capability flags you expect.
+   - Cross-check LiteLLM static metadata: in a Python shell, run
      ```python
      from litellm import supports_vision
      supports_vision(model="<litellm_proxy_target_without_litellm_proxy_prefix>")
      ```
    - Decision matrix:
-     | Provider says | LiteLLM says | Action |
-     |---------------|--------------|--------|
-     | Vision ✅      | Vision ✅     | Do nothing — vision auto-enables. |
-     | Vision ❌      | Vision ✅     | Add `"disable_vision": True` (LiteLLM is wrong). |
-     | Vision ✅      | Vision ❌     | **Do not** add `disable_vision: True`. The SDK gates `vision_is_active()` on LiteLLM's `supports_vision()`, so images won't be sent until LiteLLM's metadata is updated upstream (`model_prices_and_context_window.json` in `BerriAI/litellm`). The vision integration test will be skipped, not failed — that's expected. |
-     | Vision ❌      | Vision ❌     | Do nothing. |
-   - Note the result in the PR description (e.g., "Vision: supported by provider; LiteLLM not yet aware — vision test will skip until LiteLLM is updated").
+     | Provider docs | Proxy `model_info.supports_vision` | LiteLLM static | Action |
+     |---------------|------------------------------------|----------------|--------|
+     | Vision ✅      | True (and `model_name` matches your config) | any | Do nothing — vision auto-enables via the proxy metadata. |
+     | Vision ✅      | True, but `model_name` does **not** match your config | any | **Fix the model path** in your `llm_config` to match the proxy's `model_name` exactly. Don't add `disable_vision`. |
+     | Vision ✅      | not set / proxy entry has no `model_info` | any | Coordinate with infra to add `supports_vision: true` to the proxy entry (one line of YAML). Vision integration test will skip until that lands — non-blocking. |
+     | Vision ❌      | True | True | Add `"disable_vision": True` (proxy/LiteLLM are wrong). |
+     | Vision ❌      | any | any | Do nothing. |
+   - Note the result in the PR description, including the exact proxy
+     `model_name` your `llm_config["model"]` matches.
 
 2. **Reasoning (thinking / reasoning_effort)**
    - Does the model expose adjustable reasoning levels or extended thinking?
@@ -124,7 +141,7 @@ the **provider's official documentation** (don't rely only on LiteLLM):
      | Provider style | LiteLLM `reasoning_effort` support | Action |
      |----------------|-------------------------------------|--------|
      | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
-     | OpenAI-style reasoning items (OpenRouter native `reasoning` block) | ❌ | Pin via provider-specific passthrough: `"litellm_extra_body": {"reasoning": {"effort": "high"}}`. The top-level `reasoning_effort` would be dropped by `drop_params=True`, but `litellm_extra_body` is forwarded to the provider. Same pattern as `qwen3-max-thinking` (which uses `{"enable_thinking": True}`). |
+     | OpenAI-style reasoning items, provider has a non-standard reasoning param | ❌ | Pin via provider-specific passthrough: `"litellm_extra_body": {<provider-key>: <value>}` (e.g. `{"reasoning": {"effort": "high"}}` for OpenRouter, `{"enable_thinking": True}` for Qwen). **Confirm which upstream the proxy actually routes to** before choosing the key — the proxy's `litellm_params.model` (e.g. `openai/...` vs `openrouter/...`) decides what extra-body keys the upstream understands. The top-level `reasoning_effort` would otherwise be dropped by `drop_params=True`. |
      | Anthropic extended thinking (Claude Sonnet 4.5+, Haiku 4.5) | n/a | Add the model identifier to `EXTENDED_THINKING_MODELS` in `model_features.py` (see Step 2). |
      | Non-reasoning model | n/a | Do nothing. |
    - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort`, so opting in via `litellm_extra_body`; condenser thinking-block test will skip — expected for non-Anthropic reasoning models").

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -365,6 +365,15 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # https://static.stepfun.com/blog/step-3.7-flash/
+    "step-3.7-flash": {
+        "id": "step-3.7-flash",
+        "display_name": "Step 3.7 Flash",
+        "llm_config": {
+            "model": "litellm_proxy/openrouter/stepfun/step-3.7-flash",
+            "temperature": 0.0,
+        },
+    },
 }
 
 

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -366,20 +366,21 @@ MODELS = {
         },
     },
     # https://static.stepfun.com/blog/step-3.7-flash/
-    # Step 3.7 Flash is a multimodal MoE VLM with selectable OpenRouter
-    # reasoning levels (high/medium/low). We opt into "high" via
-    # litellm_extra_body because LiteLLM does not yet expose
-    # `reasoning_effort` as a supported param for this OpenRouter target,
-    # so the top-level `reasoning_effort` field would be dropped before
-    # send. Vision is gated by LiteLLM / proxy `supports_vision` metadata
-    # and cannot be force-enabled from llm_config.
+    # The eval LiteLLM proxy registers this model as `step-3.7-flash`
+    # (short alias) routing to `openai/step-3.7-flash` at
+    # api.stepfun.ai/v1, with `model_info.supports_vision=true`. We must
+    # use the proxy's exact `model_name` here so that
+    # `_get_model_info_from_litellm_proxy` matches the registry entry and
+    # picks up `supports_vision=true`. Using the longer
+    # `litellm_proxy/openrouter/stepfun/step-3.7-flash` form works at
+    # request time (proxy pass-through to OpenRouter) but misses the
+    # model_info lookup, so vision is never activated by the SDK.
     "step-3.7-flash": {
         "id": "step-3.7-flash",
         "display_name": "Step 3.7 Flash",
         "llm_config": {
-            "model": "litellm_proxy/openrouter/stepfun/step-3.7-flash",
+            "model": "litellm_proxy/step-3.7-flash",
             "temperature": 0.0,
-            "litellm_extra_body": {"reasoning": {"effort": "high"}},
         },
     },
 }

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -366,12 +366,20 @@ MODELS = {
         },
     },
     # https://static.stepfun.com/blog/step-3.7-flash/
+    # Step 3.7 Flash is a multimodal MoE VLM with selectable OpenRouter
+    # reasoning levels (high/medium/low). We opt into "high" via
+    # litellm_extra_body because LiteLLM does not yet expose
+    # `reasoning_effort` as a supported param for this OpenRouter target,
+    # so the top-level `reasoning_effort` field would be dropped before
+    # send. Vision is gated by LiteLLM / proxy `supports_vision` metadata
+    # and cannot be force-enabled from llm_config.
     "step-3.7-flash": {
         "id": "step-3.7-flash",
         "display_name": "Step 3.7 Flash",
         "llm_config": {
             "model": "litellm_proxy/openrouter/stepfun/step-3.7-flash",
             "temperature": 0.0,
+            "litellm_extra_body": {"reasoning": {"effort": "high"}},
         },
     },
 }

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -690,3 +690,16 @@ def test_minimax_m3_config():
     assert model["llm_config"]["model"] == "litellm_proxy/minimax/MiniMax-M3"
     assert model["llm_config"]["temperature"] == 1.0
     assert model["llm_config"]["top_p"] == 0.95
+
+
+def test_step_3_7_flash_config():
+    """Test that step-3.7-flash has correct configuration."""
+    model = MODELS["step-3.7-flash"]
+
+    assert model["id"] == "step-3.7-flash"
+    assert model["display_name"] == "Step 3.7 Flash"
+    assert (
+        model["llm_config"]["model"]
+        == "litellm_proxy/openrouter/stepfun/step-3.7-flash"
+    )
+    assert model["llm_config"]["temperature"] == 0.0

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -703,3 +703,9 @@ def test_step_3_7_flash_config():
         == "litellm_proxy/openrouter/stepfun/step-3.7-flash"
     )
     assert model["llm_config"]["temperature"] == 0.0
+    # Opt into OpenRouter's "high" reasoning level via litellm_extra_body,
+    # because LiteLLM does not yet expose `reasoning_effort` as a top-level
+    # supported param for this target.
+    assert model["llm_config"]["litellm_extra_body"] == {
+        "reasoning": {"effort": "high"}
+    }

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -693,19 +693,16 @@ def test_minimax_m3_config():
 
 
 def test_step_3_7_flash_config():
-    """Test that step-3.7-flash has correct configuration."""
+    """Test that step-3.7-flash has correct configuration.
+
+    The model path must match the eval LiteLLM proxy's `model_name` alias
+    exactly so that `_get_model_info_from_litellm_proxy` matches the
+    registry entry and picks up `supports_vision=true` from the
+    proxy-side `model_info`.
+    """
     model = MODELS["step-3.7-flash"]
 
     assert model["id"] == "step-3.7-flash"
     assert model["display_name"] == "Step 3.7 Flash"
-    assert (
-        model["llm_config"]["model"]
-        == "litellm_proxy/openrouter/stepfun/step-3.7-flash"
-    )
+    assert model["llm_config"]["model"] == "litellm_proxy/step-3.7-flash"
     assert model["llm_config"]["temperature"] == 0.0
-    # Opt into OpenRouter's "high" reasoning level via litellm_extra_body,
-    # because LiteLLM does not yet expose `reasoning_effort` as a top-level
-    # supported param for this target.
-    assert model["llm_config"]["litellm_extra_body"] == {
-        "reasoning": {"effort": "high"}
-    }

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -139,8 +139,29 @@ class BaseIntegrationTest(ABC):
 
         self.llm: LLM = LLM(**llm_kwargs, usage_id="test-llm")
         # TEMPORARY DIAGNOSTIC for PR #3477 (step-3.7-flash) — to be reverted
-        # once we confirm whether _model_info is populated from the eval proxy.
+        # once we confirm why _model_info is None from the eval proxy.
         # Track: https://github.com/OpenHands/software-agent-sdk/pull/3477
+        if "step-3.7-flash" in self.llm.model:
+            import httpx
+
+            try:
+                probe = httpx.get(
+                    f"{base_url}/v1/model/info",
+                    headers={"Authorization": f"Bearer {api_key}"},
+                    timeout=10.0,
+                )
+                body = probe.text
+                hit_count = body.count('"step-3.7-flash"')
+                logger.info(
+                    "[diagnostic PR #3477 probe] status=%d body_len=%d "
+                    "step_3_7_flash_substrings=%d body_head=%r",
+                    probe.status_code,
+                    len(body),
+                    hit_count,
+                    body[:500],
+                )
+            except Exception as exc:
+                logger.info("[diagnostic PR #3477 probe] EXC=%r", exc)
         logger.info(
             "[diagnostic PR #3477] model=%s model_info=%s vision_is_active=%s",
             self.llm.model,

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -16,6 +16,7 @@ from openhands.sdk import (
     Agent,
     Message,
     TextContent,
+    get_logger,
 )
 from openhands.sdk.context.condenser import CondenserBase
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
@@ -26,6 +27,9 @@ from openhands.sdk.event.llm_convertible import (
 )
 from openhands.sdk.tool import Tool
 from tests.integration.early_stopper import EarlyStopperBase, EarlyStopResult
+
+
+logger = get_logger(__name__)
 
 
 # Tool preset type for selecting which file editing toolset to use
@@ -134,6 +138,15 @@ class BaseIntegrationTest(ABC):
         }
 
         self.llm: LLM = LLM(**llm_kwargs, usage_id="test-llm")
+        # TEMPORARY DIAGNOSTIC for PR #3477 (step-3.7-flash) — to be reverted
+        # once we confirm whether _model_info is populated from the eval proxy.
+        # Track: https://github.com/OpenHands/software-agent-sdk/pull/3477
+        logger.info(
+            "[diagnostic PR #3477] model=%s model_info=%s vision_is_active=%s",
+            self.llm.model,
+            self.llm._model_info,
+            self.llm.vision_is_active(),
+        )
         self.agent: Agent = Agent(
             llm=self.llm, tools=self.tools, condenser=self.condenser
         )

--- a/tests/integration/base.py
+++ b/tests/integration/base.py
@@ -16,7 +16,6 @@ from openhands.sdk import (
     Agent,
     Message,
     TextContent,
-    get_logger,
 )
 from openhands.sdk.context.condenser import CondenserBase
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
@@ -27,9 +26,6 @@ from openhands.sdk.event.llm_convertible import (
 )
 from openhands.sdk.tool import Tool
 from tests.integration.early_stopper import EarlyStopperBase, EarlyStopResult
-
-
-logger = get_logger(__name__)
 
 
 # Tool preset type for selecting which file editing toolset to use
@@ -138,36 +134,6 @@ class BaseIntegrationTest(ABC):
         }
 
         self.llm: LLM = LLM(**llm_kwargs, usage_id="test-llm")
-        # TEMPORARY DIAGNOSTIC for PR #3477 (step-3.7-flash) — to be reverted
-        # once we confirm why _model_info is None from the eval proxy.
-        # Track: https://github.com/OpenHands/software-agent-sdk/pull/3477
-        if "step-3.7-flash" in self.llm.model:
-            import httpx
-
-            try:
-                probe = httpx.get(
-                    f"{base_url}/v1/model/info",
-                    headers={"Authorization": f"Bearer {api_key}"},
-                    timeout=10.0,
-                )
-                body = probe.text
-                hit_count = body.count('"step-3.7-flash"')
-                logger.info(
-                    "[diagnostic PR #3477 probe] status=%d body_len=%d "
-                    "step_3_7_flash_substrings=%d body_head=%r",
-                    probe.status_code,
-                    len(body),
-                    hit_count,
-                    body[:500],
-                )
-            except Exception as exc:
-                logger.info("[diagnostic PR #3477 probe] EXC=%r", exc)
-        logger.info(
-            "[diagnostic PR #3477] model=%s model_info=%s vision_is_active=%s",
-            self.llm.model,
-            self.llm._model_info,
-            self.llm.vision_is_active(),
-        )
         self.agent: Agent = Agent(
             llm=self.llm, tools=self.tools, condenser=self.condenser
         )


### PR DESCRIPTION
## Summary
Adds the `step-3.7-flash` model from StepFun to `resolve_model_config.py`, following the procedure in [`.github/run-eval/ADDINGMODEL.md`](../blob/main/.github/run-eval/ADDINGMODEL.md).

Model reference: <https://static.stepfun.com/blog/step-3.7-flash/>

> **Status:** Text + tool-use paths land in this PR and are passing integration at 100%. The remaining vision plumbing gap is tracked in #3495 as a non-blocker so we don't hold up the working text path.

## Changes
- Added `step-3.7-flash` entry to the `MODELS` dictionary in `.github/run-eval/resolve_model_config.py`
- Added `test_step_3_7_flash_config()` to `tests/cross/test_resolve_model_config.py`
- Added a new **"Vision and Reasoning Capability Check"** section to `.github/run-eval/ADDINGMODEL.md` with decision matrices for both capabilities (triggered by review feedback on this PR; covers the LiteLLM-metadata gap that determines what `disable_vision` / `reasoning_effort` actually do)
- Aligned the proxy model path with the proxy `model_name` alias (`litellm_proxy/step-3.7-flash`) so `_get_model_info_from_litellm_proxy` matches the registry entry (commit [`b0fedcd6`](https://github.com/OpenHands/software-agent-sdk/pull/3477/commits/b0fedcd6)).
  - A previous commit [`2aaf19f8`](https://github.com/OpenHands/software-agent-sdk/pull/3477/commits/2aaf19f8) had opted into OpenRouter's native reasoning block via `litellm_extra_body: {"reasoning": {"effort": "high"}}` while the model was routed as `litellm_proxy/openrouter/stepfun/...`. That opt-in was deliberately removed in `b0fedcd6` because the alias now routes via `openai/...` to StepFun's native API, where the OpenRouter `reasoning` field doesn't apply. Empirically, leaving it in regressed behavior (completion tokens 175k → 85k and one behavior test failed), consistent with the param not being honored on this route.

Per the instructions on the issue, the model is **not** added to `verified_models.py` yet.

## Configuration
- Model ID: `step-3.7-flash`
- Provider: StepFun (proxied via the eval LiteLLM proxy as `litellm_proxy/step-3.7-flash`)
- Temperature: `0.0` — Step 3.7 Flash is a Flash-tier agentic model; deterministic temperature matches our convention for similar Flash entries (e.g. `deepseek-v4-flash`, `qwen3.5-flash`)

## What landed vs. what's deferred

| Capability | Status in this PR |
|---|---|
| Text / tool-use / agentic loop | ✅ 100% (17/17 non-skipped integration tests pass) |
| Reasoning | ➖ not opted in — provider-default reasoning only. The OpenRouter `reasoning` block was tried (commit `2aaf19f8`) and removed (commit `b0fedcd6`) because the proxy alias routes via `openai/...` to StepFun's native API where that param isn't honored, and leaving it in caused a behavior regression. |
| **Vision** | ⏭️ **deferred — tracked in #3495** |

### Why vision is deferred

The provider supports vision natively (196B LLM + 1.8B ViT), and the eval LiteLLM proxy is configured with `model_info.supports_vision: true`. Despite that, at runtime the SDK's `LLM.vision_is_active()` returns `False` because `_get_model_info_from_litellm_proxy()` silently returns `None` — i.e., the `/v1/model/info` lookup isn't surfacing the proxy's `supports_vision` flag back into the SDK. Diagnostic output from a probe pushed earlier in this PR confirmed `model_info=None vision_is_active=False`. That diagnostic was reverted in [`e77b86ab`](https://github.com/OpenHands/software-agent-sdk/pull/3477/commits/e77b86ab) so this branch ships clean.

The most likely cause (per #3495) is that `/v1/model/info` is gated to admin tokens while the eval runner uses a virtual key. Researching and fixing it requires infra access / a separate SDK change, and shouldn't block landing the working text path. Issue #3495 carries the diagnostic, the candidate root-cause list, and proposed fixes (e.g. an explicit `supports_vision` opt-in on `LLM`).

The vision integration test (`t08_image_file_viewing`) is therefore correctly skipped today; the Anthropic-thinking-block condenser test (`c01_thinking_block_condenser`) remains skipped because it's Anthropic-specific and doesn't apply to OpenAI-style reasoning items.

## Integration Test Results
✅ Latest run after reverting the diagnostic: 100% (17/17, 2 expected skips for the reasons above) — see the integration test summary comments on this PR.

Fixes #3476
Vision plumbing tracked separately in #3495.

---
This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:98403a0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-98403a0-python \
  ghcr.io/openhands/agent-server:98403a0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:98403a0-golang-amd64
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-golang-amd64
ghcr.io/openhands/agent-server:98403a0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:98403a0-golang-arm64
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-golang-arm64
ghcr.io/openhands/agent-server:98403a0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:98403a0-java-amd64
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-java-amd64
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-java-amd64
ghcr.io/openhands/agent-server:98403a0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:98403a0-java-arm64
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-java-arm64
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-java-arm64
ghcr.io/openhands/agent-server:98403a0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:98403a0-python-amd64
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-python-amd64
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-python-amd64
ghcr.io/openhands/agent-server:98403a0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:98403a0-python-arm64
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-python-arm64
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-python-arm64
ghcr.io/openhands/agent-server:98403a0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:98403a0-golang
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-golang
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-golang
ghcr.io/openhands/agent-server:98403a0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:98403a0-java
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-java
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-java
ghcr.io/openhands/agent-server:98403a0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:98403a0-python
ghcr.io/openhands/agent-server:98403a0f8cba34de08bd42832ef7204f581f287d-python
ghcr.io/openhands/agent-server:openhands-add-step-3.7-flash-python
ghcr.io/openhands/agent-server:98403a0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `98403a0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `98403a0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

