### PR TITLE
Fix async ACP restart loopback secret lookup deadlock

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/acp_agent.py
+++ b/openhands-sdk/openhands/sdk/agent/acp_agent.py
@@ -2653,6 +2653,20 @@ class ACPAgent(AgentBase):
         self.init_state(state, on_event=on_event)
         self._restart_session_on_next_turn = False
 
+    async def _arestart_session_after_drain_timeout(
+        self,
+        state: ConversationState,
+        on_event: ConversationCallbackType,
+    ) -> None:
+        """Restart ACP without blocking the async conversation loop."""
+        # Restart calls init_state(), which may synchronously resolve LookupSecret
+        # values through HTTP loopback to this same agent server. Keep it off the
+        # server loop for the same reason LocalConversation.arun() offloads the
+        # initial _ensure_agent_ready() path.
+        await asyncio.to_thread(
+            self._restart_session_after_drain_timeout, state, on_event
+        )
+
     def _request_session_cancel(self) -> None:
         """Ask the ACP server to cancel the active session prompt."""
         if self._conn is None or self._executor is None or self._session_id is None:
@@ -3158,7 +3172,7 @@ class ACPAgent(AgentBase):
         if self._restart_session_on_next_turn:
             # If restart initialization fails, let the conversation transition
             # to ERROR rather than reusing an ambiguous ACP session.
-            self._restart_session_after_drain_timeout(state, on_event)
+            await self._arestart_session_after_drain_timeout(state, on_event)
 
         prompt_blocks: list[Any] | None = None
         if prompt_message is not None:

--- a/tests/sdk/agent/test_acp_agent.py
+++ b/tests/sdk/agent/test_acp_agent.py
@@ -2065,6 +2065,73 @@ class TestACPAgentAstep:
             conversation.state.execution_status == ConversationExecutionStatus.FINISHED
         )
 
+    def test_astep_restarts_session_off_caller_loop(self, tmp_path):
+        """Restart init can synchronously resolve loopback LookupSecret values.
+
+        ``astep`` must keep that restart work off the caller loop so the
+        agent-server can serve those loopback HTTP requests instead of waiting
+        for each secret lookup to time out.
+        """
+        from openhands.sdk.utils.async_executor import AsyncExecutor
+
+        agent = _make_agent()
+        conversation = self._make_conversation_with_message(tmp_path)
+        emitted: list = []
+
+        mock_client = _OpenHandsACPBridge()
+        mock_client.get_turn_usage_update = MagicMock(return_value=object())
+        agent._client = mock_client
+        agent._conn = MagicMock()
+        agent._session_id = "test-session"
+        agent._restart_session_on_next_turn = True
+
+        async def _fake_prompt(prompt_blocks, session_id):  # noqa: ARG001
+            mock_client.accumulated_text.append("answer")
+            return None
+
+        agent._conn.prompt = _fake_prompt
+
+        executor = AsyncExecutor()
+
+        async def _run_restart() -> None:
+            caller_loop = asyncio.get_running_loop()
+            caller_thread_id = threading.get_ident()
+            restart_entered = asyncio.Event()
+            release_restart = threading.Event()
+            restart_thread_ids: list[int] = []
+
+            def _blocking_restart(self, state, on_event):  # noqa: ARG001
+                assert self is agent
+                restart_thread_ids.append(threading.get_ident())
+                caller_loop.call_soon_threadsafe(restart_entered.set)
+                assert release_restart.wait(5.0)
+                agent._restart_session_on_next_turn = False
+
+            with patch.object(
+                ACPAgent,
+                "_restart_session_after_drain_timeout",
+                new=_blocking_restart,
+            ):
+                task = asyncio.create_task(
+                    agent.astep(conversation, on_event=emitted.append)
+                )
+                await asyncio.wait_for(restart_entered.wait(), timeout=5.0)
+                assert len(restart_thread_ids) == 1
+                assert restart_thread_ids[0] != caller_thread_id
+                release_restart.set()
+                await asyncio.wait_for(task, timeout=5.0)
+
+        try:
+            agent._executor = executor
+            asyncio.run(_run_restart())
+        finally:
+            executor.close()
+
+        assert (
+            conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+        )
+        assert emitted
+
     def test_astep_active_prompt_survives_idle_window(self, tmp_path):
         """End-to-end via the real portal: an actively-streaming prompt that
         runs well past ``acp_prompt_timeout`` finalizes normally.


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:

I tested this manually and can confirm that on main there is a long pause on main after a follow-up message, and a minimal pause on the PR branch.

main
<img width="972" height="416" alt="Screenshot 2026-06-17 at 2 33 43 PM" src="https://github.com/user-attachments/assets/dfc91c54-b21f-48a7-a2fa-4ea4bbd56868" />

pr
<img width="978" height="550" alt="Screenshot 2026-06-17 at 2 39 03 PM" src="https://github.com/user-attachments/assets/f24d1fde-8f59-4495-9a6e-8a3641dedef7" />

- [x] A human has tested these changes.

AGENT:

Live failure diagnosis on June 15, 2026: after an interrupted ACP turn, the next turn logged `Restarting ACP session after cancelled prompt drain timeout`, then two 30s `LookupSecret` read timeouts for loopback `/api/settings/secrets/...` URLs before ACP initialization resumed. A direct local secret endpoint request completed in milliseconds, so the issue was event-loop starvation during restart, not slow key storage.

---

## Why

ACP restart after a cancelled prompt drain timeout calls `init_state()`. ACP startup resolves registry secrets into subprocess environment variables, and `LookupSecret.get_value()` performs a synchronous HTTP GET back to the same agent-server. In async `ACPAgent.astep()`, the restart ran on the caller/server loop, so the loopback request could not be served until the synchronous secret lookup timed out.

## Summary

- Added an async ACP restart wrapper that runs the existing sync restart path via `asyncio.to_thread()`.
- Switched only `ACPAgent.astep()` to use the async wrapper; sync `step()` behavior is unchanged.
- Added regression coverage that verifies async restart initialization runs off the caller loop.

## Issue Number

N/A

## How to Test

- `uv run pytest tests/sdk/agent/test_acp_agent.py -k "astep_restarts_session_off_caller_loop or cancel_drain_restart"`
  - Result: `3 passed, 352 deselected`.
- `uv run pytest tests/sdk/agent/test_acp_agent.py`
  - Result: `355 passed, 9 warnings`.
- `uv run ruff check openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py`
  - Result: `All checks passed!`.
- `uv run ruff format --check openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py`
  - Result: `2 files already formatted`.
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/acp_agent.py tests/sdk/agent/test_acp_agent.py`
  - Result: Ruff format/lint, pycodestyle, pyright, dependency rules, and tool registration checks passed.
- Runtime reproduction check: ran a temporary `uv run python` script that starts an async loopback HTTP server, registers a real `LookupSecret` against that server, and calls `ACPAgent._arestart_session_after_drain_timeout()` while `init_state()` resolves the secret. Output included: `loopback ACP restart resolved LOOPBACK_SECRET=ok without timeout`.

## Video/Screenshots

Backend/runtime deadlock fix; no UI screenshot. Runtime reproduction output is included above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This keeps the existing restart implementation and error propagation. If restart initialization fails, `astep()` still raises so the conversation transitions to error rather than continuing with an ambiguous ACP session.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:3c4c40d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-3c4c40d-python \
  ghcr.io/openhands/agent-server:3c4c40d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:3c4c40d-golang-amd64
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-golang-amd64
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-golang-amd64
ghcr.io/openhands/agent-server:3c4c40d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:3c4c40d-golang-arm64
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-golang-arm64
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-golang-arm64
ghcr.io/openhands/agent-server:3c4c40d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:3c4c40d-java-amd64
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-java-amd64
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-java-amd64
ghcr.io/openhands/agent-server:3c4c40d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:3c4c40d-java-arm64
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-java-arm64
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-java-arm64
ghcr.io/openhands/agent-server:3c4c40d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:3c4c40d-python-amd64
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-python-amd64
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-python-amd64
ghcr.io/openhands/agent-server:3c4c40d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:3c4c40d-python-arm64
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-python-arm64
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-python-arm64
ghcr.io/openhands/agent-server:3c4c40d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:3c4c40d-golang
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-golang
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-golang
ghcr.io/openhands/agent-server:3c4c40d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:3c4c40d-java
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-java
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-java
ghcr.io/openhands/agent-server:3c4c40d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:3c4c40d-python
ghcr.io/openhands/agent-server:3c4c40d51ed353151f43692efd979700eb0cc5ca-python
ghcr.io/openhands/agent-server:codex-acp-restart-secret-lookup-off-loop-python
ghcr.io/openhands/agent-server:3c4c40d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `3c4c40d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `3c4c40d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

## Issue

Fixes #3762.