### PR TITLE
[codex] Require chat-template tokenizer for custom token counts

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2440,12 +2440,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 f"Unable to load chat-template tokenizer for {identifier!r}."
             ) from exc
 
-        if hasattr(tokenizer, "apply_chat_template"):
-            return tokenizer
-        raise ValueError(
-            f"Tokenizer {identifier!r} does not support apply_chat_template; "
-            "custom_tokenizer requires chat-template token counting."
-        )
+        if not hasattr(tokenizer, "apply_chat_template"):
+            raise ValueError(
+                f"Tokenizer {identifier!r} does not support apply_chat_template; "
+                "custom_tokenizer requires chat-template token counting."
+            )
+        if not getattr(tokenizer, "chat_template", None):
+            raise ValueError(
+                f"Tokenizer {identifier!r} does not define a chat template; "
+                "custom_tokenizer requires chat-template token counting."
+            )
+        return tokenizer
 
     @classmethod
     def from_persisted(cls, data: Any, *, context: dict[str, Any] | None = None) -> LLM:

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -578,7 +578,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         # Tokenizer
         if self.custom_tokenizer:
             self._tokenizer = create_pretrained_tokenizer(self.custom_tokenizer)
-            self._chat_template_tokenizer = self._load_chat_template_tokenizer(
+            self._chat_template_tokenizer = self._load_required_chat_template_tokenizer(
                 self.custom_tokenizer
             )
 
@@ -2309,12 +2309,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             )
             cc_tools = []
 
+        template_count = self._get_chat_template_token_count(
+            formatted_messages, cc_tools
+        )
+        if template_count is not None:
+            return template_count
+
         try:
-            template_count = self._get_chat_template_token_count(
-                formatted_messages, cc_tools
-            )
-            if template_count is not None:
-                return template_count
             return int(
                 token_counter(
                     model=self.model,
@@ -2355,22 +2356,15 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         if tokenizer is None or not hasattr(tokenizer, "apply_chat_template"):
             return None
 
-        try:
-            template_messages = self._messages_for_chat_template(formatted_messages)
-            kwargs: dict[str, Any] = {
-                "tokenize": True,
-                "add_generation_prompt": True,
-            }
-            if tools:
-                kwargs["tools"] = tools
-            tokenized = tokenizer.apply_chat_template(template_messages, **kwargs)
-            return self._count_tokenized_output(tokenized, tokenizer)
-        except Exception:
-            logger.debug(
-                "Chat-template token counting failed; falling back to LiteLLM",
-                exc_info=True,
-            )
-            return None
+        template_messages = self._messages_for_chat_template(formatted_messages)
+        kwargs: dict[str, Any] = {
+            "tokenize": True,
+            "add_generation_prompt": True,
+        }
+        if tools:
+            kwargs["tools"] = tools
+        tokenized = tokenizer.apply_chat_template(template_messages, **kwargs)
+        return self._count_tokenized_output(tokenized, tokenizer)
 
     @staticmethod
     def _count_tokenized_output(tokenized: Any, tokenizer: Any) -> int:
@@ -2417,32 +2411,41 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         return template_messages
 
     @staticmethod
-    def _load_chat_template_tokenizer(identifier: str) -> Any | None:
+    def _load_required_chat_template_tokenizer(identifier: str) -> Any:
         try:
             transformers = importlib.import_module("transformers")
-        except ModuleNotFoundError:
-            return None
-        except Exception:
-            logger.debug("Unable to import transformers", exc_info=True)
-            return None
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "LLM custom_tokenizer requires the `transformers` package so token "
+                "counts use the model chat template. Install `transformers` or "
+                "remove custom_tokenizer."
+            ) from exc
+        except Exception as exc:
+            raise RuntimeError(
+                "Unable to import `transformers` for custom_tokenizer chat-template "
+                "token counting."
+            ) from exc
 
         auto_tokenizer = getattr(transformers, "AutoTokenizer", None)
         if auto_tokenizer is None:
-            return None
+            raise RuntimeError(
+                "`transformers.AutoTokenizer` is required for custom_tokenizer "
+                "chat-template token counting."
+            )
 
         try:
             tokenizer = auto_tokenizer.from_pretrained(identifier)
-        except Exception:
-            logger.debug(
-                "Unable to load chat-template tokenizer for %s",
-                identifier,
-                exc_info=True,
-            )
-            return None
+        except Exception as exc:
+            raise RuntimeError(
+                f"Unable to load chat-template tokenizer for {identifier!r}."
+            ) from exc
 
         if hasattr(tokenizer, "apply_chat_template"):
             return tokenizer
-        return None
+        raise ValueError(
+            f"Tokenizer {identifier!r} does not support apply_chat_template; "
+            "custom_tokenizer requires chat-template token counting."
+        )
 
     @classmethod
     def from_persisted(cls, data: Any, *, context: dict[str, Any] | None = None) -> LLM:

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -365,8 +365,8 @@ def test_llm_token_counting_includes_tools(mock_token_counter, default_llm):
     assert "message" in kwargs["tools"][0]["function"]["parameters"]["properties"]
 
 
-def test_llm_load_chat_template_tokenizer_prefers_transformers(monkeypatch):
-    """The optional chat-template tokenizer uses Transformers when available."""
+def test_llm_load_required_chat_template_tokenizer_prefers_transformers(monkeypatch):
+    """The required chat-template tokenizer uses Transformers when available."""
 
     class FakeTokenizer:
         def apply_chat_template(self, messages, **kwargs):
@@ -392,10 +392,70 @@ def test_llm_load_chat_template_tokenizer_prefers_transformers(monkeypatch):
         "openhands.sdk.llm.llm.importlib.import_module", fake_import_module
     )
 
-    tokenizer = LLM._load_chat_template_tokenizer("model-with-template")
+    tokenizer = LLM._load_required_chat_template_tokenizer("model-with-template")
 
     assert isinstance(tokenizer, FakeTokenizer)
     assert FakeAutoTokenizer.loaded_identifier == "model-with-template"
+
+
+@patch("openhands.sdk.llm.llm.create_pretrained_tokenizer")
+def test_llm_custom_tokenizer_requires_transformers(
+    mock_create_pretrained_tokenizer, monkeypatch
+):
+    mock_create_pretrained_tokenizer.return_value = {
+        "type": "huggingface_tokenizer",
+        "tokenizer": object(),
+    }
+
+    def fake_import_module(name):
+        if name == "transformers":
+            raise ModuleNotFoundError(name)
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.importlib.import_module", fake_import_module
+    )
+
+    with pytest.raises(ModuleNotFoundError, match="requires the `transformers`"):
+        LLM(
+            model="openai/qwen-test",
+            api_key=SecretStr("test_key"),
+            custom_tokenizer="Qwen/Qwen3-test",
+        )
+
+
+@patch("openhands.sdk.llm.llm.create_pretrained_tokenizer")
+def test_llm_custom_tokenizer_requires_chat_template(
+    mock_create_pretrained_tokenizer, monkeypatch
+):
+    mock_create_pretrained_tokenizer.return_value = {
+        "type": "huggingface_tokenizer",
+        "tokenizer": object(),
+    }
+
+    class FakeAutoTokenizer:
+        @classmethod
+        def from_pretrained(cls, identifier):
+            return object()
+
+    class FakeTransformers:
+        AutoTokenizer = FakeAutoTokenizer
+
+    def fake_import_module(name):
+        if name == "transformers":
+            return FakeTransformers
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.importlib.import_module", fake_import_module
+    )
+
+    with pytest.raises(ValueError, match="does not support apply_chat_template"):
+        LLM(
+            model="openai/qwen-test",
+            api_key=SecretStr("test_key"),
+            custom_tokenizer="Qwen/Qwen3-test",
+        )
 
 
 @patch("openhands.sdk.llm.llm.token_counter")
@@ -461,10 +521,10 @@ def test_llm_count_tokenized_output_handles_encoding_objects(default_llm):
 
 
 @patch("openhands.sdk.llm.llm.token_counter")
-def test_llm_token_counting_falls_back_when_chat_template_fails(
+def test_llm_token_counting_raises_when_chat_template_fails(
     mock_token_counter, default_llm
 ):
-    """A broken tokenizer chat template must not break token counting."""
+    """A broken tokenizer chat template must not silently change counting methods."""
 
     class BrokenChatTemplateTokenizer:
         def apply_chat_template(self, messages, **kwargs):
@@ -474,10 +534,10 @@ def test_llm_token_counting_falls_back_when_chat_template_fails(
     mock_token_counter.return_value = 123
     messages = [Message(role="user", content=[TextContent(text="Hello")])]
 
-    token_count = default_llm.get_token_count(messages)
+    with pytest.raises(RuntimeError, match="template unavailable"):
+        default_llm.get_token_count(messages)
 
-    assert token_count == 123
-    mock_token_counter.assert_called_once()
+    mock_token_counter.assert_not_called()
 
 
 @patch("openhands.sdk.llm.llm.token_counter")

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -369,6 +369,8 @@ def test_llm_load_required_chat_template_tokenizer_prefers_transformers(monkeypa
     """The required chat-template tokenizer uses Transformers when available."""
 
     class FakeTokenizer:
+        chat_template = "template"
+
         def apply_chat_template(self, messages, **kwargs):
             return []
 
@@ -455,6 +457,46 @@ def test_llm_custom_tokenizer_requires_chat_template(
             model="openai/qwen-test",
             api_key=SecretStr("test_key"),
             custom_tokenizer="Qwen/Qwen3-test",
+        )
+
+
+@patch("openhands.sdk.llm.llm.create_pretrained_tokenizer")
+def test_llm_custom_tokenizer_rejects_missing_chat_template(
+    mock_create_pretrained_tokenizer, monkeypatch
+):
+    mock_create_pretrained_tokenizer.return_value = {
+        "type": "huggingface_tokenizer",
+        "tokenizer": object(),
+    }
+
+    class FakeTokenizer:
+        chat_template = None
+
+        def apply_chat_template(self, messages, **kwargs):
+            return []
+
+    class FakeAutoTokenizer:
+        @classmethod
+        def from_pretrained(cls, identifier):
+            return FakeTokenizer()
+
+    class FakeTransformers:
+        AutoTokenizer = FakeAutoTokenizer
+
+    def fake_import_module(name):
+        if name == "transformers":
+            return FakeTransformers
+        raise ModuleNotFoundError(name)
+
+    monkeypatch.setattr(
+        "openhands.sdk.llm.llm.importlib.import_module", fake_import_module
+    )
+
+    with pytest.raises(ValueError, match="does not define a chat template"):
+        LLM(
+            model="openai/qwen-test",
+            api_key=SecretStr("test_key"),
+            custom_tokenizer="gpt2",
         )
 
 


### PR DESCRIPTION
## Summary
- require Transformers-backed chat-template tokenization whenever `LLM.custom_tokenizer` is configured
- raise during LLM initialization when Transformers is missing, `AutoTokenizer` cannot load, or the tokenizer has no `apply_chat_template`
- stop falling back to LiteLLM token counting when chat-template tokenization fails at runtime

## Impact
This intentionally changes behavior for `custom_tokenizer` users: custom token counts now require a tokenizer that can render the model chat template. LLMs without `custom_tokenizer` keep the existing LiteLLM token-counting path.

## Testing
- `uv run ruff check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm.py`
- `uv run pytest tests/sdk/llm/test_llm.py -k 'token_counting or chat_template or custom_tokenizer'`
- `uv run pytest tests/sdk/context/condenser/test_llm_summarizing_condenser.py tests/sdk/context/condenser/test_utils.py tests/sdk/llm/test_llm.py -k 'token or chat_template or custom_tokenizer or condense'`


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:83fadd7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-83fadd7-python \
  ghcr.io/openhands/agent-server:83fadd7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:83fadd7-golang-amd64
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-golang-amd64
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-golang-amd64
ghcr.io/openhands/agent-server:83fadd7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:83fadd7-golang-arm64
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-golang-arm64
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-golang-arm64
ghcr.io/openhands/agent-server:83fadd7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:83fadd7-java-amd64
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-java-amd64
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-java-amd64
ghcr.io/openhands/agent-server:83fadd7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:83fadd7-java-arm64
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-java-arm64
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-java-arm64
ghcr.io/openhands/agent-server:83fadd7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:83fadd7-python-amd64
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-python-amd64
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-python-amd64
ghcr.io/openhands/agent-server:83fadd7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:83fadd7-python-arm64
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-python-arm64
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-python-arm64
ghcr.io/openhands/agent-server:83fadd7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:83fadd7-golang
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-golang
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-golang
ghcr.io/openhands/agent-server:83fadd7-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:83fadd7-java
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-java
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-java
ghcr.io/openhands/agent-server:83fadd7-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:83fadd7-python
ghcr.io/openhands/agent-server:83fadd71e6f473a194aa656ea561f7c757485035-python
ghcr.io/openhands/agent-server:codex-require-chat-template-tokenizer-python
ghcr.io/openhands/agent-server:83fadd7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `83fadd7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `83fadd7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Issue

Closes #3631

_This PR description update was created by an AI agent (Codex) on behalf of Graham Neubig._
