### PR TITLE
fix: cap effective_max_output_tokens for non-Bedrock custom base_url providers

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2187,6 +2187,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                             context_window,
                         )
                         effective_max_output_tokens = capped
+                    if (
+                        self.base_url is not None
+                        and effective_max_output_tokens is not None
+                        and effective_max_output_tokens > DEFAULT_MAX_OUTPUT_TOKENS_CAP
+                    ):
+                        logger.debug(
+                            "Capping max_output_tokens from %s to %s for %s "
+                            "(model metadata may exceed provider limit)",
+                            effective_max_output_tokens,
+                            DEFAULT_MAX_OUTPUT_TOKENS_CAP,
+                            self.model,
+                        )
+                        effective_max_output_tokens = DEFAULT_MAX_OUTPUT_TOKENS_CAP
                 elif isinstance(self._model_info.get("max_tokens"), int):
                     # 'max_tokens' is ambiguous: some providers use it for total
                     # context window, not output limit. Cap it to avoid requesting

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2189,6 +2189,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         effective_max_output_tokens = capped
                     if (
                         self.base_url is not None
+                        and not self.model.startswith("litellm_proxy/")
                         and effective_max_output_tokens is not None
                         and effective_max_output_tokens > DEFAULT_MAX_OUTPUT_TOKENS_CAP
                     ):

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1610,6 +1610,30 @@ def test_max_output_tokens_uses_actual_value_when_available(mock_get_model_info)
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
+def test_max_output_tokens_capped_when_model_info_exceeds_default_cap(
+    mock_get_model_info,
+):
+    """High LiteLLM max_output_tokens metadata is capped for custom gateways."""
+    from openhands.sdk.llm.llm import DEFAULT_MAX_OUTPUT_TOKENS_CAP
+
+    mock_get_model_info.return_value = {
+        "max_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_input_tokens": 262144,
+    }
+
+    llm = LLM(
+        model="moonshot/kimi-k2.5",
+        api_key=SecretStr("test-key"),
+        usage_id="test-llm",
+        base_url="https://qianfan.example.com/v1",
+    )
+
+    assert llm.max_output_tokens is None
+    assert llm.effective_max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS_CAP
+
+
+@patch("openhands.sdk.llm.llm.get_litellm_model_info")
 def test_max_output_tokens_small_max_tokens_not_capped(mock_get_model_info):
     """Test that small max_tokens fallback is not unnecessarily capped."""
     from openhands.sdk.llm.llm import DEFAULT_MAX_OUTPUT_TOKENS_CAP
@@ -1633,8 +1657,15 @@ def test_max_output_tokens_small_max_tokens_not_capped(mock_get_model_info):
     assert llm.effective_max_output_tokens < DEFAULT_MAX_OUTPUT_TOKENS_CAP
 
 
-def test_explicit_max_output_tokens_not_overridden():
+@patch("openhands.sdk.llm.llm.get_litellm_model_info")
+def test_explicit_max_output_tokens_not_overridden(mock_get_model_info):
     """Test that explicitly set max_output_tokens is respected."""
+    mock_get_model_info.return_value = {
+        "max_tokens": 262144,
+        "max_output_tokens": 131072,
+        "max_input_tokens": 262144,
+    }
+
     llm = LLM(
         model="gpt-4o",
         api_key=SecretStr("test-key"),
@@ -1657,20 +1688,20 @@ def test_max_output_tokens_capped_when_equal_to_context_window(
     max_output_tokens fills the entire context window.
     """
     mock_get_model_info.return_value = {
-        "max_output_tokens": 262144,
-        "max_input_tokens": 262144,
+        "max_output_tokens": 16384,
+        "max_input_tokens": 16384,
     }
 
     llm = LLM(
-        model="litellm_proxy/test-model-equal-windows",
+        model="bedrock/anthropic.claude-3-sonnet",
         api_key=SecretStr("test-key"),
         usage_id="test-llm",
     )
 
     assert llm.max_output_tokens is None
-    assert llm.effective_max_output_tokens == 262144 // 2
+    assert llm.effective_max_output_tokens == 16384 // 2
     assert llm.max_input_tokens is None
-    assert llm.effective_max_input_tokens == 262144
+    assert llm.effective_max_input_tokens == 16384
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -1634,6 +1634,22 @@ def test_max_output_tokens_capped_when_model_info_exceeds_default_cap(
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")
+def test_max_output_tokens_not_capped_without_custom_base_url(mock_get_model_info):
+    """Direct API (no base_url) keeps litellm's real max_output_tokens."""
+    mock_get_model_info.return_value = {
+        "max_output_tokens": 64000,
+        "max_tokens": 64000,
+        "max_input_tokens": 200000,
+    }
+    llm = LLM(
+        model="claude-opus-4-5",
+        api_key=SecretStr("test-key"),
+        usage_id="test-llm",
+    )
+    assert llm.effective_max_output_tokens == 64000
+
+
+@patch("openhands.sdk.llm.llm.get_litellm_model_info")
 def test_max_output_tokens_small_max_tokens_not_capped(mock_get_model_info):
     """Test that small max_tokens fallback is not unnecessarily capped."""
     from openhands.sdk.llm.llm import DEFAULT_MAX_OUTPUT_TOKENS_CAP
@@ -1688,20 +1704,20 @@ def test_max_output_tokens_capped_when_equal_to_context_window(
     max_output_tokens fills the entire context window.
     """
     mock_get_model_info.return_value = {
-        "max_output_tokens": 16384,
-        "max_input_tokens": 16384,
+        "max_output_tokens": 262144,
+        "max_input_tokens": 262144,
     }
 
     llm = LLM(
-        model="bedrock/anthropic.claude-3-sonnet",
+        model="litellm_proxy/test-model-equal-windows",
         api_key=SecretStr("test-key"),
         usage_id="test-llm",
     )
 
     assert llm.max_output_tokens is None
-    assert llm.effective_max_output_tokens == 16384 // 2
+    assert llm.effective_max_output_tokens == 131072
     assert llm.max_input_tokens is None
-    assert llm.effective_max_input_tokens == 16384
+    assert llm.effective_max_input_tokens == 262144
 
 
 @patch("openhands.sdk.llm.llm.get_litellm_model_info")


### PR DESCRIPTION
- [x] A human has tested these changes.

---

## Why

Issue #3317 reports a `BadRequestError` on every request when models like `moonshot/kimi-k2.5` or `deepseek/deepseek-v3.2` run through a custom `base_url`. The SDK infers `effective_max_output_tokens` from litellm metadata, but that value overshoots the provider's real API limit (litellm reports 131072 for kimi-k2.5 vs the real 98304). The existing Bedrock guard (#2247/#2264) only covered `bedrock/`-prefixed models, leaving custom-gateway routes exposed.

## Summary

- In `openhands-sdk/openhands/sdk/llm/llm.py`, when `effective_max_output_tokens` comes from litellm `max_output_tokens` metadata and exceeds `DEFAULT_MAX_OUTPUT_TOKENS_CAP`, it is now clamped to that cap for custom `base_url` routes (scoped to `self.base_url is not None`), covering the custom-gateway case in #3317 without affecting no-base_url models.
- An explicit user-set `max_output_tokens` is still honored verbatim; the override path is untouched.

## Issue Number

Closes #3317

## How to Test

Run `uv run pytest tests/sdk/llm/test_llm.py`. `test_max_output_tokens_capped_when_model_info_exceeds_default_cap` builds a `moonshot/kimi-k2.5` LLM with a custom `base_url` and litellm metadata reporting 131072, and asserts `effective_max_output_tokens == DEFAULT_MAX_OUTPUT_TOKENS_CAP`. `test_explicit_max_output_tokens_not_overridden` confirms a user-set value is respected, and the Bedrock cases keep their prior expectations.

## Video/Screenshots

N/A. This is a non-visual SDK fix to token-limit clamping logic; behavior is verified by the unit tests above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `extended_thinking_budget` interaction noted in the issue is left for a follow-up.