### PR TITLE
feat(run-eval): add gemini-3.5-flash model configuration

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -161,6 +161,14 @@ MODELS = {
             "temperature": 0.0,
         },
     },
+    "gemini-3.5-flash": {
+        "id": "gemini-3.5-flash",
+        "display_name": "Gemini 3.5 Flash",
+        "llm_config": {
+            "model": "litellm_proxy/gemini-3.5-flash",
+            "temperature": 0.0,
+        },
+    },
     "gpt-5.2": {
         "id": "gpt-5.2",
         "display_name": "GPT-5.2",

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -661,6 +661,16 @@ def test_deepseek_v4_flash_config():
     assert model["llm_config"]["model"] == "litellm_proxy/deepseek/deepseek-v4-flash"
 
 
+def test_gemini_3_5_flash_config():
+    """Test that gemini-3.5-flash has correct configuration."""
+    model = MODELS["gemini-3.5-flash"]
+
+    assert model["id"] == "gemini-3.5-flash"
+    assert model["display_name"] == "Gemini 3.5 Flash"
+    assert model["llm_config"]["model"] == "litellm_proxy/gemini-3.5-flash"
+    assert model["llm_config"]["temperature"] == 0.0
+
+
 def test_nemotron_3_ultra_550b_a55b_config():
     """Test that nemotron-3-ultra-550b-a55b has correct configuration."""
     model = MODELS["nemotron-3-ultra-550b-a55b"]


### PR DESCRIPTION
## Why

Add the newly released Gemini 3.5 Flash model so it can be used in evaluations. See [Gemini 3.5 Flash docs](https://ai.google.dev/gemini-api/docs/models/gemini-3.5-flash).

## Summary

- Add `gemini-3.5-flash` entry to `MODELS` in `.github/run-eval/resolve_model_config.py`, routed through `litellm_proxy/gemini-3.5-flash` with `temperature=0.0` — same shape as the existing `gemini-3-flash` entry.
- Add `test_gemini_3_5_flash_config` to `tests/cross/test_resolve_model_config.py`.

No changes needed in `model_features.py`: `PROMPT_CACHE_MODELS` already covers the `gemini-3` prefix, and `reasoning_effort` support is auto-detected from LiteLLM via `_supports_reasoning_effort`.

No changes to `verified_models.py`: per `ADDINGMODEL.md` guidance, models should not be added to verified lists unless a maintainer explicitly requests it.

## Issue Number

Fixes #3312

## How to Test

```bash
uv run pytest tests/cross/test_resolve_model_config.py::test_gemini_3_5_flash_config \
              tests/cross/test_resolve_model_config.py::test_all_models_valid_with_pydantic \
              tests/cross/test_resolve_model_config.py::test_find_all_models -v
```

Manual resolver check:

```bash
cd .github/run-eval
MODEL_IDS="gemini-3.5-flash" GITHUB_OUTPUT=/tmp/output.txt python resolve_model_config.py
```

Integration tests (per ADDINGMODEL.md Step 7) — run against this PR's branch:

```bash
gh workflow run integration-runner.yml \
  -f model_ids=gemini-3.5-flash \
  -f reason="Testing new model from PR" \
  --ref openhands/add-gemini-3.5-flash-model
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR is one of three that replace #3315 (which is being closed):
1. `ADDINGMODEL.md` guidance update (separate PR)
2. SDK prompt-cache-too-small retry (separate PR — required for Gemini 3.5 Flash to be usable on small initial contexts, since the model uses Vertex AI prompt caching)
3. **This PR** — `gemini-3.5-flash` model addition

The LiteLLM proxy route is `litellm_proxy/gemini-3.5-flash` (not `…-preview`). Gemini 3.5 Flash supports thinking via `thinkingLevel`, mapped to `reasoning_effort` in the SDK.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/11f2a907-c7a9-4136-9c84-c073842838f9)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8ccee31-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8ccee31-python \
  ghcr.io/openhands/agent-server:8ccee31-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8ccee31-golang-amd64
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-golang-amd64
ghcr.io/openhands/agent-server:8ccee31-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8ccee31-golang-arm64
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-golang-arm64
ghcr.io/openhands/agent-server:8ccee31-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8ccee31-java-amd64
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-java-amd64
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-java-amd64
ghcr.io/openhands/agent-server:8ccee31-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8ccee31-java-arm64
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-java-arm64
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-java-arm64
ghcr.io/openhands/agent-server:8ccee31-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8ccee31-python-amd64
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-python-amd64
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-python-amd64
ghcr.io/openhands/agent-server:8ccee31-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8ccee31-python-arm64
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-python-arm64
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-python-arm64
ghcr.io/openhands/agent-server:8ccee31-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8ccee31-golang
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-golang
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-golang
ghcr.io/openhands/agent-server:8ccee31-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8ccee31-java
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-java
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-java
ghcr.io/openhands/agent-server:8ccee31-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8ccee31-python
ghcr.io/openhands/agent-server:8ccee318bb6f5f9797c9869c8452cc7488b83b62-python
ghcr.io/openhands/agent-server:openhands-add-gemini-3.5-flash-model-python
ghcr.io/openhands/agent-server:8ccee31-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8ccee31-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8ccee31-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->