### PR TITLE
fix(acp): require tokens key before selecting chatgpt auth method

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -284,6 +284,27 @@ def _codex_auth_file(env: dict[str, str]) -> Path:
     return Path.home() / _CHATGPT_AUTH_PATH
 
 
+def _codex_auth_file_is_chatgpt(env: dict[str, str]) -> bool:
+    """Return True only if ``auth.json`` is in ChatGPT-subscription format.
+
+    Codex itself rewrites ``$CODEX_HOME/auth.json`` during apikey-mode sessions
+    with ``{"auth_mode": "apikey", "OPENAI_API_KEY": "..."}``. That file's mere
+    presence used to make :func:`_select_auth_method` prefer ``chatgpt`` on a
+    restart, after which ``conn.authenticate("chatgpt")`` hung indefinitely
+    waiting for browser-based OAuth (issue #3627). The ChatGPT token blob is
+    keyed by ``tokens``; require that key before claiming the file is usable
+    for the ``chatgpt`` auth method.
+    """
+    path = _codex_auth_file(env)
+    if not path.is_file():
+        return False
+    try:
+        data = json.loads(path.read_text())
+    except (OSError, ValueError):
+        return False
+    return isinstance(data, dict) and "tokens" in data
+
+
 def _select_auth_method(
     auth_methods: list[Any],
     env: dict[str, str],
@@ -308,7 +329,7 @@ def _select_auth_method(
     method_ids = {m.id for m in auth_methods}
     # Prefer file-backed subscription / service-account logins when their
     # credential file is present.
-    if "chatgpt" in method_ids and _codex_auth_file(env).is_file():
+    if "chatgpt" in method_ids and _codex_auth_file_is_chatgpt(env):
         return "chatgpt"
     gac = env.get("GOOGLE_APPLICATION_CREDENTIALS")
     if "vertex-ai" in method_ids and gac and Path(gac).is_file():

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4155,6 +4155,9 @@ class TestClientForkTextRouting:
 # ---------------------------------------------------------------------------
 
 
+_CHATGPT_AUTH_JSON = '{"tokens": {"id_token": "x", "access_token": "y"}}'
+
+
 class TestSelectAuthMethod:
     """Test auto-detection of ACP auth method from env vars."""
 
@@ -4189,7 +4192,7 @@ class TestSelectAuthMethod:
         ]
         auth_dir = tmp_path / ".codex"
         auth_dir.mkdir()
-        (auth_dir / "auth.json").write_text("{}", encoding="utf-8")
+        (auth_dir / "auth.json").write_text(_CHATGPT_AUTH_JSON, encoding="utf-8")
 
         env = {"OPENAI_API_KEY": "sk-test"}
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
@@ -4218,7 +4221,7 @@ class TestSelectAuthMethod:
         methods = [self._make_auth_method("chatgpt")]
         auth_dir = tmp_path / ".codex"
         auth_dir.mkdir()
-        (auth_dir / "auth.json").write_text("{}", encoding="utf-8")
+        (auth_dir / "auth.json").write_text(_CHATGPT_AUTH_JSON, encoding="utf-8")
 
         with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=tmp_path):
             assert _select_auth_method(methods, {}) == "chatgpt"
@@ -4288,7 +4291,7 @@ class TestSelectAuthMethod:
         even though ~/.codex/auth.json does not exist."""
         codex_home = tmp_path / "conv" / "acp" / "codex"
         codex_home.mkdir(parents=True)
-        (codex_home / "auth.json").write_text("{}", encoding="utf-8")
+        (codex_home / "auth.json").write_text(_CHATGPT_AUTH_JSON, encoding="utf-8")
         methods = [self._make_auth_method("chatgpt")]
         empty_home = tmp_path / "home"
         empty_home.mkdir()
@@ -4322,6 +4325,44 @@ class TestSelectAuthMethod:
             assert _codex_auth_file({}) == home / ".codex" / "auth.json"
         ch = tmp_path / "ch"
         assert _codex_auth_file({"CODEX_HOME": str(ch)}) == ch / "auth.json"
+
+    # -- apikey-format auth.json must not be treated as chatgpt (#3627) -----
+
+    def test_apikey_format_auth_file_falls_back_to_api_key(self, tmp_path):
+        """Codex rewrites $CODEX_HOME/auth.json with {"auth_mode": "apikey", ...}
+        during apikey-mode sessions. On a restart, that file must NOT be picked
+        as ``chatgpt`` or codex-acp hangs on browser-based OAuth (issue #3627).
+        """
+        codex_home = tmp_path / "codex"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text(
+            '{"auth_mode": "apikey", "OPENAI_API_KEY": "sk-test"}',
+            encoding="utf-8",
+        )
+        methods = [
+            self._make_auth_method("chatgpt"),
+            self._make_auth_method("openai-api-key"),
+        ]
+        env = {"CODEX_HOME": str(codex_home), "OPENAI_API_KEY": "sk-test"}
+        empty_home = tmp_path / "home"
+        empty_home.mkdir()
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=empty_home):
+            assert _select_auth_method(methods, env) == "openai-api-key"
+
+    def test_malformed_auth_file_falls_back_to_api_key(self, tmp_path):
+        """A non-JSON / unreadable auth.json must not trip chatgpt selection."""
+        codex_home = tmp_path / "codex"
+        codex_home.mkdir()
+        (codex_home / "auth.json").write_text("not-json{", encoding="utf-8")
+        methods = [
+            self._make_auth_method("chatgpt"),
+            self._make_auth_method("openai-api-key"),
+        ]
+        env = {"CODEX_HOME": str(codex_home), "OPENAI_API_KEY": "sk-test"}
+        empty_home = tmp_path / "home"
+        empty_home.mkdir()
+        with patch("openhands.sdk.agent.acp_agent.Path.home", return_value=empty_home):
+            assert _select_auth_method(methods, env) == "openai-api-key"
 
     # -- Gemini Vertex AI service-account detection (issue #1020) ----------
 


### PR DESCRIPTION
HUMAN:

When acp_isolate_data_dir=True and codex-acp is driven with API-key auth
(OPENAI_API_KEY only, no CODEX_AUTH_JSON), the first session/new
succeeds, and during that session codex rewrites $CODEX_HOME/auth.json
with {"auth_mode": "apikey", "OPENAI_API_KEY": "..."}.

On the next launch (pod recycle / agent-server restart) _select_auth_method
in acp_agent.py saw the file at _codex_auth_file(env) and returned
"chatgpt", because the check only verified file presence:

if "chatgpt" in method_ids and _codex_auth_file(env).is_file():
    return "chatgpt"



<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [x] A human has tested these changes.

AGENT:

---

## Why

When `acp_isolate_data_dir=True` and codex-acp is driven with API-key auth
(`OPENAI_API_KEY` only, no `CODEX_AUTH_JSON`), the first `session/new`
succeeds, and during that session codex rewrites `$CODEX_HOME/auth.json`
with `{"auth_mode": "apikey", "OPENAI_API_KEY": "..."}`.

On the next launch (pod recycle / agent-server restart) `_select_auth_method`
in `acp_agent.py` saw the file at `_codex_auth_file(env)` and returned
`"chatgpt"`, because the check only verified file *presence*:

```python
if "chatgpt" in method_ids and _codex_auth_file(env).is_file():
    return "chatgpt"
```

codex-acp then read the apikey-format file as if it were a ChatGPT token
blob and hung indefinitely waiting for browser-based OAuth.

The production cloud path is unaffected — canvas always sends
`CODEX_AUTH_JSON` so the SDK materialises a proper chatgpt-format
`auth.json` before codex starts and codex never overwrites it. The bug
only manifested in test harnesses / non-standard deployments running with
API-key auth and `acp_isolate_data_dir=True` (discovered during the ACP
cloud pivot local validation, canvas#1290).

## Summary

- Add `_codex_auth_file_is_chatgpt(env)` which parses `auth.json` and
  requires a top-level `"tokens"` key — the marker that distinguishes
  the ChatGPT subscription token blob from the apikey-mode file codex
  writes for itself.
- Gate the `chatgpt` branch in `_select_auth_method` on this stricter
  check so an apikey-format file falls through to the
  `openai-api-key` / `codex-api-key` fallback instead of triggering
  the OAuth hang.
- Update existing fixtures that wrote `{}` as `auth.json` to use the
  real chatgpt-format payload, and add two new tests:
  `test_apikey_format_auth_file_falls_back_to_api_key` (reproduces the
  bug from #3627) and `test_malformed_auth_file_falls_back_to_api_key`
  (defensive coverage for unreadable / non-JSON files).

## Issue Number

Fixes #3627

## How to Test

```bash
uv run pytest tests/sdk/agent/test_acp_agent.py::TestSelectAuthMethod -x -q
```

Result: `20 passed`, including the two new tests
(`test_apikey_format_auth_file_falls_back_to_api_key`,
`test_malformed_auth_file_falls_back_to_api_key`) that fail on `main`
and pass with this change.

End-to-end repro (matches the issue's reproduction sequence):

1. Create an `ACPAgent` conversation with `acp_isolate_data_dir=True`,
   `OPENAI_API_KEY` in secrets (no `CODEX_AUTH_JSON`).
2. First turn completes via `openai-api-key`. codex-acp writes
   `$CODEX_HOME/auth.json` with `{"auth_mode": "apikey", ...}`.
3. Restart the agent-server.
4. Send a follow-up message. With this fix, `_select_auth_method`
   returns `"openai-api-key"` (file does not contain `"tokens"`)
   instead of `"chatgpt"`, and the conversation proceeds without
   hanging on browser-based OAuth.

## Video/Screenshots

N/A — auth-path selection change, exercised through the new unit tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Behavior is unchanged on the production cloud path (`CODEX_AUTH_JSON`
  materialises a proper chatgpt-format file with `"tokens"`).
- The helper accepts only `dict`s containing `"tokens"`; malformed or
  non-dict JSON also falls back to the API-key path, which is the safe
  default.

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3b4c5606-b9ff-4c00-9b31-697bac5d7a80)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4e17202-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4e17202-python \
  ghcr.io/openhands/agent-server:4e17202-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4e17202-golang-amd64
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-golang-amd64
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-golang-amd64
ghcr.io/openhands/agent-server:4e17202-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4e17202-golang-arm64
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-golang-arm64
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-golang-arm64
ghcr.io/openhands/agent-server:4e17202-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4e17202-java-amd64
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-java-amd64
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-java-amd64
ghcr.io/openhands/agent-server:4e17202-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4e17202-java-arm64
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-java-arm64
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-java-arm64
ghcr.io/openhands/agent-server:4e17202-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4e17202-python-amd64
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-python-amd64
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-python-amd64
ghcr.io/openhands/agent-server:4e17202-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4e17202-python-arm64
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-python-arm64
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-python-arm64
ghcr.io/openhands/agent-server:4e17202-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4e17202-golang
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-golang
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-golang
ghcr.io/openhands/agent-server:4e17202-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4e17202-java
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-java
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-java
ghcr.io/openhands/agent-server:4e17202-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4e17202-python
ghcr.io/openhands/agent-server:4e17202a131eac18a31c5ad4e89feb73d49c5574-python
ghcr.io/openhands/agent-server:openhands-fix-acp-auth-format-check-3627-python
ghcr.io/openhands/agent-server:4e17202-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4e17202-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4e17202-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->