### PR TITLE
[AgentProfile][sdk] AgentProfile kind-discriminated union

### DIFF
--- a/openhands-sdk/openhands/sdk/profiles/__init__.py
+++ b/openhands-sdk/openhands/sdk/profiles/__init__.py
@@ -6,6 +6,7 @@ from openhands.sdk.profiles.agent_profile import (
     AgentProfile,
     AgentProfileBase,
     OpenHandsAgentProfile,
+    ProfileVerificationSettings,
     validate_agent_profile,
 )
 
@@ -16,5 +17,6 @@ __all__ = [
     "AgentProfile",
     "AgentProfileBase",
     "OpenHandsAgentProfile",
+    "ProfileVerificationSettings",
     "validate_agent_profile",
 ]

--- a/openhands-sdk/openhands/sdk/profiles/__init__.py
+++ b/openhands-sdk/openhands/sdk/profiles/__init__.py
@@ -1,0 +1,20 @@
+"""Named, reference-bearing agent launch specs (``AgentProfile``)."""
+
+from openhands.sdk.profiles.agent_profile import (
+    AGENT_PROFILE_SCHEMA_VERSION,
+    ACPAgentProfile,
+    AgentProfile,
+    AgentProfileBase,
+    OpenHandsAgentProfile,
+    validate_agent_profile,
+)
+
+
+__all__ = [
+    "AGENT_PROFILE_SCHEMA_VERSION",
+    "ACPAgentProfile",
+    "AgentProfile",
+    "AgentProfileBase",
+    "OpenHandsAgentProfile",
+    "validate_agent_profile",
+]

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -1,32 +1,10 @@
-"""``AgentProfile`` — the top-level, named, **reference-bearing** launch spec.
+"""``AgentProfile`` — the named, reference-bearing agent launch spec.
 
-An ``AgentProfile`` is the kind-discriminated union a user picks when starting a
-conversation. It mirrors the proven ``Discriminator("agent_kind")`` + ``Tag``
-pattern of :data:`~openhands.sdk.settings.model.AgentSettingsConfig`, but is a
-**separate** union with a fundamentally different contract:
-
-* ``AgentSettingsConfig`` is *resolved* — it embeds the concrete ``llm`` and
-  ``mcp_config`` (with their secrets) ready to build an agent.
-* ``AgentProfile`` carries only *references* — ``llm_profile_ref`` and
-  ``mcp_server_refs`` — and is **secret-free at rest**. The resolver (#3717)
-  dereferences those into an ``AgentSettingsConfig`` at launch time.
-
-Where secrets actually live:
-
-* LLM credentials → on the referenced LLM profile (the LLM profile store).
-* MCP server configs (with their secrets) → the user's global ``mcp_config``;
-  the profile only names which of those servers to expose.
-* ACP provider credentials → the env-keyed secret store, *derived* from
-  ``acp_server`` via :data:`~openhands.sdk.settings.acp_providers.ACP_PROVIDERS`.
-  The profile references them by env-var name; values ride the single
-  ``state.secret_registry`` ← ``request.secrets`` channel (#1022/#1039).
-
-The two identity fields are distinct: :attr:`id` is the stable UUID provenance
-handle (what conversations record), while :attr:`name` is the human-facing,
-renameable key.
-
-The editor for these profiles is fully custom React, so — unlike the settings
-models — profile fields carry no ``SettingsFieldMetadata`` annotations.
+A separate ``Discriminator("agent_kind")`` + ``Tag`` union from
+:data:`~openhands.sdk.settings.model.AgentSettingsConfig`: the profile carries
+*references* (``llm_profile_ref`` / ``mcp_server_refs``) and is secret-free at
+rest, whereas the settings union embeds the resolved ``llm`` / ``mcp_config``.
+See epic #3713 for the resolution model.
 """
 
 from __future__ import annotations
@@ -84,11 +62,8 @@ class AgentProfileBase(BaseModel):
         ge=0,
         description="Monotonic revision counter, bumped on each saved edit.",
     )
-    # ``null`` = use all of the user's globally configured MCP servers (current
-    # behavior); a non-null list filters ``mcp_config.mcpServers`` to the named
-    # keys (a name absent from the global config is a dangling ref — the
-    # resolver, #3717, hard-errors). ``null`` and ``[]`` are deliberately
-    # distinct: ``[]`` selects *no* servers.
+    # null = all of the user's MCP servers; [] = none; a non-null list filters
+    # to the named keys. null and [] are deliberately distinct.
     mcp_server_refs: list[str] | None = Field(
         default=None,
         description=(

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -1,0 +1,331 @@
+"""``AgentProfile`` — the top-level, named, **reference-bearing** launch spec.
+
+An ``AgentProfile`` is the kind-discriminated union a user picks when starting a
+conversation. It mirrors the proven ``Discriminator("agent_kind")`` + ``Tag``
+pattern of :data:`~openhands.sdk.settings.model.AgentSettingsConfig`, but is a
+**separate** union with a fundamentally different contract:
+
+* ``AgentSettingsConfig`` is *resolved* — it embeds the concrete ``llm`` and
+  ``mcp_config`` (with their secrets) ready to build an agent.
+* ``AgentProfile`` carries only *references* — ``llm_profile_ref`` and
+  ``mcp_server_refs`` — and is **secret-free at rest**. The resolver (#3717)
+  dereferences those into an ``AgentSettingsConfig`` at launch time.
+
+Where secrets actually live:
+
+* LLM credentials → on the referenced LLM profile (the LLM profile store).
+* MCP server configs (with their secrets) → the user's global ``mcp_config``;
+  the profile only names which of those servers to expose.
+* ACP provider credentials → the env-keyed secret store, *derived* from
+  ``acp_server`` via :data:`~openhands.sdk.settings.acp_providers.ACP_PROVIDERS`.
+  The profile references them by env-var name; values ride the single
+  ``state.secret_registry`` ← ``request.secrets`` channel (#1022/#1039).
+
+The two identity fields are distinct: :attr:`id` is the stable UUID provenance
+handle (what conversations record), while :attr:`name` is the human-facing,
+renameable key.
+
+The editor for these profiles is fully custom React, so — unlike the settings
+models — profile fields carry no ``SettingsFieldMetadata`` annotations.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Mapping
+from typing import Annotated, Any, Literal
+from uuid import UUID, uuid4
+
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Discriminator,
+    Field,
+    Tag,
+    TypeAdapter,
+)
+
+from openhands.sdk.settings.model import (
+    ACPServerKind,
+    CondenserSettingsConfig,
+    LLMSummarizingCondenserSettings,
+    VerificationSettings,
+)
+from openhands.sdk.skills import Skill
+
+
+AGENT_PROFILE_SCHEMA_VERSION = 1
+
+
+class AgentProfileBase(BaseModel):
+    """Shared identity + provenance fields for every ``AgentProfile`` variant.
+
+    ``extra="forbid"`` is what gives the union its cross-variant safety: a
+    payload tagged ``agent_kind="acp"`` that also carries ``llm_profile_ref``
+    (or an OpenHands payload carrying ``acp_*``) is rejected rather than
+    silently dropping the foreign field into a mongrel profile.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    schema_version: int = Field(default=AGENT_PROFILE_SCHEMA_VERSION, ge=1)
+    id: UUID = Field(
+        default_factory=uuid4,
+        description=(
+            "Stable provenance handle for this profile. Conversations record "
+            "this UUID; it never changes, even when the profile is renamed."
+        ),
+    )
+    name: str = Field(
+        min_length=1,
+        description="Human-facing, renameable key shown in the profile picker.",
+    )
+    revision: int = Field(
+        default=0,
+        ge=0,
+        description="Monotonic revision counter, bumped on each saved edit.",
+    )
+    # ``null`` = use all of the user's globally configured MCP servers (current
+    # behavior); a non-null list filters ``mcp_config.mcpServers`` to the named
+    # keys (a name absent from the global config is a dangling ref — the
+    # resolver, #3717, hard-errors). ``null`` and ``[]`` are deliberately
+    # distinct: ``[]`` selects *no* servers.
+    mcp_server_refs: list[str] | None = Field(
+        default=None,
+        description=(
+            "Which of the user's globally configured MCP servers to expose. "
+            "null = all; [] = none; a non-null list = filter to the named keys."
+        ),
+    )
+
+
+class OpenHandsAgentProfile(AgentProfileBase):
+    """``agent_kind="openhands"`` profile — references an LLM profile by name.
+
+    Mirrors the configurable surface of
+    :class:`~openhands.sdk.settings.model.OpenHandsAgentSettings`, except the
+    concrete ``llm`` is replaced by :attr:`llm_profile_ref` (resolved against
+    the LLM profile store) and ``mcp_config`` by the inherited
+    :attr:`~AgentProfileBase.mcp_server_refs`.
+    """
+
+    agent_kind: Literal["openhands"] = Field(
+        default="openhands",
+        description=(
+            "Discriminator for the ``AgentProfile`` union. ``'openhands'`` "
+            "selects the standard built-in OpenHands agent."
+        ),
+    )
+    llm_profile_ref: str = Field(
+        min_length=1,
+        description=(
+            "Name of the saved LLM profile to resolve for this agent. The "
+            "profile itself stores no LLM credential — it lives on the "
+            "referenced LLM profile."
+        ),
+    )
+    agent: str = Field(
+        default="CodeActAgent",
+        description="Agent class to build.",
+    )
+    skills: list[Skill] = Field(
+        default_factory=list,
+        description="Skills that extend the agent's context.",
+    )
+    system_message_suffix: str | None = Field(
+        default=None,
+        description="Optional suffix appended to the system prompt.",
+    )
+    condenser: CondenserSettingsConfig = Field(
+        default_factory=LLMSummarizingCondenserSettings,
+        description="Condenser settings for the agent.",
+    )
+    verification: VerificationSettings = Field(
+        default_factory=VerificationSettings,
+        description="Verification settings for the agent critic.",
+    )
+    enable_sub_agents: bool = Field(
+        default=False,
+        description="Enable sub-agent delegation via TaskToolSet.",
+    )
+    tool_concurrency_limit: int = Field(
+        default=1,
+        ge=1,
+        description=(
+            "Maximum number of tool calls to execute concurrently per agent "
+            "step. 1 = sequential (default)."
+        ),
+    )
+
+
+class ACPAgentProfile(AgentProfileBase):
+    """``agent_kind="acp"`` profile — names an ACP backend, stores no credential.
+
+    There is no ``llm_profile_ref`` and no embedded credential: the ACP
+    subprocess makes its own model calls, and the provider's credential
+    (env-var name) is derived from :attr:`acp_server` via the
+    :data:`~openhands.sdk.settings.acp_providers.ACP_PROVIDERS` registry. The
+    value rides the conversation secrets channel, never the profile.
+    """
+
+    agent_kind: Literal["acp"] = Field(
+        default="acp",
+        description=(
+            "Discriminator for the ``AgentProfile`` union. ``'acp'`` selects an "
+            "ACP-delegating agent."
+        ),
+    )
+    acp_server: ACPServerKind = Field(
+        default="claude-code",
+        description=(
+            "Which ACP-compatible backend to launch. The provider's credential "
+            "env-var name is derived from this via the ACP_PROVIDERS registry."
+        ),
+    )
+    acp_model: str | None = Field(
+        default=None,
+        description=(
+            "Model identifier for the ACP server (e.g. 'claude-opus-4-8'). "
+            "Leave blank to let the server pick its default."
+        ),
+    )
+    acp_session_mode: str | None = Field(
+        default=None,
+        description=(
+            "Session mode ID (e.g. 'bypassPermissions'). Leave blank to "
+            "auto-detect from the ACP server type."
+        ),
+    )
+    acp_prompt_timeout: float = Field(
+        default=1800.0,
+        gt=0,
+        description=(
+            "Inactivity timeout (seconds) for a single ACP prompt() round-trip; "
+            "resets on every update from the server."
+        ),
+    )
+    acp_command: str | None = Field(
+        default=None,
+        description=(
+            "Optional explicit command to launch the ACP subprocess. Leave "
+            "blank to use the default for ``acp_server``."
+        ),
+    )
+    acp_args: list[str] | None = Field(
+        default=None,
+        description="Additional arguments appended to the ACP server command.",
+    )
+
+
+def _agent_profile_discriminator(value: Any) -> str:
+    """Discriminator for :data:`AgentProfile` — defaults to ``'openhands'``.
+
+    A payload without an explicit ``agent_kind`` is treated as the standard
+    OpenHands variant, mirroring
+    :func:`~openhands.sdk.settings.model._agent_settings_discriminator`.
+    """
+    if isinstance(value, BaseModel):
+        return getattr(value, "agent_kind", "openhands")
+    if isinstance(value, Mapping):
+        return value.get("agent_kind", "openhands")
+    return "openhands"
+
+
+AgentProfile = Annotated[
+    Annotated[OpenHandsAgentProfile, Tag("openhands")]
+    | Annotated[ACPAgentProfile, Tag("acp")],
+    Discriminator(_agent_profile_discriminator),
+]
+"""Discriminated union over the agent-profile variants.
+
+Use :func:`validate_agent_profile` (or a :class:`~pydantic.TypeAdapter`) to
+validate/construct instances from raw payloads.
+"""
+
+
+PersistedProfileMigrator = Callable[[dict[str, Any]], dict[str, Any]]
+
+# Registered per *source* schema_version; each migrator returns a payload with
+# an advanced ``schema_version``. Empty while only v1 exists — the first schema
+# bump adds ``{1: _migrate_v1_to_v2}`` here.
+_AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {}
+
+
+def _apply_persisted_migrations(payload: dict[str, Any]) -> dict[str, Any]:
+    """Bring a persisted ``AgentProfile`` payload up to the current schema.
+
+    A payload missing ``schema_version`` predates versioning (or is a freshly
+    authored dict); canonicalize it by stamping the field to ``1``. Otherwise
+    the version is validated and walked forward through
+    :data:`_AGENT_PROFILE_MIGRATIONS`. Mirrors the migration dispatcher in
+    ``settings/model.py``.
+    """
+    migrated = dict(payload)
+    version_raw = migrated.get("schema_version")
+    if version_raw is None:
+        migrated["schema_version"] = 1
+        version = 1
+    elif isinstance(version_raw, int) and not isinstance(version_raw, bool):
+        version = version_raw
+    else:
+        raise TypeError(
+            "AgentProfile schema_version must be an integer, got "
+            f"{type(version_raw).__name__}."
+        )
+
+    if version < 0:
+        raise ValueError("AgentProfile schema_version must be non-negative.")
+    if version > AGENT_PROFILE_SCHEMA_VERSION:
+        raise ValueError(
+            f"AgentProfile schema_version {version} is newer than supported "
+            f"version {AGENT_PROFILE_SCHEMA_VERSION}."
+        )
+
+    while version < AGENT_PROFILE_SCHEMA_VERSION:
+        migrate = _AGENT_PROFILE_MIGRATIONS.get(version)
+        if migrate is None:
+            raise ValueError(
+                f"No migration registered for AgentProfile schema_version {version}."
+            )
+        migrated = migrate(dict(migrated))
+        next_version = migrated.get("schema_version")
+        if not isinstance(next_version, int) or isinstance(next_version, bool):
+            raise ValueError(
+                f"Migration for AgentProfile schema_version {version} did not "
+                "produce a valid integer schema_version."
+            )
+        if next_version <= version:
+            raise ValueError(
+                f"Migration for AgentProfile schema_version {version} did not "
+                "advance the schema_version."
+            )
+        version = next_version
+
+    return migrated
+
+
+_AGENT_PROFILE_ADAPTER: TypeAdapter[OpenHandsAgentProfile | ACPAgentProfile] = (
+    TypeAdapter(AgentProfile)
+)
+
+
+def validate_agent_profile(
+    data: Any,
+    *,
+    context: Mapping[str, Any] | None = None,
+) -> OpenHandsAgentProfile | ACPAgentProfile:
+    """Load and validate an ``AgentProfile`` payload, narrowing on ``agent_kind``.
+
+    Already-validated instances pass through unchanged. Raw mappings are
+    migrated to the current schema version, then validated against
+    :data:`AgentProfile`, so the return is always a canonical variant.
+    """
+    if isinstance(data, OpenHandsAgentProfile | ACPAgentProfile):
+        return data
+    if isinstance(data, BaseModel):
+        payload = data.model_dump(mode="json")
+    elif isinstance(data, Mapping):
+        payload = dict(data)
+    else:
+        raise TypeError("AgentProfile payload must be a mapping or BaseModel.")
+    payload = _apply_persisted_migrations(payload)
+    return _AGENT_PROFILE_ADAPTER.validate_python(payload, context=context)

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -25,13 +25,31 @@ from pydantic import (
 from openhands.sdk.settings.model import (
     ACPServerKind,
     CondenserSettingsConfig,
+    CriticMode,
     LLMSummarizingCondenserSettings,
-    VerificationSettings,
 )
 from openhands.sdk.skills import Skill
 
 
 AGENT_PROFILE_SCHEMA_VERSION = 1
+
+
+class ProfileVerificationSettings(BaseModel):
+    """Secret-free critic/refinement policy for a profile.
+
+    The non-credential subset of
+    :class:`~openhands.sdk.settings.model.VerificationSettings`: ``critic_api_key``
+    is omitted so the profile holds no secret. The critic reuses the resolved
+    LLM profile's key (the existing ``critic_api_key=None`` behavior).
+    """
+
+    critic_enabled: bool = False
+    critic_mode: CriticMode = "finish_and_message"
+    enable_iterative_refinement: bool = False
+    critic_threshold: float = Field(default=0.6, ge=0.0, le=1.0)
+    max_refinement_iterations: int = Field(default=3, ge=1)
+    critic_server_url: str | None = None
+    critic_model_name: str | None = None
 
 
 class AgentProfileBase(BaseModel):
@@ -114,9 +132,9 @@ class OpenHandsAgentProfile(AgentProfileBase):
         default_factory=LLMSummarizingCondenserSettings,
         description="Condenser settings for the agent.",
     )
-    verification: VerificationSettings = Field(
-        default_factory=VerificationSettings,
-        description="Verification settings for the agent critic.",
+    verification: ProfileVerificationSettings = Field(
+        default_factory=ProfileVerificationSettings,
+        description="Critic/verification policy (secret-free; no critic_api_key).",
     )
     enable_sub_agents: bool = Field(
         default=False,

--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -12,7 +12,14 @@ from xml.sax.saxutils import escape as xml_escape
 import frontmatter
 import yaml
 from fastmcp.mcp_config import MCPConfig
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.skills.exceptions import SkillError, SkillValidationError
@@ -268,6 +275,25 @@ class Skill(BaseModel):
             except Exception as e:
                 raise SkillValidationError(f"Invalid MCPConfig dictionary: {e}") from e
         return v
+
+    @field_serializer("mcp_tools")
+    def _serialize_mcp_tools(
+        self, value: dict | None, info: SerializationInfo
+    ) -> dict | None:
+        """Mask credentials in ``mcp_tools`` (``mcpServers.*.env``/``headers``).
+
+        ``mcp_tools`` is an unmodeled ``dict``, so it would otherwise dump its
+        MCP server secrets in plaintext wherever a ``Skill`` is serialized.
+        Route it through the same ``serialize_mcp_config`` as settings
+        ``mcp_config``: redacted by default, plaintext under ``expose_secrets``,
+        encrypted under a cipher. Imported lazily to avoid the
+        settings.model -> agent_context -> skills import cycle.
+        """
+        if not value:
+            return value
+        from openhands.sdk.settings.model import serialize_mcp_config
+
+        return serialize_mcp_config(MCPConfig.model_validate(value), info)
 
     PATH_TO_THIRD_PARTY_SKILL_NAME: ClassVar[dict[str, str]] = {
         ".cursorrules": "cursorrules",

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -19,6 +19,7 @@ from openhands.sdk.profiles import (
     OpenHandsAgentProfile,
     validate_agent_profile,
 )
+from openhands.sdk.skills import Skill
 
 
 _ADAPTER: TypeAdapter[OpenHandsAgentProfile | ACPAgentProfile] = TypeAdapter(
@@ -322,3 +323,50 @@ def test_verification_field_cannot_carry_a_secret() -> None:
     exposed = profile.model_dump(mode="json", context={"expose_secrets": True})
     assert "critic_api_key" not in exposed["verification"]
     assert "sk-real-secret-value" not in json.dumps(exposed)
+
+
+def _skill_with_mcp_secret() -> Skill:
+    return Skill(
+        name="leaky",
+        content="do stuff",
+        mcp_tools={
+            "mcpServers": {
+                "svc": {
+                    "url": "https://x.test",
+                    "headers": {"Authorization": "Bearer sk-HEADER-SECRET"},
+                    "env": {"API_KEY": "env-SECRET"},
+                }
+            }
+        },
+    )
+
+
+def test_skills_mcp_tools_credentials_are_masked_at_rest() -> None:
+    """``Skill.mcp_tools`` (an unmodeled dict) can carry an MCP server credential
+    in ``env`` / ``headers``; the profile must mask it at rest like
+    ``OpenHandsAgentSettings.mcp_config`` does — not dump it in plaintext."""
+    profile = OpenHandsAgentProfile(
+        name="oh", llm_profile_ref="default", skills=[_skill_with_mcp_secret()]
+    )
+
+    default_dump = json.dumps(profile.model_dump(mode="json"))
+    assert "sk-HEADER-SECRET" not in default_dump
+    assert "env-SECRET" not in default_dump
+
+    # Opt-in exposure surfaces the real values (parity with mcp_config).
+    exposed = json.dumps(
+        profile.model_dump(mode="json", context={"expose_secrets": True})
+    )
+    assert "sk-HEADER-SECRET" in exposed
+    assert "env-SECRET" in exposed
+
+
+def test_skills_without_secrets_round_trip() -> None:
+    """A plain skill (no mcp_tools secrets) still round-trips unchanged."""
+    profile = OpenHandsAgentProfile(
+        name="oh",
+        llm_profile_ref="default",
+        skills=[Skill(name="clean", content="hello")],
+    )
+    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
+    assert reloaded == profile

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -1,0 +1,298 @@
+"""Tests for the ``AgentProfile`` kind-discriminated union.
+
+Mirrors the ``AgentSettingsConfig`` union tests in ``tests/sdk/test_settings.py``:
+round-trip both variants, confirm narrowing on ``agent_kind``, confirm the
+cross-variant fields are rejected, and confirm the ``mcp_server_refs`` null/[]
+distinction. Adds the profile-specific contract: secret-free at rest.
+"""
+
+from uuid import UUID, uuid4
+
+import pytest
+from pydantic import TypeAdapter, ValidationError
+
+from openhands.sdk.profiles import (
+    AGENT_PROFILE_SCHEMA_VERSION,
+    ACPAgentProfile,
+    AgentProfile,
+    OpenHandsAgentProfile,
+    validate_agent_profile,
+)
+
+
+_ADAPTER: TypeAdapter[OpenHandsAgentProfile | ACPAgentProfile] = TypeAdapter(
+    AgentProfile
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction + round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_openhands_profile_round_trips() -> None:
+    profile = OpenHandsAgentProfile(
+        name="my-openhands",
+        llm_profile_ref="default",
+        revision=3,
+        mcp_server_refs=["fetch"],
+        system_message_suffix="be terse",
+        enable_sub_agents=True,
+        tool_concurrency_limit=4,
+    )
+    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
+
+    assert isinstance(reloaded, OpenHandsAgentProfile)
+    assert reloaded == profile
+    assert reloaded.agent_kind == "openhands"
+    assert reloaded.agent == "CodeActAgent"
+    assert reloaded.llm_profile_ref == "default"
+    assert reloaded.revision == 3
+    assert reloaded.mcp_server_refs == ["fetch"]
+    assert reloaded.tool_concurrency_limit == 4
+
+
+def test_acp_profile_round_trips() -> None:
+    profile = ACPAgentProfile(
+        name="my-acp",
+        acp_server="codex",
+        acp_model="gpt-5.5/medium",
+        acp_session_mode="full-access",
+        acp_prompt_timeout=600.0,
+        acp_command="codex-acp",
+        acp_args=["--flag"],
+        mcp_server_refs=None,
+    )
+    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
+
+    assert isinstance(reloaded, ACPAgentProfile)
+    assert reloaded == profile
+    assert reloaded.agent_kind == "acp"
+    assert reloaded.acp_server == "codex"
+    assert reloaded.acp_model == "gpt-5.5/medium"
+    assert reloaded.acp_command == "codex-acp"
+    assert reloaded.acp_args == ["--flag"]
+    assert reloaded.mcp_server_refs is None
+
+
+def test_acp_profile_minimal_defaults() -> None:
+    profile = validate_agent_profile({"agent_kind": "acp", "name": "minimal"})
+
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.acp_server == "claude-code"
+    assert profile.acp_model is None
+    assert profile.acp_session_mode is None
+    assert profile.acp_prompt_timeout == 1800.0
+    assert profile.acp_command is None
+    assert profile.acp_args is None
+
+
+# ---------------------------------------------------------------------------
+# Discriminator + validation
+# ---------------------------------------------------------------------------
+
+
+def test_validate_dispatches_on_agent_kind() -> None:
+    openhands = validate_agent_profile(
+        {"agent_kind": "openhands", "name": "oh", "llm_profile_ref": "default"}
+    )
+    assert isinstance(openhands, OpenHandsAgentProfile)
+    assert openhands.agent_kind == "openhands"
+
+    acp = validate_agent_profile(
+        {"agent_kind": "acp", "name": "acp", "acp_model": "claude-opus-4-8"}
+    )
+    assert isinstance(acp, ACPAgentProfile)
+    assert acp.agent_kind == "acp"
+
+
+def test_missing_discriminator_defaults_to_openhands() -> None:
+    profile = validate_agent_profile({"name": "oh", "llm_profile_ref": "default"})
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.agent_kind == "openhands"
+
+
+def test_type_adapter_narrows_directly() -> None:
+    """A bare ``TypeAdapter(AgentProfile)`` (no migration) narrows correctly."""
+    acp = _ADAPTER.validate_python({"agent_kind": "acp", "name": "acp"})
+    assert isinstance(acp, ACPAgentProfile)
+
+
+def test_validate_passes_through_instances() -> None:
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
+    assert validate_agent_profile(profile) is profile
+
+
+def test_validate_rejects_non_mapping() -> None:
+    with pytest.raises(TypeError, match="must be a mapping or BaseModel"):
+        validate_agent_profile(["not", "a", "mapping"])
+
+
+# ---------------------------------------------------------------------------
+# Cross-variant field rejection (extra="forbid")
+# ---------------------------------------------------------------------------
+
+
+def test_acp_rejects_llm_profile_ref() -> None:
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {"agent_kind": "acp", "name": "acp", "llm_profile_ref": "default"}
+        )
+
+
+def test_openhands_rejects_acp_fields() -> None:
+    for acp_field, value in (
+        ("acp_server", "codex"),
+        ("acp_model", "gpt-5.5/medium"),
+        ("acp_command", "codex-acp"),
+        ("acp_args", ["--flag"]),
+        ("acp_session_mode", "full-access"),
+        ("acp_prompt_timeout", 600.0),
+    ):
+        with pytest.raises(ValidationError):
+            validate_agent_profile(
+                {
+                    "agent_kind": "openhands",
+                    "name": "oh",
+                    "llm_profile_ref": "default",
+                    acp_field: value,
+                }
+            )
+
+
+def test_openhands_requires_llm_profile_ref() -> None:
+    with pytest.raises(ValidationError):
+        validate_agent_profile({"agent_kind": "openhands", "name": "oh"})
+
+
+def test_acp_rejects_unknown_acp_server() -> None:
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {"agent_kind": "acp", "name": "acp", "acp_server": "not-a-provider"}
+        )
+
+
+# ---------------------------------------------------------------------------
+# mcp_server_refs: null vs [] are distinct
+# ---------------------------------------------------------------------------
+
+
+def test_mcp_server_refs_null_vs_empty_are_distinct() -> None:
+    use_all = validate_agent_profile(
+        {"name": "a", "llm_profile_ref": "d", "mcp_server_refs": None}
+    )
+    use_none = validate_agent_profile(
+        {"name": "b", "llm_profile_ref": "d", "mcp_server_refs": []}
+    )
+    subset = validate_agent_profile(
+        {"name": "c", "llm_profile_ref": "d", "mcp_server_refs": ["fetch"]}
+    )
+
+    assert use_all.mcp_server_refs is None
+    assert use_none.mcp_server_refs == []
+    assert subset.mcp_server_refs == ["fetch"]
+
+    # The distinction must survive a serialize → reload round-trip.
+    assert (
+        validate_agent_profile(use_all.model_dump(mode="json")).mcp_server_refs is None
+    )
+    assert (
+        validate_agent_profile(use_none.model_dump(mode="json")).mcp_server_refs == []
+    )
+
+
+def test_mcp_server_refs_default_is_null() -> None:
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="d")
+    assert profile.mcp_server_refs is None
+
+
+# ---------------------------------------------------------------------------
+# schema_version + migration
+# ---------------------------------------------------------------------------
+
+
+def test_schema_version_defaults_to_current() -> None:
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="d")
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
+
+
+def test_payload_missing_schema_version_canonicalizes() -> None:
+    payload = {"agent_kind": "acp", "name": "acp"}
+    assert "schema_version" not in payload
+    profile = validate_agent_profile(payload)
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
+
+
+def test_rejects_newer_schema_version() -> None:
+    with pytest.raises(ValueError, match="newer than supported"):
+        validate_agent_profile(
+            {
+                "name": "oh",
+                "llm_profile_ref": "d",
+                "schema_version": AGENT_PROFILE_SCHEMA_VERSION + 1,
+            }
+        )
+
+
+def test_rejects_non_integer_schema_version() -> None:
+    with pytest.raises(TypeError, match="must be an integer"):
+        validate_agent_profile(
+            {"name": "oh", "llm_profile_ref": "d", "schema_version": "1"}
+        )
+
+
+def test_rejects_negative_schema_version() -> None:
+    with pytest.raises(ValueError, match="non-negative"):
+        validate_agent_profile(
+            {"name": "oh", "llm_profile_ref": "d", "schema_version": -1}
+        )
+
+
+# ---------------------------------------------------------------------------
+# Identity: id (stable UUID) vs name (renameable)
+# ---------------------------------------------------------------------------
+
+
+def test_id_is_uuid_and_autogenerated() -> None:
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="d")
+    assert isinstance(profile.id, UUID)
+    other = OpenHandsAgentProfile(name="oh", llm_profile_ref="d")
+    assert profile.id != other.id
+
+
+def test_explicit_id_is_preserved_across_round_trip() -> None:
+    fixed = uuid4()
+    profile = validate_agent_profile(
+        {"name": "oh", "llm_profile_ref": "d", "id": str(fixed)}
+    )
+    assert profile.id == fixed
+    assert validate_agent_profile(profile.model_dump(mode="json")).id == fixed
+
+
+def test_name_is_required() -> None:
+    with pytest.raises(ValidationError):
+        validate_agent_profile({"llm_profile_ref": "d"})
+
+
+# ---------------------------------------------------------------------------
+# Secret-free at rest
+# ---------------------------------------------------------------------------
+
+
+def test_openhands_profile_persists_no_secret_fields() -> None:
+    dumped = OpenHandsAgentProfile(name="oh", llm_profile_ref="default").model_dump(
+        mode="json"
+    )
+    # The profile carries a *reference*, never the credential itself.
+    assert "llm" not in dumped
+    assert "api_key" not in dumped
+    assert "llm_profile_ref" in dumped
+
+
+def test_acp_profile_persists_no_secret_fields() -> None:
+    dumped = ACPAgentProfile(name="acp", acp_server="claude-code").model_dump(
+        mode="json"
+    )
+    # No embedded credential and no acp_env-style secret bag on the profile.
+    for key in ("llm", "api_key", "acp_env", "secrets", "agent_context"):
+        assert key not in dumped

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -6,6 +6,7 @@ cross-variant fields are rejected, and confirm the ``mcp_server_refs`` null/[]
 distinction. Adds the profile-specific contract: secret-free at rest.
 """
 
+import json
 from uuid import UUID, uuid4
 
 import pytest
@@ -296,3 +297,28 @@ def test_acp_profile_persists_no_secret_fields() -> None:
     # No embedded credential and no acp_env-style secret bag on the profile.
     for key in ("llm", "api_key", "acp_env", "secrets", "agent_context"):
         assert key not in dumped
+
+
+def test_verification_field_cannot_carry_a_secret() -> None:
+    """The verification block is secret-free: ``critic_api_key`` is not a field,
+    so a payload supplying it is stripped and can never be exposed at rest."""
+    profile = validate_agent_profile(
+        {
+            "name": "oh",
+            "llm_profile_ref": "default",
+            "verification": {
+                "critic_enabled": True,
+                "critic_model_name": "gpt-5.5",
+                "critic_api_key": "sk-real-secret-value",
+            },
+        }
+    )
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert not hasattr(profile.verification, "critic_api_key")
+    assert profile.verification.critic_enabled is True
+    assert profile.verification.critic_model_name == "gpt-5.5"
+
+    # Even forcing secret exposure must not surface the value (it isn't stored).
+    exposed = profile.model_dump(mode="json", context={"expose_secrets": True})
+    assert "critic_api_key" not in exposed["verification"]
+    assert "sk-real-secret-value" not in json.dumps(exposed)

--- a/tests/sdk/skills/test_skill_serialization.py
+++ b/tests/sdk/skills/test_skill_serialization.py
@@ -363,6 +363,7 @@ def test_mcp_tools_real_values_remain_accessible_in_memory():
     runtime MCP usage is unaffected."""
     skill = _skill_with_mcp_secret()
 
+    assert skill.mcp_tools is not None
     env = skill.mcp_tools["mcpServers"]["svc"]["env"]
     assert env["API_KEY"] == _MCP_SECRET
 

--- a/tests/sdk/skills/test_skill_serialization.py
+++ b/tests/sdk/skills/test_skill_serialization.py
@@ -295,3 +295,81 @@ def test_discriminated_union_with_pydantic_model():
     # First skill is always-active (trigger is None)
     assert model.skills[1].trigger.type == "keyword"
     assert model.skills[2].trigger.type == "task"
+
+
+# A clearly identifiable secret value for the mcp_tools masking tests.
+_MCP_SECRET = "ghp_SUPER_SECRET_TOKEN_SHOULD_NOT_LEAK"
+
+
+def _skill_with_mcp_secret() -> Skill:
+    return Skill(
+        name="leaky",
+        content="do stuff",
+        mcp_tools={
+            "mcpServers": {
+                "svc": {
+                    "url": "https://x.test",
+                    "headers": {"Authorization": f"Bearer {_MCP_SECRET}"},
+                    "env": {"API_KEY": _MCP_SECRET},
+                }
+            }
+        },
+    )
+
+
+def test_mcp_tools_secrets_redacted_by_default():
+    """mcp_tools env/headers carry MCP credentials; they must be redacted at
+    rest, just like settings mcp_config -- not dumped in plaintext."""
+    skill = _skill_with_mcp_secret()
+
+    dumped = json.dumps(skill.model_dump(mode="json"))
+    assert _MCP_SECRET not in dumped
+
+    json_dumped = skill.model_dump_json()
+    assert _MCP_SECRET not in json_dumped
+
+
+def test_mcp_tools_secrets_exposed_under_expose_secrets():
+    """Opt-in exposure surfaces the real values (parity with mcp_config)."""
+    skill = _skill_with_mcp_secret()
+
+    exposed = json.dumps(
+        skill.model_dump(mode="json", context={"expose_secrets": "plaintext"})
+    )
+    assert _MCP_SECRET in exposed
+
+
+def test_mcp_tools_secrets_encrypted_under_cipher():
+    """With a cipher in context, secrets are encrypted (not plaintext, not
+    dropped) so they can be decrypted on restore."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    skill = _skill_with_mcp_secret()
+    cipher = Cipher(secret_key="test-encryption-key")
+
+    encrypted = json.dumps(
+        skill.model_dump(
+            mode="json", context={"expose_secrets": "encrypted", "cipher": cipher}
+        )
+    )
+    assert _MCP_SECRET not in encrypted
+    # The header/env keys survive; only their values are transformed.
+    assert "Authorization" in encrypted
+    assert "API_KEY" in encrypted
+
+
+def test_mcp_tools_real_values_remain_accessible_in_memory():
+    """Masking is serialization-only: the live attribute keeps real values so
+    runtime MCP usage is unaffected."""
+    skill = _skill_with_mcp_secret()
+
+    env = skill.mcp_tools["mcpServers"]["svc"]["env"]
+    assert env["API_KEY"] == _MCP_SECRET
+
+
+def test_mcp_tools_none_round_trips_unchanged():
+    """A skill without mcp_tools still serializes mcp_tools as None."""
+    skill = Skill(name="clean", content="hello")
+    dumped = skill.model_dump(mode="json")
+    assert dumped["mcp_tools"] is None
+    assert Skill.model_validate(dumped) == skill


### PR DESCRIPTION
HUMAN:

First SDK building block for the AgentProfile epic (#3713): the kind-discriminated,
reference-bearing, secret-free AgentProfile model. Reviewed the field set against the
epic design and confirmed it stays a separate union from AgentSettingsConfig.

---

AGENT:

## Why

The `AgentProfile` is the top-level named launch spec a user selects when starting a
conversation. It must be a **separate** discriminated union from `AgentSettingsConfig`:
the profile carries *references* (`llm_profile_ref` / `mcp_server_refs`) and holds **no
secrets at rest**, whereas the resolved `AgentSettingsConfig` embeds the concrete `llm` /
`mcp_config` (with secrets). This PR lands that model as the first SDK substrate of the
epic (#3713); the resolver that dereferences a profile into settings is #3717.

## Summary

- New module `openhands-sdk/openhands/sdk/profiles/agent_profile.py` mirroring the
  `Discriminator("agent_kind")` + `Tag` pattern at `settings/model.py`, but **not**
  extending `AgentSettingsConfig`.
- `OpenHandsAgentProfile` (`agent_kind="openhands"`): `llm_profile_ref`, `agent`,
  `skills`, `system_message_suffix`, `condenser`, `verification`, `enable_sub_agents`,
  `tool_concurrency_limit`, plus shared `id`/`name`/`revision`/`mcp_server_refs`.
- `ACPAgentProfile` (`agent_kind="acp"`): `acp_server`, `acp_model`, `acp_session_mode`,
  `acp_prompt_timeout`, `acp_command`, `acp_args`, `mcp_server_refs` — **no**
  `llm_profile_ref` and **no** credential field (provider secrets are derived from
  `acp_server` via the `ACP_PROVIDERS` registry and ride `state.secret_registry`).
- `extra="forbid"` on the base so each variant rejects the other's fields.
- `mcp_server_refs`: `null` = all of the user's MCP servers, `[]` = none, a non-null list
  = filter — `null` and `[]` are distinct.
- `schema_version` field + `_apply_persisted_migrations` dispatcher (a payload missing
  `schema_version` canonicalizes to 1) + `validate_agent_profile`.
- No `SettingsFieldMetadata` annotations — the editor is fully custom React.

## Issue Number

Closes #3715. Part of epic #3713.

## How to Test

New unit tests mirror the `AgentSettingsConfig` union tests and cover every acceptance
criterion (round-trip both variants, narrow on `agent_kind`, ACP rejects
`llm_profile_ref`, OpenHands rejects `acp_*`, `null` vs `[]` distinct, schema-version
migration, secret-free at rest).

```
$ uv run pytest tests/sdk/profiles/test_agent_profile.py -q
24 passed

$ uv run pytest tests/sdk/test_settings.py -q
119 passed   # no regression in the sibling settings union

$ uv run ruff format --check openhands-sdk/openhands/sdk/profiles/ tests/sdk/profiles/
$ uv run ruff check openhands-sdk/openhands/sdk/profiles/ tests/sdk/profiles/
All checks passed!

$ uv run pyright openhands-sdk/openhands/sdk/profiles/ tests/sdk/profiles/
0 errors, 0 warnings, 0 informations
```

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is model-only. Persistence store (#3716) and the profile→settings resolver (#3717)
land in follow-up PRs; `mcp_server_refs` dangling-ref enforcement is the resolver's job.







<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f405cd5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f405cd5-python \
  ghcr.io/openhands/agent-server:f405cd5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f405cd5-golang-amd64
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-golang-amd64
ghcr.io/openhands/agent-server:agent-profile-model-golang-amd64
ghcr.io/openhands/agent-server:f405cd5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f405cd5-golang-arm64
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-golang-arm64
ghcr.io/openhands/agent-server:agent-profile-model-golang-arm64
ghcr.io/openhands/agent-server:f405cd5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f405cd5-java-amd64
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-java-amd64
ghcr.io/openhands/agent-server:agent-profile-model-java-amd64
ghcr.io/openhands/agent-server:f405cd5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f405cd5-java-arm64
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-java-arm64
ghcr.io/openhands/agent-server:agent-profile-model-java-arm64
ghcr.io/openhands/agent-server:f405cd5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f405cd5-python-amd64
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-python-amd64
ghcr.io/openhands/agent-server:agent-profile-model-python-amd64
ghcr.io/openhands/agent-server:f405cd5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f405cd5-python-arm64
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-python-arm64
ghcr.io/openhands/agent-server:agent-profile-model-python-arm64
ghcr.io/openhands/agent-server:f405cd5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f405cd5-golang
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-golang
ghcr.io/openhands/agent-server:agent-profile-model-golang
ghcr.io/openhands/agent-server:f405cd5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f405cd5-java
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-java
ghcr.io/openhands/agent-server:agent-profile-model-java
ghcr.io/openhands/agent-server:f405cd5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f405cd5-python
ghcr.io/openhands/agent-server:f405cd5c3dc32a0278ec8ea47347e183e1636cb1-python
ghcr.io/openhands/agent-server:agent-profile-model-python
ghcr.io/openhands/agent-server:f405cd5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f405cd5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f405cd5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->