### PR TITLE
test(agent-server): add cross lease coverage

### DIFF
--- a/tests/cross/test_conversation_lease_behavior.py
+++ b/tests/cross/test_conversation_lease_behavior.py
@@ -1,0 +1,153 @@
+"""Integration-like tests for conversation lease ownership."""
+
+import json
+from pathlib import Path
+
+import pytest
+from litellm.types.utils import ChatCompletionMessageToolCall, Function
+
+from openhands.agent_server.conversation_lease import (
+    LEASE_FILE_NAME,
+    ConversationOwnershipLostError,
+)
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.models import StartConversationRequest
+from openhands.sdk import LLM, Agent
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.event import ActionEvent, AgentErrorEvent, Event, ObservationEvent
+from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.workspace import LocalWorkspace
+from openhands.tools.terminal.definition import TerminalAction, TerminalObservation
+
+
+def _request(workspace_dir: Path) -> StartConversationRequest:
+    return StartConversationRequest(
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(workspace_dir)),
+        confirmation_policy=NeverConfirm(),
+    )
+
+
+def _create_running_terminal_action(tool_call_id: str = "call_1") -> ActionEvent:
+    tool_call = MessageToolCall.from_chat_tool_call(
+        ChatCompletionMessageToolCall(
+            id=tool_call_id,
+            type="function",
+            function=Function(
+                name="terminal",
+                arguments='{"command": "sleep 30"}',
+            ),
+        )
+    )
+    return ActionEvent(
+        thought=[TextContent(text="run sleep")],
+        action=TerminalAction(command="sleep 30"),
+        tool_name="terminal",
+        tool_call_id=tool_call_id,
+        tool_call=tool_call,
+        llm_response_id="response_1",
+        security_risk=SecurityRisk.LOW,
+        summary="run sleep",
+    )
+
+
+def _terminal_observation(action: ActionEvent, text: str = "done") -> ObservationEvent:
+    return ObservationEvent(
+        observation=TerminalObservation.from_text(
+            text,
+            command="sleep 30",
+            exit_code=0,
+        ),
+        action_id=action.id,
+        tool_name="terminal",
+        tool_call_id=action.tool_call_id,
+    )
+
+
+def _load_disk_events(conversation_dir: Path) -> list[Event]:
+    event_files = sorted(
+        (conversation_dir / "events").glob("event-*.json"),
+        key=lambda path: int(path.name.split("-")[1]),
+    )
+    return [Event.model_validate_json(path.read_text()) for path in event_files]
+
+
+def _expire_lease(conversation_dir: Path) -> None:
+    lease_path = conversation_dir / LEASE_FILE_NAME
+    payload = json.loads(lease_path.read_text())
+    payload["expires_at"] = 0
+    lease_path.write_text(json.dumps(payload))
+
+
+@pytest.mark.asyncio
+async def test_live_lease_blocks_split_brain_resume_with_disk_events(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(_request(workspace_dir))
+        assert primary._event_services is not None
+        primary_event_service = primary._event_services[conversation_info.id]
+        primary_state = await primary_event_service.get_state()
+        conversation_dir = conversations_dir / conversation_info.id.hex
+
+        running_action = _create_running_terminal_action()
+        primary_state.events.append(running_action)
+        primary_state.execution_status = ConversationExecutionStatus.RUNNING
+
+        assert [
+            type(event).__name__ for event in _load_disk_events(conversation_dir)
+        ] == [
+            "ActionEvent",
+            "ConversationStateUpdateEvent",
+        ]
+
+        async with ConversationService(
+            conversations_dir=conversations_dir
+        ) as secondary:
+            assert secondary._event_services is not None
+            assert conversation_info.id not in secondary._event_services
+            primary_state.events.append(_terminal_observation(running_action))
+
+        disk_events = _load_disk_events(conversation_dir)
+        assert any(isinstance(event, ObservationEvent) for event in disk_events)
+        assert not any(isinstance(event, AgentErrorEvent) for event in disk_events)
+
+
+@pytest.mark.asyncio
+async def test_expired_lease_takeover_fences_stale_writer_with_disk_events(tmp_path):
+    conversations_dir = tmp_path / "conversations"
+    workspace_dir = tmp_path / "workspace"
+    workspace_dir.mkdir()
+
+    async with ConversationService(conversations_dir=conversations_dir) as primary:
+        conversation_info, _ = await primary.start_conversation(_request(workspace_dir))
+        assert primary._event_services is not None
+        primary_event_service = primary._event_services[conversation_info.id]
+        primary_state = await primary_event_service.get_state()
+        conversation_dir = conversations_dir / conversation_info.id.hex
+
+        running_action = _create_running_terminal_action()
+        primary_state.events.append(running_action)
+        primary_state.execution_status = ConversationExecutionStatus.RUNNING
+        _expire_lease(conversation_dir)
+
+        async with ConversationService(
+            conversations_dir=conversations_dir
+        ) as secondary:
+            assert secondary._event_services is not None
+            assert conversation_info.id in secondary._event_services
+
+            disk_events = _load_disk_events(conversation_dir)
+            assert any(isinstance(event, AgentErrorEvent) for event in disk_events)
+
+            with pytest.raises(ConversationOwnershipLostError):
+                primary_state.events.append(
+                    _terminal_observation(running_action, "late result")
+                )
+
+            with pytest.raises(ConversationOwnershipLostError):
+                primary_state.execution_status = ConversationExecutionStatus.ERROR


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:

Provide evidence that the code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain exactly the command that you ran, and provide evidence that the code works as expected, either in the form of log outputs or screenshots. In addition, if it is a bug fix, also run the same code before the bug fix and demonstrate that the code did NOT work before the fix to demonstrate that you were able to reproduce the problem.
-->

HUMAN:
This PR proposes to add more testing for conversation lease.

- [x] A human has tested these changes.

---

AGENT:

## Why

Fixing test coverage for a rare distributed pattern.

## Summary
- add cross-package conversation lease coverage using real `ConversationService` instances and temp-dir persistence
- verify a live owner blocks split-brain resume while still appending the late observation event to disk
- verify expired lease takeover writes recovery events and fences the stale writer

## Validation
- `uv run pre-commit run --files tests/cross/test_conversation_lease_behavior.py`
- `uv run pytest tests/cross/test_conversation_lease_behavior.py -q`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/7f38c824-93bf-4034-940d-2ff17dc634ad)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:00a19e8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-00a19e8-python \
  ghcr.io/openhands/agent-server:00a19e8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:00a19e8-golang-amd64
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-golang-amd64
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-golang-amd64
ghcr.io/openhands/agent-server:00a19e8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:00a19e8-golang-arm64
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-golang-arm64
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-golang-arm64
ghcr.io/openhands/agent-server:00a19e8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:00a19e8-java-amd64
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-java-amd64
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-java-amd64
ghcr.io/openhands/agent-server:00a19e8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:00a19e8-java-arm64
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-java-arm64
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-java-arm64
ghcr.io/openhands/agent-server:00a19e8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:00a19e8-python-amd64
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-python-amd64
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-python-amd64
ghcr.io/openhands/agent-server:00a19e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:00a19e8-python-arm64
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-python-arm64
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-python-arm64
ghcr.io/openhands/agent-server:00a19e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:00a19e8-golang
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-golang
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-golang
ghcr.io/openhands/agent-server:00a19e8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:00a19e8-java
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-java
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-java
ghcr.io/openhands/agent-server:00a19e8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:00a19e8-python
ghcr.io/openhands/agent-server:00a19e81ac17da3d821fe695bff808efa84c192b-python
ghcr.io/openhands/agent-server:cross-conversation-lease-tests-python
ghcr.io/openhands/agent-server:00a19e8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `00a19e8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `00a19e8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->