### PR TITLE
PLTF-2899: serialize webhook events with model_dump(mode="json")

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1256,9 +1256,15 @@ class WebhookSubscriber(Subscriber):
         if self.session_api_key:
             headers["X-Session-API-Key"] = self.session_api_key
 
-        # Convert events to serializable format
+        # Convert events to a JSON-serializable format. mode="json" is required
+        # so types like set and SecretStr become JSON-safe primitives; without
+        # it httpx's encoder raises "Object of type set/SecretStr is not JSON
+        # serializable", every retry fails identically, and the events are
+        # dropped. (Mirrors ConversationWebhookSubscriber.post_conversation_info.)
         event_data = [
-            event.model_dump() if hasattr(event, "model_dump") else event.__dict__
+            event.model_dump(mode="json")
+            if hasattr(event, "model_dump")
+            else event.__dict__
             for event in events_to_post
         ]
 

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -411,6 +411,9 @@ class TestWebhookSubscriberPostEvents:
         """
         import json as _json
 
+        # Test event with types that model_dump() leaves non-JSON-serializable.
+        # Note: deliberately not a ConversationEvent; we only care about serialization
+        # of pydantic models with tricky field types for the webhook POST payload.
         class _EventWithTrickyTypes(BaseModel):
             tags: set[str]
             secret: SecretStr
@@ -426,6 +429,7 @@ class TestWebhookSubscriberPostEvents:
             service=mock_event_service,
             spec=webhook_spec,
         )
+        # Deliberately assign non-ConversationEvent for regression test.
         subscriber.queue = [
             _EventWithTrickyTypes(tags={"a", "b"}, secret=SecretStr("shh"))  # type: ignore[assignment]
         ]

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -427,7 +427,7 @@ class TestWebhookSubscriberPostEvents:
             spec=webhook_spec,
         )
         subscriber.queue = [
-            _EventWithTrickyTypes(tags={"a", "b"}, secret=SecretStr("shh"))
+            _EventWithTrickyTypes(tags={"a", "b"}, secret=SecretStr("shh"))  # type: ignore[assignment]
         ]
 
         await subscriber._post_events()

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -13,7 +13,7 @@ from uuid import uuid4
 
 import httpx
 import pytest
-from pydantic import SecretStr, ValidationError
+from pydantic import BaseModel, SecretStr, ValidationError
 
 from openhands.agent_server.config import WebhookSpec
 from openhands.agent_server.conversation_service import (
@@ -337,7 +337,7 @@ class TestWebhookSubscriberPostEvents:
         mock_client.request.assert_called_once_with(
             method="POST",
             url=expected_url,
-            json=[event.model_dump() for event in sample_events[:3]],
+            json=[event.model_dump(mode="json") for event in sample_events[:3]],
             headers={
                 "Content-Type": "application/json",
                 "Authorization": "Bearer token",
@@ -388,10 +388,56 @@ class TestWebhookSubscriberPostEvents:
         mock_client.request.assert_called_once_with(
             method="POST",
             url=expected_url,
-            json=[event.model_dump() for event in sample_events[:2]],
+            json=[event.model_dump(mode="json") for event in sample_events[:2]],
             headers=expected_headers,
             timeout=30.0,
         )
+
+    @pytest.mark.asyncio
+    @patch("httpx.AsyncClient")
+    async def test_post_events_serializes_set_and_secretstr(
+        self,
+        mock_client_class,
+        mock_event_service,
+        webhook_spec,
+        sample_conversation_id,
+    ):
+        """Regression: events containing set / SecretStr must serialize.
+
+        Plain model_dump() leaves set and SecretStr as Python objects that
+        httpx's JSON encoder cannot serialize ("Object of type set/SecretStr is
+        not JSON serializable"), failing every retry and dropping the events.
+        model_dump(mode="json") makes them JSON-safe.
+        """
+        import json as _json
+
+        class _EventWithTrickyTypes(BaseModel):
+            tags: set[str]
+            secret: SecretStr
+
+        mock_client = AsyncMock()
+        mock_response = AsyncMock()
+        mock_response.raise_for_status.return_value = None
+        mock_client.request.return_value = mock_response
+        mock_client_class.return_value.__aenter__.return_value = mock_client
+
+        subscriber = WebhookSubscriber(
+            conversation_id=sample_conversation_id,
+            service=mock_event_service,
+            spec=webhook_spec,
+        )
+        subscriber.queue = [
+            _EventWithTrickyTypes(tags={"a", "b"}, secret=SecretStr("shh"))
+        ]
+
+        await subscriber._post_events()
+
+        posted_json = mock_client.request.call_args.kwargs["json"]
+        # httpx serializes this internally; it must not raise TypeError.
+        _json.dumps(posted_json)
+        assert isinstance(posted_json[0]["tags"], list)
+        # SecretStr is masked, not leaked, in JSON mode.
+        assert posted_json[0]["secret"] != "shh"
 
     @pytest.mark.asyncio
     async def test_post_events_empty_queue(


### PR DESCRIPTION
## Why

`WebhookSubscriber._post_events` serialized events with `event.model_dump()` (no `mode`), leaving types like `set` and `pydantic.SecretStr` as Python objects. httpx's JSON encoder then raises `TypeError: Object of type set is not JSON serializable` (and the same for `SecretStr`). Because the payload is unchanged between retries, all 4 attempts fail identically and the events are **dropped** — they're never delivered to the webhook.

In production this is high-volume (~446 `set` + ~54 `SecretStr` failures/day) and is a likely cause of conversations appearing stalled on the consumer side while the agent is actually progressing.

The sibling `ConversationWebhookSubscriber.post_conversation_info` already does the right thing with `model_dump(mode="json")`; the events poster was inconsistent.

Fixes OpenHands/software-agent-sdk#3516.

## Summary

- `WebhookSubscriber._post_events` now uses `event.model_dump(mode="json")`, producing JSON-safe primitives (`set` → `list`, `SecretStr` → masked string).
- Updated the two existing `_post_events` assertions to expect `mode="json"`.
- Added a regression test (`test_post_events_serializes_set_and_secretstr`) that fails before the fix.

## Issue Number

OpenHands/software-agent-sdk#3516

## How to Test

Unit tests:
```
uv run pytest tests/agent_server/test_webhook_subscriber.py -k "post_events"
```

Reproduction (before vs after), mirroring the failing serialization path:
```python
import json
from pydantic import BaseModel, SecretStr

class Event(BaseModel):
    tags: set[str]
    secret: SecretStr

e = Event(tags={"a", "b"}, secret=SecretStr("shh"))
json.dumps(e.model_dump())              # BEFORE: TypeError: Object of type set is not JSON serializable
json.dumps(e.model_dump(mode="json"))   # AFTER:  {"tags": ["a", "b"], "secret": "**********"}
```
Observed output:
```
BEFORE  model_dump():            TypeError -> Object of type set is not JSON serializable
AFTER   model_dump(mode='json'): {"tags": ["a", "b"], "secret": "**********"}
```
This matches the production log line `Webhook post attempt N failed: Object of type set is not JSON serializable`.

## Type

- [x] Bug fix

## Notes

- `mode="json"` also masks `SecretStr` (`"**********"`) rather than leaking secret values into webhook payloads — a desirable side effect.
- The `else event.__dict__` fallback (for non-pydantic events) is left unchanged; in practice events are pydantic models with `model_dump`.

---
_This was created by an AI assistant._


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:28e8179-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-28e8179-python \
  ghcr.io/openhands/agent-server:28e8179-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:28e8179-golang-amd64
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-golang-amd64
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-golang-amd64
ghcr.io/openhands/agent-server:28e8179-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:28e8179-golang-arm64
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-golang-arm64
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-golang-arm64
ghcr.io/openhands/agent-server:28e8179-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:28e8179-java-amd64
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-java-amd64
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-java-amd64
ghcr.io/openhands/agent-server:28e8179-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:28e8179-java-arm64
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-java-arm64
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-java-arm64
ghcr.io/openhands/agent-server:28e8179-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:28e8179-python-amd64
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-python-amd64
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-python-amd64
ghcr.io/openhands/agent-server:28e8179-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:28e8179-python-arm64
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-python-arm64
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-python-arm64
ghcr.io/openhands/agent-server:28e8179-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:28e8179-golang
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-golang
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-golang
ghcr.io/openhands/agent-server:28e8179-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:28e8179-java
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-java
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-java
ghcr.io/openhands/agent-server:28e8179-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:28e8179-python
ghcr.io/openhands/agent-server:28e8179b84b304c0160fbd49449e4fd6a43c0183-python
ghcr.io/openhands/agent-server:fix-webhook-events-json-serializable-python
ghcr.io/openhands/agent-server:28e8179-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `28e8179-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `28e8179-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->