### PR TITLE
fix(llm): recognize claude-fable-5 as a reasoning model

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -89,8 +89,33 @@ def _normalized_supported_openai_params(model: str | None) -> frozenset[str]:
     return frozenset(params or ())
 
 
+# SDK-side override allowlist for models that support the ``reasoning_effort``
+# parameter but are not (yet) recognized by LiteLLM's
+# ``get_supported_openai_params`` registry. Without this, brand-new model ids
+# fall through to the non-reasoning branch in ``chat_options.py`` and the SDK
+# leaves ``temperature``/``top_p`` in the request, which providers like
+# Anthropic now reject for these models with
+# ``temperature is deprecated for this model``.
+#
+# Entries should be removed once the corresponding LiteLLM release ships
+# metadata for the model.
+REASONING_EFFORT_MODELS: list[str] = [
+    # https://www.anthropic.com/news/claude-fable-5
+    "claude-fable-5",
+]
+
+
 def _supports_reasoning_effort(model: str | None) -> bool:
-    """Return True if LiteLLM says the model accepts reasoning_effort."""
+    """Return True if LiteLLM or our override list says the model accepts
+    ``reasoning_effort``.
+
+    The override list (``REASONING_EFFORT_MODELS``) lets us recognize new
+    reasoning models before LiteLLM's metadata catches up, so the chat-options
+    layer can strip ``temperature``/``top_p`` (and forward ``reasoning_effort``)
+    before the request reaches the provider.
+    """
+    if model_matches(model or "", REASONING_EFFORT_MODELS):
+        return True
     return "reasoning_effort" in _normalized_supported_openai_params(model)
 
 

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -61,6 +61,13 @@ def test_model_matches(name, pattern, expected):
         ("litellm_proxy/gpt-5", True),
         ("litellm_proxy/claude-opus-4-5", True),
         ("litellm_proxy/gemini-3-flash-preview", True),
+        # SDK-side override for models LiteLLM doesn't yet recognize.
+        # claude-fable-5 must be detected as a reasoning model so the chat
+        # options layer strips temperature/top_p before the request reaches
+        # Anthropic (which rejects temperature for this model).
+        ("claude-fable-5", True),
+        ("anthropic/claude-fable-5", True),
+        ("litellm_proxy/anthropic/claude-fable-5", True),
         # LiteLLM proxy with deployment path prefixes (prod/, dev/, staging/, test/)
         ("litellm_proxy/prod/claude-opus-4-5-20251101", True),
         ("litellm_proxy/dev/claude-opus-4-5", True),


### PR DESCRIPTION
## Problem

The smoke-test SWE-bench eval for `claude-fable-5` ([eval run `27243970491`](https://openhands-eval-monitor.vercel.app/?run=swebench%2Flitellm_proxy-anthropic-claude-fable-5%2F27243970491%2F&days=15)) failed every instance with:

```
LLMBadRequestError: AnthropicException - {"type":"error","error":{"type":"invalid_request_error",
  "message":"`temperature` is deprecated for this model."}}
```

Total proxy spend: $0. Every instance hit the wall on its first LLM call. The integration-test workflow for the same commit passed, which made this look like a pipeline-only quirk, but it turned out to be a real SDK gap.

## Root cause

`openhands-sdk/openhands/sdk/llm/options/chat_options.py` already strips `temperature` and `top_p` for any model the SDK considers a reasoning model:

```python
if supports_reasoning_effort:
    ...
    if "gemini" not in llm.model.lower():
        out.pop("temperature", None)
        out.pop("top_p", None)
```

`supports_reasoning_effort` is decided by `_supports_reasoning_effort(model)` in `model_features.py`, which delegates to LiteLLM's `get_supported_openai_params(...)` registry. For `claude-opus-4-7` / `4-8`, LiteLLM reports `reasoning_effort` as supported, so the SDK pops `temperature` and Anthropic never sees it. For the brand-new `claude-fable-5` id, LiteLLM has no metadata yet, so `supports_reasoning_effort` is `False`, the strip branch is skipped, and the eval pipeline's `temperature: 0.0` default flows straight through to Anthropic — which now rejects it.

## Fix

Add an SDK-side override allowlist (`REASONING_EFFORT_MODELS`) consulted before the LiteLLM lookup, and put `claude-fable-5` on it. The chat-options layer then pops `temperature`/`top_p` and forwards `reasoning_effort` for fable-5 too, restoring parity with the Opus models. Entries should be dropped once LiteLLM ships metadata for the model.

This is a minimal, behavior-preserving change:

```python
REASONING_EFFORT_MODELS: list[str] = [
    # https://www.anthropic.com/news/claude-fable-5
    "claude-fable-5",
]

def _supports_reasoning_effort(model: str | None) -> bool:
    if model_matches(model or "", REASONING_EFFORT_MODELS):
        return True
    return "reasoning_effort" in _normalized_supported_openai_params(model)
```

## Verification

- `tests/sdk/llm/test_model_features.py` extended with cases for `claude-fable-5` (bare id, `anthropic/` prefix, and `litellm_proxy/anthropic/` prefix). All 149 tests in the file pass.
- Spot-checked `get_features(...)` for several ids — no regressions:

  | Model | `supports_reasoning_effort` |
  |---|---|
  | `litellm_proxy/anthropic/claude-fable-5` | True (new) |
  | `litellm_proxy/anthropic/claude-opus-4-7` | True (via LiteLLM, unchanged) |
  | `litellm_proxy/anthropic/claude-opus-4-8` | True (via LiteLLM, unchanged) |
  | `litellm_proxy/anthropic/claude-3-5-sonnet` | False (unchanged) |

## Notes / follow-ups (out of scope for this PR)

- The eval-job workflow in `OpenHands/evaluation` injects `temperature: 0.0` into the LLM config JSON even when the `resolve_model_config.py` entry omits it. That's a pre-existing latent issue — it's only visible because `claude-fable-5` is the first model to actually reject `temperature` at the provider. Worth fixing there too so the model config in this repo is authoritative.
- This change only flips the reasoning-effort flag. If we want `claude-fable-5` to also get the full extended-thinking treatment (`thinking={...}` config + `anthropic-beta: interleaved-thinking-...` header), it should also be added to `EXTENDED_THINKING_MODELS`. Happy to do that in this PR if desired; left out for now to keep the fix narrowly scoped to the failing eval.

---

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://app.all-hands.dev/conversations/99ca0030-7bf1-499e-b82d-c553fdc78f05)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:52519d4-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-52519d4-python \
  ghcr.io/openhands/agent-server:52519d4-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:52519d4-golang-amd64
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-golang-amd64
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-golang-amd64
ghcr.io/openhands/agent-server:52519d4-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:52519d4-golang-arm64
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-golang-arm64
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-golang-arm64
ghcr.io/openhands/agent-server:52519d4-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:52519d4-java-amd64
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-java-amd64
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-java-amd64
ghcr.io/openhands/agent-server:52519d4-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:52519d4-java-arm64
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-java-arm64
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-java-arm64
ghcr.io/openhands/agent-server:52519d4-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:52519d4-python-amd64
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-python-amd64
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-python-amd64
ghcr.io/openhands/agent-server:52519d4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:52519d4-python-arm64
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-python-arm64
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-python-arm64
ghcr.io/openhands/agent-server:52519d4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:52519d4-golang
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-golang
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-golang
ghcr.io/openhands/agent-server:52519d4-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:52519d4-java
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-java
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-java
ghcr.io/openhands/agent-server:52519d4-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:52519d4-python
ghcr.io/openhands/agent-server:52519d46850759db731981850b07ef09b60e993f-python
ghcr.io/openhands/agent-server:add-claude-fable-5-reasoning-effort-python
ghcr.io/openhands/agent-server:52519d4-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `52519d4-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `52519d4-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->