### PR TITLE
feat: load multiple org/user skill repositories per request

### DIFF
--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -102,8 +102,16 @@ class SkillsRequest(BaseModel):
     project_dir: str | None = Field(
         default=None, description="Workspace directory path for project skills"
     )
+    org_configs: list[OrgConfig] | None = Field(
+        default=None,
+        description="Organization/user skill repositories to load concurrently",
+    )
     org_config: OrgConfig | None = Field(
-        default=None, description="Organization skills configuration"
+        default=None,
+        description=(
+            "Deprecated single organization skills configuration. Kept for "
+            "backward compatibility; prefer org_configs."
+        ),
     )
     sandbox_config: SandboxConfig | None = Field(
         default=None, description="Sandbox skills configuration"
@@ -268,11 +276,13 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
             for url in request.sandbox_config.exposed_urls
         ]
 
-    org_repo_url = None
-    org_name = None
-    if request.org_config:
-        org_repo_url = request.org_config.org_repo_url
-        org_name = request.org_config.org_name
+    # Prefer the list form; fall back to the deprecated single org_config so
+    # older app-servers keep working.
+    org_repos: list[tuple[str, str]] = []
+    if request.org_configs:
+        org_repos = [(c.org_repo_url, c.org_name) for c in request.org_configs]
+    elif request.org_config:
+        org_repos = [(request.org_config.org_repo_url, request.org_config.org_name)]
 
     # Call the service
     result = load_all_skills(
@@ -281,8 +291,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
         load_project=request.load_project,
         load_org=request.load_org,
         project_dir=request.project_dir,
-        org_repo_url=org_repo_url,
-        org_name=org_name,
+        org_repos=org_repos,
         sandbox_exposed_urls=sandbox_urls,
         marketplace_path=request.marketplace_path,
     )

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -108,9 +108,10 @@ class SkillsRequest(BaseModel):
     )
     org_config: OrgConfig | None = Field(
         default=None,
+        deprecated=True,
         description=(
-            "Deprecated single organization skills configuration. Kept for "
-            "backward compatibility; prefer org_configs."
+            "Deprecated since v1.28.0 and scheduled for removal in v1.33.0. "
+            "Single organization skills configuration; prefer org_configs."
         ),
     )
     sandbox_config: SandboxConfig | None = Field(
@@ -281,7 +282,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
     org_repos: list[tuple[str, str]] = []
     if request.org_configs:
         org_repos = [(c.org_repo_url, c.org_name) for c in request.org_configs]
-    elif request.org_config:
+    elif "org_config" in request.model_fields_set and request.org_config:
         org_repos = [(request.org_config.org_repo_url, request.org_config.org_name)]
 
     # Call the service

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -366,8 +366,9 @@ def load_all_skills(
                     f"Failed to load organization skills for {org_name}: {e}"
                 )
         org_skills = merge_skills(per_repo_skills)
-        if org_skills:
-            logger.info(f"Loaded {len(org_skills)} organization skills")
+        # Always log the count (including 0) so a failed/empty org load is
+        # visible when org loading was requested.
+        logger.info(f"Loaded {len(org_skills)} organization skills")
     sources["org"] = len(org_skills)
     skill_lists.append(org_skills)
 

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -119,18 +119,20 @@ def load_org_skills_from_url(
     """
     all_skills: list[Skill] = []
 
-    # Determine the temporary directory for cloning
+    # Determine a unique temporary directory for cloning. Two repos can share
+    # the same org_name (e.g. {login}/.openhands and {login}/.agents), and
+    # concurrent conversations may clone the same org, so the directory must be
+    # unique per call rather than derived solely from org_name.
     if working_dir:
         base_dir = Path(working_dir) if isinstance(working_dir, str) else working_dir
-        temp_dir = base_dir / f"_org_skills_{org_name}"
+        base_dir.mkdir(parents=True, exist_ok=True)
+        temp_dir = Path(
+            tempfile.mkdtemp(prefix=f"_org_skills_{org_name}_", dir=base_dir)
+        )
     else:
-        temp_dir = Path(tempfile.gettempdir()) / f"openhands_org_skills_{org_name}"
+        temp_dir = Path(tempfile.mkdtemp(prefix=f"openhands_org_skills_{org_name}_"))
 
     try:
-        # Clean up any existing temp directory
-        if temp_dir.exists():
-            shutil.rmtree(temp_dir)
-
         # Clone the organization repository (shallow clone for efficiency)
         logger.info(f"Cloning organization skills repository for {org_name}")
         try:
@@ -294,8 +296,7 @@ def load_all_skills(
     load_project: bool = True,
     load_org: bool = True,
     project_dir: str | None = None,
-    org_repo_url: str | None = None,
-    org_name: str | None = None,
+    org_repos: list[tuple[str, str]] | None = None,
     sandbox_exposed_urls: list[ExposedUrlData] | None = None,
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
 ) -> SkillLoadResult:
@@ -315,8 +316,8 @@ def load_all_skills(
         load_project: Whether to load project skills from workspace.
         load_org: Whether to load organization-level skills.
         project_dir: Workspace directory path for project skills.
-        org_repo_url: Pre-authenticated Git URL for org skills.
-        org_name: Organization name for org skills.
+        org_repos: Pre-authenticated (Git URL, org name) pairs for org skills.
+            All repos are loaded and merged into the single org tier.
         sandbox_exposed_urls: List of exposed URLs from sandbox.
         marketplace_path: Relative marketplace JSON path for public skills.
             Pass None to load all public skills without marketplace filtering.
@@ -347,17 +348,26 @@ def load_all_skills(
     sources["sdk_base"] = len(sdk_base)
     skill_lists.append(list(sdk_base.values()))
 
-    # 4. Load organization skills
+    # 4. Load organization skills (one or more repos merged into a single tier;
+    # later repos override earlier ones on name collision).
     org_skills: list[Skill] = []
-    if load_org and org_repo_url and org_name:
-        try:
-            org_skills = load_org_skills_from_url(
-                org_repo_url=org_repo_url,
-                org_name=org_name,
-            )
+    if load_org and org_repos:
+        per_repo_skills: list[list[Skill]] = []
+        for org_repo_url, org_name in org_repos:
+            try:
+                per_repo_skills.append(
+                    load_org_skills_from_url(
+                        org_repo_url=org_repo_url,
+                        org_name=org_name,
+                    )
+                )
+            except Exception as e:
+                logger.warning(
+                    f"Failed to load organization skills for {org_name}: {e}"
+                )
+        org_skills = merge_skills(per_repo_skills)
+        if org_skills:
             logger.info(f"Loaded {len(org_skills)} organization skills")
-        except Exception as e:
-            logger.warning(f"Failed to load organization skills: {e}")
     sources["org"] = len(org_skills)
     skill_lists.append(org_skills)
 

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -83,8 +83,8 @@ class TestGetSkillsEndpoint:
             assert call_kwargs["project_dir"] == "/workspace/myproject"
             assert call_kwargs["load_project"] is True
 
-    def test_get_skills_with_org_config(self, client):
-        """Test skills request with organization configuration."""
+    def test_get_skills_legacy_org_config_supported(self, client):
+        """A deprecated single org_config is normalized to a one-entry org_repos."""
         with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
             mock_load.return_value = SkillLoadResult(skills=[], sources={})
 
@@ -103,9 +103,42 @@ class TestGetSkillsEndpoint:
 
             assert response.status_code == 200
             mock_load.assert_called_once()
-            call_kwargs = mock_load.call_args[1]
-            assert call_kwargs["org_repo_url"] == "https://github.com/myorg/.openhands"
-            assert call_kwargs["org_name"] == "myorg"
+            assert mock_load.call_args[1]["org_repos"] == [
+                ("https://github.com/myorg/.openhands", "myorg")
+            ]
+
+    def test_get_skills_with_org_configs_list(self, client):
+        """Multiple org_configs are forwarded as an ordered list of (url, name)."""
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.return_value = SkillLoadResult(skills=[], sources={})
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "load_org": True,
+                    "org_configs": [
+                        {
+                            "repository": "hieptl/.openhands",
+                            "provider": "github",
+                            "org_repo_url": "https://github.com/hieptl/.openhands",
+                            "org_name": "hieptl",
+                        },
+                        {
+                            "repository": "hieptl/.agents",
+                            "provider": "github",
+                            "org_repo_url": "https://github.com/hieptl/.agents",
+                            "org_name": "hieptl",
+                        },
+                    ],
+                },
+            )
+
+            assert response.status_code == 200
+            mock_load.assert_called_once()
+            assert mock_load.call_args[1]["org_repos"] == [
+                ("https://github.com/hieptl/.openhands", "hieptl"),
+                ("https://github.com/hieptl/.agents", "hieptl"),
+            ]
 
     def test_get_skills_with_sandbox_config(self, client):
         """Test skills request with sandbox configuration."""

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -357,6 +357,58 @@ class TestLoadAllSkills:
             assert len(shared_skills) == 1
             assert shared_skills[0].content == "project"
 
+    def test_load_all_skills_loops_and_merges_multiple_org_repos(self):
+        """Every org repo is loaded (in order) and merged into the org source."""
+        with patch(self._PATCH_TARGET, return_value={}):
+            with patch(
+                "openhands.agent_server.skills_service.load_org_skills_from_url",
+                side_effect=[
+                    [Skill(name="org_a", content="a", trigger=None)],
+                    [Skill(name="org_b", content="b", trigger=None)],
+                ],
+            ) as mock_org:
+                result = load_all_skills(
+                    load_public=False,
+                    load_user=False,
+                    load_project=False,
+                    load_org=True,
+                    org_repos=[
+                        ("https://git/hieptl/.openhands", "hieptl"),
+                        ("https://git/hieptl/.agents", "hieptl"),
+                    ],
+                )
+
+        assert result.sources["org"] == 2
+        assert [c.kwargs["org_repo_url"] for c in mock_org.call_args_list] == [
+            "https://git/hieptl/.openhands",
+            "https://git/hieptl/.agents",
+        ]
+
+    def test_load_all_skills_org_merge_precedence(self):
+        """A skill in multiple org repos resolves to the later repo's version."""
+        with patch(self._PATCH_TARGET, return_value={}):
+            with patch(
+                "openhands.agent_server.skills_service.load_org_skills_from_url",
+                side_effect=[
+                    [Skill(name="shared", content="openhands", trigger=None)],
+                    [Skill(name="shared", content="agents", trigger=None)],
+                ],
+            ):
+                result = load_all_skills(
+                    load_public=False,
+                    load_user=False,
+                    load_project=False,
+                    load_org=True,
+                    org_repos=[
+                        ("https://git/hieptl/.openhands", "hieptl"),
+                        ("https://git/hieptl/.agents", "hieptl"),
+                    ],
+                )
+
+        shared = [s for s in result.skills if s.name == "shared"]
+        assert len(shared) == 1
+        assert shared[0].content == "agents"
+
 
 class TestSyncPublicSkills:
     """Tests for sync_public_skills function."""


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

The /api/skills endpoint accepted only a single org_config, so it could clone exactly one organization skill repository per request. The app-server needs to load several global repos in one call (a user's .openhands and .agents, plus the same for each org they belong to).

* SkillsRequest gains org_configs (list[OrgConfig]); the legacy org_config is retained for backward compatibility
* get_skills normalizes input to an ordered org_repos list of (org_repo_url, org_name), preferring org_configs and falling back to org_config
* load_all_skills accepts org_repos and loops load_org_skills_from_url over each repo, merging into the single org tier (later repo wins on name collision, so .agents overrides .openhands when listed after it)
* load_org_skills_from_url clones into a unique tempfile.mkdtemp directory, since two repos can share an org_name (e.g. {login}/.openhands and {login}/.agents) and concurrent conversations may clone the same org

Existing clients are unaffected: OrgConfig is unchanged and org_config is still accepted.

Tests: TestGetSkillsEndpoint covers the org_configs list and legacy org_config fallback; TestLoadAllSkills covers looping/merging multiple org repos and org merge precedence.

- [x] A human has tested these changes.

AGENT:

---

## Why

<!-- Describe problem, motivation, etc.-->

`POST /api/skills` accepted a single `org_config`, so only one organization skill repository could be cloned per request. To make globally-scoped skills available in every conversation, the app-server needs to load multiple global repos in one call — a user's `{login}/.openhands` and `{login}/.agents`, plus the same pair for each org the user belongs to.

## Summary

<!-- 1-3 bullets describing what changed. -->
- `SkillsRequest` gains **`org_configs: list[OrgConfig]`**; the legacy `org_config` is kept (deprecated) for backward compatibility.
- `get_skills` normalizes to an ordered `org_repos` list of `(url, name)` pairs (prefers `org_configs`, falls back to `org_config`).
- `load_all_skills` loops `load_org_skills_from_url` over every repo and merges into the single `org` tier (later repo overrides on name clash).
- `load_org_skills_from_url` clones into a unique `tempfile.mkdtemp` dir so repos sharing an `org_name` (and concurrent requests) don't collide.

**Files changed:** `openhands-agent-server/openhands/agent_server/skills_router.py`, `openhands-agent-server/openhands/agent_server/skills_service.py`, `tests/agent_server/test_skills_router.py`, `tests/agent_server/test_skills_service.py`.

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

Automated (run from the repo root):

```bash
./.venv/bin/python -m pytest \
  tests/agent_server/test_skills_router.py \
  tests/agent_server/test_skills_service.py -q
# → 71 passed

./.venv/bin/ruff check  openhands-agent-server/openhands/agent_server/skills_router.py \
                        openhands-agent-server/openhands/agent_server/skills_service.py \
                        tests/agent_server/test_skills_router.py \
                        tests/agent_server/test_skills_service.py
./.venv/bin/ruff format --check <same files>
# → All checks passed / already formatted
```

End-to-end (manual): start the agent server and POST to `/api/skills` with an `org_configs` list of two authenticated repo URLs (e.g. a `.openhands` and a `.agents` repo), then confirm the response `sources["org"]` equals the combined skill count and that skills from both repos are present. Full product validation (account/org enumeration → conversation) is driven by the `OpenHands` companion PR against a live sandbox.

Representative request body:

```json
{
  "load_org": true,
  "org_configs": [
    {"repository": "hieptl/.openhands", "provider": "github",
     "org_repo_url": "https://<token>@github.com/hieptl/.openhands.git", "org_name": "hieptl"},
    {"repository": "hieptl/.agents", "provider": "github",
     "org_repo_url": "https://<token>@github.com/hieptl/.agents.git", "org_name": "hieptl"}
  ]
}
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:eb3fb87-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-eb3fb87-python \
  ghcr.io/openhands/agent-server:eb3fb87-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:eb3fb87-golang-amd64
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-golang-amd64
ghcr.io/openhands/agent-server:hieptl-app-2320-golang-amd64
ghcr.io/openhands/agent-server:eb3fb87-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:eb3fb87-golang-arm64
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-golang-arm64
ghcr.io/openhands/agent-server:hieptl-app-2320-golang-arm64
ghcr.io/openhands/agent-server:eb3fb87-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:eb3fb87-java-amd64
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-java-amd64
ghcr.io/openhands/agent-server:hieptl-app-2320-java-amd64
ghcr.io/openhands/agent-server:eb3fb87-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:eb3fb87-java-arm64
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-java-arm64
ghcr.io/openhands/agent-server:hieptl-app-2320-java-arm64
ghcr.io/openhands/agent-server:eb3fb87-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:eb3fb87-python-amd64
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-python-amd64
ghcr.io/openhands/agent-server:hieptl-app-2320-python-amd64
ghcr.io/openhands/agent-server:eb3fb87-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:eb3fb87-python-arm64
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-python-arm64
ghcr.io/openhands/agent-server:hieptl-app-2320-python-arm64
ghcr.io/openhands/agent-server:eb3fb87-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:eb3fb87-golang
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-golang
ghcr.io/openhands/agent-server:hieptl-app-2320-golang
ghcr.io/openhands/agent-server:eb3fb87-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:eb3fb87-java
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-java
ghcr.io/openhands/agent-server:hieptl-app-2320-java
ghcr.io/openhands/agent-server:eb3fb87-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:eb3fb87-python
ghcr.io/openhands/agent-server:eb3fb873d5db85f253167bf5f027b1895e91e2aa-python
ghcr.io/openhands/agent-server:hieptl-app-2320-python
ghcr.io/openhands/agent-server:eb3fb87-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `eb3fb87-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `eb3fb87-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->