### PR TITLE
refactor(metrics): surface cache-hit-rate as a derived Metrics property

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
+++ b/openhands-sdk/openhands/sdk/conversation/visualizer/default.py
@@ -394,15 +394,9 @@ class DefaultConversationVisualizer(ConversationVisualizerBase):
         input_tokens = abbr(usage.prompt_tokens or 0)
         output_tokens = abbr(usage.completion_tokens or 0)
 
-        # Cache hit rate (prompt + cache)
-        prompt = usage.prompt_tokens or 0
-        cache_read = usage.cache_read_tokens or 0
-        # litellm/OpenAI convention: prompt_tokens includes cached reads, so
-        # prompt is the right denominator. ACP (claude-agent-acp) reports
-        # input_tokens excluding cached reads, in which case the two are
-        # disjoint and the total is prompt + cache_read.
-        denom = prompt + cache_read if cache_read > prompt else prompt
-        cache_rate = f"{(cache_read / denom * 100):.2f}%" if denom > 0 else "N/A"
+        # Cache hit rate is derived on Metrics; the visualizer just formats it.
+        rate = combined_metrics.cache_hit_rate
+        cache_rate = f"{rate * 100:.2f}%" if rate is not None else "N/A"
         reasoning_tokens = usage.reasoning_tokens or 0
 
         # Cost

--- a/openhands-sdk/openhands/sdk/llm/utils/metrics.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/metrics.py
@@ -90,6 +90,24 @@ class MetricsSnapshot(BaseModel):
         default=None, description="Accumulated token usage across all calls"
     )
 
+    @property
+    def cache_hit_rate(self) -> float | None:
+        """Fraction of accumulated input tokens served from cache (0.0-1.0).
+
+        None when there is no input to measure. litellm/OpenAI count cached
+        reads inside ``prompt_tokens`` (the denominator); ACP reports them
+        separately, so when ``cache_read_tokens`` exceeds ``prompt_tokens`` the
+        denominator is their sum.
+        """
+        usage = self.accumulated_token_usage
+        if usage is None:
+            return None
+        prompt, cache_read = usage.prompt_tokens, usage.cache_read_tokens
+        denom = prompt + cache_read if cache_read > prompt else prompt
+        if denom <= 0:
+            return None
+        return cache_read / denom
+
 
 @final
 class Metrics(MetricsSnapshot):

--- a/tests/sdk/llm/test_llm_metrics.py
+++ b/tests/sdk/llm/test_llm_metrics.py
@@ -3,7 +3,13 @@
 import pytest
 from pydantic import ValidationError
 
-from openhands.sdk.llm.utils.metrics import Cost, Metrics, ResponseLatency, TokenUsage
+from openhands.sdk.llm.utils.metrics import (
+    Cost,
+    Metrics,
+    MetricsSnapshot,
+    ResponseLatency,
+    TokenUsage,
+)
 
 
 def test_cost_creation_valid():
@@ -824,3 +830,68 @@ def test_metrics_diff_current_only_not_none():
     assert diff.accumulated_token_usage.completion_tokens == 8
     assert diff.accumulated_token_usage.cache_read_tokens == 2
     assert diff.accumulated_token_usage.cache_write_tokens == 1
+
+
+@pytest.mark.parametrize(
+    "prompt_tokens, cache_read_tokens, expected",
+    [
+        # litellm/OpenAI convention: prompt_tokens already includes cached reads.
+        (100, 10, 0.10),
+        (100, 0, 0.0),
+        # cache_read == prompt -> prompt is the denominator.
+        (50, 50, 1.0),
+        # ACP convention: input excludes cached reads, so they are disjoint and
+        # the denominator is prompt + cache_read.
+        (10, 90, 0.90),
+        (0, 50, 1.0),  # zero prompt, all cache -> 100% hit (not None)
+        # Nothing to measure -> undefined.
+        (0, 0, None),
+    ],
+)
+def test_cache_hit_rate_conventions(prompt_tokens, cache_read_tokens, expected):
+    """cache_hit_rate handles both provider conventions and zero input."""
+    snapshot = MetricsSnapshot(
+        accumulated_token_usage=TokenUsage(
+            prompt_tokens=prompt_tokens, cache_read_tokens=cache_read_tokens
+        )
+    )
+    if expected is None:
+        assert snapshot.cache_hit_rate is None
+    else:
+        assert snapshot.cache_hit_rate == pytest.approx(expected)
+
+
+def test_cache_hit_rate_reflects_accumulated_usage():
+    """Metrics.cache_hit_rate derives from accumulated usage across calls."""
+    metrics = Metrics()
+    metrics.add_token_usage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        cache_read_tokens=0,
+        cache_write_tokens=0,
+        context_window=4096,
+        response_id="r1",
+    )
+    metrics.add_token_usage(
+        prompt_tokens=100,
+        completion_tokens=10,
+        cache_read_tokens=40,
+        cache_write_tokens=0,
+        context_window=4096,
+        response_id="r2",
+    )
+    # accumulated prompt=200, cache_read=40 -> 40 / 200
+    assert metrics.cache_hit_rate == pytest.approx(0.20)
+
+
+def test_cache_hit_rate_none_without_usage():
+    """No usage yet -> undefined rather than a misleading 0% or a crash."""
+    assert MetricsSnapshot(accumulated_token_usage=None).cache_hit_rate is None
+    assert Metrics().cache_hit_rate is None  # fresh metrics are all-zeros
+
+
+def test_cache_hit_rate_is_not_serialized():
+    """Derived rate stays out of the serialized schema (no public-API change)."""
+    snapshot = Metrics().get_snapshot()
+    assert "cache_hit_rate" not in snapshot.model_dump()
+    assert "cache_hit_rate" not in MetricsSnapshot.model_json_schema()["properties"]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->
  
  HUMAN:

  - [x] A human has tested these changes.
  
Just adding a new metric in the Metric class.

  AGENT:

  ---

## Why

  The cache-hit-rate was computed ad hoc inside the conversation visualizer, so it
  existed nowhere else: any future "is prompt caching actually working?" decision
  would have to recompute it and re-derive the litellm-vs-ACP token-accounting
  subtlety. Phase 0 of the prompt-registry roadmap (#3607, task 3) asks for
  surfacing it as a first-class derived metric so later phases can measure cache
  behavior. Phase 0 mandates **no public-API change**.

## Summary

  - Add a derived `cache_hit_rate` property to `MetricsSnapshot` (inherited by
    `Metrics`): the fraction of accumulated input tokens served from cache, or
    `None` when there is nothing to measure. It handles both token-accounting
    conventions — litellm/OpenAI fold cached reads into `prompt_tokens`, while ACP
    reports them separately.
  - Move the visualizer's inline calculation onto the new property (10 lines → 2);
    the rendered subtitle is unchanged (`None` ⇔ the previous `"N/A"`).
  - Keep it a plain `@property`, not a serialized field, to honor the
    "no public-API change" constraint; a test asserts it stays out of
    `model_dump()` and the JSON schema.

## Issue Number

  #3607 (task 3 of 3; the other two Phase 0 tasks ship as separate PRs).
  
## How to Test

  This is an internal derived metric plus a visualizer-formatting change; there is
  no separate end-to-end flow beyond the subtitle the visualizer already renders,
  which the tests below exercise.
  
  uv run pytest tests/sdk/llm/test_llm_metrics.py tests/sdk/conversation/test_visualizer.py
  no public-API / schema / persisted-snapshot change:
  
  uv run pytest tests/cross/test_check_sdk_api_breakage.py
                tests/cross/test_check_agent_server_rest_api_breakage.py
                tests/sdk/conversation/test_stats_update_event_snapshot.py
  
  - Programmatic access: `stats.get_combined_metrics().cache_hit_rate` returns the
    derived rate (or `None`).   
  - Visualizer: the `cache hit XX.XX%` subtitle still renders — covered by the
    existing #3044 regression test, which now runs through the new property.
  - Ran locally: 179 passed across the suites above; `pre-commit` clean
    (ruff format/lint, pycodestyle, pyright, import-rules).

  ## Video/Screenshots

  N/A — no GUI change. The visualizer subtitle output is unchanged; only the
  source of the number moved.   

  ## Type

  - [ ] Bug fix
  - [ ] Feature
  - [x] Refactor
  - [ ] Breaking change
  - [ ] Docs / chore  

  ## Notes

  - Design choice: a `@computed_field` would have added `cache_hit_rate` to the
    serialized `MetricsSnapshot` schema (it flows into the agent-server REST API
    and SDK), which the API-breakage tests would reject and which Phase 0 forbids.
    A plain `@property` exposes the value programmatically with zero schema change.
  - Behavior is preserved exactly: the old `denom == 0 → "N/A"` maps to
    `cache_hit_rate is None → "N/A"`.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:17a6899-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-17a6899-python \
  ghcr.io/openhands/agent-server:17a6899-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:17a6899-golang-amd64
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-golang-amd64
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-golang-amd64
ghcr.io/openhands/agent-server:17a6899-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:17a6899-golang-arm64
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-golang-arm64
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-golang-arm64
ghcr.io/openhands/agent-server:17a6899-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:17a6899-java-amd64
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-java-amd64
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-java-amd64
ghcr.io/openhands/agent-server:17a6899-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:17a6899-java-arm64
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-java-arm64
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-java-arm64
ghcr.io/openhands/agent-server:17a6899-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:17a6899-python-amd64
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-python-amd64
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-python-amd64
ghcr.io/openhands/agent-server:17a6899-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:17a6899-python-arm64
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-python-arm64
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-python-arm64
ghcr.io/openhands/agent-server:17a6899-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:17a6899-golang
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-golang
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-golang
ghcr.io/openhands/agent-server:17a6899-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:17a6899-java
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-java
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-java
ghcr.io/openhands/agent-server:17a6899-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:17a6899-python
ghcr.io/openhands/agent-server:17a6899873ac7ba6399cf78b17e184e54609ca1b-python
ghcr.io/openhands/agent-server:vasco-cache-hit-metric-python
ghcr.io/openhands/agent-server:17a6899-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `17a6899-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `17a6899-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->