### PR TITLE
fix: exclude read-only endpoints from idle timer

### DIFF
--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -86,7 +86,6 @@ async def _upload_file(path: str, file: UploadFile) -> Success:
 
 async def _download_file(path: str) -> FileResponse:
     """Internal helper to download a file from the workspace."""
-    update_last_execution_time()
     logger.info(f"Downloading file: {path}")
     try:
         target_path = Path(path)

--- a/openhands-agent-server/openhands/agent_server/git_router.py
+++ b/openhands-agent-server/openhands/agent_server/git_router.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException, Query
 
-from openhands.agent_server.server_details_router import update_last_execution_time
 from openhands.sdk.git.exceptions import GitError, GitRepositoryError
 from openhands.sdk.git.git_changes import get_git_changes
 from openhands.sdk.git.git_diff import get_git_diff
@@ -27,7 +26,6 @@ _REF_QUERY_DESCRIPTION = (
 
 async def _get_git_changes(path: str, ref: str | None) -> list[GitChange]:
     """Internal helper to get git changes for a given path."""
-    update_last_execution_time()
     loop = asyncio.get_running_loop()
     try:
         return await loop.run_in_executor(
@@ -42,7 +40,6 @@ async def _get_git_changes(path: str, ref: str | None) -> list[GitChange]:
 
 async def _get_git_diff(path: str, ref: str | None) -> GitDiff:
     """Internal helper to get git diff for a given path."""
-    update_last_execution_time()
     loop = asyncio.get_running_loop()
     try:
         return await loop.run_in_executor(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

The frontend polls `GET /git/changes` using TanStack Query on a short interval so the Changes tab stays live. This caused every idle agent-server pod to continuously reset `_last_event_time`, making `idle_time` in `/server_info` never grow large enough for the Kubernetes culling probe to pause the pod as long as there is an active tab open.

- [x] A human has tested these changes.

AGENT:

Ran `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/git_router.py openhands-agent-server/openhands/agent_server/file_router.py` — all hooks passed (ruff format, ruff lint, pycodestyle, pyright, import rules).

Ran `uv run pytest tests/agent_server/test_server_details_router.py tests/agent_server/test_conversation_service.py -x -q` — **83 passed**.

---

## Why

The frontend polls `GET /git/changes` using TanStack Query on a short interval so the Changes tab stays live. This caused every idle agent-server pod to continuously reset `_last_event_time`, making `idle_time` in `/server_info` never grow large enough for the Kubernetes culling probe to pause the pod. Idle cloud sandboxes were never being culled.

## Summary

- Remove `update_last_execution_time()` from `GET /git/changes` and `GET /git/diff` in `git_router.py` (both are pure reads; also removes the now-unused import).
- Remove `update_last_execution_time()` from `GET /file/download` in `file_router.py` (read-only; `POST /file/upload` retains the call).

## Issue Number

## How to Test

1. Start an agent-server and open a workspace with a git repo so the frontend begins polling `/git/changes`.
2. Send one agent message so the conversation is active, then stop interacting.
3. Poll `/server_info` every 10 s — `idle_time` should now grow steadily even while the frontend polls `/git/changes`, instead of being reset by each poll.

Alternatively, confirm the negative: with the old code, `idle_time` in `/server_info` would stay near 0 indefinitely due to the TanStack Query polling.

## Video/Screenshots

<img width="895" height="825" alt="image" src="https://github.com/user-attachments/assets/e85c2c8c-3496-47ff-8c29-a057d674dabe" />

<img width="955" height="500" alt="image" src="https://github.com/user-attachments/assets/ad57c09f-0df2-4b04-9d83-9465e72f0712" />

<img width="616" height="230" alt="image" src="https://github.com/user-attachments/assets/8c65cbfb-e94b-43e5-aa3f-d0efe42e6c01" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No behaviour change for write operations or agent activity — those still reset the idle timer normally via `_EventSubscriber`, ACP heartbeat, `POST /bash/*`, and `POST /file/upload`.

_This PR was created by an AI agent (OpenHands) on behalf of the user._