### PR TITLE
test(agent-server): isolate webhook subscriber timers

### DIFF
--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -106,6 +106,28 @@ def sample_conversation_id():
     return uuid4()
 
 
+async def _cancel_pending_webhook_flush_tasks():
+    current_task = asyncio.current_task()
+    pending_flush_tasks = [
+        task
+        for task in asyncio.all_tasks()
+        if task is not current_task
+        and not task.done()
+        and task.get_coro().__qualname__ == "WebhookSubscriber._flush_after_delay"
+    ]
+    for task in pending_flush_tasks:
+        task.cancel()
+    if pending_flush_tasks:
+        await asyncio.gather(*pending_flush_tasks, return_exceptions=True)
+
+
+@pytest.fixture(autouse=True)
+async def isolate_webhook_flush_timers():
+    await _cancel_pending_webhook_flush_tasks()
+    yield
+    await _cancel_pending_webhook_flush_tasks()
+
+
 class TestWebhookSpecValidation:
     """Test cases for WebhookSpec validation."""
 


### PR DESCRIPTION
## Summary

- Add an autouse cleanup fixture for `tests/agent_server/test_webhook_subscriber.py` that cancels and awaits leftover `WebhookSubscriber._flush_after_delay` tasks before and after each test.
- Preserve the strict retry sleep assertions instead of filtering out leaked sleeps.
- Prevent webhook flush timers created by one test from being observed by later tests that patch global `asyncio.sleep`.

## Testing

- `uv run pytest tests/agent_server/test_webhook_subscriber.py -q`
- `uv run pre-commit run --files tests/agent_server/test_webhook_subscriber.py`
- `TMUX_TMPDIR=/tmp/oh-ci-test-tmux CI=true uv run python -m pytest -vvs -n auto --cov=openhands-agent-server --cov-report=term-missing --cov-fail-under=0 --cov-config=pyproject.toml tests/agent_server`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ce144c3f-aff1-4cf2-89ee-b7468ae52435)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fda7ffd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fda7ffd-python \
  ghcr.io/openhands/agent-server:fda7ffd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fda7ffd-golang-amd64
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-golang-amd64
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-golang-amd64
ghcr.io/openhands/agent-server:fda7ffd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fda7ffd-golang-arm64
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-golang-arm64
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-golang-arm64
ghcr.io/openhands/agent-server:fda7ffd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fda7ffd-java-amd64
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-java-amd64
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-java-amd64
ghcr.io/openhands/agent-server:fda7ffd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fda7ffd-java-arm64
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-java-arm64
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-java-arm64
ghcr.io/openhands/agent-server:fda7ffd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fda7ffd-python-amd64
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-python-amd64
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-python-amd64
ghcr.io/openhands/agent-server:fda7ffd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:fda7ffd-python-arm64
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-python-arm64
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-python-arm64
ghcr.io/openhands/agent-server:fda7ffd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:fda7ffd-golang
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-golang
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-golang
ghcr.io/openhands/agent-server:fda7ffd-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:fda7ffd-java
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-java
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-java
ghcr.io/openhands/agent-server:fda7ffd-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:fda7ffd-python
ghcr.io/openhands/agent-server:fda7ffd253a68e53588cfc7b0f8dcb9609accce6-python
ghcr.io/openhands/agent-server:openhands-webhook-subscriber-test-isolation-python
ghcr.io/openhands/agent-server:fda7ffd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fda7ffd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fda7ffd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->