### PR TITLE
fix(skills): mask Skill.mcp_tools credentials at rest

### DIFF
--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -12,7 +12,14 @@ from xml.sax.saxutils import escape as xml_escape
 import frontmatter
 import yaml
 from fastmcp.mcp_config import MCPConfig
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import (
+    BaseModel,
+    Field,
+    SerializationInfo,
+    field_serializer,
+    field_validator,
+    model_validator,
+)
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.skills.exceptions import SkillError, SkillValidationError
@@ -268,6 +275,25 @@ class Skill(BaseModel):
             except Exception as e:
                 raise SkillValidationError(f"Invalid MCPConfig dictionary: {e}") from e
         return v
+
+    @field_serializer("mcp_tools")
+    def _serialize_mcp_tools(
+        self, value: dict | None, info: SerializationInfo
+    ) -> dict | None:
+        """Mask credentials in ``mcp_tools`` (``mcpServers.*.env``/``headers``).
+
+        ``mcp_tools`` is an unmodeled ``dict``, so it would otherwise dump its
+        MCP server secrets in plaintext wherever a ``Skill`` is serialized.
+        Route it through the same ``serialize_mcp_config`` as settings
+        ``mcp_config``: redacted by default, plaintext under ``expose_secrets``,
+        encrypted under a cipher. Imported lazily to avoid the
+        settings.model -> agent_context -> skills import cycle.
+        """
+        if not value:
+            return value
+        from openhands.sdk.settings.model import serialize_mcp_config
+
+        return serialize_mcp_config(MCPConfig.model_validate(value), info)
 
     PATH_TO_THIRD_PARTY_SKILL_NAME: ClassVar[dict[str, str]] = {
         ".cursorrules": "cursorrules",

--- a/tests/sdk/skills/test_skill_serialization.py
+++ b/tests/sdk/skills/test_skill_serialization.py
@@ -363,6 +363,7 @@ def test_mcp_tools_real_values_remain_accessible_in_memory():
     runtime MCP usage is unaffected."""
     skill = _skill_with_mcp_secret()
 
+    assert skill.mcp_tools is not None
     env = skill.mcp_tools["mcpServers"]["svc"]["env"]
     assert env["API_KEY"] == _MCP_SECRET
 

--- a/tests/sdk/skills/test_skill_serialization.py
+++ b/tests/sdk/skills/test_skill_serialization.py
@@ -295,3 +295,81 @@ def test_discriminated_union_with_pydantic_model():
     # First skill is always-active (trigger is None)
     assert model.skills[1].trigger.type == "keyword"
     assert model.skills[2].trigger.type == "task"
+
+
+# A clearly identifiable secret value for the mcp_tools masking tests.
+_MCP_SECRET = "ghp_SUPER_SECRET_TOKEN_SHOULD_NOT_LEAK"
+
+
+def _skill_with_mcp_secret() -> Skill:
+    return Skill(
+        name="leaky",
+        content="do stuff",
+        mcp_tools={
+            "mcpServers": {
+                "svc": {
+                    "url": "https://x.test",
+                    "headers": {"Authorization": f"Bearer {_MCP_SECRET}"},
+                    "env": {"API_KEY": _MCP_SECRET},
+                }
+            }
+        },
+    )
+
+
+def test_mcp_tools_secrets_redacted_by_default():
+    """mcp_tools env/headers carry MCP credentials; they must be redacted at
+    rest, just like settings mcp_config -- not dumped in plaintext."""
+    skill = _skill_with_mcp_secret()
+
+    dumped = json.dumps(skill.model_dump(mode="json"))
+    assert _MCP_SECRET not in dumped
+
+    json_dumped = skill.model_dump_json()
+    assert _MCP_SECRET not in json_dumped
+
+
+def test_mcp_tools_secrets_exposed_under_expose_secrets():
+    """Opt-in exposure surfaces the real values (parity with mcp_config)."""
+    skill = _skill_with_mcp_secret()
+
+    exposed = json.dumps(
+        skill.model_dump(mode="json", context={"expose_secrets": "plaintext"})
+    )
+    assert _MCP_SECRET in exposed
+
+
+def test_mcp_tools_secrets_encrypted_under_cipher():
+    """With a cipher in context, secrets are encrypted (not plaintext, not
+    dropped) so they can be decrypted on restore."""
+    from openhands.sdk.utils.cipher import Cipher
+
+    skill = _skill_with_mcp_secret()
+    cipher = Cipher(secret_key="test-encryption-key")
+
+    encrypted = json.dumps(
+        skill.model_dump(
+            mode="json", context={"expose_secrets": "encrypted", "cipher": cipher}
+        )
+    )
+    assert _MCP_SECRET not in encrypted
+    # The header/env keys survive; only their values are transformed.
+    assert "Authorization" in encrypted
+    assert "API_KEY" in encrypted
+
+
+def test_mcp_tools_real_values_remain_accessible_in_memory():
+    """Masking is serialization-only: the live attribute keeps real values so
+    runtime MCP usage is unaffected."""
+    skill = _skill_with_mcp_secret()
+
+    env = skill.mcp_tools["mcpServers"]["svc"]["env"]
+    assert env["API_KEY"] == _MCP_SECRET
+
+
+def test_mcp_tools_none_round_trips_unchanged():
+    """A skill without mcp_tools still serializes mcp_tools as None."""
+    skill = Skill(name="clean", content="hello")
+    dumped = skill.model_dump(mode="json")
+    assert dumped["mcp_tools"] is None
+    assert Skill.model_validate(dumped) == skill


### PR DESCRIPTION
HUMAN:

mask Skill.mcp_tools credentials at rest

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`Skill.mcp_tools` is an unmodeled `dict` with no masking serializer, so any MCP server credential a skill carries in `env`/`headers` is dumped in **plaintext wherever a `Skill` is serialized** — even under `expose_secrets=False`. This breaks the secret-free-at-rest invariant and is a real, pre-existing latent leak on two at-rest disk paths today (independent of AgentProfiles):

1. **Conversation state** → `base_state.json` (SDK) / `meta.json` (agent-server), via `agent.agent_context.skills[]`.
2. **`PersistedSettings`** → settings file, via `<variant>.agent_context.skills[]`.

`OpenHandsAgentSettings.mcp_config` already masks via `serialize_mcp_config`, but `agent_context.skills[].mcp_tools` bypassed it.

This is the root-cause fix for the gap surfaced in the #3757 review (which masked it only at the `OpenHandsAgentProfile` boundary). Masking on `Skill` itself covers every serialization site — `AgentContext`, conversation state, settings persistence, profiles, and any future container — and lets the per-boundary serializer on branch `agent-profile-model` be retired.

## Summary

- Add a `@field_serializer("mcp_tools")` on `Skill` that routes the value through the same `serialize_mcp_config` used for settings `mcp_config` (single masking source of truth): redacted by default, plaintext under `expose_secrets`, encrypted under a cipher.
- Import `serialize_mcp_config` **function-locally** to avoid the `settings.model → agent_context → skills` module-load cycle (the same lazy-import pattern already used elsewhere in `skill.py`).
- Masking is serialization-only — the live `self.mcp_tools` attribute keeps real values, so runtime MCP usage (which reads `agent.mcp_config`, a separate field) is unaffected.

## Issue Number

Follow-up to #3757 review.

## How to Test

Ran in the worktree (`uv run`):

```
$ uv run pytest tests/sdk/skills/test_skill_serialization.py -q
12 passed

$ uv run pytest tests/sdk/skills/ tests/sdk/conversation/test_mcp_secrets_serialization_leak.py tests/sdk/agent/test_agent_serialization.py -q
255 passed, 2 skipped
```

Cross-cutting propagation check (proves the root fix reaches the `AgentContext` path the boundary fix did not):

```python
skill = Skill(name="s", content="c", mcp_tools={"mcpServers":{"svc":{"url":"https://x",
    "headers":{"Authorization":"Bearer ghp_LEAKCHECK_999"}, "env":{"K":"ghp_LEAKCHECK_999"}}}})
ctx = AgentContext(skills=[skill])
json.dumps(ctx.model_dump(mode="json"))                                  # secret absent  -> redacted
json.dumps(ctx.model_dump(mode="json", context={"expose_secrets":"plaintext"}))  # secret present -> recoverable
```
Output: default dump → secret **absent**; `expose_secrets` → secret **present**.

`ruff check`, `ruff format --check`, and `pyright` on the changed files: clean (0 errors).

New regression tests in `tests/sdk/skills/test_skill_serialization.py`: redacted-by-default, exposed-under-`expose_secrets`, encrypted-under-cipher, real-values-accessible-in-memory, and `None` round-trip.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The masked `mcp_tools` re-serializes through `MCPConfig.model_validate(...).model_dump(exclude_defaults=True)` (same normalization as `mcp_config`); structure round-trips with `<redacted>` placeholders.
- Once this lands, the `OpenHandsAgentProfile._serialize_secret_free` boundary mask on branch `agent-profile-model` (#3757) becomes redundant and can be removed.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5adcad3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5adcad3-python \
  ghcr.io/openhands/agent-server:5adcad3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5adcad3-golang-amd64
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-golang-amd64
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-golang-amd64
ghcr.io/openhands/agent-server:5adcad3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5adcad3-golang-arm64
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-golang-arm64
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-golang-arm64
ghcr.io/openhands/agent-server:5adcad3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5adcad3-java-amd64
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-java-amd64
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-java-amd64
ghcr.io/openhands/agent-server:5adcad3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5adcad3-java-arm64
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-java-arm64
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-java-arm64
ghcr.io/openhands/agent-server:5adcad3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5adcad3-python-amd64
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-python-amd64
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-python-amd64
ghcr.io/openhands/agent-server:5adcad3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5adcad3-python-arm64
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-python-arm64
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-python-arm64
ghcr.io/openhands/agent-server:5adcad3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5adcad3-golang
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-golang
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-golang
ghcr.io/openhands/agent-server:5adcad3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5adcad3-java
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-java
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-java
ghcr.io/openhands/agent-server:5adcad3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5adcad3-python
ghcr.io/openhands/agent-server:5adcad31a23ad54cf7e9df9d4af838ea95ba59de-python
ghcr.io/openhands/agent-server:mask-skill-mcp-tools-secret-python
ghcr.io/openhands/agent-server:5adcad3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5adcad3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5adcad3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->