### PR TITLE
feat(acp): launch pinned pre-installed CLI binary instead of npx

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -252,6 +252,24 @@ class ACPProviderInfo:
     callers constructing this dataclass positionally keep working.
     """
 
+    binary_name: str | None = field(default=None, compare=False)
+    """Name of the pinned, pre-installed CLI binary for this provider, if any.
+
+    The agent-server Docker image pre-installs the ACP CLIs at a fixed version
+    and exposes thin wrappers on ``PATH`` (``claude-agent-acp``, ``codex-acp``,
+    ``gemini``). When this binary resolves via :func:`shutil.which`,
+    :meth:`~openhands.sdk.settings.model.ACPAgentSettings.resolve_acp_command`
+    rewrites the provider's ``npx -y <pkg>`` launch command to run the pinned
+    binary directly — reproducible, and free of a runtime npm download — while
+    preserving any trailing args (e.g. gemini's ``--acp``). When the binary is
+    absent (local dev), the ``npx`` command is used unchanged.
+
+    ``None`` for providers without a known pre-installed binary (and implicitly
+    for ``'custom'`` servers, which have no registry entry). Defaults to
+    ``None`` so external callers constructing this dataclass positionally keep
+    working.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Curated ``acp_model`` candidate lists for the built-in providers.
@@ -371,6 +389,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             session_meta_key="claudeCode",
             available_models=_CLAUDE_MODELS,
             default_model="claude-opus-4-7",
+            binary_name="claude-agent-acp",
         ),
         "codex": ACPProviderInfo(
             key="codex",
@@ -386,6 +405,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             available_models=_CODEX_MODELS,
             default_model="gpt-5.5/medium",
             file_secrets=_CODEX_FILE_SECRETS,
+            binary_name="codex-acp",
         ),
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
@@ -406,6 +426,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # auto-routing.
             default_model="auto-gemini-2.5",
             file_secrets=_GEMINI_FILE_SECRETS,
+            binary_name="gemini",
         ),
     }
 )

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -253,21 +253,15 @@ class ACPProviderInfo:
     """
 
     binary_name: str | None = field(default=None, compare=False)
-    """Name of the pinned, pre-installed CLI binary for this provider, if any.
+    """Pinned, pre-installed CLI binary for this provider (e.g. ``codex-acp``).
 
-    The agent-server Docker image pre-installs the ACP CLIs at a fixed version
-    and exposes thin wrappers on ``PATH`` (``claude-agent-acp``, ``codex-acp``,
-    ``gemini``). When this binary resolves via :func:`shutil.which`,
+    The agent-server image installs the ACP CLIs at a fixed version as ``PATH``
+    wrappers. When this binary resolves via :func:`shutil.which`,
     :meth:`~openhands.sdk.settings.model.ACPAgentSettings.resolve_acp_command`
-    rewrites the provider's ``npx -y <pkg>`` launch command to run the pinned
-    binary directly — reproducible, and free of a runtime npm download — while
-    preserving any trailing args (e.g. gemini's ``--acp``). When the binary is
-    absent (local dev), the ``npx`` command is used unchanged.
-
-    ``None`` for providers without a known pre-installed binary (and implicitly
-    for ``'custom'`` servers, which have no registry entry). Defaults to
-    ``None`` so external callers constructing this dataclass positionally keep
-    working.
+    rewrites the ``npx -y <pkg>`` launch command to run it directly (preserving
+    trailing args like gemini's ``--acp``); otherwise the ``npx`` command is
+    used unchanged. ``None`` for providers with no pinned binary (and ``custom``
+    servers); defaulted so positional construction keeps working.
     """
 
     data_dir_env_var: str | None = None

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
 import copy
-from collections.abc import Callable, Mapping
+import shutil
+from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
 from pathlib import Path
 from typing import (
@@ -1232,20 +1233,81 @@ class ACPAgentSettings(AgentSettingsBase):
         up the default from :data:`~openhands.sdk.settings.acp_providers.ACP_PROVIDERS`.
         Raises ``ValueError`` when :attr:`acp_server` is ``'custom'`` but
         no explicit command is set (there is no sensible default to fall back to).
+
+        The resolved command is then routed through
+        :meth:`_prefer_pinned_binary`, which rewrites an ``npx``-based launch
+        command to the pinned, pre-installed CLI binary when one is available on
+        ``PATH`` (the agent-server image case). It is a no-op for local dev,
+        custom servers, and already-resolved binary commands.
         """
         if self.acp_command:
-            return list(self.acp_command)
-        if self.acp_server == "custom":
+            command = list(self.acp_command)
+        elif self.acp_server == "custom":
             raise ValueError(
                 "ACPAgentSettings.acp_command must be set when "
                 "acp_server='custom' — there is no default to fall back to"
             )
+        else:
+            info = get_acp_provider(self.acp_server)
+            if info is None:
+                raise ValueError(
+                    f"No default ACP command for acp_server={self.acp_server!r}"
+                )
+            command = list(info.default_command)
+        return self._prefer_pinned_binary(command)
+
+    @staticmethod
+    def _parse_npx_invocation(command: Sequence[str]) -> tuple[str, list[str]] | None:
+        """Parse an ``npx``-style launch command into ``(package, extra_args)``.
+
+        ``["npx", "-y", "@scope/pkg", "--flag"]`` → ``("@scope/pkg", ["--flag"])``,
+        skipping any leading ``npx`` flags such as ``-y`` / ``--yes``. Returns
+        ``None`` when *command* is not an ``npx`` invocation (e.g. an
+        already-resolved binary path), so callers leave it untouched.
+        """
+        if len(command) < 2 or command[0] != "npx":
+            return None
+        idx = 1
+        while idx < len(command) and command[idx].startswith("-"):
+            idx += 1
+        if idx >= len(command):
+            return None
+        return command[idx], list(command[idx + 1 :])
+
+    def _prefer_pinned_binary(self, command: list[str]) -> list[str]:
+        """Rewrite an ``npx`` launch command to the pinned, pre-installed binary.
+
+        The agent-server image pre-installs each ACP CLI at a fixed version and
+        exposes a wrapper on ``PATH`` (``claude-agent-acp``, ``codex-acp``,
+        ``gemini``). Both the registry default and the explicit ``acp_command``
+        canvas sends are of the form ``npx -y <pkg>``, which downloads
+        npm-latest at spawn time — non-reproducible, requires outbound npm, and
+        drifts from the image pin. When *command* is an ``npx`` invocation of
+        this provider's known package **and** the provider's
+        :attr:`~openhands.sdk.settings.acp_providers.ACPProviderInfo.binary_name`
+        resolves via :func:`shutil.which`, rewrite it to ``[binary_name, *extra]``
+        (preserving trailing args such as gemini's ``--acp``).
+
+        Returns *command* unchanged when there is no pinned binary for the
+        provider (custom servers, forward-compat entries), when *command* is not
+        an ``npx`` invocation of the provider's package (a user-supplied custom
+        binary or a different package), or when the binary is not on ``PATH``
+        (local dev) — so ``npx`` still works everywhere the binary is absent.
+        """
         info = get_acp_provider(self.acp_server)
-        if info is None:
-            raise ValueError(
-                f"No default ACP command for acp_server={self.acp_server!r}"
-            )
-        return list(info.default_command)
+        if info is None or info.binary_name is None:
+            return command
+        default_parsed = self._parse_npx_invocation(info.default_command)
+        actual_parsed = self._parse_npx_invocation(command)
+        if default_parsed is None or actual_parsed is None:
+            return command
+        default_pkg, _ = default_parsed
+        actual_pkg, extra = actual_parsed
+        if actual_pkg != default_pkg:
+            return command
+        if shutil.which(info.binary_name) is None:
+            return command
+        return [info.binary_name, *extra]
 
     def create_agent(self) -> ACPAgent:
         """Build an :class:`ACPAgent` from these settings.

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1234,11 +1234,9 @@ class ACPAgentSettings(AgentSettingsBase):
         Raises ``ValueError`` when :attr:`acp_server` is ``'custom'`` but
         no explicit command is set (there is no sensible default to fall back to).
 
-        The resolved command is then routed through
-        :meth:`_prefer_pinned_binary`, which rewrites an ``npx``-based launch
-        command to the pinned, pre-installed CLI binary when one is available on
-        ``PATH`` (the agent-server image case). It is a no-op for local dev,
-        custom servers, and already-resolved binary commands.
+        The result is routed through :meth:`_prefer_pinned_binary`, which swaps
+        an ``npx`` command for the pinned binary when it is on ``PATH`` (a no-op
+        otherwise).
         """
         if self.acp_command:
             command = list(self.acp_command)
@@ -1275,24 +1273,15 @@ class ACPAgentSettings(AgentSettingsBase):
         return command[idx], list(command[idx + 1 :])
 
     def _prefer_pinned_binary(self, command: list[str]) -> list[str]:
-        """Rewrite an ``npx`` launch command to the pinned, pre-installed binary.
+        """Swap an ``npx -y <pkg>`` command for the provider's pinned binary.
 
-        The agent-server image pre-installs each ACP CLI at a fixed version and
-        exposes a wrapper on ``PATH`` (``claude-agent-acp``, ``codex-acp``,
-        ``gemini``). Both the registry default and the explicit ``acp_command``
-        canvas sends are of the form ``npx -y <pkg>``, which downloads
-        npm-latest at spawn time — non-reproducible, requires outbound npm, and
-        drifts from the image pin. When *command* is an ``npx`` invocation of
-        this provider's known package **and** the provider's
-        :attr:`~openhands.sdk.settings.acp_providers.ACPProviderInfo.binary_name`
-        resolves via :func:`shutil.which`, rewrite it to ``[binary_name, *extra]``
-        (preserving trailing args such as gemini's ``--acp``).
-
-        Returns *command* unchanged when there is no pinned binary for the
-        provider (custom servers, forward-compat entries), when *command* is not
-        an ``npx`` invocation of the provider's package (a user-supplied custom
-        binary or a different package), or when the binary is not on ``PATH``
-        (local dev) — so ``npx`` still works everywhere the binary is absent.
+        When *command* is an ``npx`` invocation of this provider's package and
+        the provider's ``binary_name`` resolves via :func:`shutil.which`, return
+        ``[binary_name, *extra]`` (preserving trailing args like gemini's
+        ``--acp``) — running the agent-server image's pinned wrapper instead of
+        downloading npm-latest. Returned unchanged otherwise: no pinned binary
+        (custom server), a non-matching/non-npx command, or the binary not on
+        ``PATH`` (local dev).
         """
         info = get_acp_provider(self.acp_server)
         if info is None or info.binary_name is None:

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import copy
+import itertools
 import shutil
 from collections.abc import Callable, Mapping, Sequence
 from enum import Enum
@@ -1263,14 +1264,14 @@ class ACPAgentSettings(AgentSettingsBase):
         ``None`` when *command* is not an ``npx`` invocation (e.g. an
         already-resolved binary path), so callers leave it untouched.
         """
-        if len(command) < 2 or command[0] != "npx":
+        if not command or command[0] != "npx":
             return None
-        idx = 1
-        while idx < len(command) and command[idx].startswith("-"):
-            idx += 1
-        if idx >= len(command):
+        # Drop leading npx flags (-y, --yes, ...) to find the package name.
+        rest = list(itertools.dropwhile(lambda arg: arg.startswith("-"), command[1:]))
+        if not rest:
             return None
-        return command[idx], list(command[idx + 1 :])
+        package, *extra_args = rest
+        return package, extra_args
 
     def _prefer_pinned_binary(self, command: list[str]) -> list[str]:
         """Swap an ``npx -y <pkg>`` command for the provider's pinned binary.
@@ -1286,16 +1287,17 @@ class ACPAgentSettings(AgentSettingsBase):
         info = get_acp_provider(self.acp_server)
         if info is None or info.binary_name is None:
             return command
+
         default_parsed = self._parse_npx_invocation(info.default_command)
         actual_parsed = self._parse_npx_invocation(command)
         if default_parsed is None or actual_parsed is None:
             return command
+
         default_pkg, _ = default_parsed
         actual_pkg, extra = actual_parsed
-        if actual_pkg != default_pkg:
+        if actual_pkg != default_pkg or shutil.which(info.binary_name) is None:
             return command
-        if shutil.which(info.binary_name) is None:
-            return command
+
         return [info.binary_name, *extra]
 
     def create_agent(self) -> ACPAgent:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -15,7 +15,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 from acp.exceptions import RequestError as ACPRequestError
 from acp.schema import PromptResponse
-from pydantic import SecretStr
+from pydantic import Field, SecretStr
 
 from openhands.sdk.agent.acp_agent import (
     ACPAgent,
@@ -47,6 +47,7 @@ from openhands.sdk.event import (
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.llm import ImageContent, Message, TextContent
+from openhands.sdk.secret import SecretSource
 from openhands.sdk.skills import KeywordTrigger, Skill
 from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.sdk.utils.cipher import Cipher
@@ -5812,6 +5813,45 @@ class TestACPSecretsEnvInjection:
         assert not [w for w in caught if "acp_env" in str(w.message)]
 
 
+# NOTE: these ``SecretSource`` subclasses are defined at *module* level, not
+# inside the test methods that use them. ``SecretSource`` is a
+# ``DiscriminatedUnionMixin``: every subclass auto-registers in a global
+# registry, and pydantic caches its core schema (so a once-defined subclass is
+# never GC'd). A subclass defined inside a function has ``<locals>`` in its
+# qualname, which the registry rejects with "Local classes not supported!" the
+# next time *any* discriminated-union model is validated in that worker — e.g.
+# an unrelated ``ConversationState.create()`` in another test file sharing the
+# xdist worker. Module-level (importable) subclasses avoid that cross-test
+# pollution. See openhands.sdk.utils.models._get_checked_concrete_subclasses.
+class _FakeLookupSecret(SecretSource):
+    """A ``LookupSecret``-shaped source whose ``get_value()`` returns a literal."""
+
+    stored_value: str
+
+    def get_value(self) -> str | None:
+        return self.stored_value
+
+
+class _CountingLookupSecret(SecretSource):
+    """A lookup source that records each ``get_value()`` call (to assert it is
+    *not* invoked when ``acp_env`` shadows the key)."""
+
+    stored_value: str
+    calls: list[int] = Field(default_factory=list)
+
+    def get_value(self) -> str | None:
+        self.calls.append(1)
+        return self.stored_value
+
+
+class _BrokenSecret(SecretSource):
+    """A source whose ``get_value()`` raises, to verify a failing lookup is
+    treated as "skip" rather than taking the subprocess down."""
+
+    def get_value(self) -> str | None:
+        raise OSError("network down")
+
+
 class TestACPSecretRegistryEnvInjection:
     """Tests for secret injection from the conversation's secret_registry.
 
@@ -5913,15 +5953,10 @@ class TestACPSecretRegistryEnvInjection:
         This is the wire shape canvas actually sends: a ``LookupSecret``
         whose ``get_value()`` fetches over HTTP from the agent-server's
         ``/api/settings/secrets/{name}`` endpoint.
+
+        ``_FakeLookupSecret`` is module-level (see the note above the test
+        class) so it does not pollute the global discriminated-union registry.
         """
-        from openhands.sdk.secret import SecretSource
-
-        class _FakeLookupSecret(SecretSource):
-            stored_value: str
-
-            def get_value(self) -> str | None:
-                return self.stored_value
-
         agent = _make_agent()
         env = self._run_start_capturing_env(
             agent,
@@ -5948,19 +5983,10 @@ class TestACPSecretRegistryEnvInjection:
         LookupSecret performs an HTTP request in production; calling it for
         a key that ``acp_env`` is about to override wastes a round-trip and
         can emit spurious lookup-failure warnings.
+
+        ``_CountingLookupSecret`` is module-level (see the note above the test
+        class) so it does not pollute the global discriminated-union registry.
         """
-        from pydantic import Field
-
-        from openhands.sdk.secret import SecretSource
-
-        class _CountingLookupSecret(SecretSource):
-            stored_value: str
-            calls: list[int] = Field(default_factory=list)
-
-            def get_value(self) -> str | None:
-                self.calls.append(1)
-                return self.stored_value
-
         secret = _CountingLookupSecret(stored_value="from-registry")
         agent = _make_agent(acp_env={"GITHUB_TOKEN": "from-acp-env"})
         env = self._run_start_capturing_env(
@@ -6015,13 +6041,10 @@ class TestACPSecretRegistryEnvInjection:
         that ``None`` as "skip", so a transient secret-source failure
         (network blip, expired token) doesn't take the whole ACP
         subprocess down.
+
+        ``_BrokenSecret`` is module-level (see the note above the test class)
+        so it does not pollute the global discriminated-union registry.
         """
-        from openhands.sdk.secret import SecretSource
-
-        class _BrokenSecret(SecretSource):
-            def get_value(self) -> str | None:
-                raise OSError("network down")
-
         agent = _make_agent()
         env = self._run_start_capturing_env(
             agent,

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5813,16 +5813,12 @@ class TestACPSecretsEnvInjection:
         assert not [w for w in caught if "acp_env" in str(w.message)]
 
 
-# NOTE: these ``SecretSource`` subclasses are defined at *module* level, not
-# inside the test methods that use them. ``SecretSource`` is a
-# ``DiscriminatedUnionMixin``: every subclass auto-registers in a global
-# registry, and pydantic caches its core schema (so a once-defined subclass is
-# never GC'd). A subclass defined inside a function has ``<locals>`` in its
-# qualname, which the registry rejects with "Local classes not supported!" the
-# next time *any* discriminated-union model is validated in that worker — e.g.
-# an unrelated ``ConversationState.create()`` in another test file sharing the
-# xdist worker. Module-level (importable) subclasses avoid that cross-test
-# pollution. See openhands.sdk.utils.models._get_checked_concrete_subclasses.
+# NOTE: module-level on purpose. A ``SecretSource`` (DiscriminatedUnionMixin)
+# subclass defined inside a function auto-registers globally and, having
+# ``<locals>`` in its qualname, makes the registry raise "Local classes not
+# supported!" for any later discriminated-union validation in the same xdist
+# worker (e.g. an unrelated ConversationState deserialization). Module-level
+# (importable) subclasses avoid that pollution.
 class _FakeLookupSecret(SecretSource):
     """A ``LookupSecret``-shaped source whose ``get_value()`` returns a literal."""
 
@@ -5953,9 +5949,6 @@ class TestACPSecretRegistryEnvInjection:
         This is the wire shape canvas actually sends: a ``LookupSecret``
         whose ``get_value()`` fetches over HTTP from the agent-server's
         ``/api/settings/secrets/{name}`` endpoint.
-
-        ``_FakeLookupSecret`` is module-level (see the note above the test
-        class) so it does not pollute the global discriminated-union registry.
         """
         agent = _make_agent()
         env = self._run_start_capturing_env(
@@ -5983,9 +5976,6 @@ class TestACPSecretRegistryEnvInjection:
         LookupSecret performs an HTTP request in production; calling it for
         a key that ``acp_env`` is about to override wastes a round-trip and
         can emit spurious lookup-failure warnings.
-
-        ``_CountingLookupSecret`` is module-level (see the note above the test
-        class) so it does not pollute the global discriminated-union registry.
         """
         secret = _CountingLookupSecret(stored_value="from-registry")
         agent = _make_agent(acp_env={"GITHUB_TOKEN": "from-acp-env"})
@@ -6041,9 +6031,6 @@ class TestACPSecretRegistryEnvInjection:
         that ``None`` as "skip", so a transient secret-source failure
         (network blip, expired token) doesn't take the whole ACP
         subprocess down.
-
-        ``_BrokenSecret`` is module-level (see the note above the test class)
-        so it does not pollute the global discriminated-union registry.
         """
         agent = _make_agent()
         env = self._run_start_capturing_env(

--- a/tests/sdk/conversation/test_conversation_secrets_constructor.py
+++ b/tests/sdk/conversation/test_conversation_secrets_constructor.py
@@ -17,12 +17,11 @@ from openhands.sdk.workspace import RemoteWorkspace
 from .conftest import create_mock_http_client
 
 
-# NOTE: module-level (not function-local) on purpose. ``SecretSource`` is a
-# ``DiscriminatedUnionMixin``; a subclass defined inside a function has
-# ``<locals>`` in its qualname and, once registered, makes the global registry
-# raise "Local classes not supported!" for any later discriminated-union
-# validation in the same xdist worker (e.g. an unrelated ConversationState
-# deserialization). See openhands.sdk.utils.models._get_checked_concrete_subclasses.
+# NOTE: module-level on purpose. A function-local ``SecretSource``
+# (DiscriminatedUnionMixin) subclass auto-registers globally and makes the
+# registry raise "Local classes not supported!" on any later discriminated-union
+# validation in the same xdist worker (e.g. unrelated ConversationState
+# deserialization).
 class _DynamicTokenSource(SecretSource):
     def get_value(self):
         return "dynamic-token-789"

--- a/tests/sdk/conversation/test_conversation_secrets_constructor.py
+++ b/tests/sdk/conversation/test_conversation_secrets_constructor.py
@@ -17,6 +17,22 @@ from openhands.sdk.workspace import RemoteWorkspace
 from .conftest import create_mock_http_client
 
 
+# NOTE: module-level (not function-local) on purpose. ``SecretSource`` is a
+# ``DiscriminatedUnionMixin``; a subclass defined inside a function has
+# ``<locals>`` in its qualname and, once registered, makes the global registry
+# raise "Local classes not supported!" for any later discriminated-union
+# validation in the same xdist worker (e.g. an unrelated ConversationState
+# deserialization). See openhands.sdk.utils.models._get_checked_concrete_subclasses.
+class _DynamicTokenSource(SecretSource):
+    def get_value(self):
+        return "dynamic-token-789"
+
+
+class _CallableApiKeySource(SecretSource):
+    def get_value(self):
+        return "callable-api-key"
+
+
 def create_test_agent() -> Agent:
     """Create a test agent."""
     llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
@@ -67,18 +83,10 @@ def test_local_conversation_constructor_with_callable_secrets():
     """Test LocalConversation constructor with callable secrets."""
     agent = create_test_agent()
 
-    class MyLocalConversationConstructorDynamicTokenSource(SecretSource):
-        def get_value(self):
-            return "dynamic-token-789"
-
-    class MyLocalConversationConstructorApiKeySource(SecretSource):
-        def get_value(self):
-            return "callable-api-key"
-
     test_secrets = {
         "STATIC_KEY": "static-value",
-        "DYNAMIC_TOKEN": MyLocalConversationConstructorDynamicTokenSource(),
-        "API_KEY": MyLocalConversationConstructorApiKeySource(),
+        "DYNAMIC_TOKEN": _DynamicTokenSource(),
+        "API_KEY": _CallableApiKeySource(),
     }
 
     with tempfile.TemporaryDirectory() as tmpdir:

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -6,16 +6,12 @@ from openhands.sdk.conversation.secret_registry import SecretRegistry
 from openhands.sdk.secret import SecretSource, StaticSecret
 
 
-# NOTE: these ``SecretSource`` subclasses are defined at *module* level. As a
-# ``DiscriminatedUnionMixin``, every subclass auto-registers globally and is
-# never GC'd (pydantic caches its schema); a subclass defined inside a function
-# has ``<locals>`` in its qualname, which the registry rejects with "Local
-# classes not supported!" the next time any discriminated-union model is
-# validated in the same (xdist) worker — breaking unrelated tests such as
-# ConversationState (de)serialization. Defining them once at module level also
-# avoids the "Duplicate class definition" guard that two same-named function-
-# local classes would trip. See
-# openhands.sdk.utils.models._get_checked_concrete_subclasses.
+# NOTE: module-level on purpose. A function-local ``SecretSource``
+# (DiscriminatedUnionMixin) subclass auto-registers globally and makes the
+# registry raise "Local classes not supported!" on any later discriminated-union
+# validation in the same xdist worker (breaking unrelated ConversationState
+# (de)serialization). Defining each once here also avoids the "Duplicate class
+# definition" guard that two same-named function-local classes would trip.
 class MyTokenSource(SecretSource):
     def get_value(self):
         return "dynamic-token-456"

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -6,6 +6,31 @@ from openhands.sdk.conversation.secret_registry import SecretRegistry
 from openhands.sdk.secret import SecretSource, StaticSecret
 
 
+# NOTE: these ``SecretSource`` subclasses are defined at *module* level. As a
+# ``DiscriminatedUnionMixin``, every subclass auto-registers globally and is
+# never GC'd (pydantic caches its schema); a subclass defined inside a function
+# has ``<locals>`` in its qualname, which the registry rejects with "Local
+# classes not supported!" the next time any discriminated-union model is
+# validated in the same (xdist) worker — breaking unrelated tests such as
+# ConversationState (de)serialization. Defining them once at module level also
+# avoids the "Duplicate class definition" guard that two same-named function-
+# local classes would trip. See
+# openhands.sdk.utils.models._get_checked_concrete_subclasses.
+class MyTokenSource(SecretSource):
+    def get_value(self):
+        return "dynamic-token-456"
+
+
+class MyFailingTokenSource(SecretSource):
+    def get_value(self):
+        raise ValueError("Secret retrieval failed")
+
+
+class MyWorkingTokenSource(SecretSource):
+    def get_value(self):
+        return "working-value"
+
+
 def test_update_secrets_with_static_values():
     """Test updating secrets with static string values."""
     secret_registry = SecretRegistry()
@@ -109,10 +134,6 @@ def test_get_secrets_as_env_vars_callable_values():
     """Test get_secrets_as_env_vars with callable values."""
     secret_registry = SecretRegistry()
 
-    class MyTokenSource(SecretSource):
-        def get_value(self):
-            return "dynamic-token-456"
-
     secret_registry.update_secrets(
         {
             "STATIC_KEY": "static-value",
@@ -129,14 +150,6 @@ def test_get_secrets_as_env_vars_callable_values():
 def test_get_secrets_as_env_vars_handles_callable_exceptions():
     """Test that get_secrets_as_env_vars handles exceptions from callables."""
     secret_registry = SecretRegistry()
-
-    class MyFailingTokenSource(SecretSource):
-        def get_value(self):
-            raise ValueError("Secret retrieval failed")
-
-    class MyWorkingTokenSource(SecretSource):
-        def get_value(self):
-            return "working-value"
 
     secret_registry.update_secrets(
         {
@@ -176,10 +189,6 @@ def test_get_secret_value_callable():
     """Test get_secret_value with callable values."""
     secret_registry = SecretRegistry()
 
-    class MyTokenSource(SecretSource):
-        def get_value(self):
-            return "dynamic-token-456"
-
     secret_registry.update_secrets(
         {
             "STATIC_KEY": "static-value",
@@ -194,14 +203,6 @@ def test_get_secret_value_callable():
 def test_get_secret_value_handles_exceptions():
     """Test that get_secret_value handles exceptions from callables gracefully."""
     secret_registry = SecretRegistry()
-
-    class MyFailingTokenSource(SecretSource):
-        def get_value(self):
-            raise ValueError("Secret retrieval failed")
-
-    class MyWorkingTokenSource(SecretSource):
-        def get_value(self):
-            return "working-value"
 
     secret_registry.update_secrets(
         {

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -42,6 +42,8 @@ class TestACPProviderInfo:
         assert info.session_meta_key == "claudeCode"
         assert info.default_model == "claude-opus-4-7"
         assert any(m.id == "claude-opus-4-7" for m in info.available_models)
+        # Pinned binary exposed by the agent-server image wrappers.
+        assert info.binary_name == "claude-agent-acp"
 
     def test_codex_metadata(self):
         info = ACP_PROVIDERS["codex"]
@@ -57,6 +59,7 @@ class TestACPProviderInfo:
         assert info.session_meta_key is None
         assert info.default_model == "gpt-5.5/medium"
         assert any(m.id == "gpt-5.5/medium" for m in info.available_models)
+        assert info.binary_name == "codex-acp"
 
     def test_gemini_cli_metadata(self):
         info = ACP_PROVIDERS["gemini-cli"]
@@ -72,6 +75,9 @@ class TestACPProviderInfo:
         assert info.session_meta_key is None
         assert info.default_model == "auto-gemini-2.5"
         assert any(m.id == "auto-gemini-2.5" for m in info.available_models)
+        # The Gemini CLI's ACP binary is just ``gemini`` (the ``--acp`` flag is
+        # a trailing arg, preserved by resolve_acp_command on rewrite).
+        assert info.binary_name == "gemini"
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1,4 +1,5 @@
 import json
+import shutil
 
 import pytest
 from fastmcp.mcp_config import MCPConfig
@@ -31,6 +32,7 @@ from openhands.sdk.settings import (
     CondenserSettings,
     VerificationSettings,
 )
+from openhands.sdk.settings.model import ACPServerKind
 from openhands.sdk.workspace import LocalWorkspace
 
 
@@ -575,8 +577,16 @@ def test_llm_roundtrip_preserves_llm_model() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_acp_create_agent_uses_server_default_command() -> None:
-    """With ``acp_server`` set but no explicit command, use the built-in default."""
+def test_acp_create_agent_uses_server_default_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With ``acp_server`` set but no explicit command, use the built-in default.
+
+    Pin ``shutil.which`` to ``None`` so the ``npx`` default is asserted
+    deterministically — on a host where the pinned ``claude-agent-acp`` binary
+    is installed, :meth:`resolve_acp_command` would (correctly) rewrite to it.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _: None)
     settings = ACPAgentSettings(acp_server="claude-code", acp_model="claude-opus-4-6")
     agent = settings.create_agent()
     assert isinstance(agent, ACPAgent)
@@ -588,8 +598,15 @@ def test_acp_create_agent_uses_server_default_command() -> None:
     assert agent.acp_model == "claude-opus-4-6"
 
 
-def test_acp_resolve_command_for_known_servers() -> None:
-    """Every non-custom choice must map to a runnable default."""
+def test_acp_resolve_command_for_known_servers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Every non-custom choice must map to a runnable default.
+
+    With no pinned binary on ``PATH`` (``shutil.which`` → ``None``), the
+    default stays the ``npx`` invocation.
+    """
+    monkeypatch.setattr(shutil, "which", lambda _: None)
     for server in ("claude-code", "codex", "gemini-cli"):
         settings = ACPAgentSettings(acp_server=server)
         cmd = settings.resolve_acp_command()
@@ -622,6 +639,138 @@ def test_acp_custom_server_with_command_resolves() -> None:
         acp_command=["bin", "--flag"],
     )
     assert settings.resolve_acp_command() == ["bin", "--flag"]
+
+
+# ---------------------------------------------------------------------------
+# resolve_acp_command() — prefer the pinned, pre-installed CLI binary
+#
+# The agent-server image pre-installs the ACP CLIs and exposes them as wrappers
+# on PATH (claude-agent-acp / codex-acp / gemini). resolve_acp_command rewrites
+# the ``npx -y <pkg>`` launch command — the registry default AND the explicit
+# acp_command canvas sends — to run the pinned binary directly when it is on
+# PATH (reproducible, no runtime npm download), preserving trailing args. When
+# the binary is absent (local dev), it falls back to the npx command unchanged.
+# ---------------------------------------------------------------------------
+
+
+def _which_returning(*available: str):
+    """Build a ``shutil.which`` stub resolving only the named binaries."""
+    paths = {name: f"/usr/local/bin/{name}" for name in available}
+    return lambda name: paths.get(name)
+
+
+@pytest.mark.parametrize(
+    ("server", "binary", "expected"),
+    [
+        ("claude-code", "claude-agent-acp", ["claude-agent-acp"]),
+        ("codex", "codex-acp", ["codex-acp"]),
+        # gemini's default carries a trailing ``--acp`` that must be preserved.
+        ("gemini-cli", "gemini", ["gemini", "--acp"]),
+    ],
+)
+def test_acp_resolve_command_rewrites_default_to_pinned_binary(
+    monkeypatch: pytest.MonkeyPatch,
+    server: ACPServerKind,
+    binary: str,
+    expected: list[str],
+) -> None:
+    """(a) Registry default + binary on PATH → run the pinned binary directly."""
+    monkeypatch.setattr(shutil, "which", _which_returning(binary))
+    settings = ACPAgentSettings(acp_server=server)
+    assert settings.resolve_acp_command() == expected
+
+
+def test_acp_resolve_command_rewrites_explicit_npx_command(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(b) Explicit ``npx -y <pkg>`` (what canvas sends) + binary on PATH →
+    rewritten to the pinned binary, with trailing args preserved."""
+    monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
+    settings = ACPAgentSettings(
+        acp_server="codex",
+        acp_command=["npx", "-y", "@zed-industries/codex-acp", "--verbose"],
+    )
+    assert settings.resolve_acp_command() == ["codex-acp", "--verbose"]
+
+
+def test_acp_resolve_command_keeps_npx_when_binary_absent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(c) Binary not on PATH (local dev) → the ``npx`` command is unchanged."""
+    monkeypatch.setattr(shutil, "which", lambda _: None)
+    settings = ACPAgentSettings(acp_server="codex")
+    assert settings.resolve_acp_command() == [
+        "npx",
+        "-y",
+        "@zed-industries/codex-acp",
+    ]
+
+
+def test_acp_resolve_command_leaves_custom_binary_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(d) A non-npx / user-supplied command is never rewritten, even when the
+    provider's pinned binary is on PATH."""
+    monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
+    settings = ACPAgentSettings(
+        acp_server="codex",
+        acp_command=["/opt/my-codex", "--flag"],
+    )
+    assert settings.resolve_acp_command() == ["/opt/my-codex", "--flag"]
+
+
+def test_acp_resolve_command_leaves_unknown_package_untouched(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """(d) An ``npx`` command for a *different* package is not rewritten — the
+    pinned binary only stands in for the provider's own package."""
+    monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
+    settings = ACPAgentSettings(
+        acp_server="codex",
+        acp_command=["npx", "-y", "@other/some-acp"],
+    )
+    assert settings.resolve_acp_command() == ["npx", "-y", "@other/some-acp"]
+
+
+def test_acp_resolve_command_custom_server_never_rewritten(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """``custom`` has no registry entry (hence no pinned binary), so even a
+    command that looks exactly like codex's is returned verbatim."""
+    monkeypatch.setattr(shutil, "which", _which_returning("codex-acp", "gemini"))
+    settings = ACPAgentSettings(
+        acp_server="custom",
+        acp_command=["npx", "-y", "@zed-industries/codex-acp"],
+    )
+    assert settings.resolve_acp_command() == [
+        "npx",
+        "-y",
+        "@zed-industries/codex-acp",
+    ]
+
+
+def test_acp_resolve_command_queries_which_with_binary_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The PATH probe uses the provider's ``binary_name``, not the npm package."""
+    queried: list[str] = []
+
+    def fake_which(name: str) -> str | None:
+        queried.append(name)
+        return None
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    ACPAgentSettings(acp_server="gemini-cli").resolve_acp_command()
+    assert queried == ["gemini"]
+
+
+def test_acp_create_agent_uses_pinned_binary_when_present(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """End-to-end: create_agent() bakes the rewritten command into the agent."""
+    monkeypatch.setattr(shutil, "which", _which_returning("codex-acp"))
+    agent = ACPAgentSettings(acp_server="codex").create_agent()
+    assert agent.acp_command == ["codex-acp"]
 
 
 def test_acp_api_key_env_var_maps_known_servers() -> None:
@@ -1192,9 +1341,13 @@ def test_acp_settings_base_url_env_var_from_registry() -> None:
     )
 
 
-def test_acp_resolve_command_uses_registry_defaults() -> None:
+def test_acp_resolve_command_uses_registry_defaults(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     from openhands.sdk.settings.acp_providers import ACP_PROVIDERS
 
+    # No pinned binary on PATH → registry npx default is returned verbatim.
+    monkeypatch.setattr(shutil, "which", lambda _: None)
     for server_key in ("claude-code", "codex", "gemini-cli"):
         settings = ACPAgentSettings(acp_server=server_key)
         expected = list(ACP_PROVIDERS[server_key].default_command)


### PR DESCRIPTION
## What

Make the SDK launch the **pinned, pre-installed** ACP CLI binary instead of `npx -y @<pkg>`.

The agent-server image (`openhands-agent-server/.../docker/Dockerfile`) pre-installs the ACP CLIs at a fixed version and exposes wrappers on `PATH`: `/usr/local/bin/{claude-agent-acp, codex-acp, gemini}`. But both launch paths ignored them:

- the SDK registry `default_command` is `("npx", "-y", "@<pkg>", …)`, and
- agent-canvas sends an explicit `acp_command=["npx","-y","@<pkg>"]` in its `StartConversationRequest`.

Both run `npx` → download **npm-latest at spawn time**: non-reproducible, needs outbound npm, and drifts from the Dockerfile pin.

## How

- **`settings/acp_providers.py`** — add a `binary_name` field to `ACPProviderInfo`
  (`claude-code`→`claude-agent-acp`, `codex`→`codex-acp`, `gemini-cli`→`gemini`, `None` for custom).
  Additive, defaulted (`field(default=None, compare=False)`) → **API-breakage check stays green**.
- **`settings/model.py` → `ACPAgentSettings.resolve_acp_command()`** — the single chokepoint that handles **both**
  the explicit `acp_command` and the registry default. Normalize the command: when it is an
  `["npx","-y","<provider-pkg>", *extra]` invocation **and** the provider's `binary_name` resolves via
  `shutil.which()`, rewrite to `["<binary_name>", *extra]` — preserving trailing args (e.g. gemini's `--acp`).
  Falls back to the `npx` command **unchanged** when:
  - the binary isn't on `PATH` (local dev),
  - the server is `custom` / has no registry entry,
  - the command isn't an `npx` invocation (user-supplied binary), or
  - the `npx` command is for a *different* package.

Done in `resolve_acp_command`, **not** in `acp_agent.py:_start_acp_server` — OpenHands/agent-canvas#2114 (now merged as OpenHands/OpenHands#3492) edits that path; this PR stays confined to `settings/` to avoid conflicts. Because `StartConversationRequest` validation calls `create_agent()` → `resolve_acp_command()` **inside the runtime pod**, `shutil.which()` resolves against the pod's pre-installed wrappers — so the rewrite takes effect for both the registry default and the canvas-sent `acp_command`.

## Tests

`resolve_acp_command` unit tests (mocking `shutil.which`): default + binary on PATH → `[binary, *args]`; explicit npx + binary → rewritten; binary absent → npx unchanged; custom binary / unknown package / custom server → untouched; `which` probed with `binary_name`; end-to-end via `create_agent()`. Pre-existing npx-asserting tests pin `shutil.which`→`None` so they're deterministic regardless of whether the binaries happen to be installed locally. Registry metadata tests assert the three `binary_name` values.

## Real end-to-end validation (against a PR-built image)

Built the `python` agent-server image from this branch and exercised the live path in-container:

- **In-pod rewrite** — all three providers' npx defaults *and* the explicit canvas-style npx command rewrite to the pinned binary (`claude-agent-acp` / `codex-acp` / `gemini --acp`, trailing arg preserved); custom/absent-binary fall back to npx.
- **Server path** — `POST /api/conversations` with `agent_kind=acp` stores the resolved `acp_command` (`['codex-acp']`, `['claude-agent-acp']`) — proving the rewrite runs at request-validation time in the pod.
- **Codex** — container log: `ACP server initialized: agent_name='codex-acp', agent_version='0.15.0'` (the Dockerfile pin), **0 npx** in logs.
- **Claude (real API round-trip)** — routed `claude-agent-acp` through a LiteLLM proxy via `ANTHROPIC_BASE_URL`; prompt *"reply with exactly: ACP_E2E_OK"* → genuine model response `ACP_E2E_OK`, launched via pinned `claude-agent-acp@0.30.0`.

✅ ruff (check + format), pyright, api-breakage clean; full `sdk-tests` suite green.

## Also in this PR

- **Merge of `main`** — integrates OpenHands/OpenHands#3492 (per-conversation CLI data-dir isolation); `ACPProviderInfo` now carries both `binary_name` and `data_dir_env_var`.
- **Test-isolation fix** (`test(sdk): hoist test-local SecretSource subclasses to module level`) — several tests defined `SecretSource` subclasses *inside* test functions. `SecretSource` is a `DiscriminatedUnionMixin`: such subclasses auto-register globally, are never GC'd (pydantic caches their schema), and a function-local one (`<locals>` in its qualname) makes the registry raise *"Local classes not supported!"* on the next `ConversationState` deserialization sharing that xdist worker. Latent on `main`; this branch's added tests shifted xdist's worker distribution and exposed it (the `sdk-tests` failures). Fixed by hoisting the throwaway subclasses to module level (the supported pattern) in `test_acp_agent.py`, `test_secrets_manager.py`, and `test_conversation_secrets_constructor.py` — no production-code change.

## Notes

- Part of OpenHands/agent-canvas#2117 (task 6).
- The typescript-client `acp-providers.json` mirror is intentionally **not** updated — canvas doesn't consume `binary_name`. Will update only if a drift check fails.
- The same test-local-`SecretSource` pattern still exists in `tests/cross/test_agent_secrets_integration.py` (a separate `cross-tests` job/process, not currently failing) — left for a follow-up to keep this PR scoped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dd0edb8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dd0edb8-python \
  ghcr.io/openhands/agent-server:dd0edb8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dd0edb8-golang-amd64
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-golang-amd64
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-golang-amd64
ghcr.io/openhands/agent-server:dd0edb8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dd0edb8-golang-arm64
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-golang-arm64
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-golang-arm64
ghcr.io/openhands/agent-server:dd0edb8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dd0edb8-java-amd64
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-java-amd64
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-java-amd64
ghcr.io/openhands/agent-server:dd0edb8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dd0edb8-java-arm64
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-java-arm64
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-java-arm64
ghcr.io/openhands/agent-server:dd0edb8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dd0edb8-python-amd64
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-python-amd64
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-python-amd64
ghcr.io/openhands/agent-server:dd0edb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dd0edb8-python-arm64
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-python-arm64
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-python-arm64
ghcr.io/openhands/agent-server:dd0edb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dd0edb8-golang
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-golang
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-golang
ghcr.io/openhands/agent-server:dd0edb8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:dd0edb8-java
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-java
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-java
ghcr.io/openhands/agent-server:dd0edb8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:dd0edb8-python
ghcr.io/openhands/agent-server:dd0edb818b8db4f6e7df551f6d9261809996cd69-python
ghcr.io/openhands/agent-server:acp-prefer-pinned-binary-python
ghcr.io/openhands/agent-server:dd0edb8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dd0edb8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dd0edb8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
