### PR TITLE
refactor(secrets): seed agent_context.secrets into the registry for all agents; consolidate ACP onto it

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1803,13 +1803,14 @@ class ACPAgent(AgentBase):
     def _read_conversation_secret(
         self, state: ConversationState, name: str
     ) -> str | None:
-        """Read a secret value from the canonical channel, then the drain.
+        """Read a secret value, preferring the registry over a direct read.
 
         Prefers ``state.secret_registry`` — the canonical channel, where
-        ``create_request`` lifts ``agent_context.secrets`` on the Python /
-        OpenHands-cloud path and where ``StartConversationRequest.secrets``
-        land — and falls back to ``agent_context.secrets`` for topologies that
-        do not call ``create_request`` (notably canvas-local). See #1022.
+        ``StartConversationRequest.secrets`` land and where ``LocalConversation``
+        seeds ``agent_context.secrets`` at conversation init (covering the
+        canvas-local path that does not call ``create_request``). Falls back to
+        a direct ``agent_context.secrets`` read as a safety net for states not
+        built via ``LocalConversation``. See #1022 / agent-canvas#1039.
         """
         if name in state.secret_registry.secret_sources:
             value = state.secret_registry.get_secret_value(name)
@@ -1900,8 +1901,8 @@ class ACPAgent(AgentBase):
         need a narrower scope can pin ``HOME`` via ``acp_env`` (honoured below)
         or leave isolation off for Gemini.
 
-        Ordering contract: this runs *after* the secret_registry / agent_context
-        drain and the ``acp_env`` update in :meth:`_start_acp_server`, so the
+        Ordering contract: this runs *after* the ``secret_registry`` injection
+        and the ``acp_env`` update in :meth:`_start_acp_server`, so the
         credential vars it inspects (``ANTHROPIC_API_KEY`` /
         ``CLAUDE_CODE_OAUTH_TOKEN``) are already hydrated into ``env``. Calling it
         earlier would misread the active credential and wrongly relocate Claude.

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2036,28 +2036,17 @@ class ACPAgent(AgentBase):
         client.mask = state.secret_registry.mask_secrets_in_output
 
         # Build the subprocess environment. Precedence, highest first:
-        #   acp_env > state.secret_registry > agent_context.secrets
-        #     > os.environ > default_environment
+        #   acp_env > state.secret_registry > os.environ > default_environment
         #
-        # Conversation credentials (the registry and the agent_context drain)
-        # intentionally OVERRIDE ambient os.environ: an explicit per-conversation
-        # / provider secret must win over a same-named variable in the
-        # agent-server's own environment (os.environ is the wrong process for a
-        # remote server). acp_env (deprecated) stays highest.
+        # Conversation credentials intentionally OVERRIDE ambient os.environ: an
+        # explicit per-conversation / provider secret must win over a same-named
+        # variable in the agent-server's own environment. acp_env (deprecated)
+        # stays highest.
         #
-        # Two conversation channels, because an ACP subprocess is a black box we
-        # cannot name-scan per command (unlike the regular agent's bash tool), so
-        # credentials must be injected upfront:
-        #   - state.secret_registry: the canonical channel
-        #     (StartConversationRequest.secrets; also where create_request lifts
-        #     agent_context.secrets on the Python-caller path / OpenHands cloud).
-        #   - agent_context.secrets drain: the ONLY channel that delivers
-        #     agent_context.secrets on paths that do NOT call create_request —
-        #     notably canvas-local, which builds the request in TypeScript and
-        #     relies on the server's create_agent() to fold llm.api_key into
-        #     agent_context.secrets. There is no server-side agent_context.secrets
-        #     → registry lift, so keep this drain until one exists.
-        # On a key collision the registry wins over the drain.
+        # agent_context.secrets are seeded into secret_registry at
+        # LocalConversation.__init__ (lower priority than request.secrets), so
+        # the registry is now the single channel for all secrets including
+        # provider credentials folded in by ACPAgentSettings.create_agent().
         env = default_environment()
         env.update(os.environ)
         if self.acp_env:
@@ -2076,27 +2065,7 @@ class ACPAgent(AgentBase):
         # injected as env vars, so exclude their (large blob) names from the
         # plain env-injection below; materialisation sets only the path env var.
         file_secret_names = self._present_file_secret_names(state)
-        # agent_context.secrets drain (lower precedence than the registry).
-        # Skip keys a higher tier will set — acp_env (applied last) and the
-        # registry (applied next) — to avoid a wasted SecretSource.get_value()
-        # (LookupSecret can make an HTTP request).
-        registry_names = set(state.secret_registry.secret_sources)
-        if self.agent_context and self.agent_context.secrets:
-            for name, secret in self.agent_context.secrets.items():
-                if (
-                    name in self.acp_env
-                    or name in registry_names
-                    or name in file_secret_names
-                ):
-                    continue
-                value = (
-                    secret.get_value()
-                    if isinstance(secret, SecretSource)
-                    else str(secret)
-                )
-                if value:
-                    env[name] = value
-        # state.secret_registry overrides the drain and ambient os.environ. Skip
+        # state.secret_registry overrides ambient os.environ. Skip
         # keys acp_env will set (avoids a redundant LookupSecret.get_value()).
         for name in state.secret_registry.secret_sources:
             if name in self.acp_env or name in file_secret_names:
@@ -2117,7 +2086,7 @@ class ACPAgent(AgentBase):
         # Relocate the CLI's data/config root to a per-conversation directory so
         # sandbox-sharing conversations don't race on a shared HOME (#1019).
         # Ordering is load-bearing — this must run AFTER the registry /
-        # agent_context drain and the acp_env update above (so the credential
+        # registry injection and the acp_env update above (so the credential
         # vars its Claude carve-out inspects — ANTHROPIC_API_KEY /
         # CLAUDE_CODE_OAUTH_TOKEN — are already in env, and an acp_env pin wins)
         # and BEFORE the conflict-strip below (so a CLAUDE_CONFIG_DIR it sets is

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1766,25 +1766,18 @@ class ACPAgent(AgentBase):
         advertisement: their values are written to disk, not injected as env
         vars, so advertising them as available env vars would mislead the agent.
         """
-        secret_infos = state.secret_registry.get_secret_infos()
-        agent_context = self.agent_context
+        # Advertise from state.secret_registry alone — it now holds
+        # agent_context.secrets too (seeded at conversation init, with their
+        # descriptions), so it is the single source for the <CUSTOM_SECRETS>
+        # block. Reserved file-content secrets are written to disk, not injected
+        # as env vars, so drop them from the advertisement.
         file_secret_names = self._present_file_secret_names(state)
-        if file_secret_names:
-            secret_infos = [
-                info
-                for info in secret_infos
-                if info.get("name") not in file_secret_names
-            ]
-            if agent_context is not None and agent_context.secrets:
-                agent_context = agent_context.model_copy(
-                    update={
-                        "secrets": {
-                            name: secret
-                            for name, secret in agent_context.secrets.items()
-                            if name not in file_secret_names
-                        }
-                    }
-                )
+        secret_infos = [
+            info
+            for info in state.secret_registry.get_secret_infos()
+            if info.get("name") not in file_secret_names
+        ]
+        agent_context = self.agent_context
         if agent_context is None:
             # No caller-supplied context. Only synthesize an empty one for the
             # renderer if we actually have a registry-secret advertisement to
@@ -1794,9 +1787,12 @@ class ACPAgent(AgentBase):
             # suppress.
             if not secret_infos:
                 return None
-            return AgentContext(current_datetime=None).to_acp_prompt_context(
-                additional_secret_infos=secret_infos
-            )
+            agent_context = AgentContext(current_datetime=None)
+        elif agent_context.secrets:
+            # The registry already carries these (and their descriptions), so
+            # clear the agent_context copy to advertise from the registry alone
+            # rather than re-merging a redundant second source.
+            agent_context = agent_context.model_copy(update={"secrets": {}})
         return agent_context.to_acp_prompt_context(additional_secret_infos=secret_infos)
 
     def _present_file_secret_names(self, state: ConversationState) -> set[str]:

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2032,14 +2032,17 @@ class ACPAgent(AgentBase):
         # injected as env vars, so exclude their (large blob) names from the
         # plain env-injection below; materialisation sets only the path env var.
         file_secret_names = self._present_file_secret_names(state)
-        # state.secret_registry overrides ambient os.environ. Skip
-        # keys acp_env will set (avoids a redundant LookupSecret.get_value()).
-        for name in state.secret_registry.secret_sources:
-            if name in self.acp_env or name in file_secret_names:
-                continue
-            value = state.secret_registry.get_secret_value(name)
-            if value:
-                env[name] = value
+        # Inject the whole registry: an ACP CLI is a black box we can't
+        # name-scan per command (unlike the regular agent's bash tool), so
+        # credentials must be delivered upfront. Registry values override
+        # ambient os.environ. Skip keys acp_env will set last (avoids a
+        # redundant LookupSecret.get_value()) and file secrets (materialised to
+        # disk below).
+        env.update(
+            state.secret_registry.get_all_secrets_as_env_vars(
+                exclude=set(self.acp_env) | file_secret_names
+            )
+        )
         # Materialise reserved file-content secrets to disk and point their
         # data-dir env vars (CODEX_HOME / GOOGLE_APPLICATION_CREDENTIALS) at the
         # written files. Done before acp_env so an explicit acp_env override of

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -73,7 +73,6 @@ from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.llm import LLM, ImageContent, Message, MessageToolCall, TextContent
 from openhands.sdk.logger import get_logger
 from openhands.sdk.observability.laminar import maybe_init_laminar, observe
-from openhands.sdk.secret import SecretSource
 from openhands.sdk.settings.acp_providers import (
     ACPFileSecretSpec,
     build_session_model_meta,
@@ -1800,49 +1799,21 @@ class ACPAgent(AgentBase):
             )
         return agent_context.to_acp_prompt_context(additional_secret_infos=secret_infos)
 
-    def _read_conversation_secret(
-        self, state: ConversationState, name: str
-    ) -> str | None:
-        """Read a secret value, preferring the registry over a direct read.
-
-        Prefers ``state.secret_registry`` — the canonical channel, where
-        ``StartConversationRequest.secrets`` land and where ``LocalConversation``
-        seeds ``agent_context.secrets`` at conversation init (covering the
-        canvas-local path that does not call ``create_request``). Falls back to
-        a direct ``agent_context.secrets`` read as a safety net for states not
-        built via ``LocalConversation``. See #1022 / agent-canvas#1039.
-        """
-        if name in state.secret_registry.secret_sources:
-            value = state.secret_registry.get_secret_value(name)
-            if value:
-                return value
-        if self.agent_context and self.agent_context.secrets:
-            secret = self.agent_context.secrets.get(name)
-            if secret is not None:
-                return (
-                    secret.get_value()
-                    if isinstance(secret, SecretSource)
-                    else str(secret)
-                )
-        return None
-
     def _present_file_secret_names(self, state: ConversationState) -> set[str]:
         """Reserved file-content secret names supplied for this conversation.
 
         A name counts as present if it is configured in
-        :attr:`acp_file_secrets` *and* appears in either credential channel
-        (``state.secret_registry`` or ``agent_context.secrets``). These names
-        are materialised to disk and therefore excluded from the plain env-var
-        injection and the ``<CUSTOM_SECRETS>`` advertisement (their values are
-        file blobs, not env vars the subprocess can reference by name).
+        :attr:`acp_file_secrets` *and* registered in ``state.secret_registry``
+        (which holds ``agent_context.secrets`` too, seeded at conversation
+        init). These names are materialised to disk and therefore excluded from
+        the plain env-var injection and the ``<CUSTOM_SECRETS>`` advertisement
+        (their values are file blobs, not env vars the subprocess can reference
+        by name).
         """
         configured = {spec.secret_name for spec in self.acp_file_secrets}
         if not configured:
             return set()
-        present = set(state.secret_registry.secret_sources)
-        if self.agent_context and self.agent_context.secrets:
-            present |= set(self.agent_context.secrets)
-        return present & configured
+        return set(state.secret_registry.secret_sources) & configured
 
     def _acp_file_secret_dir(self, state: ConversationState, subdir: str) -> Path:
         """Durable per-conversation directory for a credential file.
@@ -1930,12 +1901,11 @@ class ACPAgent(AgentBase):
     ) -> None:
         """Seed reserved file-content credentials onto disk and point the CLI at them.
 
-        For each spec in :attr:`acp_file_secrets` whose secret is present in
-        either credential channel (see :meth:`_read_conversation_secret`), write
-        its value to the spec's durable per-conversation directory
-        (:meth:`_acp_file_secret_dir`) and set the controlling env var
-        (``CODEX_HOME`` / ``GOOGLE_APPLICATION_CREDENTIALS``) unless the caller
-        pinned it via ``acp_env``.
+        For each spec in :attr:`acp_file_secrets` whose secret is registered in
+        ``state.secret_registry``, write its value to the spec's durable
+        per-conversation directory (:meth:`_acp_file_secret_dir`) and set the
+        controlling env var (``CODEX_HOME`` / ``GOOGLE_APPLICATION_CREDENTIALS``)
+        unless the caller pinned it via ``acp_env``.
 
         Seed-if-absent: a non-empty existing file is preserved, never clobbered
         — so a token the CLI rewrites on refresh (Codex) survives a recycle, and
@@ -1951,7 +1921,7 @@ class ACPAgent(AgentBase):
         """
         for spec in self.acp_file_secrets:
             name = spec.secret_name
-            value = self._read_conversation_secret(state, name)
+            value = state.secret_registry.get_secret_value(name)
             if not value:
                 continue
             # Seed where the data-dir env var will actually point: an explicit

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -305,10 +305,12 @@ class LocalConversation(BaseConversation):
         self._profile_store = LLMProfileStore()
         self._cipher = cipher
 
-        # Lower priority: agent_context.secrets (covers callers that don't go
-        # through create_request(), e.g. canvas / TypeScript). On resume, keep
-        # any already-persisted registry value; only fill missing entries or
-        # values lost to redacted/no-cipher serialization.
+        # Seed agent_context.secrets into the registry for every agent (regular
+        # and ACP), covering callers that skip create_request() — canvas /
+        # TypeScript, or the server-side agent_settings -> create_agent fold.
+        # Idempotent with the create_request() lift; lower priority than
+        # request.secrets (below). On resume, fill-if-absent so a persisted
+        # value is never downgraded (or lost to redacted/no-cipher serialization).
         if (ctx := getattr(self.agent, "agent_context", None)) is not None:
             ctx_secrets = getattr(ctx, "secrets", None)
             if ctx_secrets:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -318,6 +318,11 @@ class LocalConversation(BaseConversation):
                 fill_secrets: dict[str, SecretValue] = {}
                 for name, secret in ctx_secrets.items():
                     existing = existing_sources.get(name)
+                    # Refill only when absent, or when a StaticSecret lost its
+                    # value to redacted/no-cipher serialization (value is None).
+                    # Other SecretSource types (e.g. LookupSecret) are left as-is
+                    # even with a None value — that is their resolved state, not
+                    # a stale placeholder to overwrite.
                     if existing is None or (
                         isinstance(existing, StaticSecret) and existing.value is None
                     ):

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -304,20 +304,14 @@ class LocalConversation(BaseConversation):
         self._profile_store = LLMProfileStore()
         self._cipher = cipher
 
-        # Seed secret_registry from agent_context.secrets at lower priority than
-        # request.secrets.  Fills the gap for callers (e.g. canvas / TypeScript
-        # clients) that build StartConversationRequest directly without going
-        # through create_request(), so agent_context.secrets never reach
-        # request.secrets via _start_request_kwargs.  Idempotent for Python
-        # callers that do go through create_request(): request.secrets (applied
-        # next) will overwrite any duplicate keys.
+        # Lower priority: agent_context.secrets (covers callers that don't go
+        # through create_request(), e.g. canvas / TypeScript).
         if (ctx := getattr(self.agent, "agent_context", None)) is not None:
             ctx_secrets = getattr(ctx, "secrets", None)
             if ctx_secrets:
                 self.update_secrets(ctx_secrets)
 
-        # Initialize secrets from request (higher priority — applied after
-        # agent_context.secrets so they win on collision).
+        # Higher priority: request.secrets overwrites duplicate keys from above.
         if secrets:
             secret_values: dict[str, SecretValue] = {k: v for k, v in secrets.items()}
             self.update_secrets(secret_values)

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -304,9 +304,21 @@ class LocalConversation(BaseConversation):
         self._profile_store = LLMProfileStore()
         self._cipher = cipher
 
-        # Initialize secrets if provided
+        # Seed secret_registry from agent_context.secrets at lower priority than
+        # request.secrets.  Fills the gap for callers (e.g. canvas / TypeScript
+        # clients) that build StartConversationRequest directly without going
+        # through create_request(), so agent_context.secrets never reach
+        # request.secrets via _start_request_kwargs.  Idempotent for Python
+        # callers that do go through create_request(): request.secrets (applied
+        # next) will overwrite any duplicate keys.
+        if (ctx := getattr(self.agent, "agent_context", None)) is not None:
+            ctx_secrets = getattr(ctx, "secrets", None)
+            if ctx_secrets:
+                self.update_secrets(ctx_secrets)
+
+        # Initialize secrets from request (higher priority — applied after
+        # agent_context.secrets so they win on collision).
         if secrets:
-            # Convert dict[str, str] to dict[str, SecretValue]
             secret_values: dict[str, SecretValue] = {k: v for k, v in secrets.items()}
             self.update_secrets(secret_values)
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -56,6 +56,7 @@ from openhands.sdk.plugin import (
     ResolvedPluginSource,
     fetch_plugin_with_resolution,
 )
+from openhands.sdk.secret import StaticSecret
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
@@ -305,11 +306,22 @@ class LocalConversation(BaseConversation):
         self._cipher = cipher
 
         # Lower priority: agent_context.secrets (covers callers that don't go
-        # through create_request(), e.g. canvas / TypeScript).
+        # through create_request(), e.g. canvas / TypeScript). On resume, keep
+        # any already-persisted registry value; only fill missing entries or
+        # values lost to redacted/no-cipher serialization.
         if (ctx := getattr(self.agent, "agent_context", None)) is not None:
             ctx_secrets = getattr(ctx, "secrets", None)
             if ctx_secrets:
-                self.update_secrets(ctx_secrets)
+                existing_sources = self._state.secret_registry.secret_sources
+                fill_secrets: dict[str, SecretValue] = {}
+                for name, secret in ctx_secrets.items():
+                    existing = existing_sources.get(name)
+                    if existing is None or (
+                        isinstance(existing, StaticSecret) and existing.value is None
+                    ):
+                        fill_secrets[name] = secret
+                if fill_secrets:
+                    self.update_secrets(fill_secrets)
 
         # Higher priority: request.secrets overwrites duplicate keys from above.
         if secrets:

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -105,6 +105,10 @@ class SecretRegistry(OpenHandsModel):
         credentials upfront. Resolved values are tracked for output masking, and
         lookup failures are skipped rather than raised.
 
+        Note: this injects the *whole* registry; least-privilege scoping
+        (provider creds + an explicit allowlist only) is deferred to #1039
+        task 6.
+
         Args:
             exclude: Secret names to skip — e.g. keys a higher-precedence tier
                 will set anyway, or file-content secrets materialised to disk

--- a/openhands-sdk/openhands/sdk/conversation/secret_registry.py
+++ b/openhands-sdk/openhands/sdk/conversation/secret_registry.py
@@ -1,6 +1,6 @@
 """Secrets manager for handling sensitive data in conversations."""
 
-from collections.abc import Mapping
+from collections.abc import Collection, Mapping
 
 from pydantic import Field, PrivateAttr, SecretStr
 
@@ -91,6 +91,37 @@ class SecretRegistry(OpenHandsModel):
                 continue
 
         logger.debug(f"Prepared {len(env_vars)} secrets as environment variables")
+        return env_vars
+
+    def get_all_secrets_as_env_vars(
+        self, exclude: Collection[str] | None = None
+    ) -> dict[str, str]:
+        """Resolve every registered secret to an env-var mapping.
+
+        Unlike :meth:`get_secrets_as_env_vars`, which name-scans a single
+        command and injects only the secrets it references, this resolves the
+        whole registry. It is for opaque consumers (e.g. an ACP CLI subprocess)
+        that cannot be name-scanned per command and must receive their
+        credentials upfront. Resolved values are tracked for output masking, and
+        lookup failures are skipped rather than raised.
+
+        Args:
+            exclude: Secret names to skip — e.g. keys a higher-precedence tier
+                will set anyway, or file-content secrets materialised to disk
+                (avoids a wasted, possibly remote, ``get_value()``).
+
+        Returns:
+            Dictionary of environment variables to export (key -> value),
+            omitting empty values and excluded names.
+        """
+        skip = set(exclude or ())
+        env_vars: dict[str, str] = {}
+        for name in self.secret_sources:
+            if name in skip:
+                continue
+            value = self.get_secret_value(name)
+            if value:
+                env_vars[name] = value
         return env_vars
 
     def mask_secrets_in_output(self, text: str) -> str:

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1243,13 +1243,13 @@ class ACPAgentSettings(AgentSettingsBase):
         default=None,
         description=(
             "Prompt-only context for the ACP server. ``secrets`` here are "
-            "advertised to the agent (names/descriptions) and injected into the "
-            "subprocess env through two channels: ``state.secret_registry`` (on "
-            "the Python path, ``create_request`` lifts ``agent_context.secrets`` "
-            "into the registry) and a direct drain in "
-            "``ACPAgent._start_acp_server`` for callers that build the request "
-            "outside Python (e.g. canvas-local). ``create_agent`` also folds "
-            "provider credentials into these secrets."
+            "advertised to the agent (names/descriptions) and reach the "
+            "subprocess env through ``state.secret_registry``: "
+            "``LocalConversation`` seeds ``agent_context.secrets`` into the "
+            "registry at conversation init (below ``request.secrets``), so "
+            "callers that build the request outside Python (e.g. canvas-local) "
+            "are covered too, not just the ``create_request`` path. "
+            "``create_agent`` also folds provider credentials into these secrets."
         ),
     )
 

--- a/tests/cross/test_agent_secrets_integration.py
+++ b/tests/cross/test_agent_secrets_integration.py
@@ -178,6 +178,85 @@ def test_agent_without_bash_throws_warning(llm):
     conversation.close()
 
 
+# ---------------------------------------------------------------------------
+# agent_context.secrets → secret_registry lift (canvas / TypeScript gap fix)
+# ---------------------------------------------------------------------------
+
+
+def test_agent_context_secrets_seeded_into_registry_at_init(llm, tmp_path):
+    """agent_context.secrets land in secret_registry without any request.secrets.
+
+    Covers callers (e.g. canvas / TypeScript) that build StartConversationRequest
+    directly without going through create_request(), so agent_context.secrets
+    would otherwise only be visible via the _start_acp_server() drain.
+    """
+    agent = Agent(
+        llm=llm,
+        tools=[],
+        agent_context=AgentContext(
+            secrets={"ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-ctx"))}
+        ),
+    )
+    conv = LocalConversation(agent, workspace=str(tmp_path))
+    try:
+        registry = conv.state.secret_registry
+        assert registry.get_secret_value("ANTHROPIC_API_KEY") == "sk-from-ctx"
+    finally:
+        conv.close()
+
+
+def test_request_secrets_win_over_agent_context_secrets_on_collision(llm, tmp_path):
+    """request.secrets overrides agent_context.secrets when both name the same key.
+
+    request.secrets is the canonical channel and must have higher priority.
+    """
+    agent = Agent(
+        llm=llm,
+        tools=[],
+        agent_context=AgentContext(
+            secrets={"ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-ctx"))}
+        ),
+    )
+    request_secrets = {
+        "ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-request"))
+    }
+    conv = LocalConversation(agent, workspace=str(tmp_path), secrets=request_secrets)
+    try:
+        registry = conv.state.secret_registry
+        assert registry.get_secret_value("ANTHROPIC_API_KEY") == "sk-from-request"
+    finally:
+        conv.close()
+
+
+def test_agent_context_and_request_secrets_are_merged(llm, tmp_path):
+    """Non-conflicting keys from both channels appear in secret_registry."""
+    agent = Agent(
+        llm=llm,
+        tools=[],
+        agent_context=AgentContext(
+            secrets={"ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-provider"))}
+        ),
+    )
+    request_secrets = {"GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp-panel"))}
+    conv = LocalConversation(agent, workspace=str(tmp_path), secrets=request_secrets)
+    try:
+        registry = conv.state.secret_registry
+        assert registry.get_secret_value("ANTHROPIC_API_KEY") == "sk-provider"
+        assert registry.get_secret_value("GITHUB_TOKEN") == "ghp-panel"
+    finally:
+        conv.close()
+
+
+def test_no_agent_context_does_not_raise(llm, tmp_path):
+    """Conversation init succeeds when agent has no agent_context."""
+    agent = Agent(llm=llm, tools=[], agent_context=None)
+    conv = LocalConversation(agent, workspace=str(tmp_path))
+    try:
+        assert conv.state.secret_registry.get_secret_value("NONEXISTENT") is None
+    finally:
+        conv.close()
+
+
 def test_agent_secrets_integration_workflow(
     conversation: LocalConversation, terminal_executor: TerminalExecutor, agent: Agent
 ):

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -5926,12 +5926,13 @@ class TestACPSecretsEnvInjection:
     """Tests for secret injection into the ACP subprocess environment.
 
     Secrets passed via ``agent_context.secrets`` must land in the subprocess
-    env so the ACP server (Claude Code, Codex CLI, etc.) can use them. This
-    drain is the only thing that delivers ``agent_context.secrets`` to the CLI
-    on paths that don't call ``create_request`` (e.g. canvas-local, which folds
-    ``llm.api_key`` into ``agent_context.secrets`` server-side via
-    ``create_agent`` but never lifts it into ``state.secret_registry``).
-    ``acp_env`` entries take precedence over agent_context secrets.
+    env so the ACP server (Claude Code, Codex CLI, etc.) can use them. They
+    reach the subprocess through ``state.secret_registry``: ``LocalConversation``
+    seeds ``agent_context.secrets`` into the registry at init (covering
+    canvas-local, which folds ``llm.api_key`` into ``agent_context.secrets``
+    server-side via ``create_agent`` but never lifts it into ``request.secrets``),
+    and ``_start_acp_server`` injects the registry. ``acp_env`` entries take
+    precedence over registry secrets.
     """
 
     @staticmethod
@@ -5954,8 +5955,13 @@ class TestACPSecretsEnvInjection:
         return conn
 
     @staticmethod
-    def _run_start_capturing_env(agent, tmp_path) -> dict:
-        """Run _start_acp_server and return the env dict passed to the subprocess."""
+    def _run_start_capturing_env(agent, tmp_path, *, state=None) -> dict:
+        """Run _start_acp_server and return the env dict passed to the subprocess.
+
+        Pass ``state`` to run against a conversation-seeded registry (e.g. one
+        built via ``LocalConversation`` so ``agent_context.secrets`` are lifted
+        in); otherwise a bare state is used.
+        """
         from contextlib import ExitStack
 
         from openhands.sdk.utils.async_executor import AsyncExecutor
@@ -5974,14 +5980,15 @@ class TestACPSecretsEnvInjection:
         async def _fake_filter(_src, _dst):
             return None
 
-        state = _make_state(tmp_path)
+        if state is None:
+            state = _make_state(tmp_path)
         agent._executor = AsyncExecutor()
 
         with ExitStack() as stack:
             # Hermetic: exclude the runner's ambient env (e.g. a real
             # GITHUB_TOKEN / ANTHROPIC_API_KEY) so it can't shadow the
-            # registry/drain values under test — env.update(os.environ) runs
-            # before the fill-if-absent secret tiers in _start_acp_server.
+            # registry values under test — env.update(os.environ) runs
+            # before the fill-if-absent registry tier in _start_acp_server.
             stack.enter_context(patch.dict("os.environ", {}, clear=True))
             stack.enter_context(
                 patch(
@@ -6012,14 +6019,19 @@ class TestACPSecretsEnvInjection:
         return captured
 
     def test_static_secret_injected_into_subprocess_env(self, tmp_path):
-        """A StaticSecret in agent_context.secrets lands in the subprocess env.
+        """A StaticSecret in agent_context.secrets reaches the subprocess env.
 
-        This drain is what delivers ``agent_context.secrets`` to the CLI on
-        paths that don't lift them into ``state.secret_registry`` via
+        ``LocalConversation`` seeds ``agent_context.secrets`` into
+        ``state.secret_registry`` at init, and ``_start_acp_server`` injects the
+        registry — the path that delivers ``agent_context.secrets`` to the CLI
+        for callers that don't lift them into ``request.secrets`` via
         ``create_request`` (e.g. canvas-local).
         """
         from pydantic import SecretStr
 
+        from openhands.sdk.conversation.impl.local_conversation import (
+            LocalConversation,
+        )
         from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
@@ -6032,13 +6044,24 @@ class TestACPSecretsEnvInjection:
                 }
             )
         )
-        env = self._run_start_capturing_env(agent, tmp_path)
+        conv = LocalConversation(agent, workspace=str(tmp_path))
+        try:
+            env = self._run_start_capturing_env(agent, tmp_path, state=conv.state)
+        finally:
+            conv.close()
         assert env.get("GITHUB_TOKEN") == "ghp_test123"
 
     def test_acp_env_takes_precedence_over_agent_context_secret(self, tmp_path):
-        """An explicit acp_env entry wins over the same key in agent_context.secrets."""
+        """An explicit acp_env entry wins over the same key in agent_context.secrets.
+
+        ``agent_context.secrets`` reach env via the registry (seeded at
+        ``LocalConversation.__init__``); ``acp_env`` is applied last and wins.
+        """
         from pydantic import SecretStr
 
+        from openhands.sdk.conversation.impl.local_conversation import (
+            LocalConversation,
+        )
         from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
@@ -6047,8 +6070,12 @@ class TestACPSecretsEnvInjection:
                 secrets={"MY_TOKEN": StaticSecret(value=SecretStr("secret-panel"))}
             ),
         )
-        with pytest.warns(DeprecationWarning, match=r"ACPAgent\.acp_env"):
-            env = self._run_start_capturing_env(agent, tmp_path)
+        conv = LocalConversation(agent, workspace=str(tmp_path))
+        try:
+            with pytest.warns(DeprecationWarning, match=r"ACPAgent\.acp_env"):
+                env = self._run_start_capturing_env(agent, tmp_path, state=conv.state)
+        finally:
+            conv.close()
         assert env.get("MY_TOKEN") == "acp-env-wins"
 
     def test_none_value_secret_not_injected(self, tmp_path):
@@ -6121,22 +6148,28 @@ class TestACPSecretRegistryEnvInjection:
     Secrets registered via ``Conversation.update_secrets()`` — or the
     equivalent ``payload.secrets`` channel that app-server callers
     (agent-canvas, the OpenHands cloud app server) use — must land in the
-    ACP subprocess env without each caller having to also build an
-    ``AgentContext(secrets=...)`` shim around the same data.
+    ACP subprocess env. ``agent_context.secrets`` are seeded into the same
+    registry at ``LocalConversation.__init__`` (below ``request.secrets``), so
+    the registry is the single channel ``_start_acp_server`` injects from.
 
-    Same-key precedence is
-    ``acp_env > secret_registry > agent_context.secrets > os.environ``.
-    Conversation secrets (registry + the agent_context drain) override ambient
-    ``os.environ`` so an explicit per-conversation/provider secret wins over a
-    same-named server env var; the registry wins over the drain on collision.
+    Same-key precedence is ``acp_env > secret_registry > os.environ``.
+    Registry secrets override ambient ``os.environ`` so an explicit
+    per-conversation/provider secret wins over a same-named server env var.
     """
 
     @staticmethod
     def _run_start_capturing_env(
-        agent, tmp_path, *, registry_secrets=None, extra_os_env=None
+        agent, tmp_path, *, registry_secrets=None, extra_os_env=None, state=None
     ) -> dict:
-        """Re-uses the env-capture harness from TestACPSecretsEnvInjection."""
-        state = _make_state(tmp_path)
+        """Re-uses the env-capture harness from TestACPSecretsEnvInjection.
+
+        Pass ``state`` to run against a conversation-seeded registry (e.g. one
+        built via ``LocalConversation`` so ``agent_context.secrets`` are lifted
+        in); otherwise a bare state is used and ``registry_secrets`` are applied
+        directly.
+        """
+        if state is None:
+            state = _make_state(tmp_path)
         if registry_secrets:
             state.secret_registry.update_secrets(registry_secrets)
 
@@ -6254,18 +6287,22 @@ class TestACPSecretRegistryEnvInjection:
         assert env.get("GITHUB_TOKEN") == "from-acp-env"
         assert secret.calls == []
 
-    def test_registry_secret_takes_precedence_over_agent_context_secret(self, tmp_path):
-        """``secret_registry`` wins over ``agent_context.secrets`` on collision.
+    def test_request_secret_wins_and_context_only_secret_still_reaches_env(
+        self, tmp_path
+    ):
+        """request.secrets win on collision; a context-only key still reaches env.
 
-        Precedence: ``acp_env > secret_registry > agent_context.secrets >
-        os.environ``. The registry is the canonical conversation-secret channel
-        (``StartConversationRequest.secrets`` lands here). On a key collision the
-        registry value is used (the drain skips keys the registry will set); a
-        context-only key is still injected by the drain — proving the two
-        channels coexist without double-injecting.
+        Both channels flow through ``state.secret_registry``: ``LocalConversation``
+        seeds ``agent_context.secrets`` first, then ``request.secrets`` overwrite
+        colliding keys. A key present only in ``agent_context.secrets`` still
+        lands in the registry — and therefore the subprocess env — proving the
+        two channels coexist without one dropping the other.
         """
         from pydantic import SecretStr
 
+        from openhands.sdk.conversation.impl.local_conversation import (
+            LocalConversation,
+        )
         from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
@@ -6276,12 +6313,16 @@ class TestACPSecretRegistryEnvInjection:
                 }
             )
         )
-        env = self._run_start_capturing_env(
+        conv = LocalConversation(
             agent,
-            tmp_path,
-            registry_secrets={"GITHUB_TOKEN": "from-registry"},
+            workspace=str(tmp_path),
+            secrets={"GITHUB_TOKEN": StaticSecret(value=SecretStr("from-request"))},
         )
-        assert env.get("GITHUB_TOKEN") == "from-registry"
+        try:
+            env = self._run_start_capturing_env(agent, tmp_path, state=conv.state)
+        finally:
+            conv.close()
+        assert env.get("GITHUB_TOKEN") == "from-request"
         assert env.get("CONTEXT_ONLY") == "ctx-value"
 
     def test_empty_registry_does_not_change_behaviour(self, tmp_path):
@@ -6324,9 +6365,17 @@ class TestACPSecretRegistryEnvInjection:
         assert env.get("ANTHROPIC_API_KEY") == "from-registry"
 
     def test_agent_context_secret_overrides_ambient_os_environ(self, tmp_path):
-        """An agent_context.secrets drain value overrides ambient os.environ."""
+        """An agent_context secret (seeded into the registry) beats ambient os.environ.
+
+        ``LocalConversation`` lifts ``agent_context.secrets`` into the registry,
+        and registry secrets override the agent-server's own ``os.environ`` so a
+        per-conversation/provider secret wins over a same-named server env var.
+        """
         from pydantic import SecretStr
 
+        from openhands.sdk.conversation.impl.local_conversation import (
+            LocalConversation,
+        )
         from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
@@ -6334,11 +6383,16 @@ class TestACPSecretRegistryEnvInjection:
                 secrets={"GITHUB_TOKEN": StaticSecret(value=SecretStr("from-context"))}
             )
         )
-        env = self._run_start_capturing_env(
-            agent,
-            tmp_path,
-            extra_os_env={"GITHUB_TOKEN": "ambient-should-lose"},
-        )
+        conv = LocalConversation(agent, workspace=str(tmp_path))
+        try:
+            env = self._run_start_capturing_env(
+                agent,
+                tmp_path,
+                extra_os_env={"GITHUB_TOKEN": "ambient-should-lose"},
+                state=conv.state,
+            )
+        finally:
+            conv.close()
         assert env.get("GITHUB_TOKEN") == "from-context"
 
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -7160,9 +7160,12 @@ class TestACPFileSecretMaterialisation:
         # preserved 0644 file staying world-readable).
         assert refreshed.stat().st_mode & 0o777 == 0o600
 
-    def test_reads_from_agent_context_secrets_drain(self, tmp_path):
-        """The reserved secret can arrive via agent_context.secrets (canvas-local
-        path) rather than the registry."""
+    def test_reads_reserved_secret_seeded_from_agent_context(self, tmp_path):
+        """A reserved file secret supplied via agent_context.secrets (canvas-local
+        path) is seeded into the registry at conversation init and materialised."""
+        from openhands.sdk.conversation.impl.local_conversation import (
+            LocalConversation,
+        )
         from openhands.sdk.secret import StaticSecret
 
         agent = _make_agent(
@@ -7171,8 +7174,15 @@ class TestACPFileSecretMaterialisation:
                 secrets={"CODEX_AUTH_JSON": StaticSecret(value=SecretStr('{"a": 1}'))},
             ),
         )
-        state = self._state(tmp_path)
-        env = self._run_start(agent, state, conn=self._make_conn())
+        conv = LocalConversation(
+            agent,
+            workspace=str(tmp_path / "ws"),
+            persistence_dir=str(tmp_path / "conversations"),
+        )
+        try:
+            env = self._run_start(agent, conv.state, conn=self._make_conn())
+        finally:
+            conv.close()
 
         auth_file = Path(env["CODEX_HOME"]) / "auth.json"
         assert auth_file.read_text(encoding="utf-8") == '{"a": 1}'

--- a/tests/sdk/conversation/local/test_state_serialization.py
+++ b/tests/sdk/conversation/local/test_state_serialization.py
@@ -1012,6 +1012,66 @@ def test_conversation_state_secrets_with_cipher():
         assert db_env_vars == {"DATABASE_URL": "postgresql://localhost/test"}
 
 
+def test_agent_context_seed_preserves_persisted_registry_secret_on_resume():
+    """LocalConversation resume must not downgrade existing registry secrets.
+
+    ``agent_context.secrets`` is a lower-priority bootstrap source for callers
+    that do not build ``request.secrets``. If a prior request secret is already
+    persisted in the registry, reopening the conversation with no new request
+    secrets should keep the registry value.
+    """
+    from openhands.sdk.context.agent_context import AgentContext
+    from openhands.sdk.secret import StaticSecret
+    from openhands.sdk.utils.cipher import Cipher
+
+    with tempfile.TemporaryDirectory() as temp_dir:
+        llm = LLM(
+            model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm"
+        )
+        agent = Agent(
+            llm=llm,
+            tools=[],
+            agent_context=AgentContext(
+                secrets={
+                    "ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-ctx"))
+                }
+            ),
+        )
+        conv_id = uuid.UUID("12345678-1234-5678-9abc-1234567890ab")
+        cipher = Cipher(secret_key="test-secret-key")
+        conversation_kwargs = {
+            "workspace": str(Path(temp_dir) / "workspace"),
+            "persistence_dir": temp_dir,
+            "conversation_id": conv_id,
+            "cipher": cipher,
+        }
+
+        conv = LocalConversation(
+            agent,
+            **conversation_kwargs,
+            secrets={
+                "ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-from-request"))
+            },
+        )
+        try:
+            assert (
+                conv.state.secret_registry.get_secret_value("ANTHROPIC_API_KEY")
+                == "sk-from-request"
+            )
+            conv.state._save_base_state(conv.state._fs)
+        finally:
+            conv.close()
+
+        resumed = LocalConversation(agent, **conversation_kwargs)
+        try:
+            assert (
+                resumed.state.secret_registry.get_secret_value("ANTHROPIC_API_KEY")
+                == "sk-from-request"
+            )
+        finally:
+            resumed.close()
+
+
 def test_conversation_state_save_with_cipher_load_without():
     """Test loading state saved with cipher but without providing cipher.
 

--- a/tests/sdk/conversation/test_secrets_manager.py
+++ b/tests/sdk/conversation/test_secrets_manager.py
@@ -163,6 +163,58 @@ def test_get_secrets_as_env_vars_handles_callable_exceptions():
     assert env_vars == {"WORKING_SECRET": "working-value"}
 
 
+def test_get_all_secrets_as_env_vars_resolves_whole_registry():
+    """get_all_secrets_as_env_vars resolves every secret without a command scan."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets(
+        {
+            "API_KEY": "static-value",
+            "DYNAMIC_TOKEN": MyTokenSource(),
+        }
+    )
+
+    env_vars = secret_registry.get_all_secrets_as_env_vars()
+    assert env_vars == {
+        "API_KEY": "static-value",
+        "DYNAMIC_TOKEN": "dynamic-token-456",
+    }
+
+
+def test_get_all_secrets_as_env_vars_excludes_named_keys():
+    """The exclude set skips keys (e.g. ones a higher-precedence tier will set)."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets({"KEEP": "keep-value", "DROP": "drop-value"})
+
+    env_vars = secret_registry.get_all_secrets_as_env_vars(exclude={"DROP"})
+    assert env_vars == {"KEEP": "keep-value"}
+
+
+def test_get_all_secrets_as_env_vars_skips_failing_lookups():
+    """Failing lookups are swallowed, not raised; only resolvable keys returned."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets(
+        {
+            "FAILING_SECRET": MyFailingTokenSource(),
+            "WORKING_SECRET": MyWorkingTokenSource(),
+        }
+    )
+
+    env_vars = secret_registry.get_all_secrets_as_env_vars()
+    assert env_vars == {"WORKING_SECRET": "working-value"}
+
+
+def test_get_all_secrets_as_env_vars_tracks_values_for_masking():
+    """Resolved values feed _exported_values so output masking covers them."""
+    secret_registry = SecretRegistry()
+    secret_registry.update_secrets({"API_KEY": "super-secret"})
+
+    secret_registry.get_all_secrets_as_env_vars()
+    assert (
+        secret_registry.mask_secrets_in_output("leak: super-secret")
+        == "leak: <secret-hidden>"
+    )
+
+
 def test_get_secret_value_static():
     """Test get_secret_value with static string values."""
     secret_registry = SecretRegistry()


### PR DESCRIPTION
<!-- AI/LLM agents: do not edit the HUMAN section or the human-tested checkbox. -->

HUMAN:

seed agent_context.secrets into the registry for all agents; consolidate ACP onto it



- [x] A human has tested these changes.

AGENT:

Validated on the PR branch: `uv run pytest tests/sdk/conversation/test_secrets_manager.py tests/cross/test_agent_secrets_integration.py -q` → 36 passed. The all-hands QA bot independently reproduced the pre-fix behavior on `origin/main` (context-only `agent_context.secrets` absent from `state.secret_registry`) and confirmed it resolves on this branch, with request-secret precedence preserved and `agent_context=None` still initialising cleanly. The resume-regression follow-up (`8f923c95`) adds `test_agent_context_seed_preserves_persisted_registry_secret_on_resume`. Not exercised here: a live external ACP CLI turn (no provider creds in CI) — needs a human run.

---

## Why

ACP carried secrets through several parallel paths — `state.secret_registry`, an `agent_context.secrets`→env drain in `_start_acp_server()`, and per-call `agent_context`-vs-registry read fallbacks. The goal (agent-canvas#1039 tasks 1+2) is to make `state.secret_registry` the **single** store and resolution authority, matching the regular OpenHands agent.

**Accurate framing of the gap** (this supersedes an earlier draft of this description and the issue's 2026-06-05 "task 1 assessment" comment): on current `main`, both production consumers already deliver provider credentials to `state.secret_registry` via `request.secrets`, so the drain was already redundant for them:

- **agent-canvas** stores the ACP provider credential as a panel/custom secret keyed by `api_key_env_var` (`src/constants/acp-providers.ts`, `setup-acp-secrets-step.tsx`) and sends it in the top-level `payload.secrets` (`agent-server-adapter.ts`), which the agent-server seeds into the registry. Canvas ACP never sends `llm.api_key` (`ACP_SETTINGS_KEYS` excludes `llm`), so the server-side `create_agent()` fold is a no-op for it.
- **OpenHands** builds the agent then calls `conv_settings.create_request(...)` (`live_status_app_conversation_service.py`), which lifts `agent_context.secrets` → `request.secrets` → registry.

So this PR's value is **consolidation**, not closing an active production credential gap:

1. It makes the registry a guaranteed superset of `agent_context.secrets` on *every* construction path, so the drain and the dual-read fallbacks can be deleted — the actual single-channel win.
2. It is the **only layer that can capture the server-side `create_agent()` fold.** Canvas posts `agent_settings`, and `StartConversationRequest._populate_agent_from_settings` runs `create_agent()` *on the server* (`conversation/request.py`). That fold happens after the client built its request, so no client-side lift (the alternative the issue's task-1 comment proposed) can see it — only a server-side seed can. Because the agent-server always materialises a Python `LocalConversation` (`event_service.py`) regardless of client language, seeding there covers every client at one point.
3. It makes `agent_context.secrets` "just work" for direct-SDK callers that build a bare `LocalConversation` without `request.secrets` (previously they reached the subprocess only via the drain — see the rewired tests).

## Impact

- **ACP agents:** consolidation onto the registry. Drops the `agent_context.secrets`→env drain in `_start_acp_server()` and the per-call `agent_context`-vs-registry read fallbacks; `_materialise_file_secrets`, the `<CUSTOM_SECRETS>` advertisement, and the subprocess env now resolve from `state.secret_registry` alone (new `get_all_secrets_as_env_vars`). The server-side seed is also the only layer that captures the `create_agent()` credential fold (which no client-side lift can see), and output masking improves because creds route through the registry's `get_secret_value` instead of the old drain's `secret.get_value()` (which bypassed `_exported_values`).
- **Regular OpenHands agent:** no change to the production / agent-server flow — `create_request()` already lifts `agent_context.secrets` → `request.secrets` → registry, so the new fill-if-absent seed is idempotent there. The only new behavior is for direct-SDK callers that build a bare `LocalConversation(agent=…)` without `request.secrets`: their `agent_context.secrets` now reach the registry (so secret resolution + output masking work), a latent-consistency fix covered by `tests/cross/test_agent_secrets_integration.py`.

## Summary

- Seed `agent.agent_context.secrets` into `state.secret_registry` in `LocalConversation.__init__`, below `request.secrets` (request wins on collision), **fill-if-absent** so a persisted/request value is never downgraded on resume. Applies to **all** agents (regular and ACP), not just ACP.
- Drop the `agent_context.secrets`→env drain from `_start_acp_server()`; delete `_read_conversation_secret`; make `_materialise_file_secrets` / `_present_file_secret_names` / the `<CUSTOM_SECRETS>` advertisement read the registry alone.
- Add `SecretRegistry.get_all_secrets_as_env_vars(exclude=…)` — the eager whole-registry sibling of the regular agent's command-scoped resolver — and resolve the ACP subprocess env through it.

## Issue Number

agent-canvas#1039 (tasks 1 + 2).

## How to Test

```
cd openhands-sdk
uv run pytest tests/cross/test_agent_secrets_integration.py -v
uv run pytest tests/sdk/agent/test_acp_agent.py -q
uv run pytest tests/sdk/conversation/test_secrets_manager.py -q
uv run pytest tests/sdk/conversation/local/test_state_serialization.py -q
```

## Type

- [x] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Scope is cross-cutting, not ACP-only.** The seed runs for every agent. Previously `agent_context.secrets` reached the registry only via `create_request()`; now any direct `LocalConversation(agent=…)` seeds them too. This is a latent-bug fix (consistency), covered by the new `tests/cross` cases (regular `Agent`). The resume follow-up makes the seed fill-if-absent so reopening a conversation never clobbers persisted registry values.
- **Masking improvement.** The removed drain injected `agent_context` values via `secret.get_value()` straight into the env, bypassing `_exported_values`, so those values weren't masked. Routing through the registry's `get_secret_value` now self-registers them for output masking.
- **Idempotent double-lift.** On the Python path, `create_request()` still lifts `agent_context.secrets` → `request.secrets` *and* the new seed lifts them → registry. Idempotent; retiring the `create_request` lift in favour of the single seed is a possible future cleanup (left in place because `request.secrets` is the wire channel that round-trips through the cipher/expose boundary).
- **Least-privilege deferred (task 6).** `get_all_secrets_as_env_vars` injects the *whole* registry into the opaque subprocess — unchanged from the previous drain+loop, but now a named API. Scoping injection to provider creds + an explicit allowlist is deferred to #1039 task 6.
- **Explicitly NOT in this PR (deferred #1039 tasks):** `acp_env` stays functional (highest-precedence, `DeprecationWarning`) until its 1.29.0 removal (task 3); the client-side change to send creds directly in `request.secrets` and drop the `create_agent` fold (task 8); `os.environ` allowlist + provider bridge (task 4); mandatory `OH_SECRET_KEY` (task 5).



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:da40f0a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-da40f0a-python \
  ghcr.io/openhands/agent-server:da40f0a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:da40f0a-golang-amd64
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-golang-amd64
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-golang-amd64
ghcr.io/openhands/agent-server:da40f0a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:da40f0a-golang-arm64
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-golang-arm64
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-golang-arm64
ghcr.io/openhands/agent-server:da40f0a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:da40f0a-java-amd64
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-java-amd64
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-java-amd64
ghcr.io/openhands/agent-server:da40f0a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:da40f0a-java-arm64
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-java-arm64
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-java-arm64
ghcr.io/openhands/agent-server:da40f0a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:da40f0a-python-amd64
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-python-amd64
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-python-amd64
ghcr.io/openhands/agent-server:da40f0a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:da40f0a-python-arm64
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-python-arm64
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-python-arm64
ghcr.io/openhands/agent-server:da40f0a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:da40f0a-golang
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-golang
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-golang
ghcr.io/openhands/agent-server:da40f0a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:da40f0a-java
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-java
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-java
ghcr.io/openhands/agent-server:da40f0a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:da40f0a-python
ghcr.io/openhands/agent-server:da40f0aaf9cd078c22ad165e27caf8aacdc102a1-python
ghcr.io/openhands/agent-server:lift-acp-secrets-to-registry-python
ghcr.io/openhands/agent-server:da40f0a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `da40f0a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `da40f0a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->


