### PR TITLE
fix(agent-server): bump pinned codex-acp 0.11.1 → 0.15.0

### DIFF
--- a/openhands-agent-server/openhands/agent_server/docker/Dockerfile
+++ b/openhands-agent-server/openhands/agent_server/docker/Dockerfile
@@ -172,7 +172,7 @@ RUN set -ux; \
         PATH="$ACP_NODE_DIR/bin:$PATH"; \
         if "$ACP_NODE_DIR/bin/npm" install -g \
             @agentclientprotocol/claude-agent-acp@0.30.0 \
-            @zed-industries/codex-acp@0.11.1 \
+            @zed-industries/codex-acp@0.15.0 \
             @google/gemini-cli@0.38.0; then \
           # Create wrappers in /usr/local/bin that prepend ACP's Node 22 to PATH.
           # This ensures the ACP binary's #!/usr/bin/env node shebang resolves


### PR DESCRIPTION
> ## ⚠️ Correction (post-merge, 2026-06-03)
> The **"Why" below was a misdiagnosis**, and the bump had an unintended side effect. Verified by A/B against the live `@zed-industries/codex-acp` binaries:
>
> - **0.11.1 is NOT too old for the ChatGPT backend.** It completes turns fine today with a model the account supports (`gpt-5.4` / `gpt-5.4-mini`). The e2e failure was because 0.11.1 *defaults* to **`gpt-5.3-codex`**, which ChatGPT **subscription** accounts don't serve → HTTP 400 → the opaque `-32603 Internal error`. 0.15.0 "fixed" it only because it defaults to a supported model. The "suddenly broke today" was OpenAI rotating which models a ChatGPT account is offered — not a CLI/backend incompatibility.
> - **The bump regressed codex base-URL routing.** codex **0.15.0 ignores `OPENAI_BASE_URL`** (0.11.1 honored it — A/B: 0.11.1 routes to the configured endpoint; 0.15.0 always hits `api.openai.com`). This broke every codex-via-gateway/proxy flow (eval, canvas, cloud) and is the real root cause of OpenHands/benchmarks#736. Fixed in OpenHands/software-agent-sdk#3493.
>
> Net: keeping 0.15.0 is fine (newer default model, supports `gpt-5.5`), but the stated rationale was wrong and the bump needed the follow-up fix #3493. Original description preserved below.

---

## What
Bump the ACP Codex CLI pinned in the agent-server image from `@zed-industries/codex-acp@0.11.1` → `@0.15.0` (the current release; published 2026-05-22, so it clears the dependency 7-day hold).

## Why
In a **real in-container e2e** against the live ChatGPT (subscription) backend, the pinned `0.11.1` (published 2026-03-31) authenticates fine but **every turn fails with `[-32603] Internal error`**. With `@0.15.0`, the identical setup completes turns cleanly.

Reproduced with the agent-server image + a Codex ACP conversation whose ChatGPT `auth.json` was materialised into `CODEX_HOME`:
- `codex-acp@0.11.1` → auth OK (`Authenticating with ACP method: chatgpt`), then `-32603` on the prompt (retries exhausted).
- `codex-acp@0.15.0` (same credential, same materialised auth) → **full turn, real model response**.

So the pin is simply too old for the current backend. This is the kind of CLI-pin drift the image accumulates over time.

## Scope
Only `codex-acp` is bumped here (as requested). `claude-agent-acp@0.30.0` and `gemini-cli@0.38.0` are left untouched — Claude Code was verified working e2e at its current pin; bump the others separately if/when needed.

## Test
Image build installs the new pin via the existing ACP node step; functional behavior verified e2e as above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6b49dff-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6b49dff-python \
  ghcr.io/openhands/agent-server:6b49dff-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6b49dff-golang-amd64
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-golang-amd64
ghcr.io/openhands/agent-server:bump-codex-acp-golang-amd64
ghcr.io/openhands/agent-server:6b49dff-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6b49dff-golang-arm64
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-golang-arm64
ghcr.io/openhands/agent-server:bump-codex-acp-golang-arm64
ghcr.io/openhands/agent-server:6b49dff-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6b49dff-java-amd64
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-java-amd64
ghcr.io/openhands/agent-server:bump-codex-acp-java-amd64
ghcr.io/openhands/agent-server:6b49dff-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6b49dff-java-arm64
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-java-arm64
ghcr.io/openhands/agent-server:bump-codex-acp-java-arm64
ghcr.io/openhands/agent-server:6b49dff-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6b49dff-python-amd64
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-python-amd64
ghcr.io/openhands/agent-server:bump-codex-acp-python-amd64
ghcr.io/openhands/agent-server:6b49dff-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6b49dff-python-arm64
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-python-arm64
ghcr.io/openhands/agent-server:bump-codex-acp-python-arm64
ghcr.io/openhands/agent-server:6b49dff-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6b49dff-golang
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-golang
ghcr.io/openhands/agent-server:bump-codex-acp-golang
ghcr.io/openhands/agent-server:6b49dff-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6b49dff-java
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-java
ghcr.io/openhands/agent-server:bump-codex-acp-java
ghcr.io/openhands/agent-server:6b49dff-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6b49dff-python
ghcr.io/openhands/agent-server:6b49dff7541d628c2aa580680b4263a0c3f26adf-python
ghcr.io/openhands/agent-server:bump-codex-acp-python
ghcr.io/openhands/agent-server:6b49dff-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6b49dff-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6b49dff-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
