### PR TITLE
Mark maximum iterations limit and stuck as complete runs, not errors

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1251,15 +1251,19 @@ class RemoteConversation(BaseConversation):
             return False
         if status == ConversationExecutionStatus.ERROR.value:
             detail = self._get_last_error_detail()
+            if detail and "maximum iterations" in detail.lower():
+                logger.warning(
+                    "Agent reached maximum iterations limit – treating as completed: %s",
+                    detail,
+                )
+                return True
             raise ConversationRunError(
                 self._id,
                 RuntimeError(detail or "Remote conversation ended with error"),
             )
         if status == ConversationExecutionStatus.STUCK.value:
-            raise ConversationRunError(
-                self._id,
-                RuntimeError("Remote conversation got stuck"),
-            )
+            logger.warning("Remote conversation got stuck – treating as completed.")
+            return True
         return True
 
     def _handle_poll_exception(self, exc: Exception) -> None:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN: 
Log a warning when the conversation reaches maximum iterations or gets stuck, treating both as completed.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->
Previously, when the agent reaches the max step limit or stucks in a loop, it throws an error and triggers retry in `OpenHands/benchmarks`, but it's actually the agent's fault and should not retry.

## Summary

<!-- 1-3 bullets describing what changed. -->
Mark the conversation as "complete" if it's ended by reaching the step limit or stucking in a loop.

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->
Run the agent in `OpenHands/benchmarks`. Now it won't trigger retry if it reaches the max step limit or stucks in a loop.

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->
