### PR TITLE
feat(models): alias claude-fable-5 capabilities to claude-opus-4-8

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -147,6 +147,13 @@ MODELS = {
         "display_name": "Claude Fable 5",
         "llm_config": {
             "model": "litellm_proxy/anthropic/claude-fable-5",
+            # litellm.model_cost has no entry for claude-fable-5 yet, so
+            # alias capability lookups (vision, prompt cache, context
+            # window, responses API) to a known vision-capable sibling.
+            # Without this, LLM.vision_is_active() returns False and
+            # t08_image_file_viewing skips even though the model itself
+            # supports images.
+            "model_canonical_name": "anthropic/claude-opus-4-8",
         },
     },
     "claude-sonnet-4-6": {


### PR DESCRIPTION
## Description

Follow-up to #3592 (already merged), addressing https://github.com/OpenHands/software-agent-sdk/pull/3592#issuecomment-4664919128 from @juanmichelini:

> @openhands can you see why `t08_image_file_viewing` was not run? claude-fable-5 is a vision model

### Why it skipped

`t08_image_file_viewing` short-circuits when `LLM.vision_is_active()` returns `False`. Vision detection ends up calling LiteLLM's `supports_vision()` against the configured model name (and a `split("/")[-1]` fallback), plus a `litellm.model_cost[...]` lookup. For our config the resolved name is `litellm_proxy/anthropic/claude-fable-5`, and **none** of those LiteLLM lookups recognize `claude-fable-5` yet — it isn't in `litellm.model_cost`. So the SDK treats the model as "unknown / no vision" and the test plays it safe and skips.

Verified locally against the pinned LiteLLM:
```
claude-opus-4-7: supports_vision=True   ← in litellm.model_cost
claude-opus-4-8: supports_vision=True   ← in litellm.model_cost
claude-fable-5:  supports_vision=False  ← NOT in litellm.model_cost yet
```

`claude-opus-4-7` / `claude-opus-4-8` passed `t08` "for free" because LiteLLM's cost map already knows them.

### Fix

Set `model_canonical_name` to a known vision-capable Anthropic sibling (`anthropic/claude-opus-4-8`). That field exists specifically to route capability lookups (vision, prompt cache, context window, responses API) through a recognised model when the actual one isn't in LiteLLM's tables yet. Actual API requests still route via `litellm_proxy/anthropic/claude-fable-5` — only `_supports_vision()` / `_supports_prompt_cache()` / `_init_model_info_and_caps()` and friends use the canonical name.

### Side effects worth flagging

`model_canonical_name` also drives:

- `c01_thinking_block_condenser`'s extended-thinking decision. The previous run had it skipped with _"Model litellm_proxy/anthropic/claude-fable-5 does not support extended thinking (produces reasoning items instead of thinking blocks)"_. Once aliased to opus-4-8, that check will follow opus-4-8's behaviour — which is what we want if fable-5 truly mirrors opus-class capabilities.
- The context-window estimate fetched from `get_litellm_model_info(...)`.

If those assumptions are wrong for `claude-fable-5`, the canonical can be retargeted (e.g. `anthropic/claude-sonnet-4-6`) without touching the proxy routing.

## Why a new PR

\#3592 was already merged to `main` (commit `4e821bed`) by the time @juanmichelini's question was posted, so per the repo policy I'm opening this as a follow-up PR instead of pushing to the merged branch.

## Checklist

- [x] I've followed the repository's guidelines for adding new models
- [x] I've run pre-commit locally (`uv run pre-commit run --files .github/run-eval/resolve_model_config.py`)
- [x] No SDK code changes — config-only update to `.github/run-eval/resolve_model_config.py`

_This PR was created by an AI agent (OpenHands) on behalf of @juanmichelini._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/46665807-e125-4af8-ad2c-196c18403279)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7478b7c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7478b7c-python \
  ghcr.io/openhands/agent-server:7478b7c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7478b7c-golang-amd64
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-golang-amd64
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-golang-amd64
ghcr.io/openhands/agent-server:7478b7c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7478b7c-golang-arm64
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-golang-arm64
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-golang-arm64
ghcr.io/openhands/agent-server:7478b7c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7478b7c-java-amd64
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-java-amd64
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-java-amd64
ghcr.io/openhands/agent-server:7478b7c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7478b7c-java-arm64
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-java-arm64
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-java-arm64
ghcr.io/openhands/agent-server:7478b7c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7478b7c-python-amd64
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-python-amd64
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-python-amd64
ghcr.io/openhands/agent-server:7478b7c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7478b7c-python-arm64
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-python-arm64
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-python-arm64
ghcr.io/openhands/agent-server:7478b7c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7478b7c-golang
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-golang
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-golang
ghcr.io/openhands/agent-server:7478b7c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7478b7c-java
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-java
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-java
ghcr.io/openhands/agent-server:7478b7c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7478b7c-python
ghcr.io/openhands/agent-server:7478b7c924d64484a8679a681abed4ff6d261200-python
ghcr.io/openhands/agent-server:add-claude-fable-5-vision-canonical-name-python
ghcr.io/openhands/agent-server:7478b7c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7478b7c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7478b7c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->