### PR TITLE
[codex] fix ACP MCP auth forwarding

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -30,8 +30,7 @@ jobs:
 
             - name: Install oasdiff
               run: |
-                  OASDIFF_VERSION=1.18.6
-                  curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version="${OASDIFF_VERSION}" sh
+                  curl -L https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh -s -- -b /usr/local/bin
                   oasdiff --version
 
             - name: Run agent server REST API breakage check

--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -30,7 +30,8 @@ jobs:
 
             - name: Install oasdiff
               run: |
-                  curl -L https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh -s -- -b /usr/local/bin
+                  OASDIFF_VERSION=1.18.6
+                  curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version="${OASDIFF_VERSION}" sh
                   oasdiff --version
 
             - name: Run agent server REST API breakage check

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -400,6 +400,28 @@ def _extract_session_models(
 _ACPMcpServer = HttpMcpServer | SseMcpServer | McpServerStdio
 
 
+def _remote_mcp_headers(spec: dict[str, Any], name: str) -> list[HttpHeader]:
+    """Convert remote MCP headers/auth into ACP's header-only representation."""
+    raw_headers = spec.get("headers") or {}
+    headers = [
+        HttpHeader(name=str(k), value=str(v)) for k, v in raw_headers.items()
+    ]
+
+    auth = spec.get("auth")
+    has_authorization = any(h.name.lower() == "authorization" for h in headers)
+    if auth and not has_authorization:
+        if isinstance(auth, str) and auth != "oauth":
+            headers.append(HttpHeader(name="Authorization", value=f"Bearer {auth}"))
+        else:
+            logger.warning(
+                "ACP MCP server %r uses unsupported remote MCP auth type %r; "
+                "only explicit headers or string bearer tokens can be forwarded",
+                name,
+                type(auth).__name__,
+            )
+    return headers
+
+
 def _mcp_config_to_acp_servers(
     mcp_config: dict[str, Any],
     mcp_capabilities: Any,
@@ -427,7 +449,9 @@ def _mcp_config_to_acp_servers(
     A remote server whose transport the ACP server does not advertise is dropped
     with a warning rather than failing init — one misconfigured server should
     not sink the whole conversation.  ``env`` / ``headers`` maps are converted
-    to the protocol's ``[{name, value}]`` list form; their values were already
+    to the protocol's ``[{name, value}]`` list form; string ``auth`` values are
+    forwarded as bearer ``Authorization`` headers when no explicit
+    ``Authorization`` header is already present.  Their values were already
     decrypted by :class:`AgentBase`'s ``mcp_config`` validator.
     """
     servers = mcp_config.get("mcpServers")
@@ -456,10 +480,7 @@ def _mcp_config_to_acp_servers(
                 )
             )
         elif url:
-            headers = [
-                HttpHeader(name=str(k), value=str(v))
-                for k, v in (spec.get("headers") or {}).items()
-            ]
+            headers = _remote_mcp_headers(spec, str(name))
             is_sse = str(spec.get("transport") or "http").lower() == "sse"
             if not (sse_ok if is_sse else http_ok):
                 logger.warning(

--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -403,9 +403,7 @@ _ACPMcpServer = HttpMcpServer | SseMcpServer | McpServerStdio
 def _remote_mcp_headers(spec: dict[str, Any], name: str) -> list[HttpHeader]:
     """Convert remote MCP headers/auth into ACP's header-only representation."""
     raw_headers = spec.get("headers") or {}
-    headers = [
-        HttpHeader(name=str(k), value=str(v)) for k, v in raw_headers.items()
-    ]
+    headers = [HttpHeader(name=str(k), value=str(v)) for k, v in raw_headers.items()]
 
     auth = spec.get("auth")
     has_authorization = any(h.name.lower() == "authorization" for h in headers)

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -7117,6 +7117,39 @@ class TestMcpConfigToAcpServers:
             ("Authorization", "Bearer y")
         ]
 
+    def test_http_auth_maps_to_bearer_header(self):
+        from acp.schema import HttpMcpServer
+
+        cfg = {
+            "mcpServers": {
+                "remote": {
+                    "url": "https://h/mcp",
+                    "auth": "token-y",
+                }
+            }
+        }
+        out = _mcp_config_to_acp_servers(cfg, self._caps(http=True, sse=False))
+        assert len(out) == 1
+        assert isinstance(out[0], HttpMcpServer)
+        assert [(h.name, h.value) for h in out[0].headers] == [
+            ("Authorization", "Bearer token-y")
+        ]
+
+    def test_http_auth_does_not_override_authorization_header(self):
+        cfg = {
+            "mcpServers": {
+                "remote": {
+                    "url": "https://h/mcp",
+                    "headers": {"authorization": "Bearer explicit"},
+                    "auth": "token-y",
+                }
+            }
+        }
+        out = _mcp_config_to_acp_servers(cfg, self._caps(http=True, sse=False))
+        assert [(h.name, h.value) for h in out[0].headers] == [
+            ("authorization", "Bearer explicit")
+        ]
+
     def test_sse_gated_on_capability(self):
         from acp.schema import SseMcpServer
 


### PR DESCRIPTION
HUMAN:

Graham has personally tested these changes and found that the behavior was broken before this PR and fixed after it.

- [x] A human has tested these changes.

AGENT:

---

## Why

The normal SDK MCP client understands remote MCP `auth`, but ACP session creation can only receive MCP headers. ACP forwarding passed `headers` through and dropped string `auth`, so authenticated remote MCP servers could be visible in settings but unavailable to ACP providers like Codex.

## Summary

- Translate FastMCP-style remote MCP `auth` into ACP-compatible bearer headers.
- Preserve explicit Authorization headers when both `headers` and `auth` are configured.
- Add regression coverage for ACP MCP auth forwarding.

## Issue Number

Fixes #3668

## How to Test

- `uv run --project /home/gneubig/work/software-agent-sdk pytest tests/sdk/agent/test_acp_agent.py -q`
- `uv run --project /home/gneubig/work/software-agent-sdk ruff check openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py`
- OpenHands QA exercised a real `Conversation.run()` / `ACPAgent` path with a local ACP-compatible stdio server and verified `auth: "token-y"` is forwarded as `Authorization: Bearer token-y` while explicit Authorization headers are preserved.

## Video/Screenshots

N/A; this is a backend SDK/ACP integration change. The QA report on this PR includes captured `session/new` payloads from functional verification.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The PR description check still requires a human-authored note above and the human-tested checkbox to be checked before the PR can be merge-ready.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:28bd93e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-28bd93e-python \
  ghcr.io/openhands/agent-server:28bd93e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:28bd93e-golang-amd64
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-golang-amd64
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-golang-amd64
ghcr.io/openhands/agent-server:28bd93e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:28bd93e-golang-arm64
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-golang-arm64
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-golang-arm64
ghcr.io/openhands/agent-server:28bd93e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:28bd93e-java-amd64
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-java-amd64
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-java-amd64
ghcr.io/openhands/agent-server:28bd93e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:28bd93e-java-arm64
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-java-arm64
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-java-arm64
ghcr.io/openhands/agent-server:28bd93e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:28bd93e-python-amd64
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-python-amd64
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-python-amd64
ghcr.io/openhands/agent-server:28bd93e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:28bd93e-python-arm64
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-python-arm64
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-python-arm64
ghcr.io/openhands/agent-server:28bd93e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:28bd93e-golang
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-golang
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-golang
ghcr.io/openhands/agent-server:28bd93e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:28bd93e-java
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-java
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-java
ghcr.io/openhands/agent-server:28bd93e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:28bd93e-python
ghcr.io/openhands/agent-server:28bd93e93068231d1e596ece2239583b587bebe9-python
ghcr.io/openhands/agent-server:codex-acp-mcp-auth-forwarding-python
ghcr.io/openhands/agent-server:28bd93e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `28bd93e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `28bd93e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

