### PR TITLE
[codex] Isolate ACP npx launches from npm env

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -127,6 +127,12 @@ _ACP_PROMPT_RETRY_DELAYS: tuple[float, ...] = (5.0, 15.0, 30.0)  # seconds
 # Exception types that indicate transient connection issues worth retrying
 _RETRIABLE_CONNECTION_ERRORS = (OSError, ConnectionError, BrokenPipeError, EOFError)
 
+# ``npm run`` exports package/lifecycle configuration into descendants. ACP
+# providers launched through ``npx`` must not inherit that context, otherwise npm
+# can try to resolve against the parent package instead of the requested one.
+_INHERITED_NPM_ENV_EXACT: frozenset[str] = frozenset({"INIT_CWD"})
+_INHERITED_NPM_ENV_PREFIXES: tuple[str, ...] = ("npm_", "NPM_")
+
 # JSON-RPC error codes from the ACP server that are transient and worth
 # retrying.  These map to server-side failures (HTTP 500 equivalents) where
 # the session state is still valid but the request failed.
@@ -187,6 +193,15 @@ def _fingerprint_session_id(session_id: str | None) -> str:
     if len(session_id) <= _SESSION_ID_LOG_SUFFIX_LEN:
         return "<short>"
     return f"...{session_id[-_SESSION_ID_LOG_SUFFIX_LEN:]}"
+
+
+def _strip_inherited_npm_env(env: dict[str, str]) -> None:
+    """Remove npm lifecycle/config variables inherited from the parent stack."""
+    for key in list(env):
+        if key in _INHERITED_NPM_ENV_EXACT or key.startswith(
+            _INHERITED_NPM_ENV_PREFIXES
+        ):
+            env.pop(key, None)
 
 
 # Limit for asyncio.StreamReader buffers used by the ACP subprocess pipes.
@@ -2094,6 +2109,7 @@ class ACPAgent(AgentBase):
         # provider credentials folded in by ACPAgentSettings.create_agent().
         env = default_environment()
         env.update(os.environ)
+        _strip_inherited_npm_env(env)
         if self.acp_env:
             warn_deprecated(
                 "ACPAgent.acp_env",

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -33,6 +33,7 @@ from openhands.sdk.agent.acp_agent import (
     _reapply_session_model_on_resume,
     _select_auth_method,
     _serialize_tool_content,
+    _strip_inherited_npm_env,
 )
 from openhands.sdk.agent.acp_models import ACPModelInfo
 from openhands.sdk.agent.base import AgentBase
@@ -115,6 +116,23 @@ class TestACPAgentInstantiation:
     def test_creates_with_empty_default_tools(self):
         agent = _make_agent()
         assert agent.include_default_tools == []
+
+    def test_strip_inherited_npm_env_keeps_subprocesses_out_of_parent_context(self):
+        env = {
+            "INIT_CWD": "/repo",
+            "npm_config_prefix": "/repo",
+            "npm_package_name": "parent-package",
+            "NPM_CONFIG_PREFIX": "/repo",
+            "PATH": "/usr/bin",
+            "USER_VALUE": "kept",
+        }
+
+        _strip_inherited_npm_env(env)
+
+        assert env == {
+            "PATH": "/usr/bin",
+            "USER_VALUE": "kept",
+        }
 
     def test_requires_acp_command(self):
         with pytest.raises(Exception):


### PR DESCRIPTION
## Summary
- Strip inherited `npm_*`, `NPM_*`, and `INIT_CWD` variables from ACP subprocess environments.
- Preserve normal ambient environment, registry secrets, materialized file secrets, and explicit `acp_env` precedence.
- Add unit coverage for the npm environment scrubber.

## Root Cause
When the agent-server is launched through `npm run dev`, npm lifecycle/config variables are inherited by descendants. ACP providers launched through `npx` can then resolve against the parent `agent-canvas` package context instead of the requested ACP package, causing the subprocess to exit before ACP initialization.

## Validation
- `uv run pytest tests/sdk/agent/test_acp_agent.py -k strip_inherited_npm_env -q`
- Manual local smoke: started an ACP/Codex conversation and sent a follow-up through the agent-canvas ingress; both prompts completed.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3fe1317-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3fe1317-python \
  ghcr.io/openhands/agent-server:3fe1317-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3fe1317-golang-amd64
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-golang-amd64
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-golang-amd64
ghcr.io/openhands/agent-server:3fe1317-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3fe1317-golang-arm64
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-golang-arm64
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-golang-arm64
ghcr.io/openhands/agent-server:3fe1317-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3fe1317-java-amd64
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-java-amd64
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-java-amd64
ghcr.io/openhands/agent-server:3fe1317-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3fe1317-java-arm64
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-java-arm64
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-java-arm64
ghcr.io/openhands/agent-server:3fe1317-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3fe1317-python-amd64
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-python-amd64
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-python-amd64
ghcr.io/openhands/agent-server:3fe1317-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3fe1317-python-arm64
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-python-arm64
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-python-arm64
ghcr.io/openhands/agent-server:3fe1317-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3fe1317-golang
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-golang
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-golang
ghcr.io/openhands/agent-server:3fe1317-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3fe1317-java
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-java
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-java
ghcr.io/openhands/agent-server:3fe1317-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3fe1317-python
ghcr.io/openhands/agent-server:3fe1317fa76575c747f4d3f99fd5c60aaba2270d-python
ghcr.io/openhands/agent-server:codex-acp-strip-inherited-npm-env-python
ghcr.io/openhands/agent-server:3fe1317-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3fe1317-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3fe1317-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->