### PR TITLE
Release v1.28.1

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -26,7 +26,8 @@ on:
             sdk_ref:
                 description: SDK commit/ref to evaluate (must be a semantic version like v1.0.0 unless 'Allow unreleased branches' is checked)
                 required: true
-                default: v1.28.0
+                default: v1.28.1
+
 
 
 

--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-agent-server"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands Agent Server - REST/WebSocket interface for OpenHands AI Agent"
 
 requires-python = ">=3.12"

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     "python-json-logger>=3.3.0",
     "tenacity>=9.1.2",
     "websockets>=12",
-    "lmnr>=0.7.47",
+    "lmnr>=0.7.47,<0.7.53",
     "tree-sitter>=0.25",
     "tree-sitter-bash>=0.25",
 ]

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-sdk"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-tools"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands Tools - Runtime tools for AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-workspace/pyproject.toml
+++ b/openhands-workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-workspace"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands Workspace - Docker and container-based workspace implementations"
 
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2529,7 +2529,7 @@ requires-dist = [
     { name = "httpx", extras = ["socks"], specifier = ">=0.27.0" },
     { name = "joserfc", specifier = ">=1.0.0" },
     { name = "litellm", specifier = ">=1.84.1" },
-    { name = "lmnr", specifier = ">=0.7.47" },
+    { name = "lmnr", specifier = ">=0.7.47,<0.7.53" },
     { name = "pillow", specifier = ">=12.1.1" },
     { name = "pydantic", specifier = ">=2.12.5" },
     { name = "python-frontmatter", specifier = ">=1.1.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -2458,7 +2458,7 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2491,7 +2491,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-sdk" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2543,7 +2543,7 @@ provides-extras = ["boto3"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-tools" }
 dependencies = [
     { name = "binaryornot" },
@@ -2574,7 +2574,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-workspace" }
 dependencies = [
     { name = "openhands-agent-server" },


### PR DESCRIPTION
## Release v1.28.1

This PR prepares the patch release for version **1.28.1**, cherry-picking one critical bug fix from `main` on top of `v1.28.0`.

### What's included

- **fix(sdk): pin lmnr below incompatible release** (#3662) — `lmnr` 0.7.53 removed the `rollout_entrypoint` argument from `observe()`, causing fresh automation venvs to fail immediately. This constrains `lmnr>=0.7.47,<0.7.53`.

### Release Checklist
- [x] Version set to 1.28.1
- [ ] Fix any deprecation deadlines if they exist
- [ ] Integration tests pass (tagged with `integration-test`)
- [ ] Behavior tests pass (tagged with `behavior-test`)
- [ ] Example tests pass (tagged with `test-examples`)
- [ ] Confirm any `release-note-required` PRs are accurately called out in the final release notes

### What happens on merge
When this PR is merged, the `create-release.yml` workflow will automatically:
1. Create a GitHub release with tag `v1.28.1` and auto-generated notes
2. Trigger `pypi-release.yml` to publish all packages to PyPI
3. Trigger `version-bump-prs.yml` to create downstream version bump PRs

_This PR was prepared by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:edaac80-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-edaac80-python \
  ghcr.io/openhands/agent-server:edaac80-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:edaac80-golang-amd64
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-golang-amd64
ghcr.io/openhands/agent-server:rel-1.28.1-golang-amd64
ghcr.io/openhands/agent-server:edaac80-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:edaac80-golang-arm64
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-golang-arm64
ghcr.io/openhands/agent-server:rel-1.28.1-golang-arm64
ghcr.io/openhands/agent-server:edaac80-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:edaac80-java-amd64
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-java-amd64
ghcr.io/openhands/agent-server:rel-1.28.1-java-amd64
ghcr.io/openhands/agent-server:edaac80-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:edaac80-java-arm64
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-java-arm64
ghcr.io/openhands/agent-server:rel-1.28.1-java-arm64
ghcr.io/openhands/agent-server:edaac80-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:edaac80-python-amd64
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-python-amd64
ghcr.io/openhands/agent-server:rel-1.28.1-python-amd64
ghcr.io/openhands/agent-server:edaac80-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:edaac80-python-arm64
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-python-arm64
ghcr.io/openhands/agent-server:rel-1.28.1-python-arm64
ghcr.io/openhands/agent-server:edaac80-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:edaac80-golang
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-golang
ghcr.io/openhands/agent-server:rel-1.28.1-golang
ghcr.io/openhands/agent-server:edaac80-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:edaac80-java
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-java
ghcr.io/openhands/agent-server:rel-1.28.1-java
ghcr.io/openhands/agent-server:edaac80-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:edaac80-python
ghcr.io/openhands/agent-server:edaac806d1599a4ee1662fd4008fbcd7b537ecd1-python
ghcr.io/openhands/agent-server:rel-1.28.1-python
ghcr.io/openhands/agent-server:edaac80-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `edaac80-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `edaac80-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->