### PR TITLE
fix(conversation): run ACP cold-start off the event loop in arun()

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1119,7 +1119,14 @@ class LocalConversation(BaseConversation):
         """
         self._arun_task = asyncio.current_task()
         self._cancel_token = CancellationToken()
-        self._ensure_agent_ready()
+        # Off-load lazy init to a worker thread: init_state may block the loop
+        # (an ACP agent resolves credentials via a synchronous LookupSecret
+        # httpx.get). When the agent-server runs arun() on its event loop and
+        # that lookup points back at the same single-process server, doing it
+        # inline freezes the loop so the lookup can never be served — a
+        # self-deadlock that ReadTimeouts after 30s (agent-canvas#1072).
+        # _ensure_agent_ready is thread-safe and already runs off-loop in run().
+        await asyncio.to_thread(self._ensure_agent_ready)
 
         with self._state:
             if isinstance(self.agent, ACPAgent) and self._state.execution_status in (

--- a/tests/sdk/conversation/test_interrupt.py
+++ b/tests/sdk/conversation/test_interrupt.py
@@ -10,7 +10,8 @@ Covers:
 """
 
 import asyncio
-from unittest.mock import MagicMock
+import threading
+from unittest.mock import MagicMock, patch
 
 import pytest
 from litellm.types.utils import ModelResponse
@@ -421,3 +422,31 @@ async def test_execute_batch_skips_all_on_pre_cancelled_token():
         assert len(r) == 1
         assert isinstance(r[0], AgentErrorEvent)
         assert "cancelled" in r[0].error.lower()
+
+
+@pytest.mark.asyncio
+async def test_arun_runs_init_off_the_event_loop(tmp_path):
+    """arun() offloads _ensure_agent_ready() to a worker thread.
+
+    Regression for agent-canvas#1072: an ACP agent resolves its credentials in
+    init_state via a *blocking* LookupSecret.get_value() (a synchronous
+    httpx.get). If arun() ran that inline on the event loop and the lookup
+    pointed back at the same single-process server, it would freeze the loop
+    that has to serve it — a self-deadlock. Verify init runs on a different
+    thread than the one driving the loop.
+    """
+    conv = _make_conversation(SlowLLM(sleep_seconds=0.0), tmp_path)
+
+    loop_thread_id = threading.get_ident()
+    captured: dict[str, int] = {}
+    real_ensure = conv._ensure_agent_ready
+
+    def spy_ensure() -> None:
+        captured["thread_id"] = threading.get_ident()
+        real_ensure()
+
+    with patch.object(conv, "_ensure_agent_ready", spy_ensure):
+        await asyncio.wait_for(conv.arun(), timeout=5.0)
+
+    assert captured["thread_id"] != loop_thread_id
+    assert conv.state.execution_status == ConversationExecutionStatus.FINISHED


### PR DESCRIPTION
## Problem

ACP conversations hang forever on the first turn (~60s, then permanent failure) in single-process deployments such as standalone **agent-canvas** (Docker / `npx`). Reported in OpenHands/agent-canvas#2098.

Root cause is a **self-deadlock**:

- `LocalConversation.arun()` runs `_ensure_agent_ready()` **inline on the event loop**.
- For an ACP agent, that calls `init_state()` → `_start_acp_server()`, which resolves the conversation's secrets eagerly while building the subprocess env.
- A `LookupSecret` resolves its value via a **synchronous** `httpx.get` (`secret/secrets.py`).
- The agent-server runs `arun()` on its own asyncio event loop. When the lookup URL points **back at the same single-process server** (agent-canvas builds `ANTHROPIC_API_KEY` as a loopback `LookupSecret` → `/api/settings/secrets/...`), the blocking `httpx.get` freezes the very loop that must serve it. The request can never be answered → `httpx.ReadTimeout` after 30s. `_start_acp_server` resolves the key twice (registry + `agent_context.secrets` drain), so the UI hangs ~60s before ACP startup fails.

This does not bite OpenHands Cloud because there the `LookupSecret` URL is a **separate** app-server process, so the blocking call is served by a different loop.

## Fix

Off-load `_ensure_agent_ready()` to a worker thread in `arun()`:

```python
await asyncio.to_thread(self._ensure_agent_ready)
```

`_ensure_agent_ready()` is already thread-safe (double-checked lock on conversation state) and already runs off-loop on the sync `run()` path — `arun()` was the only on-loop caller. The subprocess spawn inside `_start_acp_server` runs on its own `AsyncExecutor` portal loop, so it is unaffected. With init off the loop, the loop stays free to serve the re-entrant secret fetch and the lookup resolves normally.

## Verification (real calls)

Ran this exact patched agent-server on the host with a loopback (`OH_INTERNAL_SERVER_URL` → itself), the agent-canvas `ANTHROPIC_API_KEY` `LookupSecret`, and a real `claude-agent-acp` subprocess — A/B on the same binary, toggling only this one line:

| | Event loop | Secret resolution | Outcome |
|---|---|---|---|
| **Before (inline)** | `GET /health` froze (timed out) | `ReadTimeout: timed out` at +30s | deadlock (matches OpenHands/agent-canvas#2098) |
| **After (off-loop)** | `/run` → 409 in 0.03s | `Secret accessed` served during init | ACP initialized, prompt returned in 5.8s, **finished** |

Also reproduced the original deadlock byte-for-byte in the shipped `ghcr.io/openhands/agent-canvas:1.0.0-beta.6` image beforehand.

## Test

`tests/sdk/conversation/test_arun_init_offload.py` — a blocking `_ensure_agent_ready` that only completes if a concurrent loop coroutine can run. Fails (loop frozen) without the fix; passes with it.

Fixes OpenHands/agent-canvas#2098




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:171c459-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-171c459-python \
  ghcr.io/openhands/agent-server:171c459-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:171c459-golang-amd64
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-golang-amd64
ghcr.io/openhands/agent-server:171c459-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:171c459-golang-arm64
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-golang-arm64
ghcr.io/openhands/agent-server:171c459-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:171c459-java-amd64
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-java-amd64
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-java-amd64
ghcr.io/openhands/agent-server:171c459-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:171c459-java-arm64
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-java-arm64
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-java-arm64
ghcr.io/openhands/agent-server:171c459-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:171c459-python-amd64
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-python-amd64
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-python-amd64
ghcr.io/openhands/agent-server:171c459-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:171c459-python-arm64
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-python-arm64
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-python-arm64
ghcr.io/openhands/agent-server:171c459-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:171c459-golang
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-golang
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-golang
ghcr.io/openhands/agent-server:171c459-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:171c459-java
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-java
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-java
ghcr.io/openhands/agent-server:171c459-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:171c459-python
ghcr.io/openhands/agent-server:171c459b4677460ae45995f65b3d88c65d7f7ec9-python
ghcr.io/openhands/agent-server:fix-acp-arun-event-loop-deadlock-python
ghcr.io/openhands/agent-server:171c459-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `171c459-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `171c459-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->