### PR TITLE
fix(agent-server): report OpenAI gateway token usage

### DIFF
--- a/openhands-agent-server/openhands/agent_server/openai_service.py
+++ b/openhands-agent-server/openhands/agent_server/openai_service.py
@@ -18,6 +18,7 @@ from openhands.agent_server.openai_models import (
     OpenAIModel,
     OpenAIModelListResponse,
     OpenAIResponseMessage,
+    OpenAIUsage,
 )
 from openhands.agent_server.persistence import PersistedSettings, get_settings_store
 from openhands.sdk import LLM, Message
@@ -26,7 +27,10 @@ from openhands.sdk.conversation.request import (
     SendMessageRequest,
     StartConversationRequest,
 )
-from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.conversation.state import (
+    ConversationExecutionStatus,
+    ConversationState,
+)
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.message import ImageContent, TextContent
 from openhands.sdk.logger import get_logger
@@ -271,6 +275,20 @@ async def _delete_conversation_safely(
         )
 
 
+def _openai_usage_from_state(state: ConversationState) -> OpenAIUsage:
+    token_usage = state.stats.get_combined_metrics().accumulated_token_usage
+    if token_usage is None:
+        return OpenAIUsage()
+
+    prompt_tokens = token_usage.prompt_tokens
+    completion_tokens = token_usage.completion_tokens
+    return OpenAIUsage(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        total_tokens=prompt_tokens + completion_tokens,
+    )
+
+
 async def list_openai_models() -> OpenAIModelListResponse:
     try:
         profiles = LLMProfileStore().list_summaries()
@@ -341,6 +359,7 @@ async def run_chat_completion(
             event_service, allow_existing_response=allow_existing_response
         )
         _raise_for_terminal_error(status_value)
+        state = await event_service.get_state()
         final_response = await event_service.get_agent_final_response()
         response = OpenAIChatCompletionResponse(
             id=f"chatcmpl-{uuid4().hex}",
@@ -352,6 +371,7 @@ async def run_chat_completion(
                     message=OpenAIResponseMessage(content=final_response),
                 )
             ],
+            usage=_openai_usage_from_state(state),
         )
         assert conversation_id is not None
         return OpenAIChatCompletionResult(

--- a/tests/cross/test_remote_conversation_live_server.py
+++ b/tests/cross/test_remote_conversation_live_server.py
@@ -191,7 +191,6 @@ def patched_llm(monkeypatch: pytest.MonkeyPatch) -> None:
     ):  # type: ignore[no-untyped-def]
         from openhands.sdk.llm.llm_response import LLMResponse
         from openhands.sdk.llm.message import Message
-        from openhands.sdk.llm.utils.metrics import MetricsSnapshot
 
         # Create a minimal ModelResponse with a single assistant message
         litellm_msg = LiteLLMMessage.model_validate(
@@ -210,17 +209,21 @@ def patched_llm(monkeypatch: pytest.MonkeyPatch) -> None:
         # Convert to OpenHands Message
         message = Message.from_llm_chat_message(litellm_msg)
 
-        # Create metrics snapshot
-        metrics_snapshot = MetricsSnapshot(
-            model_name="test-model",
-            accumulated_cost=0.0,
-            max_budget_per_task=None,
-            accumulated_token_usage=None,
+        self.metrics.add_token_usage(
+            prompt_tokens=7,
+            completion_tokens=5,
+            cache_read_tokens=0,
+            cache_write_tokens=0,
+            context_window=8192,
+            response_id="test-resp",
+            reasoning_tokens=0,
         )
 
         # Return LLMResponse as expected by the agent
         return LLMResponse(
-            message=message, metrics=metrics_snapshot, raw_response=raw_response
+            message=message,
+            metrics=self.metrics.get_snapshot(),
+            raw_response=raw_response,
         )
 
     monkeypatch.setattr(LLM, "completion", fake_completion, raising=True)
@@ -638,6 +641,11 @@ def test_openai_chat_completions_gateway_over_real_server(
                 assert body["choices"][0]["message"] == {
                     "role": "assistant",
                     "content": "Hello from patched LLM",
+                }
+                assert body["usage"] == {
+                    "prompt_tokens": 7,
+                    "completion_tokens": 5,
+                    "total_tokens": 12,
                 }
                 conversation_id = response.headers["X-OpenHands-ServerConversation-ID"]
                 UUID(conversation_id)


### PR DESCRIPTION
This PR was created by an AI agent (OpenHands) on behalf of the user.

## Summary
- Populates the OpenAI chat completion `usage` field from `state.stats.get_combined_metrics().accumulated_token_usage`.
- Adds deterministic token metrics to the live gateway test and asserts `prompt_tokens`, `completion_tokens`, and `total_tokens`.

## Validation
- `TMUX_TMPDIR=/tmp/oh-test-tmux-precommit-$RANDOM uv run pre-commit run --files openhands-agent-server/openhands/agent_server/openai_service.py tests/cross/test_remote_conversation_live_server.py`
- `TMUX_TMPDIR=/tmp/oh-test-tmux-$RANDOM uv run pytest tests/cross/test_remote_conversation_live_server.py::test_openai_chat_completions_gateway_over_real_server -q`
- `TMUX_TMPDIR=/tmp/oh-test-tmux-$RANDOM uv run pytest tests/agent_server/test_api_authentication.py::test_openai_routes_accept_bearer_session_key -q`
- `TMUX_TMPDIR=/tmp/oh-test-tmux-$RANDOM uv run pytest tests/cross/test_remote_conversation_live_server.py::test_remote_conversation_over_real_server tests/cross/test_remote_conversation_live_server.py::test_openai_chat_completions_gateway_over_real_server tests/cross/test_remote_conversation_live_server.py::test_subagent_definitions_forwarded_to_server -q`

Intended to be merged into PR #3545's branch.

@smolpaws can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a82aaceb-a04b-4a67-9244-fdaad1812034)