### PR TITLE
ci: validate deprecation runway schedules

### DIFF
--- a/.github/scripts/check_deprecations.py
+++ b/.github/scripts/check_deprecations.py
@@ -2,10 +2,12 @@
 """Static analysis for deprecation deadlines.
 
 This script scans Python deprecation metadata (`deprecated`, `warn_deprecated`,
-`warn_cleanup`) and agent-server REST routes marked `deprecated=True`. If the
-current project version has reached or passed a feature's removal marker, the
-script fails with a helpful summary so legacy shims and overdue deprecated REST
-endpoints are cleaned up before release.
+`warn_cleanup`) and agent-server REST routes marked `deprecated=True`. It fails
+when a version-based deprecation schedule provides less than 5 minor releases of
+runway, or when the current project version has reached or passed a feature's
+removal marker. This catches invalid schedules when they are introduced and later
+ensures legacy shims and overdue deprecated REST endpoints are cleaned up before
+release.
 """
 
 from __future__ import annotations
@@ -41,6 +43,7 @@ ROUTE_DECORATOR_NAMES = {
 }
 HTTP_METHODS = ROUTE_DECORATOR_NAMES - {"api_route"}
 
+DEPRECATION_RUNWAY_MINOR_RELEASES = 5
 REPO_ROOT = Path(__file__).resolve().parents[2]
 
 
@@ -473,6 +476,46 @@ def _version_ge(current: str, target: str) -> bool:
         ) from exc
 
 
+def _minimum_removed_in(deprecated_in: str) -> str:
+    parsed = pkg_version.parse(deprecated_in)
+    if not isinstance(parsed, pkg_version.Version):
+        raise SystemExit(f"Invalid deprecated_in version: {deprecated_in!r}")
+    return f"{parsed.major}.{parsed.minor + DEPRECATION_RUNWAY_MINOR_RELEASES}.0"
+
+
+def _runway_error(record: DeprecationRecord) -> str | None:
+    if record.kind == "cleanup_call" or record.removed_in is None:
+        return None
+    if isinstance(record.removed_in, date):
+        return None
+    if record.deprecated_in is None:
+        return (
+            f"{record.identifier} does not declare deprecated_in; version-based "
+            "deprecations must provide an explicit runway."
+        )
+
+    try:
+        minimum_removed_in = _minimum_removed_in(record.deprecated_in)
+        if pkg_version.parse(str(record.removed_in)) >= pkg_version.parse(
+            minimum_removed_in
+        ):
+            return None
+    except pkg_version.InvalidVersion as exc:
+        raise SystemExit(
+            f"Invalid deprecation schedule at {record.path}:{record.line}: "
+            f"deprecated_in={record.deprecated_in!r}, "
+            f"removed_in={record.removed_in!r}"
+        ) from exc
+
+    return (
+        f"{record.identifier} uses an invalid deprecation schedule: "
+        f"deprecated_in={record.deprecated_in} and "
+        f"removed_in={record.removed_in}. Deprecations require at least "
+        f"{DEPRECATION_RUNWAY_MINOR_RELEASES} minor releases of runway "
+        f"(minimum removed_in: {minimum_removed_in})."
+    )
+
+
 def _should_fail(current_version: str, record: DeprecationRecord) -> bool:
     removed = record.removed_in
     if removed is None:
@@ -517,6 +560,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     argv = list(argv or [])
 
     overdue: list[DeprecationRecord] = []
+    invalid_runway: list[tuple[DeprecationRecord, str]] = []
     total_records = 0
     package_summaries: list[tuple[str, str, int]] = []
 
@@ -542,12 +586,27 @@ def main(argv: Sequence[str] | None = None) -> int:
             records.extend(_collect_rest_route_records(files, package=package.name))
 
         overdue.extend(r for r in records if _should_fail(current_version, r))
+        invalid_runway.extend(
+            (record, error)
+            for record in records
+            if (error := _runway_error(record)) is not None
+        )
         total_records += len(records)
         package_summaries.append((package.name, current_version, len(records)))
 
-    if overdue:
+    if overdue or invalid_runway:
         deprecated_items = [r for r in overdue if r.kind != "cleanup_call"]
         cleanup_items = [r for r in overdue if r.kind == "cleanup_call"]
+
+        if invalid_runway:
+            print(
+                "The following deprecation schedules provide less than "
+                f"{DEPRECATION_RUNWAY_MINOR_RELEASES} minor releases of runway:\n"
+            )
+            for record, error in invalid_runway:
+                print(_format_record(record))
+                print(f"  error:         {error}")
+                print()
 
         if deprecated_items:
             print(
@@ -573,6 +632,11 @@ def main(argv: Sequence[str] | None = None) -> int:
             print(
                 "Remove the listed workarounds before publishing a version that "
                 "meets or exceeds their cleanup deadline."
+            )
+        if invalid_runway:
+            print(
+                "Move each removal target far enough out, or remove the invalid "
+                "deprecation metadata before merging."
             )
         return 1
 

--- a/tests/cross/test_check_deprecations.py
+++ b/tests/cross/test_check_deprecations.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import ast
 import importlib.util
 import sys
+from datetime import date
 from pathlib import Path
 
 import pytest
@@ -25,6 +26,7 @@ def _load_prod_module():
 _prod = _load_prod_module()
 DeprecationRecord = _prod.DeprecationRecord
 _gather_rest_route_deprecations = _prod._gather_rest_route_deprecations
+_runway_error = _prod._runway_error
 _should_fail = _prod._should_fail
 
 
@@ -122,3 +124,91 @@ def test_should_fail_for_overdue_rest_route_record():
 
     assert _should_fail("1.14.0", record) is True
     assert _should_fail("1.13.9", record) is False
+
+
+def test_runway_error_rejects_less_than_five_minor_releases():
+    record = DeprecationRecord(
+        identifier="ACPAgentSettings.llm",
+        removed_in="1.29.0",
+        deprecated_in="1.28.0",
+        path=Path("settings.py"),
+        line=42,
+        kind="warn_call",
+        package="openhands-sdk",
+    )
+
+    error = _runway_error(record)
+
+    assert error is not None
+    assert "minimum removed_in: 1.33.0" in error
+
+
+def test_main_fails_for_invalid_runway(monkeypatch, tmp_path, capsys):
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nversion = "1.28.0"\n')
+    source_root = tmp_path / "pkg"
+    source_root.mkdir()
+    (source_root / "module.py").write_text(
+        "from openhands.sdk.utils.deprecation import warn_deprecated\n\n"
+        "def trigger():\n"
+        "    warn_deprecated(\n"
+        "        'BadFeature',\n"
+        "        deprecated_in='1.28.0',\n"
+        "        removed_in='1.29.0',\n"
+        "    )\n"
+    )
+    monkeypatch.setattr(_prod, "REPO_ROOT", tmp_path)
+    monkeypatch.setattr(
+        _prod,
+        "PACKAGES",
+        (
+            _prod.PackageConfig(
+                name="test-package",
+                pyproject=pyproject,
+                source_roots=(source_root,),
+            ),
+        ),
+    )
+
+    assert _prod.main([]) == 1
+    output = capsys.readouterr().out
+    assert "less than 5 minor releases" in output
+    assert "minimum removed_in: 1.33.0" in output
+
+
+def test_runway_error_accepts_five_minor_releases():
+    record = DeprecationRecord(
+        identifier="ACPAgentSettings.llm",
+        removed_in="1.33.0",
+        deprecated_in="1.28.0",
+        path=Path("settings.py"),
+        line=42,
+        kind="warn_call",
+        package="openhands-sdk",
+    )
+
+    assert _runway_error(record) is None
+
+
+def test_runway_error_skips_cleanup_and_date_based_removals():
+    cleanup_record = DeprecationRecord(
+        identifier="temporary workaround",
+        removed_in="1.29.0",
+        deprecated_in=None,
+        path=Path("module.py"),
+        line=12,
+        kind="cleanup_call",
+        package="openhands-sdk",
+    )
+    date_record = DeprecationRecord(
+        identifier="OldFeature",
+        removed_in=date(2027, 1, 1),
+        deprecated_in="1.28.0",
+        path=Path("module.py"),
+        line=18,
+        kind="decorator",
+        package="openhands-sdk",
+    )
+
+    assert _runway_error(cleanup_record) is None
+    assert _runway_error(date_record) is None


### PR DESCRIPTION
HUMAN:
This PR strengthens the deprecation versions checks to notify the PR author sooner if the PR doesn't follow the 5 minor releases runway.

- [x] A human has tested these changes.

AGENT:

## Why

The repository requires deprecated SDK APIs and REST endpoints to provide a 5-minor-release removal runway. Existing checks caught overdue removals, but they did not reject newly introduced version metadata that scheduled removal too soon. This change catches those invalid schedules during PR validation so authors can fix the metadata before it merges.

## Summary

- Extend `check_deprecations.py` to fail when version-based deprecation metadata schedules removal less than 5 minor releases after `deprecated_in`.
- Keep existing deadline checks intact, so invalid schedules are caught when introduced rather than only when removal is attempted or overdue.
- Add cross tests covering short, valid, skipped, and main-script failure paths.

## How to Test

- `uv run pre-commit run --files .github/scripts/check_deprecations.py tests/cross/test_check_deprecations.py`
- `uv run --with packaging python .github/scripts/check_deprecations.py`
- `uv run pytest tests/cross/test_check_deprecations.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/22713114-014c-4729-ab0f-865ab432f1bd)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2fff76d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2fff76d-python \
  ghcr.io/openhands/agent-server:2fff76d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2fff76d-golang-amd64
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-golang-amd64
ghcr.io/openhands/agent-server:deprecation-runway-introduction-golang-amd64
ghcr.io/openhands/agent-server:2fff76d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2fff76d-golang-arm64
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-golang-arm64
ghcr.io/openhands/agent-server:deprecation-runway-introduction-golang-arm64
ghcr.io/openhands/agent-server:2fff76d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2fff76d-java-amd64
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-java-amd64
ghcr.io/openhands/agent-server:deprecation-runway-introduction-java-amd64
ghcr.io/openhands/agent-server:2fff76d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2fff76d-java-arm64
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-java-arm64
ghcr.io/openhands/agent-server:deprecation-runway-introduction-java-arm64
ghcr.io/openhands/agent-server:2fff76d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2fff76d-python-amd64
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-python-amd64
ghcr.io/openhands/agent-server:deprecation-runway-introduction-python-amd64
ghcr.io/openhands/agent-server:2fff76d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2fff76d-python-arm64
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-python-arm64
ghcr.io/openhands/agent-server:deprecation-runway-introduction-python-arm64
ghcr.io/openhands/agent-server:2fff76d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2fff76d-golang
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-golang
ghcr.io/openhands/agent-server:deprecation-runway-introduction-golang
ghcr.io/openhands/agent-server:2fff76d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2fff76d-java
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-java
ghcr.io/openhands/agent-server:deprecation-runway-introduction-java
ghcr.io/openhands/agent-server:2fff76d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2fff76d-python
ghcr.io/openhands/agent-server:2fff76d8300340b9b8b9937c60c4aeba277f7871-python
ghcr.io/openhands/agent-server:deprecation-runway-introduction-python
ghcr.io/openhands/agent-server:2fff76d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2fff76d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2fff76d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
