### PR TITLE
ci: make oasdiff install deterministic

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -29,8 +29,14 @@ jobs:
               run: uv sync --frozen --group dev
 
             - name: Install oasdiff
+              env:
+                  # Keep this explicit so the installer does not query GitHub for
+                  # the latest release at runtime, which can fail under API/network
+                  # pressure before the actual REST breakage check runs.
+                  OASDIFF_VERSION: 1.18.6
+                  OASDIFF_INSTALL_DIR: /usr/local/bin
               run: |
-                  curl -L https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh -s -- -b /usr/local/bin
+                  curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version="${OASDIFF_VERSION}" INSTALL_DIR="${OASDIFF_INSTALL_DIR}" sh
                   oasdiff --version
 
             - name: Run agent server REST API breakage check


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [ ] A human has tested these changes.

AGENT:

---

## Why

The REST API breakage workflow currently lets the upstream oasdiff installer discover the latest release at runtime through the GitHub API. The main-branch run at https://github.com/OpenHands/software-agent-sdk/actions/runs/27425506730 failed before the REST breakage check because the installer could not resolve the latest oasdiff version, reporting a possible API rate-limit or network issue.

## Summary

- Make the oasdiff release explicit in the workflow so the installer does not call GitHub's latest-release API at runtime.
- Keep the version at `1.18.6`, which is the current release the same installer resolved successfully in a later run.
- Use the installer's supported `version` and `INSTALL_DIR` environment variables, and switch curl to `-fsSL` so HTTP failures fail clearly.

## Issue Number

N/A

## How to Test

- Verified the installer command locally with a temporary install directory:

```bash
tmpbin=$(mktemp -d) && OASDIFF_VERSION=1.18.6 OASDIFF_INSTALL_DIR="$tmpbin" bash -c 'curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version="${OASDIFF_VERSION}" INSTALL_DIR="${OASDIFF_INSTALL_DIR}" sh' && "$tmpbin/oasdiff" --version && rm -rf "$tmpbin"
```

Output included `oasdiff version 1.18.6`.

- `git diff --check`
- Commit hook ran `Format YAML files` successfully.

## Video/Screenshots

N/A; CI workflow robustness fix.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This is split out from #3667 so the ACP MCP auth PR does not carry an unrelated workflow change.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3379dcd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3379dcd-python \
  ghcr.io/openhands/agent-server:3379dcd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3379dcd-golang-amd64
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-golang-amd64
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-golang-amd64
ghcr.io/openhands/agent-server:3379dcd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3379dcd-golang-arm64
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-golang-arm64
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-golang-arm64
ghcr.io/openhands/agent-server:3379dcd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3379dcd-java-amd64
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-java-amd64
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-java-amd64
ghcr.io/openhands/agent-server:3379dcd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3379dcd-java-arm64
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-java-arm64
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-java-arm64
ghcr.io/openhands/agent-server:3379dcd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3379dcd-python-amd64
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-python-amd64
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-python-amd64
ghcr.io/openhands/agent-server:3379dcd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3379dcd-python-arm64
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-python-arm64
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-python-arm64
ghcr.io/openhands/agent-server:3379dcd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3379dcd-golang
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-golang
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-golang
ghcr.io/openhands/agent-server:3379dcd-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3379dcd-java
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-java
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-java
ghcr.io/openhands/agent-server:3379dcd-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3379dcd-python
ghcr.io/openhands/agent-server:3379dcdbc90deaee7083b78541ff60843042db4e-python
ghcr.io/openhands/agent-server:fix-oasdiff-installer-version-lookup-python
ghcr.io/openhands/agent-server:3379dcd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3379dcd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3379dcd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->