### PR TITLE
fix: expand per-conversation secrets in plugin source/ref before fetch

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -66,7 +66,10 @@ from openhands.sdk.security.confirmation_policy import (
     ConfirmationPolicyBase,
 )
 from openhands.sdk.skills import load_available_skills, merge_skills_by_name
-from openhands.sdk.skills.utils import expand_mcp_variables
+from openhands.sdk.skills.utils import (
+    expand_mcp_variables,
+    expand_variable_references,
+)
 from openhands.sdk.subagent import (
     AgentDefinition,
     register_file_agents,
@@ -643,14 +646,47 @@ class LocalConversation(BaseConversation):
             self._resolved_plugins = []
 
             for spec in self._plugin_specs:
+                # Expand ${VAR} placeholders in the source/ref using
+                # per-conversation secrets, so private plugins can be cloned
+                # with a token supplied via the secrets API, e.g.:
+                #   "https://x-token-auth:${MY_TOKEN}@host/org/repo.git"
+                #
+                # SECURITY: secrets only (check_env=False) -- never fold host
+                # environment variables into a URL sent to a remote git host.
+                # Braced-only (support_unbraced=False) avoids mangling a literal
+                # "$" that may legitimately appear in a token/password.
+                get_secret = self._state.secret_registry.get_secret_value
+                fetch_source = expand_variable_references(
+                    spec.source,
+                    get_secret=get_secret,
+                    check_env=False,
+                    support_unbraced=False,
+                    expand_defaults=False,
+                )
+                fetch_ref = (
+                    expand_variable_references(
+                        spec.ref,
+                        get_secret=get_secret,
+                        check_env=False,
+                        support_unbraced=False,
+                        expand_defaults=False,
+                    )
+                    if spec.ref
+                    else spec.ref
+                )
+
                 # Fetch plugin and get resolved commit SHA
                 path, resolved_ref = fetch_plugin_with_resolution(
-                    source=spec.source,
-                    ref=spec.ref,
+                    source=fetch_source,
+                    ref=fetch_ref,
                     repo_path=spec.repo_path,
                 )
 
-                # Store resolved ref for persistence
+                # Store resolved ref for persistence. Build this from the
+                # ORIGINAL spec (not the expanded values) so the persisted
+                # record keeps the ${VAR} placeholder rather than the raw
+                # secret. from_plugin_source() additionally redacts any inline
+                # credentials. Resume re-fetches via the resolved commit SHA.
                 resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
                 self._resolved_plugins.append(resolved)
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -645,35 +645,30 @@ class LocalConversation(BaseConversation):
             logger.info(f"Loading {len(self._plugin_specs)} plugin(s)...")
             self._resolved_plugins = []
 
-            for spec in self._plugin_specs:
-                # Expand ${VAR} placeholders in the source/ref using
-                # per-conversation secrets, so private plugins can be cloned
-                # with a token supplied via the secrets API, e.g.:
-                #   "https://x-token-auth:${MY_TOKEN}@host/org/repo.git"
-                #
-                # SECURITY: secrets only (check_env=False) -- never fold host
-                # environment variables into a URL sent to a remote git host.
-                # Braced-only (support_unbraced=False) avoids mangling a literal
-                # "$" that may legitimately appear in a token/password.
-                get_secret = self._state.secret_registry.get_secret_value
-                fetch_source = expand_variable_references(
-                    spec.source,
+            # Expand ${VAR} placeholders in the source/ref using per-conversation
+            # secrets, so private plugins can be cloned with a token supplied via
+            # the secrets API, e.g. "https://x-token-auth:${MY_TOKEN}@host/repo.git".
+            #
+            # SECURITY: secrets only (check_env=False) -- never fold host
+            # environment variables into a URL sent to a remote git host.
+            # Braced-only (support_unbraced=False) avoids mangling a literal "$"
+            # that may legitimately appear in a token/password. expand_defaults
+            # is False so an unknown ${VAR} is left verbatim rather than silently
+            # defaulted inside a URL.
+            get_secret = self._state.secret_registry.get_secret_value
+
+            def _expand_secret_refs(value: str) -> str:
+                return expand_variable_references(
+                    value,
                     get_secret=get_secret,
                     check_env=False,
                     support_unbraced=False,
                     expand_defaults=False,
                 )
-                fetch_ref = (
-                    expand_variable_references(
-                        spec.ref,
-                        get_secret=get_secret,
-                        check_env=False,
-                        support_unbraced=False,
-                        expand_defaults=False,
-                    )
-                    if spec.ref
-                    else spec.ref
-                )
+
+            for spec in self._plugin_specs:
+                fetch_source = _expand_secret_refs(spec.source)
+                fetch_ref = _expand_secret_refs(spec.ref) if spec.ref else spec.ref
 
                 # Fetch plugin and get resolved commit SHA
                 path, resolved_ref = fetch_plugin_with_resolution(

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -692,6 +692,39 @@ class TestPluginSourceSecretExpansion:
 
         conversation.close()
 
+    def test_unknown_var_with_default_left_untouched(self, tmp_path: Path, basic_agent):
+        """`${MISSING:-default}` is preserved verbatim (expand_defaults=False).
+
+        An unresolved variable in a URL must not be silently replaced with its
+        default -- the placeholder is left intact so the failure is visible
+        rather than producing a wrong-but-plausible URL.
+        """
+        source = "https://x-token-auth:${MISSING:-fallback}@host.example.com/o/r.git"
+        conversation, plugin_dir = self._make_conversation(
+            tmp_path, basic_agent, source
+        )
+        # No secret named MISSING registered.
+
+        captured: dict[str, str | None] = {}
+
+        def fake_fetch(source, ref=None, repo_path=None, **kwargs):
+            captured["source"] = source
+            return plugin_dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+        with patch(
+            "openhands.sdk.conversation.impl.local_conversation."
+            "fetch_plugin_with_resolution",
+            side_effect=fake_fetch,
+        ):
+            conversation._ensure_plugins_loaded()
+
+        # Placeholder preserved verbatim: the default is NOT substituted in,
+        # the whole ${MISSING:-fallback} token is left intact.
+        assert captured["source"] == source
+        assert "${MISSING:-fallback}" in (captured["source"] or "")
+
+        conversation.close()
+
     def test_ref_secret_expanded_before_fetch(self, tmp_path: Path, basic_agent):
         """A ${VAR} in the ref is also expanded from secrets."""
         source = str(tmp_path / "plugin")

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -601,3 +601,118 @@ class TestPluginMcpSecretsExpansion:
         assert header == "default-header-value"
 
         conversation.close()
+
+
+class TestPluginSourceSecretExpansion:
+    """Secrets in plugin ``source``/``ref`` are expanded before fetch.
+
+    This enables cloning private plugin repositories with a token supplied via
+    the per-conversation secrets API, e.g. a ``source`` of
+    ``https://x-token-auth:${MY_TOKEN}@host/org/repo.git``.
+    """
+
+    def _make_conversation(
+        self, tmp_path: Path, basic_agent, plugin_source: str, ref: str | None = None
+    ):
+        plugin_dir = create_test_plugin(
+            tmp_path / "plugin",
+            name="private-plugin",
+            skills=[{"name": "private-skill", "content": "Private content"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            plugins=[PluginSource(source=plugin_source, ref=ref)],
+            visualizer=None,
+        )
+        return conversation, plugin_dir
+
+    def test_source_secret_expanded_before_fetch(self, tmp_path: Path, basic_agent):
+        """A ${VAR} in the source is replaced with the secret value before clone."""
+        source = "https://x-token-auth:${MY_TOKEN}@host.example.com/org/repo.git"
+        conversation, plugin_dir = self._make_conversation(
+            tmp_path, basic_agent, source
+        )
+        conversation.update_secrets({"MY_TOKEN": "s3cr3t-value"})
+
+        captured: dict[str, str | None] = {}
+
+        def fake_fetch(source, ref=None, repo_path=None, **kwargs):
+            captured["source"] = source
+            captured["ref"] = ref
+            return plugin_dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+        with patch(
+            "openhands.sdk.conversation.impl.local_conversation."
+            "fetch_plugin_with_resolution",
+            side_effect=fake_fetch,
+        ):
+            conversation._ensure_plugins_loaded()
+
+        # The secret was expanded in the URL handed to the fetcher.
+        assert captured["source"] == (
+            "https://x-token-auth:s3cr3t-value@host.example.com/org/repo.git"
+        )
+
+        # Persisted state must NOT contain the raw secret value.
+        assert conversation.resolved_plugins is not None
+        assert "s3cr3t-value" not in conversation.resolved_plugins[0].source
+
+        conversation.close()
+
+    def test_host_env_not_expanded_in_source(
+        self, tmp_path: Path, basic_agent, monkeypatch
+    ):
+        """Host environment variables must NOT be folded into the source URL."""
+        monkeypatch.setenv("HOST_ONLY_VAR", "host-value")
+        source = "https://x-token-auth:${HOST_ONLY_VAR}@host.example.com/org/repo.git"
+        conversation, plugin_dir = self._make_conversation(
+            tmp_path, basic_agent, source
+        )
+        # Deliberately register NO secret named HOST_ONLY_VAR.
+
+        captured: dict[str, str | None] = {}
+
+        def fake_fetch(source, ref=None, repo_path=None, **kwargs):
+            captured["source"] = source
+            return plugin_dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+        with patch(
+            "openhands.sdk.conversation.impl.local_conversation."
+            "fetch_plugin_with_resolution",
+            side_effect=fake_fetch,
+        ):
+            conversation._ensure_plugins_loaded()
+
+        # Placeholder preserved verbatim - host env was not used.
+        assert captured["source"] == source
+        assert "host-value" not in (captured["source"] or "")
+
+        conversation.close()
+
+    def test_ref_secret_expanded_before_fetch(self, tmp_path: Path, basic_agent):
+        """A ${VAR} in the ref is also expanded from secrets."""
+        source = str(tmp_path / "plugin")
+        conversation, plugin_dir = self._make_conversation(
+            tmp_path, basic_agent, source, ref="${MY_REF}"
+        )
+        conversation.update_secrets({"MY_REF": "v1.2.3"})
+
+        captured: dict[str, str | None] = {}
+
+        def fake_fetch(source, ref=None, repo_path=None, **kwargs):
+            captured["ref"] = ref
+            return plugin_dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+
+        with patch(
+            "openhands.sdk.conversation.impl.local_conversation."
+            "fetch_plugin_with_resolution",
+            side_effect=fake_fetch,
+        ):
+            conversation._ensure_plugins_loaded()
+
+        assert captured["ref"] == "v1.2.3"
+
+        conversation.close()


### PR DESCRIPTION
## What & why

Expand `${VAR}` placeholders in a plugin's `source` URL (and `ref`) against the per-conversation **secret registry** before the plugin is fetched, so a **private** plugin repository can be cloned by *referencing* a secret rather than only by hard-coding the raw token.

Closes #3755.

This is the missing sibling of secret expansion for **MCP config** (#2872 / #2873) and **MCP tool parameters** (#3277 / #3278). The plugin **source** path was the only secret-consuming site that never read from the registry, so today a placeholder like `https://x-token-auth:${BITBUCKET_DATA_CENTER_TOKEN}@host/repo.git` reaches `git clone` literally and fails (surfacing as a `500` at conversation start).

## The four ways a customer can supply a git credential for a private plugin

| # | How the token is supplied | Before | After |
|---|---------------------------|:---:|:---:|
| 1 | **Hard-code** the literal token in the `source` URL | ✅ | ✅ |
| 2 | **Reference a user-profile custom secret**, e.g. `${MY_TOKEN}` | ❌ | ✅ |
| 3 | **Reference a secret passed in the conversation-start API** (`secrets` field) | ❌ | ✅ |
| 4 | **Reference an OpenHands-managed provider token**, e.g. `${GITHUB_TOKEN}`, `${GITLAB_TOKEN}`, `${BITBUCKET_TOKEN}`, `${BITBUCKET_DATA_CENTER_TOKEN}` | ❌ | ✅ |

Only scenario 1 worked before — and it is the least desirable option (raw token in the request payload and in not-yet-redacted spec serialization). Scenarios 2–4 are the patterns we want customers to use.

**Why this one change unlocks scenarios 2–4:** all three already land in the SDK `SecretRegistry` *before* plugins are fetched — they just were never consumed by the plugin path:

- **Scenario 2** → `AgentContext.secrets`, seeded into the registry in `LocalConversation.__init__` (fill-if-absent).
- **Scenario 3** → `StartConversationRequest.secrets`, applied to the registry (higher priority).
- **Scenario 4** → OpenHands registers each connected provider token in that same secrets map under `f"{PROVIDER}_TOKEN"` (SaaS: lazy `LookupSecret` via webhook; OSS: `StaticSecret`).

In every case `secret_registry.get_secret_value(name)` returns the value at the moment `_ensure_plugins_loaded()` runs.

## Implementation

In `LocalConversation._ensure_plugins_loaded()`, before `fetch_plugin_with_resolution(...)`, expand `spec.source` and `spec.ref` via the generic `expand_variable_references()` helper extracted in #3278:

- **`check_env=False`** — registered conversation **secrets only**, never host `os.environ`. Folding arbitrary host env vars into a URL sent to a remote git host would be a credential-exfiltration vector.
- **`support_unbraced=False`** — braced `${VAR}` only, so a literal `$` in a token/password is never mangled.
- **`expand_defaults=False`** — a missing secret leaves the placeholder untouched (no surprising defaults in a URL).
- **Persistence stays redacted** — `ResolvedPluginSource` is still built from the *original* spec, so the persisted `source` keeps the `${VAR}` placeholder, and `from_plugin_source()` continues to redact any inline credentials. Resume re-fetches via the resolved commit SHA, so the raw secret never lands in persisted state or logs.

## Tests

`tests/sdk/conversation/test_local_conversation_plugins.py::TestPluginSourceSecretExpansion`:

- `test_source_secret_expanded_before_fetch` — `${MY_TOKEN}` in the source is expanded to the secret value handed to the fetcher; persisted `resolved_plugins[0].source` does **not** contain the raw secret.
- `test_host_env_not_expanded_in_source` — a host env var (no matching registered secret) is **not** expanded; placeholder preserved verbatim.
- `test_ref_secret_expanded_before_fetch` — `${VAR}` in `ref` is expanded too.

- `test_unknown_var_with_default_left_untouched` — `${MISSING:-fallback}` (no matching secret) is left **verbatim**, proving `expand_defaults=False` (no silent default substitution inside a URL).

`ruff check` / `ruff format` clean on the changed files.

**Evidence:**

```
$ uv run pytest tests/sdk/conversation/test_local_conversation_plugins.py::TestPluginSourceSecretExpansion -v
::TestPluginSourceSecretExpansion::test_source_secret_expanded_before_fetch     PASSED [ 25%]
::TestPluginSourceSecretExpansion::test_host_env_not_expanded_in_source         PASSED [ 50%]
::TestPluginSourceSecretExpansion::test_unknown_var_with_default_left_untouched PASSED [ 75%]
::TestPluginSourceSecretExpansion::test_ref_secret_expanded_before_fetch        PASSED [100%]
======================== 4 passed in 0.06s =========================

$ uv run pytest tests/sdk/conversation/test_local_conversation_plugins.py -q
======================== 16 passed in 0.18s ========================
```

## Scope / non-goals & security notes

- **Out of scope: `ssh://git@...` sources.** This change only helps when the credential travels *inside* the URL. With HTTPS, the token is part of the URL itself (`https://user:${TOKEN}@host/repo.git`), so expanding `${TOKEN}` is all `git` needs to authenticate. SSH authenticates *out-of-band* with a private key (via the SSH agent / `~/.ssh`), and a URL like `ssh://git@host/repo.git` has nowhere to put a secret — so there is no placeholder to expand. Supporting private SSH sources is a separate concern: it requires provisioning an SSH key into the runtime, not expanding a variable. (Related parsing fix for the `ssh://` spelling: #3759 / #3760.)
- **Security note (scenario 4).** Because expansion is by *name*, a user can explicitly embed a provider token (e.g. `${GITHUB_TOKEN}`) into a URL for a *different* host, sending that token off-host. This is user-authored and intentional (unlike host-env expansion); worth a docs warning but not blocked here. A custom secret named identically to a provider token can shadow the managed one.
- **Relationship to credential-redaction work:**
  - Complements the redaction in #3751, #3752, and OpenHands#12959 (no conflict).
  - Scenarios 2–4 are strictly safer than scenario 1: the `source` only ever carries the `${PLACEHOLDER}`, so even the #3752 spec-serialization leak exposes the placeholder, not the secret value.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:88716f9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-88716f9-python \
  ghcr.io/openhands/agent-server:88716f9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:88716f9-golang-amd64
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-golang-amd64
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-golang-amd64
ghcr.io/openhands/agent-server:88716f9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:88716f9-golang-arm64
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-golang-arm64
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-golang-arm64
ghcr.io/openhands/agent-server:88716f9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:88716f9-java-amd64
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-java-amd64
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-java-amd64
ghcr.io/openhands/agent-server:88716f9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:88716f9-java-arm64
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-java-arm64
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-java-arm64
ghcr.io/openhands/agent-server:88716f9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:88716f9-python-amd64
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-python-amd64
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-python-amd64
ghcr.io/openhands/agent-server:88716f9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:88716f9-python-arm64
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-python-arm64
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-python-arm64
ghcr.io/openhands/agent-server:88716f9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:88716f9-golang
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-golang
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-golang
ghcr.io/openhands/agent-server:88716f9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:88716f9-java
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-java
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-java
ghcr.io/openhands/agent-server:88716f9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:88716f9-python
ghcr.io/openhands/agent-server:88716f9f545410886f5a273d308f2106f181cd88-python
ghcr.io/openhands/agent-server:expand-secrets-in-plugin-source-python
ghcr.io/openhands/agent-server:88716f9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `88716f9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `88716f9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->