### PR TITLE
fix: use timezone-aware UTC for default current_datetime in AgentContext

### DIFF
--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -5,6 +5,8 @@ from collections.abc import Mapping
 from datetime import datetime
 from typing import Any
 
+from openhands.sdk.utils.datetime import utc_now
+
 from pydantic import (
     BaseModel,
     Field,
@@ -128,13 +130,13 @@ class AgentContext(BaseModel):
         json_schema_extra={"acp_compatible": True},
     )
     current_datetime: datetime | str | None = Field(
-        default_factory=datetime.now,
+        default_factory=utc_now,
         description=(
             "Current date and time information to provide to the agent. "
             "Can be a datetime object (which will be formatted as ISO 8601) "
             "or a pre-formatted string. When provided, this information is "
             "included in the system prompt to give the agent awareness of "
-            "the current time context. Defaults to the current datetime."
+            "the current time context. Defaults to the current UTC datetime."
         ),
         json_schema_extra={"acp_compatible": True},
     )

--- a/tests/sdk/context/test_agent_context.py
+++ b/tests/sdk/context/test_agent_context.py
@@ -974,17 +974,19 @@ templates.",
         assert result is None
 
     def test_agent_context_default_datetime(self):
-        """Test that AgentContext defaults to current datetime."""
-        from datetime import datetime, timedelta
+        """Test that AgentContext defaults to current UTC datetime with tzinfo."""
+        from datetime import UTC, datetime, timedelta
 
-        before = datetime.now()
+        before = datetime.now(UTC)
         context = AgentContext()
-        after = datetime.now()
+        after = datetime.now(UTC)
 
         # Verify current_datetime is set and is a datetime object
         assert context.current_datetime is not None
         assert isinstance(context.current_datetime, datetime)
-        # Verify it's approximately the current time (within 1 second)
+        # Verify it is timezone-aware (has tzinfo)
+        assert context.current_datetime.tzinfo is not None
+        # Verify it's approximately the current UTC time (within 1 second)
         assert before <= context.current_datetime <= after + timedelta(seconds=1)
 
     def test_get_system_message_suffix_with_datetime_only(self):
@@ -1086,6 +1088,14 @@ templates.",
         assert result is not None
         assert "<CURRENT_DATETIME>" in result
         assert "The current date and time is: 2024-03-15T14:30:00" in result
+
+    def test_get_formatted_datetime_default_includes_timezone(self):
+        """Test that default datetime isoformat includes UTC offset."""
+        context = AgentContext()
+        result = context.get_formatted_datetime()
+
+        assert result is not None
+        assert "+00:00" in result
 
 
 def test_agent_context_secrets_raw_strings_redacted_by_default():


### PR DESCRIPTION
## Summary

Fixes #3438

The `current_datetime` field in `AgentContext` used `datetime.now()` (naive local time), causing the system prompt to inject a timezone-ambiguous datetime string like `2026-06-04T14:30:00` with no UTC offset. This breaks any agent time-sensitive reasoning (scheduling, expiration checks, relative-date math) and is especially problematic in cloud deployments where the server's local timezone is arbitrary.

**Root cause:** `default_factory=datetime.now` in `agent_context.py:130`

**Fix:** Replace with the existing `utc_now()` helper from `openhands.sdk.utils.datetime`, which returns `datetime.now(UTC)`. The resulting `.isoformat()` output now includes the `+00:00` suffix (e.g. `2026-06-04T14:30:00.123456+00:00`), making the injected datetime unambiguous.

## Changes

- `openhands-sdk/openhands/sdk/context/agent_context.py`: Import `utc_now`, replace `default_factory=datetime.now` with `default_factory=utc_now`
- `tests/sdk/context/test_agent_context.py`: Update `test_agent_context_default_datetime` to assert timezone-awareness; add `test_get_formatted_datetime_default_includes_timezone`

## Test plan

- [x] Existing tests passing explicit `current_datetime` values are unaffected
- [x] `test_agent_context_default_datetime` now verifies `.tzinfo is not None`
- [x] New test asserts `+00:00` appears in default formatted output
- [ ] CI should confirm no regressions in serialization/deserialization paths