### PR TITLE
feat(acp): per-conversation CLI data-dir isolation for grouped sandboxes

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -74,6 +74,7 @@ from openhands.sdk.settings.acp_providers import (
     build_session_model_meta,
     default_acp_file_secrets,
     detect_acp_provider_by_agent_name,
+    detect_acp_provider_by_command,
 )
 from openhands.sdk.tool import Tool  # noqa: TC002
 from openhands.sdk.tool.builtins.finish import FinishAction, FinishObservation
@@ -1069,6 +1070,25 @@ class ACPAgent(AgentBase):
             "servers with different file-auth schemes."
         ),
     )
+    acp_isolate_data_dir: bool = Field(
+        default=False,
+        description=(
+            "Give the ACP subprocess a per-conversation CLI data/config root "
+            "instead of the shared user ``HOME``. When True and the provider is "
+            "recognised, point its data-dir env var "
+            "(``CODEX_HOME`` / ``CLAUDE_CONFIG_DIR`` / ``HOME``; see "
+            "``ACPProviderInfo.data_dir_env_var``) at "
+            "``<persistence_dir>/acp/<provider>`` — the same per-conversation "
+            "tree materialised file-secrets use. Required for correctness when "
+            "several of a user's conversations share one sandbox "
+            "(``SandboxGroupingStrategy != NO_GROUPING``), where they would "
+            "otherwise race on one set of CLI auth/config/cache/lock files "
+            "(see #1019). Off by default: with one sandbox per conversation the "
+            "shared HOME is already private, and relocating it would hide a "
+            "pre-existing interactive login. Downstream policy decides when to "
+            "enable it; the SDK owns where the root lives."
+        ),
+    )
 
     def model_post_init(self, __context: object) -> None:
         super().model_post_init(__context)
@@ -1604,6 +1624,52 @@ class ACPAgent(AgentBase):
             root = Path(state.workspace.working_dir) / ".openhands" / "acp" / subdir
         return Path(os.path.abspath(root))
 
+    def _isolate_acp_data_dir(
+        self, state: ConversationState, env: dict[str, str]
+    ) -> None:
+        """Relocate the CLI's data/config root to a per-conversation directory.
+
+        When :attr:`acp_isolate_data_dir` is set, point the recognised provider's
+        data-dir env var (``CODEX_HOME`` / ``CLAUDE_CONFIG_DIR`` / ``HOME``) at
+        ``<persistence_dir>/acp/<provider>`` — the same per-conversation tree
+        :meth:`_materialise_file_secrets` seeds auth into, so a relocated
+        ``CODEX_HOME`` and a materialised ``auth.json`` always agree on one
+        directory. This stops conversations that share a sandbox
+        (``SandboxGroupingStrategy != NO_GROUPING``) from racing on a single
+        shared HOME's CLI auth/config/cache/lock files (#1019). The override
+        replaces an ambient value (e.g. the agent-server's own ``CODEX_HOME``):
+        the per-conversation root is what isolation is for.
+
+        No-ops for an unrecognised command or a provider without a relocation
+        lever. An explicit ``acp_env`` pin of the data-dir var wins (it has the
+        highest precedence and is honoured as the materialisation target too), so
+        leave it untouched.
+
+        Claude carve-out: ``CLAUDE_CONFIG_DIR`` also activates Claude Code's
+        OAuth credential-file flow, and :data:`_ENV_CONFLICT_MAP` then strips
+        ``ANTHROPIC_API_KEY`` / ``ANTHROPIC_BASE_URL``. Relocating it while an API
+        key is the active credential (no OAuth token present) would delete a
+        working key + proxy URL and break auth, so skip Claude in that case;
+        codex/gemini have no such coupling. (Claude's transcripts are already
+        cwd-keyed, so the residual shared state is the mostly-inert global
+        config.)
+        """
+        provider = detect_acp_provider_by_command(self.acp_command)
+        if provider is None or provider.data_dir_env_var is None:
+            return
+        env_var = provider.data_dir_env_var
+        if env_var in self.acp_env:
+            return
+        if (
+            env_var == "CLAUDE_CONFIG_DIR"
+            and env.get("ANTHROPIC_API_KEY")
+            and "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        ):
+            return
+        data_dir = self._acp_file_secret_dir(state, provider.key)
+        data_dir.mkdir(mode=0o700, parents=True, exist_ok=True)
+        env[env_var] = str(data_dir)
+
     def _materialise_file_secrets(
         self, state: ConversationState, env: dict[str, str]
     ) -> None:
@@ -1793,6 +1859,13 @@ class ACPAgent(AgentBase):
         env.update(self.acp_env)
         # Strip CLAUDECODE so nested Claude Code instances don't refuse to start
         env.pop("CLAUDECODE", None)
+
+        # Relocate the CLI's data/config root to a per-conversation directory so
+        # sandbox-sharing conversations don't race on a shared HOME (#1019).
+        # After acp_env (so a pin wins) and before the conflict-strip below (so a
+        # CLAUDE_CONFIG_DIR we set is still subject to it).
+        if self.acp_isolate_data_dir:
+            self._isolate_acp_data_dir(state, env)
 
         # Strip env vars that conflict with an active auth mechanism.
         # E.g. CLAUDE_CONFIG_DIR (OAuth credential file) conflicts with

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1653,6 +1653,21 @@ class ACPAgent(AgentBase):
         codex/gemini have no such coupling. (Claude's transcripts are already
         cwd-keyed, so the residual shared state is the mostly-inert global
         config.)
+
+        ``HOME`` (gemini-cli's only lever — it hard-codes ``~/.gemini`` and
+        ignores ``XDG``) has a wider blast radius than the surgical
+        ``CODEX_HOME`` / ``CLAUDE_CONFIG_DIR``: it also relocates the home dir
+        seen by anything the CLI subprocess itself spawns (``git``, ``npm``,
+        ``node``, shells — e.g. ``~/.gitconfig``, ``~/.npmrc``, the npm cache).
+        That is accepted as the cost of isolating Gemini at all; callers that
+        need a narrower scope can pin ``HOME`` via ``acp_env`` (honoured below)
+        or leave isolation off for Gemini.
+
+        Ordering contract: this runs *after* the secret_registry / agent_context
+        drain and the ``acp_env`` update in :meth:`_start_acp_server`, so the
+        credential vars it inspects (``ANTHROPIC_API_KEY`` /
+        ``CLAUDE_CODE_OAUTH_TOKEN``) are already hydrated into ``env``. Calling it
+        earlier would misread the active credential and wrongly relocate Claude.
         """
         provider = detect_acp_provider_by_command(self.acp_command)
         if provider is None or provider.data_dir_env_var is None:
@@ -1660,6 +1675,8 @@ class ACPAgent(AgentBase):
         env_var = provider.data_dir_env_var
         if env_var in self.acp_env:
             return
+        # Relies on the ordering contract above: ANTHROPIC_API_KEY /
+        # CLAUDE_CODE_OAUTH_TOKEN must already be hydrated into env.
         if (
             env_var == "CLAUDE_CONFIG_DIR"
             and env.get("ANTHROPIC_API_KEY")
@@ -1862,8 +1879,12 @@ class ACPAgent(AgentBase):
 
         # Relocate the CLI's data/config root to a per-conversation directory so
         # sandbox-sharing conversations don't race on a shared HOME (#1019).
-        # After acp_env (so a pin wins) and before the conflict-strip below (so a
-        # CLAUDE_CONFIG_DIR we set is still subject to it).
+        # Ordering is load-bearing — this must run AFTER the registry /
+        # agent_context drain and the acp_env update above (so the credential
+        # vars its Claude carve-out inspects — ANTHROPIC_API_KEY /
+        # CLAUDE_CODE_OAUTH_TOKEN — are already in env, and an acp_env pin wins)
+        # and BEFORE the conflict-strip below (so a CLAUDE_CONFIG_DIR it sets is
+        # still subject to the strip).
         if self.acp_isolate_data_dir:
             self._isolate_acp_data_dir(state, env)
 

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -476,19 +476,35 @@ def detect_acp_provider_by_command(
     """Identify a provider from its launch ``command``, before the subprocess runs.
 
     Each provider's :attr:`~ACPProviderInfo.agent_name_patterns` fragments
-    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``) are substrings of its
-    npm package name, so the same patterns that match the runtime ``agent_name``
-    also match the launch command — letting us pick the provider *before* the
-    server starts and reports its name (when the subprocess environment, e.g. a
-    relocated data dir, must already be set). Tolerant of version pins
-    (``@google/gemini-cli@0.43.0``) and absolute-path forms.
+    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``) are prefixes of its
+    npm-package / binary basename, so we can pick the provider *before* the server
+    starts and reports its name (when the subprocess environment, e.g. a relocated
+    data dir, must already be set).
+
+    Matching is deliberately stricter than
+    :func:`detect_acp_provider_by_agent_name` because the launch command is
+    *caller-controlled*: each token is reduced to its basename (last path segment,
+    minus a trailing ``@version`` pin) and a provider matches only when that
+    basename *starts with* one of its patterns. This accepts the real forms —
+    ``@zed-industries/codex-acp``, ``@google/gemini-cli@0.43.0``,
+    ``/opt/node_modules/.bin/codex-acp`` — while rejecting incidental substrings
+    like ``my-codex-acp-wrapper`` or ``/opt/shims/not-codex-acp`` that a plain
+    substring test would misattribute.
 
     Returns ``None`` for a custom/unrecognised command, so callers that require a
     known provider (e.g. data-dir isolation) safely no-op.
     """
-    joined = " ".join(command).lower()
+    bases: list[str] = []
+    for token in command:
+        base = token.rsplit("/", 1)[-1].lower()
+        at = base.rfind("@")
+        if at > 0:  # strip a trailing @version pin (not a leading @scope)
+            base = base[:at]
+        bases.append(base)
     for info in ACP_PROVIDERS.values():
-        if any(pat in joined for pat in info.agent_name_patterns):
+        if any(
+            base.startswith(pat) for base in bases for pat in info.agent_name_patterns
+        ):
             return info
     return None
 

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -33,7 +33,7 @@ own copies of this metadata.
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass, field
 from pathlib import PurePosixPath
 from types import MappingProxyType
@@ -252,6 +252,25 @@ class ACPProviderInfo:
     callers constructing this dataclass positionally keep working.
     """
 
+    data_dir_env_var: str | None = None
+    """Env var that relocates this CLI's per-user data/config root.
+
+    Set it to a per-conversation directory to isolate the CLI's on-disk state
+    (config, transcripts, caches, lockfiles) when several of a user's
+    conversations share one sandbox (``SandboxGroupingStrategy != NO_GROUPING``)
+    — otherwise they race on a single shared ``HOME`` (see #1019). Each CLI
+    exposes a different lever:
+
+    - ``CODEX_HOME``        — codex-acp (relocates ``~/.codex`` wholesale)
+    - ``CLAUDE_CONFIG_DIR`` — claude-agent-acp (relocates ``~/.claude*``)
+    - ``HOME``              — gemini-cli (no dedicated var; it hard-codes
+      ``~/.gemini`` and ignores ``XDG``, so only ``HOME`` moves it)
+
+    ``None`` for providers with no known relocation lever, which then skip
+    isolation. Consumed by
+    :attr:`~openhands.sdk.agent.ACPAgent.acp_isolate_data_dir`.
+    """
+
 
 # ---------------------------------------------------------------------------
 # Curated ``acp_model`` candidate lists for the built-in providers.
@@ -371,6 +390,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             session_meta_key="claudeCode",
             available_models=_CLAUDE_MODELS,
             default_model="claude-opus-4-7",
+            data_dir_env_var="CLAUDE_CONFIG_DIR",
         ),
         "codex": ACPProviderInfo(
             key="codex",
@@ -386,6 +406,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             available_models=_CODEX_MODELS,
             default_model="gpt-5.5/medium",
             file_secrets=_CODEX_FILE_SECRETS,
+            data_dir_env_var="CODEX_HOME",
         ),
         "gemini-cli": ACPProviderInfo(
             key="gemini-cli",
@@ -406,6 +427,9 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             # auto-routing.
             default_model="auto-gemini-2.5",
             file_secrets=_GEMINI_FILE_SECRETS,
+            # Gemini CLI has no dedicated config-dir var; it hard-codes
+            # ``~/.gemini`` (ignoring XDG), so only HOME relocates its state.
+            data_dir_env_var="HOME",
         ),
     }
 )
@@ -442,6 +466,29 @@ def detect_acp_provider_by_agent_name(agent_name: str) -> ACPProviderInfo | None
     lower = agent_name.lower()
     for info in ACP_PROVIDERS.values():
         if any(pat in lower for pat in info.agent_name_patterns):
+            return info
+    return None
+
+
+def detect_acp_provider_by_command(
+    command: Sequence[str],
+) -> ACPProviderInfo | None:
+    """Identify a provider from its launch ``command``, before the subprocess runs.
+
+    Each provider's :attr:`~ACPProviderInfo.agent_name_patterns` fragments
+    (``"codex-acp"``, ``"claude-agent"``, ``"gemini-cli"``) are substrings of its
+    npm package name, so the same patterns that match the runtime ``agent_name``
+    also match the launch command — letting us pick the provider *before* the
+    server starts and reports its name (when the subprocess environment, e.g. a
+    relocated data dir, must already be set). Tolerant of version pins
+    (``@google/gemini-cli@0.43.0``) and absolute-path forms.
+
+    Returns ``None`` for a custom/unrecognised command, so callers that require a
+    known provider (e.g. data-dir isolation) safely no-op.
+    """
+    joined = " ".join(command).lower()
+    for info in ACP_PROVIDERS.values():
+        if any(pat in joined for pat in info.agent_name_patterns):
             return info
     return None
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6875,6 +6875,137 @@ class TestACPFileSecretMaterialisation:
 
 
 # ---------------------------------------------------------------------------
+# Per-conversation CLI data-dir isolation (issue #1019)
+# ---------------------------------------------------------------------------
+
+
+class TestACPDataDirIsolation:
+    """``acp_isolate_data_dir`` relocates each provider's CLI data/config root to
+    ``<persistence_dir>/acp/<provider>`` so conversations sharing one sandbox
+    don't race on a shared HOME. Reuses the materialisation harness so the two
+    features are exercised against the same _start_acp_server path.
+    """
+
+    _H = TestACPFileSecretMaterialisation
+
+    @staticmethod
+    def _agent(command, **kw):
+        return ACPAgent(acp_command=command, acp_isolate_data_dir=True, **kw)
+
+    def test_codex_sets_codex_home_to_conversation_root(self, tmp_path):
+        agent = self._agent(["codex-acp"])
+        state = self._H._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(agent, state, conn=self._H._make_conn())
+        data_dir = Path(env["CODEX_HOME"])
+        assert data_dir == Path(persist) / "acp" / "codex"
+        assert data_dir.is_dir()
+        assert data_dir.stat().st_mode & 0o777 == 0o700
+
+    def test_gemini_sets_home_to_conversation_root(self, tmp_path):
+        agent = self._agent(["npx", "-y", "@google/gemini-cli", "--acp"])
+        state = self._H._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="gemini-cli")
+            )
+        assert Path(env["HOME"]) == Path(persist) / "acp" / "gemini-cli"
+
+    def test_disabled_by_default_leaves_home_shared(self, tmp_path):
+        # Same codex command, isolation OFF (the default): no CODEX_HOME injected.
+        agent = ACPAgent(acp_command=["codex-acp"])
+        state = self._H._state(tmp_path)
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(agent, state, conn=self._H._make_conn())
+        assert "CODEX_HOME" not in env
+
+    def test_unknown_command_no_ops(self, tmp_path):
+        agent = self._agent(["my-custom-acp", "serve"])
+        state = self._H._state(tmp_path)
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(agent, state, conn=self._H._make_conn())
+        assert "CODEX_HOME" not in env
+        assert "CLAUDE_CONFIG_DIR" not in env
+
+    def test_acp_env_pin_wins(self, tmp_path):
+        agent = self._agent(["codex-acp"], acp_env={"CODEX_HOME": "/pinned/codex"})
+        state = self._H._state(tmp_path)
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(agent, state, conn=self._H._make_conn())
+        assert env["CODEX_HOME"] == "/pinned/codex"
+
+    def test_falls_back_to_workspace_when_not_persisted(self, tmp_path):
+        agent = self._agent(["codex-acp"])
+        state = self._H._state(tmp_path, persisted=False)
+        assert state.persistence_dir is None
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(agent, state, conn=self._H._make_conn())
+        assert (
+            Path(env["CODEX_HOME"])
+            == Path(state.workspace.working_dir) / ".openhands" / "acp" / "codex"
+        )
+
+    def test_composes_with_materialised_codex_auth(self, tmp_path):
+        """Isolation and file-secret materialisation agree on one CODEX_HOME."""
+        from openhands.sdk.secret import StaticSecret
+
+        agent = self._agent(["codex-acp"])
+        state = self._H._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"tokens": "x"}'))}
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(agent, state, conn=self._H._make_conn())
+        codex_home = Path(env["CODEX_HOME"])
+        assert codex_home == Path(persist) / "acp" / "codex"
+        # Materialisation seeded auth.json into the SAME dir isolation points at.
+        assert (codex_home / "auth.json").read_text(
+            encoding="utf-8"
+        ) == '{"tokens": "x"}'
+
+    # --- Claude carve-out: must not knock out an active API key --------------
+
+    def test_claude_skips_when_api_key_active(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+
+        agent = self._agent(["npx", "-y", "@agentclientprotocol/claude-agent-acp"])
+        state = self._H._state(tmp_path)
+        state.secret_registry.update_secrets(
+            {"ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-live"))}
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="claude-agent-acp")
+            )
+        # Setting CLAUDE_CONFIG_DIR would trip _ENV_CONFLICT_MAP and strip the
+        # key, so isolation is skipped and the working key survives.
+        assert "CLAUDE_CONFIG_DIR" not in env
+        assert env["ANTHROPIC_API_KEY"] == "sk-live"
+
+    def test_claude_isolates_under_oauth_token(self, tmp_path):
+        from openhands.sdk.secret import StaticSecret
+
+        agent = self._agent(["npx", "-y", "@agentclientprotocol/claude-agent-acp"])
+        state = self._H._state(tmp_path)
+        persist = state.persistence_dir
+        assert persist is not None
+        state.secret_registry.update_secrets(
+            {"CLAUDE_CODE_OAUTH_TOKEN": StaticSecret(value=SecretStr("oauth-xyz"))}
+        )
+        with patch.dict("os.environ", {}, clear=True):
+            env = self._H._run_start(
+                agent, state, conn=self._H._make_conn(agent_name="claude-agent-acp")
+            )
+        assert Path(env["CLAUDE_CONFIG_DIR"]) == Path(persist) / "acp" / "claude-code"
+
+
+# ---------------------------------------------------------------------------
 # Secret masking (#1023)
 # ---------------------------------------------------------------------------
 

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -163,6 +163,18 @@ class TestDetectACPProviderByCommand:
     def test_returns_none_for_empty_command(self):
         assert detect_acp_provider_by_command([]) is None
 
+    def test_rejects_incidental_substring_in_custom_command(self):
+        # Plain substring matching would misattribute these to codex; the
+        # basename + prefix rule rejects them (basenames start with "my-"/"not-").
+        assert detect_acp_provider_by_command(["my-codex-acp-wrapper"]) is None
+        assert detect_acp_provider_by_command(["/opt/shims/not-codex-acp"]) is None
+
+    def test_prefix_match_accepts_provider_basename_prefix(self):
+        # A basename that *starts with* the pattern is treated as that provider
+        # (mirrors how "claude-agent" must match the "claude-agent-acp" package).
+        info = detect_acp_provider_by_command(["@acme/codex-acp-shim"])
+        assert info is not None and info.key == "codex"
+
 
 class TestProviderRegistryConsistency:
     """Verify the registry is internally consistent."""

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -12,6 +12,7 @@ from openhands.sdk.settings.acp_providers import (
     ACPProviderInfo,
     build_session_model_meta,
     detect_acp_provider_by_agent_name,
+    detect_acp_provider_by_command,
     get_acp_provider,
 )
 
@@ -42,6 +43,7 @@ class TestACPProviderInfo:
         assert info.session_meta_key == "claudeCode"
         assert info.default_model == "claude-opus-4-7"
         assert any(m.id == "claude-opus-4-7" for m in info.available_models)
+        assert info.data_dir_env_var == "CLAUDE_CONFIG_DIR"
 
     def test_codex_metadata(self):
         info = ACP_PROVIDERS["codex"]
@@ -57,6 +59,7 @@ class TestACPProviderInfo:
         assert info.session_meta_key is None
         assert info.default_model == "gpt-5.5/medium"
         assert any(m.id == "gpt-5.5/medium" for m in info.available_models)
+        assert info.data_dir_env_var == "CODEX_HOME"
 
     def test_gemini_cli_metadata(self):
         info = ACP_PROVIDERS["gemini-cli"]
@@ -72,6 +75,8 @@ class TestACPProviderInfo:
         assert info.session_meta_key is None
         assert info.default_model == "auto-gemini-2.5"
         assert any(m.id == "auto-gemini-2.5" for m in info.available_models)
+        # Gemini CLI has no dedicated config-dir var, so only HOME relocates it.
+        assert info.data_dir_env_var == "HOME"
 
     def test_provider_info_is_frozen(self):
         info = ACP_PROVIDERS["claude-code"]
@@ -129,6 +134,34 @@ class TestDetectACPProviderByAgentName:
 
     def test_returns_none_for_empty_string(self):
         assert detect_acp_provider_by_agent_name("") is None
+
+
+class TestDetectACPProviderByCommand:
+    def test_detects_each_provider_from_default_command(self):
+        for key, info in ACP_PROVIDERS.items():
+            detected = detect_acp_provider_by_command(list(info.default_command))
+            assert detected is not None, key
+            assert detected.key == key
+
+    def test_tolerates_version_pin(self):
+        info = detect_acp_provider_by_command(
+            ["npx", "-y", "@google/gemini-cli@0.43.0", "--acp"]
+        )
+        assert info is not None
+        assert info.key == "gemini-cli"
+
+    def test_tolerates_absolute_path_form(self):
+        info = detect_acp_provider_by_command(
+            ["/usr/local/bin/node", "/opt/node_modules/.bin/codex-acp"]
+        )
+        assert info is not None
+        assert info.key == "codex"
+
+    def test_returns_none_for_custom_command(self):
+        assert detect_acp_provider_by_command(["my-custom-acp", "serve"]) is None
+
+    def test_returns_none_for_empty_command(self):
+        assert detect_acp_provider_by_command([]) is None
 
 
 class TestProviderRegistryConsistency:


### PR DESCRIPTION
## What

Implements **option (b)** from OpenHands/agent-canvas#2114 (part of the ACP-on-Cloud epic OpenHands/OpenHands#15746): give each ACP conversation its own CLI data/config root so conversations that share a sandbox stop racing on a shared `HOME`.

Adds an **opt-in** `ACPAgent.acp_isolate_data_dir` (default `False`). When enabled and the provider is recognised from its launch command, the SDK points that CLI's data-dir env var at `<persistence_dir>/acp/<provider>` before launching the subprocess.

## Why

Under `SandboxGroupingStrategy != NO_GROUPING`, several of a user's conversations share one sandbox — and one `HOME`. The regular agent is safe by construction (state is server-managed and `conversation_id`-keyed). ACP is not:

- **cwd *is* namespaced** per conversation (`/workspace/project/{id.hex}`), so transcripts and the cwd-equality resume guard are fine.
- **`HOME` is not.** One container = one set of CLI files (`~/.codex/auth.json`, `~/.gemini/*`, `~/.claude.json`, caches, lockfiles). Concurrent ACP subprocesses race on shared auth/config/locks, and a per-conversation token/login leaks across the group.

This closes the shared-`HOME` gap while keeping the shared repo workspace.

## How

- **`ACPProviderInfo.data_dir_env_var`** — the per-provider relocation lever:
  | provider | env var | note |
  |---|---|---|
  | codex | `CODEX_HOME` | relocates `~/.codex` wholesale |
  | claude-code | `CLAUDE_CONFIG_DIR` | relocates `~/.claude*` |
  | gemini-cli | `HOME` | no dedicated var; it hard-codes `~/.gemini` and ignores `XDG`, so only `HOME` moves it |
- **`detect_acp_provider_by_command()`** — picks the provider *before* the subprocess starts (the env must be set at launch, before the server reports its name). Reuses each provider's `agent_name_patterns`, which are substrings of its npm package; tolerant of version pins (`@google/gemini-cli@0.43.0`) and absolute-path forms.
- **`ACPAgent._isolate_acp_data_dir()`** — reuses the existing `_acp_file_secret_dir(state, subdir)` (from OpenHands/OpenHands#3474), so a relocated `CODEX_HOME` and a materialised `auth.json` **always agree on one directory** (`<persistence_dir>/acp/codex`). Creates it `0700`.

### Precedence / safety
- An explicit `acp_env` pin of the data-dir var wins (highest precedence, and it's the materialisation write-target too) — left untouched.
- The override **replaces** an ambient value (e.g. the agent-server's own `CODEX_HOME`); a per-conversation root is the whole point.
- **Off by default → non-breaking.** With one sandbox per conversation `HOME` is already private, and relocating it would hide a pre-existing interactive login (e.g. local/canvas dev). Downstream policy decides when to enable it (the SDK owns *where* the root lives).

### Claude carve-out
`CLAUDE_CONFIG_DIR` also activates Claude Code's OAuth credential-file flow, and the existing `_ENV_CONFLICT_MAP` then strips `ANTHROPIC_API_KEY` / `ANTHROPIC_BASE_URL`. Relocating it while an API key is the active credential (no OAuth token present) would delete a working key + proxy URL and break auth — so Claude isolation is **skipped in that case**. It engages once an OAuth token (`CLAUDE_CODE_OAUTH_TOKEN`) is the credential. Codex/gemini have no such coupling. (Claude's transcripts are already cwd-keyed, so the residual shared state is the mostly-inert global config.)

## Composition with OpenHands/OpenHands#3474 (file-secret materialisation)
The two features deliberately share `<persistence_dir>/acp/<provider>`:
- isolation sets `CODEX_HOME` for **all** codex conversations (config/state/lock isolation), regardless of auth method;
- materialisation additionally seeds `auth.json` into that same dir for subscription codex.

A new test exercises both together and asserts they agree on one `CODEX_HOME`.

## Tests
- `acp_providers`: `data_dir_env_var` per provider; `detect_acp_provider_by_command` (default commands, version pin, abs-path, custom→None, empty→None).
- `acp_agent` (`TestACPDataDirIsolation`, reuses the materialisation harness): codex→`CODEX_HOME`, gemini→`HOME`, off-by-default, unknown command no-op, `acp_env` pin wins, non-persisted workspace fallback, composes-with-materialised-auth, Claude skip-under-API-key, Claude isolate-under-OAuth-token.

All 359 ACP + 193 settings/router tests pass; `ruff` + `pyright` clean.

## Follow-up (not in this PR)
- **OpenHands wiring**: set `acp_isolate_data_dir=True` when `sandbox_grouping_strategy != NO_GROUPING` in `live_status_app_conversation_service._build_acp_start_conversation_request` (after pinning a release that includes this). That's the *policy* half; this PR is the *mechanism*.
- Full Claude isolation under API-key auth would require refining `_ENV_CONFLICT_MAP` to trigger on the OAuth token rather than `CLAUDE_CONFIG_DIR` presence — a separate, behaviour-changing PR best done once the token path is wired.

Implements OpenHands/agent-canvas#2114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:190182e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-190182e-python \
  ghcr.io/openhands/agent-server:190182e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:190182e-golang-amd64
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-golang-amd64
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-golang-amd64
ghcr.io/openhands/agent-server:190182e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:190182e-golang-arm64
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-golang-arm64
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-golang-arm64
ghcr.io/openhands/agent-server:190182e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:190182e-java-amd64
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-java-amd64
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-java-amd64
ghcr.io/openhands/agent-server:190182e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:190182e-java-arm64
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-java-arm64
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-java-arm64
ghcr.io/openhands/agent-server:190182e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:190182e-python-amd64
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-python-amd64
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-python-amd64
ghcr.io/openhands/agent-server:190182e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:190182e-python-arm64
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-python-arm64
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-python-arm64
ghcr.io/openhands/agent-server:190182e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:190182e-golang
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-golang
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-golang
ghcr.io/openhands/agent-server:190182e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:190182e-java
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-java
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-java
ghcr.io/openhands/agent-server:190182e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:190182e-python
ghcr.io/openhands/agent-server:190182e8a2d49ba8f41d73fe68f229aa28b9955d-python
ghcr.io/openhands/agent-server:acp-isolate-cli-data-dir-python
ghcr.io/openhands/agent-server:190182e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `190182e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `190182e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->