### PR TITLE
refactor(tools): reuse shared shell parser in terminal command utilities

### DIFF
--- a/openhands-tools/openhands/tools/terminal/utils/command.py
+++ b/openhands-tools/openhands/tools/terminal/utils/command.py
@@ -2,15 +2,13 @@
 
 import re
 
-import tree_sitter_bash
-from tree_sitter import Language, Node, Parser, Tree
+from tree_sitter import Node
 
 from openhands.sdk.logger import get_logger
+from openhands.sdk.security.shell_parser import parse
 
 
 logger = get_logger(__name__)
-
-_BASH_LANGUAGE = Language(tree_sitter_bash.language())
 
 # Regions whose contents bash takes verbatim — escape doubling stops at
 # their boundaries so operators nested inside (e.g.) a double-quoted
@@ -32,12 +30,6 @@ _PRESERVE_TYPES: frozenset[str] = frozenset(
 _ESCAPE_PATTERN: re.Pattern[bytes] = re.compile(rb"\\([;&|<>])")
 
 
-def _parse(source: bytes) -> Tree:
-    # Parser is not thread-safe; the Language is. Construct a fresh
-    # Parser per call so concurrent callers cannot trample each other.
-    return Parser(_BASH_LANGUAGE).parse(source)
-
-
 def split_bash_commands(commands: str) -> list[str]:
     """Split a multi-statement bash input into top-level statements.
 
@@ -52,10 +44,10 @@ def split_bash_commands(commands: str) -> list[str]:
         return [""]
 
     source = commands.encode()
-    tree = _parse(source)
-    root = tree.root_node
+    result = parse(commands)
+    root = result.tree.root_node
 
-    if root.has_error:
+    if result.has_error:
         logger.debug(
             "tree-sitter-bash reported parse errors; returning input as-is\n"
             "[input]: %s",
@@ -88,8 +80,8 @@ def escape_bash_special_chars(command: str) -> str:
         return ""
 
     source = command.encode()
-    tree = _parse(source)
-    if tree.root_node.has_error:
+    result = parse(command)
+    if result.has_error:
         logger.debug(
             "tree-sitter-bash reported parse errors; returning input as-is\n"
             "[input]: %s",
@@ -106,7 +98,7 @@ def escape_bash_special_chars(command: str) -> str:
         for child in node.children:
             collect(child)
 
-    collect(tree.root_node)
+    collect(result.tree.root_node)
 
     out = bytearray()
     cursor = 0


### PR DESCRIPTION
HUMAN:

This PR is intentionally scoped to reusing the shared shell parser in terminal command utilities. Boring next step in the AST migration plan on issue #2721.

- [x] A human has tested these changes.

AGENT:

---

## Why

PR-B for #2721 needs `openhands-tools` to consume the shared SDK shell parser.
`command.py` was still constructing its own tree-sitter-bash `Language` and
`Parser`, duplicating parser setup after the shared entry point landed.

## Summary

- Reuse `openhands.sdk.security.shell_parser.parse` in terminal command splitting
  and escape utilities.
- Remove duplicate `tree-sitter-bash` Language/Parser construction from
  `command.py`.
- Preserve local terminal escaping details and leave analyzer, parser-helper,
  and dependency cleanup out of scope.

## Issue Number

Refs #2721

## How to Test

I ran the PR-B terminal parsing target:

```bash
uv run pytest tests/tools/terminal/test_terminal_parsing.py
```

Result: 30 tests passed, including malformed-input fallback cases and
escape-preservation cases for heredocs, parameter expansion, command
substitution, mixed nodes, and chained commands.

I also ran the file-scoped pre-commit hooks:

```bash
uv run pre-commit run --files openhands-tools/openhands/tools/terminal/utils/command.py
```

Result: Ruff format, Ruff lint, pycodestyle, pyright, import dependency rules,
and tool subclass registration all passed.

## Video/Screenshots

Not applicable; this is an internal terminal utility refactor with no UI
surface.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No analyzer migration in this PR. `PatternSecurityAnalyzer` and
`PolicyRailSecurityAnalyzer` are unchanged.

No new parser helper API is added. In particular, this PR does not add
`ParseResult.root_node`, command iterators, node text helpers, or detector
semantics.

Dependency cleanup is intentionally deferred to keep this PR reviewable as a
consumer refactor.
