### PR TITLE
Wrap condenser LLM errors as NoCondensationAvailableException

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -177,9 +177,15 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         # Do not pass extra_body explicitly. The LLM handles forwarding
         # litellm_extra_body only when it is non-empty.
-        llm_response = self.llm.completion(
-            messages=messages,
-        )
+        try:
+            llm_response = self.llm.completion(
+                messages=messages,
+            )
+        except Exception as e:
+            raise NoCondensationAvailableException(
+                f"Summarization LLM call failed: {e}"
+            ) from e
+
         # Extract summary from the LLMResponse message
         summary = None
         if llm_response.message.content:
@@ -364,7 +370,12 @@ class LLMSummarizingCondenser(RollingCondenser):
         )
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
-        llm_response = await self.llm.acompletion(messages=messages)
+        try:
+            llm_response = await self.llm.acompletion(messages=messages)
+        except Exception as e:
+            raise NoCondensationAvailableException(
+                f"Summarization LLM call failed: {e}"
+            ) from e
 
         summary = None
         if llm_response.message.content:

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -827,3 +827,27 @@ async def test_agenerate_condensation_wraps_llm_errors(mock_llm: LLM) -> None:
 
     with pytest.raises(NoCondensationAvailableException, match="boom"):
         await condenser.aget_condensation(view)
+
+
+def test_llm_error_triggers_hard_context_reset(mock_llm: LLM) -> None:
+    """A summarizer LLM failure during condense() triggers hard_context_reset."""
+    condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=10, keep_first=2)
+
+    # Force a HARD condensation requirement via a CondensationRequest
+    events: list[Event] = [message_event(f"Event {i}") for i in range(12)]
+    events.append(CondensationRequest())
+    view = View.from_events(events)
+
+    # First call (get_condensation path) fails; second call
+    # (hard_context_reset path) succeeds.
+    success_response = cast(Any, mock_llm).completion.return_value
+    cast(MagicMock, mock_llm.completion).side_effect = [
+        RuntimeError("context window exceeded"),
+        success_response,
+    ]
+
+    result = condenser.condense(view)
+
+    assert isinstance(result, Condensation)
+    assert result.summary == "Summary of forgotten events"
+    assert cast(MagicMock, mock_llm.completion).call_count == 2

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -800,3 +800,30 @@ def test_minimum_progress_threshold_met(mock_llm: LLM) -> None:
 
     assert isinstance(result, Condensation)
     assert result.summary == "Summary of forgotten events"
+
+
+def test_generate_condensation_wraps_llm_errors(mock_llm: LLM) -> None:
+    """LLM failures in _generate_condensation raise NoCondensationAvailableException."""  # noqa: E501
+    condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=10, keep_first=2)
+
+    cast(MagicMock, mock_llm.completion).side_effect = RuntimeError("boom")
+
+    events: list[Event] = [message_event(f"Event {i}") for i in range(12)]
+    view = View.from_events(events)
+
+    with pytest.raises(NoCondensationAvailableException, match="boom"):
+        condenser.get_condensation(view)
+
+
+@pytest.mark.asyncio
+async def test_agenerate_condensation_wraps_llm_errors(mock_llm: LLM) -> None:
+    """Async variant: LLM failures surface as NoCondensationAvailableException."""
+    condenser = LLMSummarizingCondenser(llm=mock_llm, max_size=10, keep_first=2)
+
+    cast(MagicMock, mock_llm.acompletion).side_effect = RuntimeError("boom")
+
+    events: list[Event] = [message_event(f"Event {i}") for i in range(12)]
+    view = View.from_events(events)
+
+    with pytest.raises(NoCondensationAvailableException, match="boom"):
+        await condenser.aget_condensation(view)


### PR DESCRIPTION
## Problem

When the summarization LLM in `LLMSummarizingCondenser` fails (e.g. `ContextWindowExceededError` because the events being summarized overflow the condenser LLM's context window), the error propagates as-is through `get_condensation()` → `condense()`.

The base-class `condense()` method only catches `NoCondensationAvailableException` — not raw LLM errors — so it never reaches the `hard_context_reset` fallback path. The agent crashes instead of recovering.

## Fix

Wrap the `self.llm.completion()` / `self.llm.acompletion()` calls in `_generate_condensation` and `_agenerate_condensation` with `try/except` that re-raises any error as `NoCondensationAvailableException`. The original error is chained via `from e`.

This means:
- **`condense()` with a SOFT requirement**: returns the uncondensed view (defers condensation)
- **`condense()` with a HARD requirement**: falls through to `hard_context_reset()`, which retries with progressively truncated event strings
- **`hard_context_reset()` itself**: still catches `Exception` around `_generate_condensation`, so its retry loop is unaffected (`NoCondensationAvailableException` is still an `Exception`)

## Tests

Added two tests (sync + async) verifying that LLM errors in `_generate_condensation` / `_agenerate_condensation` surface as `NoCondensationAvailableException`.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:41e1e4e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-41e1e4e-python \
  ghcr.io/openhands/agent-server:41e1e4e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:41e1e4e-golang-amd64
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-golang-amd64
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-golang-amd64
ghcr.io/openhands/agent-server:41e1e4e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:41e1e4e-golang-arm64
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-golang-arm64
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-golang-arm64
ghcr.io/openhands/agent-server:41e1e4e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:41e1e4e-java-amd64
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-java-amd64
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-java-amd64
ghcr.io/openhands/agent-server:41e1e4e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:41e1e4e-java-arm64
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-java-arm64
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-java-arm64
ghcr.io/openhands/agent-server:41e1e4e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:41e1e4e-python-amd64
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-python-amd64
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-python-amd64
ghcr.io/openhands/agent-server:41e1e4e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:41e1e4e-python-arm64
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-python-arm64
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-python-arm64
ghcr.io/openhands/agent-server:41e1e4e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:41e1e4e-golang
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-golang
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-golang
ghcr.io/openhands/agent-server:41e1e4e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:41e1e4e-java
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-java
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-java
ghcr.io/openhands/agent-server:41e1e4e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:41e1e4e-python
ghcr.io/openhands/agent-server:41e1e4e203029875cc8dd294631580985ad5b153-python
ghcr.io/openhands/agent-server:fix-condenser-llm-error-triggers-hard-reset-python
ghcr.io/openhands/agent-server:41e1e4e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `41e1e4e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `41e1e4e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->