### PR TITLE
fix: recognize ssh:// scheme in is_git_url()

### DIFF
--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -309,11 +309,17 @@ def is_git_url(source: str) -> bool:
         True
         >>> is_git_url("git@github.com:owner/repo.git")
         True
+        >>> is_git_url("ssh://git@github.com/owner/repo.git")
+        True
         >>> is_git_url("/local/path")
         False
     """
     # HTTPS/HTTP URLs to git repositories
     if source.startswith(("https://", "http://")):
+        return True
+
+    # SSH URL with explicit scheme: ssh://git@host[:port]/path
+    if source.startswith("ssh://"):
         return True
 
     # SSH format: git@host:path or user@host:path

--- a/tests/sdk/extensions/test_fetch.py
+++ b/tests/sdk/extensions/test_fetch.py
@@ -128,6 +128,19 @@ def test_parse_ssh_with_custom_user():
     assert url == ssh_url
 
 
+def test_parse_ssh_scheme_url():
+    """`ssh://` scheme URLs (incl. an explicit port) are recognized as git URLs.
+
+    Regression test: previously `is_git_url()` did not recognize the `ssh://`
+    scheme, so these dropped through to "Unable to parse extension source"
+    instead of being treated as a git source.
+    """
+    ssh_url = "ssh://git@bitbucket.example.com:7999/team/repo.git"
+    source_type, url = parse_extension_source(ssh_url)
+    assert source_type == SourceType.GIT
+    assert url == ssh_url
+
+
 def test_parse_relative_path_with_slash():
     source_type, url = parse_extension_source("extensions/my-ext")
     assert source_type == SourceType.LOCAL


### PR DESCRIPTION
## What & why

`is_git_url()` did not recognize the **`ssh://` URL scheme**, so a plugin/extension `source` like `ssh://git@bitbucket.example.com:7999/team/repo.git` failed at **parse** time with a misleading `Unable to parse extension source`, even though the equivalent scp-style spelling (`git@host:team/repo.git`) is recognized and proceeds to clone. This adds a one-line recognition branch so both SSH spellings behave the same.

Closes #3759.

## ⚠️ Scope — this is a deliberately narrow edge case

This only matters for a user who is doing **all** of the following:

1. cloning a **private** plugin/extension repo over **SSH** (not HTTPS), **and**
2. spelling it with the **`ssh://` scheme** specifically (the scp-style `git@host:…` form already works), **and**
3. has **manually provisioned an SSH key into the sandbox/runtime** before attaching the conversation that triggers the plugin clone.

It does **not** add SSH key provisioning and does **not** make SSH work for hosted/SaaS users who haven't injected a key. For everyone else the supported path remains an **HTTPS URL with a token** (and, with #3755, that token can be a `${SECRET}` reference). This PR purely removes a parse-level inconsistency so an *already-working* SSH setup also accepts the `ssh://` spelling.

## Change

`openhands/sdk/git/utils.py` — add an `ssh://` branch to `is_git_url()` (alongside `https://`, scp-style, `git://`, `file://`). `normalize_git_url()` and `extract_repo_name()` already handle the `ssh://` string correctly, so no other changes are needed; the source now classifies as `SourceType.GIT` and flows through the normal cached-clone path (which still succeeds only if the runtime has a usable key).

## Tests

`tests/sdk/extensions/test_fetch.py::test_parse_ssh_scheme_url` — `ssh://git@host:7999/team/repo.git` → `SourceType.GIT` (regression for the "Unable to parse" failure). All 42 tests in the file pass; `ruff check`/`format` clean.

---
_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:92adf44-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-92adf44-python \
  ghcr.io/openhands/agent-server:92adf44-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:92adf44-golang-amd64
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-golang-amd64
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-golang-amd64
ghcr.io/openhands/agent-server:92adf44-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:92adf44-golang-arm64
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-golang-arm64
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-golang-arm64
ghcr.io/openhands/agent-server:92adf44-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:92adf44-java-amd64
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-java-amd64
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-java-amd64
ghcr.io/openhands/agent-server:92adf44-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:92adf44-java-arm64
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-java-arm64
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-java-arm64
ghcr.io/openhands/agent-server:92adf44-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:92adf44-python-amd64
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-python-amd64
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-python-amd64
ghcr.io/openhands/agent-server:92adf44-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:92adf44-python-arm64
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-python-arm64
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-python-arm64
ghcr.io/openhands/agent-server:92adf44-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:92adf44-golang
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-golang
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-golang
ghcr.io/openhands/agent-server:92adf44-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:92adf44-java
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-java
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-java
ghcr.io/openhands/agent-server:92adf44-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:92adf44-python
ghcr.io/openhands/agent-server:92adf44f97604795b7b5621f2e9fe682b9620011-python
ghcr.io/openhands/agent-server:fix-ssh-scheme-git-url-recognition-python
ghcr.io/openhands/agent-server:92adf44-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `92adf44-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `92adf44-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->