### PR TITLE
ci: pin oasdiff version to avoid GitHub API rate-limit flake

### DIFF
--- a/.github/workflows/agent-server-rest-api-breakage.yml
+++ b/.github/workflows/agent-server-rest-api-breakage.yml
@@ -29,8 +29,11 @@ jobs:
               run: uv sync --frozen --group dev
 
             - name: Install oasdiff
+              # Pin the version so install.sh skips its GitHub API "latest release"
+              # lookup, which intermittently hits the 60/hr unauthenticated rate
+              # limit on shared runners and fails the whole check. Bump as needed.
               run: |
-                  curl -L https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | sh -s -- -b /usr/local/bin
+                  curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh | version=1.19.1 sh -s -- -b /usr/local/bin
                   oasdiff --version
 
             - name: Run agent server REST API breakage check


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section or human-tested checkbox.
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

HUMAN:

API breakage tests are sometime flaky. This is an effort to make them more reliable.

- [x] A human has tested these changes.

AGENT:

---

## Why

The **REST API breakage checks** workflow (`.github/workflows/agent-server-rest-api-breakage.yml`) is intermittently red in the `Install oasdiff` step with:

```
Error: Failed to get oasdiff version.
This could be due to GitHub API rate limiting or network issues.
##[error]Process completed with exit code 1.
```

This is a CI infra flake, not a real API-breakage finding — the actual `Run agent server REST API breakage check` step never runs when the install fails.

**Root cause (verified):** the step pipes the upstream `install.sh` into `sh` with no version pin. With no `version` set, `install.sh` calls `get_latest_release()` → `https://api.github.com/repos/oasdiff/oasdiff/releases/latest` to resolve "latest". Unauthenticated GitHub API requests are capped at **60/hr per IP**; on shared GitHub-hosted runners that limit is easily exhausted, so the lookup fails intermittently.

Evidence (all from run logs on 2026-06-15, gh CLI):
- `main` push (unrelated code), run `27550782864` — failed in `Install oasdiff` with the exact error above. A failure on `main` with unrelated code confirms it is environmental, not PR-specific.
- run `27551171682` — failed in `Install oasdiff`.
- run `27551356083` — now `success` on `run_attempt: 2`, i.e. a plain re-run cleared it.

Resolves #3738.

## Summary

- Pin oasdiff to `version=1.19.1` in the `Install oasdiff` step so `install.sh` short-circuits before the GitHub API "latest release" lookup (`if [ -n "$version" ]`) and downloads the release asset directly — removing the rate-limited API call that caused the flake.
- Switch `curl -L` → `curl -fsSL` so a transient HTTP error fails fast with a clear message instead of piping an error page into `sh`.

Note: the linked issue suggested `version=1.11.7`, but that is only the placeholder in `install.sh`'s error message. The workflow currently tracks "latest" (`v1.19.1`), so this PR pins to **1.19.1** to keep behavior identical rather than silently downgrading ~8 minor versions.

## Issue Number

#3738

## How to Test

This is a CI-only change (single workflow step). Verified the pinned install command locally on macOS into a temp dir, observing that it skips the API lookup and installs the pinned version:

```
$ curl -fsSL https://raw.githubusercontent.com/oasdiff/oasdiff/main/install.sh \
    | INSTALL_DIR=/tmp/oasdiff-test version=1.19.1 sh
Downloading https://github.com/oasdiff/oasdiff/releases/download/v1.19.1/oasdiff_1.19.1_darwin_all.tar.gz
Validating checksum
Extracting tar file
Installed oasdiff to /tmp/oasdiff-test

$ /tmp/oasdiff-test/oasdiff --version
oasdiff version 1.19.1
```

The download comes from the `releases/download/...` asset URL (a CDN/release download, not the rate-limited API), so no `api.github.com/.../releases/latest` request is made. The workflow YAML was also validated with `yaml.safe_load`.

On CI, the `Install oasdiff` step should now print `oasdiff version 1.19.1` deterministically and never hit the rate-limit error.

## Video/Screenshots

N/A — CI workflow change; install output and version captured above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Bump the pin when adopting newer oasdiff features; a comment on the step explains the rationale.
- A `GITHUB_TOKEN` on the step (to raise the API limit to 5000/hr) is intentionally **not** added: with the version pinned, `install.sh` makes no GitHub API calls at all, so the token would be unused.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7393101-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7393101-python \
  ghcr.io/openhands/agent-server:7393101-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7393101-golang-amd64
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-golang-amd64
ghcr.io/openhands/agent-server:7393101-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7393101-golang-arm64
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-golang-arm64
ghcr.io/openhands/agent-server:7393101-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7393101-java-amd64
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-java-amd64
ghcr.io/openhands/agent-server:7393101-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7393101-java-arm64
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-java-arm64
ghcr.io/openhands/agent-server:7393101-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7393101-python-amd64
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-python-amd64
ghcr.io/openhands/agent-server:7393101-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7393101-python-arm64
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-python-arm64
ghcr.io/openhands/agent-server:7393101-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7393101-golang
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-golang
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-golang
ghcr.io/openhands/agent-server:7393101-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7393101-java
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-java
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-java
ghcr.io/openhands/agent-server:7393101-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7393101-python
ghcr.io/openhands/agent-server:7393101f65a438ef9b4290e8aacb0fd358ad5a50-python
ghcr.io/openhands/agent-server:vasco-fix-oasdiff-rate-limit-flake-python
ghcr.io/openhands/agent-server:7393101-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7393101-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7393101-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->