### PR TITLE
Allow underscores in conversation tag keys

### DIFF
--- a/openhands-agent-server/openhands/agent_server/models.py
+++ b/openhands-agent-server/openhands/agent_server/models.py
@@ -410,8 +410,8 @@ class UpdateConversationRequest(BaseModel):
         default=None,
         description=(
             "Key-value tags to set on the conversation. Keys must be lowercase "
-            "alphanumeric. Values are arbitrary strings up to 256 characters. "
-            "Replaces all existing tags when provided."
+            "alphanumeric (underscores allowed). Values are arbitrary strings "
+            "up to 256 characters. Replaces all existing tags when provided."
         ),
     )
 
@@ -432,7 +432,7 @@ class ForkConversationRequest(BaseModel):
         default=None,
         description=(
             "Optional tags for the forked conversation. Keys must be "
-            "lowercase alphanumeric."
+            "lowercase alphanumeric (underscores allowed)."
         ),
     )
     reset_metrics: bool = Field(

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -191,7 +191,8 @@ class LocalConversation(BaseConversation):
                    decrypted when loading. If not provided, secrets are redacted
                    (lost) on serialization.
             tags: Optional key-value tags for the conversation. Keys must be
-                  lowercase alphanumeric, values up to 256 characters.
+                  lowercase alphanumeric (underscores allowed),
+                  values up to 256 characters.
             client_tools: Optional list of client-defined tool specs. Each spec
                   is registered and injected into the agent so it can call the
                   tool; the executor returns an acknowledgment and the real

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -700,7 +700,8 @@ class RemoteConversation(BaseConversation):
                        - None: No visualization
             secrets: Optional secrets to initialize the conversation with
             tags: Optional key-value tags for the conversation. Keys must be
-                  lowercase alphanumeric, values up to 256 characters.
+                  lowercase alphanumeric (underscores allowed),
+                  values up to 256 characters.
             user_id: Optional user ID to associate with observability traces
             client_tools: Optional list of client-defined tool specs. These tools
                       have no server-side executor — when the agent calls them an

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -179,7 +179,8 @@ class StartConversationRequest(BaseModel):
         default_factory=dict,
         description=(
             "Key-value tags for the conversation. Keys must be lowercase "
-            "alphanumeric. Values are arbitrary strings up to 256 characters."
+            "alphanumeric (underscores allowed). Values are arbitrary strings "
+            "up to 256 characters."
         ),
     )
     user_id: str | None = Field(

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -179,8 +179,8 @@ class ConversationState(OpenHandsModel):
     tags: ConversationTags = Field(
         default_factory=dict,
         description="User-defined key-value tags for the conversation. "
-        "Keys must be lowercase alphanumeric. Values are arbitrary strings "
-        "up to 256 characters.",
+        "Keys must be lowercase alphanumeric (underscores allowed). "
+        "Values are arbitrary strings up to 256 characters.",
     )
 
     # Agent-specific runtime state (simple dict for flexibility)
@@ -380,7 +380,8 @@ class ConversationState(OpenHandsModel):
                     saving and decrypted when loading. If not provided, secrets
                     are redacted (lost) on serialization.
             tags: Optional key-value tags for the conversation. Keys must be
-                  lowercase alphanumeric, values up to 256 characters.
+                  lowercase alphanumeric (underscores allowed),
+                  values up to 256 characters.
 
         Returns:
             ConversationState ready for use

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -18,7 +18,7 @@ ConversationTokenCallbackType = TokenCallbackType
 ConversationID = uuid.UUID
 """Type alias for conversation IDs."""
 
-TAG_KEY_PATTERN = re.compile(r"^[a-z0-9]+$")
+TAG_KEY_PATTERN = re.compile(r"^[a-z0-9_]+$")
 TAG_VALUE_MAX_LENGTH = 256
 
 
@@ -28,7 +28,8 @@ def _validate_tags(v: dict[str, str] | None) -> dict[str, str]:
     for key, value in v.items():
         if not TAG_KEY_PATTERN.match(key):
             raise ValueError(
-                f"Tag key '{key}' is invalid: keys must be lowercase alphanumeric only"
+                f"Tag key '{key}' is invalid: keys must be lowercase alphanumeric "
+                "(underscores allowed)"
             )
         if len(value) > TAG_VALUE_MAX_LENGTH:
             raise ValueError(
@@ -41,7 +42,8 @@ def _validate_tags(v: dict[str, str] | None) -> dict[str, str]:
 ConversationTags = Annotated[dict[str, str], BeforeValidator(_validate_tags)]
 """Validated dict of conversation tags.
 
-Keys must be lowercase alphanumeric. Values are arbitrary strings up to 256 chars.
+Keys must be lowercase alphanumeric, with underscores allowed
+(e.g. ``selected_workspace``). Values are arbitrary strings up to 256 chars.
 """
 
 

--- a/tests/sdk/conversation/test_tags.py
+++ b/tests/sdk/conversation/test_tags.py
@@ -34,14 +34,24 @@ def test_validate_tags_invalid_key_with_hyphen():
         _validate_tags({"my-key": "value"})
 
 
-def test_validate_tags_invalid_key_with_underscore():
-    with pytest.raises(ValueError, match="lowercase alphanumeric"):
-        _validate_tags({"my_key": "value"})
+def test_validate_tags_valid_key_with_underscore():
+    """Underscores are allowed so frontends can use snake_case keys like
+    ``selected_workspace`` and ``active_profile`` to attach UI-specific
+    metadata to a conversation without a separate localStorage store."""
+    result = _validate_tags({"my_key": "value", "selected_workspace": "/foo"})
+    assert result == {"my_key": "value", "selected_workspace": "/foo"}
 
 
 def test_validate_tags_invalid_key_with_spaces():
     with pytest.raises(ValueError, match="lowercase alphanumeric"):
         _validate_tags({"my key": "value"})
+
+
+def test_validate_tags_invalid_key_only_underscores():
+    """An underscore-only key is still considered a valid identifier under
+    the relaxed pattern; assert behaviour so future tightening surfaces."""
+    result = _validate_tags({"___": "value"})
+    assert result == {"___": "value"}
 
 
 def test_validate_tags_value_max_length():


### PR DESCRIPTION
## Summary

Relax the conversation tag key validator from `^[a-z0-9]+$` to `^[a-z0-9_]+$` so frontends can attach UI-specific metadata to a conversation using natural snake_case keys (e.g. `selected_workspace`, `active_profile`) instead of mashed-together strings like `selectedworkspace`.

## Motivation

agent-canvas currently keeps a small per-conversation localStorage shim (`conversation-metadata-store.ts`) for UI-only fields the agent runtime doesn't care about:

- `selected_repository` / `selected_branch` / `git_provider` — the home-page repo picker selection
- `selected_workspace` — the local folder the user attached at conversation creation (used by the Files tab to default to diff view)
- `active_profile` — the LLM profile name the conversation was created with / last switched to (the chat-header switcher needs this because several profiles can share the same model — see [agent-canvas#1082](https://github.com/OpenHands/agent-canvas/issues/2094))

These already round-trip cleanly through the existing `tags` field on `ConversationInfo` / `UpdateConversationRequest`, but the validator rejected the natural key names. The only mechanical workaround is to mash the names together (`selectedworkspace`, `activeprofile`), which is what we did for `acpserver` historically — readable but ugly, and it fans out a tag-key constants table that has to be kept in sync between the agent-server and every client.

With underscores allowed, agent-canvas can drop the localStorage shim and round-trip all five fields through `tags` using their normal names, completing the agent-canvas effort to eliminate per-conversation client-only state ([related agent-canvas plan](https://github.com/OpenHands/agent-canvas/issues)).

## Change

- `TAG_KEY_PATTERN`: `^[a-z0-9]+$` → `^[a-z0-9_]+$`
- Doc-strings on `ConversationTags`, `ConversationState.tags`, `CreateConversationRequest.tags`, `UpdateConversationRequest.tags`, `ForkConversationRequest.tags`, and the `Conversation`/`RemoteConversation` `tags` kwargs updated to say "(underscores allowed)"
- Existing "underscore rejected" test flipped to assert acceptance, plus a guard test for underscore-only keys (still valid under the relaxed pattern)

## Backward compatibility

Strictly additive: every key that was valid before is still valid. Existing tags written by older clients (including the `acpserver` tag agent-canvas already uses) continue to work unchanged. Hyphens, uppercase, and whitespace remain rejected.

## Tests

- `tests/sdk/conversation/test_tags.py` — 13 passed (the underscore-rejection test became an acceptance test; one new test pins down the underscore-only edge case)
- `tests/sdk/conversation/` — full suite 564/564 passing
- `tests/agent_server/` — 1151/1152 passing (the one failure is an unrelated webhook timeout test that passes in isolation; not touched by this PR)

---

_This pull request was opened by an AI agent (OpenHands) on behalf of @rbren as part of a wider agent-canvas cleanup; see the companion agent-canvas PR for the consumer-side change that motivated it._

@chuckbutkus can click here to [continue refining the PR](https://app.all-hands.dev/conversations/99f04e9d-932c-4245-a937-14330d2b5fa6)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:12ce504-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-12ce504-python \
  ghcr.io/openhands/agent-server:12ce504-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:12ce504-golang-amd64
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-golang-amd64
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-golang-amd64
ghcr.io/openhands/agent-server:12ce504-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:12ce504-golang-arm64
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-golang-arm64
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-golang-arm64
ghcr.io/openhands/agent-server:12ce504-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:12ce504-java-amd64
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-java-amd64
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-java-amd64
ghcr.io/openhands/agent-server:12ce504-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:12ce504-java-arm64
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-java-arm64
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-java-arm64
ghcr.io/openhands/agent-server:12ce504-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:12ce504-python-amd64
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-python-amd64
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-python-amd64
ghcr.io/openhands/agent-server:12ce504-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:12ce504-python-arm64
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-python-arm64
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-python-arm64
ghcr.io/openhands/agent-server:12ce504-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:12ce504-golang
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-golang
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-golang
ghcr.io/openhands/agent-server:12ce504-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:12ce504-java
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-java
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-java
ghcr.io/openhands/agent-server:12ce504-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:12ce504-python
ghcr.io/openhands/agent-server:12ce50473a5f443a6fa9621273b31564fafe02c9-python
ghcr.io/openhands/agent-server:allow-underscore-tag-keys-python
ghcr.io/openhands/agent-server:12ce504-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `12ce504-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `12ce504-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->