### PR TITLE
fix(sdk): normalize empty assistant chat content

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/message.py
+++ b/openhands-sdk/openhands/sdk/llm/message.py
@@ -310,6 +310,8 @@ class Message(BaseModel):
         if self.role == "assistant" and self.tool_calls:
             message_dict["tool_calls"] = [tc.to_chat_dict() for tc in self.tool_calls]
             self._remove_content_if_empty(message_dict)
+        else:
+            self._normalize_empty_assistant_content(message_dict)
 
         # Tool result (observation) threading
         if self.role == "tool" and self.tool_call_id is not None:
@@ -432,6 +434,14 @@ class Message(BaseModel):
             return
 
         # Any other content shape is left as-is
+
+    def _normalize_empty_assistant_content(self, message_dict: dict[str, Any]) -> None:
+        """Normalize empty plain assistant content for Chat Completions."""
+        if self.role != "assistant":
+            return
+
+        if message_dict.get("content") == []:
+            message_dict["content"] = ""
 
     def to_responses_value(self, *, vision_enabled: bool) -> str | list[dict[str, Any]]:
         """Return serialized form.

--- a/tests/sdk/llm/test_message.py
+++ b/tests/sdk/llm/test_message.py
@@ -197,6 +197,19 @@ def test_message_tool_calls_strip_blank_list_content():
     assert "content" not in result
 
 
+def test_empty_assistant_message_uses_string_content_in_list_serializer():
+    """List-serialized empty assistant messages should keep string content."""
+    from openhands.sdk.llm.message import Message
+
+    message = Message(role="assistant", content=[])
+
+    result = message.to_chat_dict(
+        **{**DEFAULT_SERIALIZATION_OPTS, "function_calling_enabled": True}
+    )
+
+    assert result == {"content": "", "role": "assistant"}
+
+
 def test_message_from_llm_chat_message_function_role_error():
     """Test Message.from_llm_chat_message with function role raises error."""
     from litellm.types.utils import Message as LiteLLMMessage

--- a/tests/sdk/llm/test_message.py
+++ b/tests/sdk/llm/test_message.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch
 
 import pytest
+from litellm.types.utils import Message as LiteLLMMessage
 
 from openhands.sdk.llm.message import Message
 
@@ -212,8 +213,6 @@ def test_empty_assistant_message_uses_string_content_in_list_serializer():
 
 def test_empty_assistant_from_llm_chat_message_uses_string_content_in_list_serializer():
     """Empty assistant LLM responses should keep string content."""
-    from litellm.types.utils import Message as LiteLLMMessage
-
     litellm_message = LiteLLMMessage(role="assistant", content=None)
     message = Message.from_llm_chat_message(litellm_message)
 
@@ -226,8 +225,6 @@ def test_empty_assistant_from_llm_chat_message_uses_string_content_in_list_seria
 
 def test_message_from_llm_chat_message_function_role_error():
     """Test Message.from_llm_chat_message with function role raises error."""
-    from litellm.types.utils import Message as LiteLLMMessage
-
     from openhands.sdk.llm.message import Message
 
     litellm_message = LiteLLMMessage(role="function", content="Function response")  # type: ignore
@@ -238,8 +235,6 @@ def test_message_from_llm_chat_message_function_role_error():
 
 def test_message_from_llm_chat_message_with_non_string_content():
     """Test Message.from_llm_chat_message with non-string content."""
-    from litellm.types.utils import Message as LiteLLMMessage
-
     from openhands.sdk.llm.message import Message
 
     # Create a message with non-string content (None or list)

--- a/tests/sdk/llm/test_message.py
+++ b/tests/sdk/llm/test_message.py
@@ -2,6 +2,8 @@ from unittest.mock import patch
 
 import pytest
 
+from openhands.sdk.llm.message import Message
+
 
 # Default serialization options for to_chat_dict() - tests can override as needed
 DEFAULT_SERIALIZATION_OPTS = {
@@ -199,9 +201,21 @@ def test_message_tool_calls_strip_blank_list_content():
 
 def test_empty_assistant_message_uses_string_content_in_list_serializer():
     """List-serialized empty assistant messages should keep string content."""
-    from openhands.sdk.llm.message import Message
-
     message = Message(role="assistant", content=[])
+
+    result = message.to_chat_dict(
+        **{**DEFAULT_SERIALIZATION_OPTS, "function_calling_enabled": True}
+    )
+
+    assert result == {"content": "", "role": "assistant"}
+
+
+def test_empty_assistant_from_llm_chat_message_uses_string_content_in_list_serializer():
+    """Empty assistant LLM responses should keep string content."""
+    from litellm.types.utils import Message as LiteLLMMessage
+
+    litellm_message = LiteLLMMessage(role="assistant", content=None)
+    message = Message.from_llm_chat_message(litellm_message)
 
     result = message.to_chat_dict(
         **{**DEFAULT_SERIALIZATION_OPTS, "function_calling_enabled": True}


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
I reproduced the issue in a downstream OpenAI-compatible Chat Completions integration during development of my coding assistant. Also reviewed the proposed SDK-level fix.

---

AGENT:
Prepared with assistance from OpenAI Codex.

## Why

Empty plain assistant messages can be serialized for Chat Completions with list-shaped content when function calling, vision, or prompt caching is enabled:

```json
{"role": "assistant", "content": []}
```

Some OpenAI-compatible Chat Completions backends reject that payload shape for assistant messages. The existing empty-content cleanup only applied to assistant tool-call messages, so assistant messages without `tool_calls` were left unnormalized.

## Summary

- Normalize exact empty list content on plain assistant Chat Completions messages to an empty string.
- Preserve the existing assistant tool-call cleanup behavior.
- Add a regression test for the list-serializer path.

## Issue Number

Fixes #3765

## How to Test

Regression and related serialization tests:

```bash
uv run pytest tests/sdk/llm/test_message.py
uv run pytest tests/sdk/llm/test_message_serialization.py
uv run pytest tests/sdk/llm
make lint
```

Results:

- `tests/sdk/llm/test_message.py`: 29 passed
- `tests/sdk/llm/test_message_serialization.py`: 16 passed
- `tests/sdk/llm`: 840 passed, 9 warnings
- `make lint`: passed

Reproduction check after the fix:

```bash
uv run python - <<'PY'
from openhands.sdk.llm.message import Message

opts = {
    "cache_enabled": False,
    "vision_enabled": False,
    "function_calling_enabled": True,
    "force_string_serializer": False,
    "send_reasoning_content": False,
}
print(Message(role="assistant", content=[]).to_chat_dict(**opts))
PY
```

Output:

```python
{'content': '', 'role': 'assistant'}
```


## Video/Screenshots

N/A. This is a Chat Completions serialization bugfix; the reproduction command above shows the affected payload shape.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This only changes Chat Completions wire-format serialization for plain assistant messages whose serialized content is exactly an empty list. It does not change stored `Message.content`, persisted event shapes, Responses API serialization, or assistant tool-call message handling.