### PR TITLE
feat: verify credentials in POST /api/mcp/test via optional tool call

### DIFF
--- a/openhands-agent-server/openhands/agent_server/mcp_router.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_router.py
@@ -6,9 +6,12 @@ to settings, where a misconfiguration would otherwise surface only at
 conversation start (and there manifest as a noisy traceback that aborts
 agent initialization).
 
-The endpoint is intentionally side-effect-free: it spins up the MCP
-connection, lists the advertised tools, then tears the connection down.
-It never mutates server state or touches stored settings.
+The endpoint never mutates server state or touches stored settings: it
+spins up the MCP connection, lists the advertised tools, optionally invokes
+one caller-chosen tool (``tool_call``), then tears the connection down.
+The optional tool call exists because listing tools does not exercise the
+credentials many servers only use inside tool handlers (e.g. the Slack MCP
+server starts fine with a bogus token); callers must pick a read-only tool.
 """
 
 from __future__ import annotations
@@ -16,12 +19,16 @@ from __future__ import annotations
 import asyncio
 from typing import Annotated, Any, Literal
 
-from fastapi import APIRouter
+import mcp.types
+from fastapi import APIRouter, Request
 from pydantic import BaseModel, Field, model_validator
 
+from openhands.agent_server._secrets_exposure import get_cipher
 from openhands.sdk.logger import get_logger
 from openhands.sdk.mcp import create_mcp_tools
 from openhands.sdk.mcp.exceptions import MCPError, MCPTimeoutError
+from openhands.sdk.utils.cipher import Cipher
+from openhands.sdk.utils.pydantic_secrets import decrypt_str_with_cipher_or_keep
 
 
 logger = get_logger(__name__)
@@ -85,6 +92,22 @@ class _RemoteMCPServerSpec(BaseModel):
         return out
 
 
+class MCPToolCallSpec(BaseModel):
+    """A single tool invocation to run as part of the connection test.
+
+    Listing tools does not exercise the credentials many servers only use
+    inside tool handlers, so callers can name one tool to invoke after the
+    listing succeeds. Callers are responsible for choosing a read-only tool;
+    the endpoint executes it verbatim.
+    """
+
+    name: str = Field(..., min_length=1, description="Name of the tool to invoke")
+    arguments: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Arguments passed to the tool unchanged.",
+    )
+
+
 class MCPTestRequest(BaseModel):
     """Body for ``POST /api/mcp/test``."""
 
@@ -108,6 +131,15 @@ class MCPTestRequest(BaseModel):
         le=120,
         description="Seconds to wait for connection + tools/list to complete.",
     )
+    tool_call: MCPToolCallSpec | None = Field(
+        default=None,
+        description=(
+            "Optional read-only tool to invoke after listing succeeds, so "
+            "callers can verify credentials the server only exercises on "
+            "tool invocation. Its outcome is reported verbatim in "
+            "`tool_result` without affecting `ok`."
+        ),
+    )
 
     @model_validator(mode="after")
     def _strip_name(self) -> MCPTestRequest:
@@ -117,6 +149,19 @@ class MCPTestRequest(BaseModel):
         return self
 
 
+class MCPToolCallResult(BaseModel):
+    """Verbatim outcome of the requested ``tool_call``.
+
+    The endpoint stays provider-neutral: many servers report upstream
+    failures (e.g. Slack's ``{"ok": false, "error": "invalid_auth"}``)
+    as ordinary text content with ``isError`` unset, so interpreting the
+    payload is the caller's job.
+    """
+
+    is_error: bool = Field(description="The MCP-level isError flag of the result.")
+    text: str = Field(description="Concatenated text content of the result.")
+
+
 class MCPTestSuccess(BaseModel):
     """Response when the candidate server connects and lists its tools."""
 
@@ -124,6 +169,10 @@ class MCPTestSuccess(BaseModel):
     tools: list[str] = Field(
         default_factory=list,
         description="Names of tools advertised by the MCP server.",
+    )
+    tool_result: MCPToolCallResult | None = Field(
+        default=None,
+        description=("Outcome of the requested `tool_call`, when one was supplied."),
     )
 
 
@@ -151,18 +200,81 @@ MCPTestResponse = MCPTestSuccess | MCPTestFailure
 # ---------------------------------------------------------------------------
 
 
-def _server_to_fastmcp_dict(spec: _StdioMCPServerSpec | _RemoteMCPServerSpec) -> dict:
+def _decrypt_mapping(cipher: Cipher | None, mapping: dict[str, str]) -> dict[str, str]:
+    """Decrypt Fernet-encrypted values round-tripped from settings.
+
+    The GUI fetches stored settings with ``X-Expose-Secrets: encrypted`` and
+    forwards the ciphertext unchanged so the edit flow can test the *real*
+    stored credentials without ever seeing them. Plaintext values (the
+    common case: freshly typed input) pass through untouched.
+    """
+    if cipher is None:
+        return dict(mapping)
+    return {
+        key: decrypt_str_with_cipher_or_keep(
+            cipher, value, description="MCP test env/headers"
+        )
+        for key, value in mapping.items()
+    }
+
+
+def _server_to_fastmcp_dict(
+    spec: _StdioMCPServerSpec | _RemoteMCPServerSpec, cipher: Cipher | None
+) -> dict:
     if isinstance(spec, _StdioMCPServerSpec):
         out: dict[str, Any] = {"command": spec.command, "args": list(spec.args)}
         if spec.env:
-            out["env"] = dict(spec.env)
+            out["env"] = _decrypt_mapping(cipher, spec.env)
         if spec.cwd:
             out["cwd"] = spec.cwd
         return out
-    return spec.to_fastmcp_dict()
+    remote = spec.to_fastmcp_dict()
+    if "headers" in remote:
+        remote["headers"] = _decrypt_mapping(cipher, remote["headers"])
+    return remote
 
 
-def _probe_mcp_server(request: MCPTestRequest) -> MCPTestResponse:
+def _run_tool_call(
+    client: Any, spec: MCPToolCallSpec, tool_names: list[str], timeout: float
+) -> MCPToolCallResult:
+    """Invoke the requested tool on the connected client.
+
+    Uses ``call_tool_mcp`` (not ``call_tool``, which raises on ``isError``)
+    so in-band failures come back as data -- mirrors ``MCPToolExecutor``.
+    A timeout is reported as an errored result rather than failing the
+    whole test: the server did connect and list, which is still useful.
+    """
+    if spec.name not in tool_names:
+        return MCPToolCallResult(
+            is_error=True,
+            text=(
+                f"Tool {spec.name!r} not advertised by server "
+                f"(available: {', '.join(tool_names) or 'none'})"
+            ),
+        )
+    try:
+        result: mcp.types.CallToolResult = client.call_async_from_sync(
+            client.call_tool_mcp,
+            name=spec.name,
+            arguments=spec.arguments,
+            timeout=timeout,
+        )
+    except TimeoutError:
+        return MCPToolCallResult(
+            is_error=True,
+            text=f"Tool {spec.name!r} call timed out after {timeout} seconds",
+        )
+    text = "\n".join(
+        block.text
+        for block in result.content
+        if isinstance(block, mcp.types.TextContent)
+    )
+    return MCPToolCallResult(is_error=bool(result.isError), text=text)
+
+
+def _probe_mcp_server(
+    request: MCPTestRequest, cipher: Cipher | None
+) -> MCPTestResponse:
     """Synchronous probe -- safe to run inside ``run_in_executor``.
 
     ``create_mcp_tools`` already runs its own event loop in a background
@@ -171,14 +283,22 @@ def _probe_mcp_server(request: MCPTestRequest) -> MCPTestResponse:
     threadpool first.
     """
 
-    config = {"mcpServers": {request.name: _server_to_fastmcp_dict(request.server)}}
+    config = {
+        "mcpServers": {request.name: _server_to_fastmcp_dict(request.server, cipher)}
+    }
 
     try:
         # ``create_mcp_tools`` returns a client that owns a background loop
         # and a (possibly long-lived) subprocess. Use the context-manager
         # form so we always tear it down, even when listing succeeded.
         with create_mcp_tools(config, timeout=request.timeout) as client:
-            return MCPTestSuccess(tools=[tool.name for tool in client.tools])
+            tool_names = [tool.name for tool in client.tools]
+            tool_result: MCPToolCallResult | None = None
+            if request.tool_call is not None:
+                tool_result = _run_tool_call(
+                    client, request.tool_call, tool_names, request.timeout
+                )
+            return MCPTestSuccess(tools=tool_names, tool_result=tool_result)
     except MCPTimeoutError as exc:
         logger.info("MCP test timed out for server %r: %s", request.name, exc)
         return MCPTestFailure(error=str(exc), error_kind="timeout")
@@ -215,11 +335,21 @@ def _probe_mcp_server(request: MCPTestRequest) -> MCPTestResponse:
         "Attempt to connect to a candidate MCP server and list its tools, "
         "without persisting any settings. Useful for validating user input "
         "in 'add MCP server' flows before storing the config. "
+        "Optionally invokes one caller-chosen (read-only) tool via "
+        "`tool_call` and reports its outcome in `tool_result`, so callers "
+        "can verify credentials that are only exercised on tool invocation. "
+        "Encrypted `env`/`headers` values round-tripped from settings are "
+        "decrypted before the connection is attempted. "
         "Returns 200 with `ok=false` for connection / timeout failures "
         "(those are expected during validation, not server errors)."
     ),
 )
-async def test_mcp_server(request: MCPTestRequest) -> MCPTestResponse:
+async def test_mcp_server(
+    request: MCPTestRequest, http_request: Request
+) -> MCPTestResponse:
     """Probe a single MCP server config and report whether it works."""
+    # Resolve the cipher here: the threadpool function below must not
+    # reach back into ``http_request.app.state``.
+    cipher = get_cipher(http_request)
     loop = asyncio.get_running_loop()
-    return await loop.run_in_executor(None, _probe_mcp_server, request)
+    return await loop.run_in_executor(None, _probe_mcp_server, request, cipher)

--- a/tests/agent_server/test_mcp_router.py
+++ b/tests/agent_server/test_mcp_router.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import json
 import sys
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import SecretStr
 
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
@@ -46,6 +48,32 @@ def http_mcp_server():
     server.stop()
 
 
+@pytest.fixture
+def slack_like_mcp_server():
+    """Server mimicking the Slack MCP server's error reporting.
+
+    Upstream API failures come back as ordinary text content
+    (``{"ok": false, "error": ...}``) with the MCP ``isError`` flag unset --
+    the exact behavior that makes a tools/list-only probe a false positive
+    for invalid credentials.
+    """
+    server = MCPTestServer("slack-like")
+
+    @server.add_tool
+    def slack_list_channels(limit: int = 100) -> str:
+        """Return a Slack-style auth failure payload as plain content."""
+        return json.dumps({"ok": False, "error": "invalid_auth"})
+
+    @server.add_tool
+    def boom() -> str:
+        """Always raise so the call result carries isError=True."""
+        raise RuntimeError("upstream exploded")
+
+    server.start(transport="http")
+    yield server
+    server.stop()
+
+
 # ---------------------------------------------------------------------------
 # Happy path
 # ---------------------------------------------------------------------------
@@ -69,6 +97,8 @@ def test_mcp_test_remote_success(client: TestClient, http_mcp_server: MCPTestSer
     body = response.json()
     assert body["ok"] is True
     assert set(body["tools"]) == {"echo", "add"}
+    # No tool_call requested -> no tool_result (back-compat with old clients).
+    assert body.get("tool_result") is None
 
 
 def test_mcp_test_shttp_alias_is_accepted(
@@ -122,6 +152,134 @@ def test_mcp_test_stdio_success(client: TestClient):
     body = response.json()
     assert body["ok"] is True, body
     assert "ping" in body["tools"]
+
+
+# ---------------------------------------------------------------------------
+# Tool-call probe (credential verification)
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_test_tool_call_reports_in_band_failure_payload(
+    client: TestClient, slack_like_mcp_server: MCPTestServer
+):
+    """The requested tool runs and its payload is reported verbatim.
+
+    Slack-style servers return upstream auth errors as ordinary content
+    with isError unset; the endpoint must surface that payload (ok stays
+    True -- interpreting it is the caller's job).
+    """
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{slack_like_mcp_server.port}/mcp",
+            },
+            "timeout": 10.0,
+            "tool_call": {"name": "slack_list_channels", "arguments": {"limit": 1}},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["tool_result"]["is_error"] is False
+    assert "invalid_auth" in body["tool_result"]["text"]
+
+
+def test_mcp_test_tool_call_handler_error_sets_is_error(
+    client: TestClient, slack_like_mcp_server: MCPTestServer
+):
+    """A tool handler that raises is reported via the isError flag."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{slack_like_mcp_server.port}/mcp",
+            },
+            "timeout": 10.0,
+            "tool_call": {"name": "boom"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["tool_result"]["is_error"] is True
+
+
+def test_mcp_test_tool_call_unknown_tool_reported_without_invocation(
+    client: TestClient, http_mcp_server: MCPTestServer
+):
+    """Requesting a tool the server doesn't advertise yields an errored
+    tool_result naming the problem instead of a blind invocation."""
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "server": {
+                "type": "http",
+                "url": f"http://127.0.0.1:{http_mcp_server.port}/mcp",
+            },
+            "timeout": 10.0,
+            "tool_call": {"name": "definitely_not_a_tool"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True
+    assert body["tool_result"]["is_error"] is True
+    assert "not advertised" in body["tool_result"]["text"]
+
+
+def test_mcp_test_decrypts_encrypted_env_values_before_spawn():
+    """Fernet-encrypted env values round-tripped from settings are decrypted
+    before the server process is spawned; plaintext values pass through.
+
+    This is what lets the edit flow test the *stored* credentials even
+    though the GUI only ever sees redacted placeholders.
+    """
+    config = Config(session_api_keys=[], secret_key=SecretStr("test-secret-key"))
+    cipher = config.cipher
+    assert cipher is not None
+    client = TestClient(create_app(config), raise_server_exceptions=False)
+    script = (
+        "import json, os\n"
+        "from fastmcp import FastMCP\n"
+        "mcp = FastMCP('env-echo')\n"
+        "@mcp.tool()\n"
+        "def read_env() -> str:\n"
+        "    return json.dumps({\n"
+        "        'bot_token': os.environ.get('SLACK_BOT_TOKEN', ''),\n"
+        "        'team_id': os.environ.get('SLACK_TEAM_ID', ''),\n"
+        "    })\n"
+        "mcp.run()\n"
+    )
+
+    response = client.post(
+        "/api/mcp/test",
+        json={
+            "name": "env-echo",
+            "server": {
+                "type": "stdio",
+                "command": sys.executable,
+                "args": ["-c", script],
+                "env": {
+                    "SLACK_BOT_TOKEN": cipher.encrypt(SecretStr("xoxb-real-token")),
+                    "SLACK_TEAM_ID": "T0123",
+                },
+            },
+            "timeout": 20.0,
+            "tool_call": {"name": "read_env"},
+        },
+    )
+
+    assert response.status_code == 200, response.text
+    body = response.json()
+    assert body["ok"] is True, body
+    seen_env = json.loads(body["tool_result"]["text"])
+    assert seen_env == {"bot_token": "xoxb-real-token", "team_id": "T0123"}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents: 

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

- [x] A human has tested these changes.

---

## Why

<!-- Describe problem, motivation, etc.-->

### Problem

<img width="1440" height="794" alt="app-2187-issue" src="https://github.com/user-attachments/assets/0f85345f-9c03-4fc4-859b-53da2a847f4e" />

`POST /api/mcp/test` validates only transport-level connectivity: it spawns the MCP server, performs the MCP handshake, lists tools, and tears down. Many MCP servers exercise their credentials **only inside tool handlers** — e.g. `@zencoderai/slack-mcp-server` starts and advertises all 8 tools with any non-empty `SLACK_TEAM_ID` / `SLACK_BOT_TOKEN`, and reports Slack API failures (`{"ok":false,"error":"invalid_auth"}`) as ordinary text content with the MCP `isError` flag unset. The endpoint therefore returns `{ok: true, tools: [...8 names]}` for a server whose credentials are invalid, and clients (the GUI) display a false "Connected" result.

A second gap compounds this: clients that store MCP secrets via settings only ever see redacted placeholders (`<redacted`), so they have no way to make the test endpoint exercise the _stored_ credentials.

### Steps to reproduce

1.  `POST /api/mcp/test` with `{"server": {"type": "stdio", "command": "npx", "args": ["-y", "@zencoderai/slack-mcp-server"], "env": {"SLACK_TEAM_ID": "T-INVALID", "SLACK_BOT_TOKEN": "xoxb-invalid"}}}`
2.  Observe `{"ok": true, "tools": [ ...8 tool names ]}` despite the invalid credentials.

### Expected

The endpoint provides a way for callers to verify credentials during the test and to test stored (encrypted-at-rest) secrets, while staying provider-neutral and side-effect-free with respect to server state.

### Proposed fix

1.  **Optional verification tool call** — `MCPTestRequest.tool_call: {name, arguments}`: after tools/list succeeds, invoke that caller-chosen (read-only) tool and report its outcome verbatim in `MCPTestSuccess.tool_result: {is_error, text}`. The endpoint does not judge in-band payloads (`ok` keeps meaning transport-level success); interpreting provider-specific error payloads is the caller's job.
2.  **Encrypted-secret round-trip** — decrypt Fernet-encrypted `env`/`headers` values (cipher from app config) before spawning, so clients can forward secrets fetched with `X-Expose-Secrets: encrypted` and the test exercises the real stored credentials. Plaintext values pass through unchanged.

### Acceptance criteria

- [ ] `tool_call` runs the named tool after a successful listing; its `isError` flag and concatenated text content are returned in `tool_result`.
- [ ] An unadvertised tool name or a tool-call timeout yields `tool_result.is_error = true` (with an explanatory message) without failing the probe.
- [ ] Fernet tokens in stdio `env` (and remote `headers`) are decrypted before the connection is attempted; plaintext passes through.
- [ ] Requests without `tool_call` behave exactly as before (`tool_result` is `null`); the request remains backward compatible for older servers (unknown field ignored).
- [ ] Covered by tests in `tests/agent_server/test_mcp_router.py`.

## Summary

<!-- 1-3 bullets describing what changed. -->
`POST /api/mcp/test` can now actually verify credentials: callers may name one read-only tool to invoke after `tools/list` succeeds, and the endpoint reports that call's outcome verbatim. It also decrypts Fernet-encrypted `env`/`headers` values so clients can test _stored_ secrets without ever seeing them.

Backend half of fixing **"MCP Test Connection reports `Connected — 8 tool(s) available` for a Slack server with invalid credentials"** (GUI PR in `agent-server-gui` consumes this API).

## Problem / root cause

The probe was connect → `tools/list` → teardown. That validates transport connectivity only:

- The Slack MCP server (`@zencoderai/slack-mcp-server`) checks env var _presence_ at startup and uses the credentials only inside tool handlers, so listing its 8 tools succeeds with garbage credentials.
- Even when a tool runs, that server reports upstream auth failures as plain text content (`{"ok":false,"error":"invalid_auth"}`) with MCP `isError` unset — so credential failure is an in-band, provider-specific signal.

## Changes (`openhands/agent_server/mcp_router.py`)

- **`MCPTestRequest.tool_call: MCPToolCallSpec | None`** — `{name, arguments}`. After a successful listing, the tool is invoked via `call_tool_mcp` (the non-raising variant, mirroring `MCPToolExecutor`) and its outcome returned in **`MCPTestSuccess.tool_result: {is_error, text}`** (text = concatenated `TextContent` blocks).
- Provider-neutral by design: `ok` still means "connected and listed"; interpreting `tool_result` payloads is the caller's job. Unadvertised tool names and tool-call timeouts yield `tool_result.is_error = true` without failing the probe.
- **Secret round-trip:** stdio `env` and remote `headers` values are passed through `decrypt_str_with_cipher_or_keep` (cipher resolved in the endpoint via `get_cipher(request)` and handed to the threadpool probe), so Fernet tokens fetched with `X-Expose-Secrets: encrypted` are decrypted before spawn; plaintext passes through unchanged.
- Docstrings updated: the endpoint still never touches stored settings; callers must choose read-only tools for `tool_call`.

## Compatibility

- No `tool_call` in the request → identical behavior to before (`tool_result` is `null`).
- Older servers ignore the new field (pydantic `extra="ignore"`), so newer clients degrade gracefully.
- OpenAPI schema regenerates cleanly with the new models.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

Resolves https://github.com/OpenHands/agent-canvas/issues/2084

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Tests (`tests/agent_server/test_mcp_router.py`, 9 → 13 passing)

- In-band failure payload (Slack-style `invalid_auth` with `isError` unset) is reported verbatim with `ok: true`.
- A raising tool handler surfaces `tool_result.is_error = true`.
- An unadvertised tool name is reported without invocation.
- Fernet-encrypted env values are decrypted before spawn while plaintext values pass through (stdio FastMCP subprocess echoes its env).
- Existing happy-path test now also pins `tool_result = null` when no `tool_call` is requested.

Run: `uv run pytest tests/agent_server/test_mcp_router.py -q` (Full `tests/agent_server` suite: 1141 passed; the only failure, `TestAutoTitle::test_autotitle_sets_title_on_first_user_message`, is pre-existing on a clean checkout and unrelated.)

## Manual verification

Probing the real Slack server with bogus credentials and `tool_call: {"name": "slack_list_channels", "arguments": {"limit": 1}}` returns `ok: true`, 8 tools, and `tool_result.text = '{"ok":false,"error":"invalid_auth"}'` — the signal the GUI turns into "Credential check failed: invalid_auth".

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

<img width="1440" height="794" alt="app-2187-output" src="https://github.com/user-attachments/assets/66b12961-8614-4807-a38b-901f011e62fe" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8339028-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8339028-python \
  ghcr.io/openhands/agent-server:8339028-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8339028-golang-amd64
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-2187-golang-amd64
ghcr.io/openhands/agent-server:8339028-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8339028-golang-arm64
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-2187-golang-arm64
ghcr.io/openhands/agent-server:8339028-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8339028-java-amd64
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-2187-java-amd64
ghcr.io/openhands/agent-server:8339028-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8339028-java-arm64
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-2187-java-arm64
ghcr.io/openhands/agent-server:8339028-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8339028-python-amd64
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-2187-python-amd64
ghcr.io/openhands/agent-server:8339028-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8339028-python-arm64
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-2187-python-arm64
ghcr.io/openhands/agent-server:8339028-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8339028-golang
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-golang
ghcr.io/openhands/agent-server:hieptl-app-2187-golang
ghcr.io/openhands/agent-server:8339028-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8339028-java
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-java
ghcr.io/openhands/agent-server:hieptl-app-2187-java
ghcr.io/openhands/agent-server:8339028-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8339028-python
ghcr.io/openhands/agent-server:833902874e06fd7be8bf986e6b745d6aca8fbd2c-python
ghcr.io/openhands/agent-server:hieptl-app-2187-python
ghcr.io/openhands/agent-server:8339028-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8339028-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8339028-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->