### PR TITLE
fix: prevent deep-merge when switching agent_kind settings variant

### DIFF
--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -146,6 +146,11 @@ class PersistedSettings(BaseModel):
         apply any schema migrations if the incoming diff contains an older
         schema version.
 
+        When ``agent_kind`` changes in the diff, the update is treated as a
+        variant replacement: the incoming diff is validated as-is rather than
+        merged with the old variant's fields. Same-kind updates retain deep-merge
+        behavior for incremental field edits.
+
         Thread Safety:
             This method is NOT thread-safe for concurrent in-memory updates.
             The assignments to ``agent_settings`` and ``conversation_settings``
@@ -176,12 +181,23 @@ class PersistedSettings(BaseModel):
 
         try:
             if isinstance(agent_update, dict):
-                agent_merged = _deep_merge(
-                    self.agent_settings.model_dump(
-                        mode="json", context={"expose_secrets": "plaintext"}
-                    ),
-                    agent_update,
-                )
+                # Check if this is a variant (agent_kind) switch
+                old_kind = self.agent_settings.agent_kind
+                new_kind = agent_update.get("agent_kind")
+                is_kind_switch = new_kind is not None and new_kind != old_kind
+
+                if is_kind_switch:
+                    # Variant replacement: validate the diff as-is without merging
+                    # with old variant's fields (which may be incompatible)
+                    agent_merged = agent_update
+                else:
+                    # Same-kind update: deep-merge for incremental field edits
+                    agent_merged = _deep_merge(
+                        self.agent_settings.model_dump(
+                            mode="json", context={"expose_secrets": "plaintext"}
+                        ),
+                        agent_update,
+                    )
                 try:
                     new_agent = validate_agent_settings(agent_merged)
                 except Exception as e:

--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -187,8 +187,20 @@ class PersistedSettings(BaseModel):
                 is_kind_switch = new_kind is not None and new_kind != old_kind
 
                 if is_kind_switch:
-                    # Variant replacement: validate the diff as-is without merging
-                    # with old variant's fields (which may be incompatible)
+                    # Variant replacement: validate the diff as-is rather than
+                    # deep-merging it onto the old variant. A kind switch picks a
+                    # different member of the AgentSettingsConfig union, and the
+                    # old variant's serialized fields are not a valid base for the
+                    # new one (e.g. ACP's acp_command has no place in
+                    # OpenHandsAgentSettings and would fail validation).
+                    #
+                    # Consequence (intentional): fields the two variants happen to
+                    # share (e.g. ``llm``) are NOT carried over — they fall back to
+                    # the new variant's defaults unless the caller restates them in
+                    # this same diff. Switching kinds is a fresh start on the new
+                    # variant, mirroring the frontend's "fresh base on kind switch"
+                    # behaviour. Callers that want to preserve a shared field must
+                    # include it in the switch payload.
                     agent_merged = agent_update
                 else:
                     # Same-kind update: deep-merge for incremental field edits

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -759,6 +759,72 @@ def test_patch_settings_switch_agent_kind_from_openhands_to_acp(client_with_sett
     assert body["agent_settings"]["acp_command"] == ["echo", "hello"]
 
 
+def test_patch_settings_same_kind_restated_still_deep_merges(client_with_settings):
+    """Re-stating the current ``agent_kind`` is NOT a variant switch: the diff
+    must still deep-merge so unrelated fields survive.
+
+    ``new_kind != old_kind`` is False when the kind is restated, so the
+    deep-merge branch runs. This pins that a client which echoes back the
+    current ``agent_kind`` alongside an incremental edit does not accidentally
+    trigger a full variant replacement (which would reset sibling fields)."""
+    # Establish a model on the default OpenHands variant.
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4o"}}},
+    )
+    assert response.status_code == 200
+
+    # Restate agent_kind=openhands while setting only the api_key. Because the
+    # kind is unchanged, this deep-merges and the model must be preserved.
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "openhands",
+                "llm": {"api_key": "sk-test-key"},
+            }
+        },
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["agent_settings"]["agent_kind"] == "openhands"
+    # The model set in the first PATCH survives — proving deep-merge ran.
+    assert body["agent_settings"]["llm"]["model"] == "gpt-4o"
+    assert body["llm_api_key_is_set"] is True
+
+
+def test_patch_settings_same_kind_merge_after_a_switch(client_with_settings):
+    """After a variant switch, subsequent same-kind PATCHes resume deep-merge.
+
+    The switch itself is a replacement, but the newly active variant must
+    behave like any other for incremental edits afterwards — a follow-up
+    field edit must not wipe the fields set during the switch."""
+    # Switch from default OpenHands to ACP, setting two ACP fields.
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "acp",
+                "acp_command": ["my-cli"],
+                "acp_env": {"FOO": "bar"},
+            }
+        },
+    )
+    assert response.status_code == 200
+    assert response.json()["agent_settings"]["acp_command"] == ["my-cli"]
+
+    # Same-kind follow-up: add an env var. Deep-merge must preserve acp_command
+    # and the pre-existing env entry.
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"acp_env": {"BAZ": "qux"}}},
+    )
+    assert response.status_code == 200
+    body = response.json()
+    assert body["agent_settings"]["acp_command"] == ["my-cli"]
+    assert set(body["agent_settings"]["acp_env"]) == {"FOO", "BAZ"}
+
+
 # ── Secrets CRUD tests ──────────────────────────────────────────────────
 
 

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -684,6 +684,81 @@ def test_patch_settings_null_on_scalar_field_fails_loudly(client_with_settings):
     assert response.status_code == 422
 
 
+def test_patch_settings_switch_agent_kind_from_acp_to_openhands(
+    client_with_settings, temp_persistence_dir
+):
+    """PATCH /api/settings can switch from ACP to OpenHands.
+
+    When ``agent_kind`` changes, incompatible fields from the old variant
+    (like ``acp_command``) must not be merged into the new variant.
+    This is a variant replacement, not a field merge."""
+    # Seed with ACP settings
+    acp = ACPAgentSettings(
+        acp_command=["echo", "test"],
+        acp_env={"KEY": "value"},
+    )
+    persisted = PersistedSettings(agent_settings=acp)
+    payload = persisted.model_dump(mode="json", context={"expose_secrets": "plaintext"})
+    _write_settings_file(temp_persistence_dir, payload)
+
+    # Verify it starts as ACP
+    get_response = client_with_settings.get("/api/settings")
+    assert get_response.json()["agent_settings"]["agent_kind"] == "acp"
+
+    # Switch to OpenHands — provide only the required fields for OpenHands variant
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "openhands",
+                "llm": {"model": "claude-3-5-sonnet-20241022"},
+            }
+        },
+    )
+
+    # Should succeed — no validation error about leftover ACP-specific fields
+    assert response.status_code == 200
+    body = response.json()
+    assert body["agent_settings"]["agent_kind"] == "openhands"
+    # ACP-specific fields should not appear in the response
+    assert "acp_command" not in body["agent_settings"]
+    assert "acp_env" not in body["agent_settings"]
+
+
+def test_patch_settings_switch_agent_kind_from_openhands_to_acp(client_with_settings):
+    """PATCH /api/settings can switch from OpenHands to ACP.
+
+    When switching to ACP, the new variant's required fields should be set
+    without interference from the old variant's fields."""
+    # Seed with OpenHands settings (default)
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "llm": {"model": "claude-3-5-sonnet-20241022"},
+            }
+        },
+    )
+    assert response.status_code == 200
+
+    # Switch to ACP
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "agent_kind": "acp",
+                "acp_command": ["echo", "hello"],
+            }
+        },
+    )
+
+    # Should succeed — no validation error about leftover OpenHands-specific fields
+    assert response.status_code == 200
+    body = response.json()
+    assert body["agent_settings"]["agent_kind"] == "acp"
+    assert body["agent_settings"]["acp_command"] == ["echo", "hello"]
+
+
 # ── Secrets CRUD tests ──────────────────────────────────────────────────
 
 

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -17,6 +17,7 @@ from openhands.agent_server.persistence import (
     reset_stores,
 )
 from openhands.agent_server.persistence.models import _deep_merge
+from openhands.sdk.llm import LLM
 from openhands.sdk.settings import (
     AGENT_SETTINGS_SCHEMA_VERSION,
     CONVERSATION_SETTINGS_SCHEMA_VERSION,
@@ -692,20 +693,25 @@ def test_patch_settings_switch_agent_kind_from_acp_to_openhands(
     When ``agent_kind`` changes, incompatible fields from the old variant
     (like ``acp_command``) must not be merged into the new variant.
     This is a variant replacement, not a field merge."""
-    # Seed with ACP settings
+    # Seed with ACP settings, including a NON-default ``llm`` model. ``llm`` is
+    # a field both variants share, so this lets us prove it is NOT silently
+    # carried into the new variant on a switch.
     acp = ACPAgentSettings(
         acp_command=["echo", "test"],
         acp_env={"KEY": "value"},
+        llm=LLM(model="acp-only-model", usage_id="default"),
     )
     persisted = PersistedSettings(agent_settings=acp)
     payload = persisted.model_dump(mode="json", context={"expose_secrets": "plaintext"})
     _write_settings_file(temp_persistence_dir, payload)
 
-    # Verify it starts as ACP
+    # Verify it starts as ACP with the seeded model.
     get_response = client_with_settings.get("/api/settings")
-    assert get_response.json()["agent_settings"]["agent_kind"] == "acp"
+    seeded = get_response.json()["agent_settings"]
+    assert seeded["agent_kind"] == "acp"
+    assert seeded["llm"]["model"] == "acp-only-model"
 
-    # Switch to OpenHands — provide only the required fields for OpenHands variant
+    # Switch to OpenHands, restating ``llm`` with a new model.
     response = client_with_settings.patch(
         "/api/settings",
         json={
@@ -723,6 +729,44 @@ def test_patch_settings_switch_agent_kind_from_acp_to_openhands(
     # ACP-specific fields should not appear in the response
     assert "acp_command" not in body["agent_settings"]
     assert "acp_env" not in body["agent_settings"]
+    # The restated ``llm`` model wins — the ACP-seeded value is gone.
+    assert body["agent_settings"]["llm"]["model"] == "claude-3-5-sonnet-20241022"
+
+
+def test_patch_settings_switch_drops_shared_field_when_not_restated(
+    client_with_settings, temp_persistence_dir
+):
+    """A shared field (``llm``) set on the OLD variant is dropped on a kind
+    switch unless the caller restates it — it falls back to the new variant's
+    default rather than silently carrying over.
+
+    This pins the intentional "fresh start on the new variant" contract: a
+    kind switch is a variant replacement, so shared fields are not inherited.
+    Callers that want to preserve a shared field must include it in the switch
+    payload (see the sibling test, which restates ``llm``)."""
+    # Seed ACP with a non-default llm model.
+    acp = ACPAgentSettings(
+        acp_command=["echo", "test"],
+        llm=LLM(model="acp-only-model", usage_id="default"),
+    )
+    persisted = PersistedSettings(agent_settings=acp)
+    payload = persisted.model_dump(mode="json", context={"expose_secrets": "plaintext"})
+    _write_settings_file(temp_persistence_dir, payload)
+
+    # Switch to OpenHands WITHOUT restating llm.
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"agent_kind": "openhands"}},
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["agent_settings"]["agent_kind"] == "openhands"
+    # The ACP-seeded model is NOT carried over; llm falls back to the
+    # OpenHands variant's default model.
+    default_model = OpenHandsAgentSettings().llm.model
+    assert body["agent_settings"]["llm"]["model"] == default_model
+    assert body["agent_settings"]["llm"]["model"] != "acp-only-model"
 
 
 def test_patch_settings_switch_agent_kind_from_openhands_to_acp(client_with_settings):


### PR DESCRIPTION
When agent_kind changes (e.g., ACP → OpenHands or vice versa), the diff is now treated as a variant replacement rather than being merged with the old variant's fields. This prevents validation errors from leftover incompatible fields like acp_command in an OpenHands settings.

Same-kind updates continue to use deep-merge for incremental field edits.

Fixes: https://github.com/OpenHands/agent-canvas/issues/2105

<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3333da3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3333da3-python \
  ghcr.io/openhands/agent-server:3333da3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3333da3-golang-amd64
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-golang-amd64
ghcr.io/openhands/agent-server:fix-agent-kind-switch-golang-amd64
ghcr.io/openhands/agent-server:3333da3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3333da3-golang-arm64
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-golang-arm64
ghcr.io/openhands/agent-server:fix-agent-kind-switch-golang-arm64
ghcr.io/openhands/agent-server:3333da3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3333da3-java-amd64
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-java-amd64
ghcr.io/openhands/agent-server:fix-agent-kind-switch-java-amd64
ghcr.io/openhands/agent-server:3333da3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3333da3-java-arm64
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-java-arm64
ghcr.io/openhands/agent-server:fix-agent-kind-switch-java-arm64
ghcr.io/openhands/agent-server:3333da3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3333da3-python-amd64
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-python-amd64
ghcr.io/openhands/agent-server:fix-agent-kind-switch-python-amd64
ghcr.io/openhands/agent-server:3333da3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3333da3-python-arm64
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-python-arm64
ghcr.io/openhands/agent-server:fix-agent-kind-switch-python-arm64
ghcr.io/openhands/agent-server:3333da3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3333da3-golang
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-golang
ghcr.io/openhands/agent-server:fix-agent-kind-switch-golang
ghcr.io/openhands/agent-server:3333da3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3333da3-java
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-java
ghcr.io/openhands/agent-server:fix-agent-kind-switch-java
ghcr.io/openhands/agent-server:3333da3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3333da3-python
ghcr.io/openhands/agent-server:3333da3ddf55ed85230d497807318d9a3c6b7dbc-python
ghcr.io/openhands/agent-server:fix-agent-kind-switch-python
ghcr.io/openhands/agent-server:3333da3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3333da3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3333da3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->