### PR TITLE
fix(task): surface non-FINISHED sub-agent runs as errors, not empty success

### DIFF
--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -355,19 +355,17 @@ class TaskManager:
         try:
             task.conversation.send_message(prompt, sender=parent_name)
             self._run_until_finished(task.id, task.conversation)
-            # A run-limit stop (cost budget or iteration cap) ends the
-            # sub-conversation in ERROR without raising; surface that to the
-            # parent instead of an empty "completed" result.
-            if (
-                task.conversation.state.execution_status
-                == ConversationExecutionStatus.ERROR
-            ):
-                task.set_error(self._run_error_detail(task.conversation))
-                logger.warning(f"Task '{task.id}' ended with an error.")
-            else:
+            status = task.conversation.state.execution_status
+            if status == ConversationExecutionStatus.FINISHED:
                 result = get_agent_final_response(task.conversation.state.events)
                 task.set_result(result)
                 logger.info(f"Task '{task.id}' completed.")
+            else:
+                # Any non-FINISHED terminal status (run-limit, stuck, paused, ...)
+                # is surfaced as an error, not an empty "completed"; the detail
+                # keeps partial output so the parent can use/retry it.
+                task.set_error(self._run_stop_detail(task.conversation, status))
+                logger.warning(f"Task '{task.id}' stopped: status '{status.value}'.")
         except Exception as e:
             task.set_error(str(e))
             logger.warning(f"Task {task.id} failed with error: {e}")
@@ -378,17 +376,24 @@ class TaskManager:
         return task
 
     @staticmethod
-    def _run_error_detail(conversation: LocalConversation) -> str:
-        """Best-effort detail for a sub-agent run that ended in ERROR (e.g. the
-        cost budget or iteration cap), so the parent sees why it stopped."""
+    def _run_stop_detail(
+        conversation: LocalConversation,
+        status: ConversationExecutionStatus,
+    ) -> str:
+        """Why a sub-agent stopped without finishing (run-limit, stuck, paused, ...),
+        plus any partial output so the parent isn't left with nothing to use."""
         errors = [
             e
             for e in conversation.state.events
             if isinstance(e, ConversationErrorEvent)
         ]
-        if errors:
-            return errors[-1].detail
-        return "Sub-agent run ended with an error."
+        reason = (
+            errors[-1].detail
+            if errors
+            else f"Sub-agent stopped without finishing (status: {status.value})."
+        )
+        partial = get_agent_final_response(conversation.state.events)
+        return f"{reason}\nPartial result:\n{partial}" if partial else reason
 
     def _run_until_finished(
         self, task_id: str, conversation: LocalConversation

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -1,6 +1,6 @@
 import uuid
 from pathlib import Path
-from typing import cast
+from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -8,6 +8,7 @@ from pydantic import SecretStr
 
 from openhands.sdk import LLM, Agent
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.hooks.config import HookConfig, HookDefinition, HookMatcher
 from openhands.sdk.subagent.registry import (
     _reset_registry_for_tests,
@@ -397,6 +398,9 @@ class TestTaskManager:
 def _make_task_with_mock_conv(task_id: str, **conv_kwargs) -> Task:
     """Create a Task with a MagicMock conversation, bypassing Pydantic validation."""
     mock_conv = MagicMock(**conv_kwargs)
+    # Default to a FINISHED run; a non-FINISHED status is now surfaced as an error,
+    # so override state.execution_status to test stuck/paused paths.
+    mock_conv.state.execution_status = ConversationExecutionStatus.FINISHED
     return Task.model_construct(
         id=task_id,
         conversation_id=uuid.uuid4(),
@@ -486,6 +490,24 @@ class TestRunTask:
         assert result.error is not None
         assert "agent exploded" in result.error
         assert result.result is None
+
+    def test_non_finished_status_surfaced_as_error(self, tmp_path):
+        """A sub-agent that ends non-FINISHED (e.g. STUCK) is surfaced as an error,
+        not reported as an empty success."""
+        manager, _ = _manager_with_parent(tmp_path)
+
+        task = _make_task_with_mock_conv("task_00000001")
+        assert task.conversation is not None
+        mock_conv = cast(Any, task.conversation)
+        mock_conv.state.execution_status = ConversationExecutionStatus.STUCK
+        mock_conv.state.events = []
+        manager._tasks[task.id] = task
+
+        result = manager._run_task(task=task, prompt="do something")
+
+        assert result.status == TaskStatus.ERROR
+        assert result.result is None
+        assert "stuck" in (result.error or "").lower()
 
     def test_run_evicts_conversation_after_error(self, tmp_path):
         """Even on error, the task's conversation should be evicted (finally block)."""
@@ -983,27 +1005,30 @@ class TestTaskManagerBudget:
 
 
 class TestRunErrorSurfacing:
-    """A sub-agent run that ends in ERROR (cost budget or iteration cap) is
-    surfaced to the parent task rather than reported as an empty success."""
+    """A sub-agent run that ends in a non-FINISHED status (stuck, paused, run-limit,
+    ...) is surfaced to the parent task rather than reported as an empty success."""
 
-    def test_run_error_detail_returns_last_error(self):
+    def test_run_stop_detail_returns_last_error(self):
         from types import SimpleNamespace
 
         from openhands.sdk.event.conversation_error import ConversationErrorEvent
 
         err = ConversationErrorEvent(
             source="environment",
-            code="MaxBudgetReached",
-            detail="Agent reached maximum budget limit ($0.05).",
+            code="MaxIterationsReached",
+            detail="Agent reached the maximum iteration limit.",
         )
         conv = SimpleNamespace(state=SimpleNamespace(events=[err]))
-        assert (
-            TaskManager._run_error_detail(cast(LocalConversation, conv)) == err.detail
+        detail = TaskManager._run_stop_detail(
+            cast(LocalConversation, conv), ConversationExecutionStatus.ERROR
         )
+        assert err.detail in detail
 
-    def test_run_error_detail_default_when_no_error_event(self):
+    def test_run_stop_detail_default_mentions_status(self):
         from types import SimpleNamespace
 
         conv = SimpleNamespace(state=SimpleNamespace(events=[]))
-        detail = TaskManager._run_error_detail(cast(LocalConversation, conv))
-        assert "error" in detail.lower()
+        detail = TaskManager._run_stop_detail(
+            cast(LocalConversation, conv), ConversationExecutionStatus.STUCK
+        )
+        assert "stuck" in detail.lower()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

bug fix: a non-FINISHED sub-agent (stuck/paused/run-limit) was reported to the parent as an empty success.

- [x] A human has tested these changes.

AGENT:

Narrowly scoped bug fix for sub-agent (Task tool) result surfacing. `uv run pytest tests/tools/task/test_task_manager.py` = 53 pass; pre-commit (ruff + pyright) clean.

---

## Why

A sub-agent whose run ends in any non-`FINISHED` terminal status — stuck detection, paused, or a run-limit — was reported to the parent task as an empty *success* (`Task completed with no result`, `is_error=False`). `_run_task` only special-cased `ERROR`; every other non-`FINISHED` status fell through to the success branch, so the parent agent couldn't distinguish a real result from a silently-aborted sub-agent.

## Summary

- `_run_task` now treats only `FINISHED` as success; any other terminal status (stuck, paused, run-limit) is surfaced to the parent as an error.
- The error detail preserves any partial output (`_run_stop_detail`) so the parent can use or retry it instead of getting nothing.

## Issue Number

(none)

## How to Test

```
uv run pytest tests/tools/task/test_task_manager.py
```

Covers: a non-FINISHED (stuck) status surfaced as an error; `_run_stop_detail` returns the last error event / falls back to a status message.

## Type

- [x] Bug fix

## Notes

This PR was narrowed to the status-surfacing fix only; the per-run budget plumbing it originally carried was dropped so the budget can be reworked separately. The change here is independent of the budget feature.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:61de89c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-61de89c-python \
  ghcr.io/openhands/agent-server:61de89c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:61de89c-golang-amd64
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-golang-amd64
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-golang-amd64
ghcr.io/openhands/agent-server:61de89c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:61de89c-golang-arm64
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-golang-arm64
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-golang-arm64
ghcr.io/openhands/agent-server:61de89c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:61de89c-java-amd64
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-java-amd64
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-java-amd64
ghcr.io/openhands/agent-server:61de89c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:61de89c-java-arm64
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-java-arm64
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-java-arm64
ghcr.io/openhands/agent-server:61de89c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:61de89c-python-amd64
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-python-amd64
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-python-amd64
ghcr.io/openhands/agent-server:61de89c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:61de89c-python-arm64
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-python-arm64
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-python-arm64
ghcr.io/openhands/agent-server:61de89c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:61de89c-golang
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-golang
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-golang
ghcr.io/openhands/agent-server:61de89c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:61de89c-java
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-java
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-java
ghcr.io/openhands/agent-server:61de89c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:61de89c-python
ghcr.io/openhands/agent-server:61de89cc55a99f675aaa1b3da427a9d6ce823968-python
ghcr.io/openhands/agent-server:alona-fix-subagent-budget-python
ghcr.io/openhands/agent-server:61de89c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `61de89c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `61de89c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->