### PR TITLE
Serve bundled agent-canvas frontend from agent-server

### DIFF
--- a/.github/scripts/fetch_agent_canvas_frontend.py
+++ b/.github/scripts/fetch_agent_canvas_frontend.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Fetch the prebuilt agent-canvas frontend into openhands-agent-server."""
+
+import argparse
+import shutil
+import subprocess
+import tarfile
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_TARGET = (
+    REPO_ROOT / "openhands-agent-server" / "openhands" / "agent_server" / "frontend"
+)
+DEFAULT_PACKAGE = "@openhands/agent-canvas"
+DEFAULT_VERSION = "1.0.0-rc.7"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Download the published agent-canvas build for packaging."
+    )
+    parser.add_argument("--package", default=DEFAULT_PACKAGE)
+    parser.add_argument("--version", default=DEFAULT_VERSION)
+    parser.add_argument("--target", type=Path, default=DEFAULT_TARGET)
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    package_spec = f"{args.package}@{args.version}" if args.version else args.package
+    target = args.target.resolve()
+
+    with tempfile.TemporaryDirectory(prefix="agent-canvas-frontend-") as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        subprocess.run(
+            ["npm", "pack", package_spec, "--pack-destination", str(tmp_path)],
+            check=True,
+        )
+        tarballs = list(tmp_path.glob("*.tgz"))
+        if len(tarballs) != 1:
+            raise RuntimeError(f"Expected one npm tarball, found {len(tarballs)}")
+
+        with tarfile.open(tarballs[0]) as tar:
+            tar.extractall(tmp_path, filter="data")
+
+        build_dir = tmp_path / "package" / "build"
+        index_path = build_dir / "index.html"
+        if not index_path.is_file():
+            raise RuntimeError(f"agent-canvas build missing index.html: {index_path}")
+
+        if target.exists():
+            shutil.rmtree(target)
+        shutil.copytree(build_dir, target)
+
+    print(f"Fetched {package_spec} frontend into {target}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/pypi-release.yml
+++ b/.github/workflows/pypi-release.yml
@@ -66,6 +66,9 @@ jobs:
                     openhands-agent-server
                   )
 
+                  echo "🚀 Fetching agent-canvas frontend..."
+                  python .github/scripts/fetch_agent_canvas_frontend.py
+
                   echo "🚀 Building and publishing all packages..."
                   for PKG in "${PACKAGES[@]}"; do
                     echo "===== $PKG ====="

--- a/.gitignore
+++ b/.gitignore
@@ -213,5 +213,8 @@ agent-sdk.workspace.code-workspace
 tests/integration/outputs/
 tests/integration/api_compliance/outputs/
 
+# Generated release assets
+openhands-agent-server/openhands/agent_server/frontend/
+
 # Agent-generated temp
 .agent_tmp/

--- a/openhands-agent-server/openhands/agent_server/agent-server.spec
+++ b/openhands-agent-server/openhands/agent_server/agent-server.spec
@@ -92,6 +92,9 @@ a = Analysis(
         # task_tool_set description.
         *collect_data_files("openhands.tools.preset", includes=["subagents/*.md"]),
 
+        # Optional bundled agent-canvas frontend assets.
+        *collect_data_files("openhands.agent_server", includes=["frontend/**/*"]),
+
         # Package metadata for importlib.metadata
         *copy_metadata("openhands-agent-server"),
         *copy_metadata("openhands-sdk"),

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -12,7 +12,7 @@ from urllib.parse import urlparse
 import libtmux
 from fastapi import APIRouter, Depends, FastAPI, HTTPException
 from fastapi.exceptions import RequestValidationError
-from fastapi.responses import JSONResponse, RedirectResponse
+from fastapi.responses import FileResponse, JSONResponse, RedirectResponse
 from fastapi.staticfiles import StaticFiles
 from starlette.requests import Request
 
@@ -36,6 +36,7 @@ from openhands.agent_server.desktop_router import desktop_router
 from openhands.agent_server.desktop_service import get_desktop_service
 from openhands.agent_server.event_router import event_router
 from openhands.agent_server.file_router import file_router
+from openhands.agent_server.frontend import is_frontend_path
 from openhands.agent_server.git_router import git_router
 from openhands.agent_server.hooks_router import hooks_router
 from openhands.agent_server.llm_router import llm_router
@@ -345,6 +346,44 @@ def _add_api_routes(app: FastAPI, config: Config) -> None:
     app.include_router(sockets_router)
 
 
+_FRONTEND_REJECT_PREFIXES = (
+    "/api",
+    "/sockets",
+    "/server_info",
+    "/health",
+    "/ready",
+    "/alive",
+    "/docs",
+    "/redoc",
+    "/openapi.json",
+    "/static",
+)
+
+
+def _matches_frontend_reject_prefix(path: str) -> bool:
+    request_path = f"/{path.lstrip('/')}"
+    return any(
+        request_path == prefix or request_path.startswith(f"{prefix}/")
+        for prefix in _FRONTEND_REJECT_PREFIXES
+    )
+
+
+def _resolve_frontend_file(frontend_dir: Path, path: str) -> Path | None:
+    frontend_root = frontend_dir.resolve()
+    file_path = (frontend_root / path).resolve()
+    try:
+        file_path.relative_to(frontend_root)
+    except ValueError:
+        return None
+    if file_path.is_file():
+        return file_path
+    return None
+
+
+def _is_asset_request(path: str) -> bool:
+    return bool(Path(path).suffix)
+
+
 def _setup_static_files(app: FastAPI, config: Config) -> None:
     """Set up static file serving and root redirect if configured.
 
@@ -352,14 +391,16 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
         app: FastAPI application instance.
         config: Configuration object containing static files settings.
     """
+    has_frontend = is_frontend_path(config.frontend_files_path)
+
     # Only proceed if static files are configured and directory exists
     if not (
         config.static_files_path
         and config.static_files_path.exists()
         and config.static_files_path.is_dir()
     ):
-        # Map the root path to server info if there are no static files
-        app.get("/", tags=["Server Details"])(get_server_info)
+        if not has_frontend:
+            app.get("/", tags=["Server Details"])(get_server_info)
         return
 
     # Mount static files directory
@@ -368,6 +409,9 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
         StaticFiles(directory=str(config.static_files_path)),
         name="static",
     )
+
+    if has_frontend:
+        return
 
     # Add root redirect to static files
     @app.get("/", tags=["Server Details"])
@@ -381,6 +425,30 @@ def _setup_static_files(app: FastAPI, config: Config) -> None:
             return RedirectResponse(url="/static/index.html", status_code=302)
         else:
             return RedirectResponse(url="/static/", status_code=302)
+
+
+def _setup_frontend_files(app: FastAPI, config: Config) -> None:
+    """Serve the bundled agent-canvas SPA when frontend assets are available."""
+    if not is_frontend_path(config.frontend_files_path):
+        return
+
+    frontend_dir = config.frontend_files_path
+    assert frontend_dir is not None
+    index_path = frontend_dir / "index.html"
+
+    async def serve_frontend(path: str = ""):
+        if _matches_frontend_reject_prefix(path):
+            raise HTTPException(status_code=404, detail="Not Found")
+
+        file_path = _resolve_frontend_file(frontend_dir, path)
+        if file_path is not None:
+            return FileResponse(file_path)
+        if _is_asset_request(path):
+            raise HTTPException(status_code=404, detail="Not Found")
+        return FileResponse(index_path)
+
+    app.get("/", include_in_schema=False)(serve_frontend)
+    app.get("/{path:path}", include_in_schema=False)(serve_frontend)
 
 
 def _sanitize_validation_errors(errors: Sequence[Any]) -> list[dict]:
@@ -555,6 +623,7 @@ def create_app(config: Config | None = None) -> FastAPI:
 
     _add_api_routes(app, config)
     _setup_static_files(app, config)
+    _setup_frontend_files(app, config)
     app.add_middleware(CORSDispatcher, allow_origins=config.allow_cors_origins)
     _add_exception_handlers(app)
 

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
 from openhands.agent_server.env_parser import from_env
+from openhands.agent_server.frontend import get_bundled_frontend_path
 from openhands.sdk.utils.cipher import Cipher
 
 
@@ -164,6 +165,14 @@ class Config(BaseModel):
             "The location of the directory containing static files to serve. "
             "If specified and the directory exists, static files will be served "
             "at the /static/ endpoint."
+        ),
+    )
+    frontend_files_path: Path | None = Field(
+        default_factory=get_bundled_frontend_path,
+        description=(
+            "The location of the agent-canvas frontend build to serve at /. "
+            "Defaults to bundled frontend assets when they are packaged with "
+            "openhands-agent-server."
         ),
     )
     webhooks: list[WebhookSpec] = Field(

--- a/openhands-agent-server/openhands/agent_server/frontend.py
+++ b/openhands-agent-server/openhands/agent_server/frontend.py
@@ -1,0 +1,14 @@
+from pathlib import Path
+
+
+BUNDLED_FRONTEND_PATH = Path(__file__).parent / "frontend"
+
+
+def is_frontend_path(path: Path | None) -> bool:
+    return bool(path and path.is_dir() and (path / "index.html").is_file())
+
+
+def get_bundled_frontend_path() -> Path | None:
+    if is_frontend_path(BUNDLED_FRONTEND_PATH):
+        return BUNDLED_FRONTEND_PATH
+    return None

--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -38,10 +38,11 @@ namespaces = true
 
 [tool.setuptools.package-data]
 "*" = ["py.typed"]
-# Include Docker-related files and VSCode extensions
+# Include runtime data files bundled with the agent-server package
 "openhands.agent_server" = [
   "docker/Dockerfile",
   "docker/wallpaper.svg",
+  "frontend/**/*",
   "vscode_extensions/**/*.json",
   "vscode_extensions/**/*.js",
 ]

--- a/tests/agent_server/test_api.py
+++ b/tests/agent_server/test_api.py
@@ -260,6 +260,62 @@ class TestRootRedirect:
         assert response.status_code == 200
 
 
+def test_frontend_files_served_from_root(tmp_path):
+    index = tmp_path / "index.html"
+    index.write_text('<script type="module" src="/assets/app.js"></script>')
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    (assets / "app.js").write_text("console.log('agent-canvas')")
+    (tmp_path / "favicon.svg").write_text("<svg></svg>")
+
+    app = create_app(Config(static_files_path=None, frontend_files_path=tmp_path))
+    client = TestClient(app)
+
+    root_response = client.get("/")
+    assert root_response.status_code == 200
+    assert root_response.text == index.read_text()
+    assert "text/html" in root_response.headers["content-type"]
+
+    asset_response = client.get("/assets/app.js")
+    assert asset_response.status_code == 200
+    assert asset_response.text == "console.log('agent-canvas')"
+    assert "javascript" in asset_response.headers["content-type"]
+
+    favicon_response = client.get("/favicon.svg")
+    assert favicon_response.status_code == 200
+    assert favicon_response.text == "<svg></svg>"
+
+
+def test_frontend_files_fallback_to_index_for_spa_routes(tmp_path):
+    index_content = "<html><body>agent canvas</body></html>"
+    (tmp_path / "index.html").write_text(index_content)
+
+    app = create_app(Config(static_files_path=None, frontend_files_path=tmp_path))
+    client = TestClient(app)
+
+    response = client.get("/settings/llm")
+    assert response.status_code == 200
+    assert response.text == index_content
+
+
+def test_frontend_files_do_not_fallback_for_missing_assets_or_api_paths(tmp_path):
+    (tmp_path / "index.html").write_text("<html><body>agent canvas</body></html>")
+
+    app = create_app(Config(static_files_path=None, frontend_files_path=tmp_path))
+    client = TestClient(app)
+
+    missing_asset_response = client.get("/assets/missing.js")
+    assert missing_asset_response.status_code == 404
+
+    missing_api_response = client.get("/api/not-a-real-route")
+    assert missing_api_response.status_code == 404
+    assert missing_api_response.headers["content-type"].startswith("application/json")
+
+    server_info_response = client.get("/server_info")
+    assert server_info_response.status_code == 200
+    assert server_info_response.headers["content-type"].startswith("application/json")
+
+
 class TestServiceParallelization:
     """Test that services are started and stopped in parallel."""
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [ ] A human has tested these changes.

AGENT:

---

## Why

Fixes #3658. Python-only users should be able to start `agent-server` and get the agent-canvas UI from the same process/port when the prebuilt frontend is packaged with `openhands-agent-server`.

## Summary

- Adds bundled frontend path detection and an `OH_FRONTEND_FILES_PATH`-configurable frontend build path.
- Serves agent-canvas root-relative assets and SPA fallback routes from FastAPI after API/WebSocket routes, while keeping API-like paths from falling back to `index.html`.
- Adds package/PyInstaller data inclusion and a release helper that fetches the published `@openhands/agent-canvas` build before PyPI package builds.

## Issue Number

Fixes #3658

## How to Test

- `uv run pytest tests/agent_server/test_api.py -q` — 44 passed.
- `uv run pre-commit run --files .gitignore openhands-agent-server/openhands/agent_server/api.py openhands-agent-server/openhands/agent_server/config.py openhands-agent-server/openhands/agent_server/frontend.py openhands-agent-server/openhands/agent_server/agent-server.spec openhands-agent-server/pyproject.toml tests/agent_server/test_api.py .github/scripts/fetch_agent_canvas_frontend.py .github/workflows/pypi-release.yml` — passed.
- Created a temporary fake `openhands-agent-server/openhands/agent_server/frontend/` build, ran `uv build --package openhands-agent-server --wheel --out-dir /tmp/agent-server-build-test`, and verified the wheel contained `openhands/agent_server/frontend/index.html` and `openhands/agent_server/frontend/assets/app.js`.
- Ran `python .github/scripts/fetch_agent_canvas_frontend.py --target /tmp/agent-canvas-frontend-test` and verified the fetched package produced `/tmp/agent-canvas-frontend-test/index.html` and an `assets/` directory.

## Video/Screenshots

No screenshot was captured. The FastAPI route behavior was exercised with `TestClient`: `/` serves `index.html`, `/assets/app.js` serves a real root-relative asset, SPA routes fall back to `index.html`, missing assets return 404, and missing `/api/*` paths return JSON 404s instead of frontend HTML.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The generated frontend asset directory is intentionally git-ignored; the PyPI release workflow fetches the published agent-canvas build before building distributions so the files are included by package data without committing thousands of generated frontend files.

_This PR was created by an AI agent (OpenHands) on behalf of the requester._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/30dea639-12ff-4928-be1c-b26f5049964b)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:172bc34-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-172bc34-python \
  ghcr.io/openhands/agent-server:172bc34-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:172bc34-golang-amd64
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-golang-amd64
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-golang-amd64
ghcr.io/openhands/agent-server:172bc34-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:172bc34-golang-arm64
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-golang-arm64
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-golang-arm64
ghcr.io/openhands/agent-server:172bc34-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:172bc34-java-amd64
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-java-amd64
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-java-amd64
ghcr.io/openhands/agent-server:172bc34-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:172bc34-java-arm64
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-java-arm64
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-java-arm64
ghcr.io/openhands/agent-server:172bc34-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:172bc34-python-amd64
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-python-amd64
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-python-amd64
ghcr.io/openhands/agent-server:172bc34-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:172bc34-python-arm64
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-python-arm64
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-python-arm64
ghcr.io/openhands/agent-server:172bc34-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:172bc34-golang
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-golang
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-golang
ghcr.io/openhands/agent-server:172bc34-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:172bc34-java
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-java
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-java
ghcr.io/openhands/agent-server:172bc34-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:172bc34-python
ghcr.io/openhands/agent-server:172bc348510384f1826664aaaa2039ace4788a10-python
ghcr.io/openhands/agent-server:openhands-start-agent-canvas-frontend-python
ghcr.io/openhands/agent-server:172bc34-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `172bc34-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `172bc34-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->