### PR TITLE
feat(security): supply-chain typosquat analyzer on shared shell parser

### DIFF
--- a/openhands-sdk/openhands/sdk/security/__init__.py
+++ b/openhands-sdk/openhands/sdk/security/__init__.py
@@ -13,6 +13,7 @@ from openhands.sdk.security.ensemble import EnsembleSecurityAnalyzer
 from openhands.sdk.security.grayswan import GraySwanAnalyzer
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.security.supply_chain import SupplyChainSecurityAnalyzer
 from openhands.sdk.security.toolshield_helpers import (
     auto_detect_safety_experiences,
     default_safety_experiences,
@@ -40,6 +41,7 @@ __all__ = [
     "GraySwanAnalyzer",
     "PatternSecurityAnalyzer",
     "PolicyRailSecurityAnalyzer",
+    "SupplyChainSecurityAnalyzer",
     "EnsembleSecurityAnalyzer",
     "ConfirmationPolicyBase",
     "AlwaysConfirm",

--- a/openhands-sdk/openhands/sdk/security/supply_chain/__init__.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/__init__.py
@@ -1,0 +1,26 @@
+"""Deterministic, offline detection of npm-ecosystem supply-chain typosquats.
+
+A sibling to ``defense_in_depth``: where that seam catches dangerous command
+*shapes*, this one catches a dangerous dependency *identity* -- an install of a
+package whose name is one edit away from a popular one.
+
+- ``SupplyChainSecurityAnalyzer`` -- ``SecurityAnalyzerBase`` returning
+  ``SecurityRisk.HIGH`` on a likely typosquat install, ``LOW`` otherwise.
+- ``find_typosquat_installs`` -- the pure parser entry point, for callers that
+  want the raw findings without the analyzer wrapper.
+
+No network calls, no model inference, no dependencies beyond the SDK runtime.
+"""
+
+from openhands.sdk.security.supply_chain.analyzer import SupplyChainSecurityAnalyzer
+from openhands.sdk.security.supply_chain.parser import (
+    TyposquatFinding,
+    find_typosquat_installs,
+)
+
+
+__all__ = [
+    "SupplyChainSecurityAnalyzer",
+    "find_typosquat_installs",
+    "TyposquatFinding",
+]

--- a/openhands-sdk/openhands/sdk/security/supply_chain/__init__.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/__init__.py
@@ -5,15 +5,19 @@ A sibling to ``defense_in_depth``: where that seam catches dangerous command
 package whose name is one edit away from a popular one.
 
 - ``SupplyChainSecurityAnalyzer`` -- ``SecurityAnalyzerBase`` returning
-  ``SecurityRisk.HIGH`` on a likely typosquat install, ``LOW`` otherwise.
+  ``SecurityRisk.HIGH`` on a likely typosquat install and
+  ``SecurityRisk.UNKNOWN`` when analysis cannot complete.
 - ``find_typosquat_installs`` -- the pure parser entry point, for callers that
   want the raw findings without the analyzer wrapper.
+- ``SupplyChainAnalysisIncompleteError`` -- signals that the parser could not
+  produce a complete finding set.
 
 No network calls, no model inference, no dependencies beyond the SDK runtime.
 """
 
 from openhands.sdk.security.supply_chain.analyzer import SupplyChainSecurityAnalyzer
 from openhands.sdk.security.supply_chain.parser import (
+    SupplyChainAnalysisIncompleteError,
     TyposquatFinding,
     find_typosquat_installs,
 )
@@ -21,6 +25,7 @@ from openhands.sdk.security.supply_chain.parser import (
 
 __all__ = [
     "SupplyChainSecurityAnalyzer",
+    "SupplyChainAnalysisIncompleteError",
     "find_typosquat_installs",
     "TyposquatFinding",
 ]

--- a/openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py
@@ -1,0 +1,160 @@
+"""Raise the risk of npm typosquat installs at the action boundary.
+
+``PatternSecurityAnalyzer`` catches what a command *does* lexically (rm -rf,
+curl | sh). It does not catch a command that runs a perfectly ordinary
+``npm install`` of a package whose name is one keystroke off a popular one --
+``lodahs`` instead of ``lodash``. That is a supply-chain attack the other
+deterministic analyzers in this seam miss, because the danger is in the
+*identity* of the dependency, not the shape of the command.
+
+``SupplyChainSecurityAnalyzer`` closes that gap. It reads the command string from
+the action's tool call (the ``"command"`` key of the raw tool-call arguments)
+and hands it to
+``find_typosquat_installs``, which normalizes the command to defeat
+encoding-evasion and parses it offline with the shared tree-sitter-bash view (no
+network, no disk). It returns ``SecurityRisk.HIGH`` when an install/runner
+target is one edit away from a curated popular package. It never hard-denies;
+pairing it with ``ConfirmRisky`` asks a human to make the call.
+
+Unlike the pattern/policy analyzers in ``defense_in_depth``, this analyzer does
+not import their private extraction/normalization helpers. It scans ONLY the
+command string (never tool name, thought, reasoning, or summary), which keeps
+the two-corpus invariant -- a typosquat mentioned only in reasoning stays LOW.
+Encoding-evasion normalization (zero-width/fullwidth/bidi defeat) lives in the
+parser entry point, so both this analyzer and direct parser callers share it.
+"""
+
+from __future__ import annotations
+
+import json
+
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.logger import get_logger
+from openhands.sdk.security.analyzer import SecurityAnalyzerBase
+from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.security.supply_chain.parser import find_typosquat_installs
+
+
+logger = get_logger(__name__)
+
+
+def _command_string(action: ActionEvent) -> str:
+    """Extract the shell command string from an action's tool call.
+
+    Reads the raw tool-call ``arguments`` JSON and returns its ``"command"``
+    key. Returns ``""`` when there is no non-empty command string -- the
+    analyzer then stays LOW. Only the command string is scanned; tool name,
+    thought, reasoning and summary are never read, which preserves the
+    two-corpus invariant.
+    """
+    tool_call = action.tool_call
+    if tool_call is not None and tool_call.arguments:
+        try:
+            parsed = json.loads(tool_call.arguments)
+        except (json.JSONDecodeError, TypeError):
+            return ""
+        if isinstance(parsed, dict):
+            command = parsed.get("command")
+            if isinstance(command, str):
+                return command
+
+    return ""
+
+
+class SupplyChainSecurityAnalyzer(SecurityAnalyzerBase):
+    """Flag npm-ecosystem typosquat installs so a human can approve them.
+
+    Use this when an agent can run shell commands and you want to catch the
+    one-edit-off dependency install that pattern and policy-rail analyzers do
+    not see. It returns ``SecurityRisk.HIGH`` on a likely typosquat and
+    ``SecurityRisk.LOW`` otherwise -- it never blocks on its own. The check is
+    deterministic and offline: it scans only the command string of the action
+    (the ``"command"`` key of the tool-call arguments), never the agent's
+    reasoning text, so merely *mentioning* ``lodahs`` in a thought does not
+    trip it.
+
+    The extraction layer runs on the shared tree-sitter-bash command view, so
+    command chaining, pipes, subshells and path-qualified managers parse
+    structurally.
+
+    Scope, stated honestly. The analyzer decodes the static obfuscations a real
+    shell collapses to a fixed string before exec, and checks each result against
+    the typosquat heuristic:
+
+    - quote removal (``"lodahs"``, ``lo'adsh'``), backslash unescaping
+      (``lo\\adsh``), interior-quote concatenation (``lo""adsh``), ANSI-C
+      ``$'...'`` escapes, line-continuation joining, and bounded static
+      comma-brace expansion (``lo{a,}dsh`` -> ``loadsh``/``lodsh``, each checked).
+
+    What stays LOW because it cannot be resolved statically:
+
+    - runtime expansion -- shell variables (``$PKG``), command/process
+      substitution (``$(...)``, ```...```, ``<(...)``) and arithmetic
+      substitution: the installed name is unknowable offline;
+    - homoglyphs / Unicode confusables: only invisible/zero-width characters and
+      fullwidth NFKC folds are normalized, not look-alike letters;
+    - an install nested inside an inner command string (``bash -c '...'``,
+      ``echo '...'``): treated as one opaque argument to the outer command (the
+      documented xfail residue), pending recursive command-string parsing;
+    - brace forms outside the bounded comma case: ranges (``{1..3}``), nested
+      braces, and a brace touching a quote or variable stay opaque.
+
+    It flags the typosquats it can prove statically and is explicit about what it
+    does not catch; it never blocks on its own.
+
+    Example::
+
+        from openhands.sdk.security import (
+            SupplyChainSecurityAnalyzer,
+            ConfirmRisky,
+            SecurityRisk,
+        )
+
+        analyzer = SupplyChainSecurityAnalyzer()
+        policy = ConfirmRisky(threshold=SecurityRisk.HIGH)
+    """
+
+    def security_risk(self, action: ActionEvent) -> SecurityRisk:
+        """Return ``HIGH`` if the command installs a likely typosquat, else
+        ``LOW``.
+
+        The command string is handed straight to ``find_typosquat_installs``,
+        which normalizes it (stripping zero-width/bidi/format characters and
+        NFKC-folding fullwidth glyphs) so an attacker cannot hide ``lodahs``
+        behind an invisible character or fullwidth ``ｎｐｍ`` before parsing it on
+        the shared tree-sitter view. A crafted lone-surrogate command can make
+        the UTF-8 strict encode in the parser raise ``UnicodeEncodeError``, and a
+        pathologically nested/chained command (hundreds of ``$()`` levels or
+        chained operators) can make the recursive tree-sitter-bash walkers raise
+        ``RecursionError``; both are caught and treated as LOW so the analyzer
+        never raises out of the security seam. That adversarially-nested input is
+        a known limitation: it is not analyzed and stays LOW, never a crash.
+        """
+        command = _command_string(action)
+        if not command:
+            return SecurityRisk.LOW
+
+        try:
+            findings = find_typosquat_installs(command)
+        except (UnicodeEncodeError, RecursionError):
+            # Intentional fail-open. UnicodeEncodeError: a lone-surrogate command
+            # cannot be UTF-8 encoded to run, so there is no real install to
+            # flag. RecursionError: pathologically nested/chained input (hundreds
+            # of $() levels or chained operators) exhausts the recursion stack in
+            # the shared parser's recursive walkers, so it is not analyzed (a
+            # known limitation) rather than crashing the seam. Either way, there
+            # is nothing to flag -- stay LOW.
+            logger.debug(
+                "Supply-chain check skipped: command is not UTF-8 encodable "
+                "(lone surrogate) or too deeply nested/chained to parse; "
+                "treating as LOW."
+            )
+            return SecurityRisk.LOW
+        if findings:
+            logger.debug(
+                "Supply-chain typosquat flagged: %s",
+                "; ".join(f.reason for f in findings),
+            )
+            return SecurityRisk.HIGH
+
+        return SecurityRisk.LOW

--- a/openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py
@@ -32,7 +32,10 @@ from openhands.sdk.event import ActionEvent
 from openhands.sdk.logger import get_logger
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 from openhands.sdk.security.risk import SecurityRisk
-from openhands.sdk.security.supply_chain.parser import find_typosquat_installs
+from openhands.sdk.security.supply_chain.parser import (
+    SupplyChainAnalysisIncompleteError,
+    find_typosquat_installs,
+)
 
 
 logger = get_logger(__name__)
@@ -66,12 +69,12 @@ class SupplyChainSecurityAnalyzer(SecurityAnalyzerBase):
 
     Use this when an agent can run shell commands and you want to catch the
     one-edit-off dependency install that pattern and policy-rail analyzers do
-    not see. It returns ``SecurityRisk.HIGH`` on a likely typosquat and
-    ``SecurityRisk.LOW`` otherwise -- it never blocks on its own. The check is
-    deterministic and offline: it scans only the command string of the action
-    (the ``"command"`` key of the tool-call arguments), never the agent's
-    reasoning text, so merely *mentioning* ``lodahs`` in a thought does not
-    trip it.
+    not see. It returns ``SecurityRisk.HIGH`` on a likely typosquat,
+    ``SecurityRisk.UNKNOWN`` when the command cannot be analyzed completely,
+    and ``SecurityRisk.LOW`` otherwise. The check is deterministic and offline:
+    it scans only the command string of the action (the ``"command"`` key of the
+    tool-call arguments), never the agent's reasoning text, so merely
+    *mentioning* ``lodahs`` in a thought does not trip it.
 
     The extraction layer runs on the shared tree-sitter-bash command view, so
     command chaining, pipes, subshells and path-qualified managers parse
@@ -115,20 +118,15 @@ class SupplyChainSecurityAnalyzer(SecurityAnalyzerBase):
     """
 
     def security_risk(self, action: ActionEvent) -> SecurityRisk:
-        """Return ``HIGH`` if the command installs a likely typosquat, else
-        ``LOW``.
+        """Return ``HIGH`` for a typosquat and ``UNKNOWN`` if analysis is incomplete.
 
         The command string is handed straight to ``find_typosquat_installs``,
         which normalizes it (stripping zero-width/bidi/format characters and
         NFKC-folding fullwidth glyphs) so an attacker cannot hide ``lodahs``
         behind an invisible character or fullwidth ``ｎｐｍ`` before parsing it on
-        the shared tree-sitter view. A crafted lone-surrogate command can make
-        the UTF-8 strict encode in the parser raise ``UnicodeEncodeError``, and a
-        pathologically nested/chained command (hundreds of ``$()`` levels or
-        chained operators) can make the recursive tree-sitter-bash walkers raise
-        ``RecursionError``; both are caught and treated as LOW so the analyzer
-        never raises out of the security seam. That adversarially-nested input is
-        a known limitation: it is not analyzed and stays LOW, never a crash.
+        the shared tree-sitter view. A lone-surrogate command cannot be encoded
+        for execution and stays LOW. Oversized or pathologically nested/chained
+        input that cannot be analyzed completely returns UNKNOWN.
         """
         command = _command_string(action)
         if not command:
@@ -136,20 +134,15 @@ class SupplyChainSecurityAnalyzer(SecurityAnalyzerBase):
 
         try:
             findings = find_typosquat_installs(command)
-        except (UnicodeEncodeError, RecursionError):
-            # Intentional fail-open. UnicodeEncodeError: a lone-surrogate command
-            # cannot be UTF-8 encoded to run, so there is no real install to
-            # flag. RecursionError: pathologically nested/chained input (hundreds
-            # of $() levels or chained operators) exhausts the recursion stack in
-            # the shared parser's recursive walkers, so it is not analyzed (a
-            # known limitation) rather than crashing the seam. Either way, there
-            # is nothing to flag -- stay LOW.
+        except UnicodeEncodeError:
             logger.debug(
-                "Supply-chain check skipped: command is not UTF-8 encodable "
-                "(lone surrogate) or too deeply nested/chained to parse; "
+                "Supply-chain check skipped: command is not UTF-8 encodable; "
                 "treating as LOW."
             )
             return SecurityRisk.LOW
+        except SupplyChainAnalysisIncompleteError as exc:
+            logger.debug("Supply-chain analysis incomplete: %s", exc)
+            return SecurityRisk.UNKNOWN
         if findings:
             logger.debug(
                 "Supply-chain typosquat flagged: %s",

--- a/openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py
@@ -14,7 +14,8 @@ and hands it to
 encoding-evasion and parses it offline with the shared tree-sitter-bash view (no
 network, no disk). It returns ``SecurityRisk.HIGH`` when an install/runner
 target is one edit away from a curated popular package. It never hard-denies;
-pairing it with ``ConfirmRisky`` asks a human to make the call.
+recognized incomplete-analysis conditions return ``SecurityRisk.UNKNOWN``.
+Pairing it with ``ConfirmRisky`` asks a human to make the call.
 
 Unlike the pattern/policy analyzers in ``defense_in_depth``, this analyzer does
 not import their private extraction/normalization helpers. It scans ONLY the
@@ -89,18 +90,27 @@ class SupplyChainSecurityAnalyzer(SecurityAnalyzerBase):
       ``$'...'`` escapes, line-continuation joining, and bounded static
       comma-brace expansion (``lo{a,}dsh`` -> ``loadsh``/``lodsh``, each checked).
 
-    What stays LOW because it cannot be resolved statically:
+    What stays LOW because no risky package identity can be proved:
 
-    - runtime expansion -- shell variables (``$PKG``), command/process
+    - runtime expansion in package-manager operands -- shell variables
+      (``$PKG``), command/process
       substitution (``$(...)``, ```...```, ``<(...)``) and arithmetic
       substitution: the installed name is unknowable offline;
     - homoglyphs / Unicode confusables: only invisible/zero-width characters and
       fullwidth NFKC folds are normalized, not look-alike letters;
-    - an install nested inside an inner command string (``bash -c '...'``,
-      ``echo '...'``): treated as one opaque argument to the outer command (the
-      documented xfail residue), pending recursive command-string parsing;
+    - inert quoted data such as ``echo 'npm install lodahs'``: the string is an
+      argument, not an executable command;
+    - npm runner call strings such as ``npx -c 'npm install lodahs'``: their
+      CLI-specific argv semantics remain documented strict-xfail residue;
     - brace forms outside the bounded comma case: ranges (``{1..3}``), nested
       braces, and a brace touching a quote or variable stay opaque.
+
+    A recognized POSIX-style shell invocation that selects an executable
+    command string (``bash -c '...'``, ``sh -lc '...'``) returns UNKNOWN rather
+    than LOW. Recursive command-string parsing is intentionally outside this
+    analyzer's current scope, so ``ConfirmRisky`` applies its configurable
+    fallback instead of silently allowing the command. Oversized or
+    pathologically nested/chained input follows the same UNKNOWN boundary.
 
     It flags the typosquats it can prove statically and is explicit about what it
     does not catch; it never blocks on its own.
@@ -126,7 +136,8 @@ class SupplyChainSecurityAnalyzer(SecurityAnalyzerBase):
         behind an invisible character or fullwidth ``ｎｐｍ`` before parsing it on
         the shared tree-sitter view. A lone-surrogate command cannot be encoded
         for execution and stays LOW. Oversized or pathologically nested/chained
-        input that cannot be analyzed completely returns UNKNOWN.
+        input, including a recognized shell ``-c`` command string that is not
+        recursively parsed, returns UNKNOWN.
         """
         command = _command_string(action)
         if not command:

--- a/openhands-sdk/openhands/sdk/security/supply_chain/parser.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/parser.py
@@ -1,0 +1,1856 @@
+"""Offline, deterministic detection of npm-ecosystem typosquat installs.
+
+Given a shell command an agent is about to run, this module decides whether
+it installs (or executes via a package runner) an npm package whose name is
+one edit away from a popular package, e.g. ``lodahs`` for ``lodash``. That is
+the classic typosquat supply-chain attack: the agent fat-fingers a name or an
+attacker plants a near-name package, and the wrong dependency gets installed.
+
+The check is pure: no network, no filesystem, no new dependencies beyond the
+tree-sitter-bash view already used elsewhere in the SDK. The typosquat decision
+(the OSA distance, the popular-package corpus) and the install/runner subcommand
+routing are computed here; the extraction layer runs on a shared
+tree-sitter-bash command view (``openhands.sdk.security._shell_ast``) rather than
+a hand-rolled char scanner, so command chaining, pipes, path-qualified managers
+and subshells parse structurally. The entry point
+:func:`find_typosquat_installs` returns one finding per distinct flagged
+package; the caller decides what to do (the analyzer raises the risk to
+``HIGH`` so a human is asked, never a hard deny).
+
+Hardening:
+
+- enumerate every ``command`` node via ``iter_commands`` -- this surfaces
+  sub-commands across ``&&``, ``||``, ``;``, ``|``, ``&``, newline, subshells,
+  ``if``/``for``/``while`` bodies and ``$(...)`` substitutions structurally,
+  replacing the old separator scanner;
+- peel wrapper commands (``sudo``, ``env``, ...) with their leading options and
+  env assignments, since the AST does not unwrap them;
+- recover obfuscated operands: ``"lodahs"``/``'lodahs'`` and interior-quote or
+  backslash forms (``lo""adsh``, ``load"sh"``, ``lo'adsh'``, ``lo\\adsh``,
+  ``l"o"a"d"s"h"``) parse opaque, so a bounded shell-literal decode walks the
+  single operand word and concatenates its adjacent quoted/escaped/bare
+  segments into the one argv token the shell would pass, re-admitting it only if
+  it matches a strict package-spec shape (any command substitution, variable
+  expansion, embedded space or leftover metacharacter stays opaque);
+- expand a static comma-brace operand the way bash does before exec:
+  ``lo{a,}dsh`` becomes the two argv tokens ``loadsh`` and ``lodsh``, and EACH
+  expansion is checked against the typosquat heuristic, so a near-name hidden in
+  a brace alternative is flagged. This is bounded and narrow: it applies only to
+  a word that is a concatenation of bare literals and brace/comma punctuation,
+  with a hard cap on total expansions (32) and brace groups (8). Ranges
+  (``{1..3}``), nested braces (``a{b,{c,d}}``), a brace touching a quote or a
+  variable (``lo{a,}d"s"h``, ``lo{a,$X}dsh``), and escaped braces
+  (``lo\\{a,\\}dsh``) are OUT OF SCOPE and stay opaque (LOW);
+
+What this module decodes (static forms a real shell collapses to a fixed string
+before exec) and what it leaves opaque is an explicit, honest boundary:
+
+- DECODED (can raise to HIGH): quote removal (``"lodahs"``, ``lo'adsh'``),
+  backslash unescaping (``lo\\adsh``), interior-quote concatenation
+  (``lo""adsh``), ANSI-C ``$'...'`` escapes, line-continuation joining
+  (``loa\\<newline>dsh``), and the static comma-brace expansion above.
+- OUT OF SCOPE (stays LOW, never decoded): any runtime expansion -- shell
+  variables (``$PKG``), command/process substitution (``$(...)``, ```...```,
+  ``<(...)``) and arithmetic substitution (``$((...))``); homoglyphs and other
+  Unicode confusables (only invisible/zero-width characters and fullwidth NFKC
+  folds are normalized, not look-alike letters); and an install nested inside an
+  inner command string such as ``bash -c '...'`` (treated as one opaque
+  argument). This module flags the typosquats it can prove statically; it does
+  not claim to catch every obfuscation.
+
+- dispatch on the package-manager binary POSIX basename (path prefix stripped
+  by the AST, ``/usr/bin/npm`` -> ``npm``);
+- apply one consistent flag policy everywhere (subcommand skipping, install
+  collection, runner collection): a known value-taking flag written bare
+  (``--registry``, ``--prefix``, ...) consumes its next token, ``--flag=value``
+  is self-contained, and every other flag -- including any unknown long flag --
+  is boolean and consumes nothing, matching how npm/yarn/pnpm/bun actually parse;
+- collect install targets after the install subcommand;
+- collect the single executed package for runners (``npx``/``bunx``/``dlx``):
+  the first positional after flag handling is the executed package (the
+  typosquat target), trailing tokens are that program's own arguments;
+- strip a trailing ``@version`` from a package spec while keeping the scope;
+- flag a candidate iff its Optimal-String-Alignment distance to a popular
+  name is exactly 1 AND that popular name is longer than four characters.
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from dataclasses import dataclass
+
+from tree_sitter import Node
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.security._shell_ast import (
+    ShellCommand,
+    ShellWord,
+    command_basename,
+    iter_commands,
+    parse_shell_program,
+)
+
+
+logger = get_logger(__name__)
+
+# Generous upper bound on the command length we will parse. The recursive
+# tree-sitter-bash walkers in the shared ``_shell_ast`` view (and the operand
+# decoders here) descend per nested ``$()`` level or chained operator, so a
+# pathologically nested/chained command (hundreds of ``$()`` levels or
+# operators) can exhaust the Python recursion stack. A real install command is
+# at most a few hundred bytes; this cap is set far above any legitimate command
+# (a chained build line, a long scoped-package install) so it never drops a real
+# command, only an absurd one whose only purpose is to blow the stack. Even
+# above the cap, :func:`find_typosquat_installs` would still not crash (the
+# RecursionError below is caught), but skipping the parse avoids the wasted work.
+_MAX_COMMAND_LENGTH = 100_000
+
+
+# ---------------------------------------------------------------------------
+# Curated data: popular packages, wrappers, managers, subcommands, flags.
+#
+# Do not reorder POPULAR_PACKAGES casually: the first matching popular name
+# within OSA distance 1 is the one reported, so ordering affects the suggestion
+# (not whether a hit occurs).
+# ---------------------------------------------------------------------------
+
+POPULAR_PACKAGES: tuple[str, ...] = (
+    "react",
+    "react-dom",
+    "vue",
+    "angular",
+    "lodash",
+    "axios",
+    "express",
+    "next",
+    "tailwindcss",
+    "typescript",
+    "vite",
+    "webpack",
+    "eslint",
+    "prettier",
+    "jest",
+    "mocha",
+    "chalk",
+    "commander",
+    "chokidar",
+    "moment",
+    "dayjs",
+    "uuid",
+    "yargs",
+    "zod",
+    "rxjs",
+    "ramda",
+    "dotenv",
+    "cors",
+    "body-parser",
+    "socket.io",
+    "mongoose",
+    "sequelize",
+    "prisma",
+    "redux",
+    "react-router",
+    "react-router-dom",
+    "react-query",
+    "framer-motion",
+    "styled-components",
+    "antd",
+    "bootstrap",
+    "jquery",
+    "underscore",
+    "request",
+    "node-fetch",
+    "got",
+    "puppeteer",
+    "playwright",
+    "cheerio",
+    "fs-extra",
+    "minimatch",
+    "rimraf",
+    "semver",
+    "debug",
+    "winston",
+    "pino",
+    "morgan",
+    "helmet",
+    "passport",
+    "bcrypt",
+    "jsonwebtoken",
+    "argon2",
+    "mysql2",
+    "redis",
+    "ioredis",
+    "nodemon",
+    "concurrently",
+)
+
+# Lookup set built once from POPULAR_PACKAGES.
+_POPULAR_SET: frozenset[str] = frozenset(POPULAR_PACKAGES)
+
+# Leading binaries that wrap another command. They are skipped (with their
+# leading options) before dispatching on the real package-manager binary.
+_WRAPPER_COMMANDS: frozenset[str] = frozenset(
+    {
+        "sudo",
+        "doas",
+        "env",
+        "time",
+        "nice",
+        "nohup",
+        "stdbuf",
+        "command",
+        "xargs",
+    }
+)
+
+# Package managers that install dependencies.
+_PACKAGE_MANAGERS: frozenset[str] = frozenset({"npm", "npm.cmd", "yarn", "pnpm", "bun"})
+
+# Standalone package runners (npx-like) where the executed package is the
+# target.
+_RUNNERS: frozenset[str] = frozenset({"npx", "npx.cmd", "bunx", "bunx.cmd"})
+
+# Install subcommands per manager that collect package args.
+_INSTALL_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "npm": frozenset({"install", "i", "add"}),
+    "yarn": frozenset({"add"}),
+    "pnpm": frozenset({"add", "install", "i"}),
+    "bun": frozenset({"add", "install", "i"}),
+}
+
+# Runner subcommands per manager where only the executed package is the target.
+_RUNNER_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "npm": frozenset({"exec", "x"}),
+    "yarn": frozenset({"dlx"}),
+    "pnpm": frozenset({"dlx"}),
+    "bun": frozenset({"x"}),
+}
+
+# Every real subcommand keyword each manager recognizes, used by
+# ``_find_subcommand_index`` to validate the routing token. Skipping leading
+# global flags can land on a stray flag-value (``beta`` after a bare ``--tag``
+# we did not enumerate); if that landed token is NOT one of these real
+# subcommand keywords, the scan keeps going rather than giving up, so the
+# install behind it is still reached. This is the version-independent backstop
+# for any value-taking flag missing from the value-flag sets
+# (``_SHARED_VALUE_TAKING_FLAGS`` / ``_NPM_ONLY_VALUE_TAKING_FLAGS``). The set is the
+# union of the install/runner subcommands above plus the other documented
+# subcommands (``npm help``, ``yarn help``, ``pnpm help``, ``bun --help``), so a
+# genuine non-install subcommand such as ``run`` still stops the scan and is NOT
+# skipped (which would mis-route ``npm run build install x`` into a false
+# positive). Curated, not exhaustive across every alias/version, but covers the
+# package-flow subcommands and the common ones an agent emits.
+_KNOWN_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "npm": frozenset(
+        {
+            "access",
+            "adduser",
+            "audit",
+            "bugs",
+            "cache",
+            "ci",
+            "completion",
+            "config",
+            "dedupe",
+            "deprecate",
+            "diff",
+            "dist-tag",
+            "docs",
+            "doctor",
+            "edit",
+            "exec",
+            "explain",
+            "explore",
+            "find-dupes",
+            "fund",
+            "get",
+            "help",
+            "help-search",
+            "init",
+            "install",
+            "install-ci-test",
+            "install-test",
+            "link",
+            "ll",
+            "login",
+            "logout",
+            "ls",
+            "org",
+            "outdated",
+            "owner",
+            "pack",
+            "ping",
+            "pkg",
+            "prefix",
+            "profile",
+            "prune",
+            "publish",
+            "query",
+            "rebuild",
+            "repo",
+            "restart",
+            "root",
+            "run",
+            "run-script",
+            "sbom",
+            "search",
+            "set",
+            "shrinkwrap",
+            "star",
+            "stars",
+            "start",
+            "stop",
+            "team",
+            "test",
+            "token",
+            "trust",
+            "undeprecate",
+            "uninstall",
+            "unpublish",
+            "unstar",
+            "update",
+            "version",
+            "view",
+            "whoami",
+            "remove",
+            "rm",
+            "create",
+            "i",
+            "in",
+            "ins",
+            "inst",
+            "insta",
+            "instal",
+            "isnt",
+            "isnta",
+            "isntal",
+            "isntall",
+            "add",
+            "x",
+            "un",
+            "up",
+            "ln",
+            "c",
+            "s",
+            "se",
+            "list",
+            "t",
+            "tst",
+            "ddp",
+            "v",
+            "r",
+            "rb",
+        }
+    ),
+    "yarn": frozenset(
+        {
+            "access",
+            "add",
+            "audit",
+            "autoclean",
+            "bin",
+            "cache",
+            "check",
+            "config",
+            "create",
+            "dlx",
+            "exec",
+            "generate-lock-entry",
+            "global",
+            "help",
+            "import",
+            "info",
+            "init",
+            "install",
+            "licenses",
+            "link",
+            "list",
+            "login",
+            "logout",
+            "node",
+            "outdated",
+            "owner",
+            "pack",
+            "policies",
+            "publish",
+            "remove",
+            "run",
+            "tag",
+            "team",
+            "unlink",
+            "unplug",
+            "upgrade",
+            "upgrade-interactive",
+            "version",
+            "versions",
+            "why",
+            "workspace",
+            "workspaces",
+            "set",
+            "up",
+            "patch",
+            "patch-commit",
+            "dedupe",
+            "rebuild",
+            "explain",
+            "constraints",
+        }
+    ),
+    "pnpm": frozenset(
+        {
+            "add",
+            "audit",
+            "bin",
+            "config",
+            "create",
+            "dedupe",
+            "deploy",
+            "dlx",
+            "doctor",
+            "env",
+            "exec",
+            "fetch",
+            "import",
+            "init",
+            "install",
+            "i",
+            "licenses",
+            "link",
+            "list",
+            "ls",
+            "outdated",
+            "pack",
+            "patch",
+            "patch-commit",
+            "patch-remove",
+            "prune",
+            "publish",
+            "rebuild",
+            "remove",
+            "rm",
+            "uninstall",
+            "un",
+            "root",
+            "run",
+            "server",
+            "setup",
+            "start",
+            "store",
+            "test",
+            "t",
+            "unlink",
+            "update",
+            "up",
+            "why",
+            "import-tarball",
+            "add-tarball",
+            "ci",
+        }
+    ),
+    "bun": frozenset(
+        {
+            "add",
+            "audit",
+            "build",
+            "create",
+            "dev",
+            "exec",
+            "info",
+            "init",
+            "install",
+            "i",
+            "link",
+            "outdated",
+            "pack",
+            "patch",
+            "pm",
+            "publish",
+            "remove",
+            "rm",
+            "repl",
+            "run",
+            "test",
+            "unlink",
+            "update",
+            "upgrade",
+            "why",
+            "x",
+            "a",
+            "c",
+            "ci",
+            "why",
+        }
+    ),
+}
+
+# Known value-taking flags across the npm/yarn/pnpm/bun CLIs. This is the ONE
+# value-consuming rule shared by subcommand-skipping, install collection, and
+# runner collection: when one of these flags is written bare (no ``=``), the
+# following token is its value and is skipped. ``--flag=value`` is always
+# self-contained. EVERY other flag (including any unknown long flag) is treated
+# as boolean and consumes nothing, matching how these CLIs actually parse.
+#
+# Value-consumption is MANAGER-AWARE: the SAME spelling is a value flag in one
+# CLI and a boolean switch in another. The canonical example is ``-w``: in npm
+# it is ``--workspace <name>`` (Type String, consumes a value), but in pnpm it
+# is ``--workspace-root`` (a boolean "act on the workspace root"), and yarn/bun
+# expose no value-taking ``-w`` at all. Treating ``-w`` as value-taking for
+# pnpm/yarn/bun is a FALSE NEGATIVE: ``pnpm add -w expres`` would skip
+# ``expres``. So the table is split into a shared set valid for every manager
+# plus an npm-only set; :func:`_consumes_next_value` takes the manager and ORs
+# them only for npm.
+#
+# Accuracy matters in BOTH directions: a value-taking flag wrongly omitted lets
+# an unknown pre-subcommand flag mis-route (false negative -- partly backstopped
+# by the subcommand-keyword validation in ``_find_subcommand_index``), while a
+# BOOLEAN flag wrongly added here would skip the real package that follows it
+# (a new false negative). Every entry below is therefore verified to take a
+# scalar value for the manager(s) it applies to, not to be a boolean switch.
+#
+# SHARED basis: ``npm help 7 config`` flag ``Type:`` (``tag``=String,
+# ``audit-level``/``install-strategy``=enum String, ``scope``/``otp``/``ca``/
+# ``cert``/``key``=String, ``maxsockets``/``fetch-retries``/``fetch-timeout``=
+# Number, ``https-proxy``/``proxy``=URL, ``before``=Date, ``cafile``=Path,
+# ``registry``=URL, ``prefix``/``-C``=Path, ``loglevel``=enum,
+# ``save-prefix``=String) and the pnpm/yarn/bun help (``--store-dir <dir>``,
+# ``--node-linker``, ``-C/--dir <dir>``, ``--cwd <path>``, ``-F/--filter
+# <pattern>``, ``--user/global-config``). These spellings are value-taking (or
+# simply unused, hence harmless) in every manager.
+#
+# ``--legacy-peer-deps`` is deliberately EXCLUDED: npm types it ``Boolean``, so
+# it must consume nothing.
+_SHARED_VALUE_TAKING_FLAGS: frozenset[str] = frozenset(
+    {
+        "--registry",
+        "--prefix",
+        "-C",
+        "--before",
+        "--userconfig",
+        "--globalconfig",
+        "--cwd",
+        "--store-dir",
+        "--config",
+        "--cache",
+        "--cafile",
+        "--ca",
+        "--cert",
+        "--key",
+        "--node-linker",
+        "--loglevel",
+        "--filter",
+        "--dir",
+        "--save-prefix",
+        "--tag",
+        "--audit-level",
+        "--install-strategy",
+        "--scope",
+        "--otp",
+        "--https-proxy",
+        "--proxy",
+        "--maxsockets",
+        "--fetch-retries",
+        "--fetch-timeout",
+    }
+)
+
+# npm-ONLY value-taking flags. These consume a value under npm but are NOT
+# value-taking under pnpm/yarn/bun, so applying them there would skip a real
+# package.
+#
+# - ``-w`` / ``--workspace``: npm ``Type: String`` (a workspace name/path),
+#   so npm consumes the next token. pnpm spells ``-w`` as the BOOLEAN
+#   ``--workspace-root`` and uses ``--filter`` (shared) for selection; yarn's
+#   ``workspace`` is a SUBCOMMAND, not a ``-w`` flag, and yarn/bun ``add`` take
+#   no value-taking ``-w``/``--workspace``. So for pnpm/yarn/bun these stay
+#   boolean and the package after them is collected.
+# - ``--omit`` / ``--include``: npm enum flags (``Type:`` omit/include enum),
+#   value-taking under npm. pnpm/yarn/bun do not define them; leaving them out
+#   for those managers keeps an unrelated bare ``--omit foo pkg`` from eating
+#   ``foo`` there. (npm uses these to select dependency groups.)
+_NPM_ONLY_VALUE_TAKING_FLAGS: frozenset[str] = frozenset(
+    {
+        "--workspace",
+        "-w",
+        "--omit",
+        "--include",
+    }
+)
+
+# Redirection tokens that are never package specs.
+_REDIRECTION_TOKENS: frozenset[str] = frozenset({">", ">>", "<"})
+
+
+# ---------------------------------------------------------------------------
+# Finding type
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class TyposquatFinding:
+    """A single flagged install: a likely typosquat and the name it resembles.
+
+    ``package`` is the normalized (lowercased, version-stripped) candidate as
+    written by the agent; ``suggestion`` is the popular package it is one edit
+    away from. ``reason`` is a human-readable line suitable for a permission
+    prompt.
+    """
+
+    package: str
+    suggestion: str
+
+    @property
+    def reason(self) -> str:
+        """Human-readable explanation suitable for a permission prompt."""
+        return (
+            f"`{self.package}` is one edit away from the "
+            f"popular package `{self.suggestion}`"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Encoding-evasion normalization
+#
+# Self-contained and property-based: instead of a hand-maintained table of
+# invisible code points, classify each character by its Unicode general
+# category and a handful of default-ignorable ranges the category check alone
+# misses, then NFKC-fold so fullwidth ``ｎｐｍ`` becomes ASCII ``npm``. This runs
+# at the public entry so both the parser entry and the analyzer (which calls it)
+# are protected from ``lod<ZWSP>ahs`` and U+0085/U+2028/U+2029 line-splitting
+# evasions. Combining marks (Mn) are intentionally NOT stripped; homoglyph
+# folding is out of scope.
+# ---------------------------------------------------------------------------
+
+# Whitespace that must survive normalization: tabs and the line separators the
+# tree-sitter-bash view needs as command boundaries, plus the normal space.
+_KEEP_WHITESPACE: frozenset[str] = frozenset({"\t", "\n", "\r", " "})
+
+# General categories whose code points are stripped: format (Cf), control (Cc),
+# unassigned (Cn), and the line/paragraph separators (Zl, Zp) -- the latter two
+# are what make U+2028/U+2029 split a package name when left in.
+_STRIP_CATEGORIES: frozenset[str] = frozenset({"Cf", "Cc", "Cn", "Zl", "Zp"})
+
+
+def _is_default_ignorable_extra(code_point: int) -> bool:
+    """Report default-ignorable code points the category check alone misses.
+
+    Variation selectors (U+FE00..U+FE0F, U+E0100..U+E01EF), Mongolian free
+    variation selectors (U+180B..U+180E), and the tag block (U+E0000..U+E007F)
+    are assigned non-format categories yet are invisible joiners an attacker can
+    splice into a name, so they are stripped explicitly.
+    """
+    return (
+        0xFE00 <= code_point <= 0xFE0F
+        or 0xE0100 <= code_point <= 0xE01EF
+        or 0x180B <= code_point <= 0x180E
+        or 0xE0000 <= code_point <= 0xE007F
+    )
+
+
+def _normalize(command: str) -> str:
+    """Strip invisible/zero-width characters then NFKC-fold ``command``.
+
+    Per character: keep tab/newline/carriage-return/space verbatim; drop any
+    code point whose Unicode general category is one of ``Cf``/``Cc``/``Cn``/
+    ``Zl``/``Zp`` (this removes zero-width spaces, bidi controls, soft hyphens,
+    BOM, U+0085/U+2028/U+2029 and unassigned code points) or that falls in a
+    default-ignorable range the category check misses (variation selectors,
+    Mongolian FVS, tag characters); keep everything else. Then apply NFKC so
+    fullwidth/compatibility glyphs collapse to their ASCII form. General
+    combining marks are deliberately preserved (homoglyphs are out of scope).
+    """
+    stripped = [
+        ch
+        for ch in command
+        if ch in _KEEP_WHITESPACE
+        or (
+            unicodedata.category(ch) not in _STRIP_CATEGORIES
+            and not _is_default_ignorable_extra(ord(ch))
+        )
+    ]
+    return unicodedata.normalize("NFKC", "".join(stripped))
+
+
+# ---------------------------------------------------------------------------
+# Line-continuation joining
+#
+# bash joins an unquoted backslash-newline into nothing before tokenizing, so
+# ``loa\<newline>dsh`` is the single word ``loadsh``. tree-sitter-bash does not
+# fold this -- it leaves ``loa`` and ``dsh`` as two adjacent words -- so the
+# obfuscated package would slip through. We remove the backslash-newline at the
+# source level before parsing, exactly the way the shell does. Whether a
+# backslash-newline is removed depends on the surrounding quoting context, so we
+# track the full bash state with three flags rather than single-quote alone:
+#
+# - in a single-quoted ``'...'`` span the backslash-newline is LITERAL and kept
+#   (``'loa\<newline>dsh'`` stays the literal ``loa\<newline>dsh``);
+# - in a double-quoted ``"..."`` span bash DOES remove the backslash-newline
+#   (``"loa\<newline>dsh"`` is ``loadsh``), so we join it;
+# - in a ``#`` comment the rest of the physical line is discarded by the shell,
+#   so a backslash-newline there is not a continuation and we keep the text
+#   verbatim (the comment is dropped later by the tree-sitter view anyway).
+#
+# Tracking only single quotes (the old behavior) desynced on an apostrophe
+# inside a double-quoted arg (``"a'b"``) or inside a ``# don't`` comment: the
+# stray ``'`` toggled the single-quote flag, so a following real
+# backslash-newline continuation hiding a typosquat was wrongly treated as
+# inside single quotes and left unjoined (false negative). Modeling all three
+# contexts fixes that while preserving the single-quote literal case. We
+# deliberately do NOT model ANSI-C ``$'...'`` or here-doc bodies here: a
+# ``\<newline>`` inside ``$'...'`` is an escaped newline either way (it does not
+# change the package name shape), and a here-doc body is not an operand we
+# collect from.
+# ---------------------------------------------------------------------------
+
+
+def _join_line_continuations(command: str) -> str:
+    """Remove unquoted ``backslash-newline`` line continuations, as bash does.
+
+    Walks ``command`` once, modeling bash's lexical state with three flags --
+    ``in_single_quote``, ``in_double_quote`` and ``in_comment`` -- because
+    whether a backslash-newline is a continuation depends on that context:
+
+    - outside all quotes, an unescaped ``'`` opens a single-quoted span and an
+      unescaped ``"`` opens a double-quoted span; a ``'`` while in a double-quote
+      and a ``"`` while in a single-quote are literal (they do not toggle);
+    - a ``#`` that begins a word (start of input or after whitespace, and not
+      inside any quote) starts a comment that runs to the next newline;
+    - a backslash-newline (optionally a preceding carriage return for CRLF) is
+      collapsed ONLY when not in a single-quote and not in a comment -- bash
+      removes it outside quotes AND inside double quotes, but keeps it literal
+      inside single quotes and ignores it inside a comment.
+
+    Everything else is preserved verbatim, so command boundaries (bare newlines),
+    quoted text and comment text are untouched.
+    """
+    if "\\" not in command:
+        return command
+    out: list[str] = []
+    i = 0
+    n = len(command)
+    in_single_quote = False
+    in_double_quote = False
+    in_comment = False
+    while i < n:
+        ch = command[i]
+
+        # A bare newline ends a comment and resets the line context.
+        if ch == "\n":
+            in_comment = False
+            out.append(ch)
+            i += 1
+            continue
+
+        if in_comment:
+            # Inside a comment everything is verbatim until the newline above; a
+            # backslash-newline here is not a continuation (bash discards the
+            # rest of the physical line).
+            out.append(ch)
+            i += 1
+            continue
+
+        # Quote toggling: a quote char only opens/closes when not inside the
+        # OTHER kind of quote (a ' in "..." and a " in '...' are literal).
+        if ch == "'" and not in_double_quote:
+            in_single_quote = not in_single_quote
+            out.append(ch)
+            i += 1
+            continue
+        if ch == '"' and not in_single_quote:
+            in_double_quote = not in_double_quote
+            out.append(ch)
+            i += 1
+            continue
+
+        # A ``#`` that begins a word, outside all quotes, starts a comment.
+        if (
+            ch == "#"
+            and not in_single_quote
+            and not in_double_quote
+            and (i == 0 or command[i - 1] in " \t\n")
+        ):
+            in_comment = True
+            out.append(ch)
+            i += 1
+            continue
+
+        # Line continuation: collapse a backslash-newline unless we are inside a
+        # single-quote (literal) -- comments are handled above. bash removes it
+        # outside quotes and inside double quotes alike.
+        if ch == "\\" and not in_single_quote and i + 1 < n:
+            nxt = command[i + 1]
+            if nxt == "\n":
+                i += 2
+                continue
+            if nxt == "\r" and i + 2 < n and command[i + 2] == "\n":
+                i += 3
+                continue
+
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def find_typosquat_installs(command: str) -> list[TyposquatFinding]:
+    """Return one finding per distinct likely-typosquat package in ``command``.
+
+    Normalizes ``command`` first (stripping invisible/zero-width characters and
+    NFKC-folding fullwidth glyphs) so an attacker cannot hide ``lodahs`` as
+    ``lod<ZWSP>ahs`` or split a name with U+0085/U+2028/U+2029, then parses it
+    once with the shared tree-sitter-bash view, walks every ``command`` node
+    (which surfaces sub-commands across ``&&``, ``||``, ``;``, ``|``, ``&``,
+    newline, subshells and ``$(...)``), collects the packages each
+    install/runner would fetch, and keeps those exactly one edit away from a
+    popular name. Returns an empty list for anything that is not such an install
+    (e.g. ``npm run build``, ``git status``, an empty string). De-duplicates by
+    normalized package name, preserving first-seen order. Parse uncertainty
+    (``has_error``) is tolerated: tree-sitter recovers and still surfaces the
+    operands.
+
+    Known limitation (never a crash, always fail-open to "no finding"):
+    pathologically nested or chained input -- hundreds of ``$(...)`` levels
+    (``x$($($(...)))``) or hundreds of chained operators
+    (``ls && ls && ... && ls``) -- builds a parse tree so deep that the
+    recursive tree-sitter-bash walkers in the shared ``_shell_ast`` view exhaust
+    the Python recursion stack. Such input is NOT analyzed: it is treated as
+    "no finding" (returns ``[]``) and never raises. An absurdly large command
+    (beyond :data:`_MAX_COMMAND_LENGTH`, far above any legitimate install line)
+    is short-circuited to ``[]`` for the same reason, and a ``RecursionError``
+    from the parse/walk is caught and turned into ``[]`` as a defensive backstop,
+    so nothing escapes this seam. This is a deliberate, documented boundary: not
+    analyzing adversarially-nested noise is acceptable; a crash in the security
+    seam is not.
+    """
+    # Generous early guard: an absurdly large command cannot be a real install
+    # line and only risks blowing the recursive walkers, so skip it as "no
+    # finding". The cap is set far above any legitimate command, so it never
+    # drops a real long install (see _MAX_COMMAND_LENGTH).
+    if len(command) > _MAX_COMMAND_LENGTH:
+        logger.debug(
+            "Supply-chain check skipped: command length %d exceeds %d; "
+            "treating as no finding.",
+            len(command),
+            _MAX_COMMAND_LENGTH,
+        )
+        return []
+
+    findings: list[TyposquatFinding] = []
+    seen: set[str] = set()
+    try:
+        program = parse_shell_program(_join_line_continuations(_normalize(command)))
+        for cmd in iter_commands(program):
+            for pkg in _collect_packages_from_command(cmd):
+                name = _normalize_package_name(pkg)
+                suggestion = _find_typosquat_target(name)
+                if suggestion is None or name in seen:
+                    continue
+                seen.add(name)
+                findings.append(TyposquatFinding(package=name, suggestion=suggestion))
+    except RecursionError:
+        # Pathologically nested/chained input (hundreds of $() levels or chained
+        # operators) builds a parse tree so deep the recursive walkers in the
+        # shared _shell_ast view exhaust the stack. Fail open to "no finding":
+        # such adversarial noise is not analyzed, but it never crashes the seam.
+        logger.debug(
+            "Supply-chain check skipped: command is too deeply nested/chained to "
+            "parse without exhausting the recursion stack; treating as no finding."
+        )
+        return []
+    return findings
+
+
+# ---------------------------------------------------------------------------
+# Per-command package collection (AST-driven)
+# ---------------------------------------------------------------------------
+
+
+def _collect_packages_from_command(cmd: ShellCommand) -> list[str]:
+    """Dispatch a single parsed command and collect its install/runner targets.
+
+    The tree-sitter view excludes redirects, comments and leading
+    ``VAR=val`` assignments from ``cmd.words`` already, so this only has to:
+    peel wrapper commands (``sudo``/``env``/...), recover static operand
+    values from possibly-quoted words, then route on the binary basename.
+    Returns the package specs this command would install or execute via a
+    recognized npm-ecosystem manager, or an empty list otherwise.
+    """
+    base = command_basename(cmd)
+    if base is None:
+        # The AST flags the command name opaque for two different reasons: a
+        # genuine runtime expansion (``$CMD``, ``$(...)``) that is unknowable,
+        # or static obfuscation (``n"p"m``, ``\\npm``, ``$'npm'``) that a real
+        # shell collapses to a fixed binary name before exec. Try the same
+        # bounded literal decode used for operands; a runtime element keeps it
+        # opaque (returns None) and the command stays LOW as before.
+        base = _decode_command_name(cmd)
+        if base is None:
+            return []
+
+    words = list(cmd.words)
+    base, words = _peel_wrappers(base, words)
+    if base is None:
+        return []
+
+    # Flatten each word into the argv token(s) the shell would pass. A normal
+    # word yields one token; an unknowable word yields a single sentinel that
+    # occupies the slot but can never be a flag, redirection, subcommand keyword
+    # or package spec; a static comma-brace word (``lo{a,}dsh``) yields one token
+    # per expansion (``loadsh``, ``lodsh``), exactly as bash expands it before
+    # exec. This keeps the install/runner routing functions operating on a plain
+    # ``list[str]`` while preserving positional semantics (an opaque runner
+    # target still stops collection with no target).
+    recovered: list[str] = []
+    for word in words:
+        recovered.extend(_recover_word_tokens(word))
+
+    if base in _RUNNERS:
+        # Standalone runners are npm/bun flavored. The npm-only value flags
+        # (``-w``/``--omit``/``--include``) do not affect a runner target (the
+        # first positional), but pass the matching manager so value-flag skipping
+        # matches each runner's CLI exactly.
+        runner_manager = "bun" if base in ("bunx", "bunx.cmd") else "npm"
+        return _collect_runner_target(recovered, runner_manager)
+
+    if base in _PACKAGE_MANAGERS:
+        manager = "npm" if base == "npm.cmd" else base
+        return _collect_manager_packages(manager, recovered)
+
+    return []
+
+
+def _decode_command_name(cmd: ShellCommand) -> str | None:
+    """Statically decode an obfuscated command-name word to its POSIX basename.
+
+    The shared AST marks a command name opaque whenever it is not a single bare
+    ``word``: that covers both runtime expansions (``$CMD``, ``$(echo npm)``)
+    and pure static obfuscation (``n"p"m``, ``\\npm``, ``$'npm'``,
+    ``/usr/''bin/npm``) that the shell collapses to a fixed binary before exec.
+    This applies the same bounded literal decode used for operands
+    (:func:`_decode_shell_literal`: quote removal, backslash unescape, ANSI-C,
+    concatenation) to the command-name word, then strips the POSIX path prefix
+    so ``/usr/bin/npm`` becomes ``npm``.
+
+    Returns the decoded basename, or ``None`` when the name is unknowable: a
+    missing name, a runtime element anywhere inside it, or a decoded value that
+    does not match the strict package-spec shape (so an embedded space or
+    leftover metacharacter stays opaque and the command stays LOW).
+    """
+    name = cmd.name
+    if name is None:
+        return None
+    # The command_name node wraps exactly one named child (word / string /
+    # concatenation / ansi_c_string / simple_expansion ...). Decode that child;
+    # fall back to the command_name node itself if the shape is unexpected.
+    inner = name.node.named_children
+    target = inner[0] if len(inner) == 1 else name.node
+    decoded = _decode_shell_literal(target)
+    if decoded is None:
+        return None
+    # Strip the POSIX path prefix first (``/usr/bin/npm`` -> ``npm``) so a
+    # path-qualified obfuscated manager is recognized, then re-admit the bare
+    # basename only if it matches the strict package-spec shape -- this keeps an
+    # embedded space or leftover metacharacter opaque (LOW).
+    basename = _strip_path_prefix(decoded)
+    if not _PACKAGE_SPEC_RE.match(basename):
+        return None
+    return basename
+
+
+# Placeholder for an opaque word in the recovered argv. A single null byte can
+# never start with "-", is in no flag/keyword/redirection set, and fails
+# ``_is_package_spec`` -- so it is positionally present but never collected.
+_OPAQUE_SENTINEL = "\x00"
+
+
+def _peel_wrappers(
+    base: str, words: list[ShellWord]
+) -> tuple[str | None, list[ShellWord]]:
+    """Strip wrapper binaries (``sudo``/``env``/...) and re-derive the binary.
+
+    The AST does not unwrap ``sudo npm ...`` or ``env FOO=bar npm ...``: the
+    command name is ``sudo``/``env`` and the real binary is the first operand.
+    While the basename is a wrapper, drop it, then drop any leading ``-`` flags
+    and ``KEY=VALUE`` env-assignment-shaped words, and promote the first
+    remaining plain word to the new binary (POSIX basename, one quote pair
+    stripped). Returns ``(None, [])`` if no real binary follows the wrapper.
+    """
+    while base in _WRAPPER_COMMANDS:
+        i = 0
+        n = len(words)
+        while i < n and (
+            words[i].text.startswith("-")
+            or _is_env_assignment(_strip_one_quote_pair(words[i].text))
+        ):
+            i += 1
+        if i >= n:
+            return None, []
+        binary_word = words[i]
+        binary_value = _recover_word(binary_word)
+        if binary_value is None:
+            # Opaque binary after the wrapper -- unknowable.
+            return None, []
+        base = _strip_path_prefix(binary_value)
+        words = words[i + 1 :]
+    return base, words
+
+
+def _recover_word(word: ShellWord) -> str | None:
+    """Recover the static string value of a word, or ``None`` if unknowable.
+
+    A non-opaque word is its own text. An opaque word may still be a single,
+    statically-known package operand that was obfuscated with interior quoting
+    or backslash escaping -- ``lo""adsh``, ``load"sh"``, ``lo'adsh'``,
+    ``lo\\adsh``, ``l"o"a"d"s"h"`` all resolve to the one argv token ``loadsh``
+    in a real shell. :func:`_decode_shell_literal` walks the tree-sitter view of
+    that one word and concatenates the adjacent quoted/escaped/bare segments
+    into the literal string the shell would pass, returning ``None`` the moment
+    it meets a runtime element (command substitution, variable expansion,
+    backticks, process/arithmetic substitution).
+
+    To stay a *bounded operand-name* decode and never widen what counts as a
+    package, the decoded value is re-admitted only if it matches the strict
+    package-spec shape :data:`_PACKAGE_SPEC_RE` (optional ``@scope/``, an
+    ``@version`` suffix, no whitespace, no leftover metacharacters). So
+    ``"lodahs"`` and ``lo""adsh`` are recovered, while ``"$(...)"``, ``$CMD``,
+    a glob, or ``"a b"`` (embedded space) decode to ``None`` and are treated as
+    unknown, not benign.
+    """
+    if not word.opaque:
+        return word.text
+    decoded = _decode_shell_literal(word.node)
+    if decoded is not None and _PACKAGE_SPEC_RE.match(decoded):
+        return decoded
+    return None
+
+
+def _recover_word_tokens(word: ShellWord) -> list[str]:
+    """Recover the argv token(s) a single word would pass to the binary.
+
+    Most words map to exactly one token: a known static value when
+    :func:`_recover_word` can recover it, or the single :data:`_OPAQUE_SENTINEL`
+    when it cannot (a runtime expansion, an embedded space, a leftover
+    metacharacter -- unknowable, so it occupies the slot but is never collected).
+
+    The one word that maps to *several* tokens is a static comma-brace word like
+    ``lo{a,}dsh``: bash expands it to ``loadsh`` and ``lodsh`` (two argv tokens)
+    before exec, so a typosquat hidden behind a brace alternative would otherwise
+    slip through as an opaque concatenation. :func:`_expand_static_braces`
+    performs that bounded expansion (comma lists only; ranges, nesting, quotes
+    and any runtime element are out of scope and keep the word opaque), and each
+    resulting token is re-admitted only if it matches the strict package-spec
+    shape -- so ``lo{a,}d sh`` (space) or ``lo{a,}{bc}dsh`` (leftover ``{``)
+    contribute nothing. When brace expansion does not apply, this falls back to
+    the single-token recovery, so existing behavior is unchanged.
+    """
+    expansions = _expand_static_braces(word)
+    if expansions is not None:
+        return [exp for exp in expansions if _PACKAGE_SPEC_RE.match(exp)] or [
+            _OPAQUE_SENTINEL
+        ]
+    value = _recover_word(word)
+    return [value if value is not None else _OPAQUE_SENTINEL]
+
+
+# ---------------------------------------------------------------------------
+# Bounded static comma-brace expansion
+#
+# bash performs brace expansion textually BEFORE other expansions, so
+# ``lo{a,}dsh`` becomes the two argv words ``loadsh`` and ``lodsh``.
+# tree-sitter parses such a word as a ``concatenation`` of bare ``word``
+# segments (``lo`` ``{`` ``a,`` ``}`` ``dsh``) and marks it opaque, so without
+# this step a typosquat hidden behind a brace alternative is never checked.
+#
+# This is a DELIBERATELY NARROW decode. It applies ONLY when the word is a
+# ``concatenation`` whose every child is a bare ``word`` -- which structurally
+# guarantees there is no quote (``string``/``raw_string``), no runtime element
+# (``simple_expansion``/``command_substitution``/...) and no range
+# (``brace_expression`` for ``{1..3}``) anywhere in the word. On that pure-static
+# text it expands top-level comma lists with a hard cap on total expansions and
+# on brace-group count. Everything else stays opaque (LOW):
+#
+# - ranges ``{1..3}`` and nested braces ``a{b,{c,d}}`` -> bail (return ``None``);
+# - a brace touching a quote or a variable (``lo{a,}d"s"h``, ``lo{a,$X}dsh``) ->
+#   the concatenation has a non-``word`` child, so the pure-word gate excludes it;
+# - escaped braces ``lo\{a,\}dsh`` -> a single ``word`` node, never a brace here;
+# - a comma-less group ``{abc}`` -> bash leaves it literal, so do we (the literal
+#   brace then fails the package-spec guard and is dropped).
+# ---------------------------------------------------------------------------
+
+# Hard caps so a crafted word cannot blow up the expansion (``{a,b}`` repeated):
+# total expanded tokens and number of expanding brace groups are both bounded.
+_MAX_BRACE_EXPANSIONS = 32
+_MAX_BRACE_GROUPS = 8
+
+# Characters allowed in a pure static comma-brace word. Anything else (a
+# backslash, whitespace, a shell metacharacter) means the word is not a clean
+# static brace operand, so expansion bails and the word stays opaque. Package
+# specs use ascii letters/digits and ``. _ - / @``; braces add ``{ } ,``.
+_BRACE_WORD_CHARS: frozenset[str] = frozenset(
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/@{},"
+)
+
+
+def _is_pure_brace_word(word: ShellWord) -> bool:
+    """Report whether ``word`` is a ``concatenation`` of only bare ``word`` nodes.
+
+    That structure is the gate for static brace expansion: it guarantees the
+    word carries no quote, no runtime expansion and no range ``brace_expression``
+    -- only literal text and brace/comma punctuation -- so the joined text can be
+    expanded purely textually the way bash does.
+    """
+    node = word.node
+    if node.type != "concatenation":
+        return False
+    children = node.named_children
+    if not children:
+        return False
+    return all(child.type == "word" for child in children)
+
+
+def _expand_static_braces(word: ShellWord) -> list[str] | None:
+    """Expand a static comma-brace word into its argv tokens, or ``None``.
+
+    Returns ``None`` (meaning "not a clean static comma-brace; leave it to the
+    single-token recovery, which keeps it opaque") when the word is not a pure
+    bare-``word`` concatenation, contains a character outside
+    :data:`_BRACE_WORD_CHARS`, has no actually-expanding brace group, or hits a
+    range/nesting/unbalanced/cap condition. Otherwise returns the full list of
+    expansions (the cartesian product across every top-level comma group),
+    exactly as bash would produce them. The caller validates each token against
+    the package-spec shape.
+    """
+    if not _is_pure_brace_word(word):
+        return None
+    text = word.text
+    if "{" not in text:
+        return None
+    if any(ch not in _BRACE_WORD_CHARS for ch in text):
+        return None
+
+    # segments: (is_literal, value) where value is a literal str or a list of
+    # alternatives for an expanding brace group.
+    segments: list[tuple[bool, str | list[str]]] = []
+    i = 0
+    n = len(text)
+    groups = 0
+    while i < n:
+        ch = text[i]
+        if ch == "}":
+            return None  # unbalanced close brace
+        if ch != "{":
+            j = i
+            while j < n and text[j] not in "{}":
+                j += 1
+            segments.append((True, text[i:j]))
+            i = j
+            continue
+        # Find the matching close brace; bail on nesting (depth > 1).
+        depth = 0
+        j = i
+        comma_at_top = False
+        while j < n:
+            c = text[j]
+            if c == "{":
+                depth += 1
+                if depth > 1:
+                    return None  # nested brace -> out of scope
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    break
+            elif c == "," and depth == 1:
+                comma_at_top = True
+            j += 1
+        if j >= n or depth != 0:
+            return None  # unbalanced open brace
+        inner = text[i + 1 : j]
+        if ".." in inner:
+            return None  # numeric/char range -> out of scope
+        if not comma_at_top:
+            # bash leaves a comma-less ``{abc}`` literal; the leftover brace then
+            # fails the package-spec guard, so it is dropped, never collected.
+            segments.append((True, text[i : j + 1]))
+            i = j + 1
+            continue
+        groups += 1
+        if groups > _MAX_BRACE_GROUPS:
+            return None
+        segments.append((False, inner.split(",")))
+        i = j + 1
+
+    if groups == 0:
+        return None  # no expanding group -> not a brace operand we handle
+
+    results = [""]
+    for is_literal, value in segments:
+        if is_literal:
+            assert isinstance(value, str)
+            results = [r + value for r in results]
+            continue
+        assert isinstance(value, list)
+        expanded: list[str] = []
+        for prefix in results:
+            for alt in value:
+                expanded.append(prefix + alt)
+                if len(expanded) > _MAX_BRACE_EXPANSIONS:
+                    return None  # cap exceeded -> bail rather than blow up
+        results = expanded
+    return results
+
+
+# Strict npm package-spec shape, case-insensitive. Optional ``@scope/`` prefix,
+# a single path segment, and an optional ``@version`` suffix (which may contain
+# any non-space characters, e.g. a tag, range or git url). A decoded operand is
+# only re-admitted as a package name if it matches this -- this is the
+# false-positive guard that keeps embedded spaces, leftover globs, and runtime
+# expansions out, no matter how the segments were quoted.
+_PACKAGE_SPEC_RE: re.Pattern[str] = re.compile(
+    r"^@?[a-z0-9][a-z0-9._-]*(/[a-z0-9][a-z0-9._-]*)?(@[^\s]+)?$",
+    re.IGNORECASE,
+)
+
+# Tree-sitter node types that introduce a value only known at runtime. If any of
+# these appears anywhere inside an operand word, the word is opaque and is never
+# decoded into a package name.
+_RUNTIME_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "simple_expansion",
+        "expansion",
+        "command_substitution",
+        "process_substitution",
+        "arithmetic_expansion",
+    }
+)
+
+
+def _decode_shell_literal(node: Node) -> str | None:
+    """Reconstruct the literal argv token for a single operand word.
+
+    Walks the tree-sitter view of one word and concatenates the value of each
+    adjacent segment exactly as the shell would join them into one argument:
+
+    - ``concatenation`` -- decode and join every child segment;
+    - ``string`` (double-quoted) -- the joined ``string_content`` with
+      double-quote backslash unescaping; any non-content child (an expansion or
+      substitution inside the quotes) makes it opaque;
+    - ``raw_string`` (single-quoted) -- the verbatim inner text (no expansion,
+      no unescaping);
+    - ``ansi_c_string`` (``$'...'``) -- the inner text with the common ANSI-C
+      escapes (``\\n``/``\\t``/``\\xHH``/octal/``\\uHHHH`` ...) resolved;
+    - ``word`` -- the bare text with POSIX unquoted backslash unescaping;
+    - any runtime node (``$...``, ``$(...)``, backticks, ``<(...)``) -- opaque.
+
+    Returns the decoded literal, or ``None`` if any segment is opaque. The
+    caller is responsible for validating the result against the strict
+    package-spec shape; this function only reconstructs, it does not judge.
+    """
+    node_type = node.type
+
+    if node_type in _RUNTIME_NODE_TYPES:
+        return None
+
+    if node_type == "word":
+        return _unescape_unquoted(_node_text(node))
+
+    if node_type == "raw_string":
+        text = _node_text(node)
+        # Strip the surrounding single quotes; content is fully literal.
+        return text[1:-1] if len(text) >= 2 else ""
+
+    if node_type == "ansi_c_string":
+        return _decode_ansi_c_string(_node_text(node))
+
+    if node_type == "string":
+        return _decode_double_quoted(node)
+
+    if node_type == "concatenation":
+        parts: list[str] = []
+        for child in node.named_children:
+            decoded = _decode_shell_literal(child)
+            if decoded is None:
+                return None
+            parts.append(decoded)
+        return "".join(parts)
+
+    # Any other node type (string_content handled inline below, numbers, etc.)
+    # is unexpected in operand position -- treat as opaque to stay safe.
+    return None
+
+
+def _decode_double_quoted(node: Node) -> str | None:
+    """Decode a double-quoted ``string`` node to its literal content.
+
+    Returns ``None`` if the quotes contain any expansion or substitution
+    (a non ``string_content`` child). An empty ``""`` decodes to the empty
+    string. Backslash escapes are resolved per double-quote rules.
+    """
+    parts: list[str] = []
+    for child in node.named_children:
+        if child.type != "string_content":
+            return None
+        parts.append(_unescape_double_quoted(_node_text(child)))
+    return "".join(parts)
+
+
+def _node_text(node: Node) -> str:
+    """Return a tree-sitter node's source text, ``""`` for an empty node.
+
+    ``Node.text`` is typed ``bytes | None`` (None only for a zero-width node),
+    so this collapses that to a decoded ``str`` and keeps the decoder total.
+    """
+    raw = node.text
+    return raw.decode() if raw is not None else ""
+
+
+def _unescape_unquoted(text: str) -> str:
+    """Resolve POSIX unquoted backslash escapes: ``\\x`` -> ``x``.
+
+    Outside quotes a backslash quotes the single following character (so
+    ``lo\\adsh`` -> ``loadsh``, ``l\\o\\a\\d\\s\\h`` -> ``loadsh``). A trailing
+    backslash with no following character is dropped.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n:
+            out.append(text[i + 1])
+            i += 2
+            continue
+        if ch == "\\":
+            i += 1
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+# Inside double quotes a backslash is literal UNLESS it precedes one of these.
+_DQ_ESCAPABLE: frozenset[str] = frozenset({"$", "`", '"', "\\", "\n"})
+
+
+def _unescape_double_quoted(text: str) -> str:
+    """Resolve double-quote backslash escapes in ``string_content``.
+
+    Inside ``"..."`` a backslash only escapes ``$``, `````, ``"``, ``\\`` and a
+    newline; before anything else the backslash is a literal character. This
+    keeps ``lo\\nadsh`` as the literal ``lo\\nadsh`` (not a newline) while still
+    folding an escaped quote.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(text)
+    while i < n:
+        ch = text[i]
+        if ch == "\\" and i + 1 < n and text[i + 1] in _DQ_ESCAPABLE:
+            out.append(text[i + 1])
+            i += 2
+            continue
+        out.append(ch)
+        i += 1
+    return "".join(out)
+
+
+# Single-character ANSI-C escapes (``$'...'``) that map to one literal char.
+# Only the common, package-name-relevant set is resolved; anything else falls
+# through to the literal-backslash branch in :func:`_decode_ansi_c_string`.
+_ANSI_C_SIMPLE_ESCAPES: dict[str, str] = {
+    "n": "\n",
+    "t": "\t",
+    "r": "\r",
+    "\\": "\\",
+    "'": "'",
+    '"': '"',
+    "a": "\a",
+    "b": "\b",
+    "f": "\f",
+    "v": "\v",
+    "e": "\x1b",
+    "E": "\x1b",
+}
+
+
+def _decode_ansi_c_string(text: str) -> str | None:
+    """Decode an ANSI-C ``$'...'`` quoted string to its literal value.
+
+    ``text`` is the full node text including the ``$'`` prefix and closing
+    ``'``. Resolves the common escapes a real bash applies inside ``$'...'``:
+    ``\\n \\t \\r \\\\ \\' \\"`` and the rarer control escapes, ``\\xHH`` (1-2
+    hex digits), ``\\0NN``/``\\NNN`` (octal), and ``\\uHHHH``/``\\UHHHHHHHH``
+    (Unicode). An unrecognised ``\\x`` keeps the backslash literal, matching
+    bash. A trailing lone backslash is kept literal. Returns the decoded string;
+    the caller validates it against the strict package-spec shape, so a control
+    character or space simply fails that guard and stays opaque.
+    """
+    if len(text) < 3 or not text.startswith("$'") or not text.endswith("'"):
+        # Not the expected $'...' shape; let the spec guard reject it.
+        return text
+    inner = text[2:-1]
+    out: list[str] = []
+    i = 0
+    n = len(inner)
+    while i < n:
+        ch = inner[i]
+        if ch != "\\" or i + 1 >= n:
+            out.append(ch)
+            i += 1
+            continue
+        nxt = inner[i + 1]
+        if nxt in _ANSI_C_SIMPLE_ESCAPES:
+            out.append(_ANSI_C_SIMPLE_ESCAPES[nxt])
+            i += 2
+            continue
+        if nxt == "x":
+            decoded, consumed = _read_radix_escape(inner, i + 2, 16, 2)
+            if consumed:
+                out.append(decoded)
+                i += 2 + consumed
+                continue
+            # `\x` with no hex digit: literal backslash, per bash.
+            out.append("\\")
+            i += 1
+            continue
+        if nxt in ("u", "U"):
+            width = 4 if nxt == "u" else 8
+            decoded, consumed = _read_radix_escape(inner, i + 2, 16, width)
+            if consumed:
+                out.append(decoded)
+                i += 2 + consumed
+                continue
+            out.append("\\")
+            i += 1
+            continue
+        if "0" <= nxt <= "7":
+            # `\NNN` and `\0NN`: up to three octal digits after the backslash.
+            decoded, consumed = _read_radix_escape(inner, i + 1, 8, 3)
+            out.append(decoded)
+            i += 1 + consumed
+            continue
+        # Unknown escape: keep the backslash literal (matches bash).
+        out.append("\\")
+        i += 1
+    return "".join(out)
+
+
+def _read_radix_escape(
+    text: str, start: int, radix: int, max_digits: int
+) -> tuple[str, int]:
+    """Read up to ``max_digits`` base-``radix`` digits and return ``(char, n)``.
+
+    Returns the decoded single character and how many digits were consumed.
+    ``("", 0)`` means no valid digit was present. A code point that is not a
+    valid Unicode scalar (e.g. a surrogate) yields the empty string but still
+    reports the digits consumed, so the escape is dropped rather than left as a
+    raw backslash; the package-spec guard rejects the result regardless.
+    """
+    digits = "0123456789abcdef"[:radix]
+    j = start
+    end = min(len(text), start + max_digits)
+    while j < end and text[j].lower() in digits:
+        j += 1
+    consumed = j - start
+    if consumed == 0:
+        return "", 0
+    code_point = int(text[start:j], radix)
+    try:
+        return chr(code_point), consumed
+    except (ValueError, OverflowError):
+        return "", consumed
+
+
+def _strip_one_quote_pair(text: str) -> str:
+    """Strip one matched pair of surrounding single or double quotes."""
+    if len(text) >= 2:
+        first, last = text[0], text[-1]
+        if (first == "'" and last == "'") or (first == '"' and last == '"'):
+            return text[1:-1]
+    return text
+
+
+def _is_env_assignment(token: str) -> bool:
+    """Report whether ``token`` is a ``KEY=VALUE`` assignment.
+
+    The key must be a valid shell identifier: a leading letter or underscore
+    followed by letters, digits, or underscores.
+    """
+    eq = token.find("=")
+    if eq <= 0:
+        return False
+    key = token[:eq]
+    for j, c in enumerate(key):
+        is_alpha = c == "_" or ("A" <= c <= "Z") or ("a" <= c <= "z")
+        is_digit = "0" <= c <= "9"
+        if j == 0 and not is_alpha:
+            return False
+        if j > 0 and not is_alpha and not is_digit:
+            return False
+    return True
+
+
+def _strip_path_prefix(token: str) -> str:
+    """Strip a POSIX path prefix on a binary name: ``/usr/bin/npm`` -> ``npm``.
+
+    Splits on ``/`` only, matching ``command_basename`` (``posixpath.basename``)
+    so the wrapper-peel binary and the direct-dispatch binary derive their name
+    under one POSIX rule. Backslash path separators are out of scope: the targets
+    are POSIX shells, and treating ``\\`` as a separator would mis-handle an
+    operand whose name legitimately contained a backslash.
+    """
+    idx = token.rfind("/")
+    return token[idx + 1 :] if idx >= 0 else token
+
+
+# ---------------------------------------------------------------------------
+# Manager dispatch
+# ---------------------------------------------------------------------------
+
+
+# Transparent prefix subcommands per manager: a routing token that is NOT itself
+# an install/runner action but wraps one on the remaining args. ``yarn global
+# add expres`` / ``yarn global remove pkg`` run ``add``/``remove`` in the global
+# scope: ``global`` is a known yarn subcommand, so the scan stops on it, yet the
+# real action (``add``) lives behind it. We advance past the wrapper and
+# re-resolve the real subcommand on the remainder, so ``add``/``remove`` route
+# correctly (``yarn global add expres`` -> express HIGH; ``yarn global remove
+# lodash`` -> not an install sub -> LOW). Only yarn has this form; npm/pnpm/bun
+# install globally with a ``-g``/``--global`` flag (boolean, already handled),
+# not a wrapping subcommand. A small recursion bound stops a pathological
+# ``yarn global global global ...`` from looping.
+_TRANSPARENT_PREFIX_SUBCOMMANDS: dict[str, frozenset[str]] = {
+    "yarn": frozenset({"global"}),
+}
+
+# Max nested transparent-prefix unwraps. One real prefix (``global``) is enough
+# in practice; the bound just stops a crafted ``yarn global global ... add`` from
+# recursing without limit.
+_MAX_PREFIX_UNWRAP: int = 8
+
+
+def _collect_manager_packages(manager: str, args: list[str]) -> list[str]:
+    """Find the subcommand, then collect install packages or the runner target.
+
+    Skips leading global options before the subcommand. Returns an empty list
+    for non-install/non-runner subcommands (e.g. ``npm run build``). Transparent
+    prefix subcommands (yarn ``global``) are unwrapped so the real action behind
+    them (``add``/``remove``) routes.
+    """
+    install_subs = _INSTALL_SUBCOMMANDS.get(manager, frozenset())
+    runner_subs = _RUNNER_SUBCOMMANDS.get(manager, frozenset())
+    known_subs = _KNOWN_SUBCOMMANDS.get(manager, frozenset())
+    prefix_subs = _TRANSPARENT_PREFIX_SUBCOMMANDS.get(manager, frozenset())
+
+    # Unwrap any transparent prefix wrapper (yarn ``global``) before deciding the
+    # action, so ``yarn global add expres`` routes through ``add``.
+    for _ in range(_MAX_PREFIX_UNWRAP):
+        sub_index = _find_subcommand_index(args, known_subs, manager)
+        if sub_index == -1:
+            return []
+        subcommand = args[sub_index]
+        if subcommand in prefix_subs:
+            args = args[sub_index + 1 :]
+            continue
+        break
+    else:
+        # Exhausted the unwrap budget on nested prefixes; treat as unresolvable.
+        return []
+
+    rest = args[sub_index + 1 :]
+
+    if subcommand in install_subs:
+        return _collect_install_packages(rest, manager)
+    if subcommand in runner_subs:
+        return _collect_runner_target(rest, manager)
+    return []
+
+
+def _consumes_next_value(token: str, manager: str) -> bool:
+    """Report whether ``token`` consumes the following token as its value.
+
+    The single value-consuming rule shared by subcommand skipping, install
+    collection, and runner collection: a bare flag (no ``=``) consumes its next
+    token only when it is a known value-taking flag for ``manager``. A
+    ``--flag=value`` is self-contained, and every other flag (including any
+    unknown long flag) is boolean and consumes nothing -- matching how the
+    npm/yarn/pnpm/bun CLIs actually parse.
+
+    Value-consumption is manager-aware: the shared
+    :data:`_SHARED_VALUE_TAKING_FLAGS` apply to every manager, while
+    :data:`_NPM_ONLY_VALUE_TAKING_FLAGS` (``-w``/``--workspace``/``--omit``/
+    ``--include``) apply ONLY to npm. Under pnpm/yarn/bun, ``-w`` is the boolean
+    ``--workspace-root`` (pnpm) or simply unused (yarn/bun), so it must consume
+    nothing or the package after it is skipped (``pnpm add -w expres``).
+    """
+    if "=" in token:
+        return False
+    if token in _SHARED_VALUE_TAKING_FLAGS:
+        return True
+    return manager == "npm" and token in _NPM_ONLY_VALUE_TAKING_FLAGS
+
+
+def _find_subcommand_index(
+    args: list[str], known_subcommands: frozenset[str], manager: str
+) -> int:
+    """Return the index of the subcommand, skipping leading global options.
+
+    Applies the shared :func:`_consumes_next_value` rule (manager-aware): a
+    known value-taking flag for ``manager`` written bare consumes the following
+    token, every other flag is boolean.
+
+    Robustness backstop: after the value-flag skip, the first non-option token is
+    accepted as the subcommand only when it is one of ``known_subcommands`` (the
+    real subcommand keywords for this manager). If it is NOT -- which happens when
+    an UNKNOWN bare value flag we did not enumerate leaked its value into this
+    position (``npm --someunknownvalflag X install pkg`` lands on ``X``) -- the
+    token is skipped and the scan continues, so the install behind it is still
+    reached. A token that genuinely is not a subcommand (e.g. a stray operand
+    before any subcommand) is simply skipped too; if no known subcommand is ever
+    found, returns -1 and the command stays LOW. Because the known value-taking
+    flags consume their own value first, a flag value that happens to equal a
+    subcommand keyword (``npm --tag install install pkg``: ``--tag`` eats the
+    first ``install``) is handled correctly and the real ``install`` routes.
+    """
+    i = 0
+    n = len(args)
+    while i < n:
+        token = args[i]
+        if token.startswith("-"):
+            if _consumes_next_value(token, manager) and i + 1 < n:
+                i += 2
+            else:
+                i += 1
+            continue
+        if token in known_subcommands:
+            return i
+        # Not a real subcommand keyword: a leaked value from an unknown bare
+        # value flag (or a stray operand). Skip it and keep scanning so an
+        # install hidden behind it is not lost.
+        i += 1
+    return -1
+
+
+def _collect_install_packages(args: list[str], manager: str) -> list[str]:
+    """Collect package specs after an install subcommand.
+
+    Applies the shared :func:`_consumes_next_value` rule (manager-aware): a
+    known value-taking flag for ``manager`` written bare also skips its value
+    token; every other flag is boolean. So ``pnpm add -w expres`` collects
+    ``expres`` (pnpm ``-w`` is boolean), while ``npm install -w pkg loadsh``
+    skips the npm ``-w`` value ``pkg`` and collects ``loadsh``. Redirection
+    tokens are skipped too. An unknown long flag swallows no value, so
+    ``--unknownflag axio lodash`` collects both ``axio`` and ``lodash``.
+    """
+    packages: list[str] = []
+    i = 0
+    n = len(args)
+    while i < n:
+        token = args[i]
+
+        if token in _REDIRECTION_TOKENS:
+            i += 1
+            continue
+
+        if token.startswith("-"):
+            if _consumes_next_value(token, manager):
+                i += 1
+            i += 1
+            continue
+
+        if _is_package_spec(token):
+            packages.append(token)
+        i += 1
+
+    return packages
+
+
+def _collect_runner_target(args: list[str], manager: str) -> list[str]:
+    """Return the single executed package for a runner invocation.
+
+    Honors ``-p``/``--package`` and ``--package=NAME``/``-p=NAME``, whose value
+    is the package to execute. Otherwise it applies the shared
+    :func:`_consumes_next_value` rule (manager-aware) to skip known value-taking
+    flags and treats every other flag as boolean, then returns the FIRST
+    positional token as the executed package -- the typosquat target. Trailing
+    positionals are arguments to that program, never install targets
+    (``npx create-react-app my-app`` -> ``create-react-app``; an unknown long
+    flag swallows no value, so ``npx --some-flag value lodahs`` yields ``value``).
+    """
+    i = 0
+    n = len(args)
+    while i < n:
+        token = args[i]
+
+        if token.startswith("--package="):
+            return [token[len("--package=") :]]
+        if token.startswith("-p="):
+            return [token[len("-p=") :]]
+        if token in ("-p", "--package"):
+            if i + 1 < n:
+                return [args[i + 1]]
+            return []
+
+        if token in _REDIRECTION_TOKENS:
+            i += 1
+            continue
+
+        if token.startswith("-"):
+            if _consumes_next_value(token, manager):
+                i += 1
+            i += 1
+            continue
+
+        if _is_package_spec(token):
+            return [token]
+        return []
+
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Package-name handling
+# ---------------------------------------------------------------------------
+
+
+def _is_package_spec(token: str) -> bool:
+    """Report whether ``token`` can be a package spec.
+
+    True when the first character is ascii-alphanumeric or ``_``, or when it
+    is a scoped name starting ``@`` that contains ``/``.
+    """
+    if not token:
+        return False
+    first = token[0]
+    if first == "_" or first.isascii() and first.isalnum():
+        return True
+    if first == "@" and "/" in token:
+        return True
+    return False
+
+
+def _normalize_package_name(spec: str) -> str:
+    """Strip a trailing ``@version`` while keeping the scope; lowercase.
+
+    ``@scope/pkg@1.2.3`` -> ``@scope/pkg``; ``lodash@4`` -> ``lodash``;
+    ``@scope/pkg`` -> ``@scope/pkg``.
+    """
+    name = spec
+    if name.startswith("@"):
+        slash = name.find("/")
+        if slash != -1:
+            at = name.find("@", slash)
+            if at != -1:
+                name = name[:at]
+    else:
+        at = name.find("@")
+        if at > 0:
+            name = name[:at]
+    return name.lower()
+
+
+# ---------------------------------------------------------------------------
+# Typosquat decision
+# ---------------------------------------------------------------------------
+
+# Real, mainstream npm packages that legitimately sit one OSA edit from a
+# popular name and would otherwise be flagged as a typosquat of it. The OSA-1
+# heuristic cannot tell ``preact`` (a real 80M+/month React-compatible library)
+# from ``loadsh`` (a non-existent name one edit off ``lodash``); both are
+# distance 1 from a popular package. This is a precision-only allowlist: a name
+# here is suppressed because it is itself a genuine, established package, not a
+# fat-finger of one. It can ONLY ever suppress its own exact spelling, so it can
+# never let an actual typosquat through -- every entry was confirmed to exist on
+# the npm registry as a real, non-malicious package with its own repository.
+#
+# Entries are kept SHORT and each is justified (npm last-month downloads / repo
+# verified on the public registry at the time of writing):
+#
+# - ``preact``    -- distance 1 from ``react``; ~86M downloads/month,
+#                    github.com/preactjs/preact (Fast 3kb React-compatible VDOM).
+# - ``prettierx`` -- distance 1 from ``prettier``; a real named fork of Prettier,
+#                    github.com/brodybits/prettierx, published to npm.
+# - ``moments``   -- distance 1 from ``moment``; a real package by egoist,
+#                    github.com/egoist/moments, published to npm.
+#
+# Add a name here ONLY after confirming it is an established, real package on the
+# registry; never add a name that does not exist (that would be allowlisting a
+# typosquat). Names already in :data:`POPULAR_PACKAGES` need no entry -- they are
+# suppressed by the ``candidate in _POPULAR_SET`` check below.
+_KNOWN_LEGIT: frozenset[str] = frozenset(
+    {
+        "preact",
+        "prettierx",
+        "moments",
+    }
+)
+
+
+def _find_typosquat_target(candidate: str) -> str | None:
+    """Return the popular package ``candidate`` typosquats, or ``None``.
+
+    Flagged iff ``candidate`` is NOT itself popular, NOT in the curated
+    :data:`_KNOWN_LEGIT` allowlist of real packages that happen to sit one edit
+    from a popular name, AND its minimum Optimal-String-Alignment distance to
+    some popular name is exactly 1 AND that popular name is longer than four
+    characters (short names produce too many false positives). The allowlist is
+    precision-only: it suppresses only its own exact, registry-confirmed names,
+    so it never lets a genuine typosquat through.
+    """
+    if candidate in _POPULAR_SET or candidate in _KNOWN_LEGIT:
+        return None
+    for popular in POPULAR_PACKAGES:
+        if len(popular) <= 4:
+            continue
+        if _osa_distance_within(candidate, popular, 1) == 1:
+            return popular
+    return None
+
+
+def _osa_distance_within(a: str, b: str, max_distance: int) -> int:
+    """Optimal String Alignment distance, capped at ``max_distance + 1``.
+
+    OSA (restricted Damerau-Levenshtein) counts insertion, deletion,
+    substitution, and transposition of two ADJACENT characters, with the
+    restriction that no substring is edited more than once. The cap lets the
+    caller exit early: any returned value greater than ``max_distance`` means
+    "farther than max". A two-row rolling buffer keeps memory at O(len(b)).
+    """
+    la, lb = len(a), len(b)
+    if abs(la - lb) > max_distance:
+        return max_distance + 1
+
+    prev_prev = [0] * (lb + 1)
+    prev = list(range(lb + 1))
+    curr = [0] * (lb + 1)
+
+    for i in range(1, la + 1):
+        curr[0] = i
+        row_min = curr[0]
+        ai = a[i - 1]
+        for j in range(1, lb + 1):
+            cost = 0 if ai == b[j - 1] else 1
+            best = prev[j] + 1  # deletion
+            ins = curr[j - 1] + 1  # insertion
+            if ins < best:
+                best = ins
+            sub = prev[j - 1] + cost  # substitution
+            if sub < best:
+                best = sub
+            if i > 1 and j > 1 and ai == b[j - 2] and a[i - 2] == b[j - 1]:
+                trans = prev_prev[j - 2] + 1
+                if trans < best:
+                    best = trans
+            curr[j] = best
+            if best < row_min:
+                row_min = best
+        if row_min > max_distance:
+            return max_distance + 1
+        prev_prev, prev, curr = prev, curr, prev_prev
+
+    if prev[lb] > max_distance:
+        return max_distance + 1
+    return prev[lb]

--- a/openhands-sdk/openhands/sdk/security/supply_chain/parser.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/parser.py
@@ -14,8 +14,9 @@ tree-sitter-bash command view (``openhands.sdk.security._shell_ast``) rather tha
 a hand-rolled char scanner, so command chaining, pipes, path-qualified managers
 and subshells parse structurally. The entry point
 :func:`find_typosquat_installs` returns one finding per distinct flagged
-package; the caller decides what to do (the analyzer raises the risk to
-``HIGH`` so a human is asked, never a hard deny).
+package. If an unresolved parser state or resource limit prevents a complete
+analysis, it raises :class:`SupplyChainAnalysisIncompleteError` instead of
+returning a benign-looking empty result.
 
 Hardening:
 
@@ -77,12 +78,12 @@ before exec) and what it leaves opaque is an explicit, honest boundary:
 from __future__ import annotations
 
 import re
+import shlex
 import unicodedata
 from dataclasses import dataclass
 
 from tree_sitter import Node
 
-from openhands.sdk.logger import get_logger
 from openhands.sdk.security._shell_ast import (
     ShellCommand,
     ShellWord,
@@ -92,18 +93,14 @@ from openhands.sdk.security._shell_ast import (
 )
 
 
-logger = get_logger(__name__)
-
 # Generous upper bound on the command length we will parse. The recursive
 # tree-sitter-bash walkers in the shared ``_shell_ast`` view (and the operand
 # decoders here) descend per nested ``$()`` level or chained operator, so a
 # pathologically nested/chained command (hundreds of ``$()`` levels or
 # operators) can exhaust the Python recursion stack. A real install command is
 # at most a few hundred bytes; this cap is set far above any legitimate command
-# (a chained build line, a long scoped-package install) so it never drops a real
-# command, only an absurd one whose only purpose is to blow the stack. Even
-# above the cap, :func:`find_typosquat_installs` would still not crash (the
-# RecursionError below is caught), but skipping the parse avoids the wasted work.
+# (a chained build line, a long scoped-package install). Inputs above the cap
+# are reported as incomplete rather than parsed or treated as benign.
 _MAX_COMMAND_LENGTH = 100_000
 
 
@@ -203,6 +200,71 @@ _WRAPPER_COMMANDS: frozenset[str] = frozenset(
         "xargs",
     }
 )
+
+_WRAPPER_VALUE_TAKING_OPTIONS: dict[str, frozenset[str]] = {
+    "sudo": frozenset(
+        {
+            "-C",
+            "-D",
+            "-g",
+            "-h",
+            "-p",
+            "-R",
+            "-r",
+            "-T",
+            "-t",
+            "-U",
+            "-u",
+            "--chdir",
+            "--chroot",
+            "--close-from",
+            "--command-timeout",
+            "--group",
+            "--host",
+            "--other-user",
+            "--prompt",
+            "--role",
+            "--type",
+            "--user",
+        }
+    ),
+    "doas": frozenset({"-a", "-C", "-u"}),
+    "env": frozenset({"-a", "-C", "-u", "--argv0", "--chdir", "--unset"}),
+    "time": frozenset({"-f", "-o", "--format", "--output"}),
+    "nice": frozenset({"-n", "--adjustment"}),
+    "nohup": frozenset(),
+    "stdbuf": frozenset({"-e", "-i", "-o", "--error", "--input", "--output"}),
+    "command": frozenset(),
+    "xargs": frozenset(
+        {
+            "-a",
+            "-d",
+            "-E",
+            "-I",
+            "-J",
+            "-L",
+            "-n",
+            "-P",
+            "-R",
+            "-S",
+            "-s",
+            "--arg-file",
+            "--delimiter",
+            "--eof",
+            "--max-args",
+            "--max-chars",
+            "--max-lines",
+            "--max-procs",
+            "--process-slot-var",
+            "--replace",
+        }
+    ),
+}
+
+_ENV_SPLIT_OPTIONS: frozenset[str] = frozenset({"-S", "--split-string"})
+_WRAPPERS_ACCEPTING_ASSIGNMENTS: frozenset[str] = frozenset({"env", "sudo"})
+_MAX_WRAPPER_DEPTH = 64
+_MAX_ENV_SPLIT_EXPANSIONS = 64
 
 # Package managers that install dependencies.
 _PACKAGE_MANAGERS: frozenset[str] = frozenset({"npm", "npm.cmd", "yarn", "pnpm", "bun"})
@@ -582,8 +644,12 @@ _REDIRECTION_TOKENS: frozenset[str] = frozenset({">", ">>", "<"})
 
 
 # ---------------------------------------------------------------------------
-# Finding type
+# Result and error types
 # ---------------------------------------------------------------------------
+
+
+class SupplyChainAnalysisIncompleteError(RuntimeError):
+    """Raised when the parser cannot complete a reliable command analysis."""
 
 
 @dataclass(frozen=True)
@@ -812,55 +878,50 @@ def find_typosquat_installs(command: str) -> list[TyposquatFinding]:
     (``has_error``) is tolerated: tree-sitter recovers and still surfaces the
     operands.
 
-    Known limitation (never a crash, always fail-open to "no finding"):
-    pathologically nested or chained input -- hundreds of ``$(...)`` levels
-    (``x$($($(...)))``) or hundreds of chained operators
-    (``ls && ls && ... && ls``) -- builds a parse tree so deep that the
-    recursive tree-sitter-bash walkers in the shared ``_shell_ast`` view exhaust
-    the Python recursion stack. Such input is NOT analyzed: it is treated as
-    "no finding" (returns ``[]``) and never raises. An absurdly large command
-    (beyond :data:`_MAX_COMMAND_LENGTH`, far above any legitimate install line)
-    is short-circuited to ``[]`` for the same reason, and a ``RecursionError``
-    from the parse/walk is caught and turned into ``[]`` as a defensive backstop,
-    so nothing escapes this seam. This is a deliberate, documented boundary: not
-    analyzing adversarially-nested noise is acceptable; a crash in the security
-    seam is not.
+    Raises :class:`SupplyChainAnalysisIncompleteError` when an unresolved parser
+    state or resource limit prevents complete analysis. Callers must not mistake
+    those cases for a benign empty finding list.
     """
-    # Generous early guard: an absurdly large command cannot be a real install
-    # line and only risks blowing the recursive walkers, so skip it as "no
-    # finding". The cap is set far above any legitimate command, so it never
-    # drops a real long install (see _MAX_COMMAND_LENGTH).
     if len(command) > _MAX_COMMAND_LENGTH:
-        logger.debug(
-            "Supply-chain check skipped: command length %d exceeds %d; "
-            "treating as no finding.",
-            len(command),
-            _MAX_COMMAND_LENGTH,
+        raise SupplyChainAnalysisIncompleteError(
+            f"command length {len(command)} exceeds analysis limit "
+            f"{_MAX_COMMAND_LENGTH}"
         )
-        return []
+
+    normalized_command = _join_line_continuations(_normalize(command))
+    if len(normalized_command) > _MAX_COMMAND_LENGTH:
+        raise SupplyChainAnalysisIncompleteError(
+            f"normalized command length {len(normalized_command)} exceeds "
+            f"analysis limit {_MAX_COMMAND_LENGTH}"
+        )
 
     findings: list[TyposquatFinding] = []
     seen: set[str] = set()
+    incomplete_error: SupplyChainAnalysisIncompleteError | None = None
     try:
-        program = parse_shell_program(_join_line_continuations(_normalize(command)))
+        program = parse_shell_program(normalized_command)
         for cmd in iter_commands(program):
-            for pkg in _collect_packages_from_command(cmd):
+            try:
+                packages = _collect_packages_from_command(cmd)
+            except SupplyChainAnalysisIncompleteError as exc:
+                incomplete_error = incomplete_error or exc
+                continue
+
+            for pkg in packages:
                 name = _normalize_package_name(pkg)
                 suggestion = _find_typosquat_target(name)
                 if suggestion is None or name in seen:
                     continue
                 seen.add(name)
                 findings.append(TyposquatFinding(package=name, suggestion=suggestion))
-    except RecursionError:
-        # Pathologically nested/chained input (hundreds of $() levels or chained
-        # operators) builds a parse tree so deep the recursive walkers in the
-        # shared _shell_ast view exhaust the stack. Fail open to "no finding":
-        # such adversarial noise is not analyzed, but it never crashes the seam.
-        logger.debug(
-            "Supply-chain check skipped: command is too deeply nested/chained to "
-            "parse without exhausting the recursion stack; treating as no finding."
-        )
-        return []
+    except RecursionError as exc:
+        if findings:
+            return findings
+        raise SupplyChainAnalysisIncompleteError(
+            "command is too deeply nested or chained for complete analysis"
+        ) from exc
+    if incomplete_error is not None and not findings:
+        raise incomplete_error
     return findings
 
 
@@ -892,21 +953,9 @@ def _collect_packages_from_command(cmd: ShellCommand) -> list[str]:
             return []
 
     words = list(cmd.words)
-    base, words = _peel_wrappers(base, words)
+    base, recovered = _peel_wrappers(base, words)
     if base is None:
         return []
-
-    # Flatten each word into the argv token(s) the shell would pass. A normal
-    # word yields one token; an unknowable word yields a single sentinel that
-    # occupies the slot but can never be a flag, redirection, subcommand keyword
-    # or package spec; a static comma-brace word (``lo{a,}dsh``) yields one token
-    # per expansion (``loadsh``, ``lodsh``), exactly as bash expands it before
-    # exec. This keeps the install/runner routing functions operating on a plain
-    # ``list[str]`` while preserving positional semantics (an opaque runner
-    # target still stops collection with no target).
-    recovered: list[str] = []
-    for word in words:
-        recovered.extend(_recover_word_tokens(word))
 
     if base in _RUNNERS:
         # Standalone runners are npm/bun flavored. The npm-only value flags
@@ -967,36 +1016,151 @@ def _decode_command_name(cmd: ShellCommand) -> str | None:
 _OPAQUE_SENTINEL = "\x00"
 
 
-def _peel_wrappers(
-    base: str, words: list[ShellWord]
-) -> tuple[str | None, list[ShellWord]]:
-    """Strip wrapper binaries (``sudo``/``env``/...) and re-derive the binary.
+_WrapperArg = ShellWord | str
 
-    The AST does not unwrap ``sudo npm ...`` or ``env FOO=bar npm ...``: the
-    command name is ``sudo``/``env`` and the real binary is the first operand.
-    While the basename is a wrapper, drop it, then drop any leading ``-`` flags
-    and ``KEY=VALUE`` env-assignment-shaped words, and promote the first
-    remaining plain word to the new binary (POSIX basename, one quote pair
-    stripped). Returns ``(None, [])`` if no real binary follows the wrapper.
-    """
-    while base in _WRAPPER_COMMANDS:
+
+def _peel_wrappers(base: str, words: list[ShellWord]) -> tuple[str | None, list[str]]:
+    """Strip wrapper binaries and recover the remaining command argv."""
+    args: list[_WrapperArg] = list(words)
+    env_split_expansions = 0
+
+    for _ in range(_MAX_WRAPPER_DEPTH):
+        if base not in _WRAPPER_COMMANDS:
+            recovered: list[str] = []
+            for arg in args:
+                if isinstance(arg, str):
+                    recovered.append(arg)
+                else:
+                    recovered.extend(_recover_word_tokens(arg))
+            return base, recovered
+
         i = 0
-        n = len(words)
-        while i < n and (
-            words[i].text.startswith("-")
-            or _is_env_assignment(_strip_one_quote_pair(words[i].text))
+        while i < len(args):
+            token = _static_wrapper_arg(args[i])
+            if token is None:
+                raise SupplyChainAnalysisIncompleteError(
+                    f"cannot resolve an argument to the {base} wrapper"
+                )
+
+            if token == "--":
+                i += 1
+                break
+
+            split_value, consumed = _env_split_value(base, token, args, i)
+            if split_value is not None:
+                env_split_expansions += 1
+                if env_split_expansions > _MAX_ENV_SPLIT_EXPANSIONS:
+                    raise SupplyChainAnalysisIncompleteError(
+                        "env split-string expansion limit exceeded"
+                    )
+                args[i : i + consumed] = _split_env_string(split_value)
+                continue
+
+            if token.startswith("-") and token != "-":
+                i += 1
+                if _wrapper_option_consumes_next(base, token):
+                    if i >= len(args):
+                        return None, []
+                    i += 1
+                continue
+
+            if base in _WRAPPERS_ACCEPTING_ASSIGNMENTS and _is_env_assignment(token):
+                i += 1
+                continue
+            break
+
+        if i >= len(args):
+            return None, []
+
+        binary_value = _static_wrapper_arg(args[i])
+        binary_basename = (
+            _strip_path_prefix(binary_value) if binary_value is not None else None
+        )
+        if binary_basename is None or not _PACKAGE_SPEC_RE.match(binary_basename):
+            raise SupplyChainAnalysisIncompleteError(
+                f"cannot resolve the command executed by the {base} wrapper"
+            )
+        base = binary_basename
+        args = args[i + 1 :]
+
+    raise SupplyChainAnalysisIncompleteError("wrapper nesting limit exceeded")
+
+
+def _static_wrapper_arg(arg: _WrapperArg) -> str | None:
+    """Return a wrapper argument's static shell value, if knowable."""
+    if isinstance(arg, str):
+        return arg
+    if not arg.opaque:
+        return arg.text
+    return _decode_shell_literal(arg.node)
+
+
+def _wrapper_option_consumes_next(wrapper: str, token: str) -> bool:
+    """Return whether a bare wrapper option consumes the following argv item."""
+    value_options = _WRAPPER_VALUE_TAKING_OPTIONS[wrapper]
+    if token.startswith("--"):
+        return "=" not in token and token in value_options
+
+    for offset, option_char in enumerate(token[1:], start=1):
+        if f"-{option_char}" in value_options:
+            return offset == len(token) - 1
+    return False
+
+
+def _env_split_value(
+    wrapper: str, token: str, args: list[_WrapperArg], index: int
+) -> tuple[str | None, int]:
+    """Extract an env split-string option value and its consumed argv count."""
+    if wrapper != "env":
+        return None, 0
+
+    if token in _ENV_SPLIT_OPTIONS:
+        if index + 1 >= len(args):
+            raise SupplyChainAnalysisIncompleteError("env split-string has no value")
+        value = _static_wrapper_arg(args[index + 1])
+        if value is None:
+            raise SupplyChainAnalysisIncompleteError(
+                "env split-string contains runtime expansion"
+            )
+        return value, 2
+
+    if token.startswith("--split-string="):
+        return token.partition("=")[2], 1
+
+    if token.startswith("-") and not token.startswith("--"):
+        short_options = token[1:]
+        split_index = short_options.find("S")
+        if split_index != -1 and all(
+            option in "0iv" for option in short_options[:split_index]
         ):
-            i += 1
-        if i >= n:
-            return None, []
-        binary_word = words[i]
-        binary_value = _recover_word(binary_word)
-        if binary_value is None:
-            # Opaque binary after the wrapper -- unknowable.
-            return None, []
-        base = _strip_path_prefix(binary_value)
-        words = words[i + 1 :]
-    return base, words
+            attached_value = short_options[split_index + 1 :]
+            if attached_value:
+                return attached_value, 1
+            if index + 1 >= len(args):
+                raise SupplyChainAnalysisIncompleteError(
+                    "env split-string has no value"
+                )
+            value = _static_wrapper_arg(args[index + 1])
+            if value is None:
+                raise SupplyChainAnalysisIncompleteError(
+                    "env split-string contains runtime expansion"
+                )
+            return value, 2
+    return None, 0
+
+
+def _split_env_string(value: str) -> list[str]:
+    """Split a statically known env ``-S`` operand into argv tokens."""
+    if any(char in value for char in ("#", "$", "\\")):
+        raise SupplyChainAnalysisIncompleteError(
+            "env split-string uses unsupported dynamic or escape syntax"
+        )
+    try:
+        return shlex.split(value, comments=False, posix=True)
+    except ValueError as exc:
+        raise SupplyChainAnalysisIncompleteError(
+            "env split-string has invalid quoting"
+        ) from exc
 
 
 def _recover_word(word: ShellWord) -> str | None:
@@ -1733,12 +1897,16 @@ def _is_package_spec(token: str) -> bool:
 
 
 def _normalize_package_name(spec: str) -> str:
-    """Strip a trailing ``@version`` while keeping the scope; lowercase.
+    """Resolve an npm alias, strip a trailing version, and lowercase.
 
     ``@scope/pkg@1.2.3`` -> ``@scope/pkg``; ``lodash@4`` -> ``lodash``;
-    ``@scope/pkg`` -> ``@scope/pkg``.
+    ``alias@npm:lodash@4`` -> ``lodash``.
     """
     name = spec
+    alias_separator = name.find("@", 1)
+    if alias_separator != -1 and name.lower().startswith("@npm:", alias_separator):
+        name = name[alias_separator + len("@npm:") :]
+
     if name.startswith("@"):
         slash = name.find("/")
         if slash != -1:

--- a/openhands-sdk/openhands/sdk/security/supply_chain/parser.py
+++ b/openhands-sdk/openhands/sdk/security/supply_chain/parser.py
@@ -50,14 +50,19 @@ before exec) and what it leaves opaque is an explicit, honest boundary:
   backslash unescaping (``lo\\adsh``), interior-quote concatenation
   (``lo""adsh``), ANSI-C ``$'...'`` escapes, line-continuation joining
   (``loa\\<newline>dsh``), and the static comma-brace expansion above.
-- OUT OF SCOPE (stays LOW, never decoded): any runtime expansion -- shell
+- OUT OF SCOPE (stays LOW, never decoded): package-manager operands containing
+  runtime expansion -- shell
   variables (``$PKG``), command/process substitution (``$(...)``, ```...```,
   ``<(...)``) and arithmetic substitution (``$((...))``); homoglyphs and other
   Unicode confusables (only invisible/zero-width characters and fullwidth NFKC
-  folds are normalized, not look-alike letters); and an install nested inside an
-  inner command string such as ``bash -c '...'`` (treated as one opaque
-  argument). This module flags the typosquats it can prove statically; it does
-  not claim to catch every obfuscation.
+  folds are normalized, not look-alike letters); and npm runner call strings
+  such as ``npx -c '...'``. The runner cases are pinned as strict xfails while
+  their CLI-specific argv semantics remain out of scope. Ordinary string data
+  such as ``echo 'npm install lodahs'`` is inert and LOW.
+- INCOMPLETE (the analyzer returns ``SecurityRisk.UNKNOWN``): an executable
+  command string selected by a recognized POSIX-style shell invocation (for
+  example, ``bash -c '...'``). Recursive command-string parsing remains out of
+  scope, but the executable payload is not misclassified as benign.
 
 - dispatch on the package-manager binary POSIX basename (path prefix stripped
   by the AST, ``/usr/bin/npm`` -> ``npm``);
@@ -192,6 +197,7 @@ _WRAPPER_COMMANDS: frozenset[str] = frozenset(
         "sudo",
         "doas",
         "env",
+        "exec",
         "time",
         "nice",
         "nohup",
@@ -230,6 +236,7 @@ _WRAPPER_VALUE_TAKING_OPTIONS: dict[str, frozenset[str]] = {
     ),
     "doas": frozenset({"-a", "-C", "-u"}),
     "env": frozenset({"-a", "-C", "-u", "--argv0", "--chdir", "--unset"}),
+    "exec": frozenset({"-a"}),
     "time": frozenset({"-f", "-o", "--format", "--output"}),
     "nice": frozenset({"-n", "--adjustment"}),
     "nohup": frozenset(),
@@ -272,6 +279,51 @@ _PACKAGE_MANAGERS: frozenset[str] = frozenset({"npm", "npm.cmd", "yarn", "pnpm",
 # Standalone package runners (npx-like) where the executed package is the
 # target.
 _RUNNERS: frozenset[str] = frozenset({"npx", "npx.cmd", "bunx", "bunx.cmd"})
+_RUNNER_CALL_OPTIONS: frozenset[str] = frozenset({"-c", "--call"})
+
+# POSIX-style shells whose ``-c`` invocation option executes a command string.
+# Shells with materially different invocation grammars (fish, csh/tcsh,
+# PowerShell) are intentionally excluded rather than guessed at.
+_COMMAND_STRING_SHELLS: frozenset[str] = frozenset(
+    {
+        "ash",
+        "bash",
+        "dash",
+        "ksh",
+        "ksh93",
+        "mksh",
+        "rbash",
+        "rksh",
+        "rzsh",
+        "sh",
+        "zsh",
+    }
+)
+
+_COMMON_SHELL_VALUE_OPTIONS: frozenset[str] = frozenset({"-o", "+o"})
+_BASH_VALUE_OPTIONS = _COMMON_SHELL_VALUE_OPTIONS | frozenset(
+    {"-O", "+O", "--init-file", "--rcfile"}
+)
+_KSH_VALUE_OPTIONS = _COMMON_SHELL_VALUE_OPTIONS | frozenset({"-R", "-T"})
+_SHELL_VALUE_OPTIONS: dict[str, frozenset[str]] = {
+    "ash": _COMMON_SHELL_VALUE_OPTIONS,
+    "bash": _BASH_VALUE_OPTIONS,
+    "dash": _COMMON_SHELL_VALUE_OPTIONS,
+    "ksh": _KSH_VALUE_OPTIONS,
+    "ksh93": _KSH_VALUE_OPTIONS,
+    "mksh": _COMMON_SHELL_VALUE_OPTIONS | frozenset({"-T"}),
+    "rbash": _BASH_VALUE_OPTIONS,
+    "rksh": _KSH_VALUE_OPTIONS,
+    "rzsh": _COMMON_SHELL_VALUE_OPTIONS,
+    "sh": _COMMON_SHELL_VALUE_OPTIONS,
+    "zsh": _COMMON_SHELL_VALUE_OPTIONS,
+}
+
+# ``sh`` is an implementation-selected shell name. Options outside the POSIX
+# invocation grammar have implementation-specific arity, so their presence is
+# incomplete rather than guessed from whichever shell provides ``sh`` locally.
+_POSIX_SH_INVOCATION_FLAGS: frozenset[str] = frozenset("abCefhimnuvxcs")
+_SHELL_CLUSTER_FLAGS: frozenset[str] = frozenset("abCDefhiklmnrstuvxcBDHPORT")
 
 # Install subcommands per manager that collect package args.
 _INSTALL_SUBCOMMANDS: dict[str, frozenset[str]] = {
@@ -630,12 +682,17 @@ _SHARED_VALUE_TAKING_FLAGS: frozenset[str] = frozenset(
 #   value-taking under npm. pnpm/yarn/bun do not define them; leaving them out
 #   for those managers keeps an unrelated bare ``--omit foo pkg`` from eating
 #   ``foo`` there. (npm uses these to select dependency groups.)
+# - ``--script-shell`` / legacy npx ``--shell`` / ``--node-options``: npm/npx
+#   string configuration values that must not be promoted to runner targets.
 _NPM_ONLY_VALUE_TAKING_FLAGS: frozenset[str] = frozenset(
     {
         "--workspace",
         "-w",
         "--omit",
         "--include",
+        "--script-shell",
+        "--shell",
+        "--node-options",
     }
 )
 
@@ -930,6 +987,9 @@ def find_typosquat_installs(command: str) -> list[TyposquatFinding]:
 # ---------------------------------------------------------------------------
 
 
+_WrapperArg = ShellWord | str
+
+
 def _collect_packages_from_command(cmd: ShellCommand) -> list[str]:
     """Dispatch a single parsed command and collect its install/runner targets.
 
@@ -953,9 +1013,16 @@ def _collect_packages_from_command(cmd: ShellCommand) -> list[str]:
             return []
 
     words = list(cmd.words)
-    base, recovered = _peel_wrappers(base, words)
+    base, args = _peel_wrappers(base, words)
     if base is None:
         return []
+
+    if _has_unresolved_shell_command_string(base, args):
+        raise SupplyChainAnalysisIncompleteError(
+            f"{base} may execute a command string that was not recursively analyzed"
+        )
+
+    recovered = _recover_command_args(args)
 
     if base in _RUNNERS:
         # Standalone runners are npm/bun flavored. The npm-only value flags
@@ -970,6 +1037,100 @@ def _collect_packages_from_command(cmd: ShellCommand) -> list[str]:
         return _collect_manager_packages(manager, recovered)
 
     return []
+
+
+def _has_unresolved_shell_command_string(base: str, args: list[_WrapperArg]) -> bool:
+    """Return whether ``base`` may execute an unanalysed command string.
+
+    POSIX-style shells continue parsing invocation options until the first
+    operand, even when ``c`` appeared in an earlier short-option cluster. A
+    leading ``--`` ends option parsing, while one after ``-c`` ends the options
+    and leaves the following operand as the command string. Only the presence
+    of an effective payload is classified here; its contents remain opaque and
+    therefore make the overall supply-chain analysis incomplete. An opaque
+    invocation argument before the operand boundary is incomplete as well,
+    because its runtime value can select ``-c`` or terminate option parsing.
+    """
+    if base not in _COMMAND_STRING_SHELLS:
+        return False
+
+    value_options = _SHELL_VALUE_OPTIONS[base]
+    command_string_mode = False
+    noexec = False
+    i = 0
+    while i < len(args):
+        token = _static_wrapper_arg(args[i])
+        if token is None:
+            return True
+
+        if token == "--" or token == "-":
+            i += 1
+            break
+
+        if token.startswith("--"):
+            if base == "sh":
+                return True
+            i += 1
+            if token in value_options:
+                i += 1
+            continue
+
+        if token.startswith(("-", "+")) and token not in {"-", "+"}:
+            option_prefix = token[0]
+            flags = token[1:]
+            if base == "sh" and any(
+                flag not in _POSIX_SH_INVOCATION_FLAGS and flag != "o" for flag in flags
+            ):
+                return True
+            command_string_mode = command_string_mode or "c" in flags
+            if "n" in flags:
+                noexec = option_prefix == "-"
+            if base in {"bash", "rbash"} and option_prefix == "-" and "D" in flags:
+                noexec = True
+
+            value_option, consumes_next = _shell_value_option(token, value_options)
+            i += 1
+            if value_option is not None:
+                if not consumes_next:
+                    return True
+                if i >= len(args):
+                    break
+                value = _static_wrapper_arg(args[i])
+                if value is None:
+                    return True
+                if value_option in {"-o", "+o"} and value == "noexec":
+                    noexec = value_option == "-o"
+                i += 1
+            continue
+
+        break
+
+    if not command_string_mode or noexec or i >= len(args):
+        return False
+    payload = _static_wrapper_arg(args[i])
+    return payload is None or bool(payload.strip())
+
+
+def _shell_value_option(
+    token: str, value_options: frozenset[str]
+) -> tuple[str | None, bool]:
+    """Return a value option and whether its value is the next argv item."""
+    if token in value_options:
+        return token, True
+
+    for option in value_options:
+        if len(option) != 2 or option[0] != token[0]:
+            continue
+        option_index = token[1:].find(option[1])
+        if option_index == -1:
+            continue
+        suffix = token[option_index + 2 :]
+        consumes_next = not suffix or (
+            all(flag in _SHELL_CLUSTER_FLAGS for flag in suffix)
+            and (len(suffix) == 1 or "c" in suffix)
+        )
+        return option, consumes_next
+    return None, False
 
 
 def _decode_command_name(cmd: ShellCommand) -> str | None:
@@ -1016,23 +1177,16 @@ def _decode_command_name(cmd: ShellCommand) -> str | None:
 _OPAQUE_SENTINEL = "\x00"
 
 
-_WrapperArg = ShellWord | str
-
-
-def _peel_wrappers(base: str, words: list[ShellWord]) -> tuple[str | None, list[str]]:
+def _peel_wrappers(
+    base: str, words: list[ShellWord]
+) -> tuple[str | None, list[_WrapperArg]]:
     """Strip wrapper binaries and recover the remaining command argv."""
     args: list[_WrapperArg] = list(words)
     env_split_expansions = 0
 
     for _ in range(_MAX_WRAPPER_DEPTH):
         if base not in _WRAPPER_COMMANDS:
-            recovered: list[str] = []
-            for arg in args:
-                if isinstance(arg, str):
-                    recovered.append(arg)
-                else:
-                    recovered.extend(_recover_word_tokens(arg))
-            return base, recovered
+            return base, args
 
         i = 0
         while i < len(args):
@@ -1084,6 +1238,17 @@ def _peel_wrappers(base: str, words: list[ShellWord]) -> tuple[str | None, list[
         args = args[i + 1 :]
 
     raise SupplyChainAnalysisIncompleteError("wrapper nesting limit exceeded")
+
+
+def _recover_command_args(args: list[_WrapperArg]) -> list[str]:
+    """Recover package-manager argv after launcher-specific inspection."""
+    recovered: list[str] = []
+    for arg in args:
+        if isinstance(arg, str):
+            recovered.append(arg)
+        else:
+            recovered.extend(_recover_word_tokens(arg))
+    return recovered
 
 
 def _static_wrapper_arg(arg: _WrapperArg) -> str | None:
@@ -1195,10 +1360,10 @@ def _recover_word(word: ShellWord) -> str | None:
 def _recover_word_tokens(word: ShellWord) -> list[str]:
     """Recover the argv token(s) a single word would pass to the binary.
 
-    Most words map to exactly one token: a known static value when
-    :func:`_recover_word` can recover it, or the single :data:`_OPAQUE_SENTINEL`
-    when it cannot (a runtime expansion, an embedded space, a leftover
-    metacharacter -- unknowable, so it occupies the slot but is never collected).
+    Most words map to exactly one token: their arbitrary static shell value, or
+    the single :data:`_OPAQUE_SENTINEL` when runtime expansion makes the value
+    unknowable. A statically known ``--flag=`` prefix is retained even when its
+    value is opaque, so a runtime option value cannot hide later argv items.
 
     The one word that maps to *several* tokens is a static comma-brace word like
     ``lo{a,}dsh``: bash expands it to ``loadsh`` and ``lodsh`` (two argv tokens)
@@ -1213,11 +1378,17 @@ def _recover_word_tokens(word: ShellWord) -> list[str]:
     """
     expansions = _expand_static_braces(word)
     if expansions is not None:
-        return [exp for exp in expansions if _PACKAGE_SPEC_RE.match(exp)] or [
-            _OPAQUE_SENTINEL
-        ]
+        return expansions or [_OPAQUE_SENTINEL]
     value = _recover_word(word)
-    return [value if value is not None else _OPAQUE_SENTINEL]
+    if value is not None:
+        return [value]
+    static_value = _static_wrapper_arg(word)
+    if static_value is not None:
+        return [static_value]
+    opaque_option = re.match(r"^(--[a-z0-9][a-z0-9-]*|-[a-z])=", word.text, re.I)
+    if opaque_option is not None:
+        return [f"{opaque_option.group(1)}={_OPAQUE_SENTINEL}"]
+    return [_OPAQUE_SENTINEL]
 
 
 # ---------------------------------------------------------------------------
@@ -1253,9 +1424,10 @@ _MAX_BRACE_GROUPS = 8
 # Characters allowed in a pure static comma-brace word. Anything else (a
 # backslash, whitespace, a shell metacharacter) means the word is not a clean
 # static brace operand, so expansion bails and the word stays opaque. Package
-# specs use ascii letters/digits and ``. _ - / @``; braces add ``{ } ,``.
+# specs and option assignments use ascii letters/digits and ``. _ - / @ =``;
+# braces add ``{ } ,``.
 _BRACE_WORD_CHARS: frozenset[str] = frozenset(
-    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/@{},"
+    "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789._-/@={,}"
 )
 
 
@@ -1729,7 +1901,11 @@ def _collect_manager_packages(manager: str, args: list[str]) -> list[str]:
     if subcommand in install_subs:
         return _collect_install_packages(rest, manager)
     if subcommand in runner_subs:
-        return _collect_runner_target(rest, manager)
+        return _collect_runner_target(
+            rest,
+            manager,
+            scan_options_after_positionals=manager == "npm",
+        )
     return []
 
 
@@ -1832,47 +2008,83 @@ def _collect_install_packages(args: list[str], manager: str) -> list[str]:
     return packages
 
 
-def _collect_runner_target(args: list[str], manager: str) -> list[str]:
-    """Return the single executed package for a runner invocation.
+def _collect_runner_target(
+    args: list[str],
+    manager: str,
+    *,
+    scan_options_after_positionals: bool = False,
+) -> list[str]:
+    """Return packages fetched for a runner invocation.
 
-    Honors ``-p``/``--package`` and ``--package=NAME``/``-p=NAME``, whose value
-    is the package to execute. Otherwise it applies the shared
-    :func:`_consumes_next_value` rule (manager-aware) to skip known value-taking
-    flags and treats every other flag as boolean, then returns the FIRST
-    positional token as the executed package -- the typosquat target. Trailing
-    positionals are arguments to that program, never install targets
-    (``npx create-react-app my-app`` -> ``create-react-app``; an unknown long
-    flag swallows no value, so ``npx --some-flag value lodahs`` yields ``value``).
+    Every explicit ``-p``/``--package`` value is fetched, so repeated flags are
+    accumulated rather than allowing an earlier legitimate package to mask a
+    later typosquat. Without explicit packages, the first positional is the
+    inferred package. Standalone npx stops option parsing at that positional;
+    npm ``exec``/``x`` continues parsing options until ``--``.
     """
+    explicit_packages: list[str] = []
+    positional_target: str | None = None
+    has_call_string = False
+    options_enabled = True
     i = 0
     n = len(args)
     while i < n:
         token = args[i]
 
-        if token.startswith("--package="):
-            return [token[len("--package=") :]]
-        if token.startswith("-p="):
-            return [token[len("-p=") :]]
-        if token in ("-p", "--package"):
-            if i + 1 < n:
-                return [args[i + 1]]
-            return []
+        if options_enabled and token == "--":
+            options_enabled = False
+            i += 1
+            continue
+
+        if options_enabled:
+            if token.startswith(("--call=", "-c=")):
+                has_call_string = True
+                i += 1
+                continue
+            if token in _RUNNER_CALL_OPTIONS:
+                has_call_string = True
+                if i + 1 >= n:
+                    return []
+                i += 2
+                continue
+            if token.startswith("--package="):
+                explicit_packages.append(token[len("--package=") :])
+                i += 1
+                continue
+            if token.startswith("-p="):
+                explicit_packages.append(token[len("-p=") :])
+                i += 1
+                continue
+            if token in ("-p", "--package"):
+                if i + 1 < n:
+                    explicit_packages.append(args[i + 1])
+                    i += 2
+                    continue
+                break
 
         if token in _REDIRECTION_TOKENS:
             i += 1
             continue
 
-        if token.startswith("-"):
+        if options_enabled and token.startswith("-"):
             if _consumes_next_value(token, manager):
                 i += 1
             i += 1
             continue
 
-        if _is_package_spec(token):
-            return [token]
-        return []
+        if positional_target is None and _is_package_spec(token):
+            positional_target = token
+        if not scan_options_after_positionals:
+            break
+        i += 1
 
-    return []
+    if has_call_string and positional_target is not None:
+        return []
+    if explicit_packages:
+        return explicit_packages
+    if has_call_string:
+        return []
+    return [positional_target] if positional_target is not None else []
 
 
 # ---------------------------------------------------------------------------
@@ -1883,17 +2095,10 @@ def _collect_runner_target(args: list[str], manager: str) -> list[str]:
 def _is_package_spec(token: str) -> bool:
     """Report whether ``token`` can be a package spec.
 
-    True when the first character is ascii-alphanumeric or ``_``, or when it
-    is a scoped name starting ``@`` that contains ``/``.
+    The runner/manager argv layer preserves arbitrary static strings, so the
+    package boundary applies the same strict shape used by literal recovery.
     """
-    if not token:
-        return False
-    first = token[0]
-    if first == "_" or first.isascii() and first.isalnum():
-        return True
-    if first == "@" and "/" in token:
-        return True
-    return False
+    return _PACKAGE_SPEC_RE.match(token) is not None
 
 
 def _normalize_package_name(spec: str) -> str:

--- a/tests/sdk/security/supply_chain/test_analyzer.py
+++ b/tests/sdk/security/supply_chain/test_analyzer.py
@@ -1,0 +1,558 @@
+"""Tests for SupplyChainSecurityAnalyzer at the action boundary.
+
+Mirrors the make_action helper pattern from
+tests/sdk/security/defense_in_depth/test_pattern.py: an ActionEvent whose
+tool_call.arguments is json.dumps({"command": cmd}). Confirms the analyzer
+returns HIGH on a typosquat install and LOW otherwise, scans only the
+executable corpus (not reasoning text), and never hard-denies.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openhands.sdk.event import ActionEvent
+from openhands.sdk.llm import MessageToolCall, TextContent
+from openhands.sdk.security.confirmation_policy import ConfirmRisky
+from openhands.sdk.security.risk import SecurityRisk
+from openhands.sdk.security.supply_chain import SupplyChainSecurityAnalyzer
+
+
+# ---------------------------------------------------------------------------
+# Test helper (mirrors test_pattern.py)
+# ---------------------------------------------------------------------------
+
+
+def make_action(
+    command: str, tool_name: str = "bash", **extra_fields: str
+) -> ActionEvent:
+    """Create a minimal ActionEvent for testing."""
+    kwargs: dict = dict(
+        thought=[TextContent(text="test")],
+        tool_name=tool_name,
+        tool_call_id="test",
+        tool_call=MessageToolCall(
+            id="test",
+            name=tool_name,
+            arguments=json.dumps({"command": command}),
+            origin="completion",
+        ),
+        llm_response_id="test",
+    )
+    kwargs.update(extra_fields)
+    return ActionEvent(**kwargs)
+
+
+# ---------------------------------------------------------------------------
+# HIGH: typosquat installs
+# ---------------------------------------------------------------------------
+
+_HIGH_CASES = [
+    ("npm install lodahs", "lodash typosquat"),
+    ("npm i -D lodahs", "short flag before package"),
+    ('npm install "lodahs"', "double-quoted package"),
+    ("npm -g install lodahs", "global flag before subcommand"),
+    ("npm --prefix ui install lodahs", "value-flag before subcommand"),
+    ("FOO=bar npm install lodahs", "env assignment prefix"),
+    ("sudo npm install lodahs", "sudo wrapper"),
+    ("env FOO=bar npm install lodahs", "env wrapper inline assignment"),
+    ("npm install expres", "express typosquat"),
+    ("npm install typscript", "typescript missing letter"),
+    ("cd x && npm install lodahs", "after &&"),
+    ("cd ui\nnpm install lodahs", "after newline"),
+    ("echo hi | npm install lodahs", "after pipe"),
+    ("npx expres", "runner target"),
+    ("npx --package=lodahs some-bin", "runner --package="),
+    ("npx -p lodahs some-bin", "runner -p name"),
+    ("bunx expres", "bunx runner"),
+    ("yarn add lodahs", "yarn add"),
+    ("pnpm add lodahs", "pnpm add"),
+    ("bun add lodahs", "bun add"),
+    ("pnpm dlx expres", "pnpm dlx"),
+    ("npm install lodahs@4.17.21", "version-stripped"),
+    ("/usr/bin/npm install lodahs", "path-prefixed binary"),
+    ("npm install lodahs expres", "multiple typosquats"),
+    ("npm install --unknownflag axio lodash", "unknown flag swallows no value"),
+    ("npm install --registry http://x lodahs", "known value flag skips its value"),
+    ("npm install --before lodahs axio", "value flag eats lodahs, axio remains"),
+    ("npm install --omit=dev lodahs", "equals-form value flag self-contained"),
+    ("npx --registry http://x expres", "runner skips value flag before target"),
+    ("npm --tag beta install loadsh", "tag value flag before subcommand"),
+    ("npm --audit-level high install loadsh", "audit-level value flag before sub"),
+    ("npm --install-strategy nested install loadsh", "install-strategy value flag"),
+    ("npm --scope @myscope install loadsh", "scope value flag before subcommand"),
+    ("npm --otp 123456 install loadsh", "otp value flag before subcommand"),
+    ("npm --maxsockets 5 install loadsh", "maxsockets value flag before subcommand"),
+    ("npm --tag install install loadsh", "tag value equals install keyword"),
+    ("npm --foo bar install lodahs", "robust scan skips non-subcommand to install"),
+    ("npm --someunknownvalflag X install loadsh", "unknown value flag backstop"),
+    ("yarn --cwd /tmp add loadsh", "yarn cwd value flag before add"),
+    ("pnpm --filter foo add loadsh", "pnpm filter value flag before add"),
+    ("bun --cwd /tmp add loadsh", "bun cwd value flag before add"),
+    ("npm install --legacy-peer-deps loadsh", "legacy-peer-deps boolean not value"),
+]
+
+
+@pytest.mark.parametrize("command,desc", _HIGH_CASES, ids=[c[1] for c in _HIGH_CASES])
+def test_analyzer_high(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH, f"{desc}: expected HIGH, got {risk}"
+    # HIGH risk requires confirmation -- the human is asked, not auto-denied.
+    assert ConfirmRisky().should_confirm(risk) is True
+
+
+# ---------------------------------------------------------------------------
+# LOW: clean installs and unrelated commands
+# ---------------------------------------------------------------------------
+
+_LOW_CASES = [
+    ("npm install lodash", "legitimate lodash"),
+    ("npm install react react-dom", "multiple legit packages"),
+    ("npm install --prefix axio lodash", "axio is a flag value"),
+    ("npm install vu", "short popular name (<=4 chars)"),
+    ("npm install lodaaash", "two edits away"),
+    ("npm run build", "npm run build"),
+    ("npm install", "bare install no packages"),
+    ("npm run add lodahs", "script named add"),
+    ("yarn add", "yarn add no packages"),
+    ("npx create-react-app my-app", "runner trailing arg not target"),
+    ("npm install @scope/pkg@1.2.3", "scoped package"),
+    ("git status", "unrelated command"),
+    ("ls /tmp", "ls"),
+    ("pip install requestss", "non-npm manager out of scope"),
+    ("npx --some-flag value lodahs", "runner first positional is the target"),
+    ("npm --tag loadsh install lodash", "tag eats typosquat value, lodash legit"),
+    ("npm run build install lodahs", "run is a real subcommand, scan stops"),
+    ("npm --foo bar baz lodahs", "no real subcommand after skips stays clean"),
+    ("", "empty command"),
+]
+
+
+@pytest.mark.parametrize("command,desc", _LOW_CASES, ids=[c[1] for c in _LOW_CASES])
+def test_analyzer_low(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+    assert ConfirmRisky().should_confirm(risk) is False
+
+
+# ---------------------------------------------------------------------------
+# Two-corpus invariant: reasoning text must not trip the analyzer
+# ---------------------------------------------------------------------------
+
+
+def test_reasoning_text_does_not_trip_analyzer():
+    """A typosquat mentioned only in reasoning/summary must stay LOW.
+
+    The executable command is a harmless `ls /tmp`; the dangerous-looking
+    `npm install lodahs` appears only in thought/reasoning/summary, which the
+    analyzer must not scan.
+    """
+    action = ActionEvent(
+        thought=[TextContent(text="I could run npm install lodahs")],
+        reasoning_content="maybe npm install lodahs would help",
+        summary="considering npm install lodahs",
+        tool_name="bash",
+        tool_call_id="test",
+        tool_call=MessageToolCall(
+            id="test",
+            name="bash",
+            arguments=json.dumps({"command": "ls /tmp"}),
+            origin="completion",
+        ),
+        llm_response_id="test",
+    )
+    analyzer = SupplyChainSecurityAnalyzer()
+    assert analyzer.security_risk(action) == SecurityRisk.LOW
+
+
+def test_zero_width_evasion_still_detected():
+    """A zero-width char hiding the typosquat name is normalized away first."""
+    analyzer = SupplyChainSecurityAnalyzer()
+    # lod<ZWSP>ahs -> lodahs after normalization -> flagged as lodash.
+    assert (
+        analyzer.security_risk(make_action("npm install lod​ahs")) == SecurityRisk.HIGH
+    )
+
+
+def test_fullwidth_evasion_still_detected():
+    """Fullwidth glyphs in the command are NFKC-folded before parsing."""
+    analyzer = SupplyChainSecurityAnalyzer()
+    # Fullwidth "npm install lodahs" folds to ascii then flags lodash.
+    cmd = "ｎｐｍ install lodahs"
+    assert analyzer.security_risk(make_action(cmd)) == SecurityRisk.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Line-separator / invisible evasion regression
+#
+# U+0085 (NEL), U+2028 (line separator), U+2029 (paragraph separator) and a
+# zero-width space previously split a package name when the old analyzer ran
+# str.splitlines() before stripping invisibles. Normalization now strips them in
+# the parser entry, so each of these still flags HIGH.
+# ---------------------------------------------------------------------------
+
+_INVISIBLE_EVASION_CASES = [
+    ("npm install lod\u0085ahs", "U+0085 NEL split"),
+    ("npm install lod\u2028ahs", "U+2028 line separator split"),
+    ("npm install lod\u2029ahs", "U+2029 paragraph separator split"),
+    ("npm install load\u200bsh", "zero-width split of loadsh"),
+    ("ｎｐｍ install load\u200bsh", "fullwidth npm plus zero-width split"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _INVISIBLE_EVASION_CASES,
+    ids=[c[1] for c in _INVISIBLE_EVASION_CASES],
+)
+def test_analyzer_invisible_evasion_high(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH, f"{desc}: expected HIGH, got {risk}"
+
+
+def test_parser_entry_normalizes_zero_width_directly():
+    """The public parser entry normalizes too, not just the analyzer.
+
+    Calling find_typosquat_installs directly with a zero-width-split name must
+    still surface the typosquat, proving the entry point is not evadable.
+    """
+    from openhands.sdk.security.supply_chain.parser import find_typosquat_installs
+
+    findings = find_typosquat_installs("npm install lod​ahs")
+    assert findings, "expected the zero-width-split install to be flagged"
+    assert any(f.suggestion == "lodash" for f in findings)
+
+
+def test_analyzer_handles_non_command_arguments():
+    """A tool whose arguments are not a shell command must not crash or flag."""
+    action = ActionEvent(
+        thought=[TextContent(text="test")],
+        tool_name="file_editor",
+        tool_call_id="test",
+        tool_call=MessageToolCall(
+            id="test",
+            name="file_editor",
+            arguments=json.dumps({"path": "/tmp/x", "content": "lodahs"}),
+            origin="completion",
+        ),
+        llm_response_id="test",
+    )
+    analyzer = SupplyChainSecurityAnalyzer()
+    # "lodahs" appears as file content, not an install command -- stays LOW.
+    assert analyzer.security_risk(action) == SecurityRisk.LOW
+
+
+# ---------------------------------------------------------------------------
+# Serialization: analyzer is a DiscriminatedUnion model like its siblings
+# ---------------------------------------------------------------------------
+
+
+def test_analyzer_round_trips_through_serialization():
+    analyzer = SupplyChainSecurityAnalyzer()
+    dumped = analyzer.model_dump_json()
+    restored = SupplyChainSecurityAnalyzer.model_validate_json(dumped)
+    assert isinstance(restored, SupplyChainSecurityAnalyzer)
+    assert restored.security_risk(make_action("npm install lodahs")) == (
+        SecurityRisk.HIGH
+    )
+
+
+def test_exported_from_security_package():
+    from openhands.sdk.security import (
+        SupplyChainSecurityAnalyzer as Exported,
+    )
+
+    assert Exported is SupplyChainSecurityAnalyzer
+
+
+# ---------------------------------------------------------------------------
+# AST-structural cases (the extraction upgrade onto the shared shell view)
+# ---------------------------------------------------------------------------
+
+_AST_HIGH_CASES = [
+    ("/bin/npm install loadsh", "path-qualified manager via posix basename"),
+    ("true && npm i loadsh", "&& list traversal"),
+    ("echo done; npm i loadsh", "; traversal"),
+    ("npx loadsh", "runner via ast"),
+    ("cat foo || npm install loadsh", "|| traversal"),
+    ("npm install   loadsh", "collapsed odd spacing"),
+    ("npm install 'loadsh'", "single-quote raw_string recovery"),
+    ('npm install "loadsh"', "double-quote string recovery"),
+    ("echo $(npm install loadsh)", "command substitution nested command"),
+    ('npm install lodahs "unterminated', "parse error still yields operand"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc", _AST_HIGH_CASES, ids=[c[1] for c in _AST_HIGH_CASES]
+)
+def test_analyzer_ast_high(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH, f"{desc}: expected HIGH, got {risk}"
+
+
+_AST_LOW_CASES = [
+    ('echo "npm install lodahs"', "whole install inside a double-quoted string"),
+    ('bash -c "npm install lodahs"', "bash -c inner string is opaque"),
+    ("$(echo npm) install lodahs", "opaque outer command name skipped"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc", _AST_LOW_CASES, ids=[c[1] for c in _AST_LOW_CASES]
+)
+def test_analyzer_ast_low(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+
+
+def test_lone_surrogate_command_does_not_raise():
+    """A crafted lone-surrogate command is guarded; analyzer returns LOW.
+
+    The strict UTF-8 encode in the parser would raise UnicodeEncodeError on a
+    lone surrogate; the analyzer catches it so it never raises out of the
+    security seam (where the ensemble would otherwise fail closed to HIGH).
+    """
+    analyzer = SupplyChainSecurityAnalyzer()
+    cmd = "npm install lodahs\ud800"  # lone high surrogate
+    assert analyzer.security_risk(make_action(cmd)) == SecurityRisk.LOW
+
+
+# ---------------------------------------------------------------------------
+# Realistic terminal ActionEvent: carries a typed action AND a tool call; the
+# analyzer reads the command from the tool-call arguments.
+# ---------------------------------------------------------------------------
+
+
+def _terminal_action_event(command: str) -> ActionEvent:
+    """Build a realistic terminal ActionEvent (typed action + tool call)."""
+    from openhands.tools.terminal.definition import TerminalAction
+
+    return ActionEvent(
+        thought=[TextContent(text="test")],
+        action=TerminalAction(command=command),
+        tool_name="terminal",
+        tool_call_id="test",
+        tool_call=MessageToolCall(
+            id="test",
+            name="terminal",
+            arguments=json.dumps({"command": command}),
+            origin="completion",
+        ),
+        llm_response_id="test",
+    )
+
+
+def test_typed_terminal_action_high():
+    analyzer = SupplyChainSecurityAnalyzer()
+    action = _terminal_action_event("npm install lodahs")
+    assert analyzer.security_risk(action) == SecurityRisk.HIGH
+
+
+def test_typed_terminal_action_low():
+    analyzer = SupplyChainSecurityAnalyzer()
+    action = _terminal_action_event("npm install lodash")
+    assert analyzer.security_risk(action) == SecurityRisk.LOW
+
+
+# ---------------------------------------------------------------------------
+# Interior-quote / backslash operand obfuscation at the action boundary
+#
+# These all resolve to the single argv token `loadsh` (a typosquat of `lodash`)
+# in a real shell. The bounded operand-literal decode reconstructs that token,
+# so they raise HIGH; the runtime/split variants stay opaque and LOW.
+# ---------------------------------------------------------------------------
+
+_OBFUSCATION_HIGH_CASES = [
+    ('npm install lo""adsh', "empty double-quote middle"),
+    ('npm install load"sh"', "trailing double-quoted segment"),
+    ("npm install lo'adsh'", "trailing single-quoted segment"),
+    ("npm install lo\\adsh", "single backslash escape"),
+    ('npm install l"o"a"d"s"h"', "alternating double-quoted chars"),
+    ("npm install lo''adsh", "empty single-quote middle"),
+    ("npm install l\\o\\a\\d\\s\\h", "every char backslash-escaped"),
+    ('npm install "load"sh', "leading quoted then bare concat"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _OBFUSCATION_HIGH_CASES,
+    ids=[c[1] for c in _OBFUSCATION_HIGH_CASES],
+)
+def test_analyzer_obfuscated_operand_high(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH, f"{desc}: expected HIGH, got {risk}"
+
+
+_OBFUSCATION_LOW_CASES = [
+    ("npm install $(echo loadsh)", "command substitution stays opaque"),
+    ("npm install `echo loadsh`", "backticks stay opaque"),
+    ("npm install $CMD", "bare variable stays opaque"),
+    ('npm install "a b"', "embedded space is not one package name"),
+    ('npm install lo"$x"adsh', "variable inside quoted segment opaque"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _OBFUSCATION_LOW_CASES,
+    ids=[c[1] for c in _OBFUSCATION_LOW_CASES],
+)
+def test_analyzer_obfuscated_operand_low(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+
+
+# ---------------------------------------------------------------------------
+# Command-name obfuscation, ANSI-C operands, and line continuation (boundary)
+#
+# Same evasions exercised in the parser tests, asserted at the analyzer
+# boundary: an obfuscated manager/runner NAME (`n"p"m`, `\npm`, `$'npm'`), an
+# ANSI-C quoted operand (`$'loadsh'`, `$'loa\x64sh'`), and a backslash-newline
+# line continuation all run a real `npm install loadsh`/`npx loadsh`, so they
+# raise HIGH; runtime expansions and single-quote-preserved continuations stay
+# opaque and LOW.
+# ---------------------------------------------------------------------------
+
+_NAME_AND_ENCODING_HIGH_CASES = [
+    ('n"p"m install loadsh', "interior-quoted manager name"),
+    (r"\npm install loadsh", "backslash-escaped manager name"),
+    ("$'npm' install loadsh", "ANSI-C manager name"),
+    ('n"p"x loadsh', "interior-quoted runner name"),
+    ("$'npx' loadsh", "ANSI-C runner name"),
+    ("npm install $'loadsh'", "ANSI-C operand"),
+    (r"npm install $'loa\x64sh'", "ANSI-C hex-escape operand"),
+    ("npm install loa\\\ndsh", "operand line continuation"),
+    ("np\\\nm install loadsh", "command-name line continuation"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _NAME_AND_ENCODING_HIGH_CASES,
+    ids=[c[1] for c in _NAME_AND_ENCODING_HIGH_CASES],
+)
+def test_analyzer_name_and_encoding_high(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH, f"{desc}: expected HIGH, got {risk}"
+
+
+_NAME_AND_ENCODING_LOW_CASES = [
+    ("$CMD install loadsh", "runtime variable command name stays opaque"),
+    ("$(echo npm) install loadsh", "command-substitution name stays opaque"),
+    (r"npm install $'a b'", "ANSI-C with embedded space stays opaque"),
+    (r"npm install $'lo\tadsh'", "ANSI-C with control char stays opaque"),
+    ("npm install 'loa\\\ndsh'", "single-quoted line continuation is literal"),
+    ("$'npm' install lodash", "ANSI-C name of a legitimate install stays LOW"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _NAME_AND_ENCODING_LOW_CASES,
+    ids=[c[1] for c in _NAME_AND_ENCODING_LOW_CASES],
+)
+def test_analyzer_name_and_encoding_low(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+
+
+# ---------------------------------------------------------------------------
+# Documented residue (strict xfails): nested command-string payloads
+#
+# When the whole install lives inside an inner command string -- `bash -c
+# "npm install lodahs"`, `sh -c 'npm i loadsh'`, `echo "npm install lodahs"` --
+# the tree-sitter view treats that inner string as a single opaque argument to
+# the OUTER command (bash/sh/echo). It is never re-parsed as a command, so the
+# install is invisible to the analyzer and stays LOW (the safe default).
+#
+# Closing these needs recursive command-string parsing: recognising `-c`/`-lc`
+# shells (and `echo`-style sinks) and re-parsing their string argument as a
+# nested program. That is out of scope for the current shared AST view; it is
+# the same recursion the #2721 migration scopes for the pattern analyzer. These
+# are marked xfail(strict=True) so they flip to passing -- and fail loudly as
+# stale -- the moment that recursion lands.
+# ---------------------------------------------------------------------------
+
+_NESTED_COMMAND_STRING_RESIDUE = [
+    ('bash -c "npm install lodahs"', "bash_dash_c_double_quoted"),
+    ("sh -c 'npm i loadsh'", "sh_dash_c_single_quoted"),
+    ('echo "npm install lodahs"', "echo_double_quoted_install"),
+]
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Install lives inside an inner command string; the AST treats it as one"
+        " opaque argument to the outer bash/sh/echo. Needs recursive"
+        " command-string parsing (re-parse the -c / echoed string as a nested"
+        " program) -- out of scope for the current shared AST view; cf. the"
+        " #2721 migration scope."
+    ),
+)
+@pytest.mark.parametrize(
+    "command,desc",
+    _NESTED_COMMAND_STRING_RESIDUE,
+    ids=[c[1] for c in _NESTED_COMMAND_STRING_RESIDUE],
+)
+def test_analyzer_nested_command_string_residue_xfail(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    # Aspirational: the inner install SHOULD raise HIGH once command strings are
+    # parsed recursively. Today it stays LOW (opaque), so this xfails.
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH
+
+
+# ---------------------------------------------------------------------------
+# Pathologically nested / chained input never crashes the seam (DoS hardening)
+#
+# Hundreds of nested `$()` levels or chained operators build a parse tree deep
+# enough that the recursive tree-sitter-bash walkers raise RecursionError. The
+# analyzer widens its fail-open guard (alongside UnicodeEncodeError) to catch it
+# and return LOW, so adversarial noise is a documented non-finding, never an
+# exception escaping the security seam (where the ensemble would fail closed to
+# HIGH). A real install in a moderately-chained command still raises HIGH.
+# ---------------------------------------------------------------------------
+
+_PATHOLOGICAL_LOW_CASES = [
+    (" && ".join("ls" for _ in range(1500)), "deeply_chained_operators"),
+    ("x" + "$(" * 200 + "echo" + ")" * 200, "deeply_nested_command_substitution"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _PATHOLOGICAL_LOW_CASES,
+    ids=[c[1] for c in _PATHOLOGICAL_LOW_CASES],
+)
+def test_pathological_input_does_not_raise_and_stays_low(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    # Must not raise RecursionError; treated as a non-finding -> LOW.
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+
+
+def test_moderately_chained_real_install_still_high():
+    # The widened guard must not suppress real findings: a typosquat install
+    # behind a normal chain still raises HIGH.
+    analyzer = SupplyChainSecurityAnalyzer()
+    assert analyzer.security_risk(make_action("true && npm i loadsh")) == (
+        SecurityRisk.HIGH
+    )
+    assert (
+        analyzer.security_risk(make_action("a && b && npm install loadsh"))
+        == SecurityRisk.HIGH
+    )

--- a/tests/sdk/security/supply_chain/test_analyzer.py
+++ b/tests/sdk/security/supply_chain/test_analyzer.py
@@ -473,10 +473,11 @@ def test_analyzer_name_and_encoding_low(command: str, desc: str):
 # Documented residue (strict xfails): nested command-string payloads
 #
 # When the whole install lives inside an inner command string -- `bash -c
-# "npm install lodahs"`, `sh -c 'npm i loadsh'`, `echo "npm install lodahs"` --
-# the tree-sitter view treats that inner string as a single opaque argument to
-# the OUTER command (bash/sh/echo). It is never re-parsed as a command, so the
-# install is invisible to the analyzer and stays LOW (the safe default).
+# "npm install lodahs"`, `sh -c 'npm i loadsh'`, `npx -c 'npm install lodahs'`,
+# `echo "npm install lodahs"` -- the tree-sitter view treats that inner string as
+# a single opaque argument to the outer command. It is never re-parsed as a
+# command, so the install is invisible to the analyzer and stays LOW (the safe
+# default).
 #
 # Closing these needs recursive command-string parsing: recognising `-c`/`-lc`
 # shells (and `echo`-style sinks) and re-parsing their string argument as a
@@ -489,6 +490,7 @@ def test_analyzer_name_and_encoding_low(command: str, desc: str):
 _NESTED_COMMAND_STRING_RESIDUE = [
     ('bash -c "npm install lodahs"', "bash_dash_c_double_quoted"),
     ("sh -c 'npm i loadsh'", "sh_dash_c_single_quoted"),
+    ("npx -c 'npm install lodahs'", "npx_dash_c_inner_install"),
     ('echo "npm install lodahs"', "echo_double_quoted_install"),
 ]
 
@@ -497,7 +499,7 @@ _NESTED_COMMAND_STRING_RESIDUE = [
     strict=True,
     reason=(
         "Install lives inside an inner command string; the AST treats it as one"
-        " opaque argument to the outer bash/sh/echo. Needs recursive"
+        " opaque argument to the outer command. Needs recursive"
         " command-string parsing (re-parse the -c / echoed string as a nested"
         " program) -- out of scope for the current shared AST view; cf. the"
         " #2721 migration scope."
@@ -517,32 +519,34 @@ def test_analyzer_nested_command_string_residue_xfail(command: str, desc: str):
 
 
 # ---------------------------------------------------------------------------
-# Pathologically nested / chained input never crashes the seam (DoS hardening)
+# Pathologically nested / chained input never looks benign (DoS hardening)
 #
 # Hundreds of nested `$()` levels or chained operators build a parse tree deep
-# enough that the recursive tree-sitter-bash walkers raise RecursionError. The
-# analyzer widens its fail-open guard (alongside UnicodeEncodeError) to catch it
-# and return LOW, so adversarial noise is a documented non-finding, never an
-# exception escaping the security seam (where the ensemble would fail closed to
-# HIGH). A real install in a moderately-chained command still raises HIGH.
+# enough that the recursive tree-sitter-bash walkers cannot finish. Oversized
+# commands are bounded before parsing. Both cases return UNKNOWN so
+# `ConfirmRisky` asks a human instead of treating an unresolved command as LOW.
 # ---------------------------------------------------------------------------
 
-_PATHOLOGICAL_LOW_CASES = [
-    (" && ".join("ls" for _ in range(1500)), "deeply_chained_operators"),
+_PATHOLOGICAL_UNKNOWN_CASES = [
+    (
+        " && ".join([*("true" for _ in range(1500)), "npm install lodahs"]),
+        "deeply_chained_install",
+    ),
     ("x" + "$(" * 200 + "echo" + ")" * 200, "deeply_nested_command_substitution"),
+    ("npm install lodahs #" + "x" * 100_000, "padded_oversized_install"),
 ]
 
 
 @pytest.mark.parametrize(
     "command,desc",
-    _PATHOLOGICAL_LOW_CASES,
-    ids=[c[1] for c in _PATHOLOGICAL_LOW_CASES],
+    _PATHOLOGICAL_UNKNOWN_CASES,
+    ids=[c[1] for c in _PATHOLOGICAL_UNKNOWN_CASES],
 )
-def test_pathological_input_does_not_raise_and_stays_low(command: str, desc: str):
+def test_incomplete_analysis_returns_unknown(command: str, desc: str):
     analyzer = SupplyChainSecurityAnalyzer()
-    # Must not raise RecursionError; treated as a non-finding -> LOW.
     risk = analyzer.security_risk(make_action(command))
-    assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+    assert risk == SecurityRisk.UNKNOWN, f"{desc}: expected UNKNOWN, got {risk}"
+    assert ConfirmRisky().should_confirm(risk) is True
 
 
 def test_moderately_chained_real_install_still_high():

--- a/tests/sdk/security/supply_chain/test_analyzer.py
+++ b/tests/sdk/security/supply_chain/test_analyzer.py
@@ -3,8 +3,9 @@
 Mirrors the make_action helper pattern from
 tests/sdk/security/defense_in_depth/test_pattern.py: an ActionEvent whose
 tool_call.arguments is json.dumps({"command": cmd}). Confirms the analyzer
-returns HIGH on a typosquat install and LOW otherwise, scans only the
-executable corpus (not reasoning text), and never hard-denies.
+returns HIGH on a typosquat install, UNKNOWN when executable shell source is
+not analyzed, and LOW otherwise. It scans only the executable corpus (not
+reasoning text) and never hard-denies.
 """
 
 from __future__ import annotations
@@ -66,6 +67,16 @@ _HIGH_CASES = [
     ("npx expres", "runner target"),
     ("npx --package=lodahs some-bin", "runner --package="),
     ("npx -p lodahs some-bin", "runner -p name"),
+    (
+        "npx --package lodash --package lodahs some-bin",
+        "runner repeated package flags",
+    ),
+    ("npm exec some-bin --package lodahs", "npm exec option after positional"),
+    ("npx --call='echo safe' --package=lodahs", "runner call before package"),
+    ("npx --package='lodahs' some-bin", "quoted runner package option"),
+    ("npx --registry=$URL lodahs", "runtime equals flag before target"),
+    ("npx --script-shell /bin/sh lodahs", "runner value option before target"),
+    ("npx --package={lodash,lodahs} some-bin", "brace-expanded package options"),
     ("bunx expres", "bunx runner"),
     ("yarn add lodahs", "yarn add"),
     ("pnpm add lodahs", "pnpm add"),
@@ -124,6 +135,8 @@ _LOW_CASES = [
     ("ls /tmp", "ls"),
     ("pip install requestss", "non-npm manager out of scope"),
     ("npx --some-flag value lodahs", "runner first positional is the target"),
+    ("npx -c lodahs", "runner call string is not an inferred package"),
+    ("npm exec lodahs -c 'echo safe'", "invalid positional plus call form"),
     ("npm --tag loadsh install lodash", "tag eats typosquat value, lodash legit"),
     ("npm run build install lodahs", "run is a real subcommand, scan stops"),
     ("npm --foo bar baz lodahs", "no real subcommand after skips stays clean"),
@@ -299,7 +312,10 @@ def test_analyzer_ast_high(command: str, desc: str):
 
 _AST_LOW_CASES = [
     ('echo "npm install lodahs"', "whole install inside a double-quoted string"),
-    ('bash -c "npm install lodahs"', "bash -c inner string is opaque"),
+    ('bash -- -c "npm install lodahs"', "-- makes -c a script filename"),
+    ('bash -nc "npm install lodahs"', "noexec suppresses command execution"),
+    ('bash -o noexec -c "npm install lodahs"', "named noexec option"),
+    ('bash -c ""', "empty command string"),
     ("$(echo npm) install lodahs", "opaque outer command name skipped"),
 ]
 
@@ -311,6 +327,60 @@ def test_analyzer_ast_low(command: str, desc: str):
     analyzer = SupplyChainSecurityAnalyzer()
     risk = analyzer.security_risk(make_action(command))
     assert risk == SecurityRisk.LOW, f"{desc}: expected LOW, got {risk}"
+
+
+_EXECUTABLE_COMMAND_STRING_UNKNOWN_CASES = [
+    ('bash -c "npm install lodahs"', "bash -c static payload"),
+    ("sh -lc 'npm i loadsh'", "sh combined option cluster"),
+    ("sh -O extglob -c 'npm install lodahs'", "implementation-dependent sh option"),
+    ("/bin/dash -ec 'npm install lodahs'", "path-qualified dash"),
+    ("zsh --no-rcs -fc 'npm install lodahs'", "zsh leading option"),
+    ("bash -T -c 'npm install lodahs'", "bash boolean option before -c"),
+    ("zsh -R -c 'npm install lodahs'", "zsh boolean option before -c"),
+    ("sh +c 'npm install lodahs'", "plus-prefixed command option"),
+    ("bash -oc pipefail 'npm install lodahs'", "combined value and command flags"),
+    ("bash -xO extglob -c 'npm install lodahs'", "clustered bash value option"),
+    ("zsh -oNO_RCS -c 'npm install lodahs'", "attached zsh option value"),
+    ("ksh -o nounset -lc 'npm install lodahs'", "ksh value option"),
+    ("ksh -T 1 -c 'npm install lodahs'", "ksh trace value option"),
+    ("ksh -T1 -c 'npm install lodahs'", "attached ksh trace value"),
+    ('bash "-c" "npm install lodahs"', "quoted invocation option"),
+    ("b\"a\"sh \\-lc 'npm install lodahs'", "statically obfuscated shell argv"),
+    (
+        "sudo -u node /bin/bash -lc 'npm install lodahs'",
+        "wrapped path-qualified bash",
+    ),
+    ('bash -c "$COMMAND"', "runtime command-string payload"),
+    ('bash "$FLAGS" -c "npm install lodahs"', "runtime invocation option"),
+    ("exec -a worker bash -lc 'npm install lodahs'", "exec wrapper"),
+    ('bash -c "echo safe"', "benign but unanalysed executable payload"),
+]
+
+
+@pytest.mark.parametrize(
+    "command,desc",
+    _EXECUTABLE_COMMAND_STRING_UNKNOWN_CASES,
+    ids=[c[1] for c in _EXECUTABLE_COMMAND_STRING_UNKNOWN_CASES],
+)
+def test_executable_command_string_requires_confirmation(command: str, desc: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.UNKNOWN, f"{desc}: expected UNKNOWN, got {risk}"
+    assert ConfirmRisky().should_confirm(risk) is True
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'bash -c "$COMMAND"; npm install lodahs',
+        'npm install lodahs; bash -c "$COMMAND"',
+    ],
+)
+def test_typosquat_finding_wins_over_incomplete_command_string(command: str):
+    analyzer = SupplyChainSecurityAnalyzer()
+    risk = analyzer.security_risk(make_action(command))
+    assert risk == SecurityRisk.HIGH
+    assert ConfirmRisky().should_confirm(risk) is True
 
 
 def test_lone_surrogate_command_does_not_raise():
@@ -470,39 +540,26 @@ def test_analyzer_name_and_encoding_low(command: str, desc: str):
 
 
 # ---------------------------------------------------------------------------
-# Documented residue (strict xfails): nested command-string payloads
+# Documented residue (strict xfail): npm runner command-string payload
 #
-# When the whole install lives inside an inner command string -- `bash -c
-# "npm install lodahs"`, `sh -c 'npm i loadsh'`, `npx -c 'npm install lodahs'`,
-# `echo "npm install lodahs"` -- the tree-sitter view treats that inner string as
-# a single opaque argument to the outer command. It is never re-parsed as a
-# command, so the install is invisible to the analyzer and stays LOW (the safe
-# default).
-#
-# Closing these needs recursive command-string parsing: recognising `-c`/`-lc`
-# shells (and `echo`-style sinks) and re-parsing their string argument as a
-# nested program. That is out of scope for the current shared AST view; it is
-# the same recursion the #2721 migration scopes for the pattern analyzer. These
-# are marked xfail(strict=True) so they flip to passing -- and fail loudly as
-# stale -- the moment that recursion lands.
+# `npx -c 'npm install lodahs'` remains runner-specific residue. POSIX-style
+# shell `-c` payloads are handled separately above and return UNKNOWN; ordinary
+# echo arguments are inert data and correctly remain LOW.
 # ---------------------------------------------------------------------------
 
 _NESTED_COMMAND_STRING_RESIDUE = [
-    ('bash -c "npm install lodahs"', "bash_dash_c_double_quoted"),
-    ("sh -c 'npm i loadsh'", "sh_dash_c_single_quoted"),
     ("npx -c 'npm install lodahs'", "npx_dash_c_inner_install"),
-    ('echo "npm install lodahs"', "echo_double_quoted_install"),
+    ("npx --call='npm install lodahs'", "npx_call_inner_install"),
+    ("npm exec -c 'npm install lodahs'", "npm_exec_dash_c_inner_install"),
+    ("npm x --call='npm install lodahs'", "npm_x_call_inner_install"),
 ]
 
 
 @pytest.mark.xfail(
     strict=True,
     reason=(
-        "Install lives inside an inner command string; the AST treats it as one"
-        " opaque argument to the outer command. Needs recursive"
-        " command-string parsing (re-parse the -c / echoed string as a nested"
-        " program) -- out of scope for the current shared AST view; cf. the"
-        " #2721 migration scope."
+        "Install lives inside an npm runner command string; runner-specific"
+        " call-string parsing is out of scope for the current shared AST view."
     ),
 )
 @pytest.mark.parametrize(
@@ -512,8 +569,6 @@ _NESTED_COMMAND_STRING_RESIDUE = [
 )
 def test_analyzer_nested_command_string_residue_xfail(command: str, desc: str):
     analyzer = SupplyChainSecurityAnalyzer()
-    # Aspirational: the inner install SHOULD raise HIGH once command strings are
-    # parsed recursively. Today it stays LOW (opaque), so this xfails.
     risk = analyzer.security_risk(make_action(command))
     assert risk == SecurityRisk.HIGH
 

--- a/tests/sdk/security/supply_chain/test_parser.py
+++ b/tests/sdk/security/supply_chain/test_parser.py
@@ -1,0 +1,1196 @@
+"""Tests for the offline npm typosquat parser.
+
+Covers every install/runner shape, the hardening cases (chaining, env/wrapper
+prefixes, quoting, value-flag skips, path prefixes), the consistent flag policy,
+and every false-positive guard.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from openhands.sdk.security._shell_ast import iter_commands, parse_shell_program
+from openhands.sdk.security.supply_chain.parser import (
+    POPULAR_PACKAGES,
+    TyposquatFinding,
+    _expand_static_braces,
+    _is_env_assignment,
+    _normalize_package_name,
+    _osa_distance_within,
+    find_typosquat_installs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def assert_flags(command: str, target: str) -> None:
+    """Assert a command flags at least one typosquat resembling ``target``."""
+    findings = find_typosquat_installs(command)
+    assert findings, f'expected "{command}" to be flagged'
+    assert any(f.suggestion == target for f in findings), (
+        f'expected "{command}" to mention popular package "{target}", '
+        f"got: {[f.reason for f in findings]}"
+    )
+
+
+def assert_clean(command: str) -> None:
+    """Assert a command flags nothing."""
+    findings = find_typosquat_installs(command)
+    assert findings == [], (
+        f'expected "{command}" to be clean, got: {[f.reason for f in findings]}'
+    )
+
+
+# ---------------------------------------------------------------------------
+# npm install detection
+# ---------------------------------------------------------------------------
+
+
+class TestNpmInstallDetection:
+    def test_flags_one_edit_typosquat_of_lodash(self):
+        assert_flags("npm install lodahs", "lodash")
+
+    def test_flags_typosquats_behind_short_flags(self):
+        assert_flags("npm i -D lodahs", "lodash")
+
+    def test_flags_typosquats_quoted_in_double_quotes(self):
+        assert_flags('npm install "lodahs"', "lodash")
+
+    def test_flags_with_global_flag_before_subcommand(self):
+        assert_flags("npm -g install lodahs", "lodash")
+
+    def test_flags_with_value_taking_flag_before_subcommand(self):
+        assert_flags("npm --prefix ui install lodahs", "lodash")
+
+    def test_flags_after_env_assignment(self):
+        assert_flags("FOO=bar npm install lodahs", "lodash")
+
+    def test_flags_after_sudo_wrapper(self):
+        assert_flags("sudo npm install lodahs", "lodash")
+
+    def test_flags_after_env_wrapper_with_inline_assignment(self):
+        assert_flags("env FOO=bar npm install lodahs", "lodash")
+
+    def test_flags_typosquat_of_express(self):
+        assert_flags("npm install expres", "express")
+
+    def test_flags_typosquat_of_typescript_missing_letter(self):
+        assert_flags("npm install typscript", "typescript")
+
+
+# ---------------------------------------------------------------------------
+# Chained commands
+# ---------------------------------------------------------------------------
+
+
+class TestChainedCommands:
+    def test_parses_install_segment_after_and(self):
+        # evil is not a typosquat, but it must parse without crash or false hit.
+        assert_clean("cd x && npm install evil")
+
+    def test_flags_typosquat_after_and(self):
+        assert_flags("cd x && npm install lodahs", "lodash")
+
+    def test_flags_typosquat_after_newline(self):
+        assert_flags("cd ui\nnpm install lodahs", "lodash")
+
+    def test_flags_typosquat_after_pipe(self):
+        assert_flags("echo hi | npm install lodahs", "lodash")
+
+    def test_flags_typosquat_after_or(self):
+        assert_flags("false || npm install lodahs", "lodash")
+
+    def test_flags_typosquat_after_background(self):
+        assert_flags("sleep 1 & npm install lodahs", "lodash")
+
+
+# ---------------------------------------------------------------------------
+# Runners (npx / dlx / bunx)
+# ---------------------------------------------------------------------------
+
+
+class TestRunners:
+    def test_targets_executed_package_never_trailing_arg(self):
+        # create-react-app and my-app are both clean; the invariant is that
+        # my-app is never collected as the target.
+        assert_clean("npx create-react-app my-app")
+
+    def test_flags_typosquat_runner_target(self):
+        assert_flags("npx expres", "express")
+
+    def test_honors_package_equals_for_runner_target(self):
+        assert_flags("npx --package=lodahs some-bin", "lodash")
+
+    def test_honors_p_name_for_runner_target(self):
+        assert_flags("npx -p lodahs some-bin", "lodash")
+
+    def test_flags_bunx_runner_targets(self):
+        assert_flags("bunx expres", "express")
+
+    def test_flags_npm_exec_runner_target(self):
+        assert_flags("npm exec expres", "express")
+
+    def test_flags_bun_x_runner_target(self):
+        assert_flags("bun x expres", "express")
+
+
+# ---------------------------------------------------------------------------
+# Non-install subcommands are ignored
+# ---------------------------------------------------------------------------
+
+
+class TestNonInstallSubcommands:
+    def test_ignores_npm_run_build(self):
+        assert_clean("npm run build")
+
+    def test_ignores_bare_npm_install(self):
+        assert_clean("npm install")
+
+    def test_ignores_script_named_add(self):
+        assert_clean("npm run add lodahs")
+
+
+# ---------------------------------------------------------------------------
+# False-positive guards
+# ---------------------------------------------------------------------------
+
+
+class TestFalsePositiveGuards:
+    def test_does_not_flag_legitimate_lodash(self):
+        assert_clean("npm install lodash")
+
+    def test_does_not_flag_multiple_legitimate_packages(self):
+        assert_clean("npm install react react-dom")
+
+    def test_value_taking_flag_argument_is_not_a_package(self):
+        # axio (one edit from axios) is the --prefix value, must NOT flag;
+        # lodash is legit, so the command is clean overall.
+        assert_clean("npm install --prefix axio lodash")
+
+    def test_does_not_flag_short_popular_names(self):
+        # 'vu' is one edit from 'vue' but vue.length == 3, so it must not flag.
+        assert_clean("npm install vu")
+
+    def test_does_not_flag_two_edits_away(self):
+        assert_clean("npm install lodaaash")
+
+    def test_does_not_flag_unrelated_long_package(self):
+        assert_clean("npm install some-internal-tool")
+
+    def test_does_not_flag_registry_value(self):
+        # the --registry value must be treated as a value, not a package.
+        assert_clean("npm install --registry expres lodash")
+
+
+# ---------------------------------------------------------------------------
+# Known-legit allowlist
+#
+# Real, mainstream npm packages that happen to sit one OSA edit from a popular
+# name must NOT be flagged. The allowlist is precision-only: it suppresses only
+# its own exact, registry-confirmed names, so a genuine typosquat that is one
+# edit from the SAME popular name (e.g. loadsh/lodahs vs lodash) must still flag.
+# ---------------------------------------------------------------------------
+
+
+class TestKnownLegitAllowlist:
+    def test_does_not_flag_preact(self):
+        # preact is one edit from react but a real ~86M/month package.
+        assert_clean("npm install preact")
+
+    def test_does_not_flag_prettierx(self):
+        # prettierx is one edit from prettier but a real published fork.
+        assert_clean("npm install prettierx")
+
+    def test_does_not_flag_moments(self):
+        # moments is one edit from moment but a real published package.
+        assert_clean("npm install moments")
+
+    def test_allowlisted_package_clean_across_managers_and_runners(self):
+        # The suppression is on the resolved name, so it holds everywhere a name
+        # is collected: every install manager and every runner shape.
+        assert_clean("npm install preact")
+        assert_clean("yarn add preact")
+        assert_clean("pnpm add preact")
+        assert_clean("bun add preact")
+        assert_clean("npx preact")
+        assert_clean("npm install preact@10.29.2")
+
+    def test_allowlist_still_flags_real_typosquats_of_same_popular_name(self):
+        # Allowlisting preact must NOT suppress a genuine typosquat of react,
+        # nor a genuine typosquat of any other popular name.
+        assert_flags("npm install loadsh", "lodash")
+        assert_flags("npm install lodahs", "lodash")
+        assert_flags("npm install expres", "express")
+        assert_flags("npm install momnt", "moment")
+
+    def test_allowlisted_and_typosquat_in_same_command(self):
+        # preact is suppressed, lodahs still flags; only the real typosquat hits.
+        findings = find_typosquat_installs("npm install preact lodahs")
+        assert [f.suggestion for f in findings] == ["lodash"]
+
+
+# ---------------------------------------------------------------------------
+# Consistent flag policy (#3/#4)
+#
+# One rule across subcommand-skipping, install collection and runner collection:
+# a KNOWN value-taking flag written bare consumes its next token; ``--flag=value``
+# is self-contained; EVERY other flag (including an unknown long flag) is boolean
+# and swallows nothing. This is how npm/yarn/pnpm/bun actually parse, so an
+# unknown flag never eats the package that follows it.
+# ---------------------------------------------------------------------------
+
+
+class TestFlagConsistency:
+    def test_unknown_install_flag_swallows_no_value(self):
+        # --unknownflag is boolean -> axio (one edit from axios) is still a real
+        # install target and flags HIGH; lodash is legitimate.
+        assert_flags("npm install --unknownflag axio lodash", "axios")
+
+    def test_known_value_flag_before_subcommand_consumes_its_value(self):
+        # --registry is value-taking -> http://x is its value (skipped), and the
+        # real package lodahs flags as lodash.
+        assert_flags("npm install --registry http://x lodahs", "lodash")
+
+    def test_known_value_flag_consumes_a_typosquat_value(self):
+        # --before is value-taking -> it consumes lodahs as its value (not a
+        # package); axio remains and flags as axios.
+        assert_flags("npm install --before lodahs axio", "axios")
+
+    def test_equals_form_value_flag_is_self_contained(self):
+        # --omit=dev carries its own value -> lodahs stays a package and flags.
+        assert_flags("npm install --omit=dev lodahs", "lodash")
+
+    def test_unknown_global_flag_value_is_skipped_to_reach_install(self):
+        # --foo is boolean; 'bar' is the next token but is NOT a real npm
+        # subcommand keyword. The robust subcommand scan skips 'bar' and keeps
+        # going, reaching the real 'install' so the typosquat behind it (lodahs)
+        # is still flagged -- closing the value-flag-before-subcommand gap even
+        # for a flag we did not enumerate.
+        assert_flags("npm --foo bar install lodahs", "lodash")
+
+    def test_non_subcommand_leading_token_without_install_stays_clean(self):
+        # When nothing after the skipped non-subcommand token is a real
+        # install/runner subcommand, the scan finds no subcommand and stays LOW.
+        assert_clean("npm --foo bar baz lodahs")
+
+    def test_runner_unknown_flag_makes_next_positional_the_target(self):
+        # Per npx semantics, --some-flag is boolean, so the FIRST positional
+        # 'value' is the executed package (the runner target); 'lodahs' is a
+        # trailing argument to that program and is never an install target.
+        # 'value' is not a typosquat, so the command is clean. (Policy-pinned.)
+        assert_clean("npx --some-flag value lodahs")
+
+    def test_runner_known_value_flag_is_skipped_before_target(self):
+        # --registry is value-taking -> http://x skipped, leaving expres as the
+        # first positional runner target, which flags as express.
+        assert_flags("npx --registry http://x expres", "express")
+
+
+# ---------------------------------------------------------------------------
+# Value-taking flag BEFORE the install subcommand
+#
+# A real npm/yarn/pnpm/bun value-taking flag written bare before the install
+# subcommand consumes its own value; the subcommand and the package behind it
+# must still be reached. Previously these mis-routed to LOW because the flags
+# were absent from the value-taking set; the expanded set plus the robust
+# subcommand scan close the gap.
+# ---------------------------------------------------------------------------
+
+
+class TestValueFlagBeforeSubcommand:
+    @pytest.mark.parametrize(
+        "command",
+        [
+            "npm --tag beta install loadsh",
+            "npm --audit-level high install loadsh",
+            "npm --install-strategy nested install loadsh",
+            "npm --scope @myscope install loadsh",
+            "npm --otp 123456 install loadsh",
+            "npm --registry http://x install loadsh",
+            "npm --https-proxy http://p install loadsh",
+            "npm --proxy http://p install loadsh",
+            "npm --maxsockets 5 install loadsh",
+            "npm --fetch-retries 3 install loadsh",
+            "npm --fetch-timeout 1000 install loadsh",
+            "npm --cafile /tmp/ca.pem install loadsh",
+            "npm --ca somecert install loadsh",
+            "npm --cert somecert install loadsh",
+            "npm --key somekey install loadsh",
+            "npm --before 2020-01-01 install loadsh",
+            "npm --loglevel silent install loadsh",
+            "npm --omit dev install loadsh",
+            "npm --include optional install loadsh",
+        ],
+    )
+    def test_npm_value_flag_before_subcommand_flags(self, command: str):
+        assert_flags(command, "lodash")
+
+    def test_yarn_cwd_value_flag_before_add(self):
+        assert_flags("yarn --cwd /tmp add loadsh", "lodash")
+
+    def test_pnpm_filter_value_flag_before_add(self):
+        assert_flags("pnpm --filter foo add loadsh", "lodash")
+
+    def test_pnpm_store_dir_value_flag_before_install(self):
+        assert_flags("pnpm --store-dir /s install loadsh", "lodash")
+
+    def test_bun_cwd_value_flag_before_add(self):
+        assert_flags("bun --cwd /tmp add loadsh", "lodash")
+
+    def test_unknown_value_flag_backstop_still_reaches_install(self):
+        # --someunknownvalflag is NOT enumerated, so its value 'X' is not
+        # consumed as a value; but 'X' is not a real subcommand keyword either,
+        # so the robust scan skips it and still reaches 'install', flagging the
+        # typosquat. This is the version-independent backstop.
+        assert_flags("npm --someunknownvalflag X install loadsh", "lodash")
+
+    def test_legacy_peer_deps_is_boolean_not_value_taking(self):
+        # --legacy-peer-deps is a Boolean npm flag, so it must NOT consume the
+        # following token. loadsh stays a real install target and flags.
+        assert_flags("npm install --legacy-peer-deps loadsh", "lodash")
+
+    def test_value_flag_swallows_its_typosquat_value_not_a_package(self):
+        # --tag is value-taking, so 'loadsh' is its value (not an install
+        # target). The only real package, lodash, is legitimate -> clean.
+        assert_clean("npm --tag loadsh install lodash")
+
+
+# ---------------------------------------------------------------------------
+# Manager-aware -w / --workspace value consumption
+#
+# The SAME spelling is a value flag in one CLI and a boolean switch in another:
+# npm ``-w``/``--workspace`` takes a workspace NAME (Type String), but pnpm
+# ``-w`` is the boolean ``--workspace-root``, and yarn/bun expose no value-taking
+# ``-w`` for ``add`` (yarn ``workspace`` is a subcommand). Treating ``-w`` as
+# value-taking everywhere was a false negative: ``pnpm add -w expres`` skipped
+# ``expres``. Value consumption is now manager-aware.
+#
+# The npm-only ``--omit``/``--include`` enum flags are likewise scoped to npm:
+# under npm they consume their value; under pnpm/yarn/bun they are boolean.
+# ---------------------------------------------------------------------------
+
+
+class TestManagerAwareWorkspaceFlag:
+    def test_pnpm_w_is_boolean_so_package_after_it_flags(self):
+        # BUG #5 repro: pnpm '-w' is the boolean --workspace-root, so 'expres'
+        # is the install target, not the flag's value. Previously [] (skipped).
+        assert_flags("pnpm add -w expres", "express")
+
+    def test_pnpm_w_boolean_typosquat_of_lodash(self):
+        assert_flags("pnpm add -w lodahs", "lodash")
+
+    def test_bun_w_is_boolean_so_package_after_it_flags(self):
+        # bun 'add' has no value-taking -w, so it consumes nothing.
+        assert_flags("bun add -w expres", "express")
+
+    def test_yarn_w_is_boolean_so_package_after_it_flags(self):
+        # yarn 'add' has no value-taking -w (workspace is a subcommand), so -w
+        # consumes nothing and lodahs is the install target.
+        assert_flags("yarn add -w lodahs", "lodash")
+
+    def test_pnpm_long_workspace_root_is_boolean(self):
+        assert_flags("pnpm add --workspace-root lodahs", "lodash")
+
+    def test_npm_w_takes_workspace_value_then_flags_package(self):
+        # NO REGRESSION: npm -w consumes the workspace value 'pkg'; the real
+        # package 'loadsh' still flags.
+        assert_flags("npm install -w pkg loadsh", "lodash")
+
+    def test_npm_w_consumes_lone_typosquat_as_workspace_value(self):
+        # npm -w is value-taking: with only one token after it, that token is the
+        # workspace NAME (not a package), so nothing installs -> clean. This is
+        # the correct npm semantics, not a regression.
+        assert_clean("npm install -w lodahs")
+
+    def test_npm_long_workspace_takes_value_then_flags_package(self):
+        assert_flags("npm install --workspace ui loadsh", "lodash")
+
+    def test_npm_omit_is_value_taking_then_flags_package(self):
+        # npm --omit consumes 'dev' (enum value); 'loadsh' still flags.
+        assert_flags("npm install --omit dev loadsh", "lodash")
+
+    def test_pnpm_omit_is_boolean_so_package_after_it_flags(self):
+        # --omit/--include are npm-only; under pnpm they are boolean and consume
+        # nothing, so 'loadsh' is the install target.
+        assert_flags("pnpm add --omit loadsh", "lodash")
+
+
+# ---------------------------------------------------------------------------
+# Yarn 'global' transparent prefix wrapper
+#
+# BUG #6: 'global' is a known yarn subcommand, so the subcommand scan stopped on
+# it and never reached the real action ('add'/'remove') behind it. 'yarn global'
+# runs that action in the global scope, so it is a transparent prefix: we
+# advance past it and re-resolve the real subcommand on the remainder.
+# npm/pnpm/bun install globally with a boolean -g/--global flag (already
+# handled), not a wrapping subcommand.
+# ---------------------------------------------------------------------------
+
+
+class TestYarnGlobalPrefix:
+    def test_yarn_global_add_routes_to_add(self):
+        # BUG #6 repro: previously [] because the scan stopped at 'global'.
+        assert_flags("yarn global add expres", "express")
+
+    def test_yarn_global_add_typosquat_of_lodash(self):
+        assert_flags("yarn global add lodahs", "lodash")
+
+    def test_yarn_global_add_legit_package_is_clean(self):
+        assert_clean("yarn global add lodash")
+
+    def test_yarn_global_remove_is_not_an_install_subcommand(self):
+        # NO REGRESSION: 'remove' is not an install/runner subcommand, so even
+        # the typosquat-shaped argument behind it stays clean.
+        assert_clean("yarn global remove lodash")
+
+    def test_yarn_global_remove_typosquat_arg_still_clean(self):
+        assert_clean("yarn global remove lodahs")
+
+    def test_yarn_global_add_with_w_boolean_flag(self):
+        # Under yarn, -w is boolean (no value), so the package after it flags
+        # even behind the global prefix.
+        assert_flags("yarn global add -w expres", "express")
+
+    def test_yarn_global_bin_is_not_install(self):
+        # 'yarn global bin' is a non-install action -> clean.
+        assert_clean("yarn global bin lodahs")
+
+
+# ---------------------------------------------------------------------------
+# Flag value equal to a subcommand keyword
+#
+# A known value-taking flag must consume its value even when that value spells a
+# subcommand keyword: ``npm --tag install install loadsh`` -> ``--tag`` eats the
+# first ``install`` (its tag value), and the SECOND ``install`` is the real
+# subcommand, so loadsh flags. The flag value is never mistaken for the route.
+# ---------------------------------------------------------------------------
+
+
+class TestFlagValueEqualsSubcommandKeyword:
+    def test_tag_value_equal_to_install_keyword_routes_correctly(self):
+        assert_flags("npm --tag install install loadsh", "lodash")
+
+    def test_scope_value_equal_to_add_keyword_routes_correctly(self):
+        assert_flags("npm --scope add install loadsh", "lodash")
+
+    def test_value_equal_to_keyword_does_not_become_subcommand_when_no_install(
+        self,
+    ):
+        # --tag eats the 'install' value; nothing real follows, so no package is
+        # collected and the command stays clean (the eaten 'install' is a value,
+        # never a route).
+        assert_clean("npm --tag install lodash")
+
+
+# ---------------------------------------------------------------------------
+# Package name normalization
+# ---------------------------------------------------------------------------
+
+
+class TestPackageNameNormalization:
+    def test_strips_trailing_version_keeps_name(self):
+        assert_flags("npm install lodahs@4.17.21", "lodash")
+
+    def test_does_not_crash_on_scoped_packages_keeps_scope(self):
+        assert_clean("npm install @scope/pkg@1.2.3")
+
+    def test_normalize_scoped_version(self):
+        assert _normalize_package_name("@scope/pkg@1.2.3") == "@scope/pkg"
+
+    def test_normalize_unscoped_version(self):
+        assert _normalize_package_name("lodash@4") == "lodash"
+
+    def test_normalize_scoped_no_version(self):
+        assert _normalize_package_name("@scope/pkg") == "@scope/pkg"
+
+    def test_normalize_lowercases(self):
+        assert _normalize_package_name("LoDaHs") == "lodahs"
+
+
+# ---------------------------------------------------------------------------
+# Other package managers
+# ---------------------------------------------------------------------------
+
+
+class TestOtherPackageManagers:
+    def test_flags_yarn_add_typosquats(self):
+        assert_flags("yarn add lodahs", "lodash")
+
+    def test_flags_pnpm_add_typosquats(self):
+        assert_flags("pnpm add lodahs", "lodash")
+
+    def test_flags_bun_add_typosquats(self):
+        assert_flags("bun add lodahs", "lodash")
+
+    def test_flags_pnpm_dlx_runner_targets(self):
+        assert_flags("pnpm dlx expres", "express")
+
+    def test_flags_yarn_dlx_runner_targets(self):
+        assert_flags("yarn dlx expres", "express")
+
+    def test_ignores_yarn_add_with_no_packages(self):
+        assert_clean("yarn add")
+
+    def test_pnpm_install_short_alias(self):
+        assert_flags("pnpm i lodahs", "lodash")
+
+
+# ---------------------------------------------------------------------------
+# Multiple hits
+# ---------------------------------------------------------------------------
+
+
+class TestMultipleHits:
+    def test_collects_multiple_typosquats(self):
+        findings = find_typosquat_installs("npm install lodahs expres")
+        suggestions = {f.suggestion for f in findings}
+        assert suggestions == {"lodash", "express"}
+        assert len(findings) == 2
+
+    def test_de_duplicates_repeated_typosquat(self):
+        findings = find_typosquat_installs("npm install lodahs lodahs")
+        assert len(findings) == 1
+
+    def test_de_duplicates_across_sub_commands(self):
+        findings = find_typosquat_installs("npm install lodahs && npm install lodahs")
+        assert len(findings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Path-prefixed binaries
+# ---------------------------------------------------------------------------
+
+
+class TestPathPrefixedBinaries:
+    def test_strips_path_prefix_on_binary(self):
+        assert_flags("/usr/bin/npm install lodahs", "lodash")
+
+    def test_strips_path_prefix_on_runner(self):
+        assert_flags("/usr/local/bin/npx expres", "express")
+
+
+# ---------------------------------------------------------------------------
+# Empty / non-install commands
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyOrUnrelated:
+    def test_clean_for_empty_command(self):
+        assert_clean("")
+
+    def test_clean_for_unrelated_command(self):
+        assert_clean("git status")
+
+    def test_clean_for_pip_install(self):
+        # pip is not an npm-ecosystem manager; out of scope, must not flag.
+        assert_clean("pip install requestss")
+
+
+# ---------------------------------------------------------------------------
+# Reason wording
+# ---------------------------------------------------------------------------
+
+
+class TestReasonWording:
+    def test_reason_wording(self):
+        findings = find_typosquat_installs("npm install lodahs")
+        assert len(findings) == 1
+        assert findings[0].reason == (
+            "`lodahs` is one edit away from the popular package `lodash`"
+        )
+
+    def test_finding_is_frozen(self):
+        finding = TyposquatFinding(package="lodahs", suggestion="lodash")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            finding.package = "x"  # type: ignore[misc]
+
+
+# ---------------------------------------------------------------------------
+# OSA distance unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestOsaDistance:
+    @pytest.mark.parametrize(
+        "a,b,expected",
+        [
+            ("lodash", "lodash", 0),
+            ("lodahs", "lodash", 1),  # adjacent transposition
+            ("expres", "express", 1),  # deletion
+            ("typscript", "typescript", 1),  # insertion
+            ("axio", "axios", 1),  # deletion
+            ("lodaaash", "lodash", 2),  # two edits -> capped to 2 (> max)
+        ],
+    )
+    def test_distance_values(self, a: str, b: str, expected: int):
+        assert _osa_distance_within(a, b, 1) == expected
+
+    def test_length_gap_short_circuits(self):
+        # Length difference exceeds max -> returns max + 1 without full DP.
+        assert _osa_distance_within("a", "abcdef", 1) == 2
+
+
+# ---------------------------------------------------------------------------
+# Sub-command traversal (now via the tree-sitter AST view).
+#
+# The hand-rolled _split_sub_commands char scanner was replaced by
+# iter_commands over the parsed shell tree; these assertions pin the resulting
+# behavior end-to-end instead of poking at the deleted splitter.
+# ---------------------------------------------------------------------------
+
+
+class TestSubCommandTraversal:
+    def test_quoted_operators_are_not_separators(self):
+        # The ';' lives inside a double-quoted echo arg; the install after &&
+        # is still surfaced, and the quoted ';' does not create a spurious one.
+        assert_flags('echo "a ; b" && npm install lodahs', "lodash")
+
+    def test_double_operator_chaining(self):
+        # Both halves are parsed; the install after && is flagged.
+        assert_flags("true && npm install lodahs", "lodash")
+
+    def test_semicolon_separated_commands(self):
+        assert_flags("echo done; npm i lodahs", "lodash")
+
+    def test_repeated_empty_separators_are_harmless(self):
+        assert_flags(";;; npm install lodahs ;;;", "lodash")
+
+    def test_or_separated_commands(self):
+        assert_flags("cat foo || npm install lodahs", "lodash")
+
+    def test_background_separated_commands(self):
+        assert_flags("sleep 1 & npm install lodahs", "lodash")
+
+
+# ---------------------------------------------------------------------------
+# AST structural cases (the correctness upgrade over the char scanner).
+# ---------------------------------------------------------------------------
+
+
+class TestAstStructural:
+    def test_path_qualified_manager_via_posix_basename(self):
+        assert_flags("/bin/npm install loadsh", "lodash")
+
+    def test_collapsed_odd_spacing(self):
+        assert_flags("npm install   loadsh", "lodash")
+
+    def test_single_quote_raw_string_recovery(self):
+        assert_flags("npm install 'loadsh'", "lodash")
+
+    def test_double_quote_string_recovery(self):
+        assert_flags('npm install "loadsh"', "lodash")
+
+    def test_command_substitution_nested_command_surfaced(self):
+        # iter_commands descends into $(...), so the inner install is scanned.
+        assert_flags("echo $(npm install loadsh)", "lodash")
+
+    def test_runner_via_ast(self):
+        assert_flags("npx loadsh", "lodash")
+
+    def test_whole_install_inside_double_quoted_string_is_inert(self):
+        # The entire install is one echo argument (a string), not a command.
+        assert_clean('echo "npm install lodahs"')
+
+    def test_bash_dash_c_inner_string_is_opaque(self):
+        # Known coverage limitation: the inner -c string is an opaque argument
+        # to bash and is not surfaced as a command by the AST view.
+        assert_clean('bash -c "npm install lodahs"')
+
+    def test_opaque_outer_command_name_is_skipped(self):
+        # The outer command name $(echo npm) is opaque -> that command is
+        # skipped; the inner 'echo npm' yields no manager. Clean overall.
+        assert_clean("$(echo npm) install lodahs")
+
+    def test_parse_error_still_yields_operand(self):
+        # Unterminated quote -> program has_error, but tree-sitter recovers and
+        # the lodahs operand is still surfaced.
+        assert_flags('npm install lodahs "unterminated', "lodash")
+
+
+# ---------------------------------------------------------------------------
+# Interior-quote / backslash obfuscation of the operand name
+#
+# A real shell collapses interior quoting and backslash escapes inside one
+# argv token: `npm install lo""adsh` runs `npm install loadsh`. The bounded
+# operand-literal decode reconstructs that single token and re-admits it only
+# when it matches a strict package-spec shape, so the obfuscated typosquats
+# below now flag while runtime expansions and embedded spaces stay opaque.
+# ---------------------------------------------------------------------------
+
+
+class TestOperandObfuscation:
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ('npm install lo""adsh', "empty double-quote in the middle"),
+            ('npm install load"sh"', "trailing double-quoted segment"),
+            ("npm install lo'adsh'", "trailing single-quoted raw_string segment"),
+            ("npm install lo\\adsh", "single backslash escape"),
+            ('npm install l"o"a"d"s"h"', "every other char double-quoted"),
+            ("npm install lo'a'dsh", "interior single-quoted segment"),
+            ("npm install lo''adsh", "empty single-quote in the middle"),
+            ("npm install l\\o\\a\\d\\s\\h", "every char backslash-escaped"),
+            ('npm install "load"sh', "leading double-quoted then bare concat"),
+            ("npm install 'load'sh", "leading single-quoted then bare concat"),
+            ("npm i lo\\adsh", "obfuscation behind the i alias"),
+            ("npx lo\\adsh", "obfuscated runner target"),
+            ("sudo npm install lo''adsh", "obfuscation behind a wrapper"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_obfuscated_operand_is_decoded_and_flagged(self, command: str, desc: str):
+        assert_flags(command, "lodash")
+
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("npm install $(echo loadsh)", "command substitution stays opaque"),
+            ("npm install `echo loadsh`", "backticks stay opaque"),
+            ("npm install $CMD", "bare variable stays opaque"),
+            ("npm install lo$xadsh", "interior variable stays opaque"),
+            ("npm install lo*dsh", "glob stays opaque"),
+            ('npm install "a b"', "embedded space is not a single package name"),
+            ('npm install lo"$x"adsh', "variable inside a quoted segment is opaque"),
+            (
+                'npm install lo"$(id)"adsh',
+                "command substitution inside a quoted segment is opaque",
+            ),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_runtime_or_split_operand_stays_opaque(self, command: str, desc: str):
+        assert_clean(command)
+
+    def test_exact_popular_name_with_interior_quotes_stays_clean(self):
+        # Decoding must not turn a legitimate popular package into a hit just
+        # because it was quoted: `lo""dash` decodes to the popular `lodash`.
+        assert_clean('npm install lo""dash')
+
+    def test_scoped_name_via_single_quotes_is_recovered_not_flagged(self):
+        # A quoted scoped name decodes to @scope/pkg and is a valid spec, but it
+        # is not a typosquat, so the command stays clean (proves decode + the
+        # strict spec accept scoped/@version shapes without false positives).
+        assert_clean("npm install '@scope/pkg'")
+
+
+# ---------------------------------------------------------------------------
+# Command-NAME obfuscation
+#
+# A real shell collapses interior quoting, backslash escapes and ANSI-C quoting
+# in the COMMAND NAME too: `n"p"m install loadsh`, `\npm ...`, `$'npm' ...` all
+# exec the binary `npm`. The same bounded literal decode used for operands is
+# applied to the command-name word (then the POSIX path prefix is stripped)
+# before dispatch, so these obfuscated managers/runners are recognized. A
+# runtime expansion in the name (`$CMD`, `$(echo npm)`) stays opaque and LOW.
+# ---------------------------------------------------------------------------
+
+
+class TestCommandNameObfuscation:
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ('n"p"m install loadsh', "interior double-quote in npm"),
+            ("n'p'm install loadsh", "interior single-quote in npm"),
+            (r"\npm install loadsh", "leading backslash escape"),
+            (r"n\p\m install loadsh", "interior backslash escapes"),
+            ("$'npm' install loadsh", "ANSI-C quoted npm"),
+            ('np"m" install loadsh', "trailing double-quoted segment"),
+            ("/usr/''bin/npm install loadsh", "path-qualified with empty quote"),
+            ("sudo $'npm' install loadsh", "ANSI-C name behind a wrapper"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_obfuscated_manager_name_is_decoded_and_flagged(
+        self, command: str, desc: str
+    ):
+        assert_flags(command, "lodash")
+
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ('n"p"x loadsh', "interior double-quote in npx runner"),
+            (r"\npx loadsh", "backslash-escaped npx runner"),
+            ("$'npx' loadsh", "ANSI-C quoted npx runner"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_obfuscated_runner_name_is_decoded_and_flagged(
+        self, command: str, desc: str
+    ):
+        assert_flags(command, "lodash")
+
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("$CMD install loadsh", "bare variable command name stays opaque"),
+            ("$(echo npm) install loadsh", "command substitution name stays opaque"),
+            ("${NPM} install loadsh", "brace-expansion name stays opaque"),
+            ("`echo npm` install loadsh", "backtick name stays opaque"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_runtime_command_name_stays_opaque(self, command: str, desc: str):
+        assert_clean(command)
+
+    def test_obfuscated_name_of_popular_stays_clean(self):
+        # Decoding the name must not invent a hit: `$'npm' install lodash`
+        # installs the popular package, so the command stays clean.
+        assert_clean("$'npm' install lodash")
+
+    def test_obfuscated_non_manager_name_stays_clean(self):
+        # An obfuscated name that decodes to a non-manager binary must not be
+        # routed into install collection.
+        assert_clean("$'echo' npm install loadsh")
+
+
+# ---------------------------------------------------------------------------
+# ANSI-C ($'...') operand decoding
+#
+# bash decodes `$'...'` escapes before passing the argument: `$'loadsh'` is the
+# token `loadsh`, and `$'loa\x64sh'` is also `loadsh` (\x64 == 'd'). The literal
+# decoder resolves the common ANSI-C escapes and re-admits the result only when
+# it matches the strict package-spec shape, so a control char or space stays
+# opaque (LOW).
+# ---------------------------------------------------------------------------
+
+
+class TestAnsiCOperandDecoding:
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("npm install $'loadsh'", "plain ANSI-C operand"),
+            (r"npm install $'loa\x64sh'", "hex escape backslash-x64 -> d"),
+            (r"npm install $'loa\144sh'", "octal escape backslash-144 -> d"),
+            (r"npm install $'loa\u0064sh'", "unicode escape backslash-u0064 -> d"),
+            (r"npm install $'\x6coadsh'", "leading hex escape backslash-x6c -> l"),
+            ("npx $'loadsh'", "ANSI-C runner target"),
+            (r"npm install lo$'a'dsh", "ANSI-C segment concatenated with bare"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_ansi_c_operand_is_decoded_and_flagged(self, command: str, desc: str):
+        assert_flags(command, "lodash")
+
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            (r"npm install $'a b'", "embedded space is not one package name"),
+            (r"npm install $'lo\tadsh'", "embedded tab control char stays opaque"),
+            (r"npm install $'lo\nadsh'", "embedded newline stays opaque"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_ansi_c_operand_with_metachar_stays_opaque(self, command: str, desc: str):
+        assert_clean(command)
+
+    def test_ansi_c_of_popular_stays_clean(self):
+        # `$'lodash'` decodes to the popular package -> not a typosquat.
+        assert_clean("npm install $'lodash'")
+
+
+# ---------------------------------------------------------------------------
+# Backslash-newline line continuation
+#
+# bash joins an unquoted backslash-newline into nothing before tokenizing, so
+# `npm install loa\<newline>dsh` runs `npm install loadsh`. tree-sitter-bash
+# does not fold it, so the join is done at the source level before parsing,
+# matching the shell -- but a backslash-newline INSIDE single quotes is literal
+# in bash and is preserved (so it does NOT become `loadsh`).
+# ---------------------------------------------------------------------------
+
+
+class TestLineContinuation:
+    def test_line_continuation_in_operand_joins_to_package(self):
+        assert_flags("npm install loa\\\ndsh", "lodash")
+
+    def test_line_continuation_mid_operand_joins(self):
+        assert_flags("npm install lo\\\nadsh", "lodash")
+
+    def test_line_continuation_in_command_name_joins(self):
+        assert_flags("np\\\nm install loadsh", "lodash")
+
+    def test_crlf_line_continuation_joins(self):
+        assert_flags("npm install loa\\\r\ndsh", "lodash")
+
+    def test_line_continuation_does_not_merge_separate_commands(self):
+        # A bare newline (no backslash) still separates commands; only the
+        # backslash-newline is removed.
+        assert_flags("cd ui\nnpm install lodahs", "lodash")
+
+    def test_backslash_newline_inside_single_quotes_is_literal(self):
+        # bash keeps the backslash-newline literal inside single quotes, so the
+        # package is literally `loa\<newline>dsh`, never `loadsh` -- stays clean.
+        assert_clean("npm install 'loa\\\ndsh'")
+
+    def test_backslash_newline_inside_double_quotes_joins(self):
+        # bash DOES remove a backslash-newline inside double quotes, so
+        # `npm install "loa\<newline>dsh"` runs `npm install loadsh`.
+        assert_flags('npm install "loa\\\ndsh"', "lodash")
+
+    def test_apostrophe_in_double_quoted_arg_does_not_desync_continuation(self):
+        # An apostrophe inside a double-quoted arg (`"a'b"`) is a LITERAL quote,
+        # not a single-quote opener. The old joiner tracked only single-quote
+        # state and flipped on this `'`, so the following real backslash-newline
+        # continuation was wrongly treated as inside single quotes and left
+        # unjoined -- a false negative. The typosquat must now be flagged.
+        quote = chr(39)
+        command = "npm install " + quote.join(['"a', 'b"']) + " loa\\\ndsh"
+        assert command == 'npm install "a' + chr(39) + 'b" loa\\\ndsh'
+        assert_flags(command, "lodash")
+
+    def test_apostrophe_in_comment_does_not_desync_continuation(self):
+        # An apostrophe inside a `# comment` is consumed by the comment, not a
+        # single-quote opener. The old single-quote-only joiner flipped on this
+        # `'`, desyncing the state for the NEXT command's backslash-newline
+        # continuation and hiding the typosquat. Both must now be flagged.
+        quote = chr(39)
+        command = "npm install pkg # don" + quote + "t\nnpm install loa\\\ndsh"
+        assert (
+            command == "npm install pkg # don" + chr(39) + "t\nnpm install loa\\\ndsh"
+        )
+        assert_flags(command, "lodash")
+
+    def test_double_quote_inside_single_quotes_is_literal(self):
+        # A `"` inside single quotes must NOT open a double-quote span; the
+        # backslash-newline inside the single-quoted arg stays literal -> clean.
+        assert_clean("npm install 'a\"b loa\\\ndsh'")
+
+
+# ---------------------------------------------------------------------------
+# Encoding-evasion normalization at the parser entry
+#
+# The public entry point normalizes before parsing, stripping invisible /
+# zero-width / line-separator code points and NFKC-folding fullwidth glyphs.
+# These regressions pin that the parser itself (not just the analyzer) defeats
+# the evasion -- including U+0085/U+2028/U+2029, which previously split a
+# package name when splitlines() ran before invisibles were stripped.
+# ---------------------------------------------------------------------------
+
+
+class TestEncodingEvasionNormalization:
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("npm install lod\u0085ahs", "U+0085 NEL line separator split"),
+            ("npm install lod\u2028ahs", "U+2028 line separator split"),
+            ("npm install lod\u2029ahs", "U+2029 paragraph separator split"),
+            ("npm install lod\u200bahs", "zero-width space split"),
+            ("npm install load\u200bsh", "zero-width split of loadsh"),
+            ("ｎｐｍ install lodahs", "fullwidth npm folds to ascii"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_invisible_or_fullwidth_evasion_is_flagged(self, command: str, desc: str):
+        assert_flags(command, "lodash")
+
+    def test_normalize_keeps_newlines_as_command_boundaries(self):
+        # A real newline must survive normalization so the install after it is a
+        # separate command the AST view surfaces.
+        assert_flags("cd ui\nnpm install lodahs", "lodash")
+
+    def test_normalize_does_not_invent_typosquats(self):
+        # Legitimate lodash with an embedded zero-width still decodes to lodash
+        # (popular) -- it must stay clean, not become a hit.
+        assert_clean("npm install lod​ash")
+
+
+# ---------------------------------------------------------------------------
+# Env-assignment unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestEnvAssignment:
+    @pytest.mark.parametrize(
+        "token,expected",
+        [
+            ("FOO=bar", True),
+            ("_X=1", True),
+            ("A1_B=v", True),
+            ("=bar", False),
+            ("1FOO=bar", False),
+            ("FO-O=bar", False),
+            ("npm", False),
+        ],
+    )
+    def test_env_assignment(self, token: str, expected: bool):
+        assert _is_env_assignment(token) is expected
+
+
+# ---------------------------------------------------------------------------
+# Data integrity
+# ---------------------------------------------------------------------------
+
+
+class TestDataIntegrity:
+    def test_no_popular_package_flags_itself(self):
+        # Every curated popular name must be treated as legitimate, never a
+        # typosquat of another popular name.
+        for pkg in POPULAR_PACKAGES:
+            assert_clean(f"npm install {pkg}")
+
+
+# ---------------------------------------------------------------------------
+# Static comma-brace expansion of the operand name
+#
+# bash expands a comma-brace word textually before exec, so `npm install
+# lo{a,}dsh` actually runs `npm install loadsh lodsh` (two argv words). Without
+# expansion that word parses as one opaque concatenation and the `loadsh`
+# typosquat slips through. The bounded expander below decodes ONLY the pure
+# static comma-brace form (no ranges, no nesting, no quotes, no runtime element),
+# checks every expansion against the typosquat heuristic, and caps total
+# expansions so a crafted word cannot blow up.
+# ---------------------------------------------------------------------------
+
+
+def _brace_word(command: str):
+    """Return the first command word whose text contains a brace, for unit tests."""
+    program = parse_shell_program(command)
+    for cmd in iter_commands(program):
+        for word in cmd.words:
+            if "{" in word.text:
+                return word
+    raise AssertionError(f"no brace word found in {command!r}")
+
+
+class TestBraceExpansion:
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("npm install lo{a,}dsh", "reviewer case: loadsh alternative"),
+            ("npm install {axio,lodash}", "first alt axio is a typosquat of axios"),
+            ("npm i {react,lodahs}", "second alt lodahs is a typosquat of lodash"),
+            ("npm install lod{a,}sh", "lodash core with empty alt yields lodash+lodsh"),
+            ("npx {lodahs,foo}", "runner first positional brace target"),
+            ("yarn add {expres,foo}", "yarn add brace alternative typosquat"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_static_brace_alternative_is_expanded_and_flagged(
+        self, command: str, desc: str
+    ):
+        # Each command has at least one brace alternative one edit off a popular
+        # package; expansion must surface it.
+        findings = find_typosquat_installs(command)
+        assert findings, f'expected "{command}" ({desc}) to be flagged'
+
+    def test_reviewer_case_flags_loadsh_for_lodash(self):
+        # The exact reviewer report: `npm install lo{a,}dsh` -> bash argv
+        # `loadsh lodsh`; `loadsh` is one edit from `lodash`.
+        assert_flags("npm install lo{a,}dsh", "lodash")
+        findings = find_typosquat_installs("npm install lo{a,}dsh")
+        assert any(f.package == "loadsh" for f in findings), (
+            f"expected the loadsh expansion, got {[f.package for f in findings]}"
+        )
+
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("npm install a{x,y}b", "neither axb nor ayb resembles a popular name"),
+            ("npm install pre{,fix}", "pre/prefix are not typosquats"),
+            ("npm install {react,lodash}", "both alternatives are legitimate popular"),
+            ("npm install {vue,react}{,-dom}", "vue/react/react-dom all popular"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_benign_brace_expansion_stays_clean(self, command: str, desc: str):
+        assert_clean(command)
+
+    @pytest.mark.parametrize(
+        "command,desc",
+        [
+            ("npm install lo{a,$X}dsh", "runtime variable inside brace stays opaque"),
+            ("npm install pkg{1..3}", "numeric range is out of scope"),
+            ("npm install lo{a,{b,c}}dsh", "nested brace is out of scope"),
+            ('npm install "lo{a,}dsh"', "quoted brace is not expanded by bash"),
+            ('npm install lo{a,}d"s"h', "brace touching a quote stays opaque"),
+            ("npm install lo\\{a,\\}dsh", "escaped braces are literal, not expanded"),
+            ("npm install {abc}sh", "comma-less brace is literal in bash"),
+        ],
+        ids=lambda v: v if " " not in v else None,
+    )
+    def test_out_of_scope_brace_forms_stay_low(self, command: str, desc: str):
+        # These would each expand to a typosquat IF we handled them, but they are
+        # deliberately out of scope; the analyzer must stay LOW, not guess.
+        assert_clean(command)
+
+    def test_runtime_brace_does_not_invent_a_typosquat(self):
+        # `lo{a,$X}dsh` could be `loadsh` at runtime, but $X is unknowable; we
+        # must not flag the static `loa...` alternative as if it were the value.
+        assert_clean("npm install lo{a,$X}dsh")
+
+    def test_expansion_cap_bails_instead_of_blowing_up(self):
+        # 4 * 4 * 4 = 64 combinations exceeds the 32 cap, so the expander returns
+        # None (treated as opaque) rather than materializing 64 tokens.
+        word = _brace_word("x p{a,b,c,d}{a,b,c,d}{a,b,c,d}sh")
+        assert _expand_static_braces(word) is None
+        # And end to end it stays clean (no blow-up, no finding).
+        assert_clean("npm install p{a,b,c,d}{a,b,c,d}{a,b,c,d}sh")
+
+    def test_group_count_cap_bails(self):
+        # Nine expanding groups exceeds the 8-group cap -> opaque.
+        word = _brace_word("x " + "{a,b}" * 9)
+        assert _expand_static_braces(word) is None
+
+    def test_expansion_matches_bash_order_and_values(self):
+        # Cartesian product across two groups, in bash's order.
+        word = _brace_word("x {a,b}{c,d}")
+        assert _expand_static_braces(word) == ["ac", "ad", "bc", "bd"]
+
+    def test_plain_word_is_not_treated_as_brace(self):
+        # A word with no brace must return None so the normal single-token
+        # recovery path runs unchanged.
+        word = _brace_word("x lod{a,}sh")  # has brace, sanity that helper works
+        assert _expand_static_braces(word) == ["lodash", "lodsh"]
+
+
+# ---------------------------------------------------------------------------
+# Pathologically nested / chained input (DoS hardening)
+#
+# The recursive tree-sitter-bash walkers in the shared `_shell_ast` view descend
+# per nested `$()` level and per chained operator, so hundreds of either can
+# exhaust the Python recursion stack and raise RecursionError. `find_typosquat_
+# installs` must NEVER let that escape: it catches the RecursionError (and
+# short-circuits absurdly large commands) and returns [] -- "no finding" -- so a
+# crafted command can only ever fail to be analyzed, not crash the seam. This is
+# a documented limitation, not a guess: such adversarial noise stays clean.
+# ---------------------------------------------------------------------------
+
+
+class TestPathologicalInputDoesNotCrash:
+    def test_deeply_chained_operators_return_empty_without_raising(self):
+        # 1500 `&&`-chained commands build a deep right-leaning parse tree.
+        command = " && ".join("ls" for _ in range(1500))
+        # No exception, and nothing flagged (none of these is an install).
+        assert find_typosquat_installs(command) == []
+
+    def test_deeply_nested_command_substitution_returns_empty(self):
+        # 200 levels of `$( ... )` nesting; the walkers would otherwise recurse
+        # past the stack limit. Must return [] without raising.
+        command = "x" + "$(" * 200 + "echo" + ")" * 200
+        assert find_typosquat_installs(command) == []
+
+    def test_absurdly_large_command_is_short_circuited(self):
+        # Beyond _MAX_COMMAND_LENGTH the command is skipped as "no finding"
+        # before parsing, so even a huge input cannot blow the walkers.
+        command = "ls " * 50_000  # well over the 100k-char guard
+        assert find_typosquat_installs(command) == []
+
+    def test_moderately_chained_real_install_still_flags(self):
+        # The guard must NOT drop a legitimate long command: a real typosquat
+        # install behind dozens of chained steps is still flagged HIGH.
+        prefix = " && ".join(f"echo step{i}" for i in range(50))
+        command = f"{prefix} && npm install loadsh"
+        findings = find_typosquat_installs(command)
+        assert any(f.suggestion == "lodash" for f in findings), (
+            f"expected lodash typosquat, got {[f.reason for f in findings]}"
+        )
+
+    def test_real_install_in_short_chain_still_flags(self):
+        # Sanity that the try/except wrapper did not change normal behavior.
+        assert_flags("true && npm i loadsh", "lodash")
+        assert_flags("a && b && npm install loadsh", "lodash")

--- a/tests/sdk/security/supply_chain/test_parser.py
+++ b/tests/sdk/security/supply_chain/test_parser.py
@@ -164,6 +164,79 @@ def test_wrapper_option_value_is_not_promoted_to_package_manager():
     assert_clean("sudo -u npm install lodahs")
 
 
+@pytest.mark.parametrize(
+    "command",
+    [
+        'bash -c "npm install lodahs"',
+        "sh -lc 'npm i loadsh'",
+        "sh -O extglob -c 'npm install lodahs'",
+        "sh --rcfile /tmp/nope -c 'npm install lodahs'",
+        "/bin/dash -ec 'npm install lodahs'",
+        "zsh --no-rcs -fc 'npm install lodahs'",
+        "bash -T -c 'npm install lodahs'",
+        "zsh -R -c 'npm install lodahs'",
+        "zsh -O -c 'npm install lodahs'",
+        "zsh +O -c 'npm install lodahs'",
+        "sh +c 'npm install lodahs'",
+        "bash -oc pipefail 'npm install lodahs'",
+        "bash +oc pipefail 'npm install lodahs'",
+        "bash -Oc extglob 'npm install lodahs'",
+        "bash -xO extglob -c 'npm install lodahs'",
+        "bash -Ox extglob -c 'npm install lodahs'",
+        "zsh -xo nounset -c 'npm install lodahs'",
+        "zsh -oNO_RCS -c 'npm install lodahs'",
+        "zsh +oRCS -c 'npm install lodahs'",
+        "ksh -o nounset -lc 'npm install lodahs'",
+        "ksh -oerrexit -c 'npm install lodahs'",
+        "ksh +oerrexit -c 'npm install lodahs'",
+        "ksh -T 1 -c 'npm install lodahs'",
+        "ksh -xT 1 -c 'npm install lodahs'",
+        "ksh -T1 -c 'npm install lodahs'",
+        "ksh -xT1 -c 'npm install lodahs'",
+        "bash -O extglob -c 'npm install lodahs'",
+        'bash "-c" "npm install lodahs"',
+        "b\"a\"sh \\-lc 'npm install lodahs'",
+        'bash "$FLAGS" -c "npm install lodahs"',
+        'bash "$FLAG" "npm install lodahs"',
+        "exec -a worker bash -lc 'npm install lodahs'",
+        "sudo -u node /bin/bash -lc 'npm install lodahs'",
+        "env -S 'bash -lc \"npm install lodahs\"'",
+    ],
+)
+def test_executable_shell_command_strings_are_incomplete(command: str):
+    with pytest.raises(
+        SupplyChainAnalysisIncompleteError,
+        match="may execute a command string that was not recursively analyzed",
+    ):
+        find_typosquat_installs(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "bash -c",
+        "bash -c ''",
+        "bash -nc 'npm install lodahs'",
+        "bash -o noexec -c 'npm install lodahs'",
+        "bash -- -c 'npm install lodahs'",
+        "bash script.sh -c 'npm install lodahs'",
+    ],
+)
+def test_nonexecuted_shell_command_string_arguments_are_clean(command: str):
+    assert_clean(command)
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        'bash -c "$COMMAND"; npm install lodahs',
+        'npm install lodahs; bash -c "$COMMAND"',
+    ],
+)
+def test_static_finding_wins_over_incomplete_shell_command(command: str):
+    assert_flags(command, "lodash")
+
+
 # ---------------------------------------------------------------------------
 # Chained commands
 # ---------------------------------------------------------------------------
@@ -218,6 +291,53 @@ class TestRunners:
 
     def test_flags_bun_x_runner_target(self):
         assert_flags("bun x expres", "express")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "npx --package lodash --package lodahs some-bin",
+        "npx --package lodahs --package lodash some-bin",
+        "npx -p lodash -p lodahs some-bin",
+        "npx --package=lodash --package=lodahs some-bin",
+        "npm exec --package lodash --package lodahs -- some-bin",
+        "npm exec some-bin --package lodahs",
+        "npm exec some-bin -p lodahs",
+        "npm x some-bin --package=lodahs",
+        "npx -c 'echo safe' --package lodahs",
+        "npx --call='echo safe' --package=lodahs",
+        "npx -c='echo safe' --package lodahs",
+        "npx --package='lodahs' some-bin",
+        'npx "--package=lodahs" some-bin',
+        "npm exec --package='lodahs' -- some-bin",
+        "npx --registry=$URL lodahs",
+        "npx --package=$PKG --package lodahs some-bin",
+        "npx --script-shell /bin/sh lodahs",
+        "npx --shell /bin/sh lodahs",
+        "npx --node-options trace lodahs",
+        "npx --package={lodash,lodahs} some-bin",
+        "npx --package=lo{dah,da}s some-bin",
+        "npm exec --package={lodash,lodahs} -- some-bin",
+    ],
+)
+def test_runner_collects_every_explicit_package(command: str):
+    assert_flags(command, "lodash")
+
+
+def test_standalone_npx_stops_parsing_options_after_target():
+    assert_clean("npx lodash --package lodahs")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "npx -c lodahs",
+        "npm exec -c lodahs",
+        "npm exec lodahs -c 'echo safe'",
+    ],
+)
+def test_runner_call_string_is_not_an_inferred_package(command: str):
+    assert_clean(command)
 
 
 # ---------------------------------------------------------------------------
@@ -788,11 +908,6 @@ class TestAstStructural:
     def test_whole_install_inside_double_quoted_string_is_inert(self):
         # The entire install is one echo argument (a string), not a command.
         assert_clean('echo "npm install lodahs"')
-
-    def test_bash_dash_c_inner_string_is_opaque(self):
-        # Known coverage limitation: the inner -c string is an opaque argument
-        # to bash and is not surfaced as a command by the AST view.
-        assert_clean('bash -c "npm install lodahs"')
 
     def test_opaque_outer_command_name_is_skipped(self):
         # The outer command name $(echo npm) is opaque -> that command is

--- a/tests/sdk/security/supply_chain/test_parser.py
+++ b/tests/sdk/security/supply_chain/test_parser.py
@@ -13,7 +13,9 @@ import pytest
 
 from openhands.sdk.security._shell_ast import iter_commands, parse_shell_program
 from openhands.sdk.security.supply_chain.parser import (
+    _MAX_COMMAND_LENGTH,
     POPULAR_PACKAGES,
+    SupplyChainAnalysisIncompleteError,
     TyposquatFinding,
     _expand_static_braces,
     _is_env_assignment,
@@ -81,6 +83,85 @@ class TestNpmInstallDetection:
 
     def test_flags_typosquat_of_typescript_missing_letter(self):
         assert_flags("npm install typscript", "typescript")
+
+
+# ---------------------------------------------------------------------------
+# Command wrappers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sudo -u node npm install lodahs",
+        "doas -u node npm install lodahs",
+        "env -u FOO npm install lodahs",
+        "time -f %E npm install lodahs",
+        "nice -n 10 npm install lodahs",
+        "stdbuf -o L npm install lodahs",
+        "xargs -n 1 npm install lodahs",
+        "xargs -J % npm install lodahs",
+        "xargs -R 1 npm install lodahs",
+        "xargs -S 255 npm install lodahs",
+    ],
+)
+def test_wrapper_value_options_do_not_hide_package_manager(command: str):
+    assert_flags(command, "lodash")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "sudo -unode npm install lodahs",
+        "env --unset=FOO npm install lodahs",
+        "nice --adjustment=10 npm install lodahs",
+        "stdbuf --output=L npm install lodahs",
+        "xargs -n1 npm install lodahs",
+    ],
+)
+def test_attached_wrapper_option_values_do_not_hide_package_manager(command: str):
+    assert_flags(command, "lodash")
+
+
+@pytest.mark.parametrize(
+    "command",
+    [
+        "env -S npm install lodahs",
+        "env -S 'npm install lodahs'",
+        "env -iS 'npm install lodahs'",
+        "env -vS'npm install lodahs'",
+        "env --split-string='npm install lodahs'",
+    ],
+)
+def test_env_static_split_string_is_resolved(command: str):
+    assert_flags(command, "lodash")
+
+
+def test_runtime_env_split_string_is_incomplete():
+    with pytest.raises(SupplyChainAnalysisIncompleteError):
+        find_typosquat_installs('env -S "$COMMAND install lodahs"')
+
+
+def test_static_typosquat_finding_wins_over_later_incomplete_command():
+    assert_flags(
+        'npm install lodahs; env -S "$COMMAND install lodash"',
+        "lodash",
+    )
+
+
+def test_wrapper_option_terminator_and_nesting_reach_package_manager():
+    assert_flags(
+        "sudo -u node -- env -u FOO nice -n 10 -- npm install lodahs",
+        "lodash",
+    )
+
+
+def test_path_qualified_manager_behind_wrapper_is_reached():
+    assert_flags("sudo -- /usr/local/bin/npm install lodahs", "lodash")
+
+
+def test_wrapper_option_value_is_not_promoted_to_package_manager():
+    assert_clean("sudo -u npm install lodahs")
 
 
 # ---------------------------------------------------------------------------
@@ -510,6 +591,18 @@ class TestPackageNameNormalization:
 
     def test_normalize_lowercases(self):
         assert _normalize_package_name("LoDaHs") == "lodahs"
+
+    def test_flags_typosquat_npm_alias_target(self):
+        assert_flags("npm install lodash@npm:loadsh", "lodash")
+
+    def test_ignores_alias_name_when_npm_target_is_popular(self):
+        assert_clean("npm install loadsh@npm:lodash")
+
+    def test_normalize_scoped_versioned_npm_alias_target(self):
+        assert (
+            _normalize_package_name("@scope/alias@npm:@target/pkg@1.2.3")
+            == "@target/pkg"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1153,32 +1246,33 @@ class TestBraceExpansion:
 #
 # The recursive tree-sitter-bash walkers in the shared `_shell_ast` view descend
 # per nested `$()` level and per chained operator, so hundreds of either can
-# exhaust the Python recursion stack and raise RecursionError. `find_typosquat_
-# installs` must NEVER let that escape: it catches the RecursionError (and
-# short-circuits absurdly large commands) and returns [] -- "no finding" -- so a
-# crafted command can only ever fail to be analyzed, not crash the seam. This is
-# a documented limitation, not a guess: such adversarial noise stays clean.
+# exhaust the Python recursion stack. The parser translates that implementation
+# error, and its command-length bound, into an explicit incomplete-analysis
+# result so callers cannot mistake an unresolved command for a benign one.
 # ---------------------------------------------------------------------------
 
 
-class TestPathologicalInputDoesNotCrash:
-    def test_deeply_chained_operators_return_empty_without_raising(self):
-        # 1500 `&&`-chained commands build a deep right-leaning parse tree.
-        command = " && ".join("ls" for _ in range(1500))
-        # No exception, and nothing flagged (none of these is an install).
-        assert find_typosquat_installs(command) == []
+class TestPathologicalInputIsIncomplete:
+    def test_deeply_chained_install_is_not_treated_as_benign(self):
+        command = " && ".join([*("true" for _ in range(1500)), "npm install lodahs"])
+        with pytest.raises(SupplyChainAnalysisIncompleteError):
+            find_typosquat_installs(command)
 
-    def test_deeply_nested_command_substitution_returns_empty(self):
-        # 200 levels of `$( ... )` nesting; the walkers would otherwise recurse
-        # past the stack limit. Must return [] without raising.
+    def test_deeply_nested_command_substitution_is_incomplete(self):
         command = "x" + "$(" * 200 + "echo" + ")" * 200
-        assert find_typosquat_installs(command) == []
+        with pytest.raises(SupplyChainAnalysisIncompleteError):
+            find_typosquat_installs(command)
 
-    def test_absurdly_large_command_is_short_circuited(self):
-        # Beyond _MAX_COMMAND_LENGTH the command is skipped as "no finding"
-        # before parsing, so even a huge input cannot blow the walkers.
-        command = "ls " * 50_000  # well over the 100k-char guard
-        assert find_typosquat_installs(command) == []
+    def test_padded_install_over_length_limit_is_incomplete(self):
+        command = "npm install lodahs #" + "x" * _MAX_COMMAND_LENGTH
+        with pytest.raises(SupplyChainAnalysisIncompleteError):
+            find_typosquat_installs(command)
+
+    def test_nfkc_expansion_over_length_limit_is_incomplete(self):
+        command = "npm install lodahs #" + "ﬃ" * (_MAX_COMMAND_LENGTH // 2)
+        assert len(command) < _MAX_COMMAND_LENGTH
+        with pytest.raises(SupplyChainAnalysisIncompleteError):
+            find_typosquat_installs(command)
 
     def test_moderately_chained_real_install_still_flags(self):
         # The guard must NOT drop a legitimate long command: a real typosquat


### PR DESCRIPTION
HUMAN:

 I personally tested the rebased head `2007bd7c` locally.

  - Supply-chain suite: 394 passed, 4 xfailed
  - Full security suite: 815 passed, 7 skipped, 17 xfailed
  - Changed-file pre-commit: all applicable checks passed

- [x] A human has tested these changes.

AGENT:

---

## Why

`PatternSecurityAnalyzer` and the policy-rail analyzers catch dangerous command shapes such as `rm -rf` or `curl | sh`. They do not catch a normal-looking `npm install` where the risky part is the dependency identity, for example `lodahs` instead of `lodash`.

This PR adds a deterministic, offline `SupplyChainSecurityAnalyzer` for that gap. It parses the shell command through the shared tree-sitter-bash `_shell_ast` view and raises `SecurityRisk.HIGH` for likely npm typosquat installs so `ConfirmRisky` can ask a human. It never hard-denies on its own.

## Summary

- Adds `openhands-sdk/openhands/sdk/security/supply_chain/` and exports `SupplyChainSecurityAnalyzer` from `openhands.sdk.security`.
- Detects candidates with capped Optimal-String-Alignment distance against a curated popular-package corpus.
- Flags only when the candidate is not itself popular, is exactly distance 1 from a popular package, and the popular package name is longer than 4 characters.
- Reads only `tool_call.arguments["command"]`, never tool name, thought, reasoning, or summary.
- Uses the shared `_shell_ast` command view for chained, piped, backgrounded, subshell, `$(...)`, path-qualified, wrapper, and runner installs.
- Handles static shell obfuscation for package operands and manager names: quote removal, backslash escapes, ANSI-C strings, adjacent concatenation, line continuations, and bounded comma brace expansion.
- Keeps runtime expansion, Unicode homoglyph/confusable matching, and inner command-string recursion out of scope.

## Issue Number

Implements #3560, aligned with #2721, and built on the shared shell AST from #3609.

## How to Test

Everything runs offline: no network, no model, and no new runtime dependency beyond the tree-sitter-bash view already in the SDK.

```
# new module + tests
uv run pytest tests/sdk/security/supply_chain/ -q
# => 364 passed, 3 xfailed

# full security suite
uv run pytest tests/sdk/security/ -q
# => 713 passed, 16 xfailed

# lint, types, and import layering
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/security/supply_chain/analyzer.py \
  openhands-sdk/openhands/sdk/security/supply_chain/parser.py \
  openhands-sdk/openhands/sdk/security/__init__.py \
  tests/sdk/security/supply_chain/test_analyzer.py \
  tests/sdk/security/supply_chain/test_parser.py
# => Ruff format / Ruff lint / pycodestyle / pyright / import rules / tool registration: all Passed
```

The 3 supply_chain xfails are the documented nested-command-string limitation described below.

## Video/Screenshots

<img width="1798" height="1398" alt="Local test run: supply_chain 364 passed/3 xfailed and full security 713 passed/16 xfailed" src="https://github.com/user-attachments/assets/6a8e38a6-dcab-42ba-a5c6-6f343cbe668e" />

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Layering.** The parser imports `openhands.sdk.security._shell_ast` as a private sibling module inside `security/`. It does not import `openhands.tools` or private `defense_in_depth` helpers, and the import-layering hook passes.

**Normalization.** `find_typosquat_installs` normalizes before parsing: NFKC fold, strips invisible/default-ignorable/control/line-separator code points, and preserves real `\t`, `\n`, `\r`, and spaces so shell structure is not lost.

**Flag handling.** Install and runner extraction share one manager-aware flag policy: known value-taking flags consume a value, `--flag=value` is self-contained, and unknown flags are treated as boolean.

**Precision.** A small allowlist suppresses known legitimate packages that are one edit from popular names, such as `preact` next to `react`.

**Limitations.** Runtime expansion (`$VAR`, `$(...)`, backticks, process/arithmetic substitution), Unicode homoglyphs/confusables, and install commands hidden inside inner command strings such as `bash -c "npm install lodahs"` stay `LOW` by design. The inner-command-string cases are marked `xfail(strict=True)` so they fail loudly if recursive parsing lands later.

**Pathological input.** Lone-surrogate commands, absurdly large commands, and deep parse-tree recursion are caught and treated as `LOW` so the analyzer does not raise out of the security seam.
