### PR TITLE
fix(sdk): avoid switch_llm deadlock when the run loop holds the state lock

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -108,6 +108,10 @@ class LocalConversation(BaseConversation):
     delete_on_close: bool = True
     _arun_task: asyncio.Task[None] | None
     _cancel_token: CancellationToken | None
+    # True while run()/arun() executes an agent step while holding the state
+    # lock. Tools run on worker threads, so a tool that mutates state (e.g.
+    # switch_llm) must reuse that lock instead of re-acquiring it (#3485).
+    _step_holds_state_lock: bool
     # Plugin lazy loading state
     _plugin_specs: list[PluginSource] | None
     _resolved_plugins: list[ResolvedPluginSource] | None
@@ -185,6 +189,7 @@ class LocalConversation(BaseConversation):
         self._cleanup_initiated = False
         self._arun_task = None
         self._cancel_token = None
+        self._step_holds_state_lock = False
 
         # Store plugin specs for lazy loading (no IO in constructor)
         # Plugins will be loaded on first run() or send_message() call
@@ -759,7 +764,12 @@ class LocalConversation(BaseConversation):
         except KeyError:
             new_llm = llm
             self.llm_registry.add(new_llm)
-        with self._state:
+        # When this runs as a tool inside an in-progress agent step, the run
+        # loop already holds the state lock on another thread and is blocked
+        # awaiting this tool call; re-acquiring it here (on the tool worker
+        # thread) would deadlock. Reuse the lock the step already holds (#3485).
+        lock = contextlib.nullcontext() if self._step_holds_state_lock else self._state
+        with lock:
             self.agent = self.agent.model_copy(update={"llm": new_llm})
             self._state.agent = self.agent
             self._pin_prompt_cache_key()
@@ -1013,9 +1023,16 @@ class LocalConversation(BaseConversation):
                             ConversationExecutionStatus.RUNNING
                         )
 
-                    self.agent.step(
-                        self, on_event=self._on_event, on_token=self._on_token
-                    )
+                    # Mark the step as holding the state lock so state-mutating
+                    # tools (e.g. switch_llm) running on worker threads reuse it
+                    # instead of deadlocking on a re-acquire (#3485).
+                    self._step_holds_state_lock = True
+                    try:
+                        self.agent.step(
+                            self, on_event=self._on_event, on_token=self._on_token
+                        )
+                    finally:
+                        self._step_holds_state_lock = False
                     iteration += 1
 
                     # Check for non-finished terminal conditions
@@ -1241,11 +1258,19 @@ class LocalConversation(BaseConversation):
                         # silently re-enter the lock and corrupt history. Such
                         # unrelated mutators must be dispatched via
                         # run_in_executor onto a worker thread.
-                        await self.agent.astep(
-                            self,
-                            on_event=self._on_event,
-                            on_token=self._on_token,
-                        )
+                        # Mark the step as holding the state lock so
+                        # state-mutating tools (e.g. switch_llm) running on
+                        # worker threads reuse it instead of deadlocking on a
+                        # re-acquire while this await holds it (#3485).
+                        self._step_holds_state_lock = True
+                        try:
+                            await self.agent.astep(
+                                self,
+                                on_event=self._on_event,
+                                on_token=self._on_token,
+                            )
+                        finally:
+                            self._step_holds_state_lock = False
                         iteration += 1
 
                         if (

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -109,8 +109,9 @@ class LocalConversation(BaseConversation):
     _arun_task: asyncio.Task[None] | None
     _cancel_token: CancellationToken | None
     # True while run()/arun() executes an agent step while holding the state
-    # lock. Tools run on worker threads, so a tool that mutates state (e.g.
-    # switch_llm) must reuse that lock instead of re-acquiring it (#3485).
+    # lock. A state-mutating tool (e.g. switch_llm) runs on a worker thread, so
+    # it must skip re-acquiring the lock the run loop holds while blocked
+    # awaiting that tool (#3485).
     _step_holds_state_lock: bool
     # Plugin lazy loading state
     _plugin_specs: list[PluginSource] | None
@@ -764,11 +765,16 @@ class LocalConversation(BaseConversation):
         except KeyError:
             new_llm = llm
             self.llm_registry.add(new_llm)
-        # When this runs as a tool inside an in-progress agent step, the run
-        # loop already holds the state lock on another thread and is blocked
-        # awaiting this tool call; re-acquiring it here (on the tool worker
-        # thread) would deadlock. Reuse the lock the step already holds (#3485).
-        lock = contextlib.nullcontext() if self._step_holds_state_lock else self._state
+        # A switch_llm tool runs on a worker thread while run()/arun() holds the
+        # state lock across the agent step on another thread, blocked awaiting
+        # this very tool. Re-acquiring _state here would deadlock, so skip it:
+        # the run loop is parked and no other mutator can run, so the swap is
+        # safe without the lock (#3485). Only skip when the lock is held by a
+        # different thread (the run loop); when the caller already owns it (a
+        # sync step, or the switch endpoint reentering on the event-loop thread)
+        # acquire normally — FIFOLock is reentrant for the owning thread.
+        skip_lock = self._step_holds_state_lock and not self._state.owned()
+        lock = contextlib.nullcontext() if skip_lock else self._state
         with lock:
             self.agent = self.agent.model_copy(update={"llm": new_llm})
             self._state.agent = self.agent
@@ -1024,8 +1030,8 @@ class LocalConversation(BaseConversation):
                         )
 
                     # Mark the step as holding the state lock so state-mutating
-                    # tools (e.g. switch_llm) running on worker threads reuse it
-                    # instead of deadlocking on a re-acquire (#3485).
+                    # tools (e.g. switch_llm) running on worker threads skip
+                    # re-acquiring it instead of deadlocking (#3485).
                     self._step_holds_state_lock = True
                     try:
                         self.agent.step(
@@ -1260,8 +1266,8 @@ class LocalConversation(BaseConversation):
                         # run_in_executor onto a worker thread.
                         # Mark the step as holding the state lock so
                         # state-mutating tools (e.g. switch_llm) running on
-                        # worker threads reuse it instead of deadlocking on a
-                        # re-acquire while this await holds it (#3485).
+                        # worker threads skip re-acquiring it instead of
+                        # deadlocking while this await holds it (#3485).
                         self._step_holds_state_lock = True
                         try:
                             await self.agent.astep(

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -1,3 +1,4 @@
+import asyncio
 import json
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -10,10 +11,15 @@ from openhands.sdk.agent import Agent
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.context.condenser import LLMSummarizingCondenser
 from openhands.sdk.conversation.persistence_const import BASE_STATE
-from openhands.sdk.conversation.state import ConversationState
-from openhands.sdk.llm import llm_profile_store
+from openhands.sdk.conversation.state import (
+    ConversationExecutionStatus,
+    ConversationState,
+)
+from openhands.sdk.llm import Message, MessageToolCall, TextContent, llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.testing import TestLLM
+from openhands.sdk.tool import Tool, register_tool
+from openhands.sdk.tool.builtins import SwitchLLMTool
 from openhands.sdk.utils.cipher import Cipher
 
 
@@ -407,3 +413,56 @@ def test_duplicate_usage_ids_in_registration_loop_are_silently_deduped(tmp_path)
 
     # First-write-wins: only one entry under the shared usage_id
     assert conv.llm_registry.list_usage_ids().count("default") == 1
+
+
+def test_switch_llm_tool_during_arun_does_not_deadlock(profile_store, tmp_path):
+    """Regression for #3485: a ``switch_llm`` tool call during ``arun()`` must
+    not deadlock the conversation runtime.
+
+    ``arun()`` holds the ConversationState lock across the (async) agent step
+    while tools execute on worker threads. ``switch_llm()`` used to re-acquire
+    that lock from the tool worker thread, which deadlocked against the run
+    loop that already held it and was blocked awaiting the tool — no
+    observation was ever emitted and the conversation hung in ``running``.
+
+    The agent emits the switch and a finish in a single step, so the switch
+    happens mid-step (the deadlock site) and the run can complete.
+    """
+    register_tool("SwitchLLMTool", SwitchLLMTool)
+
+    llm = TestLLM.from_messages(
+        [
+            Message(
+                role="assistant",
+                content=[TextContent(text="")],
+                tool_calls=[
+                    MessageToolCall(
+                        id="switch_1",
+                        name="switch_llm",
+                        arguments='{"profile_name": "fast", "reason": "test"}',
+                        origin="completion",
+                    ),
+                    MessageToolCall(
+                        id="finish_1",
+                        name="finish",
+                        arguments='{"message": "done"}',
+                        origin="completion",
+                    ),
+                ],
+            ),
+        ],
+        model="default-model",
+        usage_id="test-llm",
+    )
+
+    agent = Agent(llm=llm, tools=[Tool(name="SwitchLLMTool")])
+    conv = LocalConversation(agent=agent, workspace=tmp_path, visualizer=None)
+    conv.send_message("please switch")
+
+    # Bounded so a regression surfaces as a fast test failure rather than a
+    # hung suite. On the fixed path arun() completes near-instantly.
+    asyncio.run(asyncio.wait_for(conv.arun(), timeout=10))
+
+    assert conv.state.execution_status == ConversationExecutionStatus.FINISHED
+    # The switch took effect: the agent now carries the 'fast' profile's model.
+    assert conv.agent.llm.model == "fast-model"

--- a/tests/sdk/conversation/test_switch_model.py
+++ b/tests/sdk/conversation/test_switch_model.py
@@ -18,8 +18,6 @@ from openhands.sdk.conversation.state import (
 from openhands.sdk.llm import Message, MessageToolCall, TextContent, llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.testing import TestLLM
-from openhands.sdk.tool import Tool, register_tool
-from openhands.sdk.tool.builtins import SwitchLLMTool
 from openhands.sdk.utils.cipher import Cipher
 
 
@@ -428,8 +426,6 @@ def test_switch_llm_tool_during_arun_does_not_deadlock(profile_store, tmp_path):
     The agent emits the switch and a finish in a single step, so the switch
     happens mid-step (the deadlock site) and the run can complete.
     """
-    register_tool("SwitchLLMTool", SwitchLLMTool)
-
     llm = TestLLM.from_messages(
         [
             Message(
@@ -455,7 +451,8 @@ def test_switch_llm_tool_during_arun_does_not_deadlock(profile_store, tmp_path):
         usage_id="test-llm",
     )
 
-    agent = Agent(llm=llm, tools=[Tool(name="SwitchLLMTool")])
+    # Resolve the tools from BUILT_IN_TOOL_CLASSES (no global registry writes).
+    agent = Agent(llm=llm, include_default_tools=["FinishTool", "SwitchLLMTool"])
     conv = LocalConversation(agent=agent, workspace=tmp_path, visualizer=None)
     conv.send_message("please switch")
 


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

Invoking the **`switch_llm`** tool mid-conversation deadlocks the conversation
runtime: the call never completes, no `SwitchLLMObservation` is emitted, and the
conversation hangs in `running`. Regression introduced in v1.23.0 by async LLM
completion (#3284).

Root cause: `run()`/`arun()` hold the `ConversationState` FIFO lock across the
entire agent step, while tools execute on worker threads (`run_in_executor`).
`switch_llm()` — reached by the tool via `switch_profile()` — re-acquires that
same lock from the tool worker thread. The lock is reentrant *per thread*, so the
cross-thread re-acquire blocks: the run loop holds the lock and is blocked
awaiting the tool, while the tool is blocked awaiting the lock.

Confirmed in pure SDK (no agent-server) by driving `arun()` with a `switch_llm`
tool call — the worker thread parks in `FIFOLock.acquire` ← `switch_llm`
(`with self._state:`) while the event-loop thread holds `_state` across
`await astep()`.

## Summary

- Track when an agent step is executing while the run loop holds the state lock
  (`_step_holds_state_lock`), set around `step()`/`astep()` in `run()`/`arun()`.
- `switch_llm()` reuses that already-held lock instead of re-acquiring it across
  threads. Standalone `switch_llm()`/`switch_profile()` calls (no active run)
  acquire the lock exactly as before.

## Issue Number

Closes #3485

## How to Test

New regression test `test_switch_llm_tool_during_arun_does_not_deadlock` drives
`arun()` with an agent that emits a `switch_llm` tool call, bounded by a timeout
so a regression fails fast instead of hanging:

- **Before** the fix: `1 failed in 10.12s` (deadlock → `arun()` cancelled →
  conversation `paused`, not `finished`).
- **After** the fix: `1 passed in 0.10s` (switch applied, conversation
  `finished`).

```
uv run pytest tests/sdk/conversation/test_switch_model.py tests/sdk/conversation/test_interrupt.py -q
# 34 passed
```

Broader sweep (run/arun, parallel tool execution, message-while-finishing):
`182 passed`. `pre-commit` (ruff, pycodestyle, pyright) passes on the changed
files.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c8d3dfb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c8d3dfb-python \
  ghcr.io/openhands/agent-server:c8d3dfb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c8d3dfb-golang-amd64
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-golang-amd64
ghcr.io/openhands/agent-server:c8d3dfb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c8d3dfb-golang-arm64
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-golang-arm64
ghcr.io/openhands/agent-server:c8d3dfb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c8d3dfb-java-amd64
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-java-amd64
ghcr.io/openhands/agent-server:c8d3dfb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c8d3dfb-java-arm64
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-java-arm64
ghcr.io/openhands/agent-server:c8d3dfb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c8d3dfb-python-amd64
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-python-amd64
ghcr.io/openhands/agent-server:c8d3dfb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c8d3dfb-python-arm64
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-python-arm64
ghcr.io/openhands/agent-server:c8d3dfb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c8d3dfb-golang
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-golang
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-golang
ghcr.io/openhands/agent-server:c8d3dfb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c8d3dfb-java
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-java
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-java
ghcr.io/openhands/agent-server:c8d3dfb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c8d3dfb-python
ghcr.io/openhands/agent-server:c8d3dfbca53f6b8c42eb1c8a40caa8cc0f4b2e22-python
ghcr.io/openhands/agent-server:vasco-fix-switch-llm-deadlock-python
ghcr.io/openhands/agent-server:c8d3dfb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c8d3dfb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c8d3dfb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->