### PR TITLE
fix: remove the LLM settings->profile auto-migration

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -105,38 +105,6 @@ def _has_api_key(llm: LLM) -> bool:
     return bool(llm.api_key.get_secret_value().strip())
 
 
-def _model_to_profile_name(model: str) -> str:
-    """Convert a model name to a valid profile name.
-
-    Transforms model names like "openai/gpt-4o" or "anthropic/claude-3-opus"
-    into valid profile names by:
-    - Taking just the model part after provider prefix (if present)
-    - Replacing invalid characters with dashes
-    - Truncating to max 64 characters
-    """
-    import re
-
-    # Extract model name after provider prefix (e.g., "openai/gpt-4o" -> "gpt-4o")
-    if "/" in model:
-        model = model.rsplit("/", 1)[-1]
-
-    # Replace any character that's not alphanumeric, dash, underscore, or dot
-    # Profile names must match: ^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$
-    sanitized = re.sub(r"[^A-Za-z0-9._-]", "-", model)
-
-    # Ensure it starts with alphanumeric (required by profile name pattern)
-    if sanitized and not sanitized[0].isalnum():
-        sanitized = "m" + sanitized
-
-    # Truncate to max 64 characters
-    sanitized = sanitized[:64]
-
-    # Remove trailing non-alphanumeric characters
-    sanitized = sanitized.rstrip("._-")
-
-    return sanitized or "default"
-
-
 @profiles_router.get("", response_model=ProfileListResponse)
 async def list_profiles(request: Request) -> ProfileListResponse:
     """List all saved LLM profiles.
@@ -144,17 +112,7 @@ async def list_profiles(request: Request) -> ProfileListResponse:
     Returns the list of profiles along with the currently active profile name,
     if one has been activated. The active_profile tracks which LLM profile
     configuration is currently in use.
-
-    Auto-creates a profile named after the model if:
-    - No profiles exist
-    - agent_settings.llm has an API key configured
-
-    The API key check ensures we only auto-create when the user has actually
-    configured their LLM (not just relying on defaults). This allows users
-    with existing LLM configurations to see their settings as a profile
-    without manual creation.
     """
-    cipher = get_cipher(request)
     config = get_config(request)
     settings_store = get_settings_store(config)
     settings = settings_store.load() or PersistedSettings()
@@ -163,42 +121,9 @@ async def list_profiles(request: Request) -> ProfileListResponse:
     with _store_errors():
         summaries = store.list_summaries()
 
-    active_profile = settings.active_profile
-
-    # Auto-create profile from existing LLM settings if no profiles exist
-    # but an API key is configured. Use the model name as the profile name.
-    if not summaries and settings.llm_api_key_is_set:
-        llm = settings.agent_settings.llm
-        profile_name = _model_to_profile_name(llm.model or "default")
-        try:
-            with _store_errors():
-                store.save(
-                    profile_name,
-                    llm,
-                    include_secrets=True,
-                    cipher=cipher,
-                )
-
-            # Update settings to mark this as active
-            def set_active(s: PersistedSettings) -> PersistedSettings:
-                s.active_profile = profile_name
-                return s
-
-            settings_store.update(set_active)
-            active_profile = profile_name
-
-            # Refresh summaries to include the new profile
-            summaries = store.list_summaries()
-            logger.info(
-                f"Auto-created '{profile_name}' profile from existing LLM settings"
-            )
-        except Exception as e:
-            # Log but don't fail - auto-creation is a convenience feature
-            logger.warning(f"Failed to auto-create profile: {e}")
-
     return ProfileListResponse(
         profiles=[ProfileInfo(**s) for s in summaries],
-        active_profile=active_profile,
+        active_profile=settings.active_profile,
     )
 
 

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1026,42 +1026,17 @@ def test_rename_inactive_profile_preserves_active_profile(client, store):
 # ── Auto-Create Profile Tests ─────────────────────────────────────────────
 
 
-def test_list_profiles_auto_creates_profile_named_after_model(client):
-    """Auto-creates profile named after model when API key is configured."""
-    # Configure LLM settings with API key (required for auto-creation)
+def test_list_profiles_does_not_auto_create_from_settings(client):
+    """A configured LLM + API key with no profiles must NOT create a profile.
+
+    The legacy one-time settings->profile migration was removed: profiles are
+    created explicitly, so an LLM key lingering in agent_settings never
+    materializes a profile on its own.
+    """
     client.patch(
         "/api/settings",
         json={
-            "agent_settings_diff": {
-                "llm": {
-                    "model": "gpt-4o",
-                    "api_key": "sk-auto-test",
-                    "temperature": 0.5,
-                }
-            }
-        },
-    )
-
-    # List profiles should auto-create a profile named after the model
-    response = client.get("/api/profiles")
-
-    assert response.status_code == 200
-    body = response.json()
-    assert len(body["profiles"]) == 1
-    assert body["profiles"][0]["name"] == "gpt-4o"  # Named after model
-    assert body["profiles"][0]["model"] == "gpt-4o"
-    assert body["profiles"][0]["api_key_set"] is True
-    assert body["active_profile"] == "gpt-4o"
-
-
-def test_list_profiles_auto_creates_profile_strips_provider_prefix(client):
-    """Auto-created profile strips provider prefix from model name."""
-    client.patch(
-        "/api/settings",
-        json={
-            "agent_settings_diff": {
-                "llm": {"model": "openai/gpt-4o-mini", "api_key": "sk-prefix-test"}
-            }
+            "agent_settings_diff": {"llm": {"model": "gpt-4o", "api_key": "sk-no-auto"}}
         },
     )
 
@@ -1069,31 +1044,8 @@ def test_list_profiles_auto_creates_profile_strips_provider_prefix(client):
 
     assert response.status_code == 200
     body = response.json()
-    # Should use just "gpt-4o-mini" not "openai/gpt-4o-mini"
-    assert body["profiles"][0]["name"] == "gpt-4o-mini"
-    assert body["active_profile"] == "gpt-4o-mini"
-
-
-def test_list_profiles_auto_creates_profile_sanitizes_special_chars(client):
-    """Auto-created profile sanitizes special characters in model name."""
-    client.patch(
-        "/api/settings",
-        json={
-            "agent_settings_diff": {
-                "llm": {
-                    "model": "anthropic/claude-3.5-sonnet@beta",
-                    "api_key": "sk-special",
-                }
-            }
-        },
-    )
-
-    response = client.get("/api/profiles")
-
-    assert response.status_code == 200
-    body = response.json()
-    # @ should be replaced with -
-    assert body["profiles"][0]["name"] == "claude-3.5-sonnet-beta"
+    assert body["profiles"] == []
+    assert body["active_profile"] is None
 
 
 def test_list_profiles_no_auto_create_without_api_key(client):
@@ -1148,52 +1100,19 @@ def test_list_profiles_no_auto_create_when_profiles_exist(client, store):
     assert body["profiles"][0]["name"] == "existing-profile"
 
 
-def test_list_profiles_auto_create_is_idempotent(client):
-    """Multiple calls to list_profiles don't create duplicate profiles."""
-    # Configure LLM with API key
-    client.patch(
-        "/api/settings",
-        json={
-            "agent_settings_diff": {
-                "llm": {"model": "gpt-4o", "api_key": "sk-idempotent-test"}
-            }
-        },
-    )
+def test_list_profiles_no_auto_create_after_deleting_active_profile(client, store):
+    """Deleting all profiles leaves the list empty (regression).
 
-    # First call creates profile
-    response1 = client.get("/api/profiles")
-    assert response1.status_code == 200
-    assert len(response1.json()["profiles"]) == 1
+    Activating a profile copies its API key into agent_settings; with no
+    auto-create from settings, that lingering key must not resurrect a
+    profile on the next list call.
+    """
+    llm = LLM(model="gpt-4o", api_key="sk-test")
+    store.save("my-profile", llm, include_secrets=True)
+    client.post("/api/profiles/my-profile/activate")
 
-    # Second call should not create another
-    response2 = client.get("/api/profiles")
-    assert response2.status_code == 200
-    assert len(response2.json()["profiles"]) == 1
-    assert response2.json()["profiles"][0]["name"] == "gpt-4o"
+    client.delete("/api/profiles/my-profile")
+    response = client.get("/api/profiles")
 
-
-def test_auto_created_profile_persists(client, store):
-    """Auto-created profile is persisted and can be loaded."""
-    # Configure LLM with API key
-    client.patch(
-        "/api/settings",
-        json={
-            "agent_settings_diff": {
-                "llm": {
-                    "model": "gpt-4o",
-                    "api_key": "sk-persist-test",
-                    "temperature": 0.7,
-                }
-            }
-        },
-    )
-
-    # Trigger auto-creation
-    client.get("/api/profiles")
-
-    # Verify profile was saved with model name
-    loaded = store.load("gpt-4o")
-    assert loaded.model == "gpt-4o"
-    assert loaded.temperature == 0.7
-    assert loaded.api_key is not None
-    assert loaded.api_key.get_secret_value() == "sk-persist-test"
+    assert response.status_code == 200
+    assert response.json()["profiles"] == []

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6095,21 +6095,6 @@ class TestACPSecretsEnvInjection:
         assert not [w for w in caught if "acp_env" in str(w.message)]
 
 
-# NOTE: module-level on purpose. A ``SecretSource`` (DiscriminatedUnionMixin)
-# subclass defined inside a function auto-registers globally and, having
-# ``<locals>`` in its qualname, makes the registry raise "Local classes not
-# supported!" for any later discriminated-union validation in the same xdist
-# worker (e.g. an unrelated ConversationState deserialization). Module-level
-# (importable) subclasses avoid that pollution.
-class _FakeLookupSecret(SecretSource):
-    """A ``LookupSecret``-shaped source whose ``get_value()`` returns a literal."""
-
-    stored_value: str
-
-    def get_value(self) -> str | None:
-        return self.stored_value
-
-
 class _CountingLookupSecret(SecretSource):
     """A lookup source that records each ``get_value()`` call (to assert it is
     *not* invoked when ``acp_env`` shadows the key)."""


### PR DESCRIPTION
## Why
Deleting all LLM profiles recreated one. `GET /api/profiles` auto-created a profile from `agent_settings.llm` whenever the store was empty and an API key was set — a one-time migration that also re-fired after an explicit delete-all (activation copies the key into `agent_settings`; delete leaves it).

## What
Remove the auto-create-from-settings migration entirely. `list_profiles` is now a pure read: it lists saved profiles and returns the stored `active_profile` as-is. Profiles are created/activated only explicitly, so a key lingering in `agent_settings` never materializes a profile.

The agent-server stays a neutral API — keeping the "always have an active profile" UX policy out of it. That reconciliation (auto-activate when none is active, handle a dangling pointer) lives in the client (agent-canvas, OpenHands/agent-canvas#1128), since other consumers (e.g. SaaS) own the LLM differently.

## Breaking change
A user who configured an LLM before profiles existed and never engaged with profiles now sees an empty list instead of a migrated profile; they create a profile explicitly (their key remains in `agent_settings`, and the GUI's "LLM not configured" banner guides them — OpenHands/agent-canvas#1128).

## Test
`tests/agent_server/test_profiles_router.py`: **73 passed**. Removed the 5 auto-create tests; added `test_list_profiles_does_not_auto_create_from_settings` (key + no profile → stays empty) and `test_list_profiles_no_auto_create_after_deleting_active_profile` (delete-all → stays empty).

Refs OpenHands/agent-canvas#2120




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d4fe643-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d4fe643-python \
  ghcr.io/openhands/agent-server:d4fe643-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d4fe643-golang-amd64
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-golang-amd64
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-golang-amd64
ghcr.io/openhands/agent-server:d4fe643-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d4fe643-golang-arm64
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-golang-arm64
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-golang-arm64
ghcr.io/openhands/agent-server:d4fe643-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d4fe643-java-amd64
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-java-amd64
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-java-amd64
ghcr.io/openhands/agent-server:d4fe643-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d4fe643-java-arm64
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-java-arm64
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-java-arm64
ghcr.io/openhands/agent-server:d4fe643-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d4fe643-python-amd64
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-python-amd64
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-python-amd64
ghcr.io/openhands/agent-server:d4fe643-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d4fe643-python-arm64
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-python-arm64
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-python-arm64
ghcr.io/openhands/agent-server:d4fe643-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d4fe643-golang
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-golang
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-golang
ghcr.io/openhands/agent-server:d4fe643-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d4fe643-java
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-java
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-java
ghcr.io/openhands/agent-server:d4fe643-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d4fe643-python
ghcr.io/openhands/agent-server:d4fe643c967376b8df3e12fd685d39d9828f39af-python
ghcr.io/openhands/agent-server:fix-profiles-no-resurrect-after-delete-all-python
ghcr.io/openhands/agent-server:d4fe643-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d4fe643-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d4fe643-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->