### PR TITLE
Sync v1.28.1 release bookkeeping

### DIFF
--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -26,7 +26,7 @@ on:
             sdk_ref:
                 description: SDK commit/ref to evaluate (must be a semantic version like v1.0.0 unless 'Allow unreleased branches' is checked)
                 required: true
-                default: v1.28.0
+                default: v1.28.1
 
 
 

--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-agent-server"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands Agent Server - REST/WebSocket interface for OpenHands AI Agent"
 
 requires-python = ">=3.12"

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-sdk"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-tools"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands Tools - Runtime tools for AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-workspace/pyproject.toml
+++ b/openhands-workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-workspace"
-version = "1.28.0"
+version = "1.28.1"
 description = "OpenHands Workspace - Docker and container-based workspace implementations"
 
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2458,7 +2458,7 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2491,7 +2491,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-sdk" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2543,7 +2543,7 @@ provides-extras = ["boto3"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-tools" }
 dependencies = [
     { name = "binaryornot" },
@@ -2574,7 +2574,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.28.0"
+version = "1.28.1"
 source = { editable = "openhands-workspace" }
 dependencies = [
     { name = "openhands-agent-server" },


### PR DESCRIPTION
## Summary
- update the default `sdk_ref` in `run-eval.yml` from `v1.28.0` to `v1.28.1`
- sync package versions and `uv.lock` to `1.28.1`, matching the already-published patch release

## Context
The v1.28.1 patch release was published from `rel-1.28.1`, but that release PR was closed unmerged. This PR lands the bookkeeping that would normally come through the release PR without using a `rel-*` branch.

## Validation
- `uv run pre-commit run --files .github/workflows/run-eval.yml openhands-agent-server/pyproject.toml openhands-sdk/pyproject.toml openhands-tools/pyproject.toml openhands-workspace/pyproject.toml uv.lock`

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/3e32e629-fc77-4c95-b2dc-ed7337726c33)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dc35ee3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dc35ee3-python \
  ghcr.io/openhands/agent-server:dc35ee3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dc35ee3-golang-amd64
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-golang-amd64
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-golang-amd64
ghcr.io/openhands/agent-server:dc35ee3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dc35ee3-golang-arm64
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-golang-arm64
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-golang-arm64
ghcr.io/openhands/agent-server:dc35ee3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dc35ee3-java-amd64
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-java-amd64
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-java-amd64
ghcr.io/openhands/agent-server:dc35ee3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dc35ee3-java-arm64
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-java-arm64
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-java-arm64
ghcr.io/openhands/agent-server:dc35ee3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dc35ee3-python-amd64
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-python-amd64
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-python-amd64
ghcr.io/openhands/agent-server:dc35ee3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dc35ee3-python-arm64
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-python-arm64
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-python-arm64
ghcr.io/openhands/agent-server:dc35ee3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dc35ee3-golang
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-golang
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-golang
ghcr.io/openhands/agent-server:dc35ee3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:dc35ee3-java
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-java
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-java
ghcr.io/openhands/agent-server:dc35ee3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:dc35ee3-python
ghcr.io/openhands/agent-server:dc35ee38336466719c743acc72155a6ed859c378-python
ghcr.io/openhands/agent-server:chore-sync-v1-28-1-bookkeeping-python
ghcr.io/openhands/agent-server:dc35ee3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dc35ee3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dc35ee3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->