### PR TITLE
Register claude-opus-4-8 in Claude Code ACP provider

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -267,6 +267,7 @@ class ACPProviderInfo:
 # the newest 1M-capable model — keep their labels version-less to match).
 # ``opusplan`` routes planning to Opus and execution to Sonnet.
 _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="claude-opus-4-8", label="Claude Opus 4.8"),
     ACPModelOption(id="claude-opus-4-7", label="Claude Opus 4.7"),
     ACPModelOption(id="claude-opus-4-6", label="Claude Opus 4.6"),
     ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),
@@ -370,7 +371,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             supports_runtime_model_switch=True,
             session_meta_key="claudeCode",
             available_models=_CLAUDE_MODELS,
-            default_model="claude-opus-4-7",
+            default_model="claude-opus-4-8",
         ),
         "codex": ACPProviderInfo(
             key="codex",

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -40,7 +40,8 @@ class TestACPProviderInfo:
         # ... but it DOES support session/set_model for mid-conversation switches.
         assert info.supports_runtime_model_switch is True
         assert info.session_meta_key == "claudeCode"
-        assert info.default_model == "claude-opus-4-7"
+        assert info.default_model == "claude-opus-4-8"
+        assert any(m.id == "claude-opus-4-8" for m in info.available_models)
         assert any(m.id == "claude-opus-4-7" for m in info.available_models)
 
     def test_codex_metadata(self):


### PR DESCRIPTION
- [ ] A human has tested these changes.

---

## Why

#3424 added `claude-opus-4-8` to the SDK's verified model lists (`VERIFIED_ANTHROPIC_MODELS`, `VERIFIED_OPENHANDS_MODELS`), to `model_features.py` (`PROMPT_CACHE_MODELS`), and to the eval `resolve_model_config.py`. However, the Claude Code ACP provider's model picker in `openhands-sdk/openhands/sdk/settings/acp_providers.py` — `_CLAUDE_MODELS` and its corresponding `default_model` — was not bumped alongside it. As a result, ACP users selecting the `claude-code` harness still see `claude-opus-4-7` as the newest Opus option and as the preselected default.

This PR closes that gap so the Claude Code ACP picker matches the verified model registry.

## Summary

- Add `ACPModelOption(id="claude-opus-4-8", label="Claude Opus 4.8")` to `_CLAUDE_MODELS` in `openhands-sdk/openhands/sdk/settings/acp_providers.py`, placed above the existing `claude-opus-4-7` / `claude-opus-4-6` entries (matching the established ordering convention where newer Opus versions come first).
- Promote `claude-opus-4-8` to the `claude-code` provider's `default_model`, mirroring how `claude-opus-4-7` previously became the default when it was added.
- Update `tests/sdk/settings/test_acp_providers.py::TestACPProviderInfo::test_claude_code_metadata` to assert the new default and to keep verifying `claude-opus-4-7` remains in `available_models` (so we don't accidentally regress the picker).

## Issue Number

Fixes #3488

## How to Test

```bash
# Targeted: ACP provider metadata + Claude Code picker assertions
uv run pytest tests/sdk/settings/test_acp_providers.py -v

# Broader sanity: full ACP settings + ACPAgent suites (these consume
# the provider registry / model picker)
uv run pytest tests/sdk/settings/ tests/sdk/agent/test_acp_agent.py -q

# Lint/format/type-check the touched files
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/settings/acp_providers.py \
  tests/sdk/settings/test_acp_providers.py
```

Locally observed: `38 passed` for `test_acp_providers.py` and `345 passed` for the combined settings + `test_acp_agent.py` run; pre-commit passes (ruff format, ruff lint, pycodestyle, pyright, import-dependency rules, tool registration).

## Video/Screenshots

N/A — registry-only change. No runtime/UI surface beyond the model picker's contents, which is covered by the updated unit test.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Scope is intentionally narrow: only the `_CLAUDE_MODELS` tuple, the `claude-code` provider's `default_model`, and the corresponding test assertion are touched. No other model entries, ordering, formatting, or unrelated providers are modified — consistent with `.github/run-eval/ADDINGMODEL.md`'s "only add new content" guidance.
- Like #3424, this PR does **not** add `claude-opus-4-8` to `REASONING_EFFORT_MODELS` or `EXTENDED_THINKING_MODELS`, matching the existing treatment of `claude-opus-4-7`.
- The `default_model` bump is the one existing-code change: the established pattern in this repo has been to promote each newest released Opus to the Claude Code default (4.6 → 4.7 → 4.8) so users get the latest model out of the box without a custom `acp_model` override.

---
_This PR was opened by an AI agent (OpenHands) on behalf of @juanmichelini in response to a request on #3488._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3ec7d6bb-83ae-4862-ae41-3e70f308fb08)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ca2ebeb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ca2ebeb-python \
  ghcr.io/openhands/agent-server:ca2ebeb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ca2ebeb-golang-amd64
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-golang-amd64
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-golang-amd64
ghcr.io/openhands/agent-server:ca2ebeb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ca2ebeb-golang-arm64
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-golang-arm64
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-golang-arm64
ghcr.io/openhands/agent-server:ca2ebeb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ca2ebeb-java-amd64
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-java-amd64
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-java-amd64
ghcr.io/openhands/agent-server:ca2ebeb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ca2ebeb-java-arm64
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-java-arm64
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-java-arm64
ghcr.io/openhands/agent-server:ca2ebeb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ca2ebeb-python-amd64
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-python-amd64
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-python-amd64
ghcr.io/openhands/agent-server:ca2ebeb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ca2ebeb-python-arm64
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-python-arm64
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-python-arm64
ghcr.io/openhands/agent-server:ca2ebeb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ca2ebeb-golang
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-golang
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-golang
ghcr.io/openhands/agent-server:ca2ebeb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ca2ebeb-java
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-java
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-java
ghcr.io/openhands/agent-server:ca2ebeb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ca2ebeb-python
ghcr.io/openhands/agent-server:ca2ebebac85ef0ab533e59eacccc90daf0e37e05-python
ghcr.io/openhands/agent-server:openhands-add-claude-opus-4-8-to-acp-providers-python
ghcr.io/openhands/agent-server:ca2ebeb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ca2ebeb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ca2ebeb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->