### PR TITLE
docs(agents): add explicit comments policy to AGENTS.md 

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -317,6 +317,11 @@ gh run rerun <RUN_ID> --repo <OWNER>/<REPO> --failed
 - Avoid getattr/hasattr guards and instead enforce type correctness by relying on explicit type assertions and proper object usage, ensuring functions only receive the expected Pydantic models or typed inputs. Prefer type hints and validated models over runtime shape checks.
 - Prefer accessing typed attributes directly. If necessary, convert inputs up front into a canonical shape; avoid purely hypothetical fallbacks.
 - Use real newlines in commit messages; do not write literal "\n".
+- Comments policy: write comments sparingly and strategically. Prefer making the code self-explanatory through clear naming and structure over adding prose.
+  - Do NOT add comments that restate what the code already says, summarize the surrounding diff/PR, or narrate the change history ("previously we did X, now we do Y"). That kind of context belongs in the PR description or commit message, not in the source — `git blame` and the PR are the source of truth for *why* a change was made.
+  - Do NOT describe non-local parts of the system (other modules, callers, downstream behavior) in a comment unless there is a mechanism to keep that description in sync. Such comments drift and become misleading.
+  - DO add a comment when the code expresses something genuinely unintuitive: a non-obvious invariant, a workaround for an external bug, a subtle ordering/locking requirement, or a deliberate trade-off the reader cannot infer from the code itself.
+  - When in doubt, prefer restructuring or renaming over commenting. A 3-line change should not produce 19 lines of comments — if it feels like it needs that much narration, the explanation belongs in the PR description.
 
 </CODE>
 


### PR DESCRIPTION
## Why

Issue #3498 calls out that agent-authored PRs (especially on Claude Opus 4.7/4.8 — see the analysis in [#3498](https://github.com/OpenHands/software-agent-sdk/issues/3498#issuecomment-4617160820)) often add long, narrative comment blocks that:

- restate what the code already says,
- summarize the surrounding diff / PR description,
- describe non-local parts of the system with no way to stay in sync.

The reporter asked specifically for an explicit "comments policy" item in the SDK contributor guidelines, e.g. `AGENTS.md` `<CODE>` section.

## Summary

- Adds a new "Comments policy" bullet (with sub-bullets) to the `<CODE>` section of root [`AGENTS.md`](https://github.com/OpenHands/software-agent-sdk/blob/main/AGENTS.md), covering:
  - prefer self-explanatory code over prose,
  - don't restate code, narrate the diff, or paraphrase the PR description (that's what the PR / `git blame` are for),
  - don't describe non-local behavior in comments without a sync mechanism (it drifts),
  - DO comment on genuinely unintuitive things (invariants, workarounds, ordering/locking, deliberate trade-offs),
  - a 3-line change shouldn't produce 19 lines of comments — direct callback to the PR cited in the issue.

## Issue Number

Closes #3498

## How to Test

Documentation-only change. Verified by:

- Re-reading the `<CODE>` section of `AGENTS.md` to confirm the new policy is consistent in tone/structure with the surrounding bullets.
- `uv run pre-commit run --files AGENTS.md` — passes (no hooks apply to Markdown files in this repo's pre-commit config, so it correctly skips).

No code/runtime behavior changes, so no automated tests were added per the contributor checklist (`You do NOT need to write new tests if there are only changes to documentation or configuration files.`).

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini in response to https://github.com/OpenHands/software-agent-sdk/issues/3498.


@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/23039ac3-9f41-4906-9833-3d2a776fc1af)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:83dbe2b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-83dbe2b-python \
  ghcr.io/openhands/agent-server:83dbe2b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:83dbe2b-golang-amd64
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-golang-amd64
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-golang-amd64
ghcr.io/openhands/agent-server:83dbe2b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:83dbe2b-golang-arm64
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-golang-arm64
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-golang-arm64
ghcr.io/openhands/agent-server:83dbe2b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:83dbe2b-java-amd64
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-java-amd64
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-java-amd64
ghcr.io/openhands/agent-server:83dbe2b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:83dbe2b-java-arm64
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-java-arm64
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-java-arm64
ghcr.io/openhands/agent-server:83dbe2b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:83dbe2b-python-amd64
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-python-amd64
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-python-amd64
ghcr.io/openhands/agent-server:83dbe2b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:83dbe2b-python-arm64
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-python-arm64
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-python-arm64
ghcr.io/openhands/agent-server:83dbe2b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:83dbe2b-golang
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-golang
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-golang
ghcr.io/openhands/agent-server:83dbe2b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:83dbe2b-java
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-java
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-java
ghcr.io/openhands/agent-server:83dbe2b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:83dbe2b-python
ghcr.io/openhands/agent-server:83dbe2bb6b39eab11a921fe19551c1486af1e170-python
ghcr.io/openhands/agent-server:openhands-comments-policy-agents-md-python
ghcr.io/openhands/agent-server:83dbe2b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `83dbe2b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `83dbe2b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->