### PR TITLE
feat(workflow): drop whole elements when truncating reduce input

### DIFF
--- a/openhands-tools/openhands/tools/workflow/impl.py
+++ b/openhands-tools/openhands/tools/workflow/impl.py
@@ -23,6 +23,7 @@ logger = get_logger(__name__)
 
 _MAX_SCRIPT_CHARS = 20_000
 _MAX_REDUCE_INPUT_CHARS = 12_000
+_TRUNCATION_MARKER = "\n... [truncated workflow intermediate results]"
 _WORKFLOW_TIMEOUT_SECONDS = 3600.0  # 1 hour; prevents indefinitely hung workflows
 _UNSAFE_CALLS = frozenset(
     {
@@ -282,18 +283,60 @@ def _render_template(
 
 
 def _format_value(value: Any) -> str:
-    if isinstance(value, str):
-        text = value
-    else:
-        text = jsonlib.dumps(value, indent=2, default=str)
+    """Serialize reduce input for the reducer prompt, bounded by
+    ``_MAX_REDUCE_INPUT_CHARS``. For lists/dicts, drop whole trailing elements
+    (keeping valid JSON) and report how many were omitted, instead of slicing
+    mid-token; everything else falls back to character truncation."""
+    if isinstance(value, (list, dict)):
+        return _truncate_structured(value)
+    text = value if isinstance(value, str) else jsonlib.dumps(value, default=str)
+    return _truncate_text(text)
+
+
+def _truncate_text(text: str) -> str:
     if len(text) <= _MAX_REDUCE_INPUT_CHARS:
         return text
-    # Character-boundary truncation can split mid-token in JSON; element-boundary
-    # truncation for list/dict inputs would be cleaner but is deferred post-MVP.
-    return (
-        text[:_MAX_REDUCE_INPUT_CHARS]
-        + "\n... [truncated workflow intermediate results]"
-    )
+    return text[:_MAX_REDUCE_INPUT_CHARS] + _TRUNCATION_MARKER
+
+
+def _truncate_structured(value: list | dict) -> str:
+    """Keep as many leading elements as fit, dropping whole elements so the JSON
+    stays valid. Always keeps at least one element; a single oversized element is
+    char-truncated as a last resort."""
+    full = jsonlib.dumps(value, indent=2, default=str)
+    if len(full) <= _MAX_REDUCE_INPUT_CHARS:
+        return full
+
+    is_dict = isinstance(value, dict)
+    items = list(value.items()) if is_dict else list(value)
+    total = len(items)
+
+    def render(kept: list) -> str:
+        body = jsonlib.dumps(dict(kept) if is_dict else kept, indent=2, default=str)
+        dropped = total - len(kept)
+        if not dropped:
+            return body
+        return (
+            f"{body}\n... [{dropped} of {total} items omitted to fit the "
+            "reduce input limit]"
+        )
+
+    # Greedy fill by per-element estimate, then correct against the actual
+    # combined serialization (which is larger than the sum of parts) so the
+    # result fits without slicing mid-token.
+    kept: list = []
+    used = 0
+    for item in items:
+        chunk = jsonlib.dumps(dict([item]) if is_dict else item, default=str)
+        if kept and used + len(chunk) > _MAX_REDUCE_INPUT_CHARS:
+            break
+        kept.append(item)
+        used += len(chunk)
+    while len(kept) > 1 and len(render(kept)) > _MAX_REDUCE_INPUT_CHARS:
+        kept.pop()
+
+    # Safety net: a single oversized element can still exceed the budget.
+    return _truncate_text(render(kept))
 
 
 def validate_workflow_script(script: str) -> None:

--- a/tests/tools/workflow/test_workflow_tool.py
+++ b/tests/tools/workflow/test_workflow_tool.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import threading
 from dataclasses import dataclass
 from typing import cast
@@ -15,6 +16,7 @@ from openhands.tools.workflow import (
     WorkflowScriptError,
 )
 from openhands.tools.workflow.impl import (
+    _MAX_REDUCE_INPUT_CHARS,
     _format_exception,
     _format_value,
     execute_workflow_script,
@@ -486,3 +488,43 @@ async def main(wf):
         "result:verify result:review x",
         "result:verify result:review y",
     ]
+
+
+def test_format_value_small_passthrough() -> None:
+    value = ["a", "b", "c"]
+    assert _format_value(value) == json.dumps(value, indent=2, default=str)
+
+
+def test_format_value_large_list_drops_whole_elements() -> None:
+    """Over-limit lists drop whole trailing elements and stay valid JSON, instead
+    of slicing mid-token."""
+    value = [f"finding {i}: " + "x" * 500 for i in range(60)]
+    out = _format_value(value)
+    assert "items omitted to fit" in out
+    assert len(out) <= _MAX_REDUCE_INPUT_CHARS + 80
+    head = out.split("\n... [")[0]
+    parsed = json.loads(head)  # must be valid JSON (the whole point)
+    assert parsed == value[: len(parsed)]  # leading elements kept, in order
+    assert 0 < len(parsed) < len(value)
+
+
+def test_format_value_large_dict_drops_whole_keys() -> None:
+    value = {f"k{i}": "y" * 500 for i in range(60)}
+    out = _format_value(value)
+    assert "items omitted to fit" in out
+    parsed = json.loads(out.split("\n... [")[0])
+    assert isinstance(parsed, dict)
+    assert 0 < len(parsed) < len(value)
+
+
+def test_format_value_single_oversized_element_char_truncated() -> None:
+    """A single element bigger than the budget falls back to char truncation."""
+    out = _format_value(["z" * (_MAX_REDUCE_INPUT_CHARS + 5000)])
+    assert out.endswith("[truncated workflow intermediate results]")
+    assert len(out) <= _MAX_REDUCE_INPUT_CHARS + 60
+
+
+def test_format_value_long_string_char_truncated() -> None:
+    out = _format_value("q" * (_MAX_REDUCE_INPUT_CHARS + 100))
+    assert out.endswith("[truncated workflow intermediate results]")
+    assert len(out) <= _MAX_REDUCE_INPUT_CHARS + 60


### PR DESCRIPTION
HUMAN:

The workflow reducer sliced its fan-in at a hard 12k-char boundary, cutting mid-JSON and silently dropping findings. This drops whole elements instead so the reducer gets valid JSON. Reviewed the change and the new tests.

- [x] A human has tested these changes.

AGENT:

---

## Why

`reduce_agent` serialized its fan-in input and then sliced it at a hard 12,000 character boundary. That cut can land mid-JSON-token and silently drop findings, in the exact repo-wide-audit path the workflow tool advertises (map findings → reduce), the reducer would receive truncated/!invalid intermediate results with no clear signal of what was lost.

## Summary

- For list/dict reduce inputs, drop **whole trailing elements** (keeping valid JSON) and append a clear `[N of M items omitted to fit the reduce input limit]` marker, keeping the leading elements.
- Scalars/strings, and the degenerate case of a single element larger than the budget, still fall back to character truncation as a safety net.
- Greedy fill by per-element estimate, then correct against the actual combined serialization so the result always fits without slicing mid-token.

## How to Test

Self-verifiable with pytest only (no LLM, no OHE):

```
uv run pytest tests/tools/workflow      # 32 passed (5 new + existing)
uv run pytest tests/tools               # 912 passed, 9 skipped, 0 failed
uv run ruff check && uv run ruff format # clean
```

New tests cover: small input passthrough; large list/dict dropping whole elements with the head remaining **valid JSON** (the whole point); a single oversized element falling back to char truncation; and long-string char truncation. The pre-existing `test_format_value_truncates_large_intermediate_results` still passes
(back-compat for the scalar path).

## Type

- [x] Feature

## Notes

Purely the reducer's input-shaping; no change to `run_agent`/`map_agents`/`pipeline`
behavior or to the workflow tool's public surface.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d08988d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d08988d-python \
  ghcr.io/openhands/agent-server:d08988d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d08988d-golang-amd64
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-golang-amd64
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-golang-amd64
ghcr.io/openhands/agent-server:d08988d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d08988d-golang-arm64
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-golang-arm64
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-golang-arm64
ghcr.io/openhands/agent-server:d08988d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d08988d-java-amd64
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-java-amd64
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-java-amd64
ghcr.io/openhands/agent-server:d08988d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d08988d-java-arm64
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-java-arm64
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-java-arm64
ghcr.io/openhands/agent-server:d08988d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d08988d-python-amd64
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-python-amd64
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-python-amd64
ghcr.io/openhands/agent-server:d08988d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d08988d-python-arm64
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-python-arm64
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-python-arm64
ghcr.io/openhands/agent-server:d08988d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d08988d-golang
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-golang
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-golang
ghcr.io/openhands/agent-server:d08988d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d08988d-java
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-java
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-java
ghcr.io/openhands/agent-server:d08988d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d08988d-python
ghcr.io/openhands/agent-server:d08988d7282d8c97cfda1c5c52f7b3bd1b99506f-python
ghcr.io/openhands/agent-server:alona-sdk-workflow-reduce-truncation-python
ghcr.io/openhands/agent-server:d08988d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d08988d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d08988d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->