### PR TITLE
Fix _GatedLLM.completion override after _return_metrics removal (rel-1.29.0)

### DIFF
--- a/tests/agent_server/test_goal_loop.py
+++ b/tests/agent_server/test_goal_loop.py
@@ -43,7 +43,6 @@ class _GatedLLM(TestLLM):
         self,
         messages,
         tools=None,
-        _return_metrics=False,
         add_security_risk_prediction=False,
         on_token=None,
         **kwargs,
@@ -53,7 +52,6 @@ class _GatedLLM(TestLLM):
         return super().completion(
             messages,
             tools,
-            _return_metrics,
             add_security_risk_prediction,
             on_token,
             **kwargs,


### PR DESCRIPTION
## Problem

Pre-commit (`pyright`) fails on `rel-1.29.0` (blocking the v1.29.0 release PR #3787) with two errors in `tests/agent_server/test_goal_loop.py`:

```
test_goal_loop.py:42 - error: Method "completion" overrides class "TestLLM" in an incompatible manner
test_goal_loop.py:58 - error: Expected 4 positional arguments (reportCallIssue)
```

This is a **logical merge conflict** between two changes that are each green on their own:

- `2bedbd8f` "Remove acp_env and `_return_metrics` deprecations (removed_in 1.29.0)" — deleted the `_return_metrics` parameter from `LLM.completion` / `TestLLM.completion` (now 4 positional params). This lives on this release branch.
- #3770 "add /goal agent-server endpoint…" — added `test_goal_loop.py`, whose `_GatedLLM.completion` was written against the **old** signature (with `_return_metrics`) and CI'd before the removal landed.

The release branch is the first tree where pyright type-checks both together.

> Note: this targets **`rel-1.29.0`**, not `main`. The `_return_metrics` removal is only on the release branch — on `main` the parameter still exists, so this override is correct there and must not be changed.

## Fix

Drop `_return_metrics` from the `_GatedLLM.completion` override — both the signature and the `super().completion(...)` call — to match the 4-positional signature on this branch. No behavior change.
