### PR TITLE
Fix release regressions

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -93,6 +93,11 @@ def _is_acp_prompt_message(event: Event) -> TypeGuard[MessageEvent]:
     )
 
 
+def _copy_event_for_fork(event: Event) -> Event:
+    # Mirrors persisted event loading and skips runtime-only fields like executors.
+    return Event.model_validate_json(event.model_dump_json(exclude_none=True))
+
+
 class LocalConversation(BaseConversation):
     agent: AgentBase
     workspace: LocalWorkspace
@@ -431,10 +436,8 @@ class LocalConversation(BaseConversation):
                 tags=tags,
             )
 
-            # Deep-copy events from source → fork so the source stays
-            # immutable.
             for event in self._state.events:
-                fork_conv._state.events.append(event.model_copy(deep=True))
+                fork_conv._state.events.append(_copy_event_for_fork(event))
             # Full rebuild: the copied events may need property enforcement
             # (same posture as cold load).
             fork_conv._state.rebuild_view()

--- a/openhands-tools/openhands/tools/browser_use/logging_fix.py
+++ b/openhands-tools/openhands/tools/browser_use/logging_fix.py
@@ -15,7 +15,7 @@ from openhands.sdk.utils.deprecation import warn_cleanup
 
 warn_cleanup(
     "Monkey patching to prevent browser_use logging interference",
-    cleanup_by="1.26.0",
+    cleanup_by="1.27.0",
     details=(
         "This workaround should be removed once browser_use fixes the "
         "problematic logging configuration code. The upstream PR #3717 "

--- a/openhands-tools/openhands/tools/browser_use/logging_fix.py
+++ b/openhands-tools/openhands/tools/browser_use/logging_fix.py
@@ -15,7 +15,7 @@ from openhands.sdk.utils.deprecation import warn_cleanup
 
 warn_cleanup(
     "Monkey patching to prevent browser_use logging interference",
-    cleanup_by="1.27.0",
+    cleanup_by="1.31.0",
     details=(
         "This workaround should be removed once browser_use fixes the "
         "problematic logging configuration code. The upstream PR #3717 "

--- a/tests/sdk/conversation/local/test_fork.py
+++ b/tests/sdk/conversation/local/test_fork.py
@@ -1,17 +1,21 @@
 """Tests for Conversation.fork() primitive."""
 
 import tempfile
+import threading
 import uuid
+from collections.abc import Sequence
 from pathlib import Path
+from typing import Self
 
 import pytest
 from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
-from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation import Conversation, LocalConversation
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.event.llm_convertible import MessageEvent, SystemPromptEvent
 from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.tool import Action, Observation, ToolDefinition, ToolExecutor
 
 
 def _agent() -> Agent:
@@ -27,6 +31,43 @@ def _msg(event_id: str, text: str = "hi") -> MessageEvent:
         llm_message=Message(role="user", content=[TextContent(text=text)]),
         source="user",
     )
+
+
+class ForkCopyMockAction(Action):
+    command: str = "test"
+
+
+class ForkCopyMockObservation(Observation):
+    pass
+
+
+class ForkCopyNonPicklableExecutor(
+    ToolExecutor[ForkCopyMockAction, ForkCopyMockObservation]
+):
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+
+    def __call__(
+        self,
+        action: ForkCopyMockAction,
+        conversation: LocalConversation | None = None,
+    ) -> ForkCopyMockObservation:
+        return ForkCopyMockObservation.from_text(action.command)
+
+
+class ForkCopyNonPicklableTool(
+    ToolDefinition[ForkCopyMockAction, ForkCopyMockObservation]
+):
+    @classmethod
+    def create(cls, *args, **kwargs) -> Sequence[Self]:
+        return [
+            cls(
+                description="test tool with a non-picklable executor",
+                action_type=ForkCopyMockAction,
+                observation_type=ForkCopyMockObservation,
+                executor=ForkCopyNonPicklableExecutor(),
+            )
+        ]
 
 
 def test_fork_creates_new_id():
@@ -62,6 +103,29 @@ def test_fork_copies_events():
         fork_ids = [e.id for e in fork.state.events]
         assert "evt-1" in fork_ids
         assert "evt-2" in fork_ids
+
+
+def test_fork_copies_system_prompt_event_with_non_picklable_executor():
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src = Conversation(agent=_agent(), persistence_dir=tmpdir, workspace=tmpdir)
+        source_tool = ForkCopyNonPicklableTool.create()[0]
+        src.state.events.append(
+            SystemPromptEvent(
+                system_prompt=TextContent(text="test system prompt"),
+                tools=[source_tool],
+            )
+        )
+
+        fork = src.fork()
+
+        source_event = src.state.events[0]
+        fork_event = fork.state.events[0]
+        assert isinstance(source_event, SystemPromptEvent)
+        assert isinstance(fork_event, SystemPromptEvent)
+        assert fork_event is not source_event
+        assert source_event.tools[0].executor is not None
+        assert fork_event.tools[0].executor is None
+        assert fork_event.tools[0].action_type is ForkCopyMockAction
 
 
 def test_fork_source_unmodified():


### PR DESCRIPTION
HUMAN:
This PR fixes the issues that failed CI and test-examples on the release 1.26.0 PR.

- [x] A human has tested these changes.


AGENT:

## Summary
- Copy forked conversation events through the persisted event JSON shape so runtime-only tool executor state is not deep-copied.
- Extend the browser_use logging workaround cleanup deadline to 1.31.0 because the pinned browser_use version still needs the workaround.

## Why
This PR fixes two release-blocking regressions from the [v1.26.0 release PR](https://github.com/OpenHands/software-agent-sdk/pull/3531):

1. `Conversation.fork()` / `RemoteConversation.fork()` can fail when copied events include runtime-only tool executor state. The active regression originated in [PR #3263](https://github.com/OpenHands/software-agent-sdk/pull/3263) (`50bfa3ede2a759d54a1d051083104ca8b76d2e70`), which added in-memory `EventLog` caching. Before #3263, appended events were effectively reloaded through the persisted JSON shape, stripping runtime-only executor state. After #3263, fork copied runtime-rich cached events, so tools with non-picklable executor internals such as terminal/tmux locks could raise `TypeError: cannot pickle _thread.lock object`.
2. The browser_use logging workaround cleanup deadline was reached at 1.26.0. Because browser_use 0.11.9 still calls `_ensure_all_loggers_use_stderr()` during import/initialization, this PR keeps the workaround and extends the cleanup deadline by five minor releases to 1.31.0.

## How to Test
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-tools/openhands/tools/browser_use/logging_fix.py tests/sdk/conversation/local/test_fork.py`
- `uv run pytest tests/sdk/conversation/local/test_fork.py -q`
- `uv run --with packaging python .github/scripts/check_deprecations.py`
- `OPENHANDS_SUPPRESS_BANNER=1 LLM_API_KEY=... LLM_BASE_URL=https://llm-proxy.app.all-hands.dev LLM_MODEL=openhands/claude-haiku-4-5-20251001 uv run python examples/01_standalone_sdk/48_conversation_fork.py`
- `env -u SESSION_API_KEY TMUX_TMPDIR=$(mktemp -d /tmp/oh-remote-example.XXXXXX) OPENHANDS_SUPPRESS_BANNER=1 LLM_API_KEY=... LLM_BASE_URL=https://llm-proxy.app.all-hands.dev LLM_MODEL=openhands/claude-haiku-4-5-20251001 uv run python examples/02_remote_agent_server/11_conversation_fork.py`

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/1838c8ff-2168-4940-b2e4-ffb072d65f29)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b5a6847-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b5a6847-python \
  ghcr.io/openhands/agent-server:b5a6847-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b5a6847-golang-amd64
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-golang-amd64
ghcr.io/openhands/agent-server:fix-fork-release-regressions-golang-amd64
ghcr.io/openhands/agent-server:b5a6847-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b5a6847-golang-arm64
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-golang-arm64
ghcr.io/openhands/agent-server:fix-fork-release-regressions-golang-arm64
ghcr.io/openhands/agent-server:b5a6847-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b5a6847-java-amd64
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-java-amd64
ghcr.io/openhands/agent-server:fix-fork-release-regressions-java-amd64
ghcr.io/openhands/agent-server:b5a6847-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b5a6847-java-arm64
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-java-arm64
ghcr.io/openhands/agent-server:fix-fork-release-regressions-java-arm64
ghcr.io/openhands/agent-server:b5a6847-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b5a6847-python-amd64
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-python-amd64
ghcr.io/openhands/agent-server:fix-fork-release-regressions-python-amd64
ghcr.io/openhands/agent-server:b5a6847-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b5a6847-python-arm64
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-python-arm64
ghcr.io/openhands/agent-server:fix-fork-release-regressions-python-arm64
ghcr.io/openhands/agent-server:b5a6847-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b5a6847-golang
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-golang
ghcr.io/openhands/agent-server:fix-fork-release-regressions-golang
ghcr.io/openhands/agent-server:b5a6847-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b5a6847-java
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-java
ghcr.io/openhands/agent-server:fix-fork-release-regressions-java
ghcr.io/openhands/agent-server:b5a6847-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b5a6847-python
ghcr.io/openhands/agent-server:b5a684705e08ad1203543add1e19fb49bb39a90f-python
ghcr.io/openhands/agent-server:fix-fork-release-regressions-python
ghcr.io/openhands/agent-server:b5a6847-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b5a6847-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b5a6847-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->




