### PR TITLE
feat(acp): carry provider key onto ACPAgent via create_agent

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -1270,6 +1270,20 @@ class ACPAgent(AgentBase):
             " ['npx', '-y', '@agentclientprotocol/claude-agent-acp']"
         ),
     )
+    acp_server: str | None = Field(
+        default=None,
+        description=(
+            "Provider registry key identifying which ACP CLI this agent runs "
+            "('claude-code', 'codex', 'gemini-cli', or 'custom'); None when the "
+            "agent is built directly rather than via ACPAgentSettings. Set by "
+            "ACPAgentSettings.create_agent() from ACPAgentSettings.acp_server so "
+            "the authoritative key survives onto the agent — and thus onto "
+            "ConversationInfo.agent — because the launch command in acp_command "
+            "does not reliably reverse-map to a provider. Informational only: "
+            "consumers use it to resolve a provider brand label / model list; "
+            "the subprocess is still launched from acp_command."
+        ),
+    )
     acp_args: list[str] = Field(
         default_factory=list,
         description="Additional arguments for the ACP server command",

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1724,6 +1724,11 @@ class ACPAgentSettings(AgentSettingsBase):
         return ACPAgent(
             llm=self.llm,
             acp_command=self.resolve_acp_command(),
+            # Carry the authoritative provider key onto the agent: acp_command
+            # alone does not reliably reverse-map to a provider, so consumers
+            # (e.g. the conversation UI resolving a brand label / model list)
+            # read it from ConversationInfo.agent.acp_server.
+            acp_server=self.acp_server,
             acp_args=list(self.acp_args),
             # Pass acp_env directly rather than via resolve_acp_env() so the
             # deprecation warning is not emitted twice on the create_agent path:

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -886,6 +886,31 @@ def test_acp_create_agent_uses_server_default_command(
         "@agentclientprotocol/claude-agent-acp@0.30.0",
     ]
     assert agent.acp_model == "claude-opus-4-6"
+    # The authoritative provider key is carried onto the agent.
+    assert agent.acp_server == "claude-code"
+
+
+def test_acp_create_agent_carries_provider_key() -> None:
+    """``create_agent`` stamps the provider key onto the agent for every choice.
+
+    ``acp_command`` does not reliably reverse-map to a provider, so the key must
+    ride the agent (and thus ``ConversationInfo.agent``) for consumers to resolve
+    a brand label / model list. Custom carries through verbatim; an agent built
+    directly (not from settings) defaults to ``None``; and the key survives a
+    serialization round-trip through the ``AgentBase`` discriminated union.
+    """
+    for server in ("claude-code", "codex", "gemini-cli", "custom"):
+        kwargs: dict[str, Any] = {"acp_server": server}
+        if server == "custom":
+            kwargs["acp_command"] = ["my-acp"]
+        agent = ACPAgentSettings(**kwargs).create_agent()
+        assert agent.acp_server == server
+
+    assert ACPAgent(acp_command=["x"]).acp_server is None
+
+    agent = ACPAgentSettings(acp_server="gemini-cli").create_agent()
+    reloaded = ACPAgent.model_validate_json(agent.model_dump_json())
+    assert reloaded.acp_server == "gemini-cli"
 
 
 def test_acp_resolve_command_for_known_servers(


### PR DESCRIPTION
<!-- AI/LLM agents: Do not edit the HUMAN section or human-tested checkbox. -->

HUMAN:

 carry provider key onto ACPAgent via create_agent

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
-->

- [x] A human has tested these changes.

AGENT:

---

## Why

The authoritative ACP provider key lives on `ACPAgentSettings.acp_server` (`claude-code` / `codex` / `gemini-cli` / `custom`), but `create_agent()` **dropped** it — the runtime `ACPAgent` kept only `acp_command`. The launch command does not reliably reverse-map to a provider, so consumers had no dependable way to recover the provider from a serialized agent (and resorted to hand-stamping an `acpserver` conversation tag).

Verified against `main` (1.28-era registry):

```
detect_acp_provider_by_command(['npx','-y','@zed-industries/claude-code-acp']) -> None   # Claude: MISS
detect_acp_provider_by_command(['npx','-y','@openai/codex','acp'])             -> None   # Codex:  MISS
detect_acp_provider_by_command(['codex-acp'])                                  -> 'codex' # pinned-binary form only
```

This is the enabling change for the cloud ACP model picker (see OpenHands/OpenHands#14796 / #14797) and the follow-up migration tracked in #3691.

## Summary

- Add optional `ACPAgent.acp_server: str | None` (default `None`).
- `ACPAgentSettings.create_agent()` populates it from `self.acp_server`, so the key rides `ConversationInfo.agent.acp_server` everywhere — consumers resolve a provider brand label / model list without reverse-parsing `acp_command` or stamping a tag. The subprocess is still launched from `acp_command`; the field is informational.
- Additive and backward-compatible: `None` for agents built directly (not from settings) and for older serialized payloads.

## Issue Number

#3691 (follow-up migration). Enables OpenHands/OpenHands#14796.

## How to Test

```bash
uv sync
uv run pytest tests/sdk/test_settings.py -q -k acp        # 41 passed (incl. new test_acp_create_agent_carries_provider_key)
uv run pyright openhands-sdk/openhands/sdk/agent/acp_agent.py openhands-sdk/openhands/sdk/settings/model.py  # 0 errors
```

End-to-end (ran locally against this branch's venv):

```python
from openhands.sdk.settings.model import ACPAgentSettings
from openhands.sdk.agent.acp_agent import ACPAgent

for key in ('claude-code','codex','gemini-cli'):
    assert ACPAgentSettings(acp_server=key).create_agent().acp_server == key
assert ACPAgentSettings(acp_server='custom', acp_command=['my-acp']).create_agent().acp_server == 'custom'
assert ACPAgent(acp_command=['x']).acp_server is None            # direct build -> None
a = ACPAgentSettings(acp_server='gemini-cli').create_agent()
assert ACPAgent.model_validate_json(a.model_dump_json()).acp_server == 'gemini-cli'   # round-trips through the union
```

Output: all assertions passed; provider keys carried through (`claude-code`/`codex`/`gemini-cli`/`custom`), `None` for direct construction, and the key survives a serialize→validate round-trip through the `AgentBase` discriminated union. `tests/cross/test_check_persisted_settings_compat.py` passes (additive field is compat-safe).

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Additive only — no public symbol removed/changed, so no API-breakage concern. Companion: OpenHands/OpenHands#14797 unblocks the picker today on the current pin; #3691 tracks rerouting OpenHands (derive in the webhook from `agent.acp_server`) and agent-canvas (read `info.agent.acp_server`, drop client-side tag stamping) to retire the `acpserver` tag once this ships and is pinned.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b70717c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b70717c-python \
  ghcr.io/openhands/agent-server:b70717c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b70717c-golang-amd64
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-golang-amd64
ghcr.io/openhands/agent-server:b70717c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b70717c-golang-arm64
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-golang-arm64
ghcr.io/openhands/agent-server:b70717c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b70717c-java-amd64
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-java-amd64
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-java-amd64
ghcr.io/openhands/agent-server:b70717c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b70717c-java-arm64
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-java-arm64
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-java-arm64
ghcr.io/openhands/agent-server:b70717c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b70717c-python-amd64
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-python-amd64
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-python-amd64
ghcr.io/openhands/agent-server:b70717c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b70717c-python-arm64
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-python-arm64
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-python-arm64
ghcr.io/openhands/agent-server:b70717c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b70717c-golang
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-golang
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-golang
ghcr.io/openhands/agent-server:b70717c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b70717c-java
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-java
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-java
ghcr.io/openhands/agent-server:b70717c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b70717c-python
ghcr.io/openhands/agent-server:b70717ca2adfae9ed719928b153a4b135a052480-python
ghcr.io/openhands/agent-server:feat-acp-agent-server-field-python
ghcr.io/openhands/agent-server:b70717c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b70717c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b70717c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->