### PR TITLE
feat(settings): Expose tool_concurrency_limit (parallel tool calls) in agent settings

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -994,6 +994,23 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             ).model_dump()
         },
     )
+    tool_concurrency_limit: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Maximum number of tool calls to execute concurrently per agent step. "
+            "1 = sequential (default). Values > 1 enable parallel tool calls; "
+            "concurrent tools share the conversation object, filesystem, and "
+            "working directory, so mutations to shared state may race."
+        ),
+        json_schema_extra={
+            SETTINGS_METADATA_KEY: SettingsFieldMetadata(
+                label="Parallel tool calls",
+                prominence=SettingProminence.MAJOR,
+                variant="openhands",
+            ).model_dump()
+        },
+    )
 
     mcp_config: MCPConfig | None = Field(
         default=None,
@@ -1090,6 +1107,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             agent_context=self.agent_context,
             condenser=self.build_condenser(self.llm),
             critic=self.build_critic(),
+            tool_concurrency_limit=self.tool_concurrency_limit,
         )
 
     def build_condenser(self, llm: LLM) -> CondenserBase | None:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1,9 +1,10 @@
 import json
 import shutil
+from typing import Any
 
 import pytest
 from fastmcp.mcp_config import MCPConfig
-from pydantic import SecretStr
+from pydantic import SecretStr, ValidationError
 
 from openhands.agent_server.models import StartConversationRequest
 from openhands.sdk import (
@@ -68,6 +69,7 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
         "tools",
         "enable_sub_agents",
         "enable_switch_llm_tool",
+        "tool_concurrency_limit",
         "mcp_config",
     }
     assert general_fields["agent"].default == "CodeActAgent"
@@ -82,6 +84,11 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
     assert general_fields["enable_switch_llm_tool"].default is True
     assert (
         general_fields["enable_switch_llm_tool"].prominence is SettingProminence.MINOR
+    )
+    assert general_fields["tool_concurrency_limit"].value_type == "integer"
+    assert general_fields["tool_concurrency_limit"].default == 1
+    assert (
+        general_fields["tool_concurrency_limit"].prominence is SettingProminence.MAJOR
     )
 
     # -- llm section --
@@ -318,6 +325,7 @@ def test_export_agent_settings_schema_emits_variant_tagged_sections() -> None:
         "tools",
         "enable_sub_agents",
         "enable_switch_llm_tool",
+        "tool_concurrency_limit",
         "mcp_config",
     }
     # No agent_kind field — each variant has its own settings page and
@@ -493,6 +501,70 @@ def test_llm_create_agent_uses_settings_llm_and_tools() -> None:
     assert isinstance(agent, Agent)
     assert agent.llm is llm
     assert agent.tools == tools
+
+
+def test_llm_create_agent_defaults_tool_concurrency_limit_to_one() -> None:
+    agent = OpenHandsAgentSettings(llm=LLM(model="test-model")).create_agent()
+    assert agent.tool_concurrency_limit == 1
+
+
+def test_tool_concurrency_limit_defaults_to_one_when_omitted_from_payload() -> None:
+    # Backward compatibility: payloads persisted before the field existed must
+    # still load and fall back to the sequential default.
+    settings = OpenHandsAgentSettings.model_validate({"agent_kind": "openhands"})
+    assert settings.tool_concurrency_limit == 1
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (1, 1),  # sequential default, explicit
+        (2, 2),
+        (8, 8),
+        (32, 32),
+        (1000, 1000),  # no upper cap — large values are accepted
+        ("4", 4),  # lax string -> int coercion
+        (4.0, 4),  # whole-number float coercion
+        (True, 1),  # bool is an int subclass; True -> 1 (>= 1, so valid)
+    ],
+)
+def test_tool_concurrency_limit_valid_values_round_trip(
+    raw: Any, expected: int
+) -> None:
+    settings = OpenHandsAgentSettings(
+        llm=LLM(model="test-model"), tool_concurrency_limit=raw
+    )
+    assert settings.tool_concurrency_limit == expected
+    assert type(settings.tool_concurrency_limit) is int
+
+    # The value must survive a JSON serialization round-trip...
+    reloaded = OpenHandsAgentSettings.model_validate(settings.model_dump(mode="json"))
+    assert reloaded.tool_concurrency_limit == expected
+
+    # ...and propagate to the constructed Agent.
+    agent = settings.create_agent()
+    assert agent.tool_concurrency_limit == expected
+
+
+@pytest.mark.parametrize(
+    "raw",
+    [
+        0,  # below ge=1
+        -1,  # negative
+        -100,
+        False,  # bool False -> 0, below ge=1
+        4.5,  # non-integral float
+        "abc",  # unparseable string
+        None,  # not Optional
+        [1],  # wrong type entirely
+    ],
+)
+def test_tool_concurrency_limit_invalid_values_rejected(raw: Any) -> None:
+    with pytest.raises(ValidationError) as exc_info:
+        OpenHandsAgentSettings(llm=LLM(model="test-model"), tool_concurrency_limit=raw)
+    assert any(
+        err["loc"] == ("tool_concurrency_limit",) for err in exc_info.value.errors()
+    )
 
 
 def test_llm_agent_settings_validates_mcp_config_as_typed_model() -> None:


### PR DESCRIPTION
HUMAN:

<!-- Replace this line with a one-sentence note (at least 20 characters) describing how you tested these changes. The "Validate PR description" check stays red until this is filled in. -->

- [x] A human has tested these changes.

AGENT:
Added the `tool_concurrency_limit` settings field, wired it through `OpenHandsAgentSettings.create_agent()`, and added schema-export + parametrized valid/coercion/validation-failure tests. Ran targeted tests, lint/type checks, the persisted-settings compatibility checker, and an end-to-end schema/propagation smoke locally (results below).

## Why

The runtime for parallel tool execution already exists in the SDK (`Agent.tool_concurrency_limit`, `ParallelToolExecutor`), but it was unreachable from schema-driven clients. `OpenHandsAgentSettings` did not expose the field and `OpenHandsAgentSettings.create_agent()` did not forward it, so any `agent_settings` payload setting `tool_concurrency_limit` was silently dropped at agent construction. This change exposes the knob end-to-end so clients can opt into parallel tool calls.

## Summary

- Added `tool_concurrency_limit: int` to `OpenHandsAgentSettings` (`default=1`, `ge=1`, no upper cap), surfaced as a `MAJOR`-prominence, `openhands`-variant settings field labeled "Parallel tool calls".
- Forwarded it in `OpenHandsAgentSettings.create_agent()` (`tool_concurrency_limit=self.tool_concurrency_limit`).
- Updated schema-export tests and added `create_agent()` round-trip, parametrized valid/coercion, and parametrized validation-failure tests (incl. backward-compat default).

## Issue Number

N/A

## How to Test

Local verification:

```bash
uv run pytest tests/sdk/test_settings.py tests/agent_server/test_settings_router.py tests/cross/test_check_persisted_settings_compat.py -q
uv run python .github/scripts/check_persisted_settings_compat.py
uv run pre-commit run --files openhands-sdk/openhands/sdk/settings/model.py tests/sdk/test_settings.py
```

Observed results:

- Targeted tests: `tests/sdk/test_settings.py` 103 passed; settings-router + compat cross tests 66 passed.
- Persisted-settings compatibility checker: all v1/v2/v3 golden fixtures and the latest PyPI baseline still load through `from_persisted()`. No `schema_version` bump or migration required (adding a defaulted field is a compatible change).
- pre-commit (ruff format/lint, pycodestyle, pyright, import rules): all passed.
- End-to-end smoke (schema export -> agent propagation -> legacy load):

```
SCHEMA  -> tool_concurrency_limit integer default= 1 prominence= major variant= openhands
AGENT   -> tool_concurrency_limit = 4
LEGACY  -> tool_concurrency_limit = 1
```

This confirms the field appears in the schema served by `GET /api/settings/agent-schema`, that a configured value propagates into the constructed `Agent`, and that payloads predating the field still load and default to sequential (`1`).

## Video/Screenshots

N/A. Backend SDK/settings change; verification is via unit tests, the compatibility checker, and the schema/propagation smoke above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Backward compatible: existing payloads without `tool_concurrency_limit` validate and default to `1` (sequential, current behavior). No upper cap is imposed at the settings layer, matching the runtime field's `ge=1`-only bound.
- Once an updated agent-server image is released, the field is served automatically via `GET /api/settings/agent-schema` (it is derived from the model), so downstream UIs (agent-canvas, OpenHands) can render it from the schema with no additional SDK work.
- Scope: this is the SDK exposure only (Phase 1 of a broader plan); the agent-canvas / OpenHands form + i18n follow-ups are intentionally out of scope here.
