### PR TITLE
fix(sdk): skip reasoning effort for DeepSeek V4 Flash

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -89,9 +89,16 @@ def _normalized_supported_openai_params(model: str | None) -> frozenset[str]:
     return frozenset(params or ())
 
 
+REASONING_EFFORT_UNSUPPORTED_MODELS: list[str] = [
+    "deepseek/deepseek-v4-flash",
+]
+
+
 def _supports_reasoning_effort(model: str | None) -> bool:
     """Return True if LiteLLM says the model accepts reasoning_effort."""
-    return "reasoning_effort" in _normalized_supported_openai_params(model)
+    return "reasoning_effort" in _normalized_supported_openai_params(
+        model
+    ) and not model_matches(model or "", REASONING_EFFORT_UNSUPPORTED_MODELS)
 
 
 EXTENDED_THINKING_MODELS: list[str] = [

--- a/tests/sdk/llm/test_chat_options.py
+++ b/tests/sdk/llm/test_chat_options.py
@@ -87,6 +87,18 @@ def test_kimi_k2_thinking_does_not_send_reasoning_effort():
     assert out.get("temperature") == 1.0
 
 
+def test_deepseek_v4_flash_does_not_send_reasoning_effort():
+    llm = DummyLLM(
+        model="litellm_proxy/deepseek/deepseek-v4-flash",
+        temperature=0.0,
+        reasoning_effort="high",
+    )
+    out = select_chat_options(llm, user_kwargs={}, has_tools=True)
+
+    assert "reasoning_effort" not in out
+    assert out.get("temperature") == 0.0
+
+
 def test_gemini_2_5_pro_without_reasoning_effort_preserves_temp_and_top_p():
     llm = DummyLLM(model="gemini-2.5-pro", reasoning_effort=None)
     out = select_chat_options(llm, user_kwargs={}, has_tools=True)

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -44,6 +44,9 @@ def test_model_matches(name, pattern, expected):
         ("gemini-1.5-pro", False),
         # DeepSeek Reasoner
         ("deepseek/deepseek-reasoner", True),
+        ("deepseek/deepseek-v4-flash", False),
+        ("litellm_proxy/deepseek/deepseek-v4-flash", False),
+        ("openrouter/deepseek/deepseek-v4-flash", False),
         # Moonshot Kimi thinking models expose reasoning content but do not
         # accept the reasoning_effort parameter.
         ("moonshot/kimi-k2.5", False),


### PR DESCRIPTION
## Summary

- Add a model-feature override so `deepseek/deepseek-v4-flash` does not advertise `reasoning_effort` support.
- Prevent chat options from sending the SDK default `reasoning_effort=high` for `litellm_proxy/deepseek/deepseek-v4-flash`.
- Keep `send_reasoning_content` behavior unchanged for DeepSeek V4 Flash.

This addresses the OpenRouter-backed DeepSeek V4 Flash failure observed in #3638, where the provider rejects top-level `reasoning_effort`.

## Tests

- `uv run pytest tests/sdk/llm/test_model_features.py tests/sdk/llm/test_chat_options.py`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/utils/model_features.py tests/sdk/llm/test_model_features.py tests/sdk/llm/test_chat_options.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/66be5659-7261-4d28-bc56-d0e19997ec91)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0ff7487-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0ff7487-python \
  ghcr.io/openhands/agent-server:0ff7487-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0ff7487-golang-amd64
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-golang-amd64
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-golang-amd64
ghcr.io/openhands/agent-server:0ff7487-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0ff7487-golang-arm64
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-golang-arm64
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-golang-arm64
ghcr.io/openhands/agent-server:0ff7487-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0ff7487-java-amd64
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-java-amd64
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-java-amd64
ghcr.io/openhands/agent-server:0ff7487-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0ff7487-java-arm64
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-java-arm64
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-java-arm64
ghcr.io/openhands/agent-server:0ff7487-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0ff7487-python-amd64
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-python-amd64
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-python-amd64
ghcr.io/openhands/agent-server:0ff7487-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0ff7487-python-arm64
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-python-arm64
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-python-arm64
ghcr.io/openhands/agent-server:0ff7487-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0ff7487-golang
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-golang
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-golang
ghcr.io/openhands/agent-server:0ff7487-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0ff7487-java
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-java
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-java
ghcr.io/openhands/agent-server:0ff7487-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0ff7487-python
ghcr.io/openhands/agent-server:0ff7487122ace06a197ee0182747cdc455720de0-python
ghcr.io/openhands/agent-server:fix-deepseek-v4-flash-reasoning-python
ghcr.io/openhands/agent-server:0ff7487-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0ff7487-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0ff7487-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->