### PR TITLE
[AgentProfile][sdk] AgentProfileStore + FK lifecycle

### DIFF
--- a/openhands-sdk/openhands/sdk/profiles/__init__.py
+++ b/openhands-sdk/openhands/sdk/profiles/__init__.py
@@ -9,6 +9,17 @@ from openhands.sdk.profiles.agent_profile import (
     ProfileVerificationSettings,
     validate_agent_profile,
 )
+from openhands.sdk.profiles.agent_profile_store import (
+    AgentProfileStore,
+    ProfileLimitExceeded,
+)
+from openhands.sdk.profiles.profile_refs import (
+    ProfileReferenced,
+    cascade_rename,
+    delete_llm_profile,
+    find_referrers,
+    rename_llm_profile,
+)
 
 
 __all__ = [
@@ -16,7 +27,14 @@ __all__ = [
     "ACPAgentProfile",
     "AgentProfile",
     "AgentProfileBase",
+    "AgentProfileStore",
     "OpenHandsAgentProfile",
+    "ProfileLimitExceeded",
+    "ProfileReferenced",
     "ProfileVerificationSettings",
+    "cascade_rename",
+    "delete_llm_profile",
+    "find_referrers",
+    "rename_llm_profile",
     "validate_agent_profile",
 ]

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
@@ -1,0 +1,307 @@
+# Required: ``AgentProfileStore.list()`` shadows the builtin in the class body,
+# so annotations like ``list[dict[str, Any]]`` would fail without deferral.
+from __future__ import annotations
+
+import json
+import re
+import tempfile
+from collections.abc import Iterator
+from contextlib import contextmanager
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Final
+
+from filelock import FileLock, Timeout
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.profiles.agent_profile import validate_agent_profile
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.profiles.agent_profile import (
+        ACPAgentProfile,
+        OpenHandsAgentProfile,
+    )
+    from openhands.sdk.utils.cipher import Cipher
+
+_DEFAULT_PROFILE_DIR: Final[Path] = Path.home() / ".openhands" / "agent-profiles"
+_LOCK_TIMEOUT_SECONDS: Final[float] = 30.0
+
+# Profile names: 1-64 chars, must start with alphanumeric, then alphanumerics
+# or '.', '_', '-'. Blocks empty names, path separators, leading dots
+# (hidden files / path traversal), and shell-special characters. Identical to
+# ``LLMProfileStore.PROFILE_NAME_PATTERN`` so the two stores share a naming
+# contract (an ``llm_profile_ref`` is an LLM-store key).
+PROFILE_NAME_PATTERN: Final[str] = r"^[A-Za-z0-9][A-Za-z0-9._-]{0,63}$"
+PROFILE_NAME_REGEX: Final[re.Pattern[str]] = re.compile(PROFILE_NAME_PATTERN)
+
+logger = get_logger(__name__)
+
+
+class ProfileLimitExceeded(Exception):
+    """Raised when saving would exceed the configured profile limit."""
+
+
+class AgentProfileStore:
+    """Standalone utility for persisting ``AgentProfile`` launch specs.
+
+    Mirrors :class:`~openhands.sdk.llm.llm_profile_store.LLMProfileStore`: one
+    JSON file per profile under ``~/.openhands/agent-profiles``, the filename is
+    the (renameable) profile ``name``, and the stable ``id`` (uuid) lives inside
+    the file. The profile is secret-free at rest except for
+    ``skills[].mcp_tools`` env/headers, which are masked by default and
+    encrypted when a ``cipher`` is supplied.
+    """
+
+    def __init__(self, base_dir: Path | str | None = None) -> None:
+        """Initialize the profile store.
+
+        Args:
+            base_dir: Directory where profiles are stored. ``None`` uses the
+                default ``~/.openhands/agent-profiles``.
+        """
+        self.base_dir = Path(base_dir) if base_dir is not None else _DEFAULT_PROFILE_DIR
+        self.base_dir.mkdir(parents=True, exist_ok=True)
+        self._file_lock = FileLock(self.base_dir / ".agent-profiles.lock")
+
+    @contextmanager
+    def _acquire_lock(self, timeout: float = _LOCK_TIMEOUT_SECONDS) -> Iterator[None]:
+        """Acquire the store file lock for safe concurrent access.
+
+        ``filelock.FileLock`` is re-entrant within a thread, so FK helpers may
+        nest this around the per-method calls without deadlocking.
+        """
+        try:
+            with self._file_lock.acquire(timeout=timeout):
+                yield
+        except Timeout:
+            logger.error(f"[AgentProfile Store] Failed to acquire lock in {timeout}s")
+            raise TimeoutError(
+                f"Agent profile store lock acquisition timed out after {timeout}s"
+            )
+
+    def list(self) -> list[str]:
+        """Return the filenames of all stored profiles (e.g. ``["a.json"]``)."""
+        with self._acquire_lock():
+            return [p.name for p in self.base_dir.glob("*.json")]
+
+    def _get_profile_path(self, name: str) -> Path:
+        """Resolve a profile name to its file path, validating the name.
+
+        Raises:
+            ValueError: If ``name`` does not match ``PROFILE_NAME_PATTERN``.
+        """
+        clean_name = name.removesuffix(".json")
+        if not PROFILE_NAME_REGEX.match(clean_name):
+            raise ValueError(
+                f"Invalid profile name: {name!r}. "
+                "Profile names must be 1-64 characters, start with a letter "
+                "or digit, and contain only letters, digits, '.', '_', or '-'."
+            )
+        return self.base_dir / f"{clean_name}.json"
+
+    def _atomic_write(self, path: Path, text: str) -> None:
+        """Write ``text`` to ``path`` via a temp file + atomic ``Path.replace``.
+
+        Callers must hold :meth:`_acquire_lock`. Shared with ``profile_refs`` so
+        the cascade rewrite reuses the same crash-safe write.
+        """
+        with tempfile.NamedTemporaryFile(
+            mode="w", dir=self.base_dir, suffix=".tmp", delete=False
+        ) as tmp:
+            tmp.write(text)
+            tmp_path = Path(tmp.name)
+        try:
+            Path.replace(tmp_path, path)
+        except Exception:
+            tmp_path.unlink(missing_ok=True)
+            raise
+
+    def save(
+        self,
+        profile: OpenHandsAgentProfile | ACPAgentProfile,
+        *,
+        cipher: Cipher | None = None,
+        max_profiles: int | None = None,
+    ) -> None:
+        """Save a profile under its own ``name``, overwriting any namesake.
+
+        With no ``cipher`` the profile is secret-free at rest:
+        ``skills[].mcp_tools`` env/headers are redacted. With a ``cipher`` those
+        values are encrypted (recoverable) rather than redacted; every other
+        field is a reference and dumps in the clear regardless. When
+        ``max_profiles`` is set, creating a *new* profile beyond the cap raises
+        ``ProfileLimitExceeded`` under the same lock as the write.
+
+        Raises:
+            ValueError: If ``profile.name`` is not a valid profile name.
+            ProfileLimitExceeded: If ``max_profiles`` would be exceeded.
+            TimeoutError: If the lock cannot be acquired.
+        """
+        profile_path = self._get_profile_path(profile.name)
+
+        # Cipher present => encrypt mcp_tools secrets; absent => redact them.
+        context: dict[str, Any] = (
+            {"cipher": cipher, "expose_secrets": "encrypted"} if cipher else {}
+        )
+        payload = profile.model_dump(mode="json", context=context)
+
+        with self._acquire_lock():
+            if max_profiles is not None and not profile_path.exists():
+                count = sum(
+                    1
+                    for p in self.base_dir.glob("*.json")
+                    if PROFILE_NAME_REGEX.match(p.stem)
+                )
+                if count >= max_profiles:
+                    raise ProfileLimitExceeded(
+                        f"Profile limit reached ({max_profiles})."
+                    )
+
+            if profile_path.exists():
+                logger.info(
+                    f"[AgentProfile Store] Overwriting profile `{profile.name}`."
+                )
+
+            self._atomic_write(profile_path, json.dumps(payload, indent=2))
+            logger.info(
+                f"[AgentProfile Store] Saved profile `{profile.name}` at {profile_path}"
+            )
+
+    def load(
+        self,
+        name: str,
+        *,
+        cipher: Cipher | None = None,
+    ) -> OpenHandsAgentProfile | ACPAgentProfile:
+        """Load and validate the profile stored under ``name``.
+
+        A ``cipher`` is threaded through the validation context for parity with
+        ``save``. Note: ``Skill.mcp_tools`` has a masking *serializer* but no
+        symmetric *validator*, so encrypted env/headers come back as ciphertext
+        — decryption is deferred to the resolver (#3717), which holds the
+        cipher. Reference fields (``llm_profile_ref`` etc.) carry no secret and
+        load unchanged.
+
+        Raises:
+            FileNotFoundError: If ``name`` does not exist.
+            ValueError: If the file is corrupted or fails validation.
+            TimeoutError: If the lock cannot be acquired.
+        """
+        profile_path = self._get_profile_path(name)
+
+        with self._acquire_lock():
+            if not profile_path.exists():
+                existing = [p.name for p in self.base_dir.glob("*.json")]
+                raise FileNotFoundError(
+                    f"Profile `{name}` not found. "
+                    f"Available profiles: {', '.join(existing) or 'none'}"
+                )
+
+            try:
+                data = json.loads(profile_path.read_text())
+                context = {"cipher": cipher} if cipher else None
+                profile = validate_agent_profile(data, context=context)
+            except Exception as e:
+                raise ValueError(f"Failed to load profile `{name}`: {e}") from e
+
+            logger.info(
+                f"[AgentProfile Store] Loaded profile `{name}` from {profile_path}"
+            )
+            return profile
+
+    def delete(self, name: str) -> None:
+        """Delete a profile, or no-op if it is absent.
+
+        Raises:
+            TimeoutError: If the lock cannot be acquired.
+        """
+        profile_path = self._get_profile_path(name)
+
+        with self._acquire_lock():
+            if not profile_path.exists():
+                logger.info(
+                    f"[AgentProfile Store] Profile `{name}` not found. Skipping."
+                )
+                return
+            profile_path.unlink()
+            logger.info(f"[AgentProfile Store] Deleted profile `{name}`")
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        """Atomically rename a profile, keeping the in-file ``name`` in sync.
+
+        Unlike a bare file move this also rewrites the persisted ``name`` field
+        (a surgical raw-JSON edit, so encrypted ``mcp_tools`` are untouched and
+        no cipher is needed). The stable ``id`` is preserved.
+
+        Raises:
+            FileNotFoundError: If ``old_name`` is missing.
+            FileExistsError: If ``new_name`` is taken.
+            ValueError: If either name is invalid.
+        """
+        old_path = self._get_profile_path(old_name)
+        new_path = self._get_profile_path(new_name)
+        new_stem = new_path.stem
+
+        with self._acquire_lock():
+            if not old_path.exists():
+                raise FileNotFoundError(f"Profile `{old_name}` not found")
+            if old_path == new_path:
+                return
+            if new_path.exists():
+                raise FileExistsError(f"Profile `{new_name}` already exists")
+
+            data = json.loads(old_path.read_text())
+            if isinstance(data, dict):
+                data["name"] = new_stem
+            self._atomic_write(new_path, json.dumps(data, indent=2))
+            old_path.unlink()
+            logger.info(
+                f"[AgentProfile Store] Renamed profile `{old_name}` to `{new_name}`"
+            )
+
+    def list_summaries(self) -> list[dict[str, Any]]:
+        """Project profile metadata without instantiating secrets.
+
+        Reads JSON directly and returns
+        ``{id, name, agent_kind, revision, llm_profile_ref, mcp_server_refs}``
+        per profile (``llm_profile_ref`` is ``None`` for ACP profiles). Files
+        with invalid names, corrupt JSON, or non-dict top-level values are
+        skipped with a warning.
+        """
+        summaries: list[dict[str, Any]] = []
+        with self._acquire_lock():
+            for path in sorted(self.base_dir.glob("*.json")):
+                name = path.stem
+                if not PROFILE_NAME_REGEX.match(name):
+                    logger.warning(
+                        f"[AgentProfile Store] Skipping invalid name {name!r}"
+                    )
+                    continue
+                try:
+                    data = json.loads(path.read_text())
+                except (OSError, json.JSONDecodeError) as e:
+                    logger.warning(
+                        f"[AgentProfile Store] Skipping corrupted profile {name!r}: {e}"
+                    )
+                    continue
+                if not isinstance(data, dict):
+                    logger.warning(
+                        f"[AgentProfile Store] Skipping non-dict profile {name!r}"
+                    )
+                    continue
+                agent_kind = data.get("agent_kind", "openhands")
+                summaries.append(
+                    {
+                        "id": data.get("id"),
+                        "name": name,
+                        "agent_kind": agent_kind,
+                        "revision": data.get("revision"),
+                        "llm_profile_ref": (
+                            data.get("llm_profile_ref")
+                            if agent_kind == "openhands"
+                            else None
+                        ),
+                        "mcp_server_refs": data.get("mcp_server_refs"),
+                    }
+                )
+        return summaries

--- a/openhands-sdk/openhands/sdk/profiles/profile_refs.py
+++ b/openhands-sdk/openhands/sdk/profiles/profile_refs.py
@@ -1,0 +1,171 @@
+"""Foreign-key lifecycle between LLM profiles and ``AgentProfile``\\ s.
+
+An ``OpenHandsAgentProfile.llm_profile_ref`` is a soft FK onto an LLM-profile
+store key. This module keeps that FK from dangling:
+
+* :func:`find_referrers` — which agent profiles cite a given LLM profile.
+* :func:`cascade_rename` — rewrite every matching ``llm_profile_ref`` in lock-step
+  with an LLM-profile rename.
+* :func:`delete_llm_profile` / :func:`rename_llm_profile` — guarded cross-store
+  operations that raise :class:`ProfileReferenced` (routers map → 409) or cascade.
+
+Lock acquisition order — **agent-profiles, then llm-profiles.**
+The two stores are HOME-rooted but independent (each has its own file lock).
+A guarded delete/rename holds the *agent-profiles* lock across the whole
+"scan referrers → mutate the LLM profile" window, so no concurrent
+``AgentProfileStore.save`` can introduce a new referrer between the check and
+the mutation (the TOCTOU this module exists to close). Always take the
+agent-profiles lock first; never the reverse, or two callers could deadlock.
+
+Scope: the FK covers ``llm_profile_ref`` only. ``mcp_server_refs`` are keys into
+the user's independently-mutable global ``mcp_config`` and are checked at
+resolve-time (#3717), not constrained here.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING
+
+from openhands.sdk.logger import get_logger
+from openhands.sdk.profiles.agent_profile_store import PROFILE_NAME_REGEX
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+    from openhands.sdk.profiles.agent_profile_store import AgentProfileStore
+
+logger = get_logger(__name__)
+
+
+class ProfileReferenced(Exception):
+    """Raised when an LLM profile cannot be deleted because agent profiles cite it.
+
+    ``referrers`` is the list of citing agent-profile names; routers surface it
+    in a 409 so the user knows what to detach first.
+    """
+
+    def __init__(self, referrers: list[str]) -> None:
+        self.referrers = list(referrers)
+        joined = ", ".join(self.referrers) or "<none>"
+        super().__init__(
+            f"LLM profile is referenced by {len(self.referrers)} agent "
+            f"profile(s): {joined}"
+        )
+
+
+def _validate_name(name: str) -> None:
+    """Reject names that are not legal profile keys (path traversal etc.)."""
+    if not PROFILE_NAME_REGEX.match(name):
+        raise ValueError(f"Invalid profile name: {name!r}.")
+
+
+def _scan_referrers(store: AgentProfileStore, llm_profile_name: str) -> list[str]:
+    """Return citing agent-profile names. Caller must hold the store lock.
+
+    Reads JSON directly (no validation/secret instantiation). Non-dict and
+    corrupt files are skipped.
+    """
+    referrers: list[str] = []
+    for path in sorted(store.base_dir.glob("*.json")):
+        if not PROFILE_NAME_REGEX.match(path.stem):
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        # agent_kind defaults to "openhands"; only that variant has the ref.
+        if data.get("agent_kind", "openhands") != "openhands":
+            continue
+        if data.get("llm_profile_ref") == llm_profile_name:
+            referrers.append(path.stem)
+    return referrers
+
+
+def _rewrite_refs(store: AgentProfileStore, old_name: str, new_name: str) -> list[str]:
+    """Repoint every ``llm_profile_ref == old_name`` to ``new_name``.
+
+    Caller must hold the store lock. Surgical raw-JSON edit: only the ref field
+    changes, so encrypted ``mcp_tools`` and the stable ``id`` are untouched and
+    no cipher is needed. Returns the names of the rewritten profiles.
+    """
+    rewritten: list[str] = []
+    for path in sorted(store.base_dir.glob("*.json")):
+        if not PROFILE_NAME_REGEX.match(path.stem):
+            continue
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            continue
+        if not isinstance(data, dict):
+            continue
+        if data.get("agent_kind", "openhands") != "openhands":
+            continue
+        if data.get("llm_profile_ref") != old_name:
+            continue
+        data["llm_profile_ref"] = new_name
+        store._atomic_write(path, json.dumps(data, indent=2))
+        rewritten.append(path.stem)
+    return rewritten
+
+
+def find_referrers(store: AgentProfileStore, llm_profile_name: str) -> list[str]:
+    """Names of the agent profiles whose ``llm_profile_ref == llm_profile_name``."""
+    with store._acquire_lock():
+        return _scan_referrers(store, llm_profile_name)
+
+
+def cascade_rename(store: AgentProfileStore, old_name: str, new_name: str) -> list[str]:
+    """Atomically repoint all ``llm_profile_ref == old_name`` to ``new_name``.
+
+    Holds the agent-profiles lock for the whole scan-and-rewrite, so concurrent
+    saves cannot interleave. Returns the rewritten profile names.
+    """
+    _validate_name(new_name)
+    with store._acquire_lock():
+        rewritten = _rewrite_refs(store, old_name, new_name)
+    if rewritten:
+        logger.info(
+            f"[Profile FK] Cascaded llm_profile_ref `{old_name}` -> `{new_name}` "
+            f"across {len(rewritten)} agent profile(s)."
+        )
+    return rewritten
+
+
+def delete_llm_profile(
+    agent_store: AgentProfileStore,
+    llm_store: LLMProfileStore,
+    llm_profile_name: str,
+) -> None:
+    """Delete an LLM profile only if no agent profile references it.
+
+    Lock order: agent-profiles (held across check + delete), then llm-profiles
+    (inside ``llm_store.delete``). Raises :class:`ProfileReferenced` naming the
+    referrers if any exist.
+    """
+    with agent_store._acquire_lock():
+        referrers = _scan_referrers(agent_store, llm_profile_name)
+        if referrers:
+            raise ProfileReferenced(referrers)
+        llm_store.delete(llm_profile_name)
+
+
+def rename_llm_profile(
+    agent_store: AgentProfileStore,
+    llm_store: LLMProfileStore,
+    old_name: str,
+    new_name: str,
+) -> list[str]:
+    """Rename an LLM profile and cascade the rename to its referrers.
+
+    Lock order: agent-profiles (held across the LLM rename + cascade), then
+    llm-profiles (inside ``llm_store.rename``). The LLM file is renamed first so
+    that if it fails (missing source / taken target) no refs are rewritten.
+    Returns the rewritten agent-profile names.
+    """
+    _validate_name(new_name)
+    with agent_store._acquire_lock():
+        llm_store.rename(old_name, new_name)
+        return _rewrite_refs(agent_store, old_name, new_name)

--- a/openhands-sdk/openhands/sdk/profiles/profile_refs.py
+++ b/openhands-sdk/openhands/sdk/profiles/profile_refs.py
@@ -141,9 +141,10 @@ def delete_llm_profile(
 ) -> None:
     """Delete an LLM profile only if no agent profile references it.
 
-    Lock order: agent-profiles (held across check + delete), then llm-profiles
-    (inside ``llm_store.delete``). Raises :class:`ProfileReferenced` naming the
-    referrers if any exist.
+    Holds the agent-profiles lock across the referrer check and the delete, then
+    delegates to ``llm_store.delete`` (which manages its own lock) — preserving
+    the agent-profiles-before-llm-profiles order. Raises
+    :class:`ProfileReferenced` naming the referrers if any exist.
     """
     with agent_store._acquire_lock():
         referrers = _scan_referrers(agent_store, llm_profile_name)
@@ -160,10 +161,11 @@ def rename_llm_profile(
 ) -> list[str]:
     """Rename an LLM profile and cascade the rename to its referrers.
 
-    Lock order: agent-profiles (held across the LLM rename + cascade), then
-    llm-profiles (inside ``llm_store.rename``). The LLM file is renamed first so
-    that if it fails (missing source / taken target) no refs are rewritten.
-    Returns the rewritten agent-profile names.
+    Holds the agent-profiles lock across the whole operation, then delegates to
+    ``llm_store.rename`` (which manages its own lock) — preserving the
+    agent-profiles-before-llm-profiles order. The LLM file is renamed first, so
+    if it fails (missing source / taken target) no refs are rewritten. Returns
+    the rewritten agent-profile names.
     """
     _validate_name(new_name)
     with agent_store._acquire_lock():

--- a/tests/sdk/profiles/test_agent_profile_store.py
+++ b/tests/sdk/profiles/test_agent_profile_store.py
@@ -1,0 +1,628 @@
+"""Tests for ``AgentProfileStore`` — mirrors the ``LLMProfileStore`` suite.
+
+Adds the profile-specific contracts: both union variants round-trip, the
+``id`` is stable across rename, ``list_summaries`` projects the FK fields
+without instantiating secrets, and ``skills[].mcp_tools`` secrets are redacted
+by default / encrypted (never cleartext) under a cipher.
+"""
+
+import concurrent.futures
+import json
+import re
+import threading
+from pathlib import Path
+
+import pytest
+
+from openhands.sdk.profiles import (
+    ACPAgentProfile,
+    AgentProfileStore,
+    OpenHandsAgentProfile,
+    ProfileLimitExceeded,
+)
+from openhands.sdk.profiles.agent_profile import AGENT_PROFILE_SCHEMA_VERSION
+from openhands.sdk.skills import Skill
+from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
+
+
+# A clearly identifiable secret carried by a skill's mcp_tools env/headers.
+_MCP_SECRET = "ghp_SUPER_SECRET_TOKEN_SHOULD_NOT_LEAK"
+
+
+@pytest.fixture
+def agent_store(tmp_path: Path) -> AgentProfileStore:
+    return AgentProfileStore(base_dir=tmp_path)
+
+
+@pytest.fixture
+def openhands_profile() -> OpenHandsAgentProfile:
+    return OpenHandsAgentProfile(
+        name="oh",
+        llm_profile_ref="default",
+        revision=2,
+        mcp_server_refs=["fetch"],
+    )
+
+
+@pytest.fixture
+def acp_profile() -> ACPAgentProfile:
+    return ACPAgentProfile(name="acp", acp_server="codex", acp_model="gpt-5.5/medium")
+
+
+def _skill_with_secret() -> Skill:
+    return Skill(
+        name="leaky",
+        content="do stuff",
+        mcp_tools={
+            "mcpServers": {
+                "svc": {
+                    "url": "https://x.test",
+                    "headers": {"Authorization": f"Bearer {_MCP_SECRET}"},
+                    "env": {"API_KEY": _MCP_SECRET},
+                }
+            }
+        },
+    )
+
+
+def _profile_with_secret_skill(name: str = "secretful") -> OpenHandsAgentProfile:
+    return OpenHandsAgentProfile(
+        name=name,
+        llm_profile_ref="default",
+        skills=[_skill_with_secret()],
+    )
+
+
+# ── Init ────────────────────────────────────────────────────────────────────
+
+
+def test_init_creates_directory(tmp_path: Path) -> None:
+    profile_dir = tmp_path / "agent-profiles"
+    assert not profile_dir.exists()
+
+    AgentProfileStore(base_dir=profile_dir)
+
+    assert profile_dir.exists()
+    assert profile_dir.is_dir()
+
+
+def test_init_with_string_path(tmp_path: Path) -> None:
+    profile_dir = str(tmp_path / "agent-profiles")
+    store = AgentProfileStore(base_dir=profile_dir)
+
+    assert store.base_dir == Path(profile_dir)
+    assert store.base_dir.exists()
+
+
+def test_init_with_existing_directory(tmp_path: Path) -> None:
+    profile_dir = tmp_path / "agent-profiles"
+    profile_dir.mkdir()
+
+    store = AgentProfileStore(base_dir=profile_dir)
+    assert store.base_dir == profile_dir
+
+
+# ── List ────────────────────────────────────────────────────────────────────
+
+
+def test_list_empty_store(agent_store: AgentProfileStore) -> None:
+    assert agent_store.list() == []
+
+
+def test_list_with_profiles(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    agent_store.save(openhands_profile.model_copy(update={"name": "oh2"}))
+
+    profiles = agent_store.list()
+    assert len(profiles) == 2
+    assert "oh.json" in profiles
+    assert "oh2.json" in profiles
+
+
+def test_list_excludes_non_json_files(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    (agent_store.base_dir / "not_a_profile.txt").write_text("hello")
+
+    assert agent_store.list() == ["oh.json"]
+
+
+# ── Save ────────────────────────────────────────────────────────────────────
+
+
+def test_save_creates_file(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    assert (agent_store.base_dir / "oh.json").exists()
+
+
+def test_save_writes_schema_version(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    data = json.loads((agent_store.base_dir / "oh.json").read_text())
+    assert data["schema_version"] == AGENT_PROFILE_SCHEMA_VERSION
+
+
+def test_save_persists_id_inside_file(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    data = json.loads((agent_store.base_dir / "oh.json").read_text())
+    assert data["id"] == str(openhands_profile.id)
+
+
+def test_load_rejects_newer_schema_version(agent_store: AgentProfileStore) -> None:
+    (agent_store.base_dir / "future.json").write_text(
+        json.dumps(
+            {
+                "schema_version": AGENT_PROFILE_SCHEMA_VERSION + 1,
+                "name": "future",
+                "llm_profile_ref": "default",
+            }
+        )
+    )
+    with pytest.raises(ValueError, match="newer than supported"):
+        agent_store.load("future")
+
+
+@pytest.mark.parametrize(
+    "name",
+    [
+        # Empty names are rejected by the model (``name`` has min_length=1), so
+        # only names the model accepts but the store rejects are covered here.
+        ".",
+        "..",
+        "my/profile",
+        ".leading-dot",
+        "-leading-dash",
+        "name with space",
+        "name@symbol",
+        "a" * 65,
+    ],
+)
+def test_save_with_invalid_profile_name(
+    name: str, agent_store: AgentProfileStore
+) -> None:
+    profile = OpenHandsAgentProfile(name=name, llm_profile_ref="default")
+    with pytest.raises(ValueError, match=re.escape(f"Invalid profile name: {name!r}.")):
+        agent_store.save(profile)
+
+
+def test_save_writes_valid_json(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    data = json.loads((agent_store.base_dir / "oh.json").read_text())
+    assert data["agent_kind"] == "openhands"
+    assert data["llm_profile_ref"] == "default"
+    assert data["mcp_server_refs"] == ["fetch"]
+
+
+def test_save_overwrites_existing(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    agent_store.save(openhands_profile.model_copy(update={"llm_profile_ref": "other"}))
+
+    loaded = agent_store.load("oh")
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    assert loaded.llm_profile_ref == "other"
+
+
+# ── Cipher round-trip / secret-at-rest ──────────────────────────────────────
+
+
+def test_save_without_cipher_redacts_skill_secret(
+    agent_store: AgentProfileStore,
+) -> None:
+    agent_store.save(_profile_with_secret_skill())
+
+    content = (agent_store.base_dir / "secretful.json").read_text()
+    assert _MCP_SECRET not in content
+
+
+def test_save_with_cipher_encrypts_skill_secret(
+    agent_store: AgentProfileStore,
+) -> None:
+    cipher = Cipher(secret_key="test-key")
+    agent_store.save(_profile_with_secret_skill(), cipher=cipher)
+
+    content = (agent_store.base_dir / "secretful.json").read_text()
+    # No cleartext, but recoverable: the stored token decrypts back via cipher.
+    assert _MCP_SECRET not in content
+    assert FERNET_TOKEN_PREFIX in content
+
+    data = json.loads(content)
+    env = data["skills"][0]["mcp_tools"]["mcpServers"]["svc"]["env"]
+    token = env["API_KEY"]
+    assert token != _MCP_SECRET
+    decrypted = cipher.decrypt(token)
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == _MCP_SECRET
+
+
+def test_roundtrip_openhands_without_cipher(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    loaded = agent_store.load("oh")
+
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    assert loaded.id == openhands_profile.id
+    assert loaded.llm_profile_ref == "default"
+    assert loaded.mcp_server_refs == ["fetch"]
+    assert loaded.revision == 2
+
+
+def test_roundtrip_acp_without_cipher(
+    agent_store: AgentProfileStore, acp_profile: ACPAgentProfile
+) -> None:
+    agent_store.save(acp_profile)
+    loaded = agent_store.load("acp")
+
+    assert isinstance(loaded, ACPAgentProfile)
+    assert loaded.id == acp_profile.id
+    assert loaded.acp_server == "codex"
+    assert loaded.acp_model == "gpt-5.5/medium"
+
+
+def test_roundtrip_with_cipher_preserves_non_secret_fields(
+    agent_store: AgentProfileStore,
+) -> None:
+    cipher = Cipher(secret_key="test-key")
+    profile = _profile_with_secret_skill()
+    agent_store.save(profile, cipher=cipher)
+    loaded = agent_store.load("secretful", cipher=cipher)
+
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    assert loaded.id == profile.id
+    assert loaded.llm_profile_ref == "default"
+    assert loaded.skills[0].name == "leaky"
+
+
+def test_load_with_cipher_leaves_skill_secret_encrypted(
+    agent_store: AgentProfileStore,
+) -> None:
+    """Skill.mcp_tools has a masking serializer but no symmetric decrypt
+    validator, so encrypted env/headers load as ciphertext. The resolver
+    (#3717) decrypts; the store only guarantees no-cleartext-at-rest."""
+    cipher = Cipher(secret_key="test-key")
+    agent_store.save(_profile_with_secret_skill(), cipher=cipher)
+    loaded = agent_store.load("secretful", cipher=cipher)
+
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    mcp_tools = loaded.skills[0].mcp_tools
+    assert mcp_tools is not None
+    token = mcp_tools["mcpServers"]["svc"]["env"]["API_KEY"]
+    assert token != _MCP_SECRET
+    decrypted = cipher.decrypt(token)
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == _MCP_SECRET
+
+
+# ── Load ────────────────────────────────────────────────────────────────────
+
+
+def test_load_nonexistent_profile(agent_store: AgentProfileStore) -> None:
+    with pytest.raises(FileNotFoundError) as exc_info:
+        agent_store.load("nonexistent")
+    assert "nonexistent" in str(exc_info.value)
+    assert "not found" in str(exc_info.value)
+
+
+def test_load_nonexistent_shows_available(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    with pytest.raises(FileNotFoundError) as exc_info:
+        agent_store.load("nonexistent")
+    assert "oh.json" in str(exc_info.value)
+
+
+def test_load_corrupted_profile(agent_store: AgentProfileStore) -> None:
+    (agent_store.base_dir / "corrupted.json").write_text("{ invalid json }")
+    with pytest.raises(ValueError) as exc_info:
+        agent_store.load("corrupted")
+    assert "Failed to load profile" in str(exc_info.value)
+
+
+# ── Delete ──────────────────────────────────────────────────────────────────
+
+
+def test_delete_existing_profile(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    assert "oh.json" in agent_store.list()
+
+    agent_store.delete("oh")
+    assert "oh.json" not in agent_store.list()
+
+
+def test_delete_nonexistent_profile(agent_store: AgentProfileStore) -> None:
+    agent_store.delete("nonexistent")
+
+
+# ── Rename ──────────────────────────────────────────────────────────────────
+
+
+def test_rename_moves_file(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    agent_store.rename("oh", "renamed")
+
+    assert (agent_store.base_dir / "renamed.json").exists()
+    assert not (agent_store.base_dir / "oh.json").exists()
+
+
+def test_rename_syncs_internal_name_and_preserves_id(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    original_id = openhands_profile.id
+    agent_store.rename("oh", "renamed")
+
+    loaded = agent_store.load("renamed")
+    assert loaded.name == "renamed"
+    assert loaded.id == original_id
+
+
+def test_rename_source_missing_raises(agent_store: AgentProfileStore) -> None:
+    with pytest.raises(FileNotFoundError, match="missing"):
+        agent_store.rename("missing", "anywhere")
+
+
+def test_rename_target_exists_raises(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    agent_store.save(openhands_profile.model_copy(update={"name": "taken"}))
+
+    with pytest.raises(FileExistsError, match="taken"):
+        agent_store.rename("oh", "taken")
+
+    assert (agent_store.base_dir / "oh.json").exists()
+    assert (agent_store.base_dir / "taken.json").exists()
+
+
+def test_rename_same_name_is_noop(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    agent_store.rename("oh", "oh")
+    assert agent_store.list() == ["oh.json"]
+
+
+def test_rename_same_name_missing_raises(agent_store: AgentProfileStore) -> None:
+    with pytest.raises(FileNotFoundError, match="ghost"):
+        agent_store.rename("ghost", "ghost")
+
+
+def test_rename_invalid_name_raises(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    with pytest.raises(ValueError, match="Invalid profile name"):
+        agent_store.rename("oh", "../escape")
+
+
+# ── list_summaries ──────────────────────────────────────────────────────────
+
+
+def test_list_summaries_empty(agent_store: AgentProfileStore) -> None:
+    assert agent_store.list_summaries() == []
+
+
+def test_list_summaries_returns_fk_fields(
+    agent_store: AgentProfileStore,
+    openhands_profile: OpenHandsAgentProfile,
+    acp_profile: ACPAgentProfile,
+) -> None:
+    agent_store.save(openhands_profile)
+    agent_store.save(acp_profile)
+
+    by_name = {s["name"]: s for s in agent_store.list_summaries()}
+
+    oh = by_name["oh"]
+    assert oh["id"] == str(openhands_profile.id)
+    assert oh["agent_kind"] == "openhands"
+    assert oh["revision"] == 2
+    assert oh["llm_profile_ref"] == "default"
+    assert oh["mcp_server_refs"] == ["fetch"]
+
+    acp = by_name["acp"]
+    assert acp["agent_kind"] == "acp"
+    # ACP profiles have no llm_profile_ref.
+    assert acp["llm_profile_ref"] is None
+
+
+def test_list_summaries_does_not_decrypt_secrets(
+    agent_store: AgentProfileStore,
+) -> None:
+    cipher = Cipher(secret_key="test-key")
+    agent_store.save(_profile_with_secret_skill(), cipher=cipher)
+
+    summaries = agent_store.list_summaries()
+    # No skill content / secret is loaded — only the FK projection.
+    assert _MCP_SECRET not in json.dumps(summaries)
+    assert summaries[0]["name"] == "secretful"
+    assert "skills" not in summaries[0]
+
+
+def test_list_summaries_skips_corrupted(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    (agent_store.base_dir / "bad.json").write_text("{ not valid json")
+
+    assert [s["name"] for s in agent_store.list_summaries()] == ["oh"]
+
+
+def test_list_summaries_skips_non_dict(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    (agent_store.base_dir / "list.json").write_text("[1, 2, 3]")
+
+    assert [s["name"] for s in agent_store.list_summaries()] == ["oh"]
+
+
+def test_list_summaries_skips_invalid_filename(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile)
+    (agent_store.base_dir / ".hidden.json").write_text('{"name": "x"}')
+    (agent_store.base_dir / "bad@name.json").write_text('{"name": "x"}')
+
+    assert [s["name"] for s in agent_store.list_summaries()] == ["oh"]
+
+
+# ── max_profiles ────────────────────────────────────────────────────────────
+
+
+def test_save_with_max_profiles_blocks_over_limit(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile.model_copy(update={"name": "a"}))
+    agent_store.save(openhands_profile.model_copy(update={"name": "b"}))
+
+    with pytest.raises(ProfileLimitExceeded, match="2"):
+        agent_store.save(
+            openhands_profile.model_copy(update={"name": "c"}), max_profiles=2
+        )
+
+
+def test_save_with_max_profiles_allows_overwrite(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile.model_copy(update={"name": "a"}))
+    agent_store.save(openhands_profile.model_copy(update={"name": "b"}))
+
+    agent_store.save(openhands_profile.model_copy(update={"name": "a"}), max_profiles=2)
+    assert len(agent_store.list()) == 2
+
+
+def test_save_with_max_profiles_ignores_invalid_filenames(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
+) -> None:
+    agent_store.save(openhands_profile.model_copy(update={"name": "real"}))
+    (agent_store.base_dir / ".hidden.json").write_text('{"name": "x"}')
+    (agent_store.base_dir / "bad@name.json").write_text('{"name": "x"}')
+
+    agent_store.save(
+        openhands_profile.model_copy(update={"name": "another"}), max_profiles=2
+    )
+    assert "another.json" in agent_store.list()
+
+
+def test_save_cleans_up_tmp_on_replace_failure(
+    agent_store: AgentProfileStore,
+    openhands_profile: OpenHandsAgentProfile,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def boom(src, dst):
+        raise OSError("disk full")
+
+    monkeypatch.setattr(Path, "replace", boom)
+
+    with pytest.raises(OSError, match="disk full"):
+        agent_store.save(openhands_profile)
+
+    assert list(agent_store.base_dir.glob("*.tmp")) == []
+
+
+# ── Concurrency ─────────────────────────────────────────────────────────────
+
+
+def test_concurrent_saves(tmp_path: Path) -> None:
+    store = AgentProfileStore(base_dir=tmp_path)
+    num_threads = 10
+    results: list[int] = []
+    errors: list[tuple[int, Exception]] = []
+
+    def save_profile(index: int) -> None:
+        try:
+            store.save(
+                OpenHandsAgentProfile(
+                    name=f"profile_{index}", llm_profile_ref=f"llm_{index}"
+                )
+            )
+            results.append(index)
+        except Exception as e:
+            errors.append((index, e))
+
+    threads = [
+        threading.Thread(target=save_profile, args=(i,)) for i in range(num_threads)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+    assert len(results) == num_threads
+    assert len(store.list()) == num_threads
+
+
+def test_concurrent_reads_and_writes(tmp_path: Path) -> None:
+    store = AgentProfileStore(base_dir=tmp_path)
+    for i in range(5):
+        store.save(
+            OpenHandsAgentProfile(name=f"profile_{i}", llm_profile_ref=f"llm_{i}")
+        )
+
+    errors: list[tuple[str, str | int, Exception]] = []
+    read_results: list[str] = []
+    write_results: list[int] = []
+
+    def read_profile(name: str) -> None:
+        try:
+            loaded = store.load(name)
+            read_results.append(loaded.name)
+        except Exception as e:
+            errors.append(("read", name, e))
+
+    def write_profile(index: int) -> None:
+        try:
+            store.save(
+                OpenHandsAgentProfile(name=f"new_profile_{index}", llm_profile_ref="x")
+            )
+            write_results.append(index)
+        except Exception as e:
+            errors.append(("write", index, e))
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=10) as executor:
+        futures = []
+        for i in range(5):
+            futures.append(executor.submit(read_profile, f"profile_{i}"))
+        for i in range(5):
+            futures.append(executor.submit(write_profile, i))
+        concurrent.futures.wait(futures)
+
+    assert errors == []
+    assert len(read_results) == 5
+    assert len(write_results) == 5
+
+
+def test_full_workflow(agent_store: AgentProfileStore) -> None:
+    profile = OpenHandsAgentProfile(name="wf", llm_profile_ref="default", revision=1)
+
+    agent_store.save(profile)
+    assert "wf.json" in agent_store.list()
+
+    loaded = agent_store.load("wf")
+    assert loaded.id == profile.id
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    assert loaded.llm_profile_ref == "default"
+
+    agent_store.rename("wf", "wf2")
+    assert agent_store.load("wf2").id == profile.id
+
+    agent_store.delete("wf2")
+    assert agent_store.list() == []

--- a/tests/sdk/profiles/test_profile_refs.py
+++ b/tests/sdk/profiles/test_profile_refs.py
@@ -1,0 +1,236 @@
+"""Tests for the LLM-profile <- AgentProfile foreign-key lifecycle."""
+
+import concurrent.futures
+import json
+from pathlib import Path
+
+import pytest
+
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.profiles import (
+    ACPAgentProfile,
+    AgentProfileStore,
+    OpenHandsAgentProfile,
+    ProfileReferenced,
+    cascade_rename,
+    delete_llm_profile,
+    find_referrers,
+    rename_llm_profile,
+)
+from openhands.sdk.skills import Skill
+from openhands.sdk.utils.cipher import Cipher
+
+
+@pytest.fixture
+def agent_store(tmp_path: Path) -> AgentProfileStore:
+    return AgentProfileStore(base_dir=tmp_path / "agent-profiles")
+
+
+@pytest.fixture
+def llm_store(tmp_path: Path) -> LLMProfileStore:
+    return LLMProfileStore(base_dir=tmp_path / "llm-profiles")
+
+
+def _oh(name: str, llm_profile_ref: str) -> OpenHandsAgentProfile:
+    return OpenHandsAgentProfile(name=name, llm_profile_ref=llm_profile_ref)
+
+
+def _ref(store: AgentProfileStore, name: str) -> str:
+    """Load a profile and return its ``llm_profile_ref`` (narrows the union)."""
+    loaded = store.load(name)
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    return loaded.llm_profile_ref
+
+
+# ── find_referrers ──────────────────────────────────────────────────────────
+
+
+def test_find_referrers_empty(agent_store: AgentProfileStore) -> None:
+    assert find_referrers(agent_store, "default") == []
+
+
+def test_find_referrers_matches_only_citing_openhands(
+    agent_store: AgentProfileStore,
+) -> None:
+    agent_store.save(_oh("a", "default"))
+    agent_store.save(_oh("b", "default"))
+    agent_store.save(_oh("c", "other"))
+    agent_store.save(ACPAgentProfile(name="d", acp_server="codex"))
+
+    referrers = find_referrers(agent_store, "default")
+    assert sorted(referrers) == ["a", "b"]
+
+
+# ── cascade_rename ──────────────────────────────────────────────────────────
+
+
+def test_cascade_rename_rewrites_matching_refs(
+    agent_store: AgentProfileStore,
+) -> None:
+    agent_store.save(_oh("a", "default"))
+    agent_store.save(_oh("b", "default"))
+    agent_store.save(_oh("c", "other"))
+
+    rewritten = cascade_rename(agent_store, "default", "renamed")
+
+    assert sorted(rewritten) == ["a", "b"]
+    assert _ref(agent_store, "a") == "renamed"
+    assert _ref(agent_store, "b") == "renamed"
+    # Non-matching profile is untouched.
+    assert _ref(agent_store, "c") == "other"
+    assert find_referrers(agent_store, "default") == []
+
+
+def test_cascade_rename_no_match_is_noop(agent_store: AgentProfileStore) -> None:
+    agent_store.save(_oh("a", "other"))
+    assert cascade_rename(agent_store, "default", "renamed") == []
+    assert _ref(agent_store, "a") == "other"
+
+
+def test_cascade_rename_preserves_id_and_encrypted_secret(
+    agent_store: AgentProfileStore,
+) -> None:
+    cipher = Cipher(secret_key="test-key")
+    secret = "ghp_DO_NOT_LEAK"
+    profile = OpenHandsAgentProfile(
+        name="a",
+        llm_profile_ref="default",
+        skills=[
+            Skill(
+                name="s",
+                content="x",
+                mcp_tools={
+                    "mcpServers": {"svc": {"command": "run", "env": {"K": secret}}}
+                },
+            )
+        ],
+    )
+    agent_store.save(profile, cipher=cipher)
+
+    cascade_rename(agent_store, "default", "renamed")
+
+    raw = (agent_store.base_dir / "a.json").read_text()
+    assert secret not in raw  # encrypted token survives the surgical edit
+    data = json.loads(raw)
+    assert data["id"] == str(profile.id)
+    assert data["llm_profile_ref"] == "renamed"
+    token = data["skills"][0]["mcp_tools"]["mcpServers"]["svc"]["env"]["K"]
+    decrypted = cipher.decrypt(token)
+    assert decrypted is not None
+    assert decrypted.get_secret_value() == secret
+
+
+def test_cascade_rename_invalid_new_name_raises(
+    agent_store: AgentProfileStore,
+) -> None:
+    agent_store.save(_oh("a", "default"))
+    with pytest.raises(ValueError, match="Invalid profile name"):
+        cascade_rename(agent_store, "default", "../escape")
+
+
+# ── ProfileReferenced ───────────────────────────────────────────────────────
+
+
+def test_profile_referenced_message_names_referrers() -> None:
+    exc = ProfileReferenced(["a", "b"])
+    assert exc.referrers == ["a", "b"]
+    assert "a" in str(exc)
+    assert "b" in str(exc)
+
+
+# ── delete_llm_profile (guarded) ────────────────────────────────────────────
+
+
+def test_delete_llm_profile_blocked_when_referenced(
+    agent_store: AgentProfileStore, llm_store: LLMProfileStore
+) -> None:
+    llm_store.save("default", LLM(usage_id="x", model="gpt-4-turbo"))
+    agent_store.save(_oh("a", "default"))
+
+    with pytest.raises(ProfileReferenced) as exc_info:
+        delete_llm_profile(agent_store, llm_store, "default")
+
+    assert exc_info.value.referrers == ["a"]
+    # The LLM profile must NOT have been deleted.
+    assert "default.json" in llm_store.list()
+
+
+def test_delete_llm_profile_succeeds_when_unreferenced(
+    agent_store: AgentProfileStore, llm_store: LLMProfileStore
+) -> None:
+    llm_store.save("default", LLM(usage_id="x", model="gpt-4-turbo"))
+    agent_store.save(_oh("a", "other"))
+
+    delete_llm_profile(agent_store, llm_store, "default")
+    assert "default.json" not in llm_store.list()
+
+
+# ── rename_llm_profile (guarded cascade) ────────────────────────────────────
+
+
+def test_rename_llm_profile_renames_and_cascades(
+    agent_store: AgentProfileStore, llm_store: LLMProfileStore
+) -> None:
+    llm_store.save("default", LLM(usage_id="x", model="gpt-4-turbo"))
+    agent_store.save(_oh("a", "default"))
+    agent_store.save(_oh("b", "default"))
+
+    rewritten = rename_llm_profile(agent_store, llm_store, "default", "renamed")
+
+    assert sorted(rewritten) == ["a", "b"]
+    assert "renamed.json" in llm_store.list()
+    assert "default.json" not in llm_store.list()
+    assert _ref(agent_store, "a") == "renamed"
+
+
+def test_rename_llm_profile_missing_source_leaves_refs_intact(
+    agent_store: AgentProfileStore, llm_store: LLMProfileStore
+) -> None:
+    agent_store.save(_oh("a", "default"))
+
+    with pytest.raises(FileNotFoundError):
+        rename_llm_profile(agent_store, llm_store, "default", "renamed")
+
+    # The LLM rename failed before any cascade, so refs are untouched.
+    assert _ref(agent_store, "a") == "default"
+
+
+# ── Concurrency ─────────────────────────────────────────────────────────────
+
+
+def test_cascade_rename_atomic_under_concurrent_access(tmp_path: Path) -> None:
+    """A cascade holds the store lock for the whole scan+rewrite, so concurrent
+    reads never observe a half-rewritten set and the final state is consistent."""
+    store = AgentProfileStore(base_dir=tmp_path)
+    num = 20
+    for i in range(num):
+        store.save(_oh(f"p{i}", "default"))
+
+    errors: list[Exception] = []
+
+    def reader() -> None:
+        try:
+            for _ in range(20):
+                # Every profile points at exactly one of the two names.
+                find_referrers(store, "default")
+                find_referrers(store, "renamed")
+        except Exception as e:  # pragma: no cover - failure path
+            errors.append(e)
+
+    def renamer() -> None:
+        try:
+            cascade_rename(store, "default", "renamed")
+        except Exception as e:  # pragma: no cover - failure path
+            errors.append(e)
+
+    with concurrent.futures.ThreadPoolExecutor(max_workers=6) as executor:
+        futures = [executor.submit(reader) for _ in range(4)]
+        futures.append(executor.submit(renamer))
+        concurrent.futures.wait(futures)
+
+    assert errors == []
+    assert find_referrers(store, "default") == []
+    assert sorted(find_referrers(store, "renamed")) == sorted(
+        f"p{i}" for i in range(num)
+    )


### PR DESCRIPTION
HUMAN:

The persistence store for agent profiles plus the foreign-key
lifecycle that keeps an `llm_profile_ref` from dangling when the underlying LLM
profile is renamed or deleted. Stacked on the model PR #3757.

---

AGENT:

## Why

Reference composition (epic #3713) needs a real store for `AgentProfile`s and a
foreign-key lifecycle so `llm_profile_ref` never silently dangles. This logic
belongs in the store/SDK layer (not routers) because it must hold the
`AgentProfileStore` file lock while scanning + rewriting refs — a save-time FK
enforced only at the HTTP layer would be a TOCTOU. `mcp_server_refs` are keys
into the user's independently-mutable global `mcp_config`, so they are checked
at resolve-time (#3717), not constrained here.

## Summary

- **`AgentProfileStore`** (`openhands/sdk/profiles/agent_profile_store.py`) —
  clones the `LLMProfileStore` shape under `~/.openhands/agent-profiles`: one
  JSON file per profile, filename = `name`, stable `id` (uuid) inside the file.
  `save`/`load`/`delete`/`rename`/`list`/`list_summaries`, `filelock`, atomic
  temp-file + `Path.replace` write, name-pattern validation, `max_profiles` cap,
  and a `cipher` param. With a cipher, `skills[].mcp_tools` env/headers are
  **encrypted at rest (recoverable)** rather than redacted; every other field is
  a reference and dumps in the clear. `rename` keeps the in-file `name` in sync
  via a surgical raw-JSON edit (no cipher needed, `id` preserved).
  `list_summaries` projects `{id, name, agent_kind, revision, llm_profile_ref,
  mcp_server_refs}` **without** instantiating secrets.
- **FK module** (`openhands/sdk/profiles/profile_refs.py`) —
  `find_referrers(store, llm_profile_name)`, `cascade_rename(store, old, new)`
  (surgical ref rewrite that leaves encrypted `mcp_tools` and the `id`
  untouched), `ProfileReferenced(referrers)` (routers map → 409), plus guarded
  cross-store `delete_llm_profile` / `rename_llm_profile`. **Lock order is
  agent-profiles then llm-profiles**, held across check+mutate to close the
  referrer TOCTOU (documented in the module docstring).
- **Cipher round-trip caveat** — `Skill.mcp_tools` has a masking *serializer*
  (#3774) but no symmetric *decrypt validator*, so encrypted values load back as
  ciphertext. The store guarantees no-cleartext-at-rest and threads the cipher
  through `load` for parity; decryption of `mcp_tools` is deferred to the
  resolver (#3717), which holds the cipher. Noted in `load`'s docstring and a
  dedicated test. Adding a symmetric `Skill.mcp_tools` decrypt validator is a
  clean follow-up to complete #3774's "decrypted on restore" intent — left out
  here to keep this PR scoped to store + FK.

## Issue Number

Closes #3716

## How to Test

New unit tests mirror the `LLMProfileStore` suite (init / list / save / load /
delete / rename / `list_summaries` / `max_profiles` / concurrency) and add the
profile-specific contracts: both union variants round-trip with and without a
cipher, no cleartext skill secret at rest, restrict-on-delete, cascade-rename
under concurrent access, and the `list_summaries` no-decrypt projection.

```
$ uv run pytest tests/sdk/profiles/ -q
90 passed in 1.63s

$ uv run ruff check openhands-sdk/openhands/sdk/profiles/ tests/sdk/profiles/test_agent_profile_store.py tests/sdk/profiles/test_profile_refs.py
All checks passed!

$ uv run ruff format --check openhands-sdk/openhands/sdk/profiles/ tests/sdk/profiles/test_agent_profile_store.py tests/sdk/profiles/test_profile_refs.py
6 files already formatted

$ uv run pyright openhands-sdk/openhands/sdk/profiles/agent_profile_store.py openhands-sdk/openhands/sdk/profiles/profile_refs.py tests/sdk/profiles/test_agent_profile_store.py tests/sdk/profiles/test_profile_refs.py
0 errors, 0 warnings, 0 informations
```

Acceptance criteria covered by tests:
- `test_save_with_cipher_encrypts_skill_secret` / `test_save_without_cipher_redacts_skill_secret` — no cleartext skill secret at rest when a cipher is set.
- `test_delete_llm_profile_blocked_when_referenced` — deleting a referenced LLM profile raises `ProfileReferenced` naming the referrers.
- `test_rename_llm_profile_renames_and_cascades` + `test_cascade_rename_atomic_under_concurrent_access` — rename cascades to all referrers, atomic under concurrency.
- `test_list_summaries_does_not_decrypt_secrets` — `list_summaries` does not decrypt.
- `test_find_referrers_matches_only_citing_openhands` — `mcp_server_refs` are not FK-constrained at save-time (only `llm_profile_ref` is scanned).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

**Stacked on #3757** (the `AgentProfile` kind-discriminated union). The base of
this PR is `agent-profile-model`, so the diff shows only the store + FK work.
Rebase onto `main` once #3757 merges.

Out of scope (deferred to their own epic issues): the resolver (#3717) and the
router (#3719). This PR is store + FK only.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:740fc7c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-740fc7c-python \
  ghcr.io/openhands/agent-server:740fc7c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:740fc7c-golang-amd64
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-golang-amd64
ghcr.io/openhands/agent-server:agent-profile-store-golang-amd64
ghcr.io/openhands/agent-server:740fc7c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:740fc7c-golang-arm64
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-golang-arm64
ghcr.io/openhands/agent-server:agent-profile-store-golang-arm64
ghcr.io/openhands/agent-server:740fc7c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:740fc7c-java-amd64
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-java-amd64
ghcr.io/openhands/agent-server:agent-profile-store-java-amd64
ghcr.io/openhands/agent-server:740fc7c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:740fc7c-java-arm64
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-java-arm64
ghcr.io/openhands/agent-server:agent-profile-store-java-arm64
ghcr.io/openhands/agent-server:740fc7c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:740fc7c-python-amd64
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-python-amd64
ghcr.io/openhands/agent-server:agent-profile-store-python-amd64
ghcr.io/openhands/agent-server:740fc7c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:740fc7c-python-arm64
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-python-arm64
ghcr.io/openhands/agent-server:agent-profile-store-python-arm64
ghcr.io/openhands/agent-server:740fc7c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:740fc7c-golang
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-golang
ghcr.io/openhands/agent-server:agent-profile-store-golang
ghcr.io/openhands/agent-server:740fc7c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:740fc7c-java
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-java
ghcr.io/openhands/agent-server:agent-profile-store-java
ghcr.io/openhands/agent-server:740fc7c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:740fc7c-python
ghcr.io/openhands/agent-server:740fc7cb2a41a1e2c8d28959b116eb68ad1f529d-python
ghcr.io/openhands/agent-server:agent-profile-store-python
ghcr.io/openhands/agent-server:740fc7c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `740fc7c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `740fc7c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->