### PR TITLE
Fix 16_deferred_init example: poll on real execution-status values

### DIFF
--- a/examples/02_remote_agent_server/16_deferred_init.py
+++ b/examples/02_remote_agent_server/16_deferred_init.py
@@ -153,14 +153,15 @@ with ManagedAPIServer(
             assert resp.status_code == 200
             data = resp.json()
             execution_status = data.get("execution_status", "unknown")
-            if execution_status in ("stopped", "paused", "error"):
+            # Terminal states per ConversationExecutionStatus.is_terminal().
+            if execution_status in ("finished", "error", "stuck"):
                 break
             logger.info(f"   status: {execution_status} ({elapsed}s elapsed)")
             time.sleep(2)
             elapsed += 2
 
         logger.info(f"✅ Conversation finished — status: {execution_status}")
-        assert execution_status in ("stopped", "paused"), (
+        assert execution_status == "finished", (
             f"Unexpected final status: {execution_status}"
         )
 


### PR DESCRIPTION
## Problem

`examples/02_remote_agent_server/16_deferred_init.py` fails with exit code 1 (e.g. in the v1.29.0 release PR #3787, after ~2m30s). The deferred-init flow itself works — dormant → 503 gate → `POST /api/init` → ready → conversation runs and the agent **finishes in ~2s**. The bug is purely in the poll/assert logic at the end of the example, which uses execution-status strings that don't exist.

The server's `ConversationExecutionStatus` terminal values are `finished`, `error`, `stuck` — there is no `"stopped"` status. The example did:

```python
if execution_status in ("stopped", "paused", "error"):   # never matches "finished"
    break
...
assert execution_status in ("stopped", "paused"), ...     # "finished" not in set
```

So:
1. Agent completes → `execution_status == "finished"`.
2. `"finished"` isn't in the break set → the loop spins the full `max_wait = 120s` (the wall of repeated `status: finished` log lines).
3. After the loop, `assert "finished" in ("stopped", "paused")` raises `AssertionError` → exit 1.

## Fix

Use the real terminal values from `ConversationExecutionStatus.is_terminal()` (`finished`/`error`/`stuck`) for the break, and assert on `"finished"`. Two-line change; no behavior change to the deferred-init feature.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:df5aff5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-df5aff5-python \
  ghcr.io/openhands/agent-server:df5aff5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:df5aff5-golang-amd64
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-golang-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-golang-amd64
ghcr.io/openhands/agent-server:df5aff5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:df5aff5-golang-arm64
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-golang-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-golang-arm64
ghcr.io/openhands/agent-server:df5aff5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:df5aff5-java-amd64
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-java-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-java-amd64
ghcr.io/openhands/agent-server:df5aff5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:df5aff5-java-arm64
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-java-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-java-arm64
ghcr.io/openhands/agent-server:df5aff5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:df5aff5-python-amd64
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-python-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-python-amd64
ghcr.io/openhands/agent-server:df5aff5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:df5aff5-python-arm64
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-python-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-python-arm64
ghcr.io/openhands/agent-server:df5aff5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:df5aff5-golang
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-golang
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-golang
ghcr.io/openhands/agent-server:df5aff5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:df5aff5-java
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-java
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-java
ghcr.io/openhands/agent-server:df5aff5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:df5aff5-python
ghcr.io/openhands/agent-server:df5aff5a79a22716a6fef02fefc0d0e1971eae6f-python
ghcr.io/openhands/agent-server:fix-deferred-init-example-terminal-status-python
ghcr.io/openhands/agent-server:df5aff5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `df5aff5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `df5aff5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->