### PR TITLE
Add nemotron-3-ultra-550b-a55b-or-paid eval model (paid OpenRouter route)

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -387,6 +387,18 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # Paid OpenRouter route (no training, smaller 262k context):
+    # https://openrouter.ai/nvidia/nemotron-3-ultra-550b-a55b
+    # Backed by the `nemotron-3-ultra-550b-a55b-or-paid` model on the LiteLLM proxy.
+    "nemotron-3-ultra-550b-a55b-or-paid": {
+        "id": "nemotron-3-ultra-550b-a55b-or-paid",
+        "display_name": "NVIDIA Nemotron-3 Ultra 550B (OpenRouter, paid)",
+        "llm_config": {
+            "model": "litellm_proxy/nemotron-3-ultra-550b-a55b-or-paid",
+            "temperature": 1.0,
+            "top_p": 0.95,
+        },
+    },
     "converse-nemotron-super-3-120b": {
         "id": "converse-nemotron-super-3-120b",
         "display_name": "NVIDIA Converse Nemotron Super 3 120B",

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -707,6 +707,20 @@ def test_nemotron_3_ultra_550b_a55b_or_config():
     assert model["llm_config"]["top_p"] == 0.95
 
 
+def test_nemotron_3_ultra_550b_a55b_or_paid_config():
+    """Test that nemotron-3-ultra-550b-a55b-or-paid (paid OpenRouter route) has correct config."""
+    model = MODELS["nemotron-3-ultra-550b-a55b-or-paid"]
+
+    assert model["id"] == "nemotron-3-ultra-550b-a55b-or-paid"
+    assert model["display_name"] == "NVIDIA Nemotron-3 Ultra 550B (OpenRouter, paid)"
+    assert (
+        model["llm_config"]["model"]
+        == "litellm_proxy/nemotron-3-ultra-550b-a55b-or-paid"
+    )
+    assert model["llm_config"]["temperature"] == 1.0
+    assert model["llm_config"]["top_p"] == 0.95
+
+
 def test_claude_opus_4_8_config():
     """Test that claude-opus-4-8 has correct configuration."""
     model = MODELS["claude-opus-4-8"]


### PR DESCRIPTION
## Summary

Adds a new eval model entry `nemotron-3-ultra-550b-a55b-or-paid` to `.github/run-eval/resolve_model_config.py`. It targets the `nemotron-3-ultra-550b-a55b-or-paid` alias on the LiteLLM proxy, which routes to the **paid** OpenRouter variant:

```
openrouter/nvidia/nemotron-3-ultra-550b-a55b
```

This complements the free-tier `nemotron-3-ultra-550b-a55b-or` entry from the parent PR #3522.

## Stacking

This PR targets the `add-nemotron-3-ultra-openrouter` branch (from #3522), so the diff shows only the paid block. Once #3522 merges, please **retarget this PR to `main`** — it will rebase cleanly because the new entry is appended directly after the free entry.

## Companion infra PR

The matching LiteLLM proxy alias is added in: All-Hands-AI/infra#1355

This eval `MODEL_ID` will only be usable once that infra PR is merged and the eval proxy reloads.

## Config added

```python
# Paid OpenRouter route (no training, smaller 262k context):
# https://openrouter.ai/nvidia/nemotron-3-ultra-550b-a55b
# Backed by the `nemotron-3-ultra-550b-a55b-or-paid` model on the LiteLLM proxy.
"nemotron-3-ultra-550b-a55b-or-paid": {
    "id": "nemotron-3-ultra-550b-a55b-or-paid",
    "display_name": "NVIDIA Nemotron-3 Ultra 550B (OpenRouter, paid)",
    "llm_config": {
        "model": "litellm_proxy/nemotron-3-ultra-550b-a55b-or-paid",
        "temperature": 1.0,
        "top_p": 0.95,
    },
},
```

Sampling parameters (`temperature=1.0`, `top_p=0.95`) are kept identical to the existing Nemotron-3 Ultra entries, per NVIDIA's recommendation for all Nemotron 3 models.

## Tests

Added `test_nemotron_3_ultra_550b_a55b_or_paid_config` in `tests/cross/test_resolve_model_config.py`, mirroring the existing ultra tests.

Sanity-checked locally that the `MODELS` dict imports without litellm and exposes the new entry as expected.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1d57419b-c2b1-4f5b-81ae-edb7f00ed81b)