### PR TITLE
fix(workspace): X-Session-API-Key header missing on POST requests to agent-server

### DIFF
--- a/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/async_remote_workspace.py
@@ -49,6 +49,13 @@ class AsyncRemoteWorkspace(RemoteWorkspaceMixin):
         try:
             kwargs = next(generator)
             while True:
+                # Merge session-level headers into every request so that the
+                # X-Session-API-Key (and any future default headers) are
+                # always present, regardless of what the generator yields.
+                merged = dict(self._headers)
+                if "headers" in kwargs:
+                    merged.update(kwargs["headers"])
+                kwargs["headers"] = merged
                 response = await self.client.request(**kwargs)
                 kwargs = generator.send(response)
         except StopIteration as e:

--- a/openhands-sdk/openhands/sdk/workspace/remote/base.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/base.py
@@ -109,6 +109,13 @@ class RemoteWorkspace(RemoteWorkspaceMixin, BaseWorkspace):
         try:
             kwargs = next(generator)
             while True:
+                # Merge session-level headers into every request so that the
+                # X-Session-API-Key (and any future default headers) are
+                # always present, regardless of what the generator yields.
+                merged = dict(self._headers)
+                if "headers" in kwargs:
+                    merged.update(kwargs["headers"])
+                kwargs["headers"] = merged
                 response = self.client.request(**kwargs)
                 kwargs = generator.send(response)
         except StopIteration as e:

--- a/openhands-sdk/openhands/sdk/workspace/remote/remote_workspace_mixin.py
+++ b/openhands-sdk/openhands/sdk/workspace/remote/remote_workspace_mixin.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import time
 from collections.abc import Generator
 from pathlib import Path, PureWindowsPath
@@ -13,6 +14,10 @@ from openhands.sdk.workspace.models import CommandResult, FileOperationResult
 
 
 _logger = logging.getLogger(__name__)
+
+# Environment variable names for session API key fallback (agent-server ecosystem).
+# These match the env vars used by the agent-server and OpenHandsCloudWorkspace.
+_SESSION_API_KEY_ENV_VARS = ("OH_SESSION_API_KEYS_0", "SESSION_API_KEY")
 
 
 def _remote_path(path: str | Path) -> str:
@@ -57,11 +62,29 @@ class RemoteWorkspaceMixin(BaseModel):
         self.host = self.host.rstrip("/")
         return super().model_post_init(context)
 
+    def _resolve_api_key(self) -> str | None:
+        """Return the session API key from the field or environment fallback.
+
+        Falls back to ``OH_SESSION_API_KEYS_0`` and ``SESSION_API_KEY`` env
+        vars (in that order) when ``api_key`` is not explicitly set.  This
+        matches the convention used by the agent-server and by
+        ``OpenHandsCloudWorkspace`` so that the SDK works out of the box when
+        those variables are already present in the agent-server ecosystem.
+        """
+        if self.api_key:
+            return self.api_key
+        for name in _SESSION_API_KEY_ENV_VARS:
+            value = os.environ.get(name)
+            if value:
+                return value
+        return None
+
     @property
     def _headers(self):
         headers = {}
-        if self.api_key:
-            headers["X-Session-API-Key"] = self.api_key
+        api_key = self._resolve_api_key()
+        if api_key:
+            headers["X-Session-API-Key"] = api_key
         return headers
 
     def _execute_command_generator(

--- a/tests/sdk/workspace/remote/test_async_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_async_remote_workspace.py
@@ -99,7 +99,9 @@ async def test_async_execute_method():
     result = await workspace._execute(test_generator())
 
     assert result == "test_result"
-    mock_client.request.assert_called_once_with(method="GET", url="http://test.com")
+    mock_client.request.assert_called_once_with(
+        method="GET", url="http://test.com", headers={}
+    )
 
 
 @pytest.mark.asyncio
@@ -300,8 +302,12 @@ async def test_async_execute_generator_completion():
 
     assert result == "final_result"
     assert mock_client.request.call_count == 2
-    mock_client.request.assert_any_call(method="GET", url="http://test1.com")
-    mock_client.request.assert_any_call(method="POST", url="http://test2.com")
+    mock_client.request.assert_any_call(
+        method="GET", url="http://test1.com", headers={}
+    )
+    mock_client.request.assert_any_call(
+        method="POST", url="http://test2.com", headers={}
+    )
 
 
 @pytest.mark.asyncio
@@ -328,9 +334,15 @@ async def test_async_execute_multiple_yields():
 
     assert result == "complex_result"
     assert mock_client.request.call_count == 3
-    mock_client.request.assert_any_call(method="POST", url="http://start.com")
-    mock_client.request.assert_any_call(method="GET", url="http://poll.com")
-    mock_client.request.assert_any_call(method="GET", url="http://result.com")
+    mock_client.request.assert_any_call(
+        method="POST", url="http://start.com", headers={}
+    )
+    mock_client.request.assert_any_call(
+        method="GET", url="http://poll.com", headers={}
+    )
+    mock_client.request.assert_any_call(
+        method="GET", url="http://result.com", headers={}
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/sdk/workspace/remote/test_remote_workspace.py
+++ b/tests/sdk/workspace/remote/test_remote_workspace.py
@@ -102,7 +102,9 @@ def test_execute_method():
     result = workspace._execute(test_generator())
 
     assert result == "test_result"
-    mock_client.request.assert_called_once_with(method="GET", url="http://test.com")
+    mock_client.request.assert_called_once_with(
+        method="GET", url="http://test.com", headers={}
+    )
 
 
 @patch("openhands.sdk.workspace.remote.base.RemoteWorkspace._execute")
@@ -289,8 +291,12 @@ def test_execute_generator_completion():
 
     assert result == "final_result"
     assert mock_client.request.call_count == 2
-    mock_client.request.assert_any_call(method="GET", url="http://test1.com")
-    mock_client.request.assert_any_call(method="POST", url="http://test2.com")
+    mock_client.request.assert_any_call(
+        method="GET", url="http://test1.com", headers={}
+    )
+    mock_client.request.assert_any_call(
+        method="POST", url="http://test2.com", headers={}
+    )
 
 
 @patch("openhands.sdk.workspace.remote.base.urlopen")


### PR DESCRIPTION
HUMAN:

This PR will close issue #3574.

- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

`RemoteWorkspaceMixin._headers` only returns `{"X-Session-API-Key": api_key}`
when `api_key` is explicitly passed as a constructor argument.  There is no
fallback to the environment variables already used by the agent-server ecosystem
(`OH_SESSION_API_KEYS_0` and `SESSION_API_KEY`).

When a caller (e.g., the Web UI) creates `RemoteWorkspace(host=..., working_dir=...)`
without providing `api_key`, every HTTP request from the SDK lacks the auth header.

## Summary

<!-- 1-3 bullets describing what changed. -->

-When the OpenHands Web UI creates a `RemoteWorkspace` without explicitly passing
`api_key`, the `X-Session-API-Key` header is never sent in HTTP requests to the
agent-server. This causes 401 Unauthorized errors on all POST endpoints.

-GET requests may incidentally succeed because the agent-server's session API key
validation is only active when `OH_SESSION_API_KEYS_*` environment variables are
set (i.e., `config.session_api_keys` is non-empty).  When the validator is
active, ALL `/api/*` routes require the header regardless of HTTP method.


## Issue Number
<!-- Required if there is a relevant issue to this PR. -->
Closes #3574 

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

All 122 workspace tests pass:
```
uv run pytest tests/sdk/workspace/ -v
```

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
