### PR TITLE
Add PR description readiness check

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,11 +1,18 @@
 <!-- Keep this PR as draft until it is ready for review. -->
 
-<!-- AI/LLM agents: 
-
-Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
+<!-- AI/LLM agents:
+Do not edit the HUMAN section or human-tested checkbox.
+In the AGENT section and the template fields below, provide evidence that the
+code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
+exactly what command you ran and include logs, screenshots, or reproduction notes.
 -->
 
+HUMAN:
+
+
 - [ ] A human has tested these changes.
+
+AGENT:
 
 ---
 

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 HUMAN_TESTED_TEXT = "A human has tested these changes."
 MIN_HUMAN_NOTE_CHARS = 20
-REQUIRED_SECTIONS = (
+REQUIRED_SECTIONS: tuple[str, ...] = (
     "Why",
     "Summary",
     "Issue Number",
@@ -19,8 +19,14 @@ REQUIRED_SECTIONS = (
     "Type",
     "Notes",
 )
-REQUIRED_FILLED_SECTIONS = ("Why", "Summary", "How to Test")
-TYPE_OPTIONS = ("Bug fix", "Feature", "Refactor", "Breaking change", "Docs / chore")
+REQUIRED_FILLED_SECTIONS: tuple[str, ...] = ("Why", "Summary", "How to Test")
+TYPE_OPTIONS: tuple[str, ...] = (
+    "Bug fix",
+    "Feature",
+    "Refactor",
+    "Breaking change",
+    "Docs / chore",
+)
 
 HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
@@ -32,8 +38,15 @@ def checkbox_re(label: str) -> re.Pattern[str]:
     return re.compile(rf"(?im)^\s*[-*]\s+\[(?P<mark>[ xX])]\s+{re.escape(label)}\s*$")
 
 
+def checkbox_is_checked(pattern: re.Pattern[str], text: str) -> bool:
+    match = pattern.search(text)
+    return match is not None and match.group("mark").lower() == "x"
+
+
 HUMAN_TESTED_RE = checkbox_re(HUMAN_TESTED_TEXT)
-TYPE_OPTION_RES = {option: checkbox_re(option) for option in TYPE_OPTIONS}
+TYPE_OPTION_RES: dict[str, re.Pattern[str]] = {
+    option: checkbox_re(option) for option in TYPE_OPTIONS
+}
 
 
 def visible_text(text: str) -> str:
@@ -93,7 +106,7 @@ def validate_pr_body(body: str) -> list[str]:
         errors.append(
             f"Keep the `- [ ] {HUMAN_TESTED_TEXT}` checkbox in the PR description."
         )
-    elif human_tested.group("mark").lower() != "x":
+    elif not checkbox_is_checked(HUMAN_TESTED_RE, body):
         errors.append(
             "A human must check `A human has tested these changes.` before review."
         )
@@ -120,9 +133,7 @@ def validate_pr_body(body: str) -> list[str]:
 
     if not missing_type_options:
         type_selected = any(
-            (match := pattern.search(body)) is not None
-            and match.group("mark").lower() == "x"
-            for pattern in TYPE_OPTION_RES.values()
+            checkbox_is_checked(pattern, body) for pattern in TYPE_OPTION_RES.values()
         )
         if not type_selected:
             errors.append("Select at least one checkbox under `## Type`.")

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 
 HUMAN_TESTED_TEXT = "A human has tested these changes."
+# Reject placeholders while allowing a concise human-written sentence.
 MIN_HUMAN_NOTE_CHARS = 20
 # These are the only PR-template sections that must remain and contain content.
 REQUIRED_TEMPLATE_FIELDS: tuple[str, ...] = ("Why", "Summary", "How to Test")
@@ -32,6 +33,7 @@ HUMAN_TESTED_RE = checkbox_re(HUMAN_TESTED_TEXT)
 
 
 def visible_text(text: str) -> str:
+    """Return PR body content that should count as author-provided text."""
     lines = []
     for line in HTML_COMMENT_RE.sub("", text).splitlines():
         stripped = line.strip()

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+
+HUMAN_TESTED_TEXT = "A human has tested these changes."
+MIN_HUMAN_NOTE_CHARS = 20
+REQUIRED_SECTIONS = (
+    "Why",
+    "Summary",
+    "Issue Number",
+    "How to Test",
+    "Video/Screenshots",
+    "Type",
+    "Notes",
+)
+REQUIRED_FILLED_SECTIONS = ("Why", "Summary", "How to Test")
+TYPE_OPTIONS = ("Bug fix", "Feature", "Refactor", "Breaking change", "Docs / chore")
+
+HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
+HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
+HUMAN_HEADING_RE = re.compile(r"(?im)^\s*HUMAN:\s*$")
+AGENT_HEADING_RE = re.compile(r"(?im)^\s*AGENT:\s*$")
+
+
+def checkbox_re(label: str) -> re.Pattern[str]:
+    return re.compile(rf"(?im)^\s*[-*]\s+\[(?P<mark>[ xX])]\s+{re.escape(label)}\s*$")
+
+
+HUMAN_TESTED_RE = checkbox_re(HUMAN_TESTED_TEXT)
+TYPE_OPTION_RES = {option: checkbox_re(option) for option in TYPE_OPTIONS}
+
+
+def visible_text(text: str) -> str:
+    lines = []
+    for line in HTML_COMMENT_RE.sub("", text).splitlines():
+        stripped = line.strip()
+        if stripped and stripped != "-":
+            lines.append(stripped)
+    return "\n".join(lines).strip()
+
+
+def first_visible_line(text: str) -> str:
+    for line in HTML_COMMENT_RE.sub("", text).splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return ""
+
+
+def extract_sections(body: str) -> dict[str, str]:
+    matches = list(HEADING_RE.finditer(body))
+    sections: dict[str, str] = {}
+    for index, match in enumerate(matches):
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(body)
+        sections[match.group(1).strip()] = body[start:end]
+    return sections
+
+
+def extract_human_note(body: str) -> str:
+    human_match = HUMAN_HEADING_RE.search(body)
+    if human_match is None:
+        return ""
+
+    checkbox_match = HUMAN_TESTED_RE.search(body, human_match.end())
+    if checkbox_match is None:
+        return ""
+
+    return visible_text(body[human_match.end() : checkbox_match.start()])
+
+
+def validate_pr_body(body: str) -> list[str]:
+    errors: list[str] = []
+
+    if first_visible_line(body) != "HUMAN:":
+        errors.append("The first visible line of the PR description must be `HUMAN:`.")
+
+    human_note = extract_human_note(body)
+    if len(human_note) < MIN_HUMAN_NOTE_CHARS:
+        errors.append(
+            "Add a short human-written note between `HUMAN:` and "
+            "the human-tested checkbox."
+        )
+
+    human_tested = HUMAN_TESTED_RE.search(body)
+    if human_tested is None:
+        errors.append(
+            f"Keep the `- [ ] {HUMAN_TESTED_TEXT}` checkbox in the PR description."
+        )
+    elif human_tested.group("mark").lower() != "x":
+        errors.append(
+            "A human must check `A human has tested these changes.` before review."
+        )
+
+    if AGENT_HEADING_RE.search(body) is None:
+        errors.append("Keep the `AGENT:` marker from the PR template.")
+
+    sections = extract_sections(body)
+    for section in REQUIRED_SECTIONS:
+        if section not in sections:
+            errors.append(f"Keep the `## {section}` section from the PR template.")
+
+    for section in REQUIRED_FILLED_SECTIONS:
+        if section in sections and not visible_text(sections[section]):
+            errors.append(f"Fill in the `## {section}` section of the PR template.")
+
+    missing_type_options = [
+        option
+        for option, pattern in TYPE_OPTION_RES.items()
+        if pattern.search(body) is None
+    ]
+    for option in missing_type_options:
+        errors.append(f"Keep the `{option}` checkbox under `## Type`.")
+
+    if not missing_type_options:
+        type_selected = any(
+            (match := pattern.search(body)) is not None
+            and match.group("mark").lower() == "x"
+            for pattern in TYPE_OPTION_RES.values()
+        )
+        if not type_selected:
+            errors.append("Select at least one checkbox under `## Type`.")
+
+    return errors
+
+
+def body_from_event(event_path: Path) -> str:
+    payload = json.loads(event_path.read_text())
+    pull_request = payload.get("pull_request")
+    if not isinstance(pull_request, dict):
+        raise ValueError("GitHub event payload does not contain a pull_request object")
+    body = pull_request.get("body")
+    return body if isinstance(body, str) else ""
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Validate pull request description readiness."
+    )
+    parser.add_argument(
+        "--body-file", type=Path, help="Read a PR description body from a file."
+    )
+    parser.add_argument(
+        "--event-path",
+        type=Path,
+        default=Path(os.environ["GITHUB_EVENT_PATH"])
+        if "GITHUB_EVENT_PATH" in os.environ
+        else None,
+        help="Read the PR description body from a GitHub event payload.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.body_file is not None:
+        body = args.body_file.read_text()
+    elif args.event_path is not None:
+        body = body_from_event(args.event_path)
+    else:
+        raise SystemExit("Pass --body-file or set GITHUB_EVENT_PATH.")
+
+    errors = validate_pr_body(body)
+    for error in errors:
+        print(f"::error::{error}")
+
+    if errors:
+        print(f"PR description validation failed with {len(errors)} error(s).")
+        return 1
+
+    print("PR description validation passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 HUMAN_TESTED_TEXT = "A human has tested these changes."
 MIN_HUMAN_NOTE_CHARS = 20
-REQUIRED_SECTIONS: tuple[str, ...] = (
+TEMPLATE_SECTIONS: tuple[str, ...] = (
     "Why",
     "Summary",
     "Issue Number",
@@ -19,7 +19,7 @@ REQUIRED_SECTIONS: tuple[str, ...] = (
     "Type",
     "Notes",
 )
-REQUIRED_FILLED_SECTIONS: tuple[str, ...] = ("Why", "Summary", "How to Test")
+NONEMPTY_SECTIONS: tuple[str, ...] = ("Why", "Summary", "How to Test")
 TYPE_OPTIONS: tuple[str, ...] = (
     "Bug fix",
     "Feature",
@@ -115,11 +115,11 @@ def validate_pr_body(body: str) -> list[str]:
         errors.append("Keep the `AGENT:` marker from the PR template.")
 
     sections = extract_sections(body)
-    for section in REQUIRED_SECTIONS:
+    for section in TEMPLATE_SECTIONS:
         if section not in sections:
             errors.append(f"Keep the `## {section}` section from the PR template.")
 
-    for section in REQUIRED_FILLED_SECTIONS:
+    for section in NONEMPTY_SECTIONS:
         if section in sections and not visible_text(sections[section]):
             errors.append(f"Fill in the `## {section}` section of the PR template.")
 

--- a/.github/scripts/check_pr_description.py
+++ b/.github/scripts/check_pr_description.py
@@ -10,23 +10,8 @@ from pathlib import Path
 
 HUMAN_TESTED_TEXT = "A human has tested these changes."
 MIN_HUMAN_NOTE_CHARS = 20
-TEMPLATE_SECTIONS: tuple[str, ...] = (
-    "Why",
-    "Summary",
-    "Issue Number",
-    "How to Test",
-    "Video/Screenshots",
-    "Type",
-    "Notes",
-)
-NONEMPTY_SECTIONS: tuple[str, ...] = ("Why", "Summary", "How to Test")
-TYPE_OPTIONS: tuple[str, ...] = (
-    "Bug fix",
-    "Feature",
-    "Refactor",
-    "Breaking change",
-    "Docs / chore",
-)
+# These are the only PR-template sections that must remain and contain content.
+REQUIRED_TEMPLATE_FIELDS: tuple[str, ...] = ("Why", "Summary", "How to Test")
 
 HTML_COMMENT_RE = re.compile(r"<!--[\s\S]*?-->")
 HEADING_RE = re.compile(r"(?m)^##\s+(.+?)\s*$")
@@ -44,9 +29,6 @@ def checkbox_is_checked(pattern: re.Pattern[str], text: str) -> bool:
 
 
 HUMAN_TESTED_RE = checkbox_re(HUMAN_TESTED_TEXT)
-TYPE_OPTION_RES: dict[str, re.Pattern[str]] = {
-    option: checkbox_re(option) for option in TYPE_OPTIONS
-}
 
 
 def visible_text(text: str) -> str:
@@ -77,6 +59,7 @@ def extract_sections(body: str) -> dict[str, str]:
 
 
 def extract_human_note(body: str) -> str:
+    """Return human-written text in the required location before the checkbox."""
     human_match = HUMAN_HEADING_RE.search(body)
     if human_match is None:
         return ""
@@ -115,28 +98,11 @@ def validate_pr_body(body: str) -> list[str]:
         errors.append("Keep the `AGENT:` marker from the PR template.")
 
     sections = extract_sections(body)
-    for section in TEMPLATE_SECTIONS:
+    for section in REQUIRED_TEMPLATE_FIELDS:
         if section not in sections:
             errors.append(f"Keep the `## {section}` section from the PR template.")
-
-    for section in NONEMPTY_SECTIONS:
-        if section in sections and not visible_text(sections[section]):
+        elif not visible_text(sections[section]):
             errors.append(f"Fill in the `## {section}` section of the PR template.")
-
-    missing_type_options = [
-        option
-        for option, pattern in TYPE_OPTION_RES.items()
-        if pattern.search(body) is None
-    ]
-    for option in missing_type_options:
-        errors.append(f"Keep the `{option}` checkbox under `## Type`.")
-
-    if not missing_type_options:
-        type_selected = any(
-            checkbox_is_checked(pattern, body) for pattern in TYPE_OPTION_RES.values()
-        )
-        if not type_selected:
-            errors.append("Select at least one checkbox under `## Type`.")
 
     return errors
 
@@ -152,7 +118,10 @@ def body_from_event(event_path: Path) -> str:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Validate pull request description readiness."
+        description=(
+            "Validate pull request description readiness from --body-file "
+            "or a GitHub event payload."
+        )
     )
     parser.add_argument(
         "--body-file", type=Path, help="Read a PR description body from a file."

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -1,0 +1,24 @@
+---
+name: PR Description Check
+
+on:
+    pull_request_target:
+        types: [opened, edited, reopened, ready_for_review, synchronize]
+
+permissions:
+    contents: read
+    pull-requests: read
+
+jobs:
+    validate-pr-description:
+        name: Validate PR description
+        if: github.event.pull_request.draft == false
+        runs-on: ubuntu-24.04
+        steps:
+            - name: Checkout trusted workflow scripts
+              uses: actions/checkout@v6
+              with:
+                  ref: ${{ github.event.pull_request.base.sha }}
+
+            - name: Validate HUMAN note and PR template
+              run: python .github/scripts/check_pr_description.py

--- a/.github/workflows/pr-description-check.yml
+++ b/.github/workflows/pr-description-check.yml
@@ -1,9 +1,12 @@
 ---
 name: PR Description Check
 
+# Use pull_request_target so fork PR descriptions can be checked, but only run
+# trusted validation code from the base branch checkout below.
+
 on:
     pull_request_target:
-        types: [opened, edited, reopened, ready_for_review, synchronize]
+        types: [opened, edited, reopened, ready_for_review]
 
 permissions:
     contents: read
@@ -12,6 +15,7 @@ permissions:
 jobs:
     validate-pr-description:
         name: Validate PR description
+        # Draft PRs may still have incomplete descriptions; validate when review starts.
         if: github.event.pull_request.draft == false
         runs-on: ubuntu-24.04
         steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -242,7 +242,7 @@ mkdir -p .pr
 # Human-only PR description fields
 
 The `HUMAN:` section and the `A human has tested these changes.` checkbox in
-PR descriptions are reserved for human maintainers/contributors only. AI agents
+PR descriptions are reserved for human contributors only. AI agents
 MUST NOT add to, edit, move, remove, or check these fields. If the PR description
 CI fails because these fields are missing, empty, or unchecked, stop and ask the
 human user to update them in their own words.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -238,6 +238,17 @@ mkdir -p .pr
 - Any analysis that helps reviewers understand the PR but isn't needed long-term
 </PR_ARTIFACTS>
 
+<PR_DESCRIPTION_HUMAN_CHECK>
+# Human-only PR description fields
+
+The `HUMAN:` section and the `A human has tested these changes.` checkbox in
+PR descriptions are reserved for human maintainers/contributors only. AI agents
+MUST NOT add to, edit, move, remove, or check these fields. If the PR description
+CI fails because these fields are missing, empty, or unchecked, stop and ask the
+human user to update them in their own words.
+</PR_DESCRIPTION_HUMAN_CHECK>
+
+
 <REVIEW_HANDLING>
 - Critically evaluate each review comment before acting on it. Not all feedback is worth implementing:
   - Does it fix a real bug or improve clarity significantly?

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,7 +245,8 @@ The `HUMAN:` section and the `A human has tested these changes.` checkbox in
 PR descriptions are reserved for human contributors only. AI agents
 MUST NOT add to, edit, move, remove, or check these fields. If the PR description
 CI fails because these fields are missing, empty, or unchecked, stop and ask the
-human user to update them in their own words.
+human user to update them in their own words. If the fields were already updated
+by a human, report the exact validator error rather than editing them yourself.
 </PR_DESCRIPTION_HUMAN_CHECK>
 
 

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -95,28 +95,25 @@ def test_human_tested_checkbox_must_be_checked():
     )
 
 
-def test_required_template_sections_must_be_present_and_filled():
+def test_required_template_fields_must_be_present_and_filled():
     how_to_test = (
         "## How to Test\n\n"
         "Ran the new validation script against a passing and failing PR body."
     )
     body = VALID_BODY.replace(how_to_test, "## How to Test\n\n<!-- TODO -->")
-    body = body.replace("## Video/Screenshots", "## Screenshots")
+    body = body.replace("## Summary", "## Details")
 
     errors = validate_pr_body(body)
 
     assert "Fill in the `## How to Test` section of the PR template." in errors
-    assert "Keep the `## Video/Screenshots` section from the PR template." in errors
+    assert "Keep the `## Summary` section from the PR template." in errors
 
 
-def test_type_section_must_keep_options_and_select_one():
-    body = VALID_BODY.replace("- [x] Feature", "- [ ] Feature")
-    body = body.replace("- [ ] Refactor", "- [ ] Cleanup")
+def test_optional_template_sections_may_be_removed():
+    body = VALID_BODY.replace("## Issue Number\n\nN/A\n\n", "")
+    body = body.split("## Video/Screenshots", maxsplit=1)[0]
 
-    errors = validate_pr_body(body)
-
-    assert "Keep the `Refactor` checkbox under `## Type`." in errors
-    assert "Select at least one checkbox under `## Type`." not in errors
+    assert validate_pr_body(body) == []
 
 
 def test_body_from_event_reads_pull_request_body(tmp_path: Path):

--- a/tests/cross/test_check_pr_description.py
+++ b/tests/cross/test_check_pr_description.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+
+def _load_prod_module():
+    repo_root = Path(__file__).resolve().parents[2]
+    script_path = repo_root / ".github" / "scripts" / "check_pr_description.py"
+    name = "check_pr_description"
+    spec = importlib.util.spec_from_file_location(name, script_path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_prod = _load_prod_module()
+validate_pr_body = _prod.validate_pr_body
+body_from_event = _prod.body_from_event
+
+
+VALID_BODY = """<!-- Keep this PR as draft until it is ready for review. -->
+
+HUMAN:
+
+I reviewed the agent's changes and confirmed they do what the PR says.
+The implementation is small and the validation output matches the goal.
+
+- [x] A human has tested these changes.
+
+AGENT:
+
+---
+
+## Why
+
+The existing workflow did not make the missing human context visible enough.
+
+## Summary
+
+- Add a required PR description readiness check.
+
+## Issue Number
+
+N/A
+
+## How to Test
+
+Ran the new validation script against a passing and failing PR body.
+
+## Video/Screenshots
+
+N/A
+
+## Type
+
+- [ ] Bug fix
+- [x] Feature
+- [ ] Refactor
+- [ ] Breaking change
+- [ ] Docs / chore
+
+## Notes
+
+N/A
+"""
+
+
+def test_valid_pr_body_passes():
+    assert validate_pr_body(VALID_BODY) == []
+
+
+def test_human_section_must_be_first_visible_line_and_filled():
+    body = VALID_BODY.replace("HUMAN:", "## Summary", 1)
+
+    errors = validate_pr_body(body)
+
+    assert "The first visible line of the PR description must be `HUMAN:`." in errors
+    assert (
+        "Add a short human-written note between `HUMAN:` and the human-tested checkbox."
+        in errors
+    )
+
+
+def test_human_tested_checkbox_must_be_checked():
+    body = VALID_BODY.replace("- [x] A human has tested", "- [ ] A human has tested")
+
+    assert (
+        "A human must check `A human has tested these changes.` before review."
+        in validate_pr_body(body)
+    )
+
+
+def test_required_template_sections_must_be_present_and_filled():
+    how_to_test = (
+        "## How to Test\n\n"
+        "Ran the new validation script against a passing and failing PR body."
+    )
+    body = VALID_BODY.replace(how_to_test, "## How to Test\n\n<!-- TODO -->")
+    body = body.replace("## Video/Screenshots", "## Screenshots")
+
+    errors = validate_pr_body(body)
+
+    assert "Fill in the `## How to Test` section of the PR template." in errors
+    assert "Keep the `## Video/Screenshots` section from the PR template." in errors
+
+
+def test_type_section_must_keep_options_and_select_one():
+    body = VALID_BODY.replace("- [x] Feature", "- [ ] Feature")
+    body = body.replace("- [ ] Refactor", "- [ ] Cleanup")
+
+    errors = validate_pr_body(body)
+
+    assert "Keep the `Refactor` checkbox under `## Type`." in errors
+    assert "Select at least one checkbox under `## Type`." not in errors
+
+
+def test_body_from_event_reads_pull_request_body(tmp_path: Path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({"pull_request": {"body": VALID_BODY}}))
+
+    assert body_from_event(event_path) == VALID_BODY


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
If the PR description CI fails because they were not filled in, stop and ask your human to fill them
in their own words!
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:
This PR proposes to make the verification of the PR description a workflow that fails if the human didn’t fill in the human-reserved sections, and/or the PR template required fields were not filled in.

- [x] A human has tested these changes.

AGENT:

This PR was created by an AI agent (OpenHands) on behalf of the user.

---

## Why

The existing HUMAN reminder in OpenHands was only an advisory PR comment, which is easy to miss during review. The intent is to make human-in-the-loop PR triage more visible and enforceable while keeping the human-only fields reserved for actual humans.

## Summary

- Add a PR description CI check for human context and required template fields.
- Add a small Python validator with tests for the HUMAN section and required template fields (`Why`, `Summary`, `How to Test`).
- Update the PR template and AGENTS.md to make HUMAN fields explicitly human-only.

## Issue Number

N/A

## How to Test

Ran:

```bash
uv run pre-commit run --files .github/scripts/check_pr_description.py tests/cross/test_check_pr_description.py .github/workflows/pr-description-check.yml .github/PULL_REQUEST_TEMPLATE.md AGENTS.md
uv run pytest tests/cross/test_check_pr_description.py -q
```

Both commands passed locally. The pytest run reported `6 passed`.

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The new `pull_request_target` workflow checks out the PR base SHA before running the validator, so untrusted PR changes cannot alter the validation code that runs with target-workflow permissions. Since this workflow is introduced by this PR, GitHub will only start running it for future PRs after it lands on the default branch.

The HUMAN section and human-tested checkbox are reserved for a human contributor; AI agents must not modify them.






<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:df53874-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-df53874-python \
  ghcr.io/openhands/agent-server:df53874-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:df53874-golang-amd64
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-golang-amd64
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-golang-amd64
ghcr.io/openhands/agent-server:df53874-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:df53874-golang-arm64
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-golang-arm64
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-golang-arm64
ghcr.io/openhands/agent-server:df53874-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:df53874-java-amd64
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-java-amd64
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-java-amd64
ghcr.io/openhands/agent-server:df53874-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:df53874-java-arm64
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-java-arm64
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-java-arm64
ghcr.io/openhands/agent-server:df53874-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:df53874-python-amd64
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-python-amd64
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-python-amd64
ghcr.io/openhands/agent-server:df53874-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:df53874-python-arm64
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-python-arm64
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-python-arm64
ghcr.io/openhands/agent-server:df53874-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:df53874-golang
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-golang
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-golang
ghcr.io/openhands/agent-server:df53874-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:df53874-java
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-java
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-java
ghcr.io/openhands/agent-server:df53874-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:df53874-python
ghcr.io/openhands/agent-server:df5387462560400893f62d4d8326ee2d9e721049-python
ghcr.io/openhands/agent-server:openhands-workspace-19mthglnzgiqfmvpbkecls-python
ghcr.io/openhands/agent-server:df53874-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `df53874-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `df53874-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
