### PR TITLE
feat(settings): add `app_preferences` block to persisted settings

### DIFF
--- a/openhands-agent-server/openhands/agent_server/persistence/models.py
+++ b/openhands-agent-server/openhands/agent_server/persistence/models.py
@@ -24,6 +24,7 @@ from pydantic import (
 
 from openhands.sdk.settings import (
     AgentSettingsConfig,
+    AppPreferences,
     ConversationSettings,
     default_agent_settings,
     validate_agent_settings,
@@ -40,10 +41,17 @@ class SettingsUpdatePayload(TypedDict, total=False):
     ``{"acp_env": {"NAME": None}}`` to drop one env-var without re-sending the
     whole map. A ``None`` on a top-level *field* is not treated as delete; it
     flows to validation as before.
+
+    ``app_preferences_diff`` is a shallow overlay — fields present in the diff
+    overwrite the persisted values, fields absent are left alone. There is no
+    deep-merge or "unset" semantic because :class:`AppPreferences` has no
+    nested maps; ``disabled_skills`` is a list and callers expect a list write
+    to replace, not merge.
     """
 
     agent_settings_diff: dict[str, Any]
     conversation_settings_diff: dict[str, Any]
+    app_preferences_diff: dict[str, Any]
     active_profile: str | None
 
 
@@ -97,7 +105,7 @@ def _deep_merge(
     return result
 
 
-PERSISTED_SETTINGS_SCHEMA_VERSION = 1
+PERSISTED_SETTINGS_SCHEMA_VERSION = 2
 
 
 class PersistedSettings(BaseModel):
@@ -109,6 +117,11 @@ class PersistedSettings(BaseModel):
 
     The ``active_profile`` field tracks which LLM profile was last activated,
     allowing frontends to display which profile is currently in use.
+
+    The ``app_preferences`` field stores frontend app-level preferences
+    (language, sound notifications, analytics consent, git identity,
+    disabled skills) that don't affect agent execution. See
+    :class:`openhands.sdk.settings.AppPreferences`.
     """
 
     schema_version: int = Field(
@@ -123,6 +136,14 @@ class PersistedSettings(BaseModel):
     active_profile: str | None = Field(
         default=None,
         description="Name of the currently active LLM profile.",
+    )
+    app_preferences: AppPreferences = Field(
+        default_factory=AppPreferences,
+        description=(
+            "Frontend app-level user preferences (language, sound notifications, "
+            "analytics opt-in, git identity, disabled skills). Persisted but not "
+            "interpreted by the agent-server."
+        ),
     )
 
     model_config = ConfigDict(populate_by_name=True)
@@ -232,11 +253,28 @@ class PersistedSettings(BaseModel):
                         f"Failed to update conversation settings: {type(e).__name__}"
                     ) from None
 
+            # Validate app_preferences before mutating anything else
+            prefs_update = payload.get("app_preferences_diff")
+            new_prefs: AppPreferences | None = None
+            if isinstance(prefs_update, dict):
+                merged_prefs = {
+                    **self.app_preferences.model_dump(mode="json"),
+                    **prefs_update,
+                }
+                try:
+                    new_prefs = AppPreferences.model_validate(merged_prefs)
+                except Exception as e:
+                    raise ValueError(
+                        f"Failed to update app preferences: {type(e).__name__}"
+                    ) from None
+
             # Phase 2: Apply validated changes atomically
             if new_agent is not None:
                 self.agent_settings = new_agent
             if new_conv is not None:
                 self.conversation_settings = new_conv
+            if new_prefs is not None:
+                self.app_preferences = new_prefs
 
             # Update active_profile if explicitly provided (including None to clear)
             if "active_profile" in payload:

--- a/openhands-agent-server/openhands/agent_server/settings_router.py
+++ b/openhands-agent-server/openhands/agent_server/settings_router.py
@@ -160,6 +160,7 @@ async def get_settings(request: Request) -> SettingsResponse:
                 mode="json"
             ),
             llm_api_key_is_set=settings.llm_api_key_is_set,
+            app_preferences=settings.app_preferences,
         )
 
 
@@ -169,11 +170,12 @@ async def update_settings(
 ) -> SettingsResponse:
     """Update settings with partial changes.
 
-    Accepts ``agent_settings_diff`` and/or ``conversation_settings_diff``
-    for incremental updates. Diffs are deep-merged; nested objects merge
-    recursively, and a ``null`` value **inside a nested map deletes that
-    entry** — the "unset" primitive that lets a client remove a single map
-    key without round-tripping the whole map. To drop one ACP env-var::
+    Accepts ``agent_settings_diff``, ``conversation_settings_diff``, and/or
+    ``app_preferences_diff`` for incremental updates. The two ``*_settings_diff``
+    fields are deep-merged; nested objects merge recursively, and a ``null``
+    value **inside a nested map deletes that entry** — the "unset" primitive
+    that lets a client remove a single map key without round-tripping the
+    whole map. To drop one ACP env-var::
 
         PATCH /api/settings
         {"agent_settings_diff": {"acp_env": {"STALE_KEY": null}}}
@@ -186,6 +188,11 @@ async def update_settings(
     A ``null`` on a top-level *field* (e.g. ``{"confirmation_mode": null}``)
     is **not** an unset — it flows to model validation as before, so it still
     fails loudly rather than silently resetting the field to its default.
+
+    ``app_preferences_diff`` is a shallow overlay (no deep merge, no unset
+    semantics): each provided field overwrites the persisted value, and
+    omitted fields are left alone. ``disabled_skills`` lists are replaced
+    wholesale rather than merged.
 
     Uses file locking to prevent concurrent updates from overwriting each other.
 
@@ -201,8 +208,9 @@ async def update_settings(
         raise HTTPException(
             status_code=400,
             detail=(
-                "At least one of agent_settings_diff or "
-                "conversation_settings_diff must be provided"
+                "At least one of agent_settings_diff, "
+                "conversation_settings_diff, or app_preferences_diff "
+                "must be provided"
             ),
         )
 
@@ -223,6 +231,7 @@ async def update_settings(
                 "conversation_settings_modified": (
                     "conversation_settings_diff" in update_data
                 ),
+                "app_preferences_modified": "app_preferences_diff" in update_data,
             },
         )
     except (ValueError, ValidationError):
@@ -256,6 +265,7 @@ async def update_settings(
         agent_settings=settings.agent_settings.model_dump(mode="json"),
         conversation_settings=settings.conversation_settings.model_dump(mode="json"),
         llm_api_key_is_set=settings.llm_api_key_is_set,
+        app_preferences=settings.app_preferences,
     )
 
 

--- a/openhands-sdk/openhands/sdk/settings/__init__.py
+++ b/openhands-sdk/openhands/sdk/settings/__init__.py
@@ -13,6 +13,7 @@ from .acp_providers import (
     get_acp_provider,
 )
 from .api_models import (
+    AppPreferences,
     SecretCreateRequest,
     SecretItemResponse,
     SecretsListResponse,
@@ -81,6 +82,7 @@ __all__ = [
     "ACPFileSecretSpec",
     "ACPModelOption",
     "ACPProviderInfo",
+    "AppPreferences",
     "build_session_model_meta",
     "default_acp_file_secrets",
     "AGENT_SETTINGS_SCHEMA_VERSION",

--- a/openhands-sdk/openhands/sdk/settings/api_models.py
+++ b/openhands-sdk/openhands/sdk/settings/api_models.py
@@ -28,11 +28,47 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
-from pydantic import BaseModel, SecretStr
+from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 
 if TYPE_CHECKING:
     from .model import AgentSettingsConfig, ConversationSettings
+
+
+# ── App Preferences ───────────────────────────────────────────────────────
+
+
+class AppPreferences(BaseModel):
+    """Frontend app-level user preferences that don't affect agent execution.
+
+    These fields are app/UI-level metadata (preferred language, sound
+    notifications, analytics opt-in, git identity used for in-conversation
+    commits) plus the list of skills the user has disabled. The agent-server
+    persists them alongside agent/conversation settings but does not interpret
+    them — the cloud equivalent (``POST /api/v1/settings``) accepts the same
+    keys at the top level, so frontends can use a single shape for both
+    backends.
+
+    Field semantics:
+
+    - ``language``, ``git_user_name``, ``git_user_email``: ``None`` means "no
+      preference set" (the frontend can fall back to its own default).
+    - ``user_consents_to_analytics``: tri-state — ``None`` means "not yet
+      asked", ``True``/``False`` are explicit answers.
+    - ``enable_sound_notifications``: ``None`` means "use frontend default";
+      ``True``/``False`` are explicit user choices.
+    - ``disabled_skills``: list of skill identifiers the user has disabled.
+      Defaults to an empty list (no skills disabled).
+    """
+
+    language: str | None = None
+    user_consents_to_analytics: bool | None = None
+    enable_sound_notifications: bool | None = None
+    git_user_name: str | None = None
+    git_user_email: str | None = None
+    disabled_skills: list[str] = Field(default_factory=list)
+
+    model_config = ConfigDict(extra="ignore")
 
 
 # ── Settings API Models ───────────────────────────────────────────────────
@@ -42,7 +78,8 @@ class SettingsResponse(BaseModel):
     """Response model for GET /api/settings.
 
     Contains the full settings payload including agent configuration,
-    conversation settings, and a flag indicating if an LLM API key is set.
+    conversation settings, app-level user preferences, and a flag indicating
+    if an LLM API key is set.
 
     The ``agent_settings`` and ``conversation_settings`` fields are raw dicts
     because the server controls secret serialization via context. Use the
@@ -53,11 +90,13 @@ class SettingsResponse(BaseModel):
         response = SettingsResponse.model_validate(api_response.json())
         agent = response.get_agent_settings()  # Returns AgentSettingsConfig
         conv = response.get_conversation_settings()  # Returns ConversationSettings
+        prefs = response.app_preferences  # Already typed
     """
 
     agent_settings: dict[str, Any]
     conversation_settings: dict[str, Any]
     llm_api_key_is_set: bool
+    app_preferences: AppPreferences = Field(default_factory=AppPreferences)
 
     def get_agent_settings(self) -> AgentSettingsConfig:
         """Parse and validate ``agent_settings`` into a typed model.
@@ -86,10 +125,18 @@ class SettingsUpdateRequest(BaseModel):
 
     Supports partial updates via diff objects that are deep-merged with
     existing settings.
+
+    ``app_preferences_diff`` accepts a partial :class:`AppPreferences` dict;
+    fields present in the diff are written through, fields omitted are left
+    untouched. The diff is *not* deep-merged because :class:`AppPreferences`
+    has no nested maps — every field is a scalar or a list, and a list
+    overwrite (rather than merge) is what callers expect for
+    ``disabled_skills``.
     """
 
     agent_settings_diff: dict[str, Any] | None = None
     conversation_settings_diff: dict[str, Any] | None = None
+    app_preferences_diff: dict[str, Any] | None = None
 
 
 # ── Secrets API Models ────────────────────────────────────────────────────

--- a/tests/agent_server/test_settings_router.py
+++ b/tests/agent_server/test_settings_router.py
@@ -540,6 +540,177 @@ def test_patch_settings_empty_payload_returns_400(client_with_settings):
     assert "At least one of" in response.json()["detail"]
 
 
+# ── app_preferences ─────────────────────────────────────────────────────
+
+
+def test_get_settings_returns_empty_app_preferences_by_default(client_with_settings):
+    """GET /api/settings returns an empty app_preferences block by default."""
+    response = client_with_settings.get("/api/settings")
+
+    assert response.status_code == 200
+    body = response.json()
+    assert "app_preferences" in body
+    assert body["app_preferences"] == {
+        "language": None,
+        "user_consents_to_analytics": None,
+        "enable_sound_notifications": None,
+        "git_user_name": None,
+        "git_user_email": None,
+        "disabled_skills": [],
+    }
+
+
+def test_patch_settings_writes_app_preferences(client_with_settings):
+    """PATCH /api/settings with app_preferences_diff persists the fields."""
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={
+            "app_preferences_diff": {
+                "language": "fr",
+                "user_consents_to_analytics": True,
+                "enable_sound_notifications": False,
+                "git_user_name": "Ada Lovelace",
+                "git_user_email": "ada@example.com",
+                "disabled_skills": ["openhands/snake", "openhands/python"],
+            }
+        },
+    )
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["app_preferences"] == {
+        "language": "fr",
+        "user_consents_to_analytics": True,
+        "enable_sound_notifications": False,
+        "git_user_name": "Ada Lovelace",
+        "git_user_email": "ada@example.com",
+        "disabled_skills": ["openhands/snake", "openhands/python"],
+    }
+
+    # Persisted across requests
+    refetch = client_with_settings.get("/api/settings")
+    assert refetch.status_code == 200
+    assert refetch.json()["app_preferences"]["language"] == "fr"
+
+
+def test_patch_settings_app_preferences_diff_is_shallow_overlay(
+    client_with_settings,
+):
+    """Partial app_preferences_diff overlays known fields, leaves others alone."""
+    client_with_settings.patch(
+        "/api/settings",
+        json={
+            "app_preferences_diff": {
+                "language": "fr",
+                "disabled_skills": ["openhands/snake"],
+            }
+        },
+    )
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"app_preferences_diff": {"git_user_name": "Ada"}},
+    )
+
+    assert response.status_code == 200
+    prefs = response.json()["app_preferences"]
+    assert prefs["language"] == "fr"
+    assert prefs["git_user_name"] == "Ada"
+    assert prefs["disabled_skills"] == ["openhands/snake"]
+
+
+def test_patch_settings_app_preferences_disabled_skills_replaces_list(
+    client_with_settings,
+):
+    """disabled_skills is replaced wholesale, not merged."""
+    client_with_settings.patch(
+        "/api/settings",
+        json={
+            "app_preferences_diff": {
+                "disabled_skills": ["openhands/snake", "openhands/python"]
+            }
+        },
+    )
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"app_preferences_diff": {"disabled_skills": []}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["app_preferences"]["disabled_skills"] == []
+
+
+def test_patch_settings_app_preferences_only_payload_is_accepted(
+    client_with_settings,
+):
+    """app_preferences_diff alone satisfies the "at least one of" check."""
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"app_preferences_diff": {"language": "fr"}},
+    )
+
+    assert response.status_code == 200
+
+
+def test_patch_settings_app_preferences_rejects_invalid_type(client_with_settings):
+    """An app_preferences_diff that fails validation returns 422."""
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"app_preferences_diff": {"disabled_skills": "not-a-list"}},
+    )
+
+    assert response.status_code == 422
+
+
+def test_patch_settings_app_preferences_does_not_clobber_agent_settings(
+    client_with_settings,
+):
+    """Writing only app_preferences must not reset agent_settings."""
+    client_with_settings.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"model": "gpt-4o"}}},
+    )
+
+    response = client_with_settings.patch(
+        "/api/settings",
+        json={"app_preferences_diff": {"language": "fr"}},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["agent_settings"]["llm"]["model"] == "gpt-4o"
+
+
+def test_persisted_settings_v1_loads_with_empty_app_preferences(
+    temp_persistence_dir, client_with_settings
+):
+    """A v1 settings file (no app_preferences) loads with the default empty block."""
+    # Write a v1 payload directly to disk
+    settings_path = temp_persistence_dir / "settings.json"
+    settings_path.write_text(
+        json.dumps(
+            {
+                "schema_version": 1,
+                "agent_settings": {
+                    "agent_kind": "openhands",
+                    "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
+                    "llm": {"model": "gpt-4o"},
+                },
+                "conversation_settings": {
+                    "schema_version": CONVERSATION_SETTINGS_SCHEMA_VERSION,
+                },
+                "active_profile": None,
+            }
+        )
+    )
+
+    response = client_with_settings.get("/api/settings")
+    assert response.status_code == 200
+    prefs = response.json()["app_preferences"]
+    assert prefs["language"] is None
+    assert prefs["disabled_skills"] == []
+
+
 def test_patch_settings_deep_merges(client_with_settings):
     """PATCH /api/settings deep-merges with existing settings."""
     # First update: set model


### PR DESCRIPTION
HUMAN:

This is a PR to add app preferences settings storage to agent-server so we don't need to store them in browser local storage in agent canvas.

- [x] A human has tested these changes.

AGENT:

Ran the full test suite for settings-related tests:
```
$ uv run pytest tests/agent_server/test_settings_router.py tests/agent_server/test_models.py tests/agent_server/test_api.py tests/agent_server/test_api_authentication.py tests/sdk/test_settings.py -q
... 257 passed
```

All 8 new tests for app_preferences functionality passed:
- test_get_settings_returns_empty_app_preferences_by_default
- test_patch_settings_writes_app_preferences
- test_patch_settings_app_preferences_diff_is_shallow_overlay
- test_patch_settings_app_preferences_disabled_skills_replaces_list
- test_patch_settings_app_preferences_only_payload_is_accepted
- test_patch_settings_app_preresses_rejects_invalid_type (422)
- test_patch_settings_app_preferences_does_not_clobber_agent_settings
- test_persisted_settings_v1_loads_with_empty_app_preferences

---

## Why

Today the local agent-server has no native home for these fields, so frontends like agent-canvas persist them in browser localStorage and reconcile manually with whatever the cloud backend returns.

## Summary

- Adds app_preferences block to PersistedSettings with fields: language, user_consents_to_analytics, enable_sound_notifications, git_user_name, git_user_email, disabled_skills
- Surfaces app_preferences on GET /api/settings and updates via PATCH /api/settings with new app_preferences_diff field
- Bumps PERSISTED_SETTINGS_SCHEMA_VERSION from 1 to 2 with backward-compatible migration
- Adds 8 new tests covering GET, PATCH, overlay semantics, validation, and v1 migration

## Issue Number

N/A (companion to agent-canvas cleanup PR)

## How to Test

1. Run the settings test suite to verify all tests pass:
   ```
   uv run pytest tests/agent_server/test_settings_router.py tests/agent_server/test_models.py tests/agent_server/test_api.py tests/agent_server/test_api_authentication.py tests/sdk/test_settings.py -q
   ```
2. Test the API manually with GET /api/settings (should return app_preferences) and PATCH /api/settings with app_preferences_diff
3. Verify v1 migration by checking that existing persisted settings files load correctly

## Video/Screenshots

N/A - backend-only changes

## Type

- [x] Feature

## Notes

- The app_preferences_diff is a shallow overlay - fields present overwrite persisted values, fields absent are left alone
- Companion PR in agent-canvas will delete app-preferences-store.ts and related helpers
