### PR TITLE
fix(sdk): pin lmnr below incompatible release

### DIFF
--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-json-logger>=3.3.0",
     "tenacity>=9.1.2",
     "websockets>=12",
-    "lmnr>=0.7.47",
+    "lmnr>=0.7.47,<0.7.53",
     "tree-sitter>=0.25",
     "tree-sitter-bash>=0.25",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -2529,7 +2529,7 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "joserfc", specifier = ">=1.0.0" },
     { name = "litellm", specifier = ">=1.84.1" },
-    { name = "lmnr", specifier = ">=0.7.47" },
+    { name = "lmnr", specifier = ">=0.7.47,<0.7.53" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:
This PR proposes the same fix pinning Laminar dependency as we did in extensions/ repo. The new version has removed a compatible argument, which makes automations built on the SDK fail.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [x] A human has tested these changes.

AGENT:

---

## Why

`lmnr` 0.7.53 removed the `rollout_entrypoint` argument from `observe()`, while the SDK's Laminar wrapper still forwards that argument. Fresh automation venvs resolving `openhands-sdk` with the previous `lmnr>=0.7.47` range could therefore install the incompatible Laminar release and fail immediately with `observe() got an unexpected keyword argument 'rollout_entrypoint'`.

This matches the mitigation in OpenHands/extensions#326, which constrains Laminar below 0.7.53.

## Summary

- Constrained the SDK dependency to `lmnr>=0.7.47,<0.7.53`.
- Refreshed `uv.lock` metadata so the workspace lock records the same dependency bound.

## Issue Number

N/A

## How to Test

Commands run:

```bash
make build
```

Result: completed successfully; the workspace resolved and installed dependencies with `lmnr==0.7.47`, satisfying the new upper bound.

```bash
uv run pre-commit run --files openhands-sdk/pyproject.toml uv.lock
```

Result: passed. Hooks with no matching files were skipped.

```bash
uv run python - <<'PY'
from pathlib import Path
from packaging.requirements import Requirement
import tomllib

with Path('openhands-sdk/pyproject.toml').open('rb') as f:
    deps = tomllib.load(f)['project']['dependencies']
lmnr = next(dep for dep in deps if dep.startswith('lmnr'))
req = Requirement(lmnr)
assert req.specifier.contains('0.7.52')
assert not req.specifier.contains('0.7.53')
print(lmnr)
PY
```

Result: printed `lmnr>=0.7.47,<0.7.53`.

## Video/Screenshots

N/A — dependency metadata-only fix validated with resolver/setup and requirement checks above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

Follow-up: once the SDK wrapper is updated for Laminar's 0.7.53+ API, this upper bound can be relaxed.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/53443759-104d-4af0-96a2-b4e539aa12f8)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e7fd321-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e7fd321-python \
  ghcr.io/openhands/agent-server:e7fd321-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e7fd321-golang-amd64
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-golang-amd64
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-golang-amd64
ghcr.io/openhands/agent-server:e7fd321-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e7fd321-golang-arm64
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-golang-arm64
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-golang-arm64
ghcr.io/openhands/agent-server:e7fd321-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e7fd321-java-amd64
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-java-amd64
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-java-amd64
ghcr.io/openhands/agent-server:e7fd321-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e7fd321-java-arm64
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-java-arm64
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-java-arm64
ghcr.io/openhands/agent-server:e7fd321-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e7fd321-python-amd64
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-python-amd64
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-python-amd64
ghcr.io/openhands/agent-server:e7fd321-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e7fd321-python-arm64
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-python-arm64
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-python-arm64
ghcr.io/openhands/agent-server:e7fd321-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e7fd321-golang
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-golang
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-golang
ghcr.io/openhands/agent-server:e7fd321-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e7fd321-java
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-java
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-java
ghcr.io/openhands/agent-server:e7fd321-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e7fd321-python
ghcr.io/openhands/agent-server:e7fd32110304110a03980be72a09880a55bcc3c5-python
ghcr.io/openhands/agent-server:fix-sdk-pin-lmnr-python
ghcr.io/openhands/agent-server:e7fd321-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e7fd321-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e7fd321-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->