### PR TITLE
feat(llm): add `vertex_cached_content` config for explicit Vertex AI caching

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -472,6 +472,25 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         ),
     )
 
+    vertex_cached_content: str | None = Field(
+        default=None,
+        description=(
+            "Reference an existing Vertex AI ``CachedContent`` resource to use as "
+            "the cache prefix for every request. Pass the full resource name, e.g. "
+            '``"cachedContents/1234567890"`` returned by '
+            "``CachedContent.create``. The SDK threads it through to LiteLLM, "
+            "which forwards it to the Vertex Gemini ``generateContent`` API as "
+            "``cachedContent``. This bypasses the inline ``cache_control`` marker "
+            "path (which only works for ``vertex_ai/`` direct, not via "
+            "``litellm_proxy/``) and gives deterministic, explicit caching for "
+            "long-running agent runs whose system + tool prefix exceeds Vertex's "
+            "minimum cache size. The caller is responsible for creating, "
+            "refreshing the TTL, and deleting the cache resource — see "
+            "https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache. "
+            "Ignored for non-Vertex / non-Gemini providers."
+        ),
+    )
+
     fallback_strategy: FallbackStrategy | None = Field(
         default=None,
         description=(

--- a/openhands-sdk/openhands/sdk/llm/options/chat_options.py
+++ b/openhands-sdk/openhands/sdk/llm/options/chat_options.py
@@ -6,6 +6,19 @@ from openhands.sdk.llm.options.common import apply_defaults_if_absent
 from openhands.sdk.llm.utils.model_features import get_features
 
 
+def _model_supports_vertex_cached_content(model: str) -> bool:
+    """Return True iff sending ``cached_content`` to this model is safe.
+
+    LiteLLM forwards ``cached_content`` as a top-level kwarg through to the
+    Vertex Gemini ``generateContent`` API. Other providers (OpenAI, Anthropic,
+    etc.) will reject unknown kwargs, so we gate emission to model names that
+    look Gemini-flavoured regardless of which LiteLLM provider prefix routes
+    them: ``vertex_ai/``, ``gemini/``, ``litellm_proxy/gemini-*`` (assuming
+    the proxy forwards to a Vertex backend), and bare ``gemini-*``.
+    """
+    return "gemini" in (model or "").lower()
+
+
 def select_chat_options(
     llm, user_kwargs: dict[str, Any], has_tools: bool
 ) -> dict[str, Any]:
@@ -98,5 +111,18 @@ def select_chat_options(
 
     if llm._prompt_cache_key:
         out["prompt_cache_key"] = llm._prompt_cache_key
+
+    # Vertex AI explicit context cache: user pre-creates a CachedContent
+    # resource (see https://cloud.google.com/vertex-ai/generative-ai/docs/context-cache)
+    # and references it by name. LiteLLM forwards the kwarg to the Vertex
+    # ``generateContent`` API as ``cachedContent``. We only emit when the model
+    # is Gemini-flavoured so unknown-kwarg-rejecting providers (OpenAI, etc.)
+    # are left untouched. User-supplied kwargs take precedence.
+    if (
+        llm.vertex_cached_content
+        and "cached_content" not in out
+        and _model_supports_vertex_cached_content(llm.model)
+    ):
+        out["cached_content"] = llm.vertex_cached_content
 
     return out

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -21,6 +21,7 @@ class DummyLLM:
     _prompt_cache_key: str | None = None
     openrouter_site_url: str = ""
     openrouter_app_name: str = ""
+    vertex_cached_content: str | None = None
 
     def _openrouter_headers(self) -> dict[str, str]:
         headers: dict[str, str] = {}
@@ -243,3 +244,91 @@ def test_chat_options_omits_openrouter_headers_when_unset():
     llm = DummyLLM(model="gpt-4o")
     out = select_chat_options(llm, user_kwargs={}, has_tools=False)
     assert "extra_headers" not in out
+
+
+# ---------------------------------------------------------------------------
+# vertex_cached_content
+# ---------------------------------------------------------------------------
+
+
+def test_vertex_cached_content_emitted_for_vertex_gemini():
+    """``vertex_cached_content`` is forwarded as ``cached_content`` for Gemini."""
+    llm = LLM(
+        model="vertex_ai/gemini-3-flash",
+        vertex_cached_content="cachedContents/1234567890",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+    assert out["cached_content"] == "cachedContents/1234567890"
+
+
+def test_vertex_cached_content_emitted_for_gemini_provider():
+    """Bare ``gemini/`` provider also gets the kwarg."""
+    llm = LLM(
+        model="gemini/gemini-3-flash",
+        vertex_cached_content="cachedContents/abc",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+    assert out["cached_content"] == "cachedContents/abc"
+
+
+def test_vertex_cached_content_emitted_for_litellm_proxy_gemini():
+    """Proxy-routed Gemini models receive the kwarg too.
+
+    Whether the proxy actually forwards it to Vertex is a proxy-side concern,
+    but the SDK must pass it through so a well-configured proxy can act on it.
+    """
+    llm = LLM(
+        model="litellm_proxy/gemini-3.5-flash",
+        vertex_cached_content="cachedContents/xyz",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+    assert out["cached_content"] == "cachedContents/xyz"
+
+
+def test_vertex_cached_content_suppressed_for_openai():
+    """Non-Gemini providers (OpenAI, Anthropic, …) must not see the kwarg.
+
+    They reject unknown kwargs, so emitting ``cached_content`` would break the
+    call. The user setting the field on a non-Gemini LLM is a misconfiguration
+    we silently tolerate rather than escalate to an error.
+    """
+    llm = LLM(
+        model="gpt-5-mini",
+        vertex_cached_content="cachedContents/should-be-ignored",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+    assert "cached_content" not in out
+
+
+def test_vertex_cached_content_suppressed_for_claude():
+    """Anthropic models likewise."""
+    llm = LLM(
+        model="claude-sonnet-4-5",
+        vertex_cached_content="cachedContents/should-be-ignored",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+    assert "cached_content" not in out
+
+
+def test_vertex_cached_content_omitted_when_unset():
+    """Default ``None`` produces no kwarg even on a Gemini model."""
+    llm = LLM(model="vertex_ai/gemini-3-flash")
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+    assert "cached_content" not in out
+
+
+def test_vertex_cached_content_respects_user_kwarg_override():
+    """A caller-supplied ``cached_content`` wins over the LLM config field.
+
+    This matches the precedence we apply elsewhere (extra_headers, etc.).
+    """
+    llm = LLM(
+        model="vertex_ai/gemini-3-flash",
+        vertex_cached_content="cachedContents/from-config",
+    )
+    out = select_chat_options(
+        llm,
+        user_kwargs={"cached_content": "cachedContents/from-caller"},
+        has_tools=True,
+    )
+    assert out["cached_content"] == "cachedContents/from-caller"


### PR DESCRIPTION
## Why

This is the second of two PRs from the gemini-3.5-flash cost investigation in [OpenHands/benchmarks#741](https://github.com/OpenHands/benchmarks/pull/741). The companion is #3581 (strip Vertex thought signatures from history).

### What I found in the data

Pulled the conversation event logs for the swebench-verified slice (10/10 resolved, $28.13 total / $2.81/instance / $11.11 outlier) and aggregated `Metrics.usage_to_metrics["default"]` across all 10 instances:

| metric | total | note |
|---|---|---|
| prompt_tokens | 19,390,285 | |
| cache_read_tokens | 5,102,668 | 26% hit rate |
| **cache_write_tokens** | **0** | across every instance |
| completion_tokens | 659,100 | |
| reasoning_tokens | 562,315 | |

So 74 % of prompt tokens are billed at the uncached `$1.50/M` rate.

### Why the existing path doesn't write a cache

The SDK already marks the system message with `cache_control: ephemeral` (and the last user/tool, Anthropic-style) and the model name `gemini-3.5-flash` matches the `"gemini-3"` substring in `PROMPT_CACHE_MODELS`, so `is_caching_prompt_active()` returns True. LiteLLM's `vertex_ai.context_caching.ContextCachingEndpoints.check_and_create_cache` does the right thing for `vertex_ai/` direct: it splits cached vs non-cached messages, checks if Google already has the resource, otherwise calls Vertex's `cachedContents` API and returns the resource name to reference.

But the benchmark runs through `litellm_proxy/gemini-3.5-flash`, not `vertex_ai/gemini-3.5-flash`. The SDK's local LiteLLM client just sends an OpenAI-style request body to the proxy URL, so whether the `cache_control` markers ever reach Vertex depends entirely on the proxy's translation layer — and the data shows it isn't translating them today.

### What this PR adds

A first-class seam for users running against Vertex (directly or via a proxy that knows how to forward the kwarg) to pre-create a `CachedContent` resource and reference it by name on every request:

```python
from openhands.sdk import LLM

llm = LLM(
    model="vertex_ai/gemini-3-flash",
    vertex_cached_content="cachedContents/1234567890",
)
```

The SDK threads it through `select_chat_options` as a top-level `cached_content=...` kwarg, which LiteLLM pops from `optional_params` in [`vertex_ai/gemini/transformation.py`](https://github.com/BerriAI/litellm/blob/v1.84.1/litellm/llms/vertex_ai/gemini/transformation.py#L826-L849) and forwards to the Vertex `generateContent` body as `cachedContent`.

### Design choices

- **No CachedContent.create inside the SDK.** Cache lifecycle (create, refresh TTL, delete) requires Vertex credentials, project/location config, and an async cache manager. Keeping that out of the SDK avoids pulling `google-cloud-aiplatform` in as a hard dependency and respects the user's existing auth setup. The user creates the resource (one `gcloud` call) and pastes its name into the LLM config.
- **Gemini-only gating.** Emitting `cached_content` for a non-Gemini model would surface as an unknown-kwarg error from OpenAI / Anthropic / etc. We gate on `"gemini" in model.lower()` — covers `vertex_ai/`, `gemini/`, `litellm_proxy/gemini-*`, and bare `gemini-*`; everything else gets the silent no-op.
- **User kwarg wins.** A caller-supplied `cached_content` in `user_kwargs` overrides the LLM config field, matching the precedence pattern used elsewhere in `chat_options.py` (extra_headers, etc.).

### Limitations (called out so reviewers can shape this)

- For the `litellm_proxy/` users this kwarg only fires if the proxy itself forwards `cached_content` to its Vertex backend. The SDK can't fix proxy configuration; this PR just exposes the field so a fixed proxy has something to receive.
- The Vertex minimum-cache-size constraint (1024–32K tokens depending on model) still applies — sub-threshold caches won't be created, but a pre-created cache always meets the bar by construction.
- This PR does **not** change the existing `cache_control` marker placement. That's a separate question (the rolling-tail marker is effectively a no-op on Vertex's first-continuous-block split, but isn't actively harmful).

## Files

- **Modified**: `openhands-sdk/openhands/sdk/llm/llm.py` — new `vertex_cached_content: str | None` field with full docstring linking to Vertex docs.
- **Modified**: `openhands-sdk/openhands/sdk/llm/options/chat_options.py` — `_model_supports_vertex_cached_content` gating + emission block at the bottom of `select_chat_options`.
- **Modified**: `tests/sdk/llm/test_chat_options.py` — 7 new tests, plus the field added to the `DummyLLM` dataclass to match the existing convention.

## Test plan

```bash
uv run pytest tests/sdk/llm/test_chat_options.py -v          # 22 passed
uv run pytest tests/sdk/llm/ tests/sdk/event/ -q             # 931 passed
uv run ruff format <files> && uv run ruff check <files>      # clean
uv run pyright openhands-sdk/openhands/sdk/llm/options/chat_options.py   # 0 errors
```

Tests cover:
- `vertex_ai/`, `gemini/`, and `litellm_proxy/gemini-*` all receive the kwarg.
- `gpt-5-mini` and `claude-sonnet-4-5` never receive it even when the field is set.
- Default `None` produces no kwarg.
- A caller-supplied `cached_content` overrides the LLM config field.

---

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini, following the cost analysis in OpenHands/benchmarks#741. Companion PR: #3581._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6a5de077-cc79-47d0-8134-71ba9499cfcb)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6f12ac8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6f12ac8-python \
  ghcr.io/openhands/agent-server:6f12ac8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6f12ac8-golang-amd64
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-golang-amd64
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-golang-amd64
ghcr.io/openhands/agent-server:6f12ac8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6f12ac8-golang-arm64
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-golang-arm64
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-golang-arm64
ghcr.io/openhands/agent-server:6f12ac8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6f12ac8-java-amd64
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-java-amd64
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-java-amd64
ghcr.io/openhands/agent-server:6f12ac8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6f12ac8-java-arm64
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-java-arm64
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-java-arm64
ghcr.io/openhands/agent-server:6f12ac8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6f12ac8-python-amd64
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-python-amd64
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-python-amd64
ghcr.io/openhands/agent-server:6f12ac8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6f12ac8-python-arm64
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-python-arm64
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-python-arm64
ghcr.io/openhands/agent-server:6f12ac8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6f12ac8-golang
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-golang
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-golang
ghcr.io/openhands/agent-server:6f12ac8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6f12ac8-java
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-java
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-java
ghcr.io/openhands/agent-server:6f12ac8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6f12ac8-python
ghcr.io/openhands/agent-server:6f12ac88ea944aeb5875579a1031cbf7a58ef2e5-python
ghcr.io/openhands/agent-server:feat-vertex-explicit-cached-content-config-python
ghcr.io/openhands/agent-server:6f12ac8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6f12ac8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6f12ac8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->