### PR TITLE
test(settings): add ACPAgentSettings mcp_config secret-preservation tests

### DIFF
--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -1606,6 +1606,56 @@ def test_openhands_agent_settings_create_agent_keeps_real_mcp_secrets() -> None:
     assert agent.mcp_config["mcpServers"]["leaky"]["env"]["API_KEY"] == "sk-mcp-secret"
 
 
+def test_acp_agent_settings_mcp_config_redacts_env_and_headers() -> None:
+    mcp_config = MCPConfig.model_validate(
+        {
+            "mcpServers": {
+                "leaky": {
+                    "command": "echo",
+                    "args": ["mcp"],
+                    "env": {"API_KEY": "sk-mcp-secret"},
+                    "headers": {"Authorization": "Bearer tok-mcp-secret"},
+                }
+            }
+        }
+    )
+    settings = ACPAgentSettings(acp_command=["echo"], mcp_config=mcp_config)
+
+    blob = settings.model_dump_json()
+    assert "sk-mcp-secret" not in blob
+    assert "tok-mcp-secret" not in blob
+
+    exposed = settings.model_dump(context={"expose_secrets": True})
+    leaky = exposed["mcp_config"]["mcpServers"]["leaky"]
+    assert leaky["env"]["API_KEY"] == "sk-mcp-secret"
+    assert leaky["headers"]["Authorization"] == "Bearer tok-mcp-secret"
+
+
+def test_acp_agent_settings_create_agent_keeps_real_mcp_secrets() -> None:
+    # create_agent must hand the subprocess real env/headers (the field serializer
+    # redacts mcp_config for transit/storage only).
+    mcp_config = MCPConfig.model_validate(
+        {
+            "mcpServers": {
+                "leaky": {
+                    "command": "echo",
+                    "args": ["mcp"],
+                    "env": {"API_KEY": "sk-mcp-secret"},
+                    "headers": {"Authorization": "Bearer tok-mcp-secret"},
+                }
+            }
+        }
+    )
+    agent = ACPAgentSettings(acp_command=["echo"], mcp_config=mcp_config).create_agent()
+
+    assert isinstance(agent, ACPAgent)
+    assert agent.mcp_config["mcpServers"]["leaky"]["env"]["API_KEY"] == "sk-mcp-secret"
+    assert (
+        agent.mcp_config["mcpServers"]["leaky"]["headers"]["Authorization"]
+        == "Bearer tok-mcp-secret"
+    )
+
+
 # ---------------------------------------------------------------------------
 # AgentSettingsBase — shared interface
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HUMAN:

Reviewed and approved — tests mirror the existing OpenHandsAgentSettings variant exactly and both pass locally.

- [x] A human has tested these changes.

AGENT:

Tests ran locally; both new tests pass. Ran full `test_settings.py` suite (118 tests, no regressions).

---

## Why

Issue #3705 requires a tested SDK contract proving `ACPAgentSettings.create_agent()` carries `mcp_config` into the constructed `ACPAgent` with secret-bearing `env`/`headers` values preserved in plaintext (not redacted for transit/storage).

The existing `test_openhands_agent_settings_create_agent_keeps_real_mcp_secrets` covers the OpenHands variant but there was no equivalent for the ACP variant.

## Summary

- Add `test_acp_agent_settings_mcp_config_redacts_env_and_headers`: verifies `model_dump_json()` masks env/headers and `expose_secrets=True` restores them.
- Add `test_acp_agent_settings_create_agent_keeps_real_mcp_secrets`: verifies `ACPAgentSettings.create_agent()` bypasses the redacting serializer and passes real env/header values to the constructed `ACPAgent`.

## Issue Number

Closes #3705 (SDK side)

## How to Test

```
pytest tests/sdk/test_settings.py::test_acp_agent_settings_mcp_config_redacts_env_and_headers \
       tests/sdk/test_settings.py::test_acp_agent_settings_create_agent_keeps_real_mcp_secrets -v
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:acb4fbc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-acb4fbc-python \
  ghcr.io/openhands/agent-server:acb4fbc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:acb4fbc-golang-amd64
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-golang-amd64
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-golang-amd64
ghcr.io/openhands/agent-server:acb4fbc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:acb4fbc-golang-arm64
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-golang-arm64
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-golang-arm64
ghcr.io/openhands/agent-server:acb4fbc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:acb4fbc-java-amd64
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-java-amd64
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-java-amd64
ghcr.io/openhands/agent-server:acb4fbc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:acb4fbc-java-arm64
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-java-arm64
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-java-arm64
ghcr.io/openhands/agent-server:acb4fbc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:acb4fbc-python-amd64
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-python-amd64
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-python-amd64
ghcr.io/openhands/agent-server:acb4fbc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:acb4fbc-python-arm64
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-python-arm64
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-python-arm64
ghcr.io/openhands/agent-server:acb4fbc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:acb4fbc-golang
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-golang
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-golang
ghcr.io/openhands/agent-server:acb4fbc-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:acb4fbc-java
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-java
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-java
ghcr.io/openhands/agent-server:acb4fbc-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:acb4fbc-python
ghcr.io/openhands/agent-server:acb4fbceee827d2827368cfc6edf93c2ec40a380-python
ghcr.io/openhands/agent-server:feat-acp-mcp-settings-tests-python
ghcr.io/openhands/agent-server:acb4fbc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `acb4fbc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `acb4fbc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->