### PR TITLE
Fix Apptainer tokenizer binds and token condensation

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -105,6 +105,13 @@ class LLMSummarizingCondenser(RollingCondenser):
         if self.max_tokens and agent_llm:
             total_tokens = get_total_token_count(view.events, agent_llm)
             if total_tokens > self.max_tokens:
+                logger.info(
+                    "Condenser token limit exceeded: total_tokens=%d max_tokens=%d "
+                    "events=%d",
+                    total_tokens,
+                    self.max_tokens,
+                    len(view),
+                )
                 reasons.add(Reason.TOKENS)
 
         # Reason 3: View exceeds maximum size in number of events.
@@ -122,12 +129,17 @@ class LLMSummarizingCondenser(RollingCondenser):
         if reasons == set():
             return None
 
-        # If the reasons are for resource constraints, we can treat it as a soft
-        # requirement. We want to condense when we can, but there's still space in the
-        # context window or we'd also see Reason.REQUEST. That means we can delay the
-        # condensation if there isn't one available (based on the view's manipulation
-        # indices).
-        resource_reasons = {Reason.TOKENS, Reason.EVENTS}
+        # Token pressure is a hard requirement in benchmark runs that use a fixed
+        # local model context: sending the next request can fail before the recovery
+        # path has a chance to run. Treat event-count pressure as soft because that
+        # threshold is only a history-management heuristic.
+        if Reason.TOKENS in reasons:
+            return CondensationRequirement.HARD
+
+        # If the remaining reasons are for resource constraints, we can treat them as
+        # a soft requirement. We want to condense when we can, but there's still space
+        # in the context window or we'd also see Reason.REQUEST.
+        resource_reasons = {Reason.EVENTS}
         if reasons.issubset(resource_reasons):
             return CondensationRequirement.SOFT
 
@@ -238,6 +250,7 @@ class LLMSummarizingCondenser(RollingCondenser):
                     events=view.events[self.keep_first :],
                     llm=agent_llm,
                     token_reduction=tokens_to_reduce,
+                    base_events=view.events[: self.keep_first],
                 )
             )
 

--- a/openhands-sdk/openhands/sdk/context/condenser/utils.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/utils.py
@@ -54,6 +54,7 @@ def get_shortest_prefix_above_token_count(
     events: Sequence[LLMConvertibleEvent],
     llm: LLM,
     token_count: int,
+    base_events: Sequence[LLMConvertibleEvent] | None = None,
 ) -> int:
     """Find the length of the shortest prefix whose token count exceeds the target.
 
@@ -88,8 +89,11 @@ def get_shortest_prefix_above_token_count(
     if not events:
         return 0
 
+    base_events = base_events or []
+    base_tokens = get_total_token_count(base_events, llm) if base_events else 0
+
     # Check if all events combined don't exceed the token count
-    total_tokens = get_total_token_count(events, llm)
+    total_tokens = get_total_token_count([*base_events, *events], llm) - base_tokens
     if total_tokens <= token_count:
         return len(events)
 
@@ -98,7 +102,9 @@ def get_shortest_prefix_above_token_count(
 
     while left < right:
         mid = (left + right) // 2
-        prefix_tokens = get_total_token_count(events[:mid], llm)
+        prefix_tokens = (
+            get_total_token_count([*base_events, *events[:mid]], llm) - base_tokens
+        )
 
         if prefix_tokens > token_count:
             # This prefix exceeds the count, try to find a shorter one
@@ -114,6 +120,7 @@ def get_suffix_length_for_token_reduction(
     events: Sequence[LLMConvertibleEvent],
     llm: LLM,
     token_reduction: int,
+    base_events: Sequence[LLMConvertibleEvent] | None = None,
 ) -> int:
     """Find how many suffix events can be kept while reducing tokens by target amount.
 
@@ -153,7 +160,12 @@ def get_suffix_length_for_token_reduction(
         return len(events)
 
     # Find the shortest prefix that exceeds the token reduction target
-    prefix_length = get_shortest_prefix_above_token_count(events, llm, token_reduction)
+    prefix_length = get_shortest_prefix_above_token_count(
+        events,
+        llm,
+        token_reduction,
+        base_events=base_events,
+    )
 
     # The suffix length is what remains after removing the prefix
     suffix_length = len(events) - prefix_length

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -577,10 +577,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
         # Tokenizer
         if self.custom_tokenizer:
-            self._tokenizer = create_pretrained_tokenizer(self.custom_tokenizer)
             self._chat_template_tokenizer = self._load_chat_template_tokenizer(
                 self.custom_tokenizer
             )
+            if self._chat_template_tokenizer is None:
+                try:
+                    self._tokenizer = create_pretrained_tokenizer(self.custom_tokenizer)
+                except Exception:
+                    logger.debug(
+                        "Unable to load LiteLLM tokenizer for %s",
+                        self.custom_tokenizer,
+                        exc_info=True,
+                    )
+                    self._tokenizer = None
 
         # Capabilities + model info
         self._init_model_info_and_caps()
@@ -2366,8 +2375,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             tokenized = tokenizer.apply_chat_template(template_messages, **kwargs)
             return self._count_tokenized_output(tokenized, tokenizer)
         except Exception:
-            logger.debug(
-                "Chat-template token counting failed; falling back to LiteLLM",
+            logger.warning(
+                "Chat-template token counting failed for %d messages and %d tools; "
+                "falling back to LiteLLM",
+                len(formatted_messages),
+                len(tools or []),
                 exc_info=True,
             )
             return None
@@ -2404,16 +2416,29 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         template_messages = copy.deepcopy(messages)
         for message in template_messages:
             content = message.get("content")
-            if not isinstance(content, list):
-                continue
-            text_parts: list[str] = []
-            for block in content:
-                if not isinstance(block, dict) or block.get("type") != "text":
-                    text_parts = []
-                    break
-                text_parts.append(str(block.get("text", "")))
-            if text_parts:
-                message["content"] = "".join(text_parts)
+            if isinstance(content, list):
+                text_parts: list[str] = []
+                for block in content:
+                    if not isinstance(block, dict) or block.get("type") != "text":
+                        text_parts = []
+                        break
+                    text_parts.append(str(block.get("text", "")))
+                if text_parts:
+                    message["content"] = "".join(text_parts)
+
+            for tool_call in message.get("tool_calls") or []:
+                function = tool_call.get("function")
+                if not isinstance(function, dict):
+                    continue
+                arguments = function.get("arguments")
+                if not isinstance(arguments, str):
+                    continue
+                try:
+                    parsed_arguments = json.loads(arguments)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(parsed_arguments, dict):
+                    function["arguments"] = parsed_arguments
         return template_messages
 
     @staticmethod

--- a/openhands-workspace/openhands/workspace/apptainer/workspace.py
+++ b/openhands-workspace/openhands/workspace/apptainer/workspace.py
@@ -79,6 +79,14 @@ class ApptainerWorkspace(RemoteWorkspace):
         default=None,
         description="Optional host directory to mount into the container.",
     )
+    extra_bind_mounts: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Additional Apptainer bind mount specs to pass as --bind values. "
+            "Use src[:dest[:opts]] syntax. OPENHANDS_APPTAINER_EXTRA_BINDS can "
+            "also provide comma-separated bind specs."
+        ),
+    )
     detach_logs: bool = Field(
         default=True, description="Whether to stream container logs in background."
     )
@@ -260,6 +268,14 @@ class ApptainerWorkspace(RemoteWorkspace):
                 self.mount_dir,
                 mount_path,
             )
+        env_extra_binds = [
+            item.strip()
+            for item in os.getenv("OPENHANDS_APPTAINER_EXTRA_BINDS", "").split(",")
+            if item.strip()
+        ]
+        for bind_spec in [*self.extra_bind_mounts, *env_extra_binds]:
+            bind_args += ["--bind", bind_spec]
+            logger.info("Adding Apptainer bind mount: %s", bind_spec)
 
         # Build container options
         container_opts: list[str] = []

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -610,9 +610,7 @@ def test_condensation_requirement_returns_none(
 @pytest.mark.parametrize(
     "reasons",
     [
-        {Reason.TOKENS},
         {Reason.EVENTS},
-        {Reason.TOKENS, Reason.EVENTS},
     ],
 )
 def test_condensation_requirement_returns_soft(
@@ -631,6 +629,28 @@ def test_condensation_requirement_returns_soft(
     ):
         result = condenser.condensation_requirement(view)
         assert result == CondensationRequirement.SOFT
+
+
+@pytest.mark.parametrize(
+    "reasons",
+    [
+        {Reason.TOKENS},
+        {Reason.TOKENS, Reason.EVENTS},
+    ],
+)
+def test_condensation_requirement_returns_hard_for_token_pressure(
+    mock_llm: LLM, reasons: set[Reason]
+) -> None:
+    """Token pressure should trigger before the next LLM request can overflow."""
+    condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=100, keep_first=2)
+    events: list[Event] = [message_event(f"Event {i}") for i in range(10)]
+    view = View.from_events(events)
+
+    with patch.object(
+        LLMSummarizingCondenser, "get_condensation_reasons", return_value=reasons
+    ):
+        result = condenser.condensation_requirement(view)
+        assert result == CondensationRequirement.HARD
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/context/condenser/test_utils.py
+++ b/tests/sdk/context/condenser/test_utils.py
@@ -279,3 +279,32 @@ class TestGetSuffixLengthForTokenReduction:
 
         # Suffix + prefix should equal total length
         assert suffix_length + prefix_length == len(events)
+
+    def test_base_events_are_included_for_prefix_token_counting(self, mock_llm: LLM):
+        """Token reduction should count suffixes in the context of kept events."""
+        base_events = [
+            message_event("system-like prefix"),
+            message_event("kept user request"),
+        ]
+        events = [
+            message_event("A" * 40),  # 40 chars -> 10 tokens
+            message_event("B" * 40),  # 40 chars -> 10 tokens
+            message_event("C" * 40),  # 40 chars -> 10 tokens
+        ]
+
+        suffix_length = get_suffix_length_for_token_reduction(
+            events,
+            mock_llm,
+            token_reduction=10,
+            base_events=base_events,
+        )
+
+        assert suffix_length == 1
+        first_counted_messages = mock_llm.get_token_count.call_args_list[0].args[0]  # type: ignore
+        counted_text = "\n".join(
+            content.text
+            for message in first_counted_messages
+            for content in message.content
+        )
+        assert "system-like prefix" in counted_text
+        assert "kept user request" in counted_text

--- a/tests/sdk/llm/test_llm.py
+++ b/tests/sdk/llm/test_llm.py
@@ -10,7 +10,7 @@ from openai.types.responses.response_output_text import ResponseOutputText
 from pydantic import SecretStr
 
 from openhands.sdk import ConversationStats, RegistryEvent
-from openhands.sdk.llm import LLM, LLMResponse, Message, TextContent
+from openhands.sdk.llm import LLM, LLMResponse, Message, MessageToolCall, TextContent
 from openhands.sdk.llm.exceptions import LLMNoResponseError
 from openhands.sdk.llm.options.responses_options import select_responses_options
 from openhands.sdk.llm.utils.metrics import Metrics, TokenUsage
@@ -432,6 +432,45 @@ def test_llm_token_counting_prefers_chat_template_tokenizer(
     assert kwargs["add_generation_prompt"] is True
     assert kwargs["tools"][0]["function"]["name"] == "finish"
     assert "message" in kwargs["tools"][0]["function"]["parameters"]["properties"]
+
+
+@patch("openhands.sdk.llm.llm.token_counter")
+def test_llm_chat_template_token_counting_parses_tool_call_arguments(
+    mock_token_counter, default_llm
+):
+    """HF chat templates may expect assistant tool-call arguments as objects."""
+
+    class FakeChatTemplateTokenizer:
+        def __init__(self):
+            self.messages = None
+
+        def apply_chat_template(self, messages, **_kwargs):
+            self.messages = messages
+            return list(range(12))
+
+    tokenizer = FakeChatTemplateTokenizer()
+    default_llm._chat_template_tokenizer = tokenizer
+    messages = [
+        Message(
+            role="assistant",
+            tool_calls=[
+                MessageToolCall(
+                    id="call_1",
+                    name="finish",
+                    arguments='{"message": "done"}',
+                    origin="completion",
+                )
+            ],
+        )
+    ]
+
+    token_count = default_llm.get_token_count(messages)
+
+    assert token_count == 12
+    mock_token_counter.assert_not_called()
+    assert tokenizer.messages is not None
+    function = tokenizer.messages[0]["tool_calls"][0]["function"]
+    assert function["arguments"] == {"message": "done"}
 
 
 def test_llm_count_tokenized_output_handles_encoding_objects(default_llm):

--- a/tests/workspace/test_apptainer_workspace.py
+++ b/tests/workspace/test_apptainer_workspace.py
@@ -22,7 +22,9 @@ def mock_apptainer_workspace(tmp_path):
     ):
         mock_exec.return_value = Mock(returncode=0, stdout="", stderr="")
 
-        def _create_workspace(*, enable_gpu: bool = False):
+        def _create_workspace(
+            *, enable_gpu: bool = False, extra_bind_mounts: list[str] | None = None
+        ):
             with (
                 patch.object(ApptainerWorkspace, "_start_container"),
                 patch.object(ApptainerWorkspace, "_wait_for_health"),
@@ -32,6 +34,7 @@ def mock_apptainer_workspace(tmp_path):
                     host_port=8000,
                     detach_logs=False,
                     enable_gpu=enable_gpu,
+                    extra_bind_mounts=extra_bind_mounts or [],
                 )
 
             return workspace, mock_exec
@@ -81,6 +84,30 @@ def test_apptainer_workspace_gpu_passthrough_flag(
     assert run_cmd[:2] == ["apptainer", "run"]
     assert ("--nv" in run_cmd) is enable_gpu
     assert workspace._sif_path in run_cmd
+
+    workspace._process = None
+    workspace._instance_name = None
+
+
+def test_apptainer_workspace_extra_bind_mounts(mock_apptainer_workspace, monkeypatch):
+    """Test that explicit and environment-provided bind mounts reach Apptainer."""
+    monkeypatch.setenv("OPENHANDS_APPTAINER_EXTRA_BINDS", "/env/src:/env/dst:ro")
+    workspace, _ = mock_apptainer_workspace(
+        extra_bind_mounts=["/host/tokenizer:/host/tokenizer:ro"]
+    )
+
+    fake_process = Mock(stdout=None)
+    with patch(
+        "openhands.workspace.apptainer.workspace.subprocess.Popen",
+        return_value=fake_process,
+    ) as mock_popen:
+        workspace._start_container()
+
+    run_cmd = mock_popen.call_args.args[0]
+
+    assert "--bind" in run_cmd
+    assert "/host/tokenizer:/host/tokenizer:ro" in run_cmd
+    assert "/env/src:/env/dst:ro" in run_cmd
 
     workspace._process = None
     workspace._instance_name = None


### PR DESCRIPTION
HUMAN:

Graham has personally tested these changes and found that they fix the observed behavior.

- [x] A human has tested these changes.

AGENT:

---

## Summary
- add extra Apptainer bind mounts so agent-server containers can see host tokenizer/model files
- prefer HF chat-template token counting for custom tokenizers and normalize assistant tool-call arguments before applying the template
- treat token-limit condenser pressure as a hard requirement and account for kept prefix events when choosing the suffix to retain

## Validation
- `uv run --frozen pytest tests/sdk/context/condenser/test_utils.py tests/sdk/context/condenser/test_llm_summarizing_condenser.py tests/sdk/llm/test_llm.py::test_llm_token_counting_prefers_chat_template_tokenizer tests/sdk/llm/test_llm.py::test_llm_chat_template_token_counting_parses_tool_call_arguments tests/workspace/test_apptainer_workspace.py`
- `uv run --frozen ruff format --check ...`
- `uv run --frozen ruff check ...`

Note: `uv` emits an existing warning while parsing `exclude-newer = "7 days"` in `pyproject.toml`; the commands still completed successfully.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d4d796b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d4d796b-python \
  ghcr.io/openhands/agent-server:d4d796b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d4d796b-golang-amd64
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-golang-amd64
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-golang-amd64
ghcr.io/openhands/agent-server:d4d796b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d4d796b-golang-arm64
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-golang-arm64
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-golang-arm64
ghcr.io/openhands/agent-server:d4d796b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d4d796b-java-amd64
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-java-amd64
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-java-amd64
ghcr.io/openhands/agent-server:d4d796b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d4d796b-java-arm64
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-java-arm64
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-java-arm64
ghcr.io/openhands/agent-server:d4d796b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d4d796b-python-amd64
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-python-amd64
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-python-amd64
ghcr.io/openhands/agent-server:d4d796b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d4d796b-python-arm64
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-python-arm64
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-python-arm64
ghcr.io/openhands/agent-server:d4d796b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d4d796b-golang
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-golang
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-golang
ghcr.io/openhands/agent-server:d4d796b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d4d796b-java
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-java
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-java
ghcr.io/openhands/agent-server:d4d796b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d4d796b-python
ghcr.io/openhands/agent-server:d4d796b56699c4cb5eeee59c1a824d18e6155780-python
ghcr.io/openhands/agent-server:fix-apptainer-tokenizer-condenser-python
ghcr.io/openhands/agent-server:d4d796b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d4d796b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d4d796b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Issue

Closes #3656