### PR TITLE
fix: coerce list-of-strings to string for str-only tool args

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -75,10 +75,15 @@ def sanitize_json_control_chars(raw: str) -> str:
 def fix_malformed_tool_arguments(
     arguments: dict[str, Any], action_type: type[Action]
 ) -> dict[str, Any]:
-    """Fix malformed tool arguments by decoding JSON strings for list/dict fields.
+    """Fix malformed tool arguments emitted by some LLMs under native fn calling.
 
-    This function handles cases where certain LLMs (such as GLM 4.6) incorrectly
-    encode array/object parameters as JSON strings when using native function calling.
+    Two malformations are repaired:
+
+    1. list/dict parameters encoded as JSON strings (e.g. GLM 4.6), which are
+       decoded back into native arrays/objects (see example below).
+    2. str-only parameters emitted as a JSON array of string chunks (e.g.
+       minimax-m2.5 chunking file_editor's old_str/new_str), which are joined
+       back into a single string.
 
     Example raw LLM output from GLM 4.6:
     {
@@ -125,9 +130,6 @@ def fix_malformed_tool_arguments(
             continue
 
         value = fixed_arguments[data_key]
-        # Skip if value is not a string
-        if not isinstance(value, str):
-            continue
 
         expected_type = field_info.annotation
 
@@ -147,6 +149,21 @@ def fix_malformed_tool_arguments(
         else:
             # For non-Union types, just check the origin
             expected_origins = [origin or expected_type]
+
+        # Some models (e.g. minimax-m2.5) chunk a str-only field such as
+        # file_editor's old_str/new_str into a JSON array; join it back.
+        if (
+            isinstance(value, list)
+            and str in expected_origins
+            and not any(exp in (list, dict) for exp in expected_origins)
+            and all(isinstance(part, str) for part in value)
+        ):
+            fixed_arguments[data_key] = "".join(value)
+            continue
+
+        # Skip if value is not a string
+        if not isinstance(value, str):
+            continue
 
         # Check if any of the expected types is list or dict
         if any(exp in (list, dict) for exp in expected_origins):

--- a/openhands-sdk/openhands/sdk/agent/utils.py
+++ b/openhands-sdk/openhands/sdk/agent/utils.py
@@ -72,6 +72,24 @@ def sanitize_json_control_chars(raw: str) -> str:
     return _CONTROL_CHAR_RE.sub(_escape_control_char, raw)
 
 
+def _is_chunked_str_field(value: Any, expected_origins: list[Any]) -> bool:
+    """Return True if a str-only field was given a list of string chunks.
+
+    Some models (e.g. minimax-m2.5) split a single string argument such as
+    file_editor's old_str/new_str into a JSON array of chunks. Such a list is
+    rejoined into one string by the caller. ``str | list[str]`` fields are
+    excluded so a genuinely-valid list is never collapsed, and lists holding
+    non-strings are rejected so they fail validation instead of being silently
+    mangled.
+    """
+    return (
+        isinstance(value, list)
+        and str in expected_origins
+        and not any(exp in (list, dict) for exp in expected_origins)
+        and all(isinstance(part, str) for part in value)
+    )
+
+
 def fix_malformed_tool_arguments(
     arguments: dict[str, Any], action_type: type[Action]
 ) -> dict[str, Any]:
@@ -150,18 +168,12 @@ def fix_malformed_tool_arguments(
             # For non-Union types, just check the origin
             expected_origins = [origin or expected_type]
 
-        # Some models (e.g. minimax-m2.5) chunk a str-only field such as
-        # file_editor's old_str/new_str into a JSON array; join it back.
-        if (
-            isinstance(value, list)
-            and str in expected_origins
-            and not any(exp in (list, dict) for exp in expected_origins)
-            and all(isinstance(part, str) for part in value)
-        ):
+        # Rejoin a str-only field that a model chunked into a JSON array.
+        if _is_chunked_str_field(value, expected_origins):
             fixed_arguments[data_key] = "".join(value)
             continue
 
-        # Skip if value is not a string
+        # Skip non-strings — the JSON decoding below only works on strings.
         if not isinstance(value, str):
             continue
 

--- a/tests/sdk/agent/test_fix_malformed_tool_arguments.py
+++ b/tests/sdk/agent/test_fix_malformed_tool_arguments.py
@@ -44,6 +44,19 @@ class JsonDecodingOptionalAction(Action):
     config: dict[str, int] | None = Field(default=None, description="Optional dict")
 
 
+class StrFieldAction(Action):
+    """Test action with str-only fields (mirrors file_editor old_str/new_str)."""
+
+    old_str: str | None = Field(default=None, description="A required string field")
+    name: str = Field(description="A regular string field")
+
+
+class StrOrListAction(Action):
+    """Test action with a field that accepts either a str or a list."""
+
+    value: str | list[str] = Field(description="A str-or-list field")
+
+
 class _NestedActionForMalformedArgs(Action):
     """Action with nested structures for testing JSON decoding.
 
@@ -328,3 +341,45 @@ def test_trailing_garbage_with_nested_braces():
     action = _NestedActionForMalformedArgs.model_validate(fixed_data)
 
     assert action.nested_dict == {"outer": {"inner": "v"}}
+
+
+def test_str_field_list_joined():
+    """A str-only field given a list of string chunks is joined (minimax-m2.5)."""
+    data = {
+        "old_str": ["[dependencies]\nhypatia = ", '{ features = ["arrow"] }'],
+        "name": "test",
+    }
+    fixed_data = fix_malformed_tool_arguments(data, StrFieldAction)
+    action = StrFieldAction.model_validate(fixed_data)
+
+    # "".join preserves embedded newlines and concatenates without separators.
+    assert action.old_str == '[dependencies]\nhypatia = { features = ["arrow"] }'
+    assert action.name == "test"
+
+
+def test_str_field_native_string_passthrough():
+    """A str-only field given a normal string is left unchanged."""
+    data = {"old_str": "already a string", "name": "test"}
+    fixed_data = fix_malformed_tool_arguments(data, StrFieldAction)
+    action = StrFieldAction.model_validate(fixed_data)
+
+    assert action.old_str == "already a string"
+
+
+def test_str_field_list_with_non_strings_not_joined():
+    """A str field given a list with non-string members is not joined."""
+    data = {"old_str": ["a", 1], "name": "test"}
+    fixed_data = fix_malformed_tool_arguments(data, StrFieldAction)
+
+    # Left as-is, so Pydantic rejects it rather than silently mangling it.
+    with pytest.raises(ValidationError):
+        StrFieldAction.model_validate(fixed_data)
+
+
+def test_str_or_list_field_list_passthrough():
+    """A str|list field given a list is valid and must not be joined."""
+    data = {"value": ["a", "b", "c"]}
+    fixed_data = fix_malformed_tool_arguments(data, StrOrListAction)
+    action = StrOrListAction.model_validate(fixed_data)
+
+    assert action.value == ["a", "b", "c"]


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fixing malformed tools for Minimax

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents must not edit this section.
-->

- [x] A human has tested these changes.

AGENT:

---

## Why

Users running `file_editor` with weaker models (reported with **minimax-m2.5**) hit a hard validation failure before the tool ever runs:

```
Error validating tool 'file_editor': 2 validation errors for FileEditorAction
old_str
  Input should be a valid string [type=string_type, input_value=['dependencies]\nhypatia-...', 'features = ["arrow'], input_type=list]
new_str
  Input should be a valid string ...
Parameters provided: ['command', 'path', 'old_str', 'new_str']
```

The model serializes the `old_str` / `new_str` arguments as a **JSON array of string chunks** instead of a single string. `FileEditorAction` declares these as `str | None`, so pydantic rejects the call and the agent only gets back a raw `string_type` error. This is the same class of malformed output the SDK already special-cases this model for in `sanitize_json_control_chars`.

## Summary

- `fix_malformed_tool_arguments` already repairs the inverse malformation (list/dict fields encoded as JSON strings, e.g. GLM 4.6); this adds the mirror case: a **str-only** field given a **list of strings** is joined back with `"".join(...)`.
- Guarded to fire only when the field's schema type is `str` and not list/dict, so genuine list fields and `str | list[str]` unions are untouched; lists with non-string members are left as-is (still rejected, never silently mangled).
- Safe by construction: `str_replace` requires an exact match, so a wrong join fails cleanly (no match → retry) rather than corrupting a file.

## Issue Number

N/A (reported via Slack).

## How to Test

Unit tests (4 added to the existing suite):

```
uv run pytest tests/sdk/agent/test_fix_malformed_tool_arguments.py -q
# 24 passed
```

End-to-end through the real argument path (`parse → normalize → fix → validate`) and the real `FileEditorExecutor` on a real file:

```python
import json, tempfile
from pathlib import Path
from pydantic import ValidationError
from openhands.sdk.agent.utils import (
    fix_malformed_tool_arguments, normalize_tool_call, parse_tool_call_arguments,
)
from openhands.tools.file_editor.definition import FileEditorAction
from openhands.tools.file_editor.impl import FileEditorExecutor

tmp = Path(tempfile.mkdtemp()); target = tmp / "Cargo.toml"
target.write_text('[dependencies]\nhypatia = { features = ["arrow"] }\n')
raw = json.dumps({
    "command": "str_replace", "path": str(target),
    "old_str": ['[dependencies]\nhypatia = ', '{ features = ["arrow"] }'],
    "new_str": ['[dependencies]\nhypatia = ', '{ features = ["arrow", "csv"] }'],
})
args = parse_tool_call_arguments(raw)
_, args = normalize_tool_call("file_editor", args, {"file_editor"})
fixed = fix_malformed_tool_arguments(args, FileEditorAction)
obs = FileEditorExecutor(workspace_root=str(tmp))(FileEditorAction.model_validate(fixed))
print(obs.is_error, repr(target.read_text()))
```

Output:

```
1) Raw (pre-fix) validation:
   ValidationError as reported in Slack: 2 errors (['string_type', 'string_type'])
2) After fix_malformed_tool_arguments:
   old_str -> '[dependencies]\nhypatia = { features = ["arrow"] }'
   new_str -> '[dependencies]\nhypatia = { features = ["arrow", "csv"] }'
3) Executing the real file_editor:
   is_error=False
   file now: '[dependencies]\nhypatia = { features = ["arrow", "csv"] }\n'
```

So the exact Slack failure (2 × `string_type`) is reproduced pre-fix, and post-fix the real `file_editor` applies the edit successfully.

## Video/Screenshots

N/A — backend change; end-to-end console output included under How to Test.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The join is a heuristic: if a model drops content *between* chunks (rather than just splitting), the joined `old_str` won't match the file — which fails safely (no edit) but won't recover the intended edit. Deliberately minimal: no re-prompt-on-detection backstop and no model-selection changes; happy to add if reviewers want them.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:34bfa99-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-34bfa99-python \
  ghcr.io/openhands/agent-server:34bfa99-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:34bfa99-golang-amd64
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-golang-amd64
ghcr.io/openhands/agent-server:34bfa99-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:34bfa99-golang-arm64
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-golang-arm64
ghcr.io/openhands/agent-server:34bfa99-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:34bfa99-java-amd64
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-java-amd64
ghcr.io/openhands/agent-server:34bfa99-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:34bfa99-java-arm64
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-java-arm64
ghcr.io/openhands/agent-server:34bfa99-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:34bfa99-python-amd64
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-python-amd64
ghcr.io/openhands/agent-server:34bfa99-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:34bfa99-python-arm64
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-python-arm64
ghcr.io/openhands/agent-server:34bfa99-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:34bfa99-golang
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-golang
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-golang
ghcr.io/openhands/agent-server:34bfa99-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:34bfa99-java
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-java
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-java
ghcr.io/openhands/agent-server:34bfa99-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:34bfa99-python
ghcr.io/openhands/agent-server:34bfa9993a9b8c9f8e6729b7b753931671fc4496-python
ghcr.io/openhands/agent-server:vasco-fix-list-str-coercion-python
ghcr.io/openhands/agent-server:34bfa99-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `34bfa99-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `34bfa99-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->