### PR TITLE
ci: accept cloud-proxy REST API breakage

### DIFF
--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -574,6 +574,7 @@ _RESPONSE_ENUM_VALUE_ADDED_IDS = frozenset(
 _EXTENSIBLE_DISCRIMINATOR_PROPERTY_RE = re.compile(
     r"HookConfig\b.*\bhooks/items/type\b"
 )
+_ACCEPTED_CLOUD_PROXY_PATH_REMOVAL_ID = "api-path-removed-without-deprecation"
 _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH = "/api/cloud-proxy"
 _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD = "post"
 _ACCEPTED_CLOUD_PROXY_REMOVAL_OPERATION_ID = "cloud_proxy_api_cloud_proxy_post"
@@ -593,7 +594,7 @@ def _is_accepted_cloud_proxy_removal(operation: dict) -> bool:
 def _is_accepted_cloud_proxy_path_removal(change: dict) -> bool:
     """Return True for oasdiff's accepted /api/cloud-proxy path-removal shape."""
     return (
-        str(change.get("id", "")) == "api-path-removed-without-deprecation"
+        str(change.get("id", "")) == _ACCEPTED_CLOUD_PROXY_PATH_REMOVAL_ID
         and str(change.get("path", "")) == _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH
         and str(change.get("operation", "")).lower()
         == _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD

--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -574,6 +574,19 @@ _RESPONSE_ENUM_VALUE_ADDED_IDS = frozenset(
 _EXTENSIBLE_DISCRIMINATOR_PROPERTY_RE = re.compile(
     r"HookConfig\b.*\bhooks/items/type\b"
 )
+_ACCEPTED_CLOUD_PROXY_REMOVAL_PATH = "/api/cloud-proxy"
+_ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD = "post"
+
+
+def _is_accepted_cloud_proxy_removal(operation: dict) -> bool:
+    """Return True for the accepted /api/cloud-proxy removal from PR #3326."""
+    path = str(operation.get("path", ""))
+    method = str(operation.get("method", "")).lower()
+    return (
+        path == _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH
+        and method == _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD
+        and operation.get("deprecated", False) is False
+    )
 
 
 def _is_additive_discriminator_enum_value(change: dict) -> bool:
@@ -815,6 +828,16 @@ def main() -> int:
             for change in other_breaking_changes
             if not _is_union_type_change_artifact(change)
         ]
+        accepted_cloud_proxy_removals = [
+            operation
+            for operation in removed_operations
+            if _is_accepted_cloud_proxy_removal(operation)
+        ]
+        removed_operations = [
+            operation
+            for operation in removed_operations
+            if not _is_accepted_cloud_proxy_removal(operation)
+        ]
 
         removal_errors = _validate_removed_operations(
             removed_operations,
@@ -829,6 +852,14 @@ def main() -> int:
 
         for error in removal_errors + property_removal_errors:
             print(f"::error title={PYPI_DISTRIBUTION} REST API::{error}")
+
+        if accepted_cloud_proxy_removals:
+            print(
+                f"\n::notice title={PYPI_DISTRIBUTION} REST API::"
+                "Accepted removal of POST /api/cloud-proxy. Maintainers "
+                "explicitly accepted this REST break in PR #3326, and that PR "
+                "is labeled release-note-required."
+            )
 
         if additive_response_oneof:
             print(
@@ -881,7 +912,8 @@ def main() -> int:
             print(
                 "Breaking changes are limited to previously-deprecated operations "
                 "or properties whose scheduled removal versions have been reached, "
-                "and/or additive response oneOf expansions."
+                "the accepted POST /api/cloud-proxy removal, and/or additive "
+                "response oneOf expansions."
             )
         else:
             return 1

--- a/.github/scripts/check_agent_server_rest_api_breakage.py
+++ b/.github/scripts/check_agent_server_rest_api_breakage.py
@@ -576,6 +576,7 @@ _EXTENSIBLE_DISCRIMINATOR_PROPERTY_RE = re.compile(
 )
 _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH = "/api/cloud-proxy"
 _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD = "post"
+_ACCEPTED_CLOUD_PROXY_REMOVAL_OPERATION_ID = "cloud_proxy_api_cloud_proxy_post"
 
 
 def _is_accepted_cloud_proxy_removal(operation: dict) -> bool:
@@ -586,6 +587,18 @@ def _is_accepted_cloud_proxy_removal(operation: dict) -> bool:
         path == _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH
         and method == _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD
         and operation.get("deprecated", False) is False
+    )
+
+
+def _is_accepted_cloud_proxy_path_removal(change: dict) -> bool:
+    """Return True for oasdiff's accepted /api/cloud-proxy path-removal shape."""
+    return (
+        str(change.get("id", "")) == "api-path-removed-without-deprecation"
+        and str(change.get("path", "")) == _ACCEPTED_CLOUD_PROXY_REMOVAL_PATH
+        and str(change.get("operation", "")).lower()
+        == _ACCEPTED_CLOUD_PROXY_REMOVAL_METHOD
+        and str(change.get("operationId", ""))
+        == _ACCEPTED_CLOUD_PROXY_REMOVAL_OPERATION_ID
     )
 
 
@@ -838,6 +851,16 @@ def main() -> int:
             for operation in removed_operations
             if not _is_accepted_cloud_proxy_removal(operation)
         ]
+        accepted_cloud_proxy_path_removals = [
+            change
+            for change in other_breaking_changes
+            if _is_accepted_cloud_proxy_path_removal(change)
+        ]
+        other_breaking_changes = [
+            change
+            for change in other_breaking_changes
+            if not _is_accepted_cloud_proxy_path_removal(change)
+        ]
 
         removal_errors = _validate_removed_operations(
             removed_operations,
@@ -853,7 +876,7 @@ def main() -> int:
         for error in removal_errors + property_removal_errors:
             print(f"::error title={PYPI_DISTRIBUTION} REST API::{error}")
 
-        if accepted_cloud_proxy_removals:
+        if accepted_cloud_proxy_removals or accepted_cloud_proxy_path_removals:
             print(
                 f"\n::notice title={PYPI_DISTRIBUTION} REST API::"
                 "Accepted removal of POST /api/cloud-proxy. Maintainers "

--- a/tests/cross/test_check_agent_server_rest_api_breakage.py
+++ b/tests/cross/test_check_agent_server_rest_api_breakage.py
@@ -254,6 +254,41 @@ def test_accepted_cloud_proxy_removal_detection_is_exact():
     )
 
 
+def test_accepted_cloud_proxy_path_removal_detection_is_exact():
+    assert _prod._is_accepted_cloud_proxy_path_removal(
+        {
+            "id": "api-path-removed-without-deprecation",
+            "path": "/api/cloud-proxy",
+            "operation": "POST",
+            "operationId": "cloud_proxy_api_cloud_proxy_post",
+        }
+    )
+    assert not _prod._is_accepted_cloud_proxy_path_removal(
+        {
+            "id": "api-path-removed-without-deprecation",
+            "path": "/api/cloud-proxy",
+            "operation": "GET",
+            "operationId": "cloud_proxy_api_cloud_proxy_post",
+        }
+    )
+    assert not _prod._is_accepted_cloud_proxy_path_removal(
+        {
+            "id": "api-path-removed-without-deprecation",
+            "path": "/api/cloud-proxy/other",
+            "operation": "POST",
+            "operationId": "cloud_proxy_api_cloud_proxy_post",
+        }
+    )
+    assert not _prod._is_accepted_cloud_proxy_path_removal(
+        {
+            "id": "api-path-removed-without-deprecation",
+            "path": "/api/cloud-proxy",
+            "operation": "POST",
+            "operationId": "other_operation",
+        }
+    )
+
+
 def test_parse_openapi_deprecation_description_extracts_versions_from_example():
     description = (
         "Nice description here with more context for API consumers.\n\n"
@@ -458,6 +493,42 @@ def test_main_allows_accepted_cloud_proxy_removal(monkeypatch, capsys):
                         "deprecated": False,
                     },
                     "text": "removed POST /api/cloud-proxy",
+                }
+            ],
+            1,
+        ),
+    )
+
+    assert _prod.main() == 0
+
+    captured = capsys.readouterr()
+    assert "Accepted removal of POST /api/cloud-proxy" in captured.out
+    assert "accepted POST /api/cloud-proxy removal" in captured.out
+
+
+def test_main_allows_accepted_cloud_proxy_path_removal(monkeypatch, capsys):
+    monkeypatch.setattr(_prod, "_read_version_from_pyproject", lambda _path: "1.28.0")
+    monkeypatch.setattr(
+        _prod, "_get_baseline_version", lambda _distribution, _current: "1.28.0"
+    )
+    monkeypatch.setattr(_prod, "_find_sdk_deprecated_fastapi_routes", lambda _root: [])
+    monkeypatch.setattr(_prod, "_generate_current_openapi", lambda: {"paths": {}})
+    monkeypatch.setattr(_prod, "_find_deprecation_policy_errors", lambda _schema: [])
+    monkeypatch.setattr(
+        _prod, "_generate_openapi_for_git_ref", lambda _ref: {"paths": {}}
+    )
+    monkeypatch.setattr(_prod, "_normalize_openapi_for_oasdiff", lambda schema: schema)
+    monkeypatch.setattr(
+        _prod,
+        "_run_oasdiff_breakage_check",
+        lambda _prev, _cur: (
+            [
+                {
+                    "id": "api-path-removed-without-deprecation",
+                    "text": "api path removed without deprecation",
+                    "operation": "POST",
+                    "operationId": "cloud_proxy_api_cloud_proxy_post",
+                    "path": "/api/cloud-proxy",
                 }
             ],
             1,

--- a/tests/cross/test_check_agent_server_rest_api_breakage.py
+++ b/tests/cross/test_check_agent_server_rest_api_breakage.py
@@ -239,6 +239,21 @@ def test_rest_deprecation_regex_matches_deprecation_check_regex():
     assert _rest_route_deprecation_re.flags == _deprecation_check_re.flags
 
 
+def test_accepted_cloud_proxy_removal_detection_is_exact():
+    assert _prod._is_accepted_cloud_proxy_removal(
+        {"path": "/api/cloud-proxy", "method": "post", "deprecated": False}
+    )
+    assert not _prod._is_accepted_cloud_proxy_removal(
+        {"path": "/api/cloud-proxy", "method": "get", "deprecated": False}
+    )
+    assert not _prod._is_accepted_cloud_proxy_removal(
+        {"path": "/api/cloud-proxy/other", "method": "post", "deprecated": False}
+    )
+    assert not _prod._is_accepted_cloud_proxy_removal(
+        {"path": "/api/cloud-proxy", "method": "post", "deprecated": True}
+    )
+
+
 def test_parse_openapi_deprecation_description_extracts_versions_from_example():
     description = (
         "Nice description here with more context for API consumers.\n\n"
@@ -416,6 +431,44 @@ def test_validate_removed_schema_properties_requires_removal_target_to_be_reache
         "version(s): v1.20.0 (current version: v1.19.0). REST API property "
         "removals require 5 minor releases of deprecation runway."
     ]
+
+
+def test_main_allows_accepted_cloud_proxy_removal(monkeypatch, capsys):
+    monkeypatch.setattr(_prod, "_read_version_from_pyproject", lambda _path: "1.28.0")
+    monkeypatch.setattr(
+        _prod, "_get_baseline_version", lambda _distribution, _current: "1.28.0"
+    )
+    monkeypatch.setattr(_prod, "_find_sdk_deprecated_fastapi_routes", lambda _root: [])
+    monkeypatch.setattr(_prod, "_generate_current_openapi", lambda: {"paths": {}})
+    monkeypatch.setattr(_prod, "_find_deprecation_policy_errors", lambda _schema: [])
+    monkeypatch.setattr(
+        _prod, "_generate_openapi_for_git_ref", lambda _ref: {"paths": {}}
+    )
+    monkeypatch.setattr(_prod, "_normalize_openapi_for_oasdiff", lambda schema: schema)
+    monkeypatch.setattr(
+        _prod,
+        "_run_oasdiff_breakage_check",
+        lambda _prev, _cur: (
+            [
+                {
+                    "id": "removed-operation",
+                    "details": {
+                        "path": "/api/cloud-proxy",
+                        "method": "post",
+                        "deprecated": False,
+                    },
+                    "text": "removed POST /api/cloud-proxy",
+                }
+            ],
+            1,
+        ),
+    )
+
+    assert _prod.main() == 0
+
+    captured = capsys.readouterr()
+    assert "Accepted removal of POST /api/cloud-proxy" in captured.out
+    assert "accepted POST /api/cloud-proxy removal" in captured.out
 
 
 def test_main_allows_scheduled_removal_with_documented_target(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

- Add a dedicated REST API breakage-check helper for the accepted `POST /api/cloud-proxy` removal from PR #3326.
- Filter only that exact removed operation before the normal deprecation-runway validation.
- Add regression coverage so other cloud-proxy methods/paths and deprecated removals are not covered by the skip.

## Validation

- `uv run pytest tests/cross/test_check_agent_server_rest_api_breakage.py`
- `uv run pre-commit run --files .github/scripts/check_agent_server_rest_api_breakage.py tests/cross/test_check_agent_server_rest_api_breakage.py`
- `uv run --with packaging python .github/scripts/check_agent_server_rest_api_breakage.py` (local environment lacks `oasdiff`, so this exercised the script's existing missing-oasdiff warning path)

## Notes

- I also labeled the removal PR #3326 with `release-note-required` so the accepted REST break is called out in release notes.

_This PR was created by an AI agent (OpenHands) on behalf of the requester._

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/a8649ee1-772c-4c7f-a435-43c7702db231)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:30ab92d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-30ab92d-python \
  ghcr.io/openhands/agent-server:30ab92d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:30ab92d-golang-amd64
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-golang-amd64
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-golang-amd64
ghcr.io/openhands/agent-server:30ab92d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:30ab92d-golang-arm64
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-golang-arm64
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-golang-arm64
ghcr.io/openhands/agent-server:30ab92d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:30ab92d-java-amd64
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-java-amd64
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-java-amd64
ghcr.io/openhands/agent-server:30ab92d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:30ab92d-java-arm64
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-java-arm64
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-java-arm64
ghcr.io/openhands/agent-server:30ab92d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:30ab92d-python-amd64
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-python-amd64
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-python-amd64
ghcr.io/openhands/agent-server:30ab92d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:30ab92d-python-arm64
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-python-arm64
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-python-arm64
ghcr.io/openhands/agent-server:30ab92d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:30ab92d-golang
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-golang
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-golang
ghcr.io/openhands/agent-server:30ab92d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:30ab92d-java
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-java
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-java
ghcr.io/openhands/agent-server:30ab92d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:30ab92d-python
ghcr.io/openhands/agent-server:30ab92d7dd72684864a316de128c2fa9ab7b7b84-python
ghcr.io/openhands/agent-server:openhands-skip-accepted-cloud-proxy-break-python
ghcr.io/openhands/agent-server:30ab92d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `30ab92d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `30ab92d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->