### PR TITLE
feat(skills): support tag/SHA in EXTENSIONS_REF; skip polling for pinned refs

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -40,7 +40,7 @@ from openhands.sdk.skills import (
 )
 from openhands.sdk.skills.skill import (
     DEFAULT_MARKETPLACE_PATH,
-    PUBLIC_SKILLS_BRANCH,
+    PUBLIC_SKILLS_REF,
     PUBLIC_SKILLS_REPO,
     _invalidate_public_skills_cache,
     load_skills_from_dir,
@@ -391,7 +391,7 @@ def sync_public_skills() -> tuple[bool, str]:
     try:
         cache_dir = get_skills_cache_dir()
         result = update_skills_repository(
-            PUBLIC_SKILLS_REPO, PUBLIC_SKILLS_BRANCH, cache_dir
+            PUBLIC_SKILLS_REPO, PUBLIC_SKILLS_REF, cache_dir
         )
 
         if result:
@@ -634,7 +634,7 @@ def _fetch_catalog_entries(marketplace_path: str) -> list[_CatalogEntry]:
     """
     cache_dir = get_skills_cache_dir()
     repo_path = update_skills_repository(
-        PUBLIC_SKILLS_REPO, PUBLIC_SKILLS_BRANCH, cache_dir
+        PUBLIC_SKILLS_REPO, PUBLIC_SKILLS_REF, cache_dir
     )
 
     if repo_path is None:

--- a/openhands-sdk/openhands/sdk/git/cached_repo.py
+++ b/openhands-sdk/openhands/sdk/git/cached_repo.py
@@ -332,22 +332,22 @@ def _update_repository(
 ) -> None:
     """Update an existing cached repository to the latest remote state.
 
-    Fetches from origin and resets to match the remote. On any failure, logs a
-    warning and returns silently—the cached repository remains usable (just
-    potentially stale).
+    For a specific ref, first attempts a purely local checkout. If that checkout
+    lands in detached HEAD (the ref is a tag or commit SHA already present in the
+    local object store), the fetch is skipped entirely — immutable refs never
+    change, so the cached objects are already correct. This lets air-gapped clients
+    with a pre-populated cache work without any network access.
+
+    If the local checkout fails (ref not yet cached) or lands on a branch (needs
+    the remote's latest), falls through to the normal fetch → checkout → reset
+    cycle. On any failure, logs a warning and returns silently so the cached
+    repository remains usable.
 
     Behavior by scenario:
-        1. ref is specified: Checkout and reset to that ref (branch/tag/commit)
-        2. ref is None, on a branch: Reset to origin/{current_branch}
-        3. ref is None, detached HEAD: Checkout the remote's default branch
-           (determined via origin/HEAD), then reset to origin/{default_branch}.
-           This handles the case where a previous fetch with a specific ref
-           (e.g., a tag) left the repo in detached HEAD state.
-
-    The detached HEAD recovery ensures that calling fetch(source, update=True)
-    without a ref always updates to "the latest", even if a previous call used
-    a specific tag or commit. Without this, the repo would be stuck on the old
-    ref with no way to get back to the default branch.
+        1. ref locally present and immutable (detached HEAD): local checkout only.
+        2. ref specified but requires fetch: fetch -> checkout + reset.
+        3. ref is None, on a branch: fetch -> reset to origin/{current_branch}.
+        4. ref is None, detached HEAD: fetch -> checkout default branch -> reset.
 
     Args:
         repo_path: Path to the repository.
@@ -355,6 +355,18 @@ def _update_repository(
             or falls back to the remote's default branch.
         git: GitHelper instance.
     """
+    if ref:
+        # Optimistically attempt a local checkout before touching the network.
+        # Detached HEAD after checkout means the ref is a tag or commit SHA that
+        # is already present in the local object store — skip the fetch entirely.
+        try:
+            git.checkout(repo_path, ref)
+            if git.get_current_branch(repo_path) is None:
+                logger.debug("Ref %r already present locally; skipping fetch", ref)
+                return
+        except GitCommandError:
+            pass  # ref not cached locally; fall through to fetch
+
     # Fetch from origin - if this fails, we still have a usable (stale) cache
     if not _try_fetch(repo_path, git):
         return

--- a/openhands-sdk/openhands/sdk/git/cached_repo.py
+++ b/openhands-sdk/openhands/sdk/git/cached_repo.py
@@ -6,6 +6,7 @@ and keeping them updated. Used by both the skills system and plugin fetching.
 
 from __future__ import annotations
 
+import re
 import shutil
 from pathlib import Path
 
@@ -21,6 +22,9 @@ logger = get_logger(__name__)
 # Default timeout for acquiring cache locks (seconds)
 # Consistent with other lock timeouts in the SDK (io/local.py, event_store.py)
 DEFAULT_LOCK_TIMEOUT = 30
+
+# Matches a full 40-character git commit SHA (lowercase hex)
+_FULL_SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
 class GitHelper:
@@ -302,14 +306,22 @@ def _clone_repository(
     Args:
         url: Git URL to clone.
         dest: Destination path.
-        branch: Branch to checkout (optional).
+        branch: Branch or tag to checkout during clone. For full 40-character
+            commit SHAs, ``--branch`` is not used; the default branch is cloned
+            in full (no ``--depth``) and the SHA is checked out afterward.
         git: GitHelper instance.
     """
     # Remove existing directory if it exists but isn't a valid git repo
     if dest.exists():
         shutil.rmtree(dest)
 
-    git.clone(url, dest, depth=1, branch=branch)
+    if branch and _FULL_SHA_RE.fullmatch(branch):
+        # git clone --branch does not accept raw commit SHAs. Clone the full
+        # history without specifying a branch, then checkout the target commit.
+        git.clone(url, dest, depth=None, branch=None)
+        git.checkout(dest, branch)
+    else:
+        git.clone(url, dest, depth=1, branch=branch)
     logger.debug(f"Repository cloned to {dest}")
 
 

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -29,6 +29,7 @@ from openhands.sdk.skills.utils import (
     find_skill_md_directories,
     find_third_party_files,
     get_skills_cache_dir,
+    is_skills_repo_pinned,
     load_and_categorize,
     load_mcp_config,
     update_skills_repository,
@@ -929,17 +930,21 @@ def load_project_skills(work_dir: str | Path) -> list[Skill]:
 
 # Public skills repository configuration
 PUBLIC_SKILLS_REPO = "https://github.com/OpenHands/extensions"
-# Allow overriding the branch via EXTENSIONS_REF environment variable
-# (used by evaluation/benchmarks workflows to test feature branches)
-PUBLIC_SKILLS_BRANCH = os.environ.get("EXTENSIONS_REF", "main")
+# Allow overriding the ref via EXTENSIONS_REF environment variable.
+# Accepts a branch name, tag (e.g. "v1.0.0"), or full 40-char commit SHA.
+PUBLIC_SKILLS_REF = os.environ.get("EXTENSIONS_REF", "main")
 DEFAULT_MARKETPLACE_PATH = "marketplaces/default.json"
 
 # Process-level cache for load_public_skills. Conversation creation re-validates
 # AgentContext several times and each validation re-runs load_public_skills
 # (git fetch + parse ~40 md files ≈ 1s). The cache short-circuits repeated calls
 # within the TTL while still picking up new skills within a minute.
+#
+# Cache value: (timestamp, skills, is_pinned)
+# When is_pinned is True (repo is at a tag or commit SHA), the entry never
+# expires — immutable refs never change so there is no reason to re-fetch.
 _PUBLIC_SKILLS_CACHE: dict[
-    tuple[str, str, str | None], tuple[float, list["Skill"]]
+    tuple[str, str, str | None], tuple[float, list["Skill"], bool]
 ] = {}
 _PUBLIC_SKILLS_CACHE_TTL_SECONDS = 60.0
 _PUBLIC_SKILLS_CACHE_LOCK = threading.Lock()
@@ -1007,16 +1012,17 @@ def load_marketplace_skill_names(
 
 def load_public_skills(
     repo_url: str = PUBLIC_SKILLS_REPO,
-    branch: str = PUBLIC_SKILLS_BRANCH,
+    ref: str = PUBLIC_SKILLS_REF,
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
 ) -> list[Skill]:
     """Load skills from the public OpenHands skills repository.
 
     This function maintains a local git clone of the public skills registry at
     https://github.com/OpenHands/extensions. On first run, it clones the repository
-    to ~/.openhands/skills-cache/. On subsequent runs, it pulls the latest changes
-    to keep the skills up-to-date. This approach is more efficient than fetching
-    individual files via HTTP.
+    to ~/.openhands/skills-cache/. On subsequent runs within the same process, it
+    returns cached results. For branch refs it re-fetches after the cache TTL; for
+    tags and commit SHAs (immutable refs) the cache never expires so no further
+    network calls are made.
 
     By default, only skills listed in the default marketplace
     (marketplaces/default.json) are loaded. Pass a different relative
@@ -1030,7 +1036,10 @@ def load_public_skills(
     Args:
         repo_url: URL of the skills repository. Defaults to the official
             OpenHands skills repository.
-        branch: Branch name to load skills from. Defaults to 'main'.
+        ref: Branch name, tag (e.g. ``"v1.0.0"``), or full 40-character commit
+            SHA to load skills from. Defaults to ``'main'``. Tags and commit
+            SHAs are treated as immutable: once loaded, the result is cached
+            for the lifetime of the process without further remote polling.
         marketplace_path: Relative path to the marketplace JSON file within the
             repository. Pass None to load all public skills without filtering.
 
@@ -1048,25 +1057,32 @@ def load_public_skills(
         >>> # Use with AgentContext
         >>> context = AgentContext(skills=public_skills)
     """
-    cache_key = (repo_url, branch, marketplace_path)
+    cache_key = (repo_url, ref, marketplace_path)
     with _PUBLIC_SKILLS_CACHE_LOCK:
         cached = _PUBLIC_SKILLS_CACHE.get(cache_key)
-        if (
-            cached is not None
-            and time.monotonic() - cached[0] < _PUBLIC_SKILLS_CACHE_TTL_SECONDS
-        ):
-            return list(cached[1])
+        if cached is not None:
+            _, cached_skills, is_pinned = cached
+            if (
+                is_pinned
+                or time.monotonic() - cached[0] < _PUBLIC_SKILLS_CACHE_TTL_SECONDS
+            ):
+                return list(cached_skills)
 
-    all_skills = []
+    all_skills: list[Skill] = []
+    is_pinned = False
 
     try:
         # Get or update the local repository
         cache_dir = get_skills_cache_dir()
-        repo_path = update_skills_repository(repo_url, branch, cache_dir)
+        repo_path = update_skills_repository(repo_url, ref, cache_dir)
 
         if repo_path is None:
             logger.warning("Failed to access public skills repository")
             return all_skills
+
+        # Detect whether the ref is immutable (tag or commit SHA in detached HEAD).
+        # Pinned repos are cached indefinitely — no re-fetching needed.
+        is_pinned = is_skills_repo_pinned(repo_path)
 
         # Load skills from the local repository
         skills_dir = repo_path / "skills"
@@ -1143,7 +1159,11 @@ def load_public_skills(
     # for the full TTL window.
     if all_skills:
         with _PUBLIC_SKILLS_CACHE_LOCK:
-            _PUBLIC_SKILLS_CACHE[cache_key] = (time.monotonic(), list(all_skills))
+            _PUBLIC_SKILLS_CACHE[cache_key] = (
+                time.monotonic(),
+                list(all_skills),
+                is_pinned,
+            )
 
     return all_skills
 

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -940,11 +940,13 @@ DEFAULT_MARKETPLACE_PATH = "marketplaces/default.json"
 # (git fetch + parse ~40 md files ≈ 1s). The cache short-circuits repeated calls
 # within the TTL while still picking up new skills within a minute.
 #
-# Cache value: (timestamp, skills, is_pinned)
-# When is_pinned is True (repo is at a tag or commit SHA), the entry never
-# expires — immutable refs never change so there is no reason to re-fetch.
+# Cache value: (timestamp, skills)
+# For mutable refs (branches), timestamp is time.monotonic() at write time and
+# the entry expires after _PUBLIC_SKILLS_CACHE_TTL_SECONDS.
+# For immutable refs (tags, commit SHAs), timestamp is float("inf") so the
+# TTL check is never satisfied and the entry lives for the process lifetime.
 _PUBLIC_SKILLS_CACHE: dict[
-    tuple[str, str, str | None], tuple[float, list["Skill"], bool]
+    tuple[str, str, str | None], tuple[float, list["Skill"]]
 ] = {}
 _PUBLIC_SKILLS_CACHE_TTL_SECONDS = 60.0
 _PUBLIC_SKILLS_CACHE_LOCK = threading.Lock()
@@ -1060,13 +1062,11 @@ def load_public_skills(
     cache_key = (repo_url, ref, marketplace_path)
     with _PUBLIC_SKILLS_CACHE_LOCK:
         cached = _PUBLIC_SKILLS_CACHE.get(cache_key)
-        if cached is not None:
-            _, cached_skills, is_pinned = cached
-            if (
-                is_pinned
-                or time.monotonic() - cached[0] < _PUBLIC_SKILLS_CACHE_TTL_SECONDS
-            ):
-                return list(cached_skills)
+        if (
+            cached is not None
+            and time.monotonic() - cached[0] < _PUBLIC_SKILLS_CACHE_TTL_SECONDS
+        ):
+            return list(cached[1])
 
     all_skills: list[Skill] = []
     is_pinned = False
@@ -1158,12 +1158,9 @@ def load_public_skills(
     # Only cache non-empty results so transient errors don't poison the cache
     # for the full TTL window.
     if all_skills:
+        timestamp = float("inf") if is_pinned else time.monotonic()
         with _PUBLIC_SKILLS_CACHE_LOCK:
-            _PUBLIC_SKILLS_CACHE[cache_key] = (
-                time.monotonic(),
-                list(all_skills),
-                is_pinned,
-            )
+            _PUBLIC_SKILLS_CACHE[cache_key] = (timestamp, list(all_skills))
 
     return all_skills
 

--- a/openhands-sdk/openhands/sdk/skills/utils.py
+++ b/openhands-sdk/openhands/sdk/skills/utils.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 from fastmcp.mcp_config import MCPConfig
 
-from openhands.sdk.git.cached_repo import try_cached_clone_or_update
+from openhands.sdk.git.cached_repo import GitHelper, try_cached_clone_or_update
 from openhands.sdk.logger import get_logger
 from openhands.sdk.skills.exceptions import SkillValidationError
 from openhands.sdk.utils.path import to_posix_path
@@ -393,7 +393,7 @@ def get_skills_cache_dir() -> Path:
 
 def update_skills_repository(
     repo_url: str,
-    branch: str,
+    ref: str,
     cache_dir: Path,
 ) -> Path | None:
     """Clone or update the local skills repository.
@@ -403,14 +403,30 @@ def update_skills_repository(
 
     Args:
         repo_url: URL of the skills repository.
-        branch: Branch name to checkout and track.
+        ref: Branch name, tag, or full commit SHA to checkout.
         cache_dir: Directory where the repository should be cached.
 
     Returns:
         Path to the local repository if successful, None otherwise.
     """
     repo_path = cache_dir / "public-skills"
-    return try_cached_clone_or_update(repo_url, repo_path, ref=branch, update=True)
+    return try_cached_clone_or_update(repo_url, repo_path, ref=ref, update=True)
+
+
+def is_skills_repo_pinned(repo_path: Path) -> bool:
+    """Return True if the local skills repo is pinned to a fixed ref.
+
+    A pinned ref is one that cannot change over time — a tag or a specific
+    commit SHA. After checking out such a ref the repository is left in
+    detached HEAD state, which is the signal used here.
+
+    Returns False on any git error so callers can safely treat the result
+    as ``False`` (i.e., keep polling) when the state cannot be determined.
+    """
+    try:
+        return GitHelper().get_current_branch(repo_path) is None
+    except Exception:
+        return False
 
 
 def discover_skill_resources(skill_dir: Path) -> SkillResources:

--- a/tests/sdk/git/test_cached_repo.py
+++ b/tests/sdk/git/test_cached_repo.py
@@ -40,6 +40,24 @@ def test_clone_with_ref(tmp_path: Path):
     )
 
 
+def test_clone_with_full_sha_uses_full_clone_and_checkout(tmp_path: Path):
+    """Full 40-char commit SHAs must use a full clone (no --depth) then checkout.
+
+    git clone --branch does not accept raw commit SHAs, so we fall back to a
+    regular (non-shallow) clone followed by an explicit checkout of the SHA.
+    """
+    mock_git = create_autospec(GitHelper)
+    dest = tmp_path / "repo"
+    sha = "a" * 40
+
+    _clone_repository("https://github.com/owner/repo.git", dest, sha, mock_git)
+
+    mock_git.clone.assert_called_once_with(
+        "https://github.com/owner/repo.git", dest, depth=None, branch=None
+    )
+    mock_git.checkout.assert_called_once_with(dest, sha)
+
+
 def test_clone_removes_existing_directory(tmp_path: Path):
     mock_git = create_autospec(GitHelper)
     dest = tmp_path / "repo"

--- a/tests/sdk/git/test_cached_repo.py
+++ b/tests/sdk/git/test_cached_repo.py
@@ -83,14 +83,39 @@ def test_update_fetches_and_resets(tmp_path: Path):
     mock_git.reset_hard.assert_called_once_with(tmp_path, "origin/main")
 
 
-def test_update_with_ref_checks_out(tmp_path: Path):
+def test_update_with_pinned_ref_skips_fetch(tmp_path: Path):
+    """Tag/commit locally present: optimistic checkout succeeds → no fetch."""
     mock_git = create_autospec(GitHelper)
-    mock_git.get_current_branch.return_value = None
+    mock_git.get_current_branch.return_value = None  # detached HEAD
 
     _update_repository(tmp_path, "v1.0.0", mock_git)
 
-    mock_git.fetch.assert_called_once_with(tmp_path)
     mock_git.checkout.assert_called_once_with(tmp_path, "v1.0.0")
+    mock_git.fetch.assert_not_called()
+
+
+def test_update_fetches_for_branch_ref(tmp_path: Path):
+    """Branch refs always fetch even when the local checkout succeeds."""
+    mock_git = create_autospec(GitHelper)
+    mock_git.get_current_branch.return_value = "main"  # on a branch, not detached
+
+    _update_repository(tmp_path, "main", mock_git)
+
+    mock_git.fetch.assert_called_once_with(tmp_path)
+
+
+def test_update_fetches_when_ref_not_present_locally(tmp_path: Path):
+    """If the optimistic checkout fails, fall through to a full fetch."""
+    mock_git = create_autospec(GitHelper)
+    mock_git.checkout.side_effect = [
+        GitCommandError("ref not found", command=["git", "checkout"], exit_code=1),
+        None,  # second checkout (inside _try_checkout_and_reset) succeeds
+    ]
+    mock_git.get_current_branch.return_value = None  # detached HEAD after fetch
+
+    _update_repository(tmp_path, "v2.0.0", mock_git)
+
+    mock_git.fetch.assert_called_once_with(tmp_path)
 
 
 def test_update_detached_head_recovers_to_default_branch(tmp_path: Path):

--- a/tests/sdk/skills/test_extensions_ref.py
+++ b/tests/sdk/skills/test_extensions_ref.py
@@ -121,23 +121,21 @@ assert PUBLIC_SKILLS_REF == "", (
 # ---------------------------------------------------------------------------
 
 
-def _seed_pinned_cache(
+def _seed_cache(
     cache: dict,
     lock: threading.Lock,
     cache_key: tuple,
     skills: list,
     *,
-    ttl: float,
-    is_pinned: bool,
+    timestamp: float,
 ) -> None:
     """Seed the public-skills cache with a synthetic entry."""
-    timestamp = time.monotonic() - ttl - 1  # guarantee TTL is already expired
     with lock:
-        cache[cache_key] = (timestamp, skills, is_pinned)
+        cache[cache_key] = (timestamp, skills)
 
 
 def test_pinned_cache_entry_never_expires():
-    """A cached entry with is_pinned=True is returned even after the TTL expires.
+    """A pinned entry (timestamp=inf) is returned even after the TTL would have elapsed.
 
     This verifies that immutable refs (tags, commit SHAs) do not trigger
     remote polling once their skills have been loaded once.
@@ -145,7 +143,6 @@ def test_pinned_cache_entry_never_expires():
     from openhands.sdk.skills.skill import (
         _PUBLIC_SKILLS_CACHE,
         _PUBLIC_SKILLS_CACHE_LOCK,
-        _PUBLIC_SKILLS_CACHE_TTL_SECONDS,
         Skill,
         _invalidate_public_skills_cache,
         load_public_skills,
@@ -155,13 +152,12 @@ def test_pinned_cache_entry_never_expires():
     cache_key = ("https://github.com/OpenHands/extensions", "v1.0.0", None)
 
     _invalidate_public_skills_cache()
-    _seed_pinned_cache(
+    _seed_cache(
         _PUBLIC_SKILLS_CACHE,
         _PUBLIC_SKILLS_CACHE_LOCK,
         cache_key,
         [fake_skill],
-        ttl=_PUBLIC_SKILLS_CACHE_TTL_SECONDS,
-        is_pinned=True,
+        timestamp=float("inf"),
     )
 
     with patch("openhands.sdk.skills.skill.update_skills_repository") as mock_update:
@@ -173,7 +169,7 @@ def test_pinned_cache_entry_never_expires():
 
 
 def test_mutable_cache_entry_expires_after_ttl():
-    """A non-pinned cache entry IS re-fetched once the TTL has passed."""
+    """A branch entry (finite timestamp) IS re-fetched once the TTL has passed."""
     from openhands.sdk.skills.skill import (
         _PUBLIC_SKILLS_CACHE,
         _PUBLIC_SKILLS_CACHE_LOCK,
@@ -187,13 +183,12 @@ def test_mutable_cache_entry_expires_after_ttl():
     cache_key = ("https://github.com/OpenHands/extensions", "main", None)
 
     _invalidate_public_skills_cache()
-    _seed_pinned_cache(
+    _seed_cache(
         _PUBLIC_SKILLS_CACHE,
         _PUBLIC_SKILLS_CACHE_LOCK,
         cache_key,
         [fake_skill],
-        ttl=_PUBLIC_SKILLS_CACHE_TTL_SECONDS,
-        is_pinned=False,
+        timestamp=time.monotonic() - _PUBLIC_SKILLS_CACHE_TTL_SECONDS - 1,
     )
 
     with patch("openhands.sdk.skills.skill.update_skills_repository") as mock_update:

--- a/tests/sdk/skills/test_extensions_ref.py
+++ b/tests/sdk/skills/test_extensions_ref.py
@@ -1,11 +1,14 @@
 """Tests for EXTENSIONS_REF environment variable support.
 
-These tests use subprocess to run each test in an isolated Python process,
-avoiding module state pollution that would affect other tests.
+Subprocess-based tests isolate module-level state (PUBLIC_SKILLS_REF is read
+at import time). In-process tests cover runtime cache behaviour.
 """
 
 import subprocess
 import sys
+import threading
+import time
+from unittest.mock import patch
 
 
 def _run_in_subprocess(test_code: str, env_extra: dict | None = None) -> None:
@@ -29,25 +32,25 @@ def _run_in_subprocess(test_code: str, env_extra: dict | None = None) -> None:
 
 
 def test_extensions_ref_default():
-    """PUBLIC_SKILLS_BRANCH should default to 'main' when EXTENSIONS_REF is not set."""
+    """PUBLIC_SKILLS_REF should default to 'main' when EXTENSIONS_REF is not set."""
     code = """
 import os
 if "EXTENSIONS_REF" in os.environ:
     del os.environ["EXTENSIONS_REF"]
-from openhands.sdk.skills.skill import PUBLIC_SKILLS_BRANCH
-assert PUBLIC_SKILLS_BRANCH == "main", (
-    f"Expected 'main' but got '{PUBLIC_SKILLS_BRANCH}'"
+from openhands.sdk.skills.skill import PUBLIC_SKILLS_REF
+assert PUBLIC_SKILLS_REF == "main", (
+    f"Expected 'main' but got '{PUBLIC_SKILLS_REF}'"
 )
 """
     _run_in_subprocess(code)
 
 
 def test_extensions_ref_custom_branch():
-    """PUBLIC_SKILLS_BRANCH should use EXTENSIONS_REF when set."""
+    """PUBLIC_SKILLS_REF should use EXTENSIONS_REF when set to a branch name."""
     code = """
-from openhands.sdk.skills.skill import PUBLIC_SKILLS_BRANCH
-assert PUBLIC_SKILLS_BRANCH == "feature-branch", (
-    f"Expected 'feature-branch' but got '{PUBLIC_SKILLS_BRANCH}'"
+from openhands.sdk.skills.skill import PUBLIC_SKILLS_REF
+assert PUBLIC_SKILLS_REF == "feature-branch", (
+    f"Expected 'feature-branch' but got '{PUBLIC_SKILLS_REF}'"
 )
 """
     _run_in_subprocess(code, {"EXTENSIONS_REF": "feature-branch"})
@@ -58,11 +61,11 @@ def test_extensions_ref_with_load_public_skills():
     code = """
 from unittest import mock
 from openhands.sdk.skills.skill import (
-    PUBLIC_SKILLS_BRANCH,
+    PUBLIC_SKILLS_REF,
     load_public_skills,
 )
-assert PUBLIC_SKILLS_BRANCH == "test-branch", (
-    f"Expected 'test-branch' but got '{PUBLIC_SKILLS_BRANCH}'"
+assert PUBLIC_SKILLS_REF == "test-branch", (
+    f"Expected 'test-branch' but got '{PUBLIC_SKILLS_REF}'"
 )
 with mock.patch(
     "openhands.sdk.skills.skill.update_skills_repository"
@@ -71,21 +74,129 @@ with mock.patch(
     load_public_skills()
     mock_update.assert_called_once()
     call_args = mock_update.call_args
-    # branch is 2nd positional arg: (repo_url, branch, cache_dir)
+    # ref is 2nd positional arg: (repo_url, ref, cache_dir)
     assert call_args[0][1] == "test-branch", (
-        f"Expected branch='test-branch' but got {call_args[0][1]}"
+        f"Expected ref='test-branch' but got {call_args[0][1]}"
     )
 """
     _run_in_subprocess(code, {"EXTENSIONS_REF": "test-branch"})
 
 
-def test_extensions_ref_empty_string():
-    """Empty EXTENSIONS_REF should fall back to 'main'."""
+def test_extensions_ref_with_tag():
+    """PUBLIC_SKILLS_REF should accept a tag value via EXTENSIONS_REF."""
     code = """
-from openhands.sdk.skills.skill import PUBLIC_SKILLS_BRANCH
-# Empty string returns empty string per os.environ.get behavior
-assert PUBLIC_SKILLS_BRANCH == "", (
-    f"Expected '' but got '{PUBLIC_SKILLS_BRANCH}'"
+from openhands.sdk.skills.skill import PUBLIC_SKILLS_REF
+assert PUBLIC_SKILLS_REF == "v1.2.3", (
+    f"Expected 'v1.2.3' but got '{PUBLIC_SKILLS_REF}'"
+)
+"""
+    _run_in_subprocess(code, {"EXTENSIONS_REF": "v1.2.3"})
+
+
+def test_extensions_ref_with_commit_sha():
+    """PUBLIC_SKILLS_REF should accept a full commit SHA via EXTENSIONS_REF."""
+    sha = "a" * 40
+    code = f"""
+from openhands.sdk.skills.skill import PUBLIC_SKILLS_REF
+assert PUBLIC_SKILLS_REF == "{sha}", (
+    f"Expected '{sha}' but got '{{PUBLIC_SKILLS_REF}}'"
+)
+"""
+    _run_in_subprocess(code, {"EXTENSIONS_REF": sha})
+
+
+def test_extensions_ref_empty_string():
+    """Empty EXTENSIONS_REF falls back to an empty string (os.environ.get behaviour)."""
+    code = """
+from openhands.sdk.skills.skill import PUBLIC_SKILLS_REF
+assert PUBLIC_SKILLS_REF == "", (
+    f"Expected '' but got '{PUBLIC_SKILLS_REF}'"
 )
 """
     _run_in_subprocess(code, {"EXTENSIONS_REF": ""})
+
+
+# ---------------------------------------------------------------------------
+# In-process tests for pinned-ref cache behaviour
+# ---------------------------------------------------------------------------
+
+
+def _seed_pinned_cache(
+    cache: dict,
+    lock: threading.Lock,
+    cache_key: tuple,
+    skills: list,
+    *,
+    ttl: float,
+    is_pinned: bool,
+) -> None:
+    """Seed the public-skills cache with a synthetic entry."""
+    timestamp = time.monotonic() - ttl - 1  # guarantee TTL is already expired
+    with lock:
+        cache[cache_key] = (timestamp, skills, is_pinned)
+
+
+def test_pinned_cache_entry_never_expires():
+    """A cached entry with is_pinned=True is returned even after the TTL expires.
+
+    This verifies that immutable refs (tags, commit SHAs) do not trigger
+    remote polling once their skills have been loaded once.
+    """
+    from openhands.sdk.skills.skill import (
+        _PUBLIC_SKILLS_CACHE,
+        _PUBLIC_SKILLS_CACHE_LOCK,
+        _PUBLIC_SKILLS_CACHE_TTL_SECONDS,
+        Skill,
+        _invalidate_public_skills_cache,
+        load_public_skills,
+    )
+
+    fake_skill = Skill(name="pinned-skill", content="pinned content")
+    cache_key = ("https://github.com/OpenHands/extensions", "v1.0.0", None)
+
+    _invalidate_public_skills_cache()
+    _seed_pinned_cache(
+        _PUBLIC_SKILLS_CACHE,
+        _PUBLIC_SKILLS_CACHE_LOCK,
+        cache_key,
+        [fake_skill],
+        ttl=_PUBLIC_SKILLS_CACHE_TTL_SECONDS,
+        is_pinned=True,
+    )
+
+    with patch("openhands.sdk.skills.skill.update_skills_repository") as mock_update:
+        result = load_public_skills(ref="v1.0.0", marketplace_path=None)
+        mock_update.assert_not_called()
+
+    assert len(result) == 1
+    assert result[0].name == "pinned-skill"
+
+
+def test_mutable_cache_entry_expires_after_ttl():
+    """A non-pinned cache entry IS re-fetched once the TTL has passed."""
+    from openhands.sdk.skills.skill import (
+        _PUBLIC_SKILLS_CACHE,
+        _PUBLIC_SKILLS_CACHE_LOCK,
+        _PUBLIC_SKILLS_CACHE_TTL_SECONDS,
+        Skill,
+        _invalidate_public_skills_cache,
+        load_public_skills,
+    )
+
+    fake_skill = Skill(name="stale-skill", content="stale content")
+    cache_key = ("https://github.com/OpenHands/extensions", "main", None)
+
+    _invalidate_public_skills_cache()
+    _seed_pinned_cache(
+        _PUBLIC_SKILLS_CACHE,
+        _PUBLIC_SKILLS_CACHE_LOCK,
+        cache_key,
+        [fake_skill],
+        ttl=_PUBLIC_SKILLS_CACHE_TTL_SECONDS,
+        is_pinned=False,
+    )
+
+    with patch("openhands.sdk.skills.skill.update_skills_repository") as mock_update:
+        mock_update.return_value = None  # simulates transient failure
+        load_public_skills(ref="main", marketplace_path=None)
+        mock_update.assert_called_once()

--- a/tests/sdk/skills/test_load_public_skills.py
+++ b/tests/sdk/skills/test_load_public_skills.py
@@ -521,8 +521,8 @@ def test_load_public_skills_custom_repo(mock_repo_dir, tmp_path):
 def test_load_public_skills_custom_branch(mock_repo_dir, tmp_path):
     """Test loading from a specific branch."""
 
-    def mock_update_repo(repo_url, branch, cache_dir):
-        assert branch == "develop"
+    def mock_update_repo(repo_url, ref, cache_dir):
+        assert ref == "develop"
         return mock_repo_dir
 
     with (
@@ -535,7 +535,7 @@ def test_load_public_skills_custom_branch(mock_repo_dir, tmp_path):
             return_value=tmp_path,
         ),
     ):
-        skills = load_public_skills(branch="develop")
+        skills = load_public_skills(ref="develop")
         assert len(skills) == 3
 
 

--- a/tests/sdk/skills/test_load_public_skills.py
+++ b/tests/sdk/skills/test_load_public_skills.py
@@ -318,14 +318,21 @@ def test_update_skills_repository_update_existing(tmp_path):
         )
 
         assert result_path == repo_path
-        # The git operations are: fetch, checkout, get_current_branch, reset
-        # (get_current_branch returns branch name so reset is called)
-        assert mock_run.call_count == 4
+        # For a branch ref, the sequence is:
+        #   1. checkout (optimistic local attempt)
+        #   2. rev-parse (detects we're on a branch → fall through to fetch)
+        #   3. fetch
+        #   4. checkout (proper update inside _try_checkout_and_reset)
+        #   5. rev-parse (detects branch again inside _checkout_ref)
+        #   6. reset --hard origin/main
+        assert mock_run.call_count == 6
         all_commands = [call[0][0] for call in mock_run.call_args_list]
-        assert all_commands[0][:3] == ["git", "fetch", "origin"]
-        assert all_commands[1][:2] == ["git", "checkout"]
-        assert all_commands[2] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
-        assert all_commands[3][:3] == ["git", "reset", "--hard"]
+        assert all_commands[0][:2] == ["git", "checkout"]
+        assert all_commands[1] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        assert all_commands[2][:3] == ["git", "fetch", "origin"]
+        assert all_commands[3][:2] == ["git", "checkout"]
+        assert all_commands[4] == ["git", "rev-parse", "--abbrev-ref", "HEAD"]
+        assert all_commands[5][:3] == ["git", "reset", "--hard"]
 
 
 def test_update_skills_repository_clone_timeout(tmp_path):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

- [x] A human has tested these changes.

---

## Why

`EXTENSIONS_REF` was read as a branch name only. There was no way to pin skills to a specific tag or commit SHA, and no way to suppress the periodic remote polling that happens when the ref is immutable.

## Summary

- **Tag and commit SHA support**: `EXTENSIONS_REF` now accepts a branch name (existing behaviour), a tag (e.g. `v1.0.0`), or a full 40-character commit SHA. For SHAs, the initial clone uses a full (non-shallow) `git clone` followed by `git checkout <sha>`, because `git clone --branch` does not accept raw commit SHAs.
- **No polling for immutable refs**: after the first clone/update, `load_public_skills` checks whether the local repo is in detached HEAD state (the git signal for tags and commits). When it is, the in-process cache entry is marked `is_pinned=True` and **never expires** — no further remote fetches happen for the lifetime of the process.
- **Rename `PUBLIC_SKILLS_BRANCH` → `PUBLIC_SKILLS_REF`** to reflect that the value is no longer branch-only.

## Issue Number

N/A

Key new tests:
- `test_clone_with_full_sha_uses_full_clone_and_checkout` — verifies SHA clone strategy
- `test_extensions_ref_with_tag` / `test_extensions_ref_with_commit_sha` — verify env var is accepted
- `test_pinned_cache_entry_never_expires` — verifies pinned cache is never TTL-expired
- `test_mutable_cache_entry_expires_after_ttl` — confirms branch refs still expire normally

## Video/Screenshots

I set my local cached public-skills repo to main:
<img width="598" height="181" alt="image" src="https://github.com/user-attachments/assets/91ec86b8-e657-4745-8dcd-1d9e914bf9b4" />

Then I set an environment variable:
```export EXTENSIONS_REF=62594156a187722344736bc2ff5edfb12c0cc75c```

Then I restart the agent server, and execute a curl command to start a conversation:
```
curl -s -X POST http://localhost:8000/api/conversations \
  -H "Content-Type: application/json" \
  -d '{"agent_settings": {"agent_context": {"load_public_skills": true,"load_user_skills": false,"load_project_skills": false}},"conversation_settings": {"workspace": {"kind": "LocalWorkspace","working_dir": "/workspace/project"},"initial_message": {"role": "user","content": [{"type": "text", "text": "Flip a coin"}],"run": true}}}'
  ```
  
  I see that my public skills repository is at the correct ref:
<img width="573" height="219" alt="image" src="https://github.com/user-attachments/assets/76c91408-0cee-4a39-b40d-18ef6f971959" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The "pinned" detection is ground-truth from git itself (detached HEAD check) rather than string-pattern heuristics, so it works for both tags and SHAs without any special-casing at the c- The "pinned" On- rocess restart the first call for a pinned ref still does one remote fetch (to clone/update). After that, the process-local cache never re-fetches. Persisting the pinned state to disk across restarts is left as a possible follow-up.
- `sync_public_skills()` in `skills_service.py` is an explicit force-refresh and continues to always fetch, even for pinned refs — which is the expected behaviour for an admin-triggered sync.

_This PR was created by an AI agent (OpenHands) on behalf of the user._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6e01d74-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6e01d74-python \
  ghcr.io/openhands/agent-server:6e01d74-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6e01d74-golang-amd64
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-golang-amd64
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-golang-amd64
ghcr.io/openhands/agent-server:6e01d74-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6e01d74-golang-arm64
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-golang-arm64
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-golang-arm64
ghcr.io/openhands/agent-server:6e01d74-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6e01d74-java-amd64
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-java-amd64
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-java-amd64
ghcr.io/openhands/agent-server:6e01d74-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6e01d74-java-arm64
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-java-arm64
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-java-arm64
ghcr.io/openhands/agent-server:6e01d74-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6e01d74-python-amd64
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-python-amd64
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-python-amd64
ghcr.io/openhands/agent-server:6e01d74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6e01d74-python-arm64
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-python-arm64
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-python-arm64
ghcr.io/openhands/agent-server:6e01d74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6e01d74-golang
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-golang
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-golang
ghcr.io/openhands/agent-server:6e01d74-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6e01d74-java
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-java
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-java
ghcr.io/openhands/agent-server:6e01d74-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6e01d74-python
ghcr.io/openhands/agent-server:6e01d748b221b18af15273c63c81f9d533761fd5-python
ghcr.io/openhands/agent-server:feat-pinned-extensions-ref-python
ghcr.io/openhands/agent-server:6e01d74-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6e01d74-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6e01d74-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->