### PR TITLE
feat(settings): add verification.critic_api_key with fallback to LLM key

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -46,6 +46,7 @@ from openhands.sdk.utils.pydantic_secrets import (
     decrypt_str_with_cipher_or_keep,
     resolve_expose_mode,
     serialize_secret,
+    validate_secret,
     validate_secret_dict,
 )
 from openhands.sdk.utils.redact import sanitize_dict
@@ -290,6 +291,34 @@ class VerificationSettings(BaseModel):
             ).model_dump()
         },
     )
+    critic_api_key: str | SecretStr | None = Field(
+        default=None,
+        description=(
+            "API key used to authenticate with the critic service. "
+            "When None, the LLM's ``api_key`` is reused, which preserves "
+            "the auto-configuration path for the All-Hands LLM proxy."
+        ),
+        json_schema_extra={
+            SETTINGS_METADATA_KEY: SettingsFieldMetadata(
+                label="Critic API Key",
+                prominence=SettingProminence.CRITICAL,
+                depends_on=("critic_enabled",),
+            ).model_dump()
+        },
+    )
+
+    @field_validator("critic_api_key")
+    @classmethod
+    def _validate_critic_api_key(
+        cls, v: str | SecretStr | None, info: ValidationInfo
+    ) -> SecretStr | None:
+        return validate_secret(v, info)
+
+    @field_serializer("critic_api_key", when_used="always")
+    def _serialize_critic_api_key(
+        self, v: SecretStr | None, info: SerializationInfo
+    ) -> Any:
+        return serialize_secret(v, info)
 
 
 def _default_llm_settings() -> LLM:
@@ -886,8 +915,15 @@ class OpenHandsAgentSettings(AgentSettingsBase):
     def build_critic(self) -> CriticBase | None:
         """Create an :class:`APIBasedCritic` from these settings.
 
-        Returns ``None`` when the critic is disabled or when the LLM
-        has no ``api_key`` (the critic service requires authentication).
+        Returns ``None`` when the critic is disabled or when no API key
+        is available (the critic service requires authentication).
+
+        If ``verification.critic_api_key`` is set it is used to
+        authenticate with the critic service; otherwise the LLM's
+        ``api_key`` is reused. This preserves the existing
+        auto-configuration path for the All-Hands LLM proxy while
+        letting deployments route the critic through a different
+        provider (e.g. an LLM proxy with its own credential).
 
         If ``verification.critic_server_url`` or
         ``verification.critic_model_name`` are set they override the
@@ -897,7 +933,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         if not self.verification.critic_enabled:
             return None
 
-        api_key = self.llm.api_key
+        api_key = self.verification.critic_api_key or self.llm.api_key
         if api_key is None:
             return None
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -47,6 +47,7 @@ from openhands.sdk.event import (
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.llm import ImageContent, Message, TextContent
+from openhands.sdk.secret import SecretSource
 from openhands.sdk.skills import KeywordTrigger, Skill
 from openhands.sdk.tool.builtins.finish import FinishAction
 from openhands.sdk.utils.cipher import Cipher
@@ -57,6 +58,23 @@ from openhands.sdk.workspace.local import LocalWorkspace
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
+
+
+class _FakeLookupSecret(SecretSource):
+    """Module-level stand-in for ``LookupSecret`` used by registry tests.
+
+    Defined at module scope (not inside a test method) so its ``__qualname__``
+    does not contain ``<locals>``. ``DiscriminatedUnionMixin`` rejects
+    subclasses whose qualname contains ``<locals>`` during ``SecretSource``
+    union validation, and any such local subclass leaks into the global
+    ``__subclasses__`` registry — breaking unrelated serialization tests
+    that run later on the same xdist worker.
+    """
+
+    stored_value: str
+
+    def get_value(self) -> str | None:
+        return self.stored_value
 
 
 def _make_agent(**kwargs) -> ACPAgent:
@@ -5914,14 +5932,6 @@ class TestACPSecretRegistryEnvInjection:
         whose ``get_value()`` fetches over HTTP from the agent-server's
         ``/api/settings/secrets/{name}`` endpoint.
         """
-        from openhands.sdk.secret import SecretSource
-
-        class _FakeLookupSecret(SecretSource):
-            stored_value: str
-
-            def get_value(self) -> str | None:
-                return self.stored_value
-
         agent = _make_agent()
         env = self._run_start_capturing_env(
             agent,

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -120,6 +120,15 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
         is SettingProminence.CRITICAL
     )
 
+    # The critic API key must surface in the schema as a CRITICAL, secret
+    # field that depends on critic_enabled — this is what the GUI uses to
+    # render a masked input gated on the toggle.
+    critic_api_key = v_fields["verification.critic_api_key"]
+    assert critic_api_key.secret is True
+    assert critic_api_key.value_type == "string"
+    assert critic_api_key.prominence is SettingProminence.CRITICAL
+    assert critic_api_key.depends_on == ["verification.critic_enabled"]
+
 
 def test_acp_agent_settings_export_schema_has_acp_section() -> None:
     schema = ACPAgentSettings.export_schema()
@@ -543,6 +552,77 @@ def test_llm_create_agent_no_critic_without_api_key() -> None:
     )
     agent = settings.create_agent()
     assert agent.critic is None
+
+
+def test_llm_create_agent_critic_uses_explicit_api_key() -> None:
+    """When ``verification.critic_api_key`` is set, the critic authenticates
+    with it instead of the LLM key. The LLM's own key is preserved untouched
+    so the main agent loop still talks to its provider."""
+    settings = OpenHandsAgentSettings(
+        llm=LLM(model="m", api_key=SecretStr("llm-key")),
+        verification=VerificationSettings(
+            critic_enabled=True,
+            critic_api_key=SecretStr("critic-key"),
+        ),
+    )
+    agent = settings.create_agent()
+    assert isinstance(agent.critic, APIBasedCritic)
+    assert isinstance(agent.critic.api_key, SecretStr)
+    assert agent.critic.api_key.get_secret_value() == "critic-key"
+    # LLM key unaffected.
+    assert isinstance(agent.llm.api_key, SecretStr)
+    assert agent.llm.api_key.get_secret_value() == "llm-key"
+
+
+def test_llm_create_agent_critic_falls_back_to_llm_api_key() -> None:
+    """Without ``verification.critic_api_key``, the legacy behavior holds:
+    the critic reuses the LLM key (auto-config path for the All-Hands proxy)."""
+    settings = OpenHandsAgentSettings(
+        llm=LLM(model="m", api_key=SecretStr("llm-key")),
+        verification=VerificationSettings(critic_enabled=True),
+    )
+    agent = settings.create_agent()
+    assert isinstance(agent.critic, APIBasedCritic)
+    assert isinstance(agent.critic.api_key, SecretStr)
+    assert agent.critic.api_key.get_secret_value() == "llm-key"
+
+
+def test_llm_create_agent_critic_with_only_critic_api_key() -> None:
+    """If the LLM has no key but ``critic_api_key`` is supplied, the critic
+    is still built — its credential is independent of the LLM's."""
+    settings = OpenHandsAgentSettings(
+        llm=LLM(model="m", api_key=None),
+        verification=VerificationSettings(
+            critic_enabled=True,
+            critic_api_key=SecretStr("critic-only-key"),
+        ),
+    )
+    agent = settings.create_agent()
+    assert isinstance(agent.critic, APIBasedCritic)
+    assert isinstance(agent.critic.api_key, SecretStr)
+    assert agent.critic.api_key.get_secret_value() == "critic-only-key"
+
+
+def test_verification_settings_critic_api_key_roundtrip() -> None:
+    """``critic_api_key`` survives dump → validate when secrets are exposed,
+    and validates from both plain strings and SecretStr inputs."""
+    settings = VerificationSettings(
+        critic_enabled=True,
+        critic_api_key="plain-string-key",
+    )
+    assert isinstance(settings.critic_api_key, SecretStr)
+    assert settings.critic_api_key.get_secret_value() == "plain-string-key"
+
+    dumped = settings.model_dump(context={"expose_secrets": "plaintext"})
+    assert dumped["critic_api_key"] == "plain-string-key"
+
+    restored = VerificationSettings.model_validate(dumped)
+    assert isinstance(restored.critic_api_key, SecretStr)
+    assert restored.critic_api_key.get_secret_value() == "plain-string-key"
+
+    # Empty strings normalize to None (consistent with LLM.api_key handling).
+    empty = VerificationSettings(critic_enabled=True, critic_api_key="")
+    assert empty.critic_api_key is None
 
 
 def test_llm_create_agent_critic_with_iterative_refinement() -> None:


### PR DESCRIPTION
## Summary

Adds `verification.critic_api_key` to `VerificationSettings` so the critic can be authenticated against a credential separate from the main LLM key. The legacy behavior (reusing `llm.api_key`) is preserved as a fallback, so this is a purely additive change.

The new field surfaces in the exported settings schema with `secret=True` and `prominence=critical`, gated on `critic_enabled` — exactly what the schema-driven settings UI in [agent-canvas#485](https://github.com/OpenHands/agent-canvas/pull/485) expects to render.

## Why this is needed

The agent-canvas PR ships a "Critic API Key" field in `/settings/verification`, but the field does not exist in the SDK's `AgentSettings` schema, so on every live backend it renders as nothing. This PR adds the missing piece. After this lands and `openhands-agent-server` picks up a build with it, the frontend field shows up automatically — no canvas-side change required.

## Changes

- `VerificationSettings.critic_api_key: str | SecretStr | None = None` with `field_meta(prominence=CRITICAL, depends_on=("critic_enabled",), label="Critic API Key")`.
- `@field_validator` + `@field_serializer` wired to the shared `validate_secret` / `serialize_secret` helpers — same pattern as `LLM.api_key` and `CriticClient.api_key`. Handles encryption-at-rest, plaintext exposure for trusted backends, and redaction for clients.
- `build_critic()` now uses `verification.critic_api_key or self.llm.api_key`, falling back to the LLM key when unset. Returns `None` only when neither is set (unchanged semantics for callers that don't set the new field).
- `validate_secret` added to the import block (was already available in `openhands.sdk.utils.pydantic_secrets`).

## Tests

`tests/sdk/test_settings.py` — added 5 new tests:

- Schema export: `verification.critic_api_key` exists with `secret=True`, prominence `CRITICAL`, `depends_on=["verification.critic_enabled"]`.
- `build_critic()` precedence: explicit `critic_api_key` is used, LLM key untouched.
- `build_critic()` fallback: without `critic_api_key`, the LLM key is reused (legacy behavior preserved).
- `build_critic()` with critic-only key: LLM key `None` + `critic_api_key` set still builds the critic.
- SecretStr roundtrip: plain-string input → `SecretStr`, dump/validate roundtrip preserves value, empty string normalizes to `None`.

All 68 settings tests + 47 critic tests pass locally (115 total). Ruff lint + format clean. Pre-commit hooks (pyright, import rules, Tool subclass registration) all pass.

## Migration / compatibility

No `schema_version` bump needed — the field is optional with default `None`, so existing persisted `AgentSettings` payloads validate unchanged.

---

This PR was created by an AI agent (OpenHands) on behalf of @xingyaoww.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c05cb7d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c05cb7d-python \
  ghcr.io/openhands/agent-server:c05cb7d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c05cb7d-golang-amd64
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-golang-amd64
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-golang-amd64
ghcr.io/openhands/agent-server:c05cb7d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c05cb7d-golang-arm64
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-golang-arm64
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-golang-arm64
ghcr.io/openhands/agent-server:c05cb7d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c05cb7d-java-amd64
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-java-amd64
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-java-amd64
ghcr.io/openhands/agent-server:c05cb7d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c05cb7d-java-arm64
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-java-arm64
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-java-arm64
ghcr.io/openhands/agent-server:c05cb7d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c05cb7d-python-amd64
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-python-amd64
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-python-amd64
ghcr.io/openhands/agent-server:c05cb7d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c05cb7d-python-arm64
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-python-arm64
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-python-arm64
ghcr.io/openhands/agent-server:c05cb7d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c05cb7d-golang
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-golang
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-golang
ghcr.io/openhands/agent-server:c05cb7d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c05cb7d-java
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-java
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-java
ghcr.io/openhands/agent-server:c05cb7d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c05cb7d-python
ghcr.io/openhands/agent-server:c05cb7d172489483860ad2a387765265f9f3f379-python
ghcr.io/openhands/agent-server:feat-verification-critic-api-key-python
ghcr.io/openhands/agent-server:c05cb7d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c05cb7d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c05cb7d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->