### PR TITLE
chore: remove already-removable deprecated leftovers (marketplace comment, skills tombstone, display_dict)

### DIFF
--- a/openhands-sdk/openhands/sdk/context/skills/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/skills/__init__.py
@@ -1,8 +1,0 @@
-"""Removed: Use openhands.sdk.skills instead.
-
-This module previously provided backward-compatible re-exports of skill
-classes. Those shims were deprecated in 1.16.0 and removed in 1.21.0.
-
-Migration:
-    from openhands.sdk.skills import Skill, load_skills_from_dir
-"""

--- a/openhands-sdk/openhands/sdk/plugin/types.py
+++ b/openhands-sdk/openhands/sdk/plugin/types.py
@@ -382,10 +382,3 @@ class CommandDefinition(BaseModel):
             source=self.source,
             allowed_tools=self.allowed_tools if self.allowed_tools else None,
         )
-
-
-# =============================================================================
-# Deprecated marketplace classes - moved to openhands.sdk.marketplace
-# =============================================================================
-# These are re-exported here for backward compatibility. Import from
-# openhands.sdk.marketplace instead.

--- a/openhands-sdk/openhands/sdk/tool/schema.py
+++ b/openhands-sdk/openhands/sdk/tool/schema.py
@@ -11,7 +11,7 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.models import (
     DiscriminatedUnionMixin,
 )
-from openhands.sdk.utils.visualize import display_dict
+from openhands.sdk.utils.visualize import display_json
 
 
 if TYPE_CHECKING:
@@ -260,7 +260,7 @@ class Action(Schema, ABC):
         # Display all action fields systematically
         content.append("Arguments:", style="bold")
         action_fields = self.model_dump()
-        content.append(display_dict(action_fields))
+        content.append(display_json(action_fields))
 
         return content
 

--- a/openhands-sdk/openhands/sdk/utils/visualize.py
+++ b/openhands-sdk/openhands/sdk/utils/visualize.py
@@ -1,14 +1,6 @@
 from rich.text import Text
 
 
-def display_dict(d) -> Text:
-    """Create a Rich Text representation of a dictionary.
-
-    This function is deprecated. Use display_json instead.
-    """
-    return display_json(d)
-
-
 def display_json(data) -> Text:
     """Create a Rich Text representation of JSON data.
 

--- a/tests/sdk/mcp/test_mcp_observation.py
+++ b/tests/sdk/mcp/test_mcp_observation.py
@@ -13,7 +13,7 @@ def test_mcp_observation_with_list_json():
     """Test that MCPToolObservation can handle JSON lists without crashing.
 
     This test reproduces and verifies the fix for the bug where
-    display_dict() would crash when MCP tools returned lists.
+    the JSON renderer would crash when MCP tools returned lists.
     """
     # Create a list that would cause the original bug
     list_data = ["item1", "item2", 42, True, None]

--- a/tests/sdk/utils/test_visualize.py
+++ b/tests/sdk/utils/test_visualize.py
@@ -2,96 +2,7 @@
 
 from rich.text import Text
 
-from openhands.sdk.utils.visualize import display_dict, display_json
-
-
-def test_display_dict_with_dictionary():
-    """Test display_dict with a dictionary input."""
-    data = {"key1": "value1", "key2": 42, "key3": None}
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert "key1" in text_content
-    assert "value1" in text_content
-    assert "key2" in text_content
-    assert "42" in text_content
-    # None fields should be skipped
-    assert "key3" not in text_content
-
-
-def test_display_dict_with_nested_structures():
-    """Test display_dict with nested dictionaries and lists."""
-    data = {
-        "simple": "value",
-        "nested_dict": {"inner": "data"},
-        "list_data": [1, 2, 3],
-        "multiline": "line1\nline2\nline3",
-    }
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert "simple" in text_content
-    assert "nested_dict" in text_content
-    assert "list_data" in text_content
-    assert "multiline" in text_content
-
-
-def test_display_dict_with_list_now_works():
-    """Test that display_dict now works with lists (bug fix)."""
-    data = ["item1", "item2", "item3"]
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert "[List with 3 items]" in text_content
-    assert "item1" in text_content
-    assert "item2" in text_content
-    assert "item3" in text_content
-
-
-def test_display_dict_with_string_now_works():
-    """Test that display_dict now works with strings."""
-    data = "just a string"
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert '"just a string"' in text_content
-
-
-def test_display_dict_with_number_now_works():
-    """Test that display_dict now works with numbers."""
-    data = 42
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert "42" in text_content
-
-
-def test_display_dict_with_boolean_now_works():
-    """Test that display_dict now works with booleans."""
-    data = True
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert "True" in text_content
-
-
-def test_display_dict_with_none_now_works():
-    """Test that display_dict now works with None."""
-    data = None
-    result = display_dict(data)
-
-    assert isinstance(result, Text)
-    text_content = str(result)
-    assert "null" in text_content
-
-
-# Tests for the new display_json function
+from openhands.sdk.utils.visualize import display_json
 
 
 def test_display_json_with_dictionary():
@@ -213,13 +124,3 @@ def test_display_json_with_nested_structures():
     assert "nested_dict" in text_content
     assert "list_data" in text_content
     assert "multiline" in text_content
-
-
-def test_display_dict_backward_compatibility():
-    """Test that display_dict still works for backward compatibility."""
-    data = {"key1": "value1", "key2": 42}
-    result_dict = display_dict(data)
-    result_json = display_json(data)
-
-    # Both should produce the same result
-    assert str(result_dict) == str(result_json)


### PR DESCRIPTION
HUMAN:
I just saw the leftovers. So I decided to delete them.

- [x] A human has tested these changes.

AGENT:

---

## Why
  
The repo has a deprecation CI gate (`.github/scripts/check_deprecations.py`) that fails a release once `current_version >= removed_in`. But it only scans `@deprecated` / `warn_deprecated` / `warn_cleanup` calls and REST-route decorators. Anything deprecated *in prose* — a docstring note, a dangling comment, a tombstone module — is invisible to it and rots silently.
  
A sweep at the current version (1.28.0) turned up three such items that are already safe to remove today (none are tracked by the gate, so this touches no deprecation metadata):
  
  - `plugin/types.py` ends with a "Deprecated marketplace classes … re-exported here for backward compatibility" comment that has **no code beneath it**. The classes moved to `openhands.sdk.marketplace` in #2786, so the comment is
  actively misleading — `from openhands.sdk.plugin.types import <Marketplace…>` already raises `ImportError`.
  - `context/skills/__init__.py` is a docstring-only tombstone for skill re-export shims that were deprecated in 1.16.0 and **removed in 1.21.0** (seven minors ago). Nothing imports the module.
  - `utils/visualize.py::display_dict()` is a one-line forwarder marked "deprecated, use `display_json`" in its docstring — yet it's still imported and called in production at `tool/schema.py:263`.

## Summary

- **`plugin/types.py`**: delete the dangling "Deprecated marketplace classes" comment block (no code, misleading).
- **`context/skills/`**: delete the docstring-only tombstone `__init__.py` (canonical location is `openhands.sdk.skills`).
- **`utils/visualize.py`**: remove `display_dict()` and repoint its only caller (`tool/schema.py`) to `display_json()`. Drop the now-redundant `display_dict` tests (the existing `display_json` suite is a superset) and fix a stale
  `display_dict()` mention in a `test_mcp_observation.py` comment.
  
## Issue Number
N/A — opportunistic cleanup found while auditing un-deleted deprecations.

## How to Test
Library-only cleanup with no behavior change (`display_dict` was a pure alias for `display_json`), so the end-to-end evidence is the real render path plus the gate staying green:
  
  ```
  # 1. No deprecated symbol remains anywhere
  grep -rn "display_dict" --include="*.py" .            # → no matches

  # 2. Affected tests 
  uv run pytest tests/sdk/utils/test_visualize.py tests/sdk/mcp/test_mcp_observation.py -q
  # 14 passed
  
  # 3. Real changed code path: tool-schema __rich__ now renders via display_json
  uv run python -c "
  from pydantic import Field
  from openhands.sdk.tool.schema import Action
  from rich.console import Console 
  class Demo(Action):
      x: int = Field(default=1); y: str = Field(default='hi')
  Console().print(Demo())"                              # renders without error
  
  # 4. Deprecation CI gate unchanged
  uv run --with packaging python .github/scripts/check_deprecations.py
  # Checked 12 deprecation metadata entries across 4 package(s) — none overdue
  
  # 5. Lint / format on all changed files
  uv run ruff check <changed files> && uv run ruff format --check <changed files>   # clean
  ```
  
  ## Type


  # 4. Deprecation CI gate unchanged

```
  uv run --with packaging python .github/scripts/check_deprecations.py
  # Checked 12 deprecation metadata entries across 4 package(s) — none overdue

  # 5. Lint / format on all changed files
  uv run ruff check <changed files> && uv run ruff format --check <changed files>   # clean
```

  ## Type

  - [ ] Bug fix
  - [ ] Feature
  - [ ] Refactor
  - [ ] Breaking change
  - [x] Docs / chore

  ## Notes

  - Net diff: 6 files, +4/−126.
  - `display_dict` was a public symbol in `openhands.sdk.utils.visualize`, but it was a deprecated pure-forwarder with one in-tree caller; removing it leaves `display_json` (identical output). Worth a glance from the SDK-API-breakage
  check in CI.
  - Scope is deliberately limited to gate-untracked prose deprecations. The 12 framework-tracked entries (e.g. the `acp_env` / `return_metrics` batch due in 1.29.0) are intentionally left alone until the version bump.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6a59af0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6a59af0-python \
  ghcr.io/openhands/agent-server:6a59af0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6a59af0-golang-amd64
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-golang-amd64
ghcr.io/openhands/agent-server:vasco-chores-golang-amd64
ghcr.io/openhands/agent-server:6a59af0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6a59af0-golang-arm64
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-golang-arm64
ghcr.io/openhands/agent-server:vasco-chores-golang-arm64
ghcr.io/openhands/agent-server:6a59af0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6a59af0-java-amd64
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-java-amd64
ghcr.io/openhands/agent-server:vasco-chores-java-amd64
ghcr.io/openhands/agent-server:6a59af0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6a59af0-java-arm64
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-java-arm64
ghcr.io/openhands/agent-server:vasco-chores-java-arm64
ghcr.io/openhands/agent-server:6a59af0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6a59af0-python-amd64
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-python-amd64
ghcr.io/openhands/agent-server:vasco-chores-python-amd64
ghcr.io/openhands/agent-server:6a59af0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6a59af0-python-arm64
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-python-arm64
ghcr.io/openhands/agent-server:vasco-chores-python-arm64
ghcr.io/openhands/agent-server:6a59af0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6a59af0-golang
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-golang
ghcr.io/openhands/agent-server:vasco-chores-golang
ghcr.io/openhands/agent-server:6a59af0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6a59af0-java
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-java
ghcr.io/openhands/agent-server:vasco-chores-java
ghcr.io/openhands/agent-server:6a59af0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6a59af0-python
ghcr.io/openhands/agent-server:6a59af0f9b224eeb44e2ec57b2a48bf0ff1822ec-python
ghcr.io/openhands/agent-server:vasco-chores-python
ghcr.io/openhands/agent-server:6a59af0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6a59af0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6a59af0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->