### PR TITLE
feat: add MCP OAuth endpoints for pre-conversation auth flow

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -41,6 +41,7 @@ from openhands.agent_server.file_router import file_router
 from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
 from openhands.agent_server.llm_router import llm_router
+from openhands.agent_server.mcp_oauth_router import mcp_oauth_router
 from openhands.agent_server.mcp_router import mcp_router
 from openhands.agent_server.middleware import CORSDispatcher
 from openhands.agent_server.profiles_router import profiles_router
@@ -314,6 +315,7 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     api_router.include_router(hooks_router)
     api_router.include_router(llm_router)
     api_router.include_router(mcp_router)
+    api_router.include_router(mcp_oauth_router)
     api_router.include_router(settings_router)
     api_router.include_router(workspaces_router)
     api_router.include_router(profiles_router)

--- a/openhands-agent-server/openhands/agent_server/mcp_oauth_router.py
+++ b/openhands-agent-server/openhands/agent_server/mcp_oauth_router.py
@@ -1,0 +1,410 @@
+"""MCP OAuth router for OpenHands agent-server.
+
+Lets frontends drive the MCP OAuth 2.1 flow **before** a conversation
+starts, so users can "Connect with OAuth" on the MCP settings page and
+see immediate confirmation rather than getting a surprise browser popup
+at conversation start.
+
+Endpoints
+---------
+``POST /api/mcp/oauth/start``
+    Initiate the OAuth flow for a remote MCP server. Returns an
+    authorization URL that the frontend opens in a popup / new tab.
+    The agent-server runs a local callback server to receive the
+    redirect and exchange the code for a token.
+
+``GET /api/mcp/oauth/status/{flow_id}``
+    Poll the state of an in-progress OAuth flow. Returns ``pending``,
+    ``completed`` (with server metadata), or ``failed``.
+
+Token persistence
+-----------------
+Tokens (access + refresh) are stored on disk under the agent-server's
+persistence directory so they survive process restarts. fastmcp's
+``OAuth`` class automatically refreshes expired access tokens using the
+stored refresh token; the user only re-authenticates if the refresh
+token itself is revoked.
+
+See https://github.com/OpenHands/software-agent-sdk/issues/3571
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, HTTPException, Request, status
+from pydantic import BaseModel, Field
+
+from openhands.agent_server._secrets_exposure import get_config
+from openhands.agent_server.persistence.store import _get_persistence_dir
+from openhands.sdk.logger import get_logger
+
+logger = get_logger(__name__)
+
+mcp_oauth_router = APIRouter(prefix="/mcp/oauth", tags=["MCP OAuth"])
+
+# ---------------------------------------------------------------------------
+# File-based token storage
+# ---------------------------------------------------------------------------
+
+_MCP_TOKEN_DIR_NAME = "mcp-oauth-tokens"
+
+
+def _get_token_dir(request: Request) -> Path:
+    """Resolve the on-disk directory for MCP OAuth tokens."""
+    config = get_config(request)
+    base = _get_persistence_dir(config)
+    token_dir = base / _MCP_TOKEN_DIR_NAME
+    token_dir.mkdir(parents=True, exist_ok=True)
+    return token_dir
+
+
+def _make_file_token_storage(token_dir: Path):
+    """Create a file-backed AsyncKeyValue store for MCP OAuth tokens.
+
+    Uses the ``key_value`` library's ``FileTreeStore`` backend, which is
+    a transitive dependency of fastmcp. Falls back to an in-memory store
+    if the import fails for any reason.
+    """
+    try:
+        from key_value.aio.stores.filetree.store import FileTreeStore
+
+        return FileTreeStore(data_directory=token_dir)
+    except Exception:
+        logger.warning(
+            "FileTreeStore not available; "
+            "MCP OAuth tokens will be stored in memory only",
+            exc_info=True,
+        )
+        from key_value.aio.stores.memory.store import MemoryStore
+
+        return MemoryStore()
+
+
+# ---------------------------------------------------------------------------
+# In-flight OAuth flow registry
+# ---------------------------------------------------------------------------
+
+
+class _OAuthFlowState:
+    """Tracks one in-progress OAuth flow."""
+
+    __slots__ = (
+        "flow_id",
+        "server_url",
+        "server_name",
+        "status",
+        "authorization_url",
+        "callback_port",
+        "error",
+        "created_at",
+        # asyncio.Event used by the background task to signal the auth URL
+        # is ready (set from the OAuth redirect_handler running inside the
+        # background event loop).
+        "_auth_url_event",
+        "_background_task",
+    )
+
+    def __init__(self, server_url: str, server_name: str) -> None:
+        self.flow_id = str(uuid.uuid4())
+        self.server_url = server_url
+        self.server_name = server_name
+        self.status: Literal["pending", "completed", "failed"] = "pending"
+        self.authorization_url: str | None = None
+        self.callback_port: int | None = None
+        self.error: str | None = None
+        self.created_at = datetime.now(timezone.utc)
+        # Coordination: set by the redirect_handler, awaited by the
+        # background-loop bootstrap so it can surface the URL early.
+        self._auth_url_event: asyncio.Event | None = None
+        self._background_task: asyncio.Task | None = None
+
+
+# flow_id -> flow state; cleaned up on terminal status read.
+_active_flows: dict[str, _OAuthFlowState] = {}
+_flows_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+class MCPOAuthStartRequest(BaseModel):
+    """Body for ``POST /api/mcp/oauth/start``."""
+
+    server_url: str = Field(
+        ...,
+        min_length=1,
+        description="Full URL of the remote MCP server endpoint.",
+    )
+    server_name: str = Field(
+        default="mcp-server",
+        min_length=1,
+        max_length=128,
+        description="Human-readable name for this server.",
+    )
+    scopes: list[str] | None = Field(
+        default=None,
+        description="OAuth scopes to request (optional override).",
+    )
+    client_id: str | None = Field(
+        default=None,
+        description=(
+            "Pre-registered OAuth client ID. When provided, "
+            "skips Dynamic Client Registration."
+        ),
+    )
+    client_secret: str | None = Field(
+        default=None,
+        description="OAuth client secret (optional, used with client_id).",
+    )
+    timeout: float = Field(
+        default=300.0,
+        gt=0,
+        le=600,
+        description="Seconds to wait for the user to complete the OAuth flow.",
+    )
+
+
+class MCPOAuthStartResponse(BaseModel):
+    """Response from ``POST /api/mcp/oauth/start``."""
+
+    flow_id: str = Field(description="Unique identifier for this OAuth flow.")
+    authorization_url: str = Field(
+        description="URL the frontend should open for user authorization."
+    )
+    callback_port: int = Field(
+        description="Port where the local callback server is listening."
+    )
+    expires_in: float = Field(description="Seconds before the flow times out.")
+
+
+class MCPOAuthStatusResponse(BaseModel):
+    """Response from ``GET /api/mcp/oauth/status/{flow_id}``."""
+
+    status: Literal["pending", "completed", "failed"]
+    server_url: str | None = None
+    server_name: str | None = None
+    error: str | None = None
+
+
+# ---------------------------------------------------------------------------
+# OAuth flow driver (async, runs as a background task)
+# ---------------------------------------------------------------------------
+
+
+async def _drive_oauth_flow(
+    flow: _OAuthFlowState,
+    token_dir: Path,
+    scopes: list[str] | None,
+    client_id: str | None,
+    client_secret: str | None,
+    timeout: float,
+) -> None:
+    """Drive the full MCP OAuth 2.1 handshake.
+
+    Uses fastmcp's ``OAuth`` class with a custom ``redirect_handler`` that
+    captures the authorization URL (so we can return it to the frontend)
+    instead of opening a browser.
+
+    The flow:
+    1. Make an HTTP request to the MCP server → receive 401
+    2. fastmcp's auth handler discovers the authorization server
+    3. Dynamic Client Registration (unless ``client_id`` is given)
+    4. ``redirect_handler`` fires → we capture the auth URL and set the
+       event so ``POST /start`` can return it immediately
+    5. ``callback_handler`` starts a local HTTP server waiting for the
+       redirect callback from the OAuth provider
+    6. User authorizes in the browser
+    7. Callback server receives the auth code
+    8. Token exchange → tokens stored on disk via file-backed storage
+    """
+    from fastmcp.client.auth import OAuth
+
+    token_storage = _make_file_token_storage(token_dir)
+
+    assert flow._auth_url_event is not None  # set by the caller
+
+    class _FrontendOAuth(OAuth):
+        """Subclass that captures the auth URL instead of opening a browser."""
+
+        async def redirect_handler(self, authorization_url: str) -> None:
+            flow.authorization_url = authorization_url
+            if hasattr(self, "redirect_port"):
+                flow.callback_port = self.redirect_port
+            assert flow._auth_url_event is not None
+            flow._auth_url_event.set()
+            logger.info("MCP OAuth authorization URL ready: %s", authorization_url)
+
+    oauth = _FrontendOAuth(
+        mcp_url=flow.server_url,
+        scopes=scopes,
+        client_name="OpenHands Agent Canvas",
+        token_storage=token_storage,
+        client_id=client_id,
+        client_secret=client_secret,
+        callback_timeout=timeout,
+    )
+
+    try:
+        # Make a request to the MCP server through httpx with the OAuth
+        # auth provider. The MCP server returns 401, which triggers the
+        # full OAuth flow (discovery → DCR → redirect → callback → token
+        # exchange). The call blocks until the user completes auth.
+        async with httpx.AsyncClient(auth=oauth, follow_redirects=True) as client:
+            await client.get(flow.server_url)
+
+        flow.status = "completed"
+        logger.info("MCP OAuth flow completed for server %r", flow.server_name)
+    except TimeoutError:
+        flow.status = "failed"
+        flow.error = f"OAuth flow timed out after {timeout} seconds"
+        logger.info("MCP OAuth flow timed out for server %r", flow.server_name)
+    except Exception as exc:
+        flow.status = "failed"
+        flow.error = (
+            f"{type(exc).__name__}: {exc}" if str(exc) else type(exc).__name__
+        )
+        logger.warning(
+            "MCP OAuth flow failed for server %r: %s",
+            flow.server_name,
+            flow.error,
+            exc_info=True,
+        )
+        # If the flow failed before the auth URL was captured, unblock
+        # the waiter so POST /start returns the error instead of timing out.
+        if not flow._auth_url_event.is_set():
+            flow._auth_url_event.set()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+_AUTH_URL_WAIT_SECONDS = 10.0  # max time to wait for discovery + DCR
+
+
+@mcp_oauth_router.post(
+    "/start",
+    response_model=MCPOAuthStartResponse,
+    summary="Start an MCP OAuth flow",
+    description=(
+        "Initiate an OAuth 2.1 flow for a remote MCP server. "
+        "Returns an authorization URL that the frontend should open in a "
+        "popup or new tab. The agent-server runs a local callback server "
+        "to receive the OAuth redirect, exchanges the code for tokens, "
+        "and persists them to disk.\n\n"
+        "Poll ``GET /api/mcp/oauth/status/{flow_id}`` to check completion."
+    ),
+)
+async def start_mcp_oauth(
+    request: MCPOAuthStartRequest, http_request: Request
+) -> MCPOAuthStartResponse:
+    """Start the MCP OAuth flow and return the authorization URL."""
+    token_dir = _get_token_dir(http_request)
+
+    flow = _OAuthFlowState(
+        server_url=request.server_url,
+        server_name=request.server_name,
+    )
+    flow._auth_url_event = asyncio.Event()
+
+    with _flows_lock:
+        _active_flows[flow.flow_id] = flow
+
+    # Launch the OAuth handshake as a background task on the current
+    # event loop. The task will set ``flow._auth_url_event`` once the
+    # authorization URL is known (usually <5 s for discovery + DCR).
+    flow._background_task = asyncio.create_task(
+        _drive_oauth_flow(
+            flow,
+            token_dir,
+            request.scopes,
+            request.client_id,
+            request.client_secret,
+            request.timeout,
+        ),
+        name=f"mcp-oauth-{flow.flow_id[:8]}",
+    )
+
+    # Wait for the authorization URL (or early failure).
+    try:
+        await asyncio.wait_for(
+            flow._auth_url_event.wait(),
+            timeout=_AUTH_URL_WAIT_SECONDS,
+        )
+    except asyncio.TimeoutError:
+        # Discovery or DCR took too long.
+        with _flows_lock:
+            _active_flows.pop(flow.flow_id, None)
+        flow._background_task.cancel()
+        raise HTTPException(
+            status_code=status.HTTP_504_GATEWAY_TIMEOUT,
+            detail=(
+                f"Could not obtain authorization URL within "
+                f"{_AUTH_URL_WAIT_SECONDS:.0f} seconds. "
+                "The MCP server may be unreachable or does not support OAuth."
+            ),
+        )
+
+    # The event was set — check whether it was because of success or failure.
+    if flow.status == "failed":
+        with _flows_lock:
+            _active_flows.pop(flow.flow_id, None)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=flow.error or "OAuth flow failed during initialization",
+        )
+
+    assert flow.authorization_url is not None
+
+    return MCPOAuthStartResponse(
+        flow_id=flow.flow_id,
+        authorization_url=flow.authorization_url,
+        callback_port=flow.callback_port or 0,
+        expires_in=request.timeout,
+    )
+
+
+@mcp_oauth_router.get(
+    "/status/{flow_id}",
+    response_model=MCPOAuthStatusResponse,
+    summary="Check MCP OAuth flow status",
+    description=(
+        "Poll the status of an in-progress MCP OAuth flow. "
+        "Returns ``pending`` while waiting for the user to authorize, "
+        "``completed`` when tokens have been persisted, or ``failed`` "
+        "with an error message."
+    ),
+)
+async def get_mcp_oauth_status(flow_id: str) -> MCPOAuthStatusResponse:
+    """Check the status of an OAuth flow."""
+    with _flows_lock:
+        flow = _active_flows.get(flow_id)
+
+    if flow is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"OAuth flow {flow_id!r} not found or already expired",
+        )
+
+    response = MCPOAuthStatusResponse(
+        status=flow.status,
+        server_url=flow.server_url if flow.status == "completed" else None,
+        server_name=flow.server_name if flow.status == "completed" else None,
+        error=flow.error if flow.status == "failed" else None,
+    )
+
+    # Clean up terminal flows so they don't leak memory.
+    if flow.status in ("completed", "failed"):
+        with _flows_lock:
+            _active_flows.pop(flow_id, None)
+
+    return response

--- a/tests/agent_server/test_mcp_oauth_router.py
+++ b/tests/agent_server/test_mcp_oauth_router.py
@@ -1,0 +1,77 @@
+"""Tests for mcp_oauth_router.py endpoints."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from openhands.agent_server.api import create_app
+from openhands.agent_server.config import Config
+
+
+@pytest.fixture
+def client() -> TestClient:
+    config = Config(session_api_keys=[])
+    return TestClient(create_app(config), raise_server_exceptions=False)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/mcp/oauth/start
+# ---------------------------------------------------------------------------
+
+
+def test_start_returns_504_for_unreachable_server(client: TestClient):
+    """An unreachable MCP server should cause a 504 (auth URL timeout)
+    or a 400 (connection error surfaced before the wait times out)."""
+    response = client.post(
+        "/api/mcp/oauth/start",
+        json={
+            "server_url": "http://127.0.0.1:1/definitely-not-listening",
+            "server_name": "unreachable",
+            "timeout": 5.0,
+        },
+    )
+    # The flow should fail because the MCP server is unreachable.
+    # Depending on timing, we get 400 (early failure) or 504 (URL timeout).
+    assert response.status_code in (400, 504), response.text
+
+
+def test_start_rejects_empty_server_url(client: TestClient):
+    """Empty server_url should be rejected at the schema layer."""
+    response = client.post(
+        "/api/mcp/oauth/start",
+        json={"server_url": "", "server_name": "empty"},
+    )
+    assert response.status_code == 422
+
+
+def test_start_rejects_zero_timeout(client: TestClient):
+    """Timeout must be > 0."""
+    response = client.post(
+        "/api/mcp/oauth/start",
+        json={
+            "server_url": "http://example.com/mcp",
+            "timeout": 0,
+        },
+    )
+    assert response.status_code == 422
+
+
+# ---------------------------------------------------------------------------
+# GET /api/mcp/oauth/status/{flow_id}
+# ---------------------------------------------------------------------------
+
+
+def test_status_returns_404_for_unknown_flow(client: TestClient):
+    """An unknown flow_id should return 404."""
+    response = client.get("/api/mcp/oauth/status/nonexistent-flow-id")
+    assert response.status_code == 404
+
+
+def test_status_response_shape(client: TestClient):
+    """The 404 response should have the expected structure."""
+    response = client.get("/api/mcp/oauth/status/unknown")
+    assert response.status_code == 404
+    body = response.json()
+    assert "detail" in body
+    assert "unknown" in body["detail"]


### PR DESCRIPTION
## Summary

Add `POST /api/mcp/oauth/start` and `GET /api/mcp/oauth/status/{flow_id}` endpoints that let frontends drive MCP OAuth 2.1 flows **during server installation** rather than deferring to conversation start.

Closes OpenHands/OpenHands#3571 | Related: [agent-canvas#1255](https://github.com/OpenHands/agent-canvas/issues/2060)

## Problem

When an MCP server is configured with `auth: "oauth"`, the OAuth flow currently happens at **conversation start** — fastmcp opens a browser via `webbrowser.open()`, runs a local callback server, and exchanges the auth code for a token. This works, but the UX is jarring: the user configures Slack/Notion MCP in settings, starts a conversation, and *then* gets a surprise browser popup.

The frontend (browser) cannot drive this flow alone due to CORS restrictions on the MCP server's discovery, DCR, and token exchange endpoints.

## Solution

### `POST /api/mcp/oauth/start`
1. Creates an `OAuth` instance using fastmcp's class with a **custom `redirect_handler`** that captures the authorization URL instead of opening a browser
2. Makes an HTTP request to the MCP server → receives 401 → triggers the full OAuth flow (discovery → DCR → auth URL generation)
3. Returns the authorization URL to the frontend within ~5s
4. Background asyncio task continues running: callback server waits for the redirect

**Request:**
```json
{
  "server_url": "https://mcp.slack.com/mcp",
  "server_name": "slack",
  "scopes": ["channels:history", "chat:write"],
  "timeout": 300
}
```

**Response:**
```json
{
  "flow_id": "uuid",
  "authorization_url": "https://slack.com/oauth/v2_user/authorize?...",
  "callback_port": 12345,
  "expires_in": 300
}
```

### `GET /api/mcp/oauth/status/{flow_id}`
Frontend polls this until `"completed"` or `"failed"`.

### Token persistence
- Uses `key_value`'s `FileTreeStore` (transitive dependency of fastmcp) backed by the agent-server persistence directory (`~/.openhands/mcp-oauth-tokens/`)
- Tokens survive process restarts
- fastmcp's `OAuthClientProvider` automatically refreshes expired access tokens using the stored refresh token; users only re-auth if the refresh token is revoked

## Token lifecycle (answering "what if creds expire?")

The MCP SDK (`mcp.client.auth.OAuthClientProvider`) handles this with a 3-tier strategy:
1. **Token still valid** → attaches it to request, no user action
2. **Token expired, refresh_token available** → silently refreshes via `_refresh_token()` 
3. **Refresh fails** → falls back to full re-auth (browser popup)

Since we persist both access_token and refresh_token to disk, the typical case is silent refresh. Re-auth only happens if the refresh_token itself is revoked by the provider.

## Files changed

| File | Description |
|------|-------------|
| `openhands-agent-server/.../mcp_oauth_router.py` | New router with `/start` and `/status/{flow_id}` endpoints |
| `openhands-agent-server/.../api.py` | Register the new router |
| `tests/agent_server/test_mcp_oauth_router.py` | Tests for validation, error handling, and status 404 |

## Testing

- All 5 new tests pass
- All 13 existing MCP router tests still pass
- The happy path (real OAuth with a live MCP server) requires manual testing since it involves browser interaction and an actual OAuth provider

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@malhotra5 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ff0d0231-e147-47f7-99cf-d3dda25596f0)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1225528-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1225528-python \
  ghcr.io/openhands/agent-server:1225528-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1225528-golang-amd64
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-golang-amd64
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-golang-amd64
ghcr.io/openhands/agent-server:1225528-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1225528-golang-arm64
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-golang-arm64
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-golang-arm64
ghcr.io/openhands/agent-server:1225528-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1225528-java-amd64
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-java-amd64
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-java-amd64
ghcr.io/openhands/agent-server:1225528-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1225528-java-arm64
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-java-arm64
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-java-arm64
ghcr.io/openhands/agent-server:1225528-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1225528-python-amd64
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-python-amd64
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-python-amd64
ghcr.io/openhands/agent-server:1225528-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1225528-python-arm64
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-python-arm64
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-python-arm64
ghcr.io/openhands/agent-server:1225528-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1225528-golang
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-golang
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-golang
ghcr.io/openhands/agent-server:1225528-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1225528-java
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-java
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-java
ghcr.io/openhands/agent-server:1225528-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1225528-python
ghcr.io/openhands/agent-server:122552895d538913e5c0b994c9a8b78939abe19a-python
ghcr.io/openhands/agent-server:feat-mcp-oauth-endpoints-python
ghcr.io/openhands/agent-server:1225528-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1225528-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1225528-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->