### PR TITLE
fix: redact credentials from GitCommandError.command field

### DIFF
--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -15,7 +15,6 @@ logger = logging.getLogger(__name__)
 GIT_EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
-
 def run_git_command(
     args: list[str],
     cwd: str | Path | None = None,

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -61,13 +61,14 @@ def run_git_command(
         if result.returncode != 0:
             # Redact credentials from command for logging and error messages
             cmd_str = _redact_args_for_logging(args)
+            redacted_args = [redact_url_credentials(a) for a in args]
             error_msg = f"Git command failed: {cmd_str}"
             logger.error(
                 f"{error_msg}. Exit code: {result.returncode}. Stderr: {result.stderr}"
             )
             raise GitCommandError(
                 message=error_msg,
-                command=args,
+                command=redacted_args,
                 exit_code=result.returncode,
                 stderr=result.stderr.strip(),
             )
@@ -77,11 +78,12 @@ def run_git_command(
 
     except subprocess.TimeoutExpired as e:
         cmd_str = _redact_args_for_logging(args)
+        redacted_args = [redact_url_credentials(a) for a in args]
         error_msg = f"Git command timed out: {cmd_str}"
         logger.error(error_msg)
         raise GitCommandError(
             message=error_msg,
-            command=args,
+            command=redacted_args,
             exit_code=-1,
             stderr="Command timed out",
         ) from e

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -15,20 +15,6 @@ logger = logging.getLogger(__name__)
 GIT_EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
-def _redact_args_for_logging(args: list[str]) -> str:
-    """Redact credentials from git command arguments for safe logging.
-
-    Joins command args with shlex.join and redacts any URLs containing credentials.
-
-    Args:
-        args: List of command arguments.
-
-    Returns:
-        A string representation of the command with credentials redacted.
-    """
-    redacted_args = [redact_url_credentials(arg) for arg in args]
-    return shlex.join(redacted_args)
-
 
 def run_git_command(
     args: list[str],
@@ -48,6 +34,9 @@ def run_git_command(
     Raises:
         GitCommandError: If the git command fails
     """
+    redacted_args = [redact_url_credentials(a) for a in args]
+    cmd_str = shlex.join(redacted_args)
+
     try:
         result = subprocess.run(
             args,
@@ -59,9 +48,6 @@ def run_git_command(
         )
 
         if result.returncode != 0:
-            # Redact credentials from command for logging and error messages
-            cmd_str = _redact_args_for_logging(args)
-            redacted_args = [redact_url_credentials(a) for a in args]
             error_msg = f"Git command failed: {cmd_str}"
             logger.error(
                 f"{error_msg}. Exit code: {result.returncode}. Stderr: {result.stderr}"
@@ -73,12 +59,10 @@ def run_git_command(
                 stderr=result.stderr.strip(),
             )
 
-        logger.debug(f"Git command succeeded: {_redact_args_for_logging(args)}")
+        logger.debug(f"Git command succeeded: {cmd_str}")
         return result.stdout.strip()
 
     except subprocess.TimeoutExpired as e:
-        cmd_str = _redact_args_for_logging(args)
-        redacted_args = [redact_url_credentials(a) for a in args]
         error_msg = f"Git command timed out: {cmd_str}"
         logger.error(error_msg)
         raise GitCommandError(
@@ -92,7 +76,7 @@ def run_git_command(
         logger.error(error_msg)
         raise GitCommandError(
             message=error_msg,
-            command=args,
+            command=redacted_args,
             exit_code=-1,
             stderr="Git executable not found",
         ) from e

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -1,6 +1,12 @@
 """Tests for URL credential redaction utilities."""
 
-from openhands.sdk.git.utils import redact_url_credentials  # re-exported for compat
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from openhands.sdk.git.exceptions import GitCommandError
+from openhands.sdk.git.utils import redact_url_credentials, run_git_command  # re-exported for compat
 from openhands.sdk.plugin.types import PluginSource, ResolvedPluginSource
 from openhands.sdk.utils.redact import (
     redact_url_credentials as redact_url_credentials_central,
@@ -195,3 +201,41 @@ class TestRedactUrlCredentialsCentralModule:
         assert (
             redact_url_credentials_central("https://t@host/r") == "https://****@host/r"
         )
+
+
+CREDENTIAL_URL = "https://oauth2:SUPERSECRET@github.com/o/r.git"
+REDACTED_URL = "https://****@github.com/o/r.git"
+
+
+class TestRunGitCommandCredentialRedaction:
+    """GitCommandError.command must never carry raw credentials across all raise sites."""
+
+    def _args(self):
+        return ["git", "clone", CREDENTIAL_URL, "/tmp/x"]
+
+    def test_nonzero_returncode_redacts_command(self):
+        completed = subprocess.CompletedProcess(
+            args=self._args(), returncode=128, stdout="", stderr="fatal: repo not found"
+        )
+        with patch("subprocess.run", return_value=completed):
+            with pytest.raises(GitCommandError) as exc_info:
+                run_git_command(self._args())
+        assert CREDENTIAL_URL not in exc_info.value.command
+        assert REDACTED_URL in exc_info.value.command
+
+    def test_timeout_expired_redacts_command(self):
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=self._args(), timeout=30),
+        ):
+            with pytest.raises(GitCommandError) as exc_info:
+                run_git_command(self._args())
+        assert CREDENTIAL_URL not in exc_info.value.command
+        assert REDACTED_URL in exc_info.value.command
+
+    def test_file_not_found_redacts_command(self):
+        with patch("subprocess.run", side_effect=FileNotFoundError):
+            with pytest.raises(GitCommandError) as exc_info:
+                run_git_command(["git-not-on-path", "clone", CREDENTIAL_URL, "/tmp/x"])
+        assert CREDENTIAL_URL not in exc_info.value.command
+        assert REDACTED_URL in exc_info.value.command

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -211,7 +211,7 @@ REDACTED_URL = "https://****@github.com/o/r.git"
 
 
 class TestRunGitCommandCredentialRedaction:
-    """GitCommandError.command must never carry raw credentials across all raise sites."""
+    """Credentials must not leak into GitCommandError.command on any error path."""
 
     def _args(self):
         return ["git", "clone", CREDENTIAL_URL, "/tmp/x"]

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -6,7 +6,10 @@ from unittest.mock import patch
 import pytest
 
 from openhands.sdk.git.exceptions import GitCommandError
-from openhands.sdk.git.utils import redact_url_credentials, run_git_command  # re-exported for compat
+from openhands.sdk.git.utils import (
+    redact_url_credentials,
+    run_git_command,
+)  # re-exported for compat
 from openhands.sdk.plugin.types import PluginSource, ResolvedPluginSource
 from openhands.sdk.utils.redact import (
     redact_url_credentials as redact_url_credentials_central,


### PR DESCRIPTION
HUMAN: 

 redact credentials from GitCommandError.command field


- [x] A human has tested these changes.

AGENT: 

## Why

Spotted in QA review of #2154. When `run_git_command()` raises `GitCommandError`, the `.command` list retained raw credential-bearing URLs (e.g. `https://user:token@host`). The error message string was already redacted via `_redact_args_for_logging()`, but callers that serialize or log the exception object could still expose credentials through `.command`.

## Summary

Apply `redact_url_credentials()` to each arg before storing it in `GitCommandError.command`, so the exception is safe to serialize regardless of how callers handle it. The `FileNotFoundError` path (git not installed) is left unredacted since it never receives a URL argument.

## How to Test

```python
from openhands.sdk.git.utils import run_git_command
from openhands.sdk.git.exceptions import GitCommandError

try:
    run_git_command(["git", "ls-remote", "https://oauth2:SECRET@127.0.0.1:1/repo"])
except GitCommandError as e:
    assert "SECRET" not in str(e.command), f"Credential leaked: {e.command}"
    assert "****" in str(e.command)
    print("PASS")
```

Or run the existing git test suite: `uv run pytest tests/sdk/git/ -q`

🤖 Generated with [Claude Code](https://claude.com/claude-code)





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b4ba8da-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b4ba8da-python \
  ghcr.io/openhands/agent-server:b4ba8da-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b4ba8da-golang-amd64
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-golang-amd64
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-golang-amd64
ghcr.io/openhands/agent-server:b4ba8da-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b4ba8da-golang-arm64
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-golang-arm64
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-golang-arm64
ghcr.io/openhands/agent-server:b4ba8da-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b4ba8da-java-amd64
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-java-amd64
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-java-amd64
ghcr.io/openhands/agent-server:b4ba8da-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b4ba8da-java-arm64
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-java-arm64
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-java-arm64
ghcr.io/openhands/agent-server:b4ba8da-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b4ba8da-python-amd64
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-python-amd64
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-python-amd64
ghcr.io/openhands/agent-server:b4ba8da-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b4ba8da-python-arm64
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-python-arm64
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-python-arm64
ghcr.io/openhands/agent-server:b4ba8da-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b4ba8da-golang
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-golang
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-golang
ghcr.io/openhands/agent-server:b4ba8da-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b4ba8da-java
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-java
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-java
ghcr.io/openhands/agent-server:b4ba8da-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b4ba8da-python
ghcr.io/openhands/agent-server:b4ba8da0efc50c8e6d2e714d288f17d433735aa1-python
ghcr.io/openhands/agent-server:fix-git-command-error-redact-command-field-python
ghcr.io/openhands/agent-server:b4ba8da-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b4ba8da-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b4ba8da-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->