### PR TITLE
Clamp max_tokens for Bedrock joint input/output budget

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -164,6 +164,23 @@ ENV_ALLOW_SHORT_CONTEXT_WINDOWS: Final[str] = "ALLOW_SHORT_CONTEXT_WINDOWS"
 # 16384 is a safe default that works for most models (GPT-4o: 16k, Claude: 8k).
 DEFAULT_MAX_OUTPUT_TOKENS_CAP: Final[int] = 16384
 
+# Some providers (notably AWS Bedrock for Anthropic models) enforce
+# ``input_tokens + max_tokens <= context_window`` on a single shared window.
+# For these providers we clamp the per-request output budget at request time so
+# our injected default ``max_tokens`` (which defaults to the model's full
+# ``max_output_tokens`` -- e.g. 64k for Sonnet 4.5) cannot push large-input
+# requests past the context window. See BerriAI/litellm#17900 for the upstream
+# default change that made this manifest.
+JOINT_BUDGET_SAFETY_MARGIN_TOKENS: Final[int] = 256
+JOINT_BUDGET_MIN_OUTPUT_TOKENS: Final[int] = 1024
+# Provider name prefixes known to enforce a joint input/output token budget.
+# Kept as a narrow allowlist so direct providers (Anthropic, OpenAI, etc.) --
+# which have independent input/output windows -- are not affected. We match by
+# prefix because LiteLLM uses both ``bedrock`` (raw provider inference) and
+# ``bedrock_converse`` (the Anthropic-on-Bedrock route, surfaced via the model
+# registry) for the same underlying API.
+_JOINT_BUDGET_PROVIDER_PREFIXES: Final[tuple[str, ...]] = ("bedrock",)
+
 # Secret-bearing fields on LLM. Kept as a single source of truth so callers that
 # need to walk secrets (e.g. cipher-aware decryption on the save path) stay in
 # sync with the serializer below.
@@ -1022,6 +1039,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         has_tools_flag = bool(cc_tools) and use_native_fc
         # Behavior-preserving: delegate to select_chat_options
         call_kwargs = select_chat_options(self, kwargs, has_tools=has_tools_flag)
+
+        # 3a) joint input/output budget clamp (e.g. Bedrock-Anthropic)
+        call_kwargs = self._clamp_max_tokens_for_joint_budget(
+            call_kwargs,
+            formatted_messages,
+            [] if use_mock_tools else cc_tools,
+        )
 
         # 4) request context for telemetry (always include context_window for metrics)
         # Always pass context_window so metrics are tracked even when
@@ -1889,6 +1913,102 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     def _model_name_for_capabilities(self) -> str:
         """Return canonical name for capability lookups (e.g., vision support)."""
         return self.model_canonical_name or self.model
+
+    def _provider_has_joint_token_budget(self) -> bool:
+        """Whether the provider enforces input + max_tokens <= context_window.
+
+        Some providers (notably AWS Bedrock for Anthropic models) share a single
+        token window between input and requested output. Direct providers
+        (Anthropic, OpenAI, etc.) have independent input/output windows.
+        """
+        provider = self._infer_model_info_provider() or ""
+        return any(provider.startswith(p) for p in _JOINT_BUDGET_PROVIDER_PREFIXES)
+
+    def _clamp_max_tokens_for_joint_budget(
+        self,
+        call_kwargs: dict[str, Any],
+        formatted_messages: list[dict[str, Any]],
+        cc_tools: list[ChatCompletionToolParam],
+    ) -> dict[str, Any]:
+        """Clamp per-request output budget for joint-window providers.
+
+        For providers like Bedrock-Anthropic, ``input_tokens + max_tokens`` must
+        not exceed the context window. Our injected default for ``max_tokens`` is
+        the model's full ``max_output_tokens`` (e.g. 64k for Sonnet 4.5), which
+        for any input larger than roughly ``context_window - max_output_tokens``
+        will fail with "Input is too long for requested model" -- even when the
+        actual response would be small. Clamp to the headroom that actually
+        remains, with a safety margin and a floor so we never send ``0``.
+
+        For non-joint providers the parameters are independent budgets and we
+        leave the kwargs untouched.
+        """
+        if not self._provider_has_joint_token_budget():
+            return call_kwargs
+
+        context_window = self.effective_max_input_tokens
+        if not context_window:
+            return call_kwargs
+
+        # Both keys may appear depending on routing (Azure / extended thinking
+        # use ``max_tokens``; everything else uses ``max_completion_tokens``).
+        budget_key = next(
+            (k for k in ("max_tokens", "max_completion_tokens") if k in call_kwargs),
+            None,
+        )
+        if budget_key is None:
+            return call_kwargs
+        current_budget = call_kwargs.get(budget_key)
+        if not isinstance(current_budget, int) or current_budget <= 0:
+            return call_kwargs
+
+        try:
+            input_tokens = int(
+                token_counter(
+                    model=self.model,
+                    messages=formatted_messages,
+                    tools=cc_tools or None,
+                    custom_tokenizer=self._tokenizer,
+                )
+            )
+        except Exception:
+            logger.debug(
+                "Joint-budget clamp: token_counter failed for %s; "
+                "leaving max_tokens unchanged",
+                self.model,
+                exc_info=True,
+            )
+            return call_kwargs
+
+        headroom = context_window - input_tokens - JOINT_BUDGET_SAFETY_MARGIN_TOKENS
+        clamped = max(min(current_budget, headroom), JOINT_BUDGET_MIN_OUTPUT_TOKENS)
+
+        if clamped >= current_budget:
+            return call_kwargs
+
+        if headroom < JOINT_BUDGET_MIN_OUTPUT_TOKENS:
+            logger.warning(
+                "Input tokens (%s) leave only %s tokens of headroom in the %s "
+                "context window for %s; sending the floor of %s. The provider "
+                "may still reject this request -- consider condensing history.",
+                input_tokens,
+                max(headroom, 0),
+                context_window,
+                self.model,
+                JOINT_BUDGET_MIN_OUTPUT_TOKENS,
+            )
+        else:
+            logger.debug(
+                "Clamping %s from %s to %s for %s "
+                "(input_tokens=%s, context_window=%s, joint-budget provider)",
+                budget_key,
+                current_budget,
+                clamped,
+                self.model,
+                input_tokens,
+                context_window,
+            )
+        return {**call_kwargs, budget_key: clamped}
 
     def _init_model_info_and_caps(self) -> None:
         self._model_info = get_litellm_model_info(

--- a/tests/sdk/llm/test_joint_budget_clamp.py
+++ b/tests/sdk/llm/test_joint_budget_clamp.py
@@ -1,0 +1,186 @@
+"""Tests for the joint input/output token budget clamp.
+
+Some providers (notably AWS Bedrock for Anthropic models) enforce
+``input_tokens + max_tokens <= context_window``. After BerriAI/litellm#17900
+litellm's default for ``max_tokens`` became the model's full
+``max_output_tokens`` (e.g. 64k for Sonnet 4.5). For Bedrock this means any
+input above roughly ``context_window - max_output_tokens`` fails with "Input
+is too long for requested model" even when the actual response would be small.
+
+These tests cover the request-time clamp added to ``LLM._finalize_completion_params``.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from pydantic import SecretStr
+
+from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.llm.llm import (
+    JOINT_BUDGET_MIN_OUTPUT_TOKENS,
+    JOINT_BUDGET_SAFETY_MARGIN_TOKENS,
+)
+
+
+def _make_llm(model: str, *, max_input_tokens: int = 200_000) -> LLM:
+    llm = LLM(
+        usage_id="test-llm",
+        model=model,
+        api_key=SecretStr("test"),
+        max_input_tokens=max_input_tokens,
+    )
+    # Stabilize across environments: skip the LiteLLM model-info lookup that
+    # happens in ``_init_model_info_and_caps`` by pinning the effective window
+    # directly. ``max_input_tokens=`` already feeds ``effective_max_input_tokens``.
+    return llm
+
+
+def test_bedrock_clamps_max_tokens_when_input_is_large():
+    """Bedrock with 195k input + 64k requested output must be clamped."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"max_completion_tokens": 64_000}
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    # Headroom = 200_000 - 195_000 - 256 = 4_744; well above the floor.
+    expected = 200_000 - 195_000 - JOINT_BUDGET_SAFETY_MARGIN_TOKENS
+    assert out["max_completion_tokens"] == expected
+    assert out["max_completion_tokens"] < 64_000
+
+
+def test_bedrock_does_not_clamp_when_input_is_small():
+    """Bedrock with small input fits the full 64k output budget unchanged."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"max_completion_tokens": 64_000}
+
+    # 50k input + 64k output = 114k, well under the 200k window.
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=50_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_completion_tokens"] == 64_000
+    # Same dict identity not required, but should be unchanged in content.
+    assert out == call_kwargs
+
+
+def test_bedrock_floor_when_input_nearly_fills_window():
+    """When headroom < floor, clamp to the floor (and warn)."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"max_completion_tokens": 64_000}
+
+    # 199.9k input leaves only ~100 tokens of true headroom, well below floor.
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=199_900):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_completion_tokens"] == JOINT_BUDGET_MIN_OUTPUT_TOKENS
+
+
+def test_anthropic_direct_is_never_clamped():
+    """Anthropic direct API has independent input/output budgets -- no clamp."""
+    llm = _make_llm("claude-sonnet-4-5-20250929")
+    call_kwargs = {"max_completion_tokens": 64_000}
+
+    # Even a huge input must not clamp on a non-joint provider.
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out is call_kwargs
+    assert out["max_completion_tokens"] == 64_000
+
+
+def test_clamps_max_tokens_key_too():
+    """The clamp targets whichever budget key is present (Azure / thinking use max_tokens)."""  # noqa: E501
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"max_tokens": 64_000}
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert "max_completion_tokens" not in out
+    assert out["max_tokens"] == 200_000 - 195_000 - JOINT_BUDGET_SAFETY_MARGIN_TOKENS
+
+
+def test_no_clamp_when_no_budget_key_present():
+    """If neither max_tokens nor max_completion_tokens is set, leave kwargs alone."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"temperature": 0.0}
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out == {"temperature": 0.0}
+
+
+def test_user_supplied_smaller_budget_is_preserved():
+    """If the caller already passed a budget that fits, don't change it."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"max_completion_tokens": 2_000}
+
+    # 195k input + user-supplied 2k output = 197k, still fits the 200k window
+    # after the safety margin. Should not be clamped.
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_completion_tokens"] == 2_000
+
+
+def test_clamp_skipped_when_token_counter_raises():
+    """If counting fails, fall back to the unclamped behavior (and log)."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    call_kwargs = {"max_completion_tokens": 64_000}
+
+    with patch(
+        "openhands.sdk.llm.llm.token_counter",
+        side_effect=RuntimeError("boom"),
+    ):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_completion_tokens"] == 64_000
+
+
+def test_finalize_completion_params_applies_clamp_end_to_end():
+    """Reproduces the customer error path: large input on Bedrock Sonnet 4.5
+    must result in a clamped budget, not the model's full 64k output."""
+    llm = _make_llm("bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0")
+    llm._effective_max_output_tokens = 64_000  # mirror what registry would set
+
+    messages = [Message(role="user", content=[TextContent(text="hello")])]
+    formatted = llm.format_messages_for_llm(messages)
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        (
+            _formatted,
+            _cc_tools,
+            _use_mock_tools,
+            call_kwargs,
+            _telemetry,
+        ) = llm._finalize_completion_params(
+            formatted_messages=formatted,
+            tools=None,
+            add_security_risk_prediction=False,
+            kwargs={},
+        )
+
+    budget = call_kwargs.get("max_tokens") or call_kwargs.get("max_completion_tokens")
+    assert budget is not None
+    assert budget < 64_000
+    # Should have clamped to headroom (well above floor for 195k input).
+    assert budget == 200_000 - 195_000 - JOINT_BUDGET_SAFETY_MARGIN_TOKENS
+
+
+def test_no_clamp_when_context_window_unknown():
+    """If we don't know the context window, we can't safely clamp."""
+    llm = LLM(
+        usage_id="test-llm",
+        model="bedrock/us.anthropic.claude-sonnet-4-5-20250929-v1:0",
+        api_key=SecretStr("test"),
+    )
+    # Force unknown window after init.
+    llm._effective_max_input_tokens = None
+    call_kwargs = {"max_completion_tokens": 64_000}
+
+    with patch("openhands.sdk.llm.llm.token_counter", return_value=195_000):
+        out = llm._clamp_max_tokens_for_joint_budget(call_kwargs, [], [])
+
+    assert out["max_completion_tokens"] == 64_000


### PR DESCRIPTION
## Why

LiteLLM 1.84.x (post [BerriAI/litellm#17900](https://github.com/BerriAI/litellm/pull/17900)) changed `AnthropicConfig.max_tokens` from a hardcoded default of `4096` to the model's full `max_output_tokens` (e.g. `64_000` for Sonnet 4.5). On AWS Bedrock — which enforces `input_tokens + max_tokens ≤ context_window` on a single shared window — this means any request with input larger than `context_window − max_output_tokens` (≈ 136k tokens for Sonnet 4.5's 200k window) now fails with `Input is too long for requested model`, *even when the actual response would be small*.

A colleague reproduced this against the customer's exact model with both `litellm==1.78.0` (pre-PR #17900) and `litellm==1.84.1`:

| Input tokens | Injected `max_tokens` | Total | 1.78.0 | 1.84.1 |
|---:|---:|---:|:---:|:---:|
| 130,000 | 4,096 / 64,000 | 134k / 194k | ✅ | ✅ |
| 140,000 | 4,096 / 64,000 | 144k / 204k | ✅ | ❌ |
| 150,000 | 4,096 / 64,000 | 154k / 214k | ✅ | ❌ |
| 170,000 | 4,096 / 64,000 | 174k / 234k | ✅ | ❌ |
| 190,000 | 4,096 / 64,000 | 194k / 254k | ✅ | ❌ |
| 195,000 | 4,096 / 64,000 | 199k / 259k | ✅ | ❌ |

The right long-term fix is upstream in litellm, but:
- The SDK already counts input tokens (for the condenser).
- The SDK is the layer that constructs the request and owns its shape.
- Relying on a third-party default for a budget that depends on *our* prompt size has always been fragile.
- An SDK-side fix ships today and is defense-in-depth against any future provider-default change.

Just reverting to `4096` would also be wrong — it'd silently cap legitimate large outputs (file writes, long refactors). The right semantics is: don't artificially cap; just don't let the request *overflow* the joint window.

## What this PR does

At chat-completion request time, after `select_chat_options` resolves the call kwargs, clamp `max_tokens` / `max_completion_tokens` to fit the joint budget *only* when the provider is in a narrow allowlist (currently `bedrock` / `bedrock_converse`). For independent-budget providers (Anthropic direct, OpenAI, etc.) the call kwargs are returned unchanged.

The clamp:
- Uses `litellm.utils.token_counter` (the same counter `LLM.get_token_count()` already uses), with `custom_tokenizer` honored.
- Mirrors `get_token_count`'s handling of mock-tools (don't double-count when tools have been inlined into the prompt).
- Applies a 256-token safety margin so we don't tightrope-walk the boundary.
- Floors at 1024 tokens so we never accidentally send 0; logs a clear warning when the floor is the best we can do.
- Preserves caller-supplied budgets that already fit.
- Falls back to the unclamped behavior if token counting raises.

## Files

- `openhands-sdk/openhands/sdk/llm/llm.py` — new constants, two new methods (`_provider_has_joint_token_budget`, `_clamp_max_tokens_for_joint_budget`), and a single call from `_finalize_completion_params`.
- `tests/sdk/llm/test_joint_budget_clamp.py` — 10 tests covering: Bedrock clamps when input is large, Bedrock doesn't clamp when input fits, floor is honored, Anthropic-direct is never clamped, both `max_tokens` and `max_completion_tokens` are handled, user-supplied small budgets are preserved, token-counter failures are graceful, unknown context window skips the clamp, and one end-to-end test through `_finalize_completion_params`.

## How to test

```bash
uv run pytest tests/sdk/llm/test_joint_budget_clamp.py tests/sdk/llm/test_chat_options.py -v
uv run pytest tests/sdk/llm/                  # 820 passed locally
uv run ruff check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_joint_budget_clamp.py
uv run ruff format --check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_joint_budget_clamp.py
```

## Follow-ups (not in this PR)

- Open an issue / PR upstream on `BerriAI/litellm` to make the default provider-aware there too, so the rest of the ecosystem gets the fix. This SDK clamp can stay as belt-and-suspenders.
- Investigate whether Vertex Anthropic enforces the same joint constraint; if so, add `"vertex_ai"` to `_JOINT_BUDGET_PROVIDER_PREFIXES`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---

_This PR was created by an AI agent (OpenHands) on behalf of the user. The investigation, repro, and review are still pending human sign-off — opened as a draft._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/2cbe4c55-f386-48a7-8dbe-2b6abad65544)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5511cef-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5511cef-python \
  ghcr.io/openhands/agent-server:5511cef-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5511cef-golang-amd64
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-golang-amd64
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-golang-amd64
ghcr.io/openhands/agent-server:5511cef-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5511cef-golang-arm64
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-golang-arm64
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-golang-arm64
ghcr.io/openhands/agent-server:5511cef-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5511cef-java-amd64
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-java-amd64
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-java-amd64
ghcr.io/openhands/agent-server:5511cef-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5511cef-java-arm64
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-java-arm64
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-java-arm64
ghcr.io/openhands/agent-server:5511cef-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5511cef-python-amd64
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-python-amd64
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-python-amd64
ghcr.io/openhands/agent-server:5511cef-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5511cef-python-arm64
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-python-arm64
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-python-arm64
ghcr.io/openhands/agent-server:5511cef-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5511cef-golang
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-golang
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-golang
ghcr.io/openhands/agent-server:5511cef-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5511cef-java
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-java
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-java
ghcr.io/openhands/agent-server:5511cef-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5511cef-python
ghcr.io/openhands/agent-server:5511cefbc0b7399f6bd6243343de5518bb40bee5-python
ghcr.io/openhands/agent-server:clamp-max-tokens-bedrock-joint-budget-python
ghcr.io/openhands/agent-server:5511cef-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5511cef-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5511cef-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->