### PR TITLE
fix(acp): classify upstream-gateway SSE bytes-repr corruption distinctly

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -20,6 +20,7 @@ import asyncio
 import inspect
 import json
 import os
+import re
 import threading
 import time
 import uuid
@@ -166,6 +167,59 @@ _ACTIVITY_SIGNAL_INTERVAL: float = 30.0
 # and, if the turn aborts before it reaches a terminal state, the live-
 # emitted event on state.events will otherwise be orphaned forever.
 _TERMINAL_TOOL_CALL_STATUSES: frozenset[str] = frozenset({"completed", "failed"})
+
+
+# Pattern for a JSON-parse error whose payload is a Python ``bytes`` __repr__
+# leaking into an SSE stream (chunk starts with ``b'data:`` or ``b"data:``).
+# Observed end-to-end with @google/gemini-cli when the upstream LLM gateway
+# (e.g. a LiteLLM proxy alias) forwards ``str(bytes)``/``repr(bytes)`` instead
+# of decoded UTF-8 chunks. The ACP server's JSON.parse then chokes on the
+# leading ``b'`` byte and the error text propagates back via ACP as
+# "Unexpected token 'b', \"b'data: {\"... is not valid JSON".
+#
+# Retrying does not help — the gateway has to be fixed — so we classify this
+# distinctly to (a) give operators a clear remediation hint and (b) let
+# eval/harness code short-circuit retries that cannot possibly succeed.
+_UPSTREAM_SSE_BYTES_REPR_PATTERN: re.Pattern[str] = re.compile(
+    r"Unexpected\s+token\s+['\"]b['\"].*b['\"]data\s*:",
+    re.IGNORECASE | re.DOTALL,
+)
+
+
+def _classify_acp_prompt_error(error_str: str) -> tuple[str, str]:
+    """Classify an exception raised out of ``conn.prompt`` into ``(code, detail)``.
+
+    Returns:
+        A tuple of ``(ConversationErrorEvent.code, ConversationErrorEvent.detail)``.
+
+        * ``UsagePolicyRefusal`` — the upstream provider refused the prompt
+          on policy grounds (the agent did nothing wrong, the model declined).
+        * ``UpstreamGatewaySSEError`` — the ACP server received a corrupted
+          SSE response from its configured LLM gateway (chunk text contains
+          a Python bytes-repr like ``b'data: {...}'``). This is deterministic;
+          retrying the same gateway will fail the same way.
+        * ``ACPPromptError`` — fallback for everything else.
+
+    The first element is the stable error code used by downstream consumers
+    (RemoteConversation surfaces it as the failure reason; benchmark eval
+    harnesses can branch on it to skip pointless retries).
+    """
+    lower = error_str.lower()
+    if "usage policy" in lower or "content policy" in lower:
+        return "UsagePolicyRefusal", error_str[:500]
+    if _UPSTREAM_SSE_BYTES_REPR_PATTERN.search(error_str):
+        remediation = (
+            "ACP server failed to parse a streaming response from its "
+            "configured LLM gateway: the SSE payload begins with a Python "
+            "bytes-repr (e.g. b'data: {...}'), which indicates the gateway "
+            "is forwarding str(bytes) instead of decoded UTF-8 chunks. "
+            "This is deterministic — retries will not help. Check the "
+            "*_BASE_URL the ACP subprocess is pointed at (LiteLLM proxy "
+            "alias, etc.) and the upstream model's streaming handler. "
+            f"Original error: {error_str[:300]}"
+        )
+        return "UpstreamGatewaySSEError", remediation[:500]
+    return "ACPPromptError", error_str[:500]
 
 
 class _PromptDrainResult(NamedTuple):
@@ -2129,15 +2183,16 @@ class ACPAgent(AgentBase):
         )
         # Emit typed ConversationErrorEvent so RemoteConversation surfaces
         # the actual detail instead of falling back to
-        # "Remote conversation ended with error".
-        is_aup = (
-            "usage policy" in error_str.lower() or "content policy" in error_str.lower()
-        )
+        # "Remote conversation ended with error".  ``_classify_acp_prompt_error``
+        # maps known signatures (policy refusals, corrupted SSE from the
+        # LLM gateway, …) to stable error codes so downstream consumers can
+        # branch on them without re-parsing the human-readable detail.
+        code, detail = _classify_acp_prompt_error(error_str)
         on_event(
             ConversationErrorEvent(
                 source="agent",
-                code="UsagePolicyRefusal" if is_aup else "ACPPromptError",
-                detail=error_str[:500],
+                code=code,
+                detail=detail,
             )
         )
         state.execution_status = ConversationExecutionStatus.ERROR

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -19,6 +19,7 @@ from pydantic import SecretStr
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _classify_acp_init_error,
+    _classify_acp_prompt_error,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
@@ -881,6 +882,67 @@ class TestClassifyACPInitError:
 
     def test_generic_exception_is_init_error(self):
         assert _classify_acp_init_error(RuntimeError("x")) == "ACPInitError"
+
+
+# ---------------------------------------------------------------------------
+# _classify_acp_prompt_error
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyACPPromptError:
+    """Cover the error-classifier used by ``ACPAgent._emit_turn_error``.
+
+    Stable codes drive downstream behaviour (RemoteConversation surfacing,
+    benchmark retry logic, telemetry dashboards), so each branch needs a
+    direct regression test.
+    """
+
+    def test_usage_policy_lower_case(self):
+        code, detail = _classify_acp_prompt_error("Request blocked by usage policy")
+        assert code == "UsagePolicyRefusal"
+        assert detail == "Request blocked by usage policy"
+
+    def test_content_policy_mixed_case(self):
+        code, _ = _classify_acp_prompt_error("Content Policy violation: harmful")
+        assert code == "UsagePolicyRefusal"
+
+    def test_upstream_sse_bytes_repr_pattern(self):
+        # Exact signature seen in GAIA eval run 26869531096 (gemini-cli 0.38.0
+        # streaming through a LiteLLM proxy alias for gemini-3-flash-preview).
+        raw = "Unexpected token 'b', \"b'data: {\"\"... is not valid JSON"
+        code, detail = _classify_acp_prompt_error(raw)
+        assert code == "UpstreamGatewaySSEError"
+        # Detail must explain the upstream root cause and include the
+        # original text so operators can grep logs.
+        assert "bytes-repr" in detail
+        assert "gateway" in detail.lower()
+        assert "Original error:" in detail
+        assert "b'data:" in detail or "b'data:" in detail.lower()
+
+    def test_upstream_sse_double_quote_variant(self):
+        # Some Node runtimes wrap the offending token in double quotes.
+        raw = 'Unexpected token "b", "b\'data: {""... is not valid JSON'
+        code, _ = _classify_acp_prompt_error(raw)
+        assert code == "UpstreamGatewaySSEError"
+
+    def test_upstream_sse_does_not_match_generic_json_error(self):
+        # A regular JSON.parse failure (no bytes-repr leading the data field)
+        # must remain a generic ACPPromptError so we do not falsely promise
+        # the user that fixing the gateway will help.
+        raw = "Unexpected token } in JSON at position 42"
+        code, _ = _classify_acp_prompt_error(raw)
+        assert code == "ACPPromptError"
+
+    def test_fallback_returns_acp_prompt_error(self):
+        code, detail = _classify_acp_prompt_error("transport reset by peer")
+        assert code == "ACPPromptError"
+        assert detail == "transport reset by peer"
+
+    def test_detail_is_truncated_to_500_chars(self):
+        # Long upstream tracebacks must not bypass the 500-char detail cap.
+        long_error = "x" * 5_000
+        _, detail = _classify_acp_prompt_error(long_error)
+        assert len(detail) <= 500
 
 
 # ---------------------------------------------------------------------------
@@ -1944,6 +2006,58 @@ class TestACPAgentAstep:
             f"expected one ConversationErrorEvent, got {emitted}"
         )
         assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+
+    def test_astep_classifies_upstream_sse_bytes_repr_failure(self, tmp_path):
+        """End-to-end: an upstream-gateway SSE corruption surfaces as
+        ``UpstreamGatewaySSEError``, not the generic ``ACPPromptError``.
+
+        Regression coverage for GAIA eval run 26869531096, where 165/165
+        gemini-cli ACP instances failed with the JS JSON.parse signature
+        ``Unexpected token 'b', "b'data: {""... is not valid JSON`` produced
+        by a misbehaving LiteLLM proxy alias. The distinct code lets the
+        eval harness skip retries that can never succeed.
+        """
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        emitted: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+
+        # Reproduce the exact error string surfaced by gemini-cli 0.38.0.
+        upstream_error = "Unexpected token 'b', \"b'data: {\"\"... is not valid JSON"
+
+        async def _failing_prompt(prompt_blocks, session_id):
+            raise RuntimeError(upstream_error)
+
+        agent._conn.prompt = _failing_prompt
+
+        executor = AsyncExecutor()
+        try:
+            agent._executor = executor
+            with pytest.raises(RuntimeError):
+                asyncio.run(agent.astep(conversation, on_event=emitted.append))
+        finally:
+            executor.close()
+
+        typed_errors = [e for e in emitted if isinstance(e, ConversationErrorEvent)]
+        assert len(typed_errors) == 1, (
+            f"expected one ConversationErrorEvent, got {emitted}"
+        )
+        err = typed_errors[0]
+        assert err.code == "UpstreamGatewaySSEError", (
+            f"expected UpstreamGatewaySSEError, got {err.code!r} "
+            f"with detail={err.detail!r}"
+        )
+        # Detail must keep the operator-actionable remediation hint.
+        assert "gateway" in err.detail.lower()
+        assert "bytes-repr" in err.detail
 
     def test_astep_times_out_while_tool_call_is_inflight(self, tmp_path):
         """A hard ACP prompt timeout still fires during an active tool call.


### PR DESCRIPTION
## Diagnosis

GAIA eval run [`26869531096`](https://openhands-eval-monitor.vercel.app/?run=gaia%2Flitellm_proxy-gemini-3-flash-preview%2F26869531096&days=15) (`gemini-3-flash-preview` via `acp-gemini`) returned **0/165 resolved** instances. Every single instance — across all 4 retry attempts and escalating resource factors — failed at the very first `prompt()` call with the same signature:

```
ConversationRunError: Conversation run failed for id=…:
    RequestError: Unexpected token 'b', "b'data: {""... is not valid JSON
```

The conversation event log confirms:
- `acp_agent_name = "gemini-cli"`, `version = "0.38.0"`
- The ACP server's `MessageEvent` content is `ACP error: Unexpected token 'b', "b'data: {""... is not valid JSON`
- Followed by `ConversationErrorEvent(code="ACPPromptError", detail="Unexpected token 'b', \"b'data: {\"… is not valid JSON")`

That JS `JSON.parse` error message tells us exactly what gemini-cli's SSE parser saw on the wire: a chunk whose text begins with **`b'data:`** — i.e. a Python `bytes.__repr__()` leaking into the SSE stream. The upstream LLM gateway (in this run, a LiteLLM proxy alias for `gemini-3-flash-preview`) is calling `str(bytes)` on streaming chunks instead of decoding them as UTF-8.

**This is a deterministic upstream gateway bug.** Retries will fail the same way; escalating CPU/memory will fail the same way. Both happened in the failing run — see `logs/instance_14569e28-…log`, where the same instance retried 4× with `resource_factor` escalating `1 → 2 → 2 → 4` and got the same error every time.

The SDK was previously labelling this as a generic `ACPPromptError`, which:
1. **Hid the real root cause from operators** — the user has to dig through tarballs to discover the `b'data:` signature
2. **Burned retry budget on a non-recoverable failure** — benchmark harnesses (e.g. `benchmarks.utils.evaluation`) treat unknown errors as transient/resource-bound and retry, when they should short-circuit

## Fix

Add `_classify_acp_prompt_error()` in `openhands.sdk.agent.acp_agent` that maps known exception signatures to stable `ConversationErrorEvent` codes:

| Code | When | Retry helps? |
|---|---|---|
| `UsagePolicyRefusal` | "usage/content policy" in error | No |
| `UpstreamGatewaySSEError` *(new)* | `Unexpected token 'b' … b'data:` pattern | **No** |
| `ACPPromptError` | fallback | Maybe |

Wire it into `_emit_turn_error()` so the typed `ConversationErrorEvent.detail` carries an actionable remediation hint instead of the opaque JS parser message:

> ACP server failed to parse a streaming response from its configured LLM gateway: the SSE payload begins with a Python bytes-repr (e.g. `b'data: {...}'`), which indicates the gateway is forwarding `str(bytes)` instead of decoded UTF-8 chunks. This is deterministic — retries will not help. Check the `*_BASE_URL` the ACP subprocess is pointed at (LiteLLM proxy alias, etc.) and the upstream model's streaming handler. Original error: …

This is the minimum SDK-side change. The actual bytes-repr forwarding bug has to be fixed in the LiteLLM proxy / gateway configuration for `gemini-3-flash-preview`; the SDK can only make the failure mode legible so the right team gets paged.

## Tests

* 7 new unit tests on `_classify_acp_prompt_error` covering every branch and the 500-char detail cap
* 1 end-to-end `astep` regression test that drives the exact gemini-cli 0.38.0 error string through `_emit_turn_error` and asserts the surfaced `ConversationErrorEvent` is `UpstreamGatewaySSEError` with the remediation hint
* All 283 existing `test_acp_agent.py` tests pass; existing `ACPPromptError` fallback behaviour is preserved

```
tests/sdk/agent/test_acp_agent.py::TestClassifyACPPromptError ✓ 7 passed
tests/sdk/agent/test_acp_agent.py::TestACPAgentAstep::test_astep_classifies_upstream_sse_bytes_repr_failure ✓ passed
tests/sdk/agent/test_acp_agent.py ........... 283 passed
```

## Follow-ups (not in this PR)

* LiteLLM proxy: fix the `gemini-3-flash-preview` alias so it streams decoded UTF-8, not `str(bytes)`. This is the actual root cause and lives outside this repo.
* `benchmarks.utils.evaluation`: consider adding `UpstreamGatewaySSEError` to the no-retry classifier so failures of this shape don't burn the full 4× retry budget.
* Once the gateway is fixed, re-run `gaia/litellm_proxy-gemini-3-flash-preview` to confirm completion rate recovers.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/5d4605f8-36bf-4d01-bbf0-3cdb855bc01d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bbd3e78-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bbd3e78-python \
  ghcr.io/openhands/agent-server:bbd3e78-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bbd3e78-golang-amd64
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-golang-amd64
ghcr.io/openhands/agent-server:bbd3e78-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bbd3e78-golang-arm64
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-golang-arm64
ghcr.io/openhands/agent-server:bbd3e78-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bbd3e78-java-amd64
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-java-amd64
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-java-amd64
ghcr.io/openhands/agent-server:bbd3e78-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bbd3e78-java-arm64
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-java-arm64
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-java-arm64
ghcr.io/openhands/agent-server:bbd3e78-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bbd3e78-python-amd64
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-python-amd64
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-python-amd64
ghcr.io/openhands/agent-server:bbd3e78-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bbd3e78-python-arm64
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-python-arm64
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-python-arm64
ghcr.io/openhands/agent-server:bbd3e78-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bbd3e78-golang
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-golang
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-golang
ghcr.io/openhands/agent-server:bbd3e78-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:bbd3e78-java
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-java
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-java
ghcr.io/openhands/agent-server:bbd3e78-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:bbd3e78-python
ghcr.io/openhands/agent-server:bbd3e7875fde79930ecdc56147bd9d68cd6035d4-python
ghcr.io/openhands/agent-server:fix-acp-classify-upstream-sse-corruption-python
ghcr.io/openhands/agent-server:bbd3e78-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bbd3e78-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bbd3e78-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->