### PR TITLE
Print agent_type in run-eval print-parameters step

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -171,6 +171,7 @@ jobs:
                   ENABLE_CONVERSATION_EVENT_LOGGING: ${{ github.event.inputs.enable_conversation_event_logging || 'true' }}
                   MAX_RETRIES: ${{ github.event.inputs.max_retries || '3' }}
                   TOOL_PRESET: ${{ github.event.inputs.tool_preset || 'default' }}
+                  AGENT_TYPE: ${{ github.event.inputs.agent_type || 'default' }}
                   PARTIAL_ARCHIVE_URL: ${{ github.event.inputs.partial_archive_url || 'N/A' }}
                   LABEL_NAME: ${{ github.event.label.name || 'N/A' }}
               run: |
@@ -195,6 +196,7 @@ jobs:
                   echo "enable_conversation_event_logging: $ENABLE_CONVERSATION_EVENT_LOGGING"
                   echo "max_retries: $MAX_RETRIES"
                   echo "tool_preset: $TOOL_PRESET"
+                  echo "agent_type: $AGENT_TYPE"
                   echo "partial_archive_url: $PARTIAL_ARCHIVE_URL"
                   echo ""
                   echo "=== Environment Variables ==="


### PR DESCRIPTION
## What

The `print-parameters` job in `run-eval.yml` echoes every `workflow_dispatch` input so the run log shows exactly what an evaluation was triggered with. `agent_type` was the **only** declared input missing from that summary — it was wired into the dispatch step but never printed.

This adds `agent_type` to both the `env:` block and the echo block of the print-parameters job, in declaration order (between `tool_preset` and `partial_archive_url`).

## Verification

Diff of declared inputs vs. printed inputs is now empty (every `workflow_dispatch` input is printed):

```
benchmark, sdk_ref, allow_unreleased_branches, eval_limit, model_ids, reason,
eval_branch, benchmarks_branch, extensions_branch, instance_ids,
num_infer_workers, num_eval_workers, enable_conversation_event_logging,
max_retries, tool_preset, agent_type, partial_archive_url
```

YAML parses cleanly and `pre-commit` (YAML formatter) passes.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f48bdb3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f48bdb3-python \
  ghcr.io/openhands/agent-server:f48bdb3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f48bdb3-golang-amd64
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-golang-amd64
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-golang-amd64
ghcr.io/openhands/agent-server:f48bdb3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f48bdb3-golang-arm64
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-golang-arm64
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-golang-arm64
ghcr.io/openhands/agent-server:f48bdb3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f48bdb3-java-amd64
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-java-amd64
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-java-amd64
ghcr.io/openhands/agent-server:f48bdb3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f48bdb3-java-arm64
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-java-arm64
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-java-arm64
ghcr.io/openhands/agent-server:f48bdb3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f48bdb3-python-amd64
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-python-amd64
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-python-amd64
ghcr.io/openhands/agent-server:f48bdb3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f48bdb3-python-arm64
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-python-arm64
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-python-arm64
ghcr.io/openhands/agent-server:f48bdb3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f48bdb3-golang
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-golang
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-golang
ghcr.io/openhands/agent-server:f48bdb3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f48bdb3-java
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-java
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-java
ghcr.io/openhands/agent-server:f48bdb3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f48bdb3-python
ghcr.io/openhands/agent-server:f48bdb3c7d78e35395b3608fc721dc2633610a4b-python
ghcr.io/openhands/agent-server:vasco-print-agent-type-in-eval-params-python
ghcr.io/openhands/agent-server:f48bdb3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f48bdb3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f48bdb3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->