### PR TITLE
fix(llm): serialize is_subscription so subscription mode survives remote agent-server transport

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -17,6 +17,7 @@ from pydantic import (
     Field,
     PrivateAttr,
     SecretStr,
+    computed_field,
     field_serializer,
     field_validator,
     model_validator,
@@ -692,6 +693,14 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             )
         return self._telemetry
 
+    @computed_field(
+        return_type=bool,
+        description=(
+            "Whether this LLM uses subscription-based authentication. "
+            "Serialized so that subscription-specific request handling "
+            "survives transport to a remote agent-server."
+        ),
+    )
     @property
     def is_subscription(self) -> bool:
         """Check if this LLM uses subscription-based authentication.
@@ -704,6 +713,24 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             bool: True if using subscription-based transport, False otherwise.
         """
         return self._is_subscription
+
+    @model_validator(mode="wrap")
+    @classmethod
+    def _restore_is_subscription(cls, data, handler):
+        """Restore the subscription flag when validating serialized data.
+
+        ``is_subscription`` is a computed field backed by the private
+        ``_is_subscription`` attribute, so plain validation would drop it.
+        Without this, an LLM created via ``LLM.subscription_login()`` loses
+        its subscription-specific request handling (streaming exemption,
+        Codex system prompt transform, reasoning-item stripping) after a
+        dump/validate round trip - e.g. when shipped to a remote
+        agent-server.
+        """
+        llm = handler(data)
+        if isinstance(data, dict) and data.get("is_subscription"):
+            llm._is_subscription = True
+        return llm
 
     def restore_metrics(self, metrics: Metrics) -> None:
         # Only used by ConversationStats to seed metrics

--- a/tests/sdk/llm/test_subscription_mode.py
+++ b/tests/sdk/llm/test_subscription_mode.py
@@ -338,3 +338,22 @@ def test_format_messages_reasoning_item_handling(
 
     serialized = json.dumps(input_items, default=str)
     assert ("rs_should_be_stripped" in serialized) == reasoning_id_present
+
+
+def test_is_subscription_survives_serialization_round_trip():
+    """is_subscription must survive model_dump -> model_validate.
+
+    A RemoteConversation serializes the LLM and the agent-server rebuilds it;
+    if the flag is lost, all subscription-specific request handling (streaming
+    exemption, system prompt transform, reasoning item stripping) silently
+    stops applying on the server side.
+    """
+    llm = _make_subscription_llm()
+    restored = LLM.model_validate(llm.model_dump(context={"expose_secrets": True}))
+    assert restored.is_subscription is True
+
+    plain = LLM(model="gpt-4o")
+    restored_plain = LLM.model_validate(
+        plain.model_dump(context={"expose_secrets": True})
+    )
+    assert restored_plain.is_subscription is False


### PR DESCRIPTION
HUMAN:
This PR proposes a mechanism to keep `is_subscription` across the wire.

- [x] A human has tested these changes.

AGENT:

---

## Why

`is_subscription` was a plain `@property` backed by the `_is_subscription` `PrivateAttr`, so it was silently dropped whenever an LLM was serialized — in particular when a `RemoteConversation` ships the agent's LLM to an agent-server. The server rebuilds the LLM with `is_subscription == False`, and every subscription-specific behavior stops applying server-side:

- the streaming `on_token` exemption in `responses()` (raises `ValueError: Streaming requires an on_token callback`),
- the Codex system-prompt transform (`transform_for_subscription`),
- reasoning-item stripping for `store=false` (follow-up requests reference unresolvable item IDs → 404 from the Codex endpoint).

Net effect: `LLM.subscription_login()` works locally but silently breaks with remote workspaces.

## Summary

- Promote the `is_subscription` property to a `@computed_field` so it is included in `model_dump()`.
- Keep the backing `_is_subscription` `PrivateAttr` and its existing write path untouched (no call-site or API changes; `OpenAISubscriptionAuth.create_llm` still sets it directly).
- Add a wrap `model_validator` that restores `_is_subscription` when validating serialized data, so the flag survives a dump → validate round trip (e.g. transport to a remote agent-server).

## Issue Number

N/A

## How to Test

Round-trip is the core of the fix:

```python
from openhands.sdk import LLM

llm = LLM(model="openai/gpt-5.2-codex", base_url="https://chatgpt.com/backend-api/codex")
llm._is_subscription = True
restored = LLM.model_validate(llm.model_dump(context={"expose_secrets": True}))
assert restored.is_subscription is True          # was False before this PR

plain = LLM(model="gpt-4o")
assert LLM.model_validate(plain.model_dump(context={"expose_secrets": True})).is_subscription is False
```

Automated:

```
uv run pytest tests/sdk/llm/test_subscription_mode.py tests/sdk -q   # 3535 passed
uv run python .github/scripts/check_sdk_api_breakage.py              # No breaking changes detected
uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py  # No breaking changes detected (exit 0)
```

A new regression test (`test_is_subscription_survives_serialization_round_trip`) covers both the subscription and plain cases. `ruff` + `pyright` clean on the touched files.

## Video/Screenshots

N/A (no UI surface).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`is_subscription` becomes an additive, read-only computed field in the serialized schema; the griffe API-breakage check sees no `ATTRIBUTE_CHANGED_VALUE` (still a property), and the REST schema gains only the additive read-only field. Backward compatible: old payloads without the field validate to `False` as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2daa3f8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2daa3f8-python \
  ghcr.io/openhands/agent-server:2daa3f8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2daa3f8-golang-amd64
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-golang-amd64
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-golang-amd64
ghcr.io/openhands/agent-server:2daa3f8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2daa3f8-golang-arm64
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-golang-arm64
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-golang-arm64
ghcr.io/openhands/agent-server:2daa3f8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2daa3f8-java-amd64
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-java-amd64
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-java-amd64
ghcr.io/openhands/agent-server:2daa3f8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2daa3f8-java-arm64
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-java-arm64
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-java-arm64
ghcr.io/openhands/agent-server:2daa3f8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2daa3f8-python-amd64
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-python-amd64
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-python-amd64
ghcr.io/openhands/agent-server:2daa3f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2daa3f8-python-arm64
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-python-arm64
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-python-arm64
ghcr.io/openhands/agent-server:2daa3f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2daa3f8-golang
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-golang
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-golang
ghcr.io/openhands/agent-server:2daa3f8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2daa3f8-java
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-java
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-java
ghcr.io/openhands/agent-server:2daa3f8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2daa3f8-python
ghcr.io/openhands/agent-server:2daa3f83fd8ad4745e04f1740a1028512979d55c-python
ghcr.io/openhands/agent-server:fix-serialize-is-subscription-python
ghcr.io/openhands/agent-server:2daa3f8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2daa3f8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2daa3f8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->