### PR TITLE
Fix _GatedLLM.completion override after _return_metrics removal

### DIFF
--- a/tests/agent_server/test_goal_loop.py
+++ b/tests/agent_server/test_goal_loop.py
@@ -43,7 +43,6 @@ class _GatedLLM(TestLLM):
         self,
         messages,
         tools=None,
-        _return_metrics=False,
         add_security_risk_prediction=False,
         on_token=None,
         **kwargs,
@@ -53,7 +52,6 @@ class _GatedLLM(TestLLM):
         return super().completion(
             messages,
             tools,
-            _return_metrics,
             add_security_risk_prediction,
             on_token,
             **kwargs,


### PR DESCRIPTION
## Problem

Pre-commit (`pyright`) fails on `main`/`rel-1.29.0` with two errors in `tests/agent_server/test_goal_loop.py`:

```
test_goal_loop.py:42 - error: Method "completion" overrides class "TestLLM" in an incompatible manner
test_goal_loop.py:58 - error: Expected 4 positional arguments (reportCallIssue)
```

This is a **logical merge conflict** between two independently-green changes that landed on 2026-06-18:

- `2bedbd8f` "Remove acp_env and `_return_metrics` deprecations (removed_in 1.29.0)" — deleted the `_return_metrics` parameter from `LLM.completion` / `TestLLM.completion` (now 4 positional params).
- #3770 "add /goal agent-server endpoint…" — added `test_goal_loop.py`, whose `_GatedLLM.completion` was written against the **old** signature (with `_return_metrics`) and was CI'd before the removal merged.

Neither PR was red on its own; the combined tree is the first place pyright type-checks both together.

## Fix

Drop `_return_metrics` from the `_GatedLLM.completion` override — both the signature and the `super().completion(...)` call — to match the current 4-positional signature. No behavior change.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:5239de8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-5239de8-python \
  ghcr.io/openhands/agent-server:5239de8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:5239de8-golang-amd64
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-golang-amd64
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-golang-amd64
ghcr.io/openhands/agent-server:5239de8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:5239de8-golang-arm64
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-golang-arm64
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-golang-arm64
ghcr.io/openhands/agent-server:5239de8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:5239de8-java-amd64
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-java-amd64
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-java-amd64
ghcr.io/openhands/agent-server:5239de8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:5239de8-java-arm64
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-java-arm64
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-java-arm64
ghcr.io/openhands/agent-server:5239de8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:5239de8-python-amd64
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-python-amd64
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-python-amd64
ghcr.io/openhands/agent-server:5239de8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:5239de8-python-arm64
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-python-arm64
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-python-arm64
ghcr.io/openhands/agent-server:5239de8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:5239de8-golang
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-golang
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-golang
ghcr.io/openhands/agent-server:5239de8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:5239de8-java
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-java
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-java
ghcr.io/openhands/agent-server:5239de8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:5239de8-python
ghcr.io/openhands/agent-server:5239de8a6dd65a9e6082d100d48a11b6bbb27db3-python
ghcr.io/openhands/agent-server:fix-goal-loop-test-return-metrics-signature-python
ghcr.io/openhands/agent-server:5239de8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `5239de8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `5239de8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->