### PR TITLE
fix(step-3.7-flash): stretch retry envelope to weather StepFun 10 RPM cap

### DIFF
--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -91,6 +91,49 @@ Add only if needed:
 - **`top_p: <value>`** - Nucleus sampling (cannot be used with `temperature` for Claude models)
 - **`litellm_extra_body: {...}`** - Provider-specific parameters (e.g., `{"enable_thinking": True}`)
 
+### Vision and Reasoning Capability Check
+
+Before finalizing the entry, explicitly check both capabilities against
+the **provider's official documentation** (don't rely only on LiteLLM):
+
+1. **Vision (multimodal input)**
+   - Does the model accept image / video input?
+   - Cross-check LiteLLM: in a Python shell, run
+     ```python
+     from litellm import supports_vision
+     supports_vision(model="<litellm_proxy_target_without_litellm_proxy_prefix>")
+     ```
+   - Decision matrix:
+     | Provider says | LiteLLM says | Action |
+     |---------------|--------------|--------|
+     | Vision ✅      | Vision ✅     | Do nothing — vision auto-enables. |
+     | Vision ❌      | Vision ✅     | Add `"disable_vision": True` (LiteLLM is wrong). |
+     | Vision ✅      | Vision ❌     | **Do not** add `disable_vision: True`. The SDK gates `vision_is_active()` on LiteLLM's `supports_vision()`, so images won't be sent until LiteLLM's metadata is updated upstream (`model_prices_and_context_window.json` in `BerriAI/litellm`). The vision integration test will be skipped, not failed — that's expected. |
+     | Vision ❌      | Vision ❌     | Do nothing. |
+   - Note the result in the PR description (e.g., "Vision: supported by provider; LiteLLM not yet aware — vision test will skip until LiteLLM is updated").
+
+2. **Reasoning (thinking / reasoning_effort)**
+   - Does the model expose adjustable reasoning levels or extended thinking?
+   - Cross-check LiteLLM:
+     ```python
+     from litellm import get_supported_openai_params
+     "reasoning_effort" in (get_supported_openai_params(
+         model="<litellm_target>", custom_llm_provider=None) or [])
+     ```
+   - Decision matrix:
+     | Provider style | LiteLLM `reasoning_effort` support | Action |
+     |----------------|-------------------------------------|--------|
+     | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Optionally pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
+     | OpenAI-style reasoning items | ❌ | **Do not** add `reasoning_effort` — `drop_params=True` will strip it before send. Leave the model at provider defaults; reasoning will still work, but you can't tune the level from `llm_config` until LiteLLM exposes the param. |
+     | Anthropic extended thinking (Claude Sonnet 4.5+, Haiku 4.5) | n/a | Add the model identifier to `EXTENDED_THINKING_MODELS` in `model_features.py` (see Step 2). |
+     | Non-reasoning model | n/a | Do nothing. |
+   - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort` for this model — leaving it unset; condenser thinking-block test will skip (expected for non-Anthropic reasoning models)").
+
+The integration runner correctly **skips** vision / extended-thinking tests
+when the SDK can't detect support. A skipped test for one of these reasons
+is **not** a failure of the PR and doesn't need to be fixed in the same PR;
+it usually means LiteLLM metadata needs to be updated upstream.
+
 ### Critical Rules
 
 1. Model ID must match dictionary key

--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -123,11 +123,11 @@ the **provider's official documentation** (don't rely only on LiteLLM):
    - Decision matrix:
      | Provider style | LiteLLM `reasoning_effort` support | Action |
      |----------------|-------------------------------------|--------|
-     | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Optionally pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
-     | OpenAI-style reasoning items | ❌ | **Do not** add `reasoning_effort` — `drop_params=True` will strip it before send. Leave the model at provider defaults; reasoning will still work, but you can't tune the level from `llm_config` until LiteLLM exposes the param. |
+     | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
+     | OpenAI-style reasoning items (OpenRouter native `reasoning` block) | ❌ | Pin via provider-specific passthrough: `"litellm_extra_body": {"reasoning": {"effort": "high"}}`. The top-level `reasoning_effort` would be dropped by `drop_params=True`, but `litellm_extra_body` is forwarded to the provider. Same pattern as `qwen3-max-thinking` (which uses `{"enable_thinking": True}`). |
      | Anthropic extended thinking (Claude Sonnet 4.5+, Haiku 4.5) | n/a | Add the model identifier to `EXTENDED_THINKING_MODELS` in `model_features.py` (see Step 2). |
      | Non-reasoning model | n/a | Do nothing. |
-   - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort` for this model — leaving it unset; condenser thinking-block test will skip (expected for non-Anthropic reasoning models)").
+   - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort`, so opting in via `litellm_extra_body`; condenser thinking-block test will skip — expected for non-Anthropic reasoning models").
 
 The integration runner correctly **skips** vision / extended-thinking tests
 when the SDK can't detect support. A skipped test for one of these reasons

--- a/.github/run-eval/ADDINGMODEL.md
+++ b/.github/run-eval/ADDINGMODEL.md
@@ -98,19 +98,36 @@ the **provider's official documentation** (don't rely only on LiteLLM):
 
 1. **Vision (multimodal input)**
    - Does the model accept image / video input?
-   - Cross-check LiteLLM: in a Python shell, run
+   - **Critical first check — proxy `model_name` alignment.** The eval
+     LiteLLM proxy stores capability metadata (`supports_vision`,
+     `supports_function_calling`, token limits, etc.) under each
+     `model_name` registered in its config. The SDK's lookup
+     (`_get_model_info_from_litellm_proxy`) does an **exact string match**
+     of `model.removeprefix("litellm_proxy/")` against the proxy's
+     `model_name`. If the strings don't match, `supports_vision` is
+     silently ignored and the SDK falls back to LiteLLM's static metadata.
+     So: **use the proxy's exact registered `model_name` in your
+     `llm_config["model"]`**, not a longer provider-prefixed alias, e.g.
+     prefer `litellm_proxy/step-3.7-flash` over
+     `litellm_proxy/openrouter/stepfun/step-3.7-flash` if the proxy entry
+     is registered as `step-3.7-flash`. Ask infra (or check the proxy
+     config) for the canonical `model_name` — and confirm `model_info`
+     has the capability flags you expect.
+   - Cross-check LiteLLM static metadata: in a Python shell, run
      ```python
      from litellm import supports_vision
      supports_vision(model="<litellm_proxy_target_without_litellm_proxy_prefix>")
      ```
    - Decision matrix:
-     | Provider says | LiteLLM says | Action |
-     |---------------|--------------|--------|
-     | Vision ✅      | Vision ✅     | Do nothing — vision auto-enables. |
-     | Vision ❌      | Vision ✅     | Add `"disable_vision": True` (LiteLLM is wrong). |
-     | Vision ✅      | Vision ❌     | **Do not** add `disable_vision: True`. The SDK gates `vision_is_active()` on LiteLLM's `supports_vision()`, so images won't be sent until LiteLLM's metadata is updated upstream (`model_prices_and_context_window.json` in `BerriAI/litellm`). The vision integration test will be skipped, not failed — that's expected. |
-     | Vision ❌      | Vision ❌     | Do nothing. |
-   - Note the result in the PR description (e.g., "Vision: supported by provider; LiteLLM not yet aware — vision test will skip until LiteLLM is updated").
+     | Provider docs | Proxy `model_info.supports_vision` | LiteLLM static | Action |
+     |---------------|------------------------------------|----------------|--------|
+     | Vision ✅      | True (and `model_name` matches your config) | any | Do nothing — vision auto-enables via the proxy metadata. |
+     | Vision ✅      | True, but `model_name` does **not** match your config | any | **Fix the model path** in your `llm_config` to match the proxy's `model_name` exactly. Don't add `disable_vision`. |
+     | Vision ✅      | not set / proxy entry has no `model_info` | any | Coordinate with infra to add `supports_vision: true` to the proxy entry (one line of YAML). Vision integration test will skip until that lands — non-blocking. |
+     | Vision ❌      | True | True | Add `"disable_vision": True` (proxy/LiteLLM are wrong). |
+     | Vision ❌      | any | any | Do nothing. |
+   - Note the result in the PR description, including the exact proxy
+     `model_name` your `llm_config["model"]` matches.
 
 2. **Reasoning (thinking / reasoning_effort)**
    - Does the model expose adjustable reasoning levels or extended thinking?
@@ -124,7 +141,7 @@ the **provider's official documentation** (don't rely only on LiteLLM):
      | Provider style | LiteLLM `reasoning_effort` support | Action |
      |----------------|-------------------------------------|--------|
      | OpenAI-style reasoning items (e.g. GPT-5, OpenRouter reasoning levels) | ✅ | Pin `"reasoning_effort": "high"` in `llm_config`. If pinned, remove `temperature` / `top_p` (they'll be auto-stripped). |
-     | OpenAI-style reasoning items (OpenRouter native `reasoning` block) | ❌ | Pin via provider-specific passthrough: `"litellm_extra_body": {"reasoning": {"effort": "high"}}`. The top-level `reasoning_effort` would be dropped by `drop_params=True`, but `litellm_extra_body` is forwarded to the provider. Same pattern as `qwen3-max-thinking` (which uses `{"enable_thinking": True}`). |
+     | OpenAI-style reasoning items, provider has a non-standard reasoning param | ❌ | Pin via provider-specific passthrough: `"litellm_extra_body": {<provider-key>: <value>}` (e.g. `{"reasoning": {"effort": "high"}}` for OpenRouter, `{"enable_thinking": True}` for Qwen). **Confirm which upstream the proxy actually routes to** before choosing the key — the proxy's `litellm_params.model` (e.g. `openai/...` vs `openrouter/...`) decides what extra-body keys the upstream understands. The top-level `reasoning_effort` would otherwise be dropped by `drop_params=True`. |
      | Anthropic extended thinking (Claude Sonnet 4.5+, Haiku 4.5) | n/a | Add the model identifier to `EXTENDED_THINKING_MODELS` in `model_features.py` (see Step 2). |
      | Non-reasoning model | n/a | Do nothing. |
    - Note the result in the PR description (e.g., "Reasoning: OpenRouter exposes high/medium/low; LiteLLM does not yet expose `reasoning_effort`, so opting in via `litellm_extra_body`; condenser thinking-block test will skip — expected for non-Anthropic reasoning models").

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -388,31 +388,13 @@ MODELS = {
             "top_p": 0.95,
         },
     },
-    # https://static.stepfun.com/blog/step-3.7-flash/
-    # The eval LiteLLM proxy registers this model as `step-3.7-flash`
-    # (short alias) routing to `openai/step-3.7-flash` at
-    # api.stepfun.ai/v1, with `model_info.supports_vision=true`. We must
-    # use the proxy's exact `model_name` here so that
-    # `_get_model_info_from_litellm_proxy` matches the registry entry and
-    # picks up `supports_vision=true`. Using the longer
-    # `litellm_proxy/openrouter/stepfun/step-3.7-flash` form works at
-    # request time (proxy pass-through to OpenRouter) but misses the
-    # model_info lookup, so vision is never activated by the SDK.
+
     "step-3.7-flash": {
         "id": "step-3.7-flash",
         "display_name": "Step 3.7 Flash",
         "llm_config": {
             "model": "litellm_proxy/step-3.7-flash",
             "temperature": 0.0,
-            # StepFun's current API tier caps step-3.7-flash at 10 RPM
-            # (see https://platform.stepfun.ai/docs/en/pricing/details
-            # #tiered-rate-limits). The eval runs many instances in
-            # parallel and each step hammers the same RPM bucket, so the
-            # SDK's default retry envelope (5 attempts, ~3 min total)
-            # exhausts long before the bucket resets and every instance
-            # ends up in `output_errors.jsonl` instead of `output.jsonl`
-            # (see OpenHands/software-agent-sdk#3496). Stretch the retry
-            # window enough to outlast a fully-saturated 60s bucket.
             "num_retries": 12,
             "retry_min_wait": 30,
             "retry_max_wait": 120,

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -365,6 +365,15 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # https://static.stepfun.com/blog/step-3.7-flash/
+    "step-3.7-flash": {
+        "id": "step-3.7-flash",
+        "display_name": "Step 3.7 Flash",
+        "llm_config": {
+            "model": "litellm_proxy/openrouter/stepfun/step-3.7-flash",
+            "temperature": 0.0,
+        },
+    },
 }
 
 

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -388,7 +388,6 @@ MODELS = {
             "top_p": 0.95,
         },
     },
-
     "step-3.7-flash": {
         "id": "step-3.7-flash",
         "display_name": "Step 3.7 Flash",

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -381,6 +381,18 @@ MODELS = {
         "llm_config": {
             "model": "litellm_proxy/step-3.7-flash",
             "temperature": 0.0,
+            # StepFun's current API tier caps step-3.7-flash at 10 RPM
+            # (see https://platform.stepfun.ai/docs/en/pricing/details
+            # #tiered-rate-limits). The eval runs many instances in
+            # parallel and each step hammers the same RPM bucket, so the
+            # SDK's default retry envelope (5 attempts, ~3 min total)
+            # exhausts long before the bucket resets and every instance
+            # ends up in `output_errors.jsonl` instead of `output.jsonl`
+            # (see OpenHands/software-agent-sdk#3496). Stretch the retry
+            # window enough to outlast a fully-saturated 60s bucket.
+            "num_retries": 12,
+            "retry_min_wait": 30,
+            "retry_max_wait": 120,
         },
     },
 }

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -366,20 +366,21 @@ MODELS = {
         },
     },
     # https://static.stepfun.com/blog/step-3.7-flash/
-    # Step 3.7 Flash is a multimodal MoE VLM with selectable OpenRouter
-    # reasoning levels (high/medium/low). We opt into "high" via
-    # litellm_extra_body because LiteLLM does not yet expose
-    # `reasoning_effort` as a supported param for this OpenRouter target,
-    # so the top-level `reasoning_effort` field would be dropped before
-    # send. Vision is gated by LiteLLM / proxy `supports_vision` metadata
-    # and cannot be force-enabled from llm_config.
+    # The eval LiteLLM proxy registers this model as `step-3.7-flash`
+    # (short alias) routing to `openai/step-3.7-flash` at
+    # api.stepfun.ai/v1, with `model_info.supports_vision=true`. We must
+    # use the proxy's exact `model_name` here so that
+    # `_get_model_info_from_litellm_proxy` matches the registry entry and
+    # picks up `supports_vision=true`. Using the longer
+    # `litellm_proxy/openrouter/stepfun/step-3.7-flash` form works at
+    # request time (proxy pass-through to OpenRouter) but misses the
+    # model_info lookup, so vision is never activated by the SDK.
     "step-3.7-flash": {
         "id": "step-3.7-flash",
         "display_name": "Step 3.7 Flash",
         "llm_config": {
-            "model": "litellm_proxy/openrouter/stepfun/step-3.7-flash",
+            "model": "litellm_proxy/step-3.7-flash",
             "temperature": 0.0,
-            "litellm_extra_body": {"reasoning": {"effort": "high"}},
         },
     },
 }

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -366,12 +366,20 @@ MODELS = {
         },
     },
     # https://static.stepfun.com/blog/step-3.7-flash/
+    # Step 3.7 Flash is a multimodal MoE VLM with selectable OpenRouter
+    # reasoning levels (high/medium/low). We opt into "high" via
+    # litellm_extra_body because LiteLLM does not yet expose
+    # `reasoning_effort` as a supported param for this OpenRouter target,
+    # so the top-level `reasoning_effort` field would be dropped before
+    # send. Vision is gated by LiteLLM / proxy `supports_vision` metadata
+    # and cannot be force-enabled from llm_config.
     "step-3.7-flash": {
         "id": "step-3.7-flash",
         "display_name": "Step 3.7 Flash",
         "llm_config": {
             "model": "litellm_proxy/openrouter/stepfun/step-3.7-flash",
             "temperature": 0.0,
+            "litellm_extra_body": {"reasoning": {"effort": "high"}},
         },
     },
 }

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -699,6 +699,11 @@ def test_step_3_7_flash_config():
     exactly so that `_get_model_info_from_litellm_proxy` matches the
     registry entry and picks up `supports_vision=true` from the
     proxy-side `model_info`.
+
+    The retry envelope is bumped above the SDK default (5/8/64) because
+    StepFun caps this model at 10 RPM on the current tier and parallel
+    inference otherwise drains the retry budget before the rate-limit
+    bucket resets, see OpenHands/software-agent-sdk#3496.
     """
     model = MODELS["step-3.7-flash"]
 
@@ -706,3 +711,9 @@ def test_step_3_7_flash_config():
     assert model["display_name"] == "Step 3.7 Flash"
     assert model["llm_config"]["model"] == "litellm_proxy/step-3.7-flash"
     assert model["llm_config"]["temperature"] == 0.0
+
+    # Retry settings must be at least these values to weather StepFun's
+    # 10 RPM tier under parallel inference.
+    assert model["llm_config"]["num_retries"] >= 10
+    assert model["llm_config"]["retry_min_wait"] >= 15
+    assert model["llm_config"]["retry_max_wait"] >= 90

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -690,3 +690,16 @@ def test_minimax_m3_config():
     assert model["llm_config"]["model"] == "litellm_proxy/minimax/MiniMax-M3"
     assert model["llm_config"]["temperature"] == 1.0
     assert model["llm_config"]["top_p"] == 0.95
+
+
+def test_step_3_7_flash_config():
+    """Test that step-3.7-flash has correct configuration."""
+    model = MODELS["step-3.7-flash"]
+
+    assert model["id"] == "step-3.7-flash"
+    assert model["display_name"] == "Step 3.7 Flash"
+    assert (
+        model["llm_config"]["model"]
+        == "litellm_proxy/openrouter/stepfun/step-3.7-flash"
+    )
+    assert model["llm_config"]["temperature"] == 0.0

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -703,3 +703,9 @@ def test_step_3_7_flash_config():
         == "litellm_proxy/openrouter/stepfun/step-3.7-flash"
     )
     assert model["llm_config"]["temperature"] == 0.0
+    # Opt into OpenRouter's "high" reasoning level via litellm_extra_body,
+    # because LiteLLM does not yet expose `reasoning_effort` as a top-level
+    # supported param for this target.
+    assert model["llm_config"]["litellm_extra_body"] == {
+        "reasoning": {"effort": "high"}
+    }

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -693,19 +693,16 @@ def test_minimax_m3_config():
 
 
 def test_step_3_7_flash_config():
-    """Test that step-3.7-flash has correct configuration."""
+    """Test that step-3.7-flash has correct configuration.
+
+    The model path must match the eval LiteLLM proxy's `model_name` alias
+    exactly so that `_get_model_info_from_litellm_proxy` matches the
+    registry entry and picks up `supports_vision=true` from the
+    proxy-side `model_info`.
+    """
     model = MODELS["step-3.7-flash"]
 
     assert model["id"] == "step-3.7-flash"
     assert model["display_name"] == "Step 3.7 Flash"
-    assert (
-        model["llm_config"]["model"]
-        == "litellm_proxy/openrouter/stepfun/step-3.7-flash"
-    )
+    assert model["llm_config"]["model"] == "litellm_proxy/step-3.7-flash"
     assert model["llm_config"]["temperature"] == 0.0
-    # Opt into OpenRouter's "high" reasoning level via litellm_extra_body,
-    # because LiteLLM does not yet expose `reasoning_effort` as a top-level
-    # supported param for this target.
-    assert model["llm_config"]["litellm_extra_body"] == {
-        "reasoning": {"effort": "high"}
-    }


### PR DESCRIPTION
Closes #3496.

## Why

The OpenHands Eval Monitor shows **0% Critic 1 Acceptance** for every recent `litellm_proxy/step-3.7-flash` run — e.g. swebench run [`26911702062`](https://openhands-eval-monitor.vercel.app/?run=swebench%2Flitellm_proxy-step-3-7-flash%2F26911702062%2F&days=15). The `run-infer-progress.txt` for that run reads `output, critic1, critic2, critic3 = 0, 5, 0, 0`: all 5 instances completed in critic_attempt_1 but went to `output_errors.jsonl`, so `output.jsonl` is empty and acceptance = `output / critic1 = 0%`. The same `output=0` pattern was visible across the parallel swebench-full and swtbench-full step-3.7-flash runs.

Datadog logs from the runtime pods (`service:eval-agent-server`, `image_tag:b0fedcd*`, `@levelname:ERROR`) are saturated with the same exception:

```
litellm.RateLimitError: Error code: 429 - OpenAIException -
    request limited RPM reached, current: 11, limit: 10.
    Please top up at https://platform.stepfun.ai/top-up.
```

StepFun's current API tier caps `step-3.7-flash` at **10 RPM**. The eval runs many instances in parallel, every step hammers the same RPM bucket, and the SDK's default retry envelope — `num_retries=5`, `retry_min_wait=8`, `retry_max_wait=64`, exponential backoff, ~3 min total — exhausts long before the bucket resets. Every conversation eventually raises `LLMRateLimitError`, which is recorded as an error.

## What

Config-only change in `.github/run-eval/resolve_model_config.py`: bump the retry envelope on the `step-3.7-flash` entry so the SDK retry loop can outlast a fully-saturated 60 s bucket.

| Setting | Default | step-3.7-flash |
|---|---|---|
| `num_retries` | 5 | **12** |
| `retry_min_wait` (s) | 8 | **30** |
| `retry_max_wait` (s) | 64 | **120** |

`num_retries`, `retry_min_wait`, and `retry_max_wait` are already first-class fields on `LLM` (see `openhands-sdk/openhands/sdk/llm/llm.py`), so no SDK code changes are needed.

The `test_step_3_7_flash_config` test in `tests/cross/test_resolve_model_config.py` was updated with lower-bound assertions (≥10 / ≥15 / ≥90) so the retry envelope can't silently regress to defaults.

## Verification

```text
$ uv run pytest tests/cross/test_resolve_model_config.py -v
========================= 40 passed, 5 warnings in 0.10s =========================
```

To verify end-to-end, kick off a `swebench` Run Eval workflow with `model_ids=step-3.7-flash` and `eval_limit=5`; `output.jsonl` should grow in lockstep with `output.critic_attempt_1.jsonl` instead of staying at 0.

## Out of scope

This is the cheapest fix that doesn't require infra changes. Longer-term we should also: (a) top up the StepFun tier so the model has realistic headroom, (b) add per-model concurrency limits in the eval harness so we don't oversubscribe RPM-constrained providers, and (c) have the LiteLLM proxy forward upstream `Retry-After` headers. Those are tracked in #3496.

---
_This PR was opened by an AI agent (OpenHands) on behalf of @juanmichelini._


@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/d64afd05-f873-4a1c-b018-6b9b97e92c90)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:c9cbd0b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-c9cbd0b-python \
  ghcr.io/openhands/agent-server:c9cbd0b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:c9cbd0b-golang-amd64
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-golang-amd64
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-golang-amd64
ghcr.io/openhands/agent-server:c9cbd0b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:c9cbd0b-golang-arm64
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-golang-arm64
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-golang-arm64
ghcr.io/openhands/agent-server:c9cbd0b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:c9cbd0b-java-amd64
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-java-amd64
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-java-amd64
ghcr.io/openhands/agent-server:c9cbd0b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:c9cbd0b-java-arm64
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-java-arm64
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-java-arm64
ghcr.io/openhands/agent-server:c9cbd0b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:c9cbd0b-python-amd64
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-python-amd64
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-python-amd64
ghcr.io/openhands/agent-server:c9cbd0b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:c9cbd0b-python-arm64
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-python-arm64
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-python-arm64
ghcr.io/openhands/agent-server:c9cbd0b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:c9cbd0b-golang
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-golang
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-golang
ghcr.io/openhands/agent-server:c9cbd0b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:c9cbd0b-java
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-java
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-java
ghcr.io/openhands/agent-server:c9cbd0b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:c9cbd0b-python
ghcr.io/openhands/agent-server:c9cbd0bdbd7e174e547df8b3260fb0bed0836ba5-python
ghcr.io/openhands/agent-server:fix-step-3-7-flash-rpm-retry-envelope-python
ghcr.io/openhands/agent-server:c9cbd0b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `c9cbd0b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `c9cbd0b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->