### PR TITLE
feat(workflow): add wf.pipeline for barrier-free staged fan-out

### DIFF
--- a/openhands-tools/openhands/tools/workflow/definition.py
+++ b/openhands-tools/openhands/tools/workflow/definition.py
@@ -79,6 +79,12 @@ Available `wf` methods:
   max_concurrency=None, description=None)`
 - `await wf.reduce_agent(items, prompt, subagent_type="general-purpose",
   description=None)`
+- `await wf.pipeline(items, *stages)` — run each item through all stages with no
+  barrier between stages (a fast item reaches a later stage while a slow item is
+  still in an earlier one). The first stage gets the item; each later stage gets
+  the previous result. Stages may be sync or async. A stage that raises drops that
+  item to `None`. Prefer this over chained `map_agents` calls when per-item stages
+  are independent, since `map_agents` fully drains each stage before the next.
 - `wf.flatten(values)` — flatten one level of nesting (not recursive)
 
 `subagent_type` must be a sub-agent type registered in the parent application.

--- a/openhands-tools/openhands/tools/workflow/impl.py
+++ b/openhands-tools/openhands/tools/workflow/impl.py
@@ -187,6 +187,40 @@ class WorkflowContext:
             )
         return [str(result) for result in results]
 
+    async def pipeline(
+        self,
+        items: Sequence[Any],
+        *stages: Callable[[Any], Any],
+    ) -> list[Any]:
+        """Run each item through all stages independently, with no barrier between
+        stages: a fast item can reach a later stage while a slow item is still in an
+        earlier one. The first stage receives the original item; each later stage
+        receives the previous stage's result. Stages may be sync or async. A stage
+        that raises drops that item to ``None`` and skips its remaining stages; other
+        items are unaffected.
+
+        Concurrency is bounded by the agent calls inside stages (which acquire the
+        shared semaphore), so pipeline adds no barrier of its own. Do not have a
+        stage re-acquire the semaphore directly; call ``run_agent``/``map_agents``.
+        """
+        if not stages:
+            raise ValueError("pipeline requires at least one stage")
+
+        async def run_chain(index: int, item: Any) -> Any:
+            value: Any = item
+            try:
+                for stage in stages:
+                    result = stage(value)
+                    value = await result if inspect.isawaitable(result) else result
+                return value
+            except Exception as exc:
+                logger.warning("pipeline: item %d failed: %s", index + 1, exc)
+                return None
+
+        return list(
+            await asyncio.gather(*(run_chain(i, item) for i, item in enumerate(items)))
+        )
+
     async def reduce_agent(
         self,
         items: Any,

--- a/tests/tools/workflow/test_workflow_tool.py
+++ b/tests/tools/workflow/test_workflow_tool.py
@@ -402,3 +402,87 @@ async def main(wf):
 """
     execute_workflow_script(script, context)
     assert manager.peak_active <= context_cap
+
+
+def test_pipeline_returns_results_in_item_order() -> None:
+    ctx = _context(_FakeTaskManager())
+
+    async def stage(value: str) -> str:
+        return value + "!"
+
+    result = asyncio.run(ctx.pipeline(["a", "b", "c"], stage))
+    assert result == ["a!", "b!", "c!"]
+
+
+def test_pipeline_has_no_barrier_between_stages() -> None:
+    """A fast item reaches a later stage while a slow item is still in stage 1."""
+    ctx = _context(_FakeTaskManager())
+    order: list[str] = []
+
+    async def stage1(item: str) -> str:
+        if item == "slow":
+            await asyncio.sleep(0.05)
+            order.append("slow:s1:end")
+        else:
+            order.append(f"{item}:s1")
+        return item
+
+    async def stage2(item: str) -> str:
+        order.append(f"{item}:s2")
+        return item
+
+    result = asyncio.run(ctx.pipeline(["slow", "fast"], stage1, stage2))
+    assert result == ["slow", "fast"]  # order preserved despite race
+    # fast reached stage 2 before slow finished stage 1 -> no barrier
+    assert order.index("fast:s2") < order.index("slow:s1:end")
+
+
+def test_pipeline_stage_failure_drops_item_to_none() -> None:
+    ctx = _context(_FakeTaskManager())
+
+    async def stage(item: str) -> str:
+        if item == "bad":
+            raise RuntimeError("boom")
+        return item.upper()
+
+    result = asyncio.run(ctx.pipeline(["ok", "bad", "ok2"], stage))
+    assert result == ["OK", None, "OK2"]
+
+
+def test_pipeline_supports_sync_and_async_stages() -> None:
+    ctx = _context(_FakeTaskManager())
+
+    def sync_stage(value: str) -> str:
+        return value + "!"
+
+    async def async_stage(value: str) -> str:
+        return value.upper()
+
+    result = asyncio.run(ctx.pipeline(["a"], sync_stage, async_stage))
+    assert result == ["A!"]
+
+
+def test_pipeline_requires_at_least_one_stage() -> None:
+    ctx = _context(_FakeTaskManager())
+    with pytest.raises(ValueError, match="at least one stage"):
+        asyncio.run(ctx.pipeline(["a"]))
+
+
+def test_pipeline_reachable_from_generated_script() -> None:
+    manager = _FakeTaskManager()
+    ctx = _context(manager)
+    script = """
+async def main(wf):
+    async def review(item):
+        return await wf.run_agent(f"review {item}")
+
+    async def verify(prev):
+        return await wf.run_agent(f"verify {prev}")
+
+    return await wf.pipeline(["x", "y"], review, verify)
+"""
+    result = execute_workflow_script(script, ctx)
+    assert result == [
+        "result:verify result:review x",
+        "result:verify result:review y",
+    ]


### PR DESCRIPTION
HUMAN:

Adds barrier-free pipelining so a slow item doesn't gate a whole stage in the workflow tool. Reviewed the implementation and the no-barrier + sandbox-script tests.

- [x] A human has tested these changes.

AGENT:

---

## Why

The dynamic workflow tool's only multi-stage primitive was chaining `map_agents` calls, each of which fully drains its stage before the next begins (a hard `asyncio.gather` barrier) — so the slowest item in a stage gates everything behind it. There was no way to pipeline work item-by-item.

## Summary

- Adds `wf.pipeline(items, *stages)`: each item flows through all stages independently with **no barrier between stages** — a fast item reaches a later stage while a slow item is still in an earlier one.
- First stage gets the item; each later stage gets the previous result. Stages may be sync or async. A stage that raises drops that item to `None` (others unaffected).
- Concurrency stays bounded by the agent calls inside stages (shared semaphore), so pipeline adds no barrier of its own and never re-acquires the non-reentrant semaphore. Tool description documents it.

## How to Test

```
uv run pytest tests/tools                 # 907 passed, 9 skipped, 0 failed
uv run pytest tests/tools/workflow        # 27 passed (6 new)
uv run ruff check && uv run ruff format   # clean
```

End-to-end evidence beyond unit assertions:
- A **deterministic no-barrier test** drives two items where a fast item provably reaches stage 2 before a slow item finishes stage 1 (asserts ordering of stage entry), confirming there is no inter-stage barrier.
- An **end-to-end sandbox test** runs `wf.pipeline` from a generated workflow script through the actual workflow execution path (validator + `exec` + task dispatch), confirming it is reachable and correct from author-written scripts: result `["result:verify result:review x", "result:verify result:review y"]`.

This is pure asyncio orchestration (no LLM behavior involved), so it is fully covered by deterministic tests with a fake task manager; a real-LLM run would only re-confirm `run_agent` works inside a stage, which the sandbox test already covers.

## Type

- [x] Feature

## Notes

Purely additive — no existing `wf` method changed; new method + one doc paragraph.
