### PR TITLE
feat(sdk): deprecate ACPAgentSettings.llm credentials — create_agent no longer reads llm.api_key/base_url

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2091,7 +2091,7 @@ class ACPAgent(AgentBase):
         # agent_context.secrets are seeded into secret_registry at
         # LocalConversation.__init__ (lower priority than request.secrets), so
         # the registry is now the single channel for all secrets including
-        # provider credentials folded in by ACPAgentSettings.create_agent().
+        # provider credentials (keyed by the provider's env var name).
         env = default_environment()
         env.update(os.environ)
         if self.acp_env:

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1184,9 +1184,13 @@ class ACPAgentSettings(AgentSettingsBase):
     tools, MCP, and (primary) LLM calls; those fields from
     :class:`OpenHandsAgentSettings` do not apply here.
 
-    The :attr:`llm` field is kept (optional) so that cost/token metrics
-    can be attributed to a real model — ``ACPAgent`` uses this purely for
-    bookkeeping and pricing lookups, not for making LLM requests.
+    The :attr:`llm` field is deprecated (removed in 1.29.0). ``ACPAgent``
+    uses it purely for cost/token attribution, never for LLM requests;
+    :attr:`acp_model` is the model identity. Credentials set on it
+    (``llm.api_key`` / ``llm.base_url``) are ignored — provider credentials
+    ride the conversation secrets channel (``request.secrets`` /
+    ``agent_context.secrets`` → ``state.secret_registry``) keyed by the
+    provider's env var name (:attr:`api_key_env_var`).
     """
 
     agent_kind: Literal["acp"] = Field(
@@ -1420,9 +1424,14 @@ class ACPAgentSettings(AgentSettingsBase):
     llm: LLM = Field(
         default_factory=_default_llm_settings,
         description=(
-            "LLM identity used for cost/token attribution. The ACP subprocess "
-            "makes its own model calls; this field is kept so metrics and "
-            "pricing lookups can point at a real model id."
+            "DEPRECATED (removed in 1.29.0): LLM identity used for cost/token "
+            "attribution. The ACP subprocess makes its own model calls; "
+            "``acp_model`` is the model identity. Credentials set here "
+            "(``api_key`` / ``base_url``) are ignored — route provider "
+            "credentials through the conversation secrets channel "
+            "(agent_context.secrets / StartConversationRequest.secrets, which "
+            "route through state.secret_registry), keyed by the provider's "
+            "env var name."
         ),
         json_schema_extra={
             SETTINGS_SECTION_METADATA_KEY: SettingsSectionMetadata(
@@ -1441,8 +1450,9 @@ class ACPAgentSettings(AgentSettingsBase):
             "``LocalConversation`` seeds ``agent_context.secrets`` into the "
             "registry at conversation init (below ``request.secrets``), so "
             "callers that build the request outside Python (e.g. canvas-local) "
-            "are covered too, not just the ``create_request`` path. "
-            "``create_agent`` also folds provider credentials into these secrets."
+            "are covered too, not just the ``create_request`` path. Provider "
+            "credentials belong here (or in ``request.secrets``) keyed by the "
+            "provider's env var name."
         ),
     )
 
@@ -1479,7 +1489,24 @@ class ACPAgentSettings(AgentSettingsBase):
         provider-specific env var names. This helper translates the generic
         :attr:`llm` settings into that provider-native subprocess environment.
         Custom servers return an empty mapping.
+
+        .. deprecated:: 1.28.0
+            Removed in 1.29.0 together with :attr:`llm`. ``create_agent()``
+            no longer reads ``llm.api_key`` / ``llm.base_url``; supply
+            provider credentials as conversation secrets keyed by
+            :attr:`api_key_env_var` (e.g. ``ANTHROPIC_API_KEY``) instead.
         """
+        warn_deprecated(
+            "ACPAgentSettings.resolve_provider_env",
+            deprecated_in="1.28.0",
+            removed_in="1.29.0",
+            details=(
+                "Supply ACP provider credentials as conversation secrets "
+                "(agent_context.secrets / StartConversationRequest.secrets, "
+                "which route through state.secret_registry) keyed by the "
+                "provider's env var name instead of ACPAgentSettings.llm."
+            ),
+        )
         env: dict[str, str] = {}
 
         api_key = self.llm.api_key
@@ -1506,11 +1533,11 @@ class ACPAgentSettings(AgentSettingsBase):
 
         Only the explicit :attr:`acp_env` entries — the user-facing
         arbitrary-env-var input that becomes ``ACPAgent.acp_env``. Provider
-        credentials are **no longer** folded in here; :meth:`create_agent`
-        routes them through :attr:`agent_context` secrets →
-        ``state.secret_registry`` instead (the canonical, cipher-protected
-        channel the regular agent uses). At spawn time ``ACPAgent`` injects
-        ``acp_env`` and the registry secrets into the subprocess env.
+        credentials are **not** folded in here; they ride the conversation
+        secrets channel → ``state.secret_registry`` (the canonical,
+        cipher-protected channel the regular agent uses). At spawn time
+        ``ACPAgent`` injects ``acp_env`` and the registry secrets into the
+        subprocess env.
 
         .. deprecated:: 1.24.0
             :attr:`acp_env` is deprecated and will be removed in 1.29.0. Pass
@@ -1633,42 +1660,35 @@ class ACPAgentSettings(AgentSettingsBase):
         which maps :attr:`acp_server` to a default when no explicit
         :attr:`acp_command` is set.
 
-        Provider credentials (``llm.api_key`` → :attr:`api_key_env_var`,
-        ``llm.base_url`` → :attr:`base_url_env_var`) are folded into
-        :attr:`agent_context` secrets rather than ``acp_env``. They then ride
-        the canonical ``agent_context.secrets`` → ``create_request`` →
-        ``request.secrets`` → ``state.secret_registry`` channel (encrypted
-        across the conversation-start boundary), exactly like the regular
-        agent's credentials, and reach the subprocess from the registry.
-        ``acp_env`` carries only the user's explicit arbitrary env vars.
+        Credentials on :attr:`llm` (``api_key`` / ``base_url``) are ignored:
+        provider credentials ride the conversation secrets channel
+        (``agent_context.secrets`` / ``StartConversationRequest.secrets``,
+        which route through ``state.secret_registry``) keyed by the
+        provider's env var name (:attr:`api_key_env_var`), exactly like the
+        regular agent's credentials, and reach the subprocess from the
+        registry. ``acp_env`` carries only the user's explicit arbitrary
+        env vars (deprecated).
         """
         from openhands.sdk.agent import ACPAgent
-        from openhands.sdk.secret import StaticSecret
 
-        # Fold provider creds into agent_context.secrets (not acp_env): on
-        # acp_env they would be dropped to ``**********`` by stores that dump
-        # agent_settings without cipher context; on agent_context.secrets they
-        # ride the StoredConversation.secrets + agent-server Cipher boundary.
-        # Wrap as StaticSecret (a SecretSource) so they validate when
-        # create_request lifts agent_context.secrets into request.secrets
-        # (typed dict[str, SecretSource]).
-        provider_secrets: dict[str, StaticSecret] = {
-            name: StaticSecret(value=SecretStr(value))
-            for name, value in self.resolve_provider_env().items()
-        }
-        agent_context = self.agent_context
-        if provider_secrets:
-            existing = (
-                dict(agent_context.secrets)
-                if agent_context is not None and agent_context.secrets
-                else {}
-            )
-            # Explicit context secrets win over provider-derived ones.
-            merged_secrets = {**provider_secrets, **existing}
-            agent_context = (
-                agent_context.model_copy(update={"secrets": merged_secrets})
-                if agent_context is not None
-                else AgentContext(current_datetime=None, secrets=merged_secrets)
+        # llm.api_key/base_url used to be folded into agent_context.secrets
+        # here. Both production clients route credentials via request.secrets
+        # already (canvas never sends llm; OpenHands strips the credentials
+        # before create_agent), so the fold only fired for direct-SDK callers
+        # — warn them toward the secrets channel instead of silently leaking
+        # a profile base_url into the subprocess (#3632).
+        if self.llm.api_key is not None or self.llm.base_url is not None:
+            warn_deprecated(
+                "ACPAgentSettings.llm credentials (api_key/base_url)",
+                deprecated_in="1.28.0",
+                removed_in="1.29.0",
+                details=(
+                    "create_agent() ignores them. Supply ACP provider "
+                    "credentials as conversation secrets (agent_context."
+                    "secrets / StartConversationRequest.secrets, which route "
+                    "through state.secret_registry) keyed by the provider's "
+                    "env var name (e.g. ANTHROPIC_API_KEY)."
+                ),
             )
 
         # Bypass ``_serialize_mcp_config``: the subprocess needs real
@@ -1694,7 +1714,7 @@ class ACPAgentSettings(AgentSettingsBase):
             acp_prompt_timeout=self.acp_prompt_timeout,
             acp_isolate_data_dir=self.acp_isolate_data_dir,
             acp_file_secrets=list(self.acp_file_secrets),
-            agent_context=agent_context,
+            agent_context=self.agent_context,
             mcp_config=mcp_config,
         )
 

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1184,7 +1184,7 @@ class ACPAgentSettings(AgentSettingsBase):
     tools, MCP, and (primary) LLM calls; those fields from
     :class:`OpenHandsAgentSettings` do not apply here.
 
-    The :attr:`llm` field is deprecated (removed in 1.29.0). ``ACPAgent``
+    The :attr:`llm` field is deprecated (removed in 1.33.0). ``ACPAgent``
     uses it purely for cost/token attribution, never for LLM requests;
     :attr:`acp_model` is the model identity. Credentials set on it
     (``llm.api_key`` / ``llm.base_url``) are ignored — provider credentials
@@ -1424,7 +1424,7 @@ class ACPAgentSettings(AgentSettingsBase):
     llm: LLM = Field(
         default_factory=_default_llm_settings,
         description=(
-            "DEPRECATED (removed in 1.29.0): LLM identity used for cost/token "
+            "DEPRECATED (removed in 1.33.0): LLM identity used for cost/token "
             "attribution. The ACP subprocess makes its own model calls; "
             "``acp_model`` is the model identity. Credentials set here "
             "(``api_key`` / ``base_url``) are ignored — route provider "
@@ -1491,7 +1491,7 @@ class ACPAgentSettings(AgentSettingsBase):
         Custom servers return an empty mapping.
 
         .. deprecated:: 1.28.0
-            Removed in 1.29.0 together with :attr:`llm`. ``create_agent()``
+            Removed in 1.33.0 together with :attr:`llm`. ``create_agent()``
             no longer reads ``llm.api_key`` / ``llm.base_url``; supply
             provider credentials as conversation secrets keyed by
             :attr:`api_key_env_var` (e.g. ``ANTHROPIC_API_KEY``) instead.
@@ -1499,7 +1499,7 @@ class ACPAgentSettings(AgentSettingsBase):
         warn_deprecated(
             "ACPAgentSettings.resolve_provider_env",
             deprecated_in="1.28.0",
-            removed_in="1.29.0",
+            removed_in="1.33.0",
             details=(
                 "Supply ACP provider credentials as conversation secrets "
                 "(agent_context.secrets / StartConversationRequest.secrets, "
@@ -1679,15 +1679,16 @@ class ACPAgentSettings(AgentSettingsBase):
         # a profile base_url into the subprocess (#3632).
         if self.llm.api_key is not None or self.llm.base_url is not None:
             warn_deprecated(
-                "ACPAgentSettings.llm credentials (api_key/base_url)",
+                "ACPAgentSettings.llm",
                 deprecated_in="1.28.0",
-                removed_in="1.29.0",
+                removed_in="1.33.0",
                 details=(
-                    "create_agent() ignores them. Supply ACP provider "
-                    "credentials as conversation secrets (agent_context."
-                    "secrets / StartConversationRequest.secrets, which route "
-                    "through state.secret_registry) keyed by the provider's "
-                    "env var name (e.g. ANTHROPIC_API_KEY)."
+                    "create_agent() ignores its api_key/base_url. Supply ACP "
+                    "provider credentials as conversation secrets "
+                    "(agent_context.secrets / StartConversationRequest."
+                    "secrets, which route through state.secret_registry) "
+                    "keyed by the provider's env var name (e.g. "
+                    "ANTHROPIC_API_KEY); use acp_model for model identity."
                 ),
             )
 

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -6138,9 +6138,8 @@ class TestACPSecretsEnvInjection:
     env so the ACP server (Claude Code, Codex CLI, etc.) can use them. They
     reach the subprocess through ``state.secret_registry``: ``LocalConversation``
     seeds ``agent_context.secrets`` into the registry at init (covering
-    canvas-local, which folds ``llm.api_key`` into ``agent_context.secrets``
-    server-side via ``create_agent`` but never lifts it into ``request.secrets``),
-    and ``_start_acp_server`` injects the registry. ``acp_env`` entries take
+    callers that never lift them into ``request.secrets``), and
+    ``_start_acp_server`` injects the registry. ``acp_env`` entries take
     precedence over registry secrets.
     """
 

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -280,16 +280,19 @@ def test_conversation_settings_create_request_with_acp_agent() -> None:
     assert request.security_analyzer is None
 
 
-def test_acp_create_request_lifts_provider_creds_into_request_secrets() -> None:
-    # End-to-end: provider creds folded into agent_context.secrets by
-    # create_agent are lifted into request.secrets by create_request — the
-    # channel that lands them in state.secret_registry on the agent-server,
-    # from where _start_acp_server injects them into the subprocess env.
+def test_acp_create_request_lifts_context_secrets_into_request_secrets() -> None:
+    # End-to-end: provider creds supplied as agent_context.secrets (keyed by
+    # the provider's env var name) are lifted into request.secrets by
+    # create_request — the channel that lands them in state.secret_registry
+    # on the agent-server, from where _start_acp_server injects them into the
+    # subprocess env. llm.api_key is no longer read (deprecated, #3632).
     agent = ACPAgentSettings(
         acp_server="claude-code",
-        llm=LLM(model="claude-opus-4-6", api_key=SecretStr("sk-provider")),
         agent_context=AgentContext(
-            secrets={"GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp_x"))}
+            secrets={
+                "ANTHROPIC_API_KEY": StaticSecret(value=SecretStr("sk-provider")),
+                "GITHUB_TOKEN": StaticSecret(value=SecretStr("ghp_x")),
+            }
         ),
     ).create_agent()
 
@@ -1099,6 +1102,8 @@ def test_acp_api_key_env_var_maps_known_servers() -> None:
 
 
 def test_acp_resolve_provider_env_from_llm_credentials() -> None:
+    # Deprecated (removed in 1.29.0 with the llm field): still functional for
+    # the deprecation window, but warns callers toward the secrets channel.
     settings = ACPAgentSettings(
         acp_server="gemini-cli",
         llm=LLM(
@@ -1108,10 +1113,13 @@ def test_acp_resolve_provider_env_from_llm_credentials() -> None:
         ),
     )
 
-    assert settings.resolve_provider_env() == {
-        "GEMINI_API_KEY": "sk-test-gemini",
-        "GEMINI_BASE_URL": "https://gemini-proxy.example.com",
-    }
+    with pytest.warns(
+        DeprecationWarning, match=r"ACPAgentSettings\.resolve_provider_env"
+    ):
+        assert settings.resolve_provider_env() == {
+            "GEMINI_API_KEY": "sk-test-gemini",
+            "GEMINI_BASE_URL": "https://gemini-proxy.example.com",
+        }
 
 
 def test_acp_resolve_provider_env_custom_server_empty() -> None:
@@ -1125,7 +1133,10 @@ def test_acp_resolve_provider_env_custom_server_empty() -> None:
         ),
     )
 
-    assert settings.resolve_provider_env() == {}
+    with pytest.warns(
+        DeprecationWarning, match=r"ACPAgentSettings\.resolve_provider_env"
+    ):
+        assert settings.resolve_provider_env() == {}
 
 
 def test_acp_resolve_acp_env_returns_only_user_entries() -> None:
@@ -1141,65 +1152,74 @@ def test_acp_resolve_acp_env_returns_only_user_entries() -> None:
     assert settings.resolve_acp_env() == {"MY_CUSTOM_VAR": "value"}
 
 
-def test_acp_create_agent_folds_provider_creds_into_agent_context_secrets() -> None:
+def test_acp_create_agent_ignores_llm_credentials() -> None:
+    # llm.api_key/base_url are deprecated (removed in 1.29.0) and no longer
+    # folded into agent_context.secrets: an LLM-profile base_url would leak
+    # into the subprocess and silently re-route its API calls (#3632).
+    # create_agent warns and ignores them; provider credentials ride the
+    # conversation secrets channel keyed by the provider's env var name.
     context = AgentContext(secrets={"GITHUB_TOKEN": "ghp_test"})
     settings = ACPAgentSettings(
         acp_server="codex",
-        llm=LLM(model="gpt-5.4", api_key=SecretStr("sk-openai")),
+        llm=LLM(
+            model="gpt-5.4",
+            api_key=SecretStr("sk-openai"),
+            base_url="https://llm-proxy.example.com",
+        ),
         agent_context=context,
         acp_env={"MY_VAR": "v"},
     )
 
-    agent = settings.create_agent()
+    with pytest.warns(DeprecationWarning, match=r"ACPAgentSettings\.llm credentials"):
+        agent = settings.create_agent()
 
-    # acp_env carries only the user's explicit env vars — not provider creds.
     assert agent.acp_env == {"MY_VAR": "v"}
-    # Provider creds are folded into agent_context.secrets (wrapped as
-    # SecretSource) alongside the caller's secrets, so they ride the
-    # create_request → request.secrets → state.secret_registry channel and
-    # reach the subprocess from the registry.
+    # The caller's secrets pass through untouched; no provider creds appear.
     assert agent.agent_context is not None
-    secrets = dict(agent.agent_context.secrets or {})
-    assert set(secrets) == {"OPENAI_API_KEY", "GITHUB_TOKEN"}
-    openai_secret = secrets["OPENAI_API_KEY"]
-    assert isinstance(openai_secret, StaticSecret)
-    assert openai_secret.get_value() == "sk-openai"
-    assert secrets["GITHUB_TOKEN"] == "ghp_test"
+    assert dict(agent.agent_context.secrets or {}) == {"GITHUB_TOKEN": "ghp_test"}
 
 
-def test_acp_create_agent_synthesizes_context_for_provider_creds() -> None:
-    # No caller agent_context, but provider creds exist → create_agent
-    # synthesizes a minimal AgentContext carrying them (current_datetime=None so
-    # it doesn't start injecting datetime the absent-context path suppressed).
+def test_acp_create_agent_credentials_warn_even_without_context() -> None:
+    # No caller agent_context: nothing is synthesized for the ignored creds —
+    # the context stays None and the deprecation warning is the only signal.
     settings = ACPAgentSettings(
         acp_server="claude-code",
         llm=LLM(model="claude-opus-4-6", api_key=SecretStr("sk-ui-key")),
     )
 
-    agent = settings.create_agent()
+    with pytest.warns(DeprecationWarning, match=r"ACPAgentSettings\.llm credentials"):
+        agent = settings.create_agent()
 
     assert agent.acp_env == {}
-    assert agent.agent_context is not None
-    assert agent.agent_context.current_datetime is None
-    secrets = dict(agent.agent_context.secrets or {})
-    assert set(secrets) == {"ANTHROPIC_API_KEY"}
-    anthropic_secret = secrets["ANTHROPIC_API_KEY"]
-    assert isinstance(anthropic_secret, StaticSecret)
-    assert anthropic_secret.get_value() == "sk-ui-key"
+    assert agent.agent_context is None
 
 
-def test_acp_create_agent_no_provider_creds_keeps_context_none() -> None:
-    # Custom server (no api_key_env_var) → no provider secrets → agent_context
-    # stays None when the caller supplied none.
+def test_acp_create_agent_without_llm_credentials_does_not_warn() -> None:
+    import warnings
+
     settings = ACPAgentSettings(
-        acp_server="custom",
-        acp_command=["custom-acp"],
-        llm=LLM(model="m", api_key=SecretStr("sk-test")),
+        acp_server="claude-code",
+        llm=LLM(model="claude-opus-4-6"),
     )
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        agent = settings.create_agent()
+
+    assert not [w for w in caught if "llm credentials" in str(w.message)]
+    assert agent.agent_context is None
+
+
+def test_acp_create_agent_passes_caller_context_through() -> None:
+    # Secrets supplied via agent_context reach the agent unchanged; they are
+    # seeded into state.secret_registry at conversation init (the canonical
+    # channel), not rewritten here.
+    context = AgentContext(secrets={"ANTHROPIC_API_KEY": "sk-direct"})
+    settings = ACPAgentSettings(acp_server="claude-code", agent_context=context)
 
     agent = settings.create_agent()
 
-    assert agent.agent_context is None
+    assert agent.agent_context is context
 
 
 def test_acp_env_emits_deprecation_warning() -> None:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1102,7 +1102,7 @@ def test_acp_api_key_env_var_maps_known_servers() -> None:
 
 
 def test_acp_resolve_provider_env_from_llm_credentials() -> None:
-    # Deprecated (removed in 1.29.0 with the llm field): still functional for
+    # Deprecated (removed in 1.33.0 with the llm field): still functional for
     # the deprecation window, but warns callers toward the secrets channel.
     settings = ACPAgentSettings(
         acp_server="gemini-cli",
@@ -1153,9 +1153,9 @@ def test_acp_resolve_acp_env_returns_only_user_entries() -> None:
 
 
 def test_acp_create_agent_ignores_llm_credentials() -> None:
-    # llm.api_key/base_url are deprecated (removed in 1.29.0) and no longer
-    # folded into agent_context.secrets: an LLM-profile base_url would leak
-    # into the subprocess and silently re-route its API calls (#3632).
+    # llm.api_key/base_url are deprecated (llm is removed in 1.33.0) and no
+    # longer folded into agent_context.secrets: an LLM-profile base_url would
+    # leak into the subprocess and silently re-route its API calls (#3632).
     # create_agent warns and ignores them; provider credentials ride the
     # conversation secrets channel keyed by the provider's env var name.
     context = AgentContext(secrets={"GITHUB_TOKEN": "ghp_test"})
@@ -1170,7 +1170,7 @@ def test_acp_create_agent_ignores_llm_credentials() -> None:
         acp_env={"MY_VAR": "v"},
     )
 
-    with pytest.warns(DeprecationWarning, match=r"ACPAgentSettings\.llm credentials"):
+    with pytest.warns(DeprecationWarning, match=r"ACPAgentSettings\.llm is deprecated"):
         agent = settings.create_agent()
 
     assert agent.acp_env == {"MY_VAR": "v"}
@@ -1187,7 +1187,7 @@ def test_acp_create_agent_credentials_warn_even_without_context() -> None:
         llm=LLM(model="claude-opus-4-6", api_key=SecretStr("sk-ui-key")),
     )
 
-    with pytest.warns(DeprecationWarning, match=r"ACPAgentSettings\.llm credentials"):
+    with pytest.warns(DeprecationWarning, match=r"ACPAgentSettings\.llm is deprecated"):
         agent = settings.create_agent()
 
     assert agent.acp_env == {}
@@ -1206,7 +1206,7 @@ def test_acp_create_agent_without_llm_credentials_does_not_warn() -> None:
         warnings.simplefilter("always")
         agent = settings.create_agent()
 
-    assert not [w for w in caught if "llm credentials" in str(w.message)]
+    assert not [w for w in caught if "ACPAgentSettings.llm" in str(w.message)]
     assert agent.agent_context is None
 
 


### PR DESCRIPTION
HUMAN: 

 deprecate ACPAgentSettings.llm credentials — create_agent no longer reads llm.api_key/base_url


- [x] A human has tested these changes.

AGENT: 

## Why

Fixes #3632; part of OpenHands/OpenHands#15722.

`ACPAgentSettings.llm` is attribution-only — the ACP subprocess makes its own model calls — but `create_agent()` folded `llm.api_key`/`llm.base_url` into `agent_context.secrets` via `resolve_provider_env()`. When a user's LLM profile carries a proxy `base_url` (e.g. an eval proxy), it leaked into the ACP subprocess as `OPENAI_BASE_URL`/`ANTHROPIC_BASE_URL` and silently re-routed its API calls, surfacing only as an opaque `-32603 Internal error` (#3632).

Neither production client needs the fold:
- **agent-canvas** never sends `llm` for ACP (`ACP_SETTINGS_KEYS` excludes it); credentials ride top-level `request.secrets` keyed by `api_key_env_var`.
- **OpenHands** strips `llm.api_key`/`llm.base_url` before `create_agent()` as a caller-side guard (kept by OpenHands/OpenHands#14733, which also moves provider credentials to ordinary named secrets riding `request.secrets`).

So the fold only ever fired for direct-SDK callers — where it was a silent foot-gun rather than a feature.

## Summary

- `create_agent()` no longer reads `llm.api_key`/`llm.base_url`. If either is set, it emits a `DeprecationWarning` (feature `ACPAgentSettings.llm`, removed in 1.33.0) pointing at the conversation secrets channel (`agent_context.secrets` / `StartConversationRequest.secrets` → `state.secret_registry`, keyed by the provider's env var name) and ignores them.
- `resolve_provider_env()` is deprecated (warns on call, still functional through the window) — scheduled for removal in 1.33.0 together with the `llm` field itself (1.28.0 + the 5-minor public-API runway; `acp_env` keeps its own compliant 1.24.0 → 1.29.0 schedule).
- `ACPAgentSettings.llm` field description and class docstring mark the field DEPRECATED (removed in 1.33.0); `acp_model` is the model identity, attribution stays internal.
- Stale fold references cleaned up in `agent_context` field description, `resolve_acp_env()` docstring, `_start_acp_server` comment, and test docstrings.
- Tests: fold tests replaced with ignore+warn coverage; `create_request` lift test now supplies the provider credential as an `agent_context` secret keyed by `ANTHROPIC_API_KEY` (the canonical channel, unchanged behavior).

No schema change: the `llm` field stays (accepted, attribution-only) until the 1.33.0 removal train, so persisted payloads and the discriminated union are untouched.

## How to Test

1. `uv run pytest tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py tests/sdk/settings/ tests/agent_server/test_settings_router.py tests/sdk/test_apply_agent_settings_diff.py` — all pass.
2. `ACPAgentSettings(acp_server="claude-code", llm=LLM(model="m", api_key=SecretStr("k"))).create_agent()` → emits `DeprecationWarning` for `ACPAgentSettings.llm credentials`; `agent.agent_context` carries no injected `ANTHROPIC_API_KEY`.
3. Same settings with the credential supplied via `agent_context.secrets={"ANTHROPIC_API_KEY": ...}` → reaches `request.secrets` via `create_request` exactly as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4ddce21-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4ddce21-python \
  ghcr.io/openhands/agent-server:4ddce21-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4ddce21-golang-amd64
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-golang-amd64
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-golang-amd64
ghcr.io/openhands/agent-server:4ddce21-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4ddce21-golang-arm64
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-golang-arm64
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-golang-arm64
ghcr.io/openhands/agent-server:4ddce21-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4ddce21-java-amd64
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-java-amd64
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-java-amd64
ghcr.io/openhands/agent-server:4ddce21-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4ddce21-java-arm64
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-java-arm64
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-java-arm64
ghcr.io/openhands/agent-server:4ddce21-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4ddce21-python-amd64
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-python-amd64
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-python-amd64
ghcr.io/openhands/agent-server:4ddce21-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4ddce21-python-arm64
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-python-arm64
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-python-arm64
ghcr.io/openhands/agent-server:4ddce21-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4ddce21-golang
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-golang
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-golang
ghcr.io/openhands/agent-server:4ddce21-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4ddce21-java
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-java
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-java
ghcr.io/openhands/agent-server:4ddce21-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4ddce21-python
ghcr.io/openhands/agent-server:4ddce219e453a3fb75aa9e3200ee05d35aae229e-python
ghcr.io/openhands/agent-server:acp-deprecate-llm-creds-python
ghcr.io/openhands/agent-server:4ddce21-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4ddce21-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4ddce21-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
