### PR TITLE
fix(acp): set codex base URL via openai_base_url config (codex ignores OPENAI_BASE_URL)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -265,6 +265,40 @@ def _select_auth_method(
     return None
 
 
+def _codex_base_url_overrides(
+    command: str, args: list[str], env: dict[str, str]
+) -> list[str]:
+    """Translate ``OPENAI_BASE_URL`` into the codex config key that sets it.
+
+    Unlike claude-agent-acp (which honours ``ANTHROPIC_BASE_URL``) and gemini-cli
+    (whose base URL is supplied via the ``authenticate`` gateway), **codex does
+    not read the ``OPENAI_BASE_URL`` env var** — its supported base-URL config
+    lives in ``config.toml`` (see the codex "Advanced configuration" docs). Its
+    built-in ``openai`` provider otherwise targets ``https://api.openai.com``, so
+    a caller that points codex at a gateway/proxy (eval LiteLLM proxy, a
+    corporate egress, etc.) via ``OPENAI_BASE_URL`` alone would have every turn
+    hit the real OpenAI API with the wrong key and fail ``401 invalid_api_key``
+    — surfaced opaquely as ACP ``-32603 Internal error``. (codex-acp 0.11.1
+    happened to honour the env var; 0.15.0 does not, so the eval/canvas/cloud
+    codex-via-proxy flows broke on the bump.)
+
+    The documented one-liner is ``openai_base_url`` — it overrides the built-in
+    ``openai`` provider's base URL without inventing a separate provider, so the
+    provider's defaults (``OPENAI_API_KEY`` env key, Responses ``wire_api``) keep
+    applying and per-conversation keys keep working. No-op for non-codex servers,
+    when ``OPENAI_BASE_URL`` is unset, or when the caller already pinned a base
+    URL / ``model_provider`` (via ``acp_args``/``-c``), which takes precedence.
+    """
+    if not any("codex-acp" in tok for tok in (command, *args)):
+        return []
+    base_url = env.get("OPENAI_BASE_URL")
+    if not base_url:
+        return []
+    if any("openai_base_url" in tok or "model_provider" in tok for tok in args):
+        return []
+    return ["-c", f'openai_base_url="{base_url}"']
+
+
 def _write_secret_file(path: Path, value: str) -> None:
     """Write ``value`` to ``path`` as a ``0600`` file.
 
@@ -1804,6 +1838,12 @@ class ACPAgent(AgentBase):
 
         command = self.acp_command[0]
         args = list(self.acp_command[1:]) + list(self.acp_args)
+        # codex ignores OPENAI_BASE_URL; translate it into the config key it
+        # reads. Reads the *fully assembled* env above, so it fires regardless of
+        # which channel delivered OPENAI_BASE_URL (agent_context.secrets,
+        # state.secret_registry / StartConversationRequest.secrets, acp_env,
+        # os.environ) — i.e. eval, canvas, and cloud all route the same way.
+        args += _codex_base_url_overrides(command, args, env)
 
         working_dir = str(state.workspace.working_dir)
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -21,6 +21,7 @@ from openhands.sdk.agent.acp_agent import (
     ACPAgent,
     _classify_acp_init_error,
     _codex_auth_file,
+    _codex_base_url_overrides,
     _estimate_cost_from_tokens,
     _extract_session_models,
     _extract_token_usage,
@@ -4126,6 +4127,58 @@ class TestSelectAuthMethod:
         env = {"GEMINI_API_KEY": "g"}
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, env) == "gemini-api-key"
+
+
+# ---------------------------------------------------------------------------
+# _codex_base_url_overrides (codex ignores OPENAI_BASE_URL)
+# ---------------------------------------------------------------------------
+
+
+class TestCodexBaseUrlOverrides:
+    def test_pins_base_url_for_codex(self):
+        # The documented one-liner: override the built-in openai provider's URL.
+        ov = _codex_base_url_overrides(
+            "codex-acp", [], {"OPENAI_BASE_URL": "https://proxy.example"}
+        )
+        assert ov == ["-c", 'openai_base_url="https://proxy.example"']
+
+    def test_detects_codex_in_any_token(self):
+        # e.g. launched via npx with the scoped package name
+        ov = _codex_base_url_overrides(
+            "npx",
+            ["-y", "@zed-industries/codex-acp@0.15.0"],
+            {"OPENAI_BASE_URL": "https://p"},
+        )
+        assert ov == ["-c", 'openai_base_url="https://p"']
+
+    def test_noop_for_non_codex(self):
+        assert (
+            _codex_base_url_overrides(
+                "claude-agent-acp", [], {"OPENAI_BASE_URL": "https://p"}
+            )
+            == []
+        )
+
+    def test_noop_when_no_base_url(self):
+        assert _codex_base_url_overrides("codex-acp", [], {}) == []
+
+    def test_noop_when_caller_already_set_base_url(self):
+        args = ["-c", 'openai_base_url="https://other"']
+        assert (
+            _codex_base_url_overrides(
+                "codex-acp", args, {"OPENAI_BASE_URL": "https://p"}
+            )
+            == []
+        )
+
+    def test_noop_when_caller_already_set_provider(self):
+        args = ["-c", 'model_provider="custom"']
+        assert (
+            _codex_base_url_overrides(
+                "codex-acp", args, {"OPENAI_BASE_URL": "https://p"}
+            )
+            == []
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What
`ACPAgent.init_state` now translates a configured `OPENAI_BASE_URL` into codex's documented config one-liner — `-c openai_base_url="<url>"` — when the ACP server is **codex**, so codex actually honors that base URL.

## Why
**codex does not read the `OPENAI_BASE_URL` env var.** Per codex's [Advanced configuration](https://developers.openai.com/codex/config-advanced) docs, base-URL config lives in `config.toml` (`openai_base_url`, or a custom `[model_providers.<id>]`); the env var isn't a supported config method. codex's built-in `openai` provider otherwise targets `https://api.openai.com`, so a caller that points codex at a gateway/proxy via `OPENAI_BASE_URL` alone had **every turn hit the real OpenAI API with the wrong key → `401 invalid_api_key`**, surfaced opaquely as ACP `-32603 "Internal error"`.

This regressed when the agent-server image bumped `codex-acp` `0.11.1 → 0.15.0` (#3478). A/B against the live binaries:

| codex-acp | reads `OPENAI_BASE_URL`? |
|---|---|
| 0.11.1 | ✅ yes (routes to the configured endpoint) |
| 0.15.0 | ❌ no (always `api.openai.com`) |

It surfaced as the commit0 acp-codex eval failing 0/N with `RequestError: Internal error` (OpenHands/benchmarks#736), but affects **any** codex-via-custom-endpoint flow (eval, canvas, cloud).

## Fix
Inject codex's documented `openai_base_url` config key (overrides the built-in `openai` provider's base URL — no separate provider needed, so its `OPENAI_API_KEY` env key and Responses `wire_api` keep applying, and per-conversation/virtual keys keep working). No-op for non-codex servers, when `OPENAI_BASE_URL` is unset, or when the caller already pinned a base URL / `model_provider` (which takes precedence).

## Test
- 6 unit tests for `_codex_base_url_overrides` (+ existing `test_acp_agent.py` green).
- Real local run against `@zed-industries/codex-acp@0.15.0`: without the fix codex hits `api.openai.com` (mock 0 requests); with it codex POSTs `/responses` to the configured base URL (mock receives the calls).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b982581-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b982581-python \
  ghcr.io/openhands/agent-server:b982581-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b982581-golang-amd64
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-golang-amd64
ghcr.io/openhands/agent-server:b982581-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b982581-golang-arm64
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-golang-arm64
ghcr.io/openhands/agent-server:b982581-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b982581-java-amd64
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-java-amd64
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-java-amd64
ghcr.io/openhands/agent-server:b982581-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b982581-java-arm64
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-java-arm64
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-java-arm64
ghcr.io/openhands/agent-server:b982581-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b982581-python-amd64
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-python-amd64
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-python-amd64
ghcr.io/openhands/agent-server:b982581-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b982581-python-arm64
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-python-arm64
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-python-arm64
ghcr.io/openhands/agent-server:b982581-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b982581-golang
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-golang
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-golang
ghcr.io/openhands/agent-server:b982581-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b982581-java
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-java
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-java
ghcr.io/openhands/agent-server:b982581-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b982581-python
ghcr.io/openhands/agent-server:b982581d4bd027e4aceb89d854753c0849fc8f4b-python
ghcr.io/openhands/agent-server:fix-acp-codex-base-url-python
ghcr.io/openhands/agent-server:b982581-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b982581-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b982581-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->