### PR TITLE
Add nemotron-3-ultra-550b-a55b-or-paid eval model (paid OpenRouter route)

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -383,6 +383,18 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # Paid OpenRouter route (no training, smaller 262k context):
+    # https://openrouter.ai/nvidia/nemotron-3-ultra-550b-a55b
+    # Backed by the `nemotron-3-ultra-550b-a55b-or-paid` model on the LiteLLM proxy.
+    "nemotron-3-ultra-550b-a55b-or-paid": {
+        "id": "nemotron-3-ultra-550b-a55b-or-paid",
+        "display_name": "NVIDIA Nemotron-3 Ultra 550B (OpenRouter, paid)",
+        "llm_config": {
+            "model": "litellm_proxy/nemotron-3-ultra-550b-a55b-or-paid",
+            "temperature": 1.0,
+            "top_p": 0.95,
+        },
+    },
     "converse-nemotron-super-3-120b": {
         "id": "converse-nemotron-super-3-120b",
         "display_name": "NVIDIA Converse Nemotron Super 3 120B",

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -695,6 +695,20 @@ def test_nemotron_3_ultra_550b_a55b_config():
     assert model["llm_config"]["top_p"] == 0.95
 
 
+def test_nemotron_3_ultra_550b_a55b_or_paid_config():
+    """Test that nemotron-3-ultra-550b-a55b-or-paid (paid OpenRouter route) has correct config."""
+    model = MODELS["nemotron-3-ultra-550b-a55b-or-paid"]
+
+    assert model["id"] == "nemotron-3-ultra-550b-a55b-or-paid"
+    assert model["display_name"] == "NVIDIA Nemotron-3 Ultra 550B (OpenRouter, paid)"
+    assert (
+        model["llm_config"]["model"]
+        == "litellm_proxy/nemotron-3-ultra-550b-a55b-or-paid"
+    )
+    assert model["llm_config"]["temperature"] == 1.0
+    assert model["llm_config"]["top_p"] == 0.95
+
+
 def test_claude_opus_4_8_config():
     """Test that claude-opus-4-8 has correct configuration."""
     model = MODELS["claude-opus-4-8"]

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -696,7 +696,7 @@ def test_nemotron_3_ultra_550b_a55b_config():
 
 
 def test_nemotron_3_ultra_550b_a55b_or_paid_config():
-    """Test that nemotron-3-ultra-550b-a55b-or-paid (paid OpenRouter route) has correct config."""
+    """Test nemotron-3-ultra-550b-a55b-or-paid (paid OpenRouter route) config."""
     model = MODELS["nemotron-3-ultra-550b-a55b-or-paid"]
 
     assert model["id"] == "nemotron-3-ultra-550b-a55b-or-paid"


### PR DESCRIPTION
- [x]  A human has tested this changes.

## Summary

Adds a new eval model entry `nemotron-3-ultra-550b-a55b-or-paid` to `.github/run-eval/resolve_model_config.py`. It targets the `nemotron-3-ultra-550b-a55b-or-paid` alias on the LiteLLM proxy, which routes to the paid OpenRouter endpoint:

- https://openrouter.ai/nvidia/nemotron-3-ultra-550b-a55b (no training, 262k context)

This complements the existing `nemotron-3-ultra-550b-a55b` entry (served via NVIDIA Integrate) so we can run evals against the paid OpenRouter route as an alternative.

This PR is a slimmed-down version of #3522 — it includes **only the paid OpenRouter endpoint**, omitting the free-tier route.

## Config added

```python
# Paid OpenRouter route (no training, smaller 262k context):
# https://openrouter.ai/nvidia/nemotron-3-ultra-550b-a55b
# Backed by the `nemotron-3-ultra-550b-a55b-or-paid` model on the LiteLLM proxy.
"nemotron-3-ultra-550b-a55b-or-paid": {
    "id": "nemotron-3-ultra-550b-a55b-or-paid",
    "display_name": "NVIDIA Nemotron-3 Ultra 550B (OpenRouter, paid)",
    "llm_config": {
        "model": "litellm_proxy/nemotron-3-ultra-550b-a55b-or-paid",
        "temperature": 1.0,
        "top_p": 0.95,
    },
},
```

Sampling parameters (`temperature=1.0`, `top_p=0.95`) are kept identical to the existing Nemotron-3 Ultra entry, per NVIDIA's recommendation for all Nemotron 3 models.

## Tests

Added `test_nemotron_3_ultra_550b_a55b_or_paid_config` in `tests/cross/test_resolve_model_config.py`, mirroring the existing `test_nemotron_3_ultra_550b_a55b_config` test.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/bd167f4b-6a3e-496a-b3e5-d832472f12cd)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:29ea543-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-29ea543-python \
  ghcr.io/openhands/agent-server:29ea543-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:29ea543-golang-amd64
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-golang-amd64
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-golang-amd64
ghcr.io/openhands/agent-server:29ea543-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:29ea543-golang-arm64
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-golang-arm64
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-golang-arm64
ghcr.io/openhands/agent-server:29ea543-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:29ea543-java-amd64
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-java-amd64
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-java-amd64
ghcr.io/openhands/agent-server:29ea543-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:29ea543-java-arm64
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-java-arm64
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-java-arm64
ghcr.io/openhands/agent-server:29ea543-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:29ea543-python-amd64
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-python-amd64
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-python-amd64
ghcr.io/openhands/agent-server:29ea543-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:29ea543-python-arm64
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-python-arm64
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-python-arm64
ghcr.io/openhands/agent-server:29ea543-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:29ea543-golang
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-golang
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-golang
ghcr.io/openhands/agent-server:29ea543-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:29ea543-java
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-java
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-java
ghcr.io/openhands/agent-server:29ea543-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:29ea543-python
ghcr.io/openhands/agent-server:29ea54362dc775cd8915a63ad82d39747b953341-python
ghcr.io/openhands/agent-server:add-nemotron-3-ultra-openrouter-paid-python
ghcr.io/openhands/agent-server:29ea543-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `29ea543-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `29ea543-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->