### PR TITLE
refactor(sdk): curate ACP model lists — verified against pinned CLIs, current generations only

### DIFF
--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -293,38 +293,30 @@ class ACPProviderInfo:
 # ``acp_model`` outside these lists is always allowed.
 # ---------------------------------------------------------------------------
 
-# Canonical model IDs the Claude Code CLI accepts. ``opus[1m]`` / ``sonnet[1m]``
-# are the SDK-documented version-agnostic 1M-context aliases (so they auto-track
-# the newest 1M-capable model — keep their labels version-less to match).
-# ``opusplan`` routes planning to Opus and execution to Sonnet.
+# Canonical model IDs the Claude Code CLI accepts, curated to the newest
+# generation per capability tier. ``opus[1m]`` is the SDK-documented
+# version-agnostic 1M-context alias (auto-tracks the newest 1M-capable model —
+# keep its label version-less to match). ``opusplan`` routes planning to Opus
+# and execution to Sonnet.
 _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="claude-fable-5", label="Claude Fable 5"),
     ACPModelOption(id="claude-opus-4-8", label="Claude Opus 4.8"),
-    ACPModelOption(id="claude-opus-4-7", label="Claude Opus 4.7"),
-    ACPModelOption(id="claude-opus-4-6", label="Claude Opus 4.6"),
     ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),
-    ACPModelOption(id="claude-opus-4-5", label="Claude Opus 4.5"),
-    ACPModelOption(id="claude-opus-4-1-20250805", label="Claude Opus 4.1"),
     ACPModelOption(id="claude-sonnet-4-6", label="Claude Sonnet 4.6"),
-    ACPModelOption(id="sonnet[1m]", label="Claude Sonnet (1M)"),
-    ACPModelOption(id="claude-sonnet-4-5", label="Claude Sonnet 4.5"),
     ACPModelOption(id="claude-haiku-4-5", label="Claude Haiku 4.5"),
     ACPModelOption(id="opusplan", label="Opus (plan) + Sonnet (execute)"),
 )
 
-# Model IDs accepted by ``@zed-industries/codex-acp``, mirroring the Codex CLI's
-# ``/model`` picker (``session/new`` ``availableModels`` on the pinned CLI).
-# Format is ``<base-model>/<effort>`` where the trailing tier
-# (``low``/``medium``/``high``/``xhigh``) hints the reasoning effort for the turn.
+# Model IDs accepted by ``@zed-industries/codex-acp`` (``session/new``
+# ``availableModels`` on the pinned CLI), curated to the frontier family plus
+# the cost-efficient mini tier. Format is ``<base-model>/<effort>`` where the
+# trailing tier (``low``/``medium``/``high``/``xhigh``) hints the reasoning
+# effort for the turn.
 _CODEX_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="gpt-5.5/low", label="GPT-5.5 (low)"),
     ACPModelOption(id="gpt-5.5/medium", label="GPT-5.5 (medium)"),
     ACPModelOption(id="gpt-5.5/high", label="GPT-5.5 (high)"),
     ACPModelOption(id="gpt-5.5/xhigh", label="GPT-5.5 (xhigh)"),
-    ACPModelOption(id="gpt-5.4/low", label="GPT-5.4 (low)"),
-    ACPModelOption(id="gpt-5.4/medium", label="GPT-5.4 (medium)"),
-    ACPModelOption(id="gpt-5.4/high", label="GPT-5.4 (high)"),
-    ACPModelOption(id="gpt-5.4/xhigh", label="GPT-5.4 (xhigh)"),
     ACPModelOption(id="gpt-5.4-mini/low", label="GPT-5.4 Mini (low)"),
     ACPModelOption(id="gpt-5.4-mini/medium", label="GPT-5.4 Mini (medium)"),
     ACPModelOption(id="gpt-5.4-mini/high", label="GPT-5.4 Mini (high)"),

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -311,7 +311,8 @@ _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
 )
 
 # Model IDs accepted by ``@zed-industries/codex-acp``, mirroring the Codex CLI's
-# ``/model`` picker. Format is ``<base-model>/<effort>`` where the trailing tier
+# ``/model`` picker (``session/new`` ``availableModels`` on the pinned CLI).
+# Format is ``<base-model>/<effort>`` where the trailing tier
 # (``low``/``medium``/``high``/``xhigh``) hints the reasoning effort for the turn.
 _CODEX_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="gpt-5.5/low", label="GPT-5.5 (low)"),
@@ -326,14 +327,6 @@ _CODEX_MODELS: tuple[ACPModelOption, ...] = (
     ACPModelOption(id="gpt-5.4-mini/medium", label="GPT-5.4 Mini (medium)"),
     ACPModelOption(id="gpt-5.4-mini/high", label="GPT-5.4 Mini (high)"),
     ACPModelOption(id="gpt-5.4-mini/xhigh", label="GPT-5.4 Mini (xhigh)"),
-    ACPModelOption(id="gpt-5.3-codex/low", label="GPT-5.3 Codex (low)"),
-    ACPModelOption(id="gpt-5.3-codex/medium", label="GPT-5.3 Codex (medium)"),
-    ACPModelOption(id="gpt-5.3-codex/high", label="GPT-5.3 Codex (high)"),
-    ACPModelOption(id="gpt-5.3-codex/xhigh", label="GPT-5.3 Codex (xhigh)"),
-    ACPModelOption(id="gpt-5.2/low", label="GPT-5.2 (low)"),
-    ACPModelOption(id="gpt-5.2/medium", label="GPT-5.2 (medium)"),
-    ACPModelOption(id="gpt-5.2/high", label="GPT-5.2 (high)"),
-    ACPModelOption(id="gpt-5.2/xhigh", label="GPT-5.2 (xhigh)"),
 )
 
 # Model IDs accepted by ``@google/gemini-cli --acp``. The ``auto-gemini-*``

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -298,6 +298,8 @@ class ACPProviderInfo:
 # the newest 1M-capable model — keep their labels version-less to match).
 # ``opusplan`` routes planning to Opus and execution to Sonnet.
 _CLAUDE_MODELS: tuple[ACPModelOption, ...] = (
+    ACPModelOption(id="claude-fable-5", label="Claude Fable 5"),
+    ACPModelOption(id="claude-opus-4-8", label="Claude Opus 4.8"),
     ACPModelOption(id="claude-opus-4-7", label="Claude Opus 4.7"),
     ACPModelOption(id="claude-opus-4-6", label="Claude Opus 4.6"),
     ACPModelOption(id="opus[1m]", label="Claude Opus (1M)"),

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -413,7 +413,7 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             supports_runtime_model_switch=True,
             session_meta_key="claudeCode",
             available_models=_CLAUDE_MODELS,
-            default_model="claude-opus-4-7",
+            default_model="claude-opus-4-8",
             binary_name="claude-agent-acp",
             data_dir_env_var="CLAUDE_CONFIG_DIR",
         ),

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -41,8 +41,8 @@ class TestACPProviderInfo:
         # ... but it DOES support session/set_model for mid-conversation switches.
         assert info.supports_runtime_model_switch is True
         assert info.session_meta_key == "claudeCode"
-        assert info.default_model == "claude-opus-4-7"
-        assert any(m.id == "claude-opus-4-7" for m in info.available_models)
+        assert info.default_model == "claude-opus-4-8"
+        assert any(m.id == "claude-opus-4-8" for m in info.available_models)
         # Pinned binary exposed by the agent-server image wrappers.
         assert info.binary_name == "claude-agent-acp"
         assert info.data_dir_env_var == "CLAUDE_CONFIG_DIR"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

curate ACP model lists

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [x] A human has tested these changes.

AGENT:

Audited every model in `_CLAUDE_MODELS` and `_CODEX_MODELS` against the Dockerfile-pinned CLIs (`claude-agent-acp@0.30.0`, `codex-acp@0.15.0`) with a raw ACP JSON-RPC harness that mirrors the SDK's exact call sequence (`initialize` → `session/new` → `session/set_mode` → `session/set_model` → `session/prompt`), authenticated with real local subscriptions (Claude Max keychain login, Codex ChatGPT `auth.json`). One fresh server process per model; PASS requires `stopReason=end_turn` plus a non-empty reply, and the post-`set_model` selected model was verified from `config_option_update` / usage telemetry.

---

## Why

`gpt-5.3-codex/*` returns an opaque `-32603` from codex-acp 0.15.0 (issue #3651, also seen in benchmarks #736). A full audit of both model lists against the pinned CLI versions found `gpt-5.2/*` equally broken, while everything else works.

## Summary

- Trim both lists to current generations for picker simplicity (registry entries are suggestions only — persisted custom `acp_model` values keep working): Claude keeps one entry per capability tier (`claude-fable-5`, `claude-opus-4-8`, `opus[1m]`, `claude-sonnet-4-6`, `claude-haiku-4-5`, `opusplan`); Codex keeps the frontier family + mini tier (`gpt-5.5/*`, `gpt-5.4-mini/*`), dropping the superseded `gpt-5.4/*`. `sonnet[1m]` is dropped here too — it was the one entry that never completed a prompt in the audit (billing-gated long context).
- Add `claude-fable-5` ("Claude Fable 5") and `claude-opus-4-8` ("Claude Opus 4.8") to `_CLAUDE_MODELS` — both released after the list was last curated and verified end-to-end on the pinned CLI (`set_model` accepted, prompt executed on the requested model per the CLI's own `config_option_update`). `claude-mythos-5` (approved-orgs only) and a speculative `fable[1m]` alias are rejected by the CLI and stay out. `default_model` bumped `claude-opus-4-7` → `claude-opus-4-8` (per maintainer request).
- Remove `gpt-5.3-codex/{low,medium,high,xhigh}` and `gpt-5.2/{low,medium,high,xhigh}` from `_CODEX_MODELS`: codex-acp 0.15.0 no longer advertises either family in `session/new` `availableModels`, and prompting on them fails with HTTP 400 `The 'gpt-5.3-codex' / 'gpt-5.2' model is not supported when using Codex with a ChatGPT account`, surfaced as the opaque `-32603`.
- Every retained entry has a verified end-to-end PASS on the pinned CLIs.

Full audit matrix (PASS = real prompt executed on the requested model):

| Provider | Model | Result |
|---|---|---|
| codex | gpt-5.5 low/medium/high/xhigh | PASS |
| codex | gpt-5.4 low/medium/high/xhigh | PASS |
| codex | gpt-5.4-mini low/medium/high/xhigh | PASS |
| codex | gpt-5.3-codex low/medium/high/xhigh | FAIL — 400 model not supported → -32603 |
| codex | gpt-5.2 low/medium/high/xhigh | FAIL — 400 model not supported → -32603 |
| claude-code | **claude-fable-5 (added)**, **claude-opus-4-8 (added)**, claude-opus-4-7 / 4-6 / 4-5 / 4-1, opus[1m], claude-sonnet-4-6 / 4-5, claude-haiku-4-5, opusplan | PASS |
| claude-code | claude-mythos-5, fable[1m] | rejected by set_model ("may not exist or you may not have access") — not added |
| claude-code | sonnet[1m] | accepted by `session/set_model`; prompt fails account-side ("Usage credits are required for long context requests") — kept, see note |

Notes from the audit (not changed here):

- `sonnet[1m]` is a valid ID on claude-agent-acp 0.30.0 (`set_model` succeeds, session enters 1M context); the prompt then fails with an Anthropic billing/capacity error that depends on the account tier (`opus[1m]` succeeds on the same subscription). Kept because it is not a CLI/registry defect.
- claude-agent-acp 0.30.0 does **not** apply the `_meta {"claudeCode": {"options": {"model": ...}}}` initial-model selection the registry relies on (`session_meta_key="claudeCode"`): the model is registered as a picker option but the session keeps running `default` (verified via 1M-context usage telemetry and Opus-level cost on a `claude-haiku-4-5` request, and by a bogus model ID succeeding silently). `session/set_model` does validate and apply. Filed as a follow-up candidate — happy to split into its own issue.

## Issue Number

Fixes #3651

## How to Test

1. `npx -y @zed-industries/codex-acp@0.15.0` with a ChatGPT-authenticated `~/.codex/auth.json`; over stdio JSON-RPC: `initialize` → `session/new` → `session/set_model {"modelId": "gpt-5.3-codex/medium"}` → `session/prompt`. The prompt returns `-32603` with the 400 "model is not supported" payload; `availableModels` in the `session/new` response lists only `gpt-5.5/*`, `gpt-5.4/*`, `gpt-5.4-mini/*`.
2. Repeat with any retained model id — prompt completes with `stopReason=end_turn`.
3. `uv run pytest tests/sdk/settings/test_acp_providers.py tests/sdk/test_settings.py tests/sdk/agent/test_acp_agent.py tests/agent_server/test_conversation_info_model.py` → 517 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a5dee7d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a5dee7d-python \
  ghcr.io/openhands/agent-server:a5dee7d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a5dee7d-golang-amd64
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-golang-amd64
ghcr.io/openhands/agent-server:a5dee7d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a5dee7d-golang-arm64
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-golang-arm64
ghcr.io/openhands/agent-server:a5dee7d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a5dee7d-java-amd64
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-java-amd64
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-java-amd64
ghcr.io/openhands/agent-server:a5dee7d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a5dee7d-java-arm64
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-java-arm64
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-java-arm64
ghcr.io/openhands/agent-server:a5dee7d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a5dee7d-python-amd64
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-python-amd64
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-python-amd64
ghcr.io/openhands/agent-server:a5dee7d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a5dee7d-python-arm64
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-python-arm64
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-python-arm64
ghcr.io/openhands/agent-server:a5dee7d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a5dee7d-golang
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-golang
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-golang
ghcr.io/openhands/agent-server:a5dee7d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a5dee7d-java
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-java
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-java
ghcr.io/openhands/agent-server:a5dee7d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a5dee7d-python
ghcr.io/openhands/agent-server:a5dee7d4224e48a57c92e8fcd569466080fc0231-python
ghcr.io/openhands/agent-server:fix-acp-remove-unsupported-models-python
ghcr.io/openhands/agent-server:a5dee7d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a5dee7d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a5dee7d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->