### PR TITLE
ci: treat Field default_factory changes as behavioral

### DIFF
--- a/.github/scripts/check_sdk_api_breakage.py
+++ b/.github/scripts/check_sdk_api_breakage.py
@@ -507,10 +507,13 @@ def _filter_field_metadata_kwargs(call: ast.Call) -> ast.Call:
     )
 
 
+FIELD_DEFAULT_KWARGS = ("default", "default_factory")
+
+
 def _field_default_node(call: ast.Call) -> ast.AST | None:
-    """Return the AST node representing a ``Field`` default value."""
+    """Return the AST node representing a ``Field`` default value/factory."""
     for kw in call.keywords:
-        if kw.arg == "default":
+        if kw.arg in FIELD_DEFAULT_KWARGS:
             return kw.value
     if call.args:
         return call.args[0]
@@ -518,19 +521,19 @@ def _field_default_node(call: ast.Call) -> ast.AST | None:
 
 
 def _remove_field_default(call: ast.Call) -> ast.Call:
-    """Return a copy of a ``Field(...)`` call without its default value."""
+    """Return a copy of a ``Field(...)`` call without its default value/factory."""
     args = list(call.args)
     if args:
         args = args[1:]
     return ast.Call(
         func=call.func,
         args=args,
-        keywords=[kw for kw in call.keywords if kw.arg != "default"],
+        keywords=[kw for kw in call.keywords if kw.arg not in FIELD_DEFAULT_KWARGS],
     )
 
 
 def _field_default_repr(value: object) -> str | None:
-    """Return the string form of a ``Field`` default value, if present."""
+    """Return the string form of a ``Field`` default value/factory, if present."""
     call = _parse_field_call(value)
     if call is None:
         return None

--- a/tests/cross/test_check_sdk_api_breakage.py
+++ b/tests/cross/test_check_sdk_api_breakage.py
@@ -629,6 +629,16 @@ def test_is_field_default_only_change_detects_keyword_default_change():
     assert _is_field_default_only_change(old, new) is True
 
 
+def test_is_field_default_only_change_detects_keyword_default_factory_change():
+    """Changing only Field default_factory is classified separately."""
+    old = "Field(default_factory=datetime.now, description='desc')"
+    new = (
+        "Field(default_factory=lambda: datetime.now().astimezone(), description='new')"
+    )
+
+    assert _is_field_default_only_change(old, new) is True
+
+
 def test_is_field_default_only_change_ignores_other_runtime_changes():
     """Changing non-default runtime kwargs is not a default-only change."""
     old = "Field(default='claude-sonnet-4-20250514', alias='model')"
@@ -642,6 +652,14 @@ def test_field_default_repr_supports_positional_default():
     assert (
         _field_default_repr("Field('gpt-5.5', description='Model name.')")
         == "'gpt-5.5'"
+    )
+
+
+def test_field_default_repr_supports_default_factory():
+    """Field default_factory values are normalized for reporting."""
+    assert (
+        _field_default_repr("Field(default_factory=datetime.now, description='desc')")
+        == "datetime.now"
     )
 
 
@@ -936,6 +954,54 @@ def test_field_default_change_is_reported_but_not_breaking(tmp_path):
             object_path="openhands.sdk.Config.model",
             old_default="'claude-sonnet-4-20250514'",
             new_default="'gpt-5.5'",
+        )
+    ]
+
+
+def test_field_default_factory_change_is_reported_but_not_breaking(tmp_path):
+    """Public Field default_factory changes should be collected for release notes."""
+    old_pkg = _write_pkg_init(tmp_path, "old", ["Config"])
+    new_pkg = _write_pkg_init(tmp_path, "new", ["Config"])
+
+    old_init = old_pkg / "__init__.py"
+    new_init = new_pkg / "__init__.py"
+
+    old_init.write_text(
+        old_init.read_text()
+        + "\nfrom datetime import datetime\n"
+        + "from pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    current_datetime: datetime = Field(default_factory=datetime.now)\n"
+    )
+    new_init.write_text(
+        new_init.read_text()
+        + "\nfrom datetime import datetime\n"
+        + "from pydantic import BaseModel, Field\n\n"
+        + "class Config(BaseModel):\n"
+        + "    current_datetime: datetime = Field(\n"
+        + "        default_factory=lambda: datetime.now().astimezone(),\n"
+        + "    )\n"
+    )
+
+    old_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "old")])
+    new_root = griffe.load("openhands.sdk", search_paths=[str(tmp_path / "new")])
+
+    field_default_changes: list[FieldDefaultChange] = []
+    total_breaks, undeprecated = _prod._compute_breakages(
+        old_root,
+        new_root,
+        _SDK_CFG,
+        field_default_changes=field_default_changes,
+    )
+
+    assert total_breaks == 0
+    assert undeprecated == 0
+    assert field_default_changes == [
+        _prod.FieldDefaultChange(
+            package="openhands.sdk",
+            object_path="openhands.sdk.Config.current_datetime",
+            old_default="datetime.now",
+            new_default="lambda: datetime.now().astimezone()",
         )
     ]
 


### PR DESCRIPTION
## Summary

- Extend the Python API breakage checker's existing Pydantic `Field(default=...)` handling to also cover `Field(default_factory=...)`.
- Keep default-factory-only changes on the behavioral/release-note-required path instead of treating them as structural Griffe breakages.
- Add focused checker tests for default_factory detection, reporting, and non-breaking classification.

## How to Test

```bash
uv run pytest tests/cross/test_check_sdk_api_breakage.py -q
uv run pre-commit run --files .github/scripts/check_sdk_api_breakage.py tests/cross/test_check_sdk_api_breakage.py
SDK_API_BREAKAGE_REPORT_PATH=/tmp/sdk-api-breakage-report.json ACP_VERSION_CHECK_BASE_REF=main uv run python .github/scripts/check_sdk_api_breakage.py
```

_This PR was created by an AI agent (OpenHands) on behalf of @enyst._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/41164a96-6b8c-45a7-b32c-4ad9a99d4926)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1d6feb0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1d6feb0-python \
  ghcr.io/openhands/agent-server:1d6feb0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1d6feb0-golang-amd64
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-golang-amd64
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-golang-amd64
ghcr.io/openhands/agent-server:1d6feb0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1d6feb0-golang-arm64
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-golang-arm64
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-golang-arm64
ghcr.io/openhands/agent-server:1d6feb0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1d6feb0-java-amd64
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-java-amd64
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-java-amd64
ghcr.io/openhands/agent-server:1d6feb0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1d6feb0-java-arm64
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-java-arm64
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-java-arm64
ghcr.io/openhands/agent-server:1d6feb0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1d6feb0-python-amd64
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-python-amd64
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-python-amd64
ghcr.io/openhands/agent-server:1d6feb0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1d6feb0-python-arm64
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-python-arm64
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-python-arm64
ghcr.io/openhands/agent-server:1d6feb0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1d6feb0-golang
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-golang
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-golang
ghcr.io/openhands/agent-server:1d6feb0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1d6feb0-java
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-java
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-java
ghcr.io/openhands/agent-server:1d6feb0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1d6feb0-python
ghcr.io/openhands/agent-server:1d6feb056e5763a44dc9305b79661e8f23b41a91-python
ghcr.io/openhands/agent-server:fix-field-default-factory-api-check-python
ghcr.io/openhands/agent-server:1d6feb0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1d6feb0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1d6feb0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->