### PR TITLE
fix(llm): enable prompt caching for claude-fable-5

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/model_features.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_features.py
@@ -146,6 +146,11 @@ PROMPT_CACHE_MODELS: list[str] = [
     "claude-opus-4-7",
     "claude-opus-4-8",
     "claude-sonnet-4-6",
+    # https://www.anthropic.com/news/claude-fable-5
+    # Listed explicitly because LiteLLM metadata does not yet recognize this
+    # model. Without it, prompt caching is silently disabled and every turn
+    # re-sends the full (growing) context at full price.
+    "claude-fable-5",
     # Do NOT add Gemini: explicit cache_control markers freeze its cache at the
     # static prefix and disable Google's implicit caching on the growing body
     # (~6-14x cost). Gemini uses implicit prefix caching instead.

--- a/tests/sdk/llm/test_model_features.py
+++ b/tests/sdk/llm/test_model_features.py
@@ -126,6 +126,12 @@ def test_extended_thinking_support(model, expected_extended_thinking):
         ("claude-sonnet-4-6", True),
         ("claude-opus-4-5", True),
         ("claude-opus-4-6", True),
+        # claude-fable-5 supports prompt caching but is too new for LiteLLM
+        # metadata, so it must be detected via the local allowlist across the
+        # raw, provider-prefixed, and litellm_proxy-prefixed forms.
+        ("claude-fable-5", True),
+        ("anthropic/claude-fable-5", True),
+        ("litellm_proxy/anthropic/claude-fable-5", True),
         # User-facing model names (no provider prefix)
         ("anthropic.claude-3-5-sonnet-20241022", True),
         ("anthropic.claude-3-haiku-20240307", True),


### PR DESCRIPTION
HUMAN:

This has been tested and needs to be merged to save costs.

  - [x] A human has tested these changes.

AGENT:

## Why

`claude-fable-5` is an Anthropic Claude model that supports prompt caching, but it was **missing from `PROMPT_CACHE_MODELS`** in `openhands/sdk/llm/utils/model_features.py`. It had already been added to `REASONING_EFFORT_MODELS` (because LiteLLM's metadata does not yet recognize the model), but the equivalent prompt-cache entry was never added.

As a result:
- `get_features(model).supports_prompt_cache` returned `False`
- `LLM.is_caching_prompt_active()` returned `False`
- `LLM._apply_prompt_caching()` was never called, so **no `cache_control` breakpoints were emitted**

Every agent turn then re-sent the full, growing conversation at full input price with **0% cache hits**, causing quadratic (O(n²)) token growth and dramatically inflated cost on long trajectories.

## Summary

- Add `claude-fable-5` to `PROMPT_CACHE_MODELS` so `cache_control` breakpoints are emitted and prompt caching activates for the model.
- Add test coverage for the raw, provider-prefixed, and `litellm_proxy`-prefixed model names.

## Evidence

This surfaced in a SWE-bench Multimodal smoke run for `litellm_proxy/anthropic/claude-fable-5`:
- A single instance (54 iterations) cost **$92.52**.
- `cache_read_tokens = 0` / `cache_write_tokens = 0` on every turn; all LLM calls logged `cache hit 0.00%`.
- Cumulative prompt tokens reached **3.85M** for one rollout.

With caching active, the bulk of those input tokens become cache reads (~10% of input price), which should cut input cost by roughly **85–90%**.

## Change

- Add `claude-fable-5` to `PROMPT_CACHE_MODELS`, mirroring how the same model is already handled in `REASONING_EFFORT_MODELS`.
- Add test coverage for the raw, provider-prefixed, and `litellm_proxy`-prefixed model names.

## How to Test

```
python -m pytest tests/sdk/llm/test_model_features.py -q
# 152 passed
```

Verified end-to-end that `get_features("litellm_proxy/anthropic/claude-fable-5").supports_prompt_cache` is now `True`.

---
_This PR was created by an AI agent (OpenHands) on behalf of the user._

@juanmichelini can click here to [continue refining the PR](https://staging.all-hands.dev/conversations/ed8abc74-7405-4cf6-8968-6c0c1c90bfe7)


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4295eb9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4295eb9-python \
  ghcr.io/openhands/agent-server:4295eb9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4295eb9-golang-amd64
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-golang-amd64
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-golang-amd64
ghcr.io/openhands/agent-server:4295eb9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4295eb9-golang-arm64
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-golang-arm64
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-golang-arm64
ghcr.io/openhands/agent-server:4295eb9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4295eb9-java-amd64
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-java-amd64
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-java-amd64
ghcr.io/openhands/agent-server:4295eb9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4295eb9-java-arm64
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-java-arm64
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-java-arm64
ghcr.io/openhands/agent-server:4295eb9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4295eb9-python-amd64
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-python-amd64
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-python-amd64
ghcr.io/openhands/agent-server:4295eb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4295eb9-python-arm64
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-python-arm64
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-python-arm64
ghcr.io/openhands/agent-server:4295eb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4295eb9-golang
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-golang
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-golang
ghcr.io/openhands/agent-server:4295eb9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4295eb9-java
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-java
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-java
ghcr.io/openhands/agent-server:4295eb9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4295eb9-python
ghcr.io/openhands/agent-server:4295eb9eaef6788167ff4dd2317eda65d7efc547-python
ghcr.io/openhands/agent-server:fix-enable-prompt-cache-claude-fable-5-python
ghcr.io/openhands/agent-server:4295eb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4295eb9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4295eb9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->