### PR TITLE
feat(task): enforce a per-run cost budget for agents and sub-agents

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -157,6 +157,9 @@ class LocalConversation(BaseConversation):
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
+        # Appended at the end (not grouped with max_iteration_per_run) to avoid
+        # shifting the position of any existing positional argument.
+        max_budget_per_run: float | None = None,
         **_: object,
     ):
         """Initialize the conversation.
@@ -328,6 +331,8 @@ class LocalConversation(BaseConversation):
         )
 
         self.max_iteration_per_run = max_iteration_per_run
+        # Hard cost ceiling (USD) for a run; None disables the budget check.
+        self.max_budget_per_run = max_budget_per_run
 
         # Initialize stuck detector
         if stuck_detection:
@@ -448,6 +453,30 @@ class LocalConversation(BaseConversation):
     @property
     def conversation_stats(self):
         return self._state.stats
+
+    def _budget_exceeded_detail(self) -> str | None:
+        """Error detail if the run has hit its cost budget, else None.
+
+        Bounds total spend across all of the run's LLMs (agent, condenser, ...),
+        complementing the iteration cap which only bounds step count.
+        """
+        if self.max_budget_per_run is None:
+            return None
+        spent = self.conversation_stats.get_combined_metrics().accumulated_cost
+        if spent < self.max_budget_per_run:
+            return None
+        return (
+            f"Agent reached maximum budget limit "
+            f"(${self.max_budget_per_run:.4f}); accumulated cost ${spent:.4f}."
+        )
+
+    def _emit_run_limit_error(self, code: str, detail: str) -> None:
+        """Mark the run failed with a run-limit ConversationErrorEvent."""
+        logger.error(detail)
+        self._state.execution_status = ConversationExecutionStatus.ERROR
+        self._on_event(
+            ConversationErrorEvent(source="environment", code=code, detail=detail)
+        )
 
     @property
     def stuck_detector(self) -> StuckDetector | None:
@@ -1212,6 +1241,14 @@ class LocalConversation(BaseConversation):
                     ):
                         break
 
+                    budget_detail = self._budget_exceeded_detail()
+                    if budget_detail and (
+                        self._state.execution_status
+                        != ConversationExecutionStatus.FINISHED
+                    ):
+                        self._emit_run_limit_error("MaxBudgetReached", budget_detail)
+                        break
+
                     if iteration >= self.max_iteration_per_run:
                         # If the agent finished on this final iteration,
                         # preserve the FINISHED status rather than
@@ -1449,6 +1486,16 @@ class LocalConversation(BaseConversation):
                         ):
                             break
 
+                        budget_detail = self._budget_exceeded_detail()
+                        if budget_detail and (
+                            self._state.execution_status
+                            != ConversationExecutionStatus.FINISHED
+                        ):
+                            self._emit_run_limit_error(
+                                "MaxBudgetReached", budget_detail
+                            )
+                            break
+
                         if iteration >= self.max_iteration_per_run:
                             if (
                                 self._state.execution_status
@@ -1615,6 +1662,14 @@ class LocalConversation(BaseConversation):
                         self.state.execution_status
                         == ConversationExecutionStatus.WAITING_FOR_CONFIRMATION
                     ):
+                        break
+
+                    budget_detail = self._budget_exceeded_detail()
+                    if budget_detail and (
+                        self._state.execution_status
+                        != ConversationExecutionStatus.FINISHED
+                    ):
+                        self._emit_run_limit_error("MaxBudgetReached", budget_detail)
                         break
 
                     if iteration >= self.max_iteration_per_run:

--- a/openhands-sdk/openhands/sdk/subagent/schema.py
+++ b/openhands-sdk/openhands/sdk/subagent/schema.py
@@ -26,6 +26,7 @@ KNOWN_FIELDS: Final[set[str]] = {
     "tools",
     "skills",
     "max_iteration_per_run",
+    "max_budget_per_run",
     "hooks",
     "profile_store_dir",
     "mcp_servers",
@@ -141,6 +142,18 @@ def _extract_max_iteration_per_run(fm: dict[str, object]) -> int | None:
     return None
 
 
+def _extract_max_budget_per_run(fm: dict[str, object]) -> float | None:
+    """Extract the per-run cost budget (USD) from a frontmatter file."""
+    raw = fm.get("max_budget_per_run")
+    if isinstance(raw, bool):
+        return None
+    if isinstance(raw, (int, float)):
+        return float(raw)
+    if isinstance(raw, str):
+        return float(raw)
+    return None
+
+
 def _extract_hooks(fm: dict[str, object]) -> HookConfig | None:
     # Parse hooks configuration
     hooks_raw = fm.get("hooks")
@@ -220,6 +233,12 @@ class AgentDefinition(BaseModel):
         default=None,
         description="Maximum iterations per run. "
         "It must be strictly positive, or None for default.",
+        gt=0,
+    )
+    max_budget_per_run: float | None = Field(
+        default=None,
+        description="Maximum accumulated cost (USD) per run for this sub-agent. "
+        "Must be strictly positive, or None for no budget.",
         gt=0,
     )
     mcp_servers: dict[str, Any] | None = Field(
@@ -310,6 +329,7 @@ class AgentDefinition(BaseModel):
         skills: list[str] = _extract_skills(fm)
         permission_mode: str | None = _extract_permission_mode(fm)
         max_iteration_per_run: int | None = _extract_max_iteration_per_run(fm)
+        max_budget_per_run: float | None = _extract_max_budget_per_run(fm)
         mcp_servers: dict[str, Any] | None = _extract_mcp_servers(fm)
         profile_store_dir: str | None = _extract_profile_store_dir(fm)
         hooks: HookConfig | None = _extract_hooks(fm)
@@ -330,6 +350,7 @@ class AgentDefinition(BaseModel):
             skills=skills,
             permission_mode=permission_mode,
             max_iteration_per_run=max_iteration_per_run,
+            max_budget_per_run=max_budget_per_run,
             mcp_servers=mcp_servers,
             hooks=hooks,
             profile_store_dir=profile_store_dir,

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -28,6 +28,7 @@ from openhands.sdk.conversation.state import (
     ConversationExecutionStatus,
     ConversationState,
 )
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.hooks.config import HookConfig
 from openhands.sdk.logger import get_logger
 from openhands.sdk.security import ConfirmationPolicyBase
@@ -251,6 +252,11 @@ class TaskManager:
             if factory.definition.max_iteration_per_run
             else self.parent_conversation.max_iteration_per_run
         )
+        # Sub-agent budget: definition value, else inherit the parent's.
+        effective_max_budget = (
+            factory.definition.max_budget_per_run
+            or self.parent_conversation.max_budget_per_run
+        )
 
         with self._tasks_lock:
             task_id, conversation_id = self._generate_ids()
@@ -258,6 +264,7 @@ class TaskManager:
             sub_conversation = self._get_conversation(
                 description=description,
                 max_iteration_per_run=effective_max_iter,
+                max_budget_per_run=effective_max_budget,
                 task_id=task_id,
                 worker_agent=worker_agent,
                 conversation_id=conversation_id,
@@ -285,6 +292,7 @@ class TaskManager:
         conversation_id: uuid.UUID,
         worker_agent: Agent,
         hook_config: HookConfig | None = None,
+        max_budget_per_run: float | None = None,
     ) -> LocalConversation:
         parent = self.parent_conversation
         parent_visualizer = parent._visualizer
@@ -301,6 +309,7 @@ class TaskManager:
             persistence_dir=self._persistence_dir,
             conversation_id=conversation_id,
             max_iteration_per_run=max_iteration_per_run,
+            max_budget_per_run=max_budget_per_run,
             hook_config=hook_config,
             delete_on_close=True,
         )
@@ -346,9 +355,19 @@ class TaskManager:
         try:
             task.conversation.send_message(prompt, sender=parent_name)
             self._run_until_finished(task.id, task.conversation)
-            result = get_agent_final_response(task.conversation.state.events)
-            task.set_result(result)
-            logger.info(f"Task '{task.id}' completed.")
+            # A run-limit stop (cost budget or iteration cap) ends the
+            # sub-conversation in ERROR without raising; surface that to the
+            # parent instead of an empty "completed" result.
+            if (
+                task.conversation.state.execution_status
+                == ConversationExecutionStatus.ERROR
+            ):
+                task.set_error(self._run_error_detail(task.conversation))
+                logger.warning(f"Task '{task.id}' ended with an error.")
+            else:
+                result = get_agent_final_response(task.conversation.state.events)
+                task.set_result(result)
+                logger.info(f"Task '{task.id}' completed.")
         except Exception as e:
             task.set_error(str(e))
             logger.warning(f"Task {task.id} failed with error: {e}")
@@ -357,6 +376,19 @@ class TaskManager:
             self._evict_task(task)
 
         return task
+
+    @staticmethod
+    def _run_error_detail(conversation: LocalConversation) -> str:
+        """Best-effort detail for a sub-agent run that ended in ERROR (e.g. the
+        cost budget or iteration cap), so the parent sees why it stopped."""
+        errors = [
+            e
+            for e in conversation.state.events
+            if isinstance(e, ConversationErrorEvent)
+        ]
+        if errors:
+            return errors[-1].detail
+        return "Sub-agent run ended with an error."
 
     def _run_until_finished(
         self, task_id: str, conversation: LocalConversation

--- a/tests/sdk/conversation/local/test_agent_status_transition.py
+++ b/tests/sdk/conversation/local/test_agent_status_transition.py
@@ -541,3 +541,87 @@ def test_execution_status_finished_on_final_iteration():
     assert len(max_iter_errors) == 0, (
         "Expected no MaxIterationsReached error when agent finishes on final iteration"
     )
+
+
+def test_execution_status_error_on_max_budget(tmp_path):
+    """Run halts with ERROR + MaxBudgetReached when the cost budget is exceeded,
+    even before the iteration cap is reached."""
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.llm.utils.metrics import Metrics
+
+    events_received: list = []
+    test_tool = StatusTransitionTestTool.create(executor=StatusCheckingExecutor([]))[0]
+    register_tool("test_tool", test_tool)
+
+    tool_call_message = Message(
+        role="assistant",
+        content=[TextContent(text="")],
+        tool_calls=[
+            MessageToolCall(
+                id="call_1",
+                name="test_tool",
+                arguments='{"command": "test_command"}',
+                origin="completion",
+            )
+        ],
+    )
+    llm = TestLLM.from_messages([tool_call_message] * 5)
+    agent = Agent(llm=llm, tools=[Tool(name="test_tool")])
+    # High iteration cap so the BUDGET is what stops the run.
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+        delete_on_close=False,
+        max_iteration_per_run=10,
+        max_budget_per_run=1.0,
+        callbacks=[lambda e: events_received.append(e)],
+    )
+    conversation.send_message(
+        Message(role="user", content=[TextContent(text="Execute command")])
+    )
+    # Pre-seed spend over the budget (TestLLM accrues no real cost).
+    conversation.conversation_stats.usage_to_metrics["spend"] = Metrics(
+        accumulated_cost=5.0
+    )
+    conversation.run()
+
+    assert conversation.state.execution_status == ConversationExecutionStatus.ERROR
+    error_events = [e for e in events_received if isinstance(e, ConversationErrorEvent)]
+    budget_errors = [e for e in error_events if e.code == "MaxBudgetReached"]
+    assert len(budget_errors) == 1
+    assert "maximum budget limit" in budget_errors[0].detail
+    # Budget stopped it, not the iteration cap.
+    assert not any(e.code == "MaxIterationsReached" for e in error_events)
+
+
+def test_finished_preserved_even_when_over_budget(tmp_path):
+    """A run that finishes is kept FINISHED even if it is over budget."""
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.llm.utils.metrics import Metrics
+
+    events_received: list = []
+    # Text-only response -> agent finishes on the first iteration.
+    finish_message = Message(
+        role="assistant", content=[TextContent(text="Task completed")]
+    )
+    llm = TestLLM.from_messages([finish_message])
+    agent = Agent(llm=llm, tools=[])
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+        delete_on_close=False,
+        max_iteration_per_run=10,
+        max_budget_per_run=1.0,
+        callbacks=[lambda e: events_received.append(e)],
+    )
+    conversation.send_message(Message(role="user", content=[TextContent(text="Do it")]))
+    conversation.conversation_stats.usage_to_metrics["spend"] = Metrics(
+        accumulated_cost=5.0
+    )
+    conversation.run()
+
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+    error_events = [e for e in events_received if isinstance(e, ConversationErrorEvent)]
+    assert not any(e.code == "MaxBudgetReached" for e in error_events)

--- a/tests/sdk/subagent/test_subagent_schema.py
+++ b/tests/sdk/subagent/test_subagent_schema.py
@@ -801,3 +801,27 @@ class TestAgentDefinitionCondenser:
         agent_md = tmp_path / "a.md"
         agent_md.write_text("---\nname: a\ncondenser: none\n---\n\nPrompt.\n")
         assert "condenser" not in AgentDefinition.load(agent_md).metadata
+
+
+class TestAgentDefinitionMaxBudget:
+    """Tests for the max_budget_per_run frontmatter field."""
+
+    def test_absent_is_none(self, tmp_path: Path):
+        md = tmp_path / "a.md"
+        md.write_text("---\nname: a\n---\n\nPrompt.\n")
+        assert AgentDefinition.load(md).max_budget_per_run is None
+
+    def test_numeric_value(self, tmp_path: Path):
+        md = tmp_path / "a.md"
+        md.write_text("---\nname: a\nmax_budget_per_run: 2.5\n---\n\nPrompt.\n")
+        assert AgentDefinition.load(md).max_budget_per_run == 2.5
+
+    def test_string_value(self, tmp_path: Path):
+        md = tmp_path / "a.md"
+        md.write_text('---\nname: a\nmax_budget_per_run: "1.0"\n---\n\nPrompt.\n')
+        assert AgentDefinition.load(md).max_budget_per_run == 1.0
+
+    def test_not_in_metadata(self, tmp_path: Path):
+        md = tmp_path / "a.md"
+        md.write_text("---\nname: a\nmax_budget_per_run: 3\n---\n\nPrompt.\n")
+        assert "max_budget_per_run" not in AgentDefinition.load(md).metadata

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -1,5 +1,6 @@
 import uuid
 from pathlib import Path
+from typing import cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -942,3 +943,67 @@ class TestTaskManagerPersistence:
         conv_persistence = conv.state.persistence_dir
         assert conv_persistence is not None
         assert str(conv_persistence).startswith(str(manager._persistence_dir))
+
+
+class TestTaskManagerBudget:
+    """The per-subagent cost budget flows from the agent definition / parent
+    into the spawned sub-conversation."""
+
+    def test_budget_from_agent_definition(self, tmp_path):
+        from openhands.sdk.subagent.registry import agent_definition_to_factory
+
+        agent_def = AgentDefinition(
+            name="budgeted", model="inherit", tools=[], max_budget_per_run=4.0
+        )
+        register_agent(
+            name="budgeted",
+            factory_func=agent_definition_to_factory(agent_def),
+            description=agent_def,
+        )
+        manager, _ = _manager_with_parent(tmp_path)
+        task = manager._create_task(subagent_type="budgeted", description=None)
+        assert task.conversation is not None
+        assert task.conversation.max_budget_per_run == 4.0
+
+    def test_budget_inherits_from_parent(self, tmp_path):
+        register_builtins_agents()
+        agent = Agent(llm=_make_llm(), tools=[])
+        parent = LocalConversation(
+            agent=agent,
+            workspace=str(tmp_path),
+            visualizer=None,
+            delete_on_close=False,
+            max_budget_per_run=7.0,
+        )
+        manager = TaskManager()
+        manager._ensure_parent(parent)
+        task = manager._create_task(subagent_type="general-purpose", description=None)
+        assert task.conversation is not None
+        assert task.conversation.max_budget_per_run == 7.0
+
+
+class TestRunErrorSurfacing:
+    """A sub-agent run that ends in ERROR (cost budget or iteration cap) is
+    surfaced to the parent task rather than reported as an empty success."""
+
+    def test_run_error_detail_returns_last_error(self):
+        from types import SimpleNamespace
+
+        from openhands.sdk.event.conversation_error import ConversationErrorEvent
+
+        err = ConversationErrorEvent(
+            source="environment",
+            code="MaxBudgetReached",
+            detail="Agent reached maximum budget limit ($0.05).",
+        )
+        conv = SimpleNamespace(state=SimpleNamespace(events=[err]))
+        assert (
+            TaskManager._run_error_detail(cast(LocalConversation, conv)) == err.detail
+        )
+
+    def test_run_error_detail_default_when_no_error_event(self):
+        from types import SimpleNamespace
+
+        conv = SimpleNamespace(state=SimpleNamespace(events=[]))
+        detail = TaskManager._run_error_detail(cast(LocalConversation, conv))
+        assert "error" in detail.lower()


### PR DESCRIPTION
HUMAN:

Agents and sub-agents only had an iteration cap, not a cost ceiling — this adds a per-run budget so a verbose run or a sub-agent fan-out can't run away on spend. Reviewed the change and the deterministic + real-LLM tests, including a spawned sub-agent halting on its budget.

- [x] A human has tested these changes.

AGENT:

---

## Why

A run was bounded only by the iteration cap (`max_iteration_per_run`), which limits step count but **not spend**. A verbose-but-productive agent, or a fan-out of sub-agents, could run away on cost with no hard ceiling. (`Metrics.max_budget_per_task` existed but was dead — stored/merged, never enforced.)

## Summary

- Add an optional `max_budget_per_run` (USD) on `LocalConversation`, enforced in the run loop next to the iteration cap (`run()` + `arun()`), preserving a `FINISHED` status set on the final step.
- Wire it through `AgentDefinition.max_budget_per_run` + `TaskManager` so spawned sub-agents inherit the parent's budget or override it from their definition.
- Surface a sub-agent run that ends in `ERROR` (budget **or** iteration cap) to the parent task, instead of reporting an empty "completed" result.

## How to Test

Deterministic (no API):
```
uv run pytest tests/sdk/conversation/local/test_agent_status_transition.py  # run-loop halt + FINISHED-preserve
uv run pytest tests/tools/task tests/sdk/subagent                            # wiring + surfacing
uv run pytest tests/sdk tests/tools                                          # 5516 passed, 0 failed
uv run ruff check && uv run pre-commit run pyright --all-files               # clean
```

Real-LLM (proxy; cost a few cents), proving spend triggers the halt naturally:

1. **Enforcement** — a spawned sub-agent with `AgentDefinition(max_budget_per_run=$0.05)`
   ran real terminal steps; real `accumulated_cost` reached **$0.0529** and the run
   halted: `MaxBudgetReached` → status `ERROR`.
2. **Sub-agent flow surfacing** — through the full `TaskManager.start_task` path, the
   parent `Task` reported:
   `error` / `"Agent reached maximum budget limit ($0.0500); accumulated cost $0.0524."`
   (previously this was a silent empty "completed").

## Type

- [x] Feature

## Notes

- **Design:** the budget lives on the conversation (mirroring `max_iteration_per_run`) and is checked against `conversation_stats.get_combined_metrics().accumulated_cost` (total across the agent + condenser LLMs). The dormant per-LLM
  `Metrics.max_budget_per_task` is left untouched — aggregating it across a run's LLMs is awkward, and a run-level limit is the natural home.
- **Heads-up (intentional, pre-existing-gap fix):** the parent-surfacing change also covers the **iteration cap**, which was equally silent before. So a sub-agent that hits `max_iteration_per_run` now surfaces as a task error too. Happy to scope this to budget-only if preferred.
- **Back-compat:** `max_budget_per_run` is appended as the last named `__init__` param (before `**_`) so no existing positional argument shifts; default `None` = no budget (no behavior change for existing runs). No `LocalConversation` is constructed positionally anywhere in the SDK/agent-server.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:029f0cc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-029f0cc-python \
  ghcr.io/openhands/agent-server:029f0cc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:029f0cc-golang-amd64
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-golang-amd64
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-golang-amd64
ghcr.io/openhands/agent-server:029f0cc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:029f0cc-golang-arm64
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-golang-arm64
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-golang-arm64
ghcr.io/openhands/agent-server:029f0cc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:029f0cc-java-amd64
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-java-amd64
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-java-amd64
ghcr.io/openhands/agent-server:029f0cc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:029f0cc-java-arm64
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-java-arm64
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-java-arm64
ghcr.io/openhands/agent-server:029f0cc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:029f0cc-python-amd64
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-python-amd64
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-python-amd64
ghcr.io/openhands/agent-server:029f0cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:029f0cc-python-arm64
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-python-arm64
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-python-arm64
ghcr.io/openhands/agent-server:029f0cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:029f0cc-golang
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-golang
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-golang
ghcr.io/openhands/agent-server:029f0cc-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:029f0cc-java
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-java
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-java
ghcr.io/openhands/agent-server:029f0cc-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:029f0cc-python
ghcr.io/openhands/agent-server:029f0cc806075773b32e3e1bc10dfd398aee1b5e-python
ghcr.io/openhands/agent-server:alona-sdk-subagent-budget-python
ghcr.io/openhands/agent-server:029f0cc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `029f0cc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `029f0cc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->