### PR TITLE
fix(subagent): freshen explicit condensers per spawn

### DIFF
--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -207,6 +207,7 @@ def agent_definition_to_factory(
         from openhands.sdk.agent.agent import Agent
         from openhands.sdk.context.agent_context import AgentContext
         from openhands.sdk.context.condenser import default_condenser
+        from openhands.sdk.llm.llm import LLM
         from openhands.sdk.tool.registry import list_registered_tools
         from openhands.sdk.tool.spec import Tool
 
@@ -258,11 +259,25 @@ def agent_definition_to_factory(
         # top-level agent) so deep runs auto-compact instead of erroring on context
         # overflow. The condenser LLM needs a distinct usage_id or its tokens get
         # deduped out of conversation stats. A NoOpCondenser disables condensation.
-        condenser = (
-            agent_def.condenser
-            if agent_def.condenser is not None
-            else default_condenser(llm.model_copy(update={"usage_id": "condenser"}))
-        )
+        if agent_def.condenser is not None:
+            condenser = agent_def.condenser
+            cond_llm = getattr(condenser, "llm", None)
+            if isinstance(cond_llm, LLM):
+                # Freshen per spawn: a distinct LLM with its own metrics (so
+                # sub-agents don't share/double-count condenser cost) and a
+                # usage_id distinct from the agent's, else its tokens get deduped.
+                usage_id = (
+                    cond_llm.usage_id
+                    if cond_llm.usage_id != llm.usage_id
+                    else "condenser"
+                )
+                fresh_llm = cond_llm.model_copy(update={"usage_id": usage_id})
+                fresh_llm.reset_metrics()
+                condenser = condenser.model_copy(update={"llm": fresh_llm})
+        else:
+            condenser = default_condenser(
+                llm.model_copy(update={"usage_id": "condenser"})
+            )
 
         return Agent(
             llm=llm,

--- a/openhands-sdk/openhands/sdk/subagent/registry.py
+++ b/openhands-sdk/openhands/sdk/subagent/registry.py
@@ -206,8 +206,10 @@ def agent_definition_to_factory(
     def _factory(llm: "LLM") -> "Agent":
         from openhands.sdk.agent.agent import Agent
         from openhands.sdk.context.agent_context import AgentContext
-        from openhands.sdk.context.condenser import default_condenser
-        from openhands.sdk.llm.llm import LLM
+        from openhands.sdk.context.condenser import (
+            LLMSummarizingCondenser,
+            default_condenser,
+        )
         from openhands.sdk.tool.registry import list_registered_tools
         from openhands.sdk.tool.spec import Tool
 
@@ -261,11 +263,11 @@ def agent_definition_to_factory(
         # deduped out of conversation stats. A NoOpCondenser disables condensation.
         if agent_def.condenser is not None:
             condenser = agent_def.condenser
-            cond_llm = getattr(condenser, "llm", None)
-            if isinstance(cond_llm, LLM):
+            if isinstance(condenser, LLMSummarizingCondenser):
                 # Freshen per spawn: a distinct LLM with its own metrics (so
                 # sub-agents don't share/double-count condenser cost) and a
                 # usage_id distinct from the agent's, else its tokens get deduped.
+                cond_llm = condenser.llm
                 usage_id = (
                     cond_llm.usage_id
                     if cond_llm.usage_id != llm.usage_id

--- a/tests/sdk/subagent/test_subagent_registry.py
+++ b/tests/sdk/subagent/test_subagent_registry.py
@@ -916,3 +916,42 @@ def test_factory_explicit_condenser_passthrough() -> None:
     agent = factory(_make_test_llm())
     assert isinstance(agent.condenser, LLMSummarizingCondenser)
     assert agent.condenser.max_size == 40
+
+
+def test_factory_explicit_condenser_fresh_per_spawn() -> None:
+    """Explicit condensers are copied per spawn so sub-agents don't share one
+    Metrics object (cross-contamination/race), and a colliding usage_id is
+    normalized so condenser tokens aren't deduped out of stats."""
+    custom = LLMSummarizingCondenser(
+        llm=_make_test_llm(),  # same usage_id as the agent -> must be normalized
+        max_size=40,
+        keep_first=2,
+    )
+    factory = agent_definition_to_factory(AgentDefinition(name="x", condenser=custom))
+    a1 = factory(_make_test_llm())
+    a2 = factory(_make_test_llm())
+
+    c1, c2 = a1.condenser, a2.condenser
+    assert isinstance(c1, LLMSummarizingCondenser)
+    assert isinstance(c2, LLMSummarizingCondenser)
+    # Fresh per spawn: distinct condenser, LLM, and Metrics objects.
+    assert c1 is not c2
+    assert c1.llm is not c2.llm
+    assert c1.llm.metrics is not c2.llm.metrics
+    # Colliding usage_id normalized; config preserved through the copy.
+    assert c1.llm.usage_id == "condenser"
+    assert c1.llm.usage_id != a1.llm.usage_id
+    assert c1.max_size == 40
+
+
+def test_factory_explicit_condenser_preserves_distinct_usage_id() -> None:
+    """A condenser usage_id that already differs from the agent's is kept."""
+    custom = LLMSummarizingCondenser(
+        llm=_make_test_llm().model_copy(update={"usage_id": "my-condenser"}),
+        max_size=40,
+        keep_first=2,
+    )
+    factory = agent_definition_to_factory(AgentDefinition(name="x", condenser=custom))
+    agent = factory(_make_test_llm())
+    assert isinstance(agent.condenser, LLMSummarizingCondenser)
+    assert agent.condenser.llm.usage_id == "my-condenser"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:
Fixes explicit-condenser metrics sharing (follow-up to #3696). Verified fresh per-spawn condenser/LLM/Metrics isolation via the subagent registry tests.

- [x] A human has tested these changes.

AGENT:

Follow-up to #3696 (default sub-agent condenser). Fixes the explicit/custom-condenser path so per-spawn metrics don't collide.

This is an object-lifecycle / metrics-isolation fix, so the proof is object identity, asserted directly: `uv run pytest tests/sdk/subagent/test_subagent_registry.py` passes, including new tests that two spawns get distinct condenser, LLM, and `Metrics` objects and that the condenser `usage_id` is distinct from the agent's. Broader `tests/sdk/subagent tests/sdk/context` = 544 pass. pre-commit (ruff + pyright) clean.

---

## Why

In #3696, the explicit/custom condenser branch of `agent_definition_to_factory` returned `agent_def.condenser` by reference. The factory runs once per sub-agent spawn, so every spawn shared one condenser instance — and therefore one `Metrics` object. That double-counts / cross-contaminates condenser cost in the parent rollup, and is a mutable-state race under concurrent same-type sub-agents. The explicit path also never gave the condenser LLM a distinct `usage_id`, so a condenser whose `usage_id` matched the agent's had its tokens deduped out of conversation stats.

## Summary

- Each spawn gets a fresh copy of an explicit condenser with its own LLM and reset metrics (no shared `Metrics` object).
- The condenser LLM `usage_id` is set distinct from the agent's — normalized to `condenser` only on collision; an already-distinct id is preserved.
- The default-condenser path is unchanged.

## Issue Number

Follow-up to #3696.

## How to Test

```
uv run pytest tests/sdk/subagent/test_subagent_registry.py
```

Covers: fresh instance/LLM/metrics per spawn, colliding `usage_id` normalized, already-distinct `usage_id` preserved.

## Type

- [x] Bug fix

## Notes

Scoped to the explicit-condenser path; the default-condenser behavior from #3696 is untouched.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1183560-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1183560-python \
  ghcr.io/openhands/agent-server:1183560-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1183560-golang-amd64
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-golang-amd64
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-golang-amd64
ghcr.io/openhands/agent-server:1183560-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1183560-golang-arm64
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-golang-arm64
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-golang-arm64
ghcr.io/openhands/agent-server:1183560-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1183560-java-amd64
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-java-amd64
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-java-amd64
ghcr.io/openhands/agent-server:1183560-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1183560-java-arm64
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-java-arm64
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-java-arm64
ghcr.io/openhands/agent-server:1183560-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1183560-python-amd64
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-python-amd64
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-python-amd64
ghcr.io/openhands/agent-server:1183560-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1183560-python-arm64
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-python-arm64
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-python-arm64
ghcr.io/openhands/agent-server:1183560-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1183560-golang
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-golang
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-golang
ghcr.io/openhands/agent-server:1183560-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1183560-java
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-java
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-java
ghcr.io/openhands/agent-server:1183560-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1183560-python
ghcr.io/openhands/agent-server:1183560bc58f6c66e03a367070cffd6c525feed9-python
ghcr.io/openhands/agent-server:alona-fix-subagent-condenser-metrics-python
ghcr.io/openhands/agent-server:1183560-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1183560-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1183560-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->