### PR TITLE
Generalize model config with family-based resolution

### DIFF
--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -458,7 +458,8 @@ def resolve_model_config(model_id: str) -> dict[str, Any]:
     entry.
     """
     if model_id in EXPLICIT_MODELS:
-        return dict(EXPLICIT_MODELS[model_id])
+        entry = EXPLICIT_MODELS[model_id]
+        return {**entry, "llm_config": dict(entry["llm_config"])}
 
     family = _resolve_family(model_id)
     if family is not None:

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -14,6 +14,7 @@ Outputs to GITHUB_OUTPUT:
 
 import json
 import os
+import re
 import signal
 import sys
 import time
@@ -44,8 +45,81 @@ if sigalrm := getattr(signal, "SIGALRM", None):
 SDK_ONLY_PARAMS = {"disable_vision", "inline_image_urls"}
 
 
-# Model configurations dictionary
-MODELS = {
+def _humanize_parts(model_id: str, prefix: str) -> str:
+    """Capitalize each hyphen-separated part after stripping ``prefix``.
+
+    Example: ``_humanize_parts("kimi-k2-thinking", "kimi-")`` -> ``"K2 Thinking"``.
+    """
+    rest = model_id.removeprefix(prefix)
+    return " ".join(part.capitalize() for part in rest.split("-"))
+
+
+# Family patterns for models whose config is fully derivable from the model ID.
+# A new version in an existing family (e.g. ``glm-5.2``) resolves automatically
+# without an explicit entry. First match wins.
+#
+# Each family defines:
+#   proxy_prefix  – LiteLLM proxy path prefix (model string = proxy_prefix + model_id)
+#   display_name  – callable(model_id) -> human-readable name
+#   llm_config    – default llm_config fields (temperature, top_p, disable_vision, …)
+FAMILIES: list[tuple[re.Pattern, dict[str, Any]]] = [
+    (
+        re.compile(r"^glm-"),
+        {
+            "proxy_prefix": "litellm_proxy/openrouter/z-ai/",
+            "display_name": lambda mid: "GLM-" + mid.removeprefix("glm-"),
+            "llm_config": {
+                "temperature": 0.0,
+                # OpenRouter GLM models are text-only despite LiteLLM reporting
+                # vision support. See #2110 (GLM-5), #1898 (GLM-4.7).
+                "disable_vision": True,
+            },
+        },
+    ),
+    (
+        re.compile(r"^kimi-k"),
+        {
+            "proxy_prefix": "litellm_proxy/moonshot/",
+            "display_name": lambda mid: "Kimi " + _humanize_parts(mid, "kimi-"),
+            "llm_config": {"temperature": 1.0},
+        },
+    ),
+    (
+        re.compile(r"^deepseek-"),
+        {
+            "proxy_prefix": "litellm_proxy/deepseek/",
+            "display_name": lambda mid: "DeepSeek " + _humanize_parts(mid, "deepseek-"),
+            "llm_config": {},
+        },
+    ),
+    (
+        re.compile(r"^claude-opus-"),
+        {
+            "proxy_prefix": "litellm_proxy/anthropic/",
+            "display_name": lambda mid: "Claude Opus "
+            + mid.removeprefix("claude-opus-").replace("-", "."),
+            "llm_config": {},
+        },
+    ),
+]
+
+
+def _resolve_family(model_id: str) -> dict[str, Any] | None:
+    """Return a copy of the matching family's defaults, or ``None``."""
+    for pattern, family in FAMILIES:
+        if pattern.match(model_id):
+            return {
+                "proxy_prefix": family["proxy_prefix"],
+                "display_name": family["display_name"](model_id),
+                "llm_config": dict(family["llm_config"]),
+            }
+    return None
+
+
+# Explicit model entries for models that **deviate** from their family pattern
+# (variant proxy strings, model-specific quirks, or families without a clean
+# pattern). Models that match a FAMILIES pattern do NOT need to be listed here.
+EXPLICIT_MODELS: dict[str, dict[str, Any]] = {
     "claude-sonnet-4-5-20250929": {
         "id": "claude-sonnet-4-5-20250929",
         "display_name": "Claude Sonnet 4.5",
@@ -54,24 +128,7 @@ MODELS = {
             "temperature": 0.0,
         },
     },
-    "kimi-k2-thinking": {
-        "id": "kimi-k2-thinking",
-        "display_name": "Kimi K2 Thinking",
-        "llm_config": {
-            "model": "litellm_proxy/moonshot/kimi-k2-thinking",
-            "temperature": 1.0,
-        },
-    },
-    # https://www.kimi.com/blog/kimi-k2-5.html
-    "kimi-k2.5": {
-        "id": "kimi-k2.5",
-        "display_name": "Kimi K2.5",
-        "llm_config": {
-            "model": "litellm_proxy/moonshot/kimi-k2.5",
-            "temperature": 1.0,
-            "top_p": 0.95,
-        },
-    },
+    # kimi-k2.6: family default + inline_image_urls quirk
     # https://www.kimi.com/blog/kimi-k2-6
     "kimi-k2.6": {
         "id": "kimi-k2.6",
@@ -85,7 +142,17 @@ MODELS = {
             "inline_image_urls": True,
         },
     },
-    # https://www.alibabacloud.com/help/en/model-studio/deep-thinking
+    # kimi-k2.5: family default + top_p override
+    # https://www.kimi.com/blog/kimi-k2-5.html
+    "kimi-k2.5": {
+        "id": "kimi-k2.5",
+        "display_name": "Kimi K2.5",
+        "llm_config": {
+            "model": "litellm_proxy/moonshot/kimi-k2.5",
+            "temperature": 1.0,
+            "top_p": 0.95,
+        },
+    },
     "qwen3-max-thinking": {
         "id": "qwen3-max-thinking",
         "display_name": "Qwen3 Max Thinking",
@@ -122,23 +189,8 @@ MODELS = {
         "id": "claude-4.6-opus",
         "display_name": "Claude 4.6 Opus",
         "llm_config": {
-            "model": "litellm_proxy/anthropic/claude-opus-4-6",
+            "model": "litellm_proxy/anthropic/claude-4-6",
             "temperature": 0.0,
-        },
-    },
-    "claude-opus-4-7": {
-        "id": "claude-opus-4-7",
-        "display_name": "Claude Opus 4.7",
-        "llm_config": {
-            "model": "litellm_proxy/anthropic/claude-opus-4-7",
-        },
-    },
-    # https://www.anthropic.com/news/claude-opus-4-8
-    "claude-opus-4-8": {
-        "id": "claude-opus-4-8",
-        "display_name": "Claude Opus 4.8",
-        "llm_config": {
-            "model": "litellm_proxy/anthropic/claude-opus-4-8",
         },
     },
     # https://www.anthropic.com/news/claude-fable-5
@@ -271,21 +323,11 @@ MODELS = {
             "top_p": 0.95,
         },
     },
+    # deepseek-v3.2-reasoner: variant proxy string (deepseek-reasoner)
     "deepseek-v3.2-reasoner": {
         "id": "deepseek-v3.2-reasoner",
         "display_name": "DeepSeek V3.2 Reasoner",
         "llm_config": {"model": "litellm_proxy/deepseek/deepseek-reasoner"},
-    },
-    # https://api-docs.deepseek.com/news/news260424
-    "deepseek-v4-pro": {
-        "id": "deepseek-v4-pro",
-        "display_name": "DeepSeek V4 Pro",
-        "llm_config": {"model": "litellm_proxy/deepseek/deepseek-v4-pro"},
-    },
-    "deepseek-v4-flash": {
-        "id": "deepseek-v4-flash",
-        "display_name": "DeepSeek V4 Flash",
-        "llm_config": {"model": "litellm_proxy/deepseek/deepseek-v4-flash"},
     },
     "qwen-3-coder": {
         "id": "qwen-3-coder",
@@ -301,36 +343,6 @@ MODELS = {
         "llm_config": {
             "model": "litellm_proxy/openai/NVIDIA-Nemotron-3-Nano-30B-A3B-FP8",
             "temperature": 0.0,
-        },
-    },
-    "glm-4.7": {
-        "id": "glm-4.7",
-        "display_name": "GLM-4.7",
-        "llm_config": {
-            "model": "litellm_proxy/openrouter/z-ai/glm-4.7",
-            "temperature": 0.0,
-            # OpenRouter glm-4.7 is text-only despite LiteLLM reporting vision support
-            "disable_vision": True,
-        },
-    },
-    "glm-5": {
-        "id": "glm-5",
-        "display_name": "GLM-5",
-        "llm_config": {
-            "model": "litellm_proxy/openrouter/z-ai/glm-5",
-            "temperature": 0.0,
-            # OpenRouter glm-5 is text-only despite LiteLLM reporting vision support
-            "disable_vision": True,
-        },
-    },
-    "glm-5.1": {
-        "id": "glm-5.1",
-        "display_name": "GLM-5.1",
-        "llm_config": {
-            "model": "litellm_proxy/openrouter/z-ai/glm-5.1",
-            "temperature": 0.0,
-            # OpenRouter glm-5.1 is text-only despite LiteLLM reporting vision support
-            "disable_vision": True,
         },
     },
     "qwen3-coder-next": {
@@ -434,6 +446,39 @@ MODELS = {
 }
 
 
+def resolve_model_config(model_id: str) -> dict[str, Any]:
+    """Resolve a model ID to its full configuration.
+
+    Models that match a ``FAMILIES`` pattern are derived automatically from
+    the family defaults — no explicit entry needed. Models that deviate from
+    their family pattern (variant proxy strings, quirks) or belong to a family
+    without a clean pattern must have an explicit entry in ``EXPLICIT_MODELS``.
+
+    Raises ``KeyError`` if the model ID matches no family and has no explicit
+    entry.
+    """
+    if model_id in EXPLICIT_MODELS:
+        return dict(EXPLICIT_MODELS[model_id])
+
+    family = _resolve_family(model_id)
+    if family is not None:
+        llm_config = dict(family["llm_config"])
+        llm_config["model"] = family["proxy_prefix"] + model_id
+        return {
+            "id": model_id,
+            "display_name": family["display_name"],
+            "llm_config": llm_config,
+        }
+
+    raise KeyError(model_id)
+
+
+# Backward-compatible dict of explicitly-registered models. Models that are
+# derived purely from a family pattern (e.g. glm-5, kimi-k2-thinking) are NOT
+# listed here but still resolve via ``find_models_by_id`` / ``resolve_model_config``.
+MODELS: dict[str, dict[str, Any]] = dict(EXPLICIT_MODELS)
+
+
 def error_exit(msg: str, exit_code: int = 1) -> None:
     """Print error message and exit."""
     print(f"ERROR: {msg}", file=sys.stderr)
@@ -451,6 +496,10 @@ def get_required_env(key: str) -> str:
 def find_models_by_id(model_ids: list[str]) -> list[dict]:
     """Find models by ID. Fails fast on missing ID.
 
+    Checks the ``MODELS`` dict first (which may be patched in tests), then
+    falls back to ``resolve_model_config`` for family-pattern-derived models
+    that are not explicitly registered.
+
     Args:
         model_ids: List of model IDs to find
 
@@ -462,12 +511,19 @@ def find_models_by_id(model_ids: list[str]) -> list[dict]:
     """
     resolved = []
     for model_id in model_ids:
-        if model_id not in MODELS:
-            available = ", ".join(sorted(MODELS.keys()))
+        if model_id in MODELS:
+            resolved.append(MODELS[model_id])
+            continue
+        try:
+            resolved.append(resolve_model_config(model_id))
+        except KeyError:
+            available = ", ".join(sorted(EXPLICIT_MODELS.keys()))
             error_exit(
-                f"Model ID '{model_id}' not found. Available models: {available}"
+                f"Model ID '{model_id}' not found. "
+                f"Available explicit models: {available}. "
+                f"Models matching a family pattern (e.g. glm-*) "
+                f"also resolve automatically."
             )
-        resolved.append(MODELS[model_id])
     return resolved
 
 

--- a/.github/run-eval/resolve_model_config.py
+++ b/.github/run-eval/resolve_model_config.py
@@ -189,7 +189,7 @@ EXPLICIT_MODELS: dict[str, dict[str, Any]] = {
         "id": "claude-4.6-opus",
         "display_name": "Claude 4.6 Opus",
         "llm_config": {
-            "model": "litellm_proxy/anthropic/claude-4-6",
+            "model": "litellm_proxy/anthropic/claude-opus-4-6",
             "temperature": 0.0,
         },
     },

--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -95,18 +95,17 @@ jobs:
                   import os
                   import sys
                   sys.path.insert(0, '.github/run-eval')
-                  from resolve_model_config import MODELS
+                  from resolve_model_config import find_models_by_id
 
                   model_ids = os.environ["MODEL_IDS"].split(",")
                   model_ids = [m.strip() for m in model_ids if m.strip()]
 
+                  # find_models_by_id exits with code 1 and prints a helpful
+                  # message if any model ID cannot be resolved.
+                  resolved = find_models_by_id(model_ids)
+
                   matrix = []
-                  for model_id in model_ids:
-                      if model_id not in MODELS:
-                          available = ", ".join(sorted(MODELS.keys()))
-                          print(f"Error: Model ID '{model_id}' not found. Available: {available}", file=sys.stderr)
-                          sys.exit(1)
-                      model = MODELS[model_id]
+                  for model_id, model in zip(model_ids, resolved):
                       # Create run-suffix from model id (replace special chars with underscore)
                       run_suffix = model_id.replace("-", "_").replace(".", "_") + "_run"
                       matrix.append({

--- a/.github/workflows/run-eval.yml
+++ b/.github/workflows/run-eval.yml
@@ -350,14 +350,25 @@ jobs:
                     MODELS_INPUT="$DEFAULT_MODEL"
                   fi
                   MODELS=$(printf '%s' "$MODELS_INPUT" | tr ', ' '\n' | sed '/^$/d' | paste -sd, -)
+
+                  # Validate model IDs using find_models_by_id (supports family-derived models)
                   ALLOWED_LIST=$(echo "$ALLOWED_MODEL_IDS_JSON" | jq -r '.[]')
-                  for MODEL in ${MODELS//,/ }; do
-                    if ! echo "$ALLOWED_LIST" | grep -Fx "$MODEL" >/dev/null; then
-                      echo "Model ID '$MODEL' not found in models.json" >&2
-                      echo "Available models: $(echo "$ALLOWED_LIST" | paste -sd, -)" >&2
-                      exit 1
-                    fi
-                  done
+                  MODEL_IDS_VALIDATED=$(MODELS="$MODELS" uv run python << 'EOF'
+                  import os, sys
+                  sys.path.insert(0, '.github/run-eval')
+                  from resolve_model_config import find_models_by_id
+                  models = os.environ.get("MODELS", "")
+                  model_ids = [m.strip() for m in models.split(",") if m.strip()]
+                  # find_models_by_id exits with code 1 and prints available models
+                  # if any ID cannot be resolved (including family-pattern matches).
+                  find_models_by_id(model_ids)
+                  print(",".join(model_ids))
+                  EOF
+                  )
+                  if [ $? -ne 0 ]; then
+                    echo "Available models: $(echo "$ALLOWED_LIST" | paste -sd, -)" >&2
+                    exit 1
+                  fi
 
                   # Sanitize values to avoid GITHUB_OUTPUT parse errors (e.g., raw SHAs)
                   SDK_SHA=$(printf '%s' "$SDK_SHA" | tr -d '\n\r')

--- a/tests/cross/test_resolve_model_config.py
+++ b/tests/cross/test_resolve_model_config.py
@@ -14,9 +14,11 @@ from pydantic import BaseModel, field_validator, model_validator
 run_eval_path = Path(__file__).parent.parent.parent / ".github" / "run-eval"
 sys.path.append(str(run_eval_path))
 from resolve_model_config import (  # noqa: E402  # type: ignore[import-not-found]
+    EXPLICIT_MODELS,
     MODELS,
     check_model,
     find_models_by_id,
+    resolve_model_config,
     run_preflight_check,
 )
 
@@ -214,15 +216,48 @@ def test_all_models_valid_with_pydantic():
     - temperature is between 0.0 and 2.0 (if present)
     - top_p is between 0.0 and 1.0 (if present)
     - reasoning_effort is one of 'low', 'medium', 'high' (if present)
+
+    Validates both explicit entries and family-derived models.
     """
+    # Collect all configs: explicit entries + family-derived models
+    all_configs = {}
+    for model_id in EXPLICIT_MODELS:
+        all_configs[model_id] = resolve_model_config(model_id)
+    # Also validate representative family-derived models (not in EXPLICIT_MODELS)
+    family_derived = [
+        "glm-4.7",
+        "glm-5",
+        "glm-5.1",
+        "glm-5.2",
+        "kimi-k2-thinking",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+    ]
+    for model_id in family_derived:
+        if model_id not in all_configs:
+            all_configs[model_id] = resolve_model_config(model_id)
+
     # This will raise ValidationError if any model is invalid
-    registry = EvalModelsRegistry(models=MODELS)
-    assert len(registry.models) == len(MODELS)
+    registry = EvalModelsRegistry(models=all_configs)
+    assert len(registry.models) == len(all_configs)
 
 
 def test_find_all_models():
     """Test that find_models_by_id works for all models."""
-    all_model_ids = list(MODELS.keys())
+    # All explicit model IDs + representative family-derived model IDs
+    all_model_ids = list(EXPLICIT_MODELS.keys()) + [
+        "glm-4.7",
+        "glm-5",
+        "glm-5.1",
+        "glm-5.2",
+        "kimi-k2-thinking",
+        "deepseek-v4-pro",
+        "deepseek-v4-flash",
+        "claude-opus-4-7",
+        "claude-opus-4-8",
+    ]
     result = find_models_by_id(all_model_ids)
 
     assert len(result) == len(all_model_ids)
@@ -260,7 +295,7 @@ def test_gpt_5_3_codex_config():
 
 def test_glm_5_config():
     """Test that glm-5 has correct configuration."""
-    model = MODELS["glm-5"]
+    model = resolve_model_config("glm-5")
 
     assert model["id"] == "glm-5"
     assert model["display_name"] == "GLM-5"
@@ -270,11 +305,22 @@ def test_glm_5_config():
 
 def test_glm_5_1_config():
     """Test that glm-5.1 has correct configuration."""
-    model = MODELS["glm-5.1"]
+    model = resolve_model_config("glm-5.1")
 
     assert model["id"] == "glm-5.1"
     assert model["display_name"] == "GLM-5.1"
     assert model["llm_config"]["model"] == "litellm_proxy/openrouter/z-ai/glm-5.1"
+    assert model["llm_config"]["disable_vision"] is True
+
+
+def test_glm_5_2_config():
+    """Test that glm-5.2 resolves automatically via the glm family pattern."""
+    model = resolve_model_config("glm-5.2")
+
+    assert model["id"] == "glm-5.2"
+    assert model["display_name"] == "GLM-5.2"
+    assert model["llm_config"]["model"] == "litellm_proxy/openrouter/z-ai/glm-5.2"
+    assert model["llm_config"]["temperature"] == 0.0
     assert model["llm_config"]["disable_vision"] is True
 
 
@@ -617,7 +663,7 @@ def test_trinity_large_thinking_config():
 
 def test_claude_opus_4_7_config():
     """Test that claude-opus-4-7 has correct configuration."""
-    model = MODELS["claude-opus-4-7"]
+    model = resolve_model_config("claude-opus-4-7")
 
     assert model["id"] == "claude-opus-4-7"
     assert model["display_name"] == "Claude Opus 4.7"
@@ -646,7 +692,7 @@ def test_gpt_5_5_config():
 
 def test_deepseek_v4_pro_config():
     """Test that deepseek-v4-pro has correct configuration."""
-    model = MODELS["deepseek-v4-pro"]
+    model = resolve_model_config("deepseek-v4-pro")
 
     assert model["id"] == "deepseek-v4-pro"
     assert model["display_name"] == "DeepSeek V4 Pro"
@@ -655,7 +701,7 @@ def test_deepseek_v4_pro_config():
 
 def test_deepseek_v4_flash_config():
     """Test that deepseek-v4-flash has correct configuration."""
-    model = MODELS["deepseek-v4-flash"]
+    model = resolve_model_config("deepseek-v4-flash")
 
     assert model["id"] == "deepseek-v4-flash"
     assert model["display_name"] == "DeepSeek V4 Flash"
@@ -711,7 +757,7 @@ def test_nemotron_3_ultra_550b_a55b_or_paid_config():
 
 def test_claude_opus_4_8_config():
     """Test that claude-opus-4-8 has correct configuration."""
-    model = MODELS["claude-opus-4-8"]
+    model = resolve_model_config("claude-opus-4-8")
 
     assert model["id"] == "claude-opus-4-8"
     assert model["display_name"] == "Claude Opus 4.8"


### PR DESCRIPTION
HUMAN: Generalize model config resolution so new model versions in existing families (e.g. glm-5.2) resolve automatically without a PR.

---

AGENT:

## Why

Every new model version required a 7-line config block in `MODELS`, even when the config was identical to other models in the same family (same proxy prefix, temperature, and flags). This meant a PR for every new model version — e.g. adding `glm-5.2` would have required another explicit entry.

## Summary

- Replaced the monolithic `MODELS` dict with `FAMILIES` (regex-pattern-based defaults) + `EXPLICIT_MODELS` (only deviant/quirky models)
- Added `resolve_model_config(model_id)` as the single entry point: explicit entry → family pattern → `KeyError`
- 4 families generalized: glm, kimi, deepseek, claude-opus — these cover the most frequently-updated model families
- `glm-5.2` resolves automatically via the `^glm-` pattern with zero config entries

## Issue Number

Relates to OpenHands/openhands-index-results#1224 (Benchmark GLM-5.2)

## How to Test

```bash
cd ~/work/software-agent-sdk
uv run pytest tests/cross/test_resolve_model_config.py -v
```

All 44 tests pass, including the new `test_glm_5_2_config` which verifies glm-5.2 resolves correctly:
- `id`: `glm-5.2`
- `display_name`: `GLM-5.2`
- `llm_config.model`: `litellm_proxy/openrouter/z-ai/glm-5.2`
- `llm_config.temperature`: `0.0`
- `llm_config.disable_vision`: `True`

Also verified manually that `find_models_by_id(["glm-5.2"])` returns the correct config, and that `resolve_model_config("glm-5.2")` derives all fields from the glm family pattern.

## Video/Screenshots

N/A — code refactor with unit test verification.

## Type

- [x] Refactor

## Notes

`MODELS` is retained as a backward-compatible alias of `EXPLICIT_MODELS` for `patch.dict` test compatibility. `find_models_by_id` checks `MODELS` first, then falls back to `resolve_model_config` for family-derived models.

_This PR was created by an AI agent (OpenHands) on behalf of the user._


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7e2454b-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7e2454b-python \
  ghcr.io/openhands/agent-server:7e2454b-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7e2454b-golang-amd64
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-golang-amd64
ghcr.io/openhands/agent-server:generalize-model-config-golang-amd64
ghcr.io/openhands/agent-server:7e2454b-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7e2454b-golang-arm64
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-golang-arm64
ghcr.io/openhands/agent-server:generalize-model-config-golang-arm64
ghcr.io/openhands/agent-server:7e2454b-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7e2454b-java-amd64
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-java-amd64
ghcr.io/openhands/agent-server:generalize-model-config-java-amd64
ghcr.io/openhands/agent-server:7e2454b-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7e2454b-java-arm64
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-java-arm64
ghcr.io/openhands/agent-server:generalize-model-config-java-arm64
ghcr.io/openhands/agent-server:7e2454b-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7e2454b-python-amd64
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-python-amd64
ghcr.io/openhands/agent-server:generalize-model-config-python-amd64
ghcr.io/openhands/agent-server:7e2454b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7e2454b-python-arm64
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-python-arm64
ghcr.io/openhands/agent-server:generalize-model-config-python-arm64
ghcr.io/openhands/agent-server:7e2454b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7e2454b-golang
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-golang
ghcr.io/openhands/agent-server:generalize-model-config-golang
ghcr.io/openhands/agent-server:7e2454b-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7e2454b-java
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-java
ghcr.io/openhands/agent-server:generalize-model-config-java
ghcr.io/openhands/agent-server:7e2454b-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7e2454b-python
ghcr.io/openhands/agent-server:7e2454b29c344db75f7ce091ed9bacf288d0c952-python
ghcr.io/openhands/agent-server:generalize-model-config-python
ghcr.io/openhands/agent-server:7e2454b-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7e2454b-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7e2454b-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->