### PR TITLE
fix(sdk): apply claude-code initial ACP model via set_session_model (claude-agent-acp ignores _meta)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -503,11 +503,11 @@ async def _maybe_set_session_model(
 
     This is the session-creation path only, gated on
     :attr:`~openhands.sdk.settings.acp_providers.ACPProviderInfo.supports_set_session_model`.
-    Providers that select their initial model via session ``_meta``
-    (claude-agent-acp, ``supports_set_session_model=False``) already received
-    the model in ``new_session()``, so this is a no-op for them. Providers that
-    use the protocol call for initial selection (codex-acp, gemini-cli) get a
-    one-shot ``set_session_model`` call here.
+    All built-in providers get a one-shot ``set_session_model`` call here.
+    claude-agent-acp used to be skipped on the assumption that it already
+    received the model via ``new_session()`` ``_meta``, but 0.30.0 silently
+    ignores that payload (#3654) — the protocol call is the only path that
+    both validates and applies the model.
 
     For unknown/custom providers (e.g. Devin CLI), we fall back to the generic
     ``set_config_option`` method with configId="model", which is a standard ACP

--- a/openhands-sdk/openhands/sdk/settings/acp_providers.py
+++ b/openhands-sdk/openhands/sdk/settings/acp_providers.py
@@ -11,9 +11,9 @@ Each record captures the static properties that are known at configuration time
 - ``default_session_mode``  ACP mode ID that disables permission prompts
 - ``agent_name_patterns``   lowercase substrings in the runtime agent name;
                             used by ``ACPAgent`` to auto-detect mode / protocol
-- ``supports_set_session_model``  whether the provider selects its *initial*
+- ``supports_set_session_model``  whether the provider applies its *initial*
                                   model via the ``set_session_model`` protocol
-                                  call (vs session ``_meta``) at session creation
+                                  call at session creation
 - ``supports_runtime_model_switch``  whether the server supports the
                                   ``session/set_model`` protocol call for
                                   runtime, mid-conversation model switching
@@ -176,12 +176,12 @@ class ACPProviderInfo:
     """``True`` if this provider selects its *initial* model via the
     ``set_session_model`` protocol call (rather than session ``_meta``).
 
-    This governs the **session-creation** path only:
-
-    - ``False`` for claude-agent-acp, which selects its initial model via
-      session ``_meta`` (see :attr:`session_meta_key`).
-    - ``True`` for codex-acp and gemini-cli, which get a one-shot
-      ``set_session_model`` call right after the session is created.
+    This governs the **session-creation** path only. ``True`` for all three
+    built-in providers, which get a one-shot ``set_session_model`` call right
+    after the session is created. claude-agent-acp was ``False`` until 0.30.0
+    was found to silently ignore the session-``_meta`` selection it relied on
+    (#3654); its ``_meta`` payload is still sent alongside (see
+    :attr:`session_meta_key`).
 
     This is **independent of** runtime switching capability — see
     :attr:`supports_runtime_model_switch`. The original meaning of this flag
@@ -192,15 +192,15 @@ class ACPProviderInfo:
     session_meta_key: str | None
     """Top-level ``_meta`` key for model selection *at session creation*.
 
-    When non-``None``, the provider selects its **initial** model via ACP
-    session ``_meta`` using the structure
+    When non-``None``, the model is additionally advertised via ACP session
+    ``_meta`` using the structure
     ``{session_meta_key: {"options": {"model": <model>}}}`` passed to
-    ``new_session()``. When ``None``, the initial model is applied with a
-    one-shot ``set_session_model`` call right after the session is created
-    (gated on :attr:`supports_set_session_model`).
+    ``new_session()``. This is best-effort only: claude-agent-acp 0.30.0
+    ignores it (#3654), so the authoritative initial selection is the
+    ``set_session_model`` call gated on :attr:`supports_set_session_model`.
 
-    This only governs the *initial* selection; runtime switches always use
-    ``set_session_model`` (gated on :attr:`supports_runtime_model_switch`).
+    Runtime switches always use ``set_session_model`` (gated on
+    :attr:`supports_runtime_model_switch`).
 
     - ``"claudeCode"`` — claude-agent-acp
     - ``None``         — codex-acp, gemini-cli
@@ -397,11 +397,13 @@ ACP_PROVIDERS: Mapping[str, ACPProviderInfo] = MappingProxyType(
             base_url_env_var="ANTHROPIC_BASE_URL",
             default_session_mode="bypassPermissions",
             agent_name_patterns=("claude-agent",),
-            # claude-agent-acp selects its *initial* model via session _meta
-            # (session_meta_key below), so the init path does NOT use
-            # set_session_model. It DOES, however, support session/set_model
-            # for mid-conversation switches.
-            supports_set_session_model=False,
+            # claude-agent-acp 0.30.0 silently ignores the session-_meta model
+            # selection (the requested model only becomes a picker option; the
+            # session keeps running "default"), so the init path must push the
+            # model via session/set_model like codex/gemini (#3654). The _meta
+            # payload (session_meta_key below) is still sent — harmless, and
+            # picks up the same model if a future CLI honours it.
+            supports_set_session_model=True,
             supports_runtime_model_switch=True,
             session_meta_key="claudeCode",
             available_models=_CLAUDE_MODELS,

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -4421,21 +4421,22 @@ class TestMaybeSetSessionModel:
         assert applied is True
 
     @pytest.mark.asyncio
-    async def test_meta_key_provider_skips_protocol_override_at_init(self):
-        # claude-agent-acp selects its *initial* model via session _meta, so the
-        # one-shot init set_session_model call is skipped (even though the
-        # provider now supports the protocol call for runtime switches).
+    async def test_claude_agent_uses_protocol_model_override(self):
+        # claude-agent-acp 0.30.0 silently ignores the session-_meta model
+        # selection (#3654), so the init path pushes the model via the same
+        # one-shot set_session_model call as codex/gemini.
         conn = AsyncMock()
         applied = await _maybe_set_session_model(
             conn,
             "claude-agent-acp",
             "session-1",
-            "claude-opus-4-6",
+            "claude-opus-4-8",
         )
-        conn.set_session_model.assert_not_called()
-        # Not applied *via this call* — claude rode the model in via _meta on
-        # new_session, which the caller accounts for separately.
-        assert applied is False
+        conn.set_session_model.assert_awaited_once_with(
+            model_id="claude-opus-4-8",
+            session_id="session-1",
+        )
+        assert applied is True
 
     @pytest.mark.asyncio
     async def test_missing_model_skips_protocol_override(self):
@@ -4481,11 +4482,8 @@ class TestReapplySessionModelOnResume:
 
     @pytest.mark.asyncio
     async def test_claude_reapplies_persisted_model_on_resume(self):
-        # claude selects its initial model via _meta (supports_set_session_model
-        # =False) but DOES support set_session_model for runtime switches.
-        # load_session() carries no _meta, so on resume the persisted model must
-        # be reapplied via the runtime-switch gate — _maybe_set_session_model
-        # would skip it.
+        # load_session() carries no model selection, so on resume the persisted
+        # model must be reapplied via the runtime-switch gate.
         conn = AsyncMock()
         applied = await _reapply_session_model_on_resume(
             conn, "claude-agent-acp", "sess-1", "claude-haiku-4-5-20251001"
@@ -5953,10 +5951,8 @@ class TestACPSessionIdPersistence:
             "acp_session_id": "stored-sess",
             "acp_session_cwd": str(tmp_path),
         }
-        # Name the server "codex-acp" so _maybe_set_session_model routes
-        # acp_model through conn.set_session_model (claude-acp uses _meta,
-        # which only applies on new_session and so wouldn't exercise the
-        # protocol-level override on the resume path).
+        # Named "codex-acp"; any built-in provider routes acp_model through
+        # conn.set_session_model on this path.
         conn = self._make_conn()
         conn.initialize.return_value.agent_info.name = "codex-acp"
         conn.initialize.return_value.auth_methods = []

--- a/tests/sdk/settings/test_acp_providers.py
+++ b/tests/sdk/settings/test_acp_providers.py
@@ -35,10 +35,10 @@ class TestACPProviderInfo:
         assert info.base_url_env_var == "ANTHROPIC_BASE_URL"
         assert info.default_session_mode == "bypassPermissions"
         assert "claude-agent" in info.agent_name_patterns
-        # claude-agent-acp selects its *initial* model via _meta (session_meta_key),
-        # so it does NOT use set_session_model at session creation ...
-        assert info.supports_set_session_model is False
-        # ... but it DOES support session/set_model for mid-conversation switches.
+        # Initial selection rides session/set_model — claude-agent-acp 0.30.0
+        # silently ignores the session-_meta payload (#3654), which is still
+        # sent as best-effort (session_meta_key below).
+        assert info.supports_set_session_model is True
         assert info.supports_runtime_model_switch is True
         assert info.session_meta_key == "claudeCode"
         assert info.default_model == "claude-opus-4-8"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

apply claude-code initial ACP model via set_session_model

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [x] A human has tested these changes.

AGENT:

Validated end-to-end against the pinned `claude-agent-acp@0.30.0` with real subscription auth, using the Claude CLI's own session transcript (`~/.claude/projects/<cwd>/<session>.jsonl`, which records the model per assistant message) as ground truth — see How to Test for the before/after.

---

## Why

claude-agent-acp 0.30.0 silently ignores the `_meta {"claudeCode": {"options": {"model": ...}}}` initial-model selection the SDK's claude-code init path relies on (#3654, discovered during the #3651 audit). The requested model is only registered as a picker option; the session keeps running the CLI default. Meanwhile `ACPAgent.current_model_id` reports the override — so every claude-code conversation claims to run the chosen model while actually running the default.

## Summary

- Flip `claude-code` to `supports_set_session_model=True`: the init path now pushes `acp_model` through the same one-shot `session/set_model` call codex/gemini already use (the call the #3651 audit verified validates-and-applies for every curated Claude model).
- Keep `session_meta_key="claudeCode"` — the `_meta` payload is still sent as best-effort and selects the same model if a future CLI honours it; docstrings updated to reflect the new contract.
- Tests: the "claude skips the protocol override at init" test now asserts the opposite (call issued, `applied=True`); registry capability assertions flipped.

Behavioural note: an invalid/inaccessible `acp_model` previously *silently succeeded* on the default model; now the CLI accepts the `set_model` (it defers validation) and the first prompt surfaces `-32603 "There's an issue with the selected model"` after the prompt-retry loop — visible failure instead of a silent wrong model.

## Issue Number

Fixes #3654

## How to Test

Run any claude-code ACP conversation with an explicit `acp_model` and check the model recorded in the CLI's transcript JSONL. With `acp_model="claude-haiku-4-5"` (script: one `Conversation.run()` turn over `ACPAgent(acp_command=["npx","-y","@agentclientprotocol/claude-agent-acp@0.30.0"], acp_model="claude-haiku-4-5")`):

```
# main (before):  current_model_id=claude-haiku-4-5  — but transcript records:
   1 "model":"claude-sonnet-4-6"        ← ran on the CLI default, override silently dropped
# this branch:    current_model_id=claude-haiku-4-5  — transcript records:
   2 "model":"claude-haiku-4-5-20251001" ← actually ran on the requested model
```

Unit tests: `uv run pytest tests/sdk/agent/test_acp_agent.py tests/sdk/settings/test_acp_providers.py tests/sdk/test_settings.py tests/agent_server/` → 1656 passed, 1 pre-existing failure (`TestAutoTitle::test_autotitle_sets_title_on_first_user_message`, also fails on clean main locally, unrelated).

Note for downstream: typescript-client's `acp-providers.json` mirrors `supports_set_session_model` — its drift job will need the one-line mirror sync after this merges (will open the companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d0d7e2e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d0d7e2e-python \
  ghcr.io/openhands/agent-server:d0d7e2e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d0d7e2e-golang-amd64
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-golang-amd64
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-golang-amd64
ghcr.io/openhands/agent-server:d0d7e2e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d0d7e2e-golang-arm64
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-golang-arm64
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-golang-arm64
ghcr.io/openhands/agent-server:d0d7e2e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d0d7e2e-java-amd64
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-java-amd64
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-java-amd64
ghcr.io/openhands/agent-server:d0d7e2e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d0d7e2e-java-arm64
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-java-arm64
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-java-arm64
ghcr.io/openhands/agent-server:d0d7e2e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d0d7e2e-python-amd64
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-python-amd64
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-python-amd64
ghcr.io/openhands/agent-server:d0d7e2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d0d7e2e-python-arm64
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-python-arm64
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-python-arm64
ghcr.io/openhands/agent-server:d0d7e2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d0d7e2e-golang
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-golang
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-golang
ghcr.io/openhands/agent-server:d0d7e2e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d0d7e2e-java
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-java
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-java
ghcr.io/openhands/agent-server:d0d7e2e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d0d7e2e-python
ghcr.io/openhands/agent-server:d0d7e2ed740f353089c84c296c336afb76aa2dc7-python
ghcr.io/openhands/agent-server:fix-acp-claude-initial-model-selection-python
ghcr.io/openhands/agent-server:d0d7e2e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d0d7e2e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d0d7e2e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->