### PR TITLE
docs(run-eval): require maintainer approval before editing verified_models.py

### DIFF
--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -52,11 +52,20 @@ This file (`resolve_model_config.py`) defines models available for evaluation. M
    - `openhands-sdk/openhands/sdk/llm/utils/model_prompt_spec.py` - GPT models only (variant detection)
    - `openhands-sdk/openhands/sdk/llm/utils/verified_models.py` - Production-ready models
 
-   > ⚠️ **When editing `verified_models.py`**: If you add a model to `VERIFIED_OPENHANDS_MODELS`,
-   > you **must also** add it to its provider-specific list (e.g. `VERIFIED_ANTHROPIC_MODELS`,
-   > `VERIFIED_GEMINI_MODELS`, `VERIFIED_MOONSHOT_MODELS`, etc.).
-   > If no list exists for the provider yet, create one and add it to the `VERIFIED_MODELS` dict.
-   > This ensures the model appears under its actual provider in the UI, not just under "openhands".
+   > ⛔ **Do NOT add a model to `verified_models.py` unless explicitly asked to.**
+   > "Verified" means the model has been validated against the OpenHands integration
+   > test suite **and** an OpenHands maintainer has approved it for the production UI.
+   > A passing integration run is *necessary but not sufficient*. New models should be
+   > added to `MODELS` in `resolve_model_config.py` (and `model_features.py` if
+   > applicable) only — leave `verified_models.py` alone until a maintainer requests it
+   > in the PR.
+   >
+   > ⚠️ **When you are explicitly asked to edit `verified_models.py`**: If you add a
+   > model to `VERIFIED_OPENHANDS_MODELS`, you **must also** add it to its
+   > provider-specific list (e.g. `VERIFIED_ANTHROPIC_MODELS`, `VERIFIED_GEMINI_MODELS`,
+   > `VERIFIED_MOONSHOT_MODELS`, etc.). If no list exists for the provider yet, create
+   > one and add it to the `VERIFIED_MODELS` dict. This ensures the model appears under
+   > its actual provider in the UI, not just under "openhands".
 
 ## Step 1: Add to resolve_model_config.py
 


### PR DESCRIPTION
## Why

When adding a new model via `resolve_model_config.py`, contributors sometimes also add the model to `verified_models.py`. That elevates the model to "verified" in the production UI, which should require maintainer review — a passing integration run alone is not sufficient.

Reviewers on PR #3315 asked for this clarification to be added to `ADDINGMODEL.md` so future PRs don't conflate "added for eval" with "verified for production".

## Summary

- Update `.github/run-eval/ADDINGMODEL.md` to make clear that `verified_models.py` should **not** be edited unless a maintainer explicitly asks for it.
- Preserve the existing guidance about cross-listing in provider-specific lists (`VERIFIED_ANTHROPIC_MODELS`, `VERIFIED_GEMINI_MODELS`, etc.) for the case where editing `verified_models.py` is requested.

## Issue Number

N/A — extracted from #3315.

## How to Test

Docs-only change. Render the file and confirm the new ⛔ note appears before the existing ⚠️ provider-list note.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR is one of three that replace #3315 (which is being closed):
1. **This PR** — `ADDINGMODEL.md` guidance update
2. SDK prompt-cache-too-small retry (separate PR)
3. `gemini-3.5-flash` model addition (separate PR, depends on this guidance)

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/11f2a907-c7a9-4136-9c84-c073842838f9)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:faf2a82-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-faf2a82-python \
  ghcr.io/openhands/agent-server:faf2a82-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:faf2a82-golang-amd64
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-golang-amd64
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-golang-amd64
ghcr.io/openhands/agent-server:faf2a82-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:faf2a82-golang-arm64
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-golang-arm64
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-golang-arm64
ghcr.io/openhands/agent-server:faf2a82-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:faf2a82-java-amd64
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-java-amd64
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-java-amd64
ghcr.io/openhands/agent-server:faf2a82-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:faf2a82-java-arm64
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-java-arm64
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-java-arm64
ghcr.io/openhands/agent-server:faf2a82-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:faf2a82-python-amd64
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-python-amd64
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-python-amd64
ghcr.io/openhands/agent-server:faf2a82-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:faf2a82-python-arm64
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-python-arm64
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-python-arm64
ghcr.io/openhands/agent-server:faf2a82-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:faf2a82-golang
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-golang
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-golang
ghcr.io/openhands/agent-server:faf2a82-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:faf2a82-java
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-java
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-java
ghcr.io/openhands/agent-server:faf2a82-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:faf2a82-python
ghcr.io/openhands/agent-server:faf2a826e9c2e4e03879edafa1e1299fbe173615-python
ghcr.io/openhands/agent-server:openhands-update-addingmodel-verified-list-guidance-python
ghcr.io/openhands/agent-server:faf2a82-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `faf2a82-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `faf2a82-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->