### PR TITLE
fix(workspace): guard __del__ against partially-constructed instances

### DIFF
--- a/openhands-workspace/openhands/workspace/docker/workspace.py
+++ b/openhands-workspace/openhands/workspace/docker/workspace.py
@@ -361,7 +361,11 @@ class DockerWorkspace(RemoteWorkspace):
 
     def __del__(self) -> None:
         """Clean up the Docker container when the workspace is destroyed."""
-        self.cleanup()
+        # Guard against accessing private attributes during interpreter shutdown
+        # or on partially-constructed instances (e.g. when validation fails
+        # before private attributes are initialised).
+        if getattr(self, "__pydantic_private__", None) is not None:
+            self.cleanup()
 
     def cleanup(self) -> None:
         """Stop and remove the Docker container."""

--- a/openhands-workspace/openhands/workspace/remote_api/workspace.py
+++ b/openhands-workspace/openhands/workspace/remote_api/workspace.py
@@ -416,7 +416,11 @@ class APIRemoteWorkspace(RemoteWorkspace):
                 pass
 
     def __del__(self) -> None:
-        self.cleanup()
+        # Guard against accessing private attributes during interpreter shutdown
+        # or on partially-constructed instances (e.g. when validation fails
+        # before private attributes are initialised).
+        if getattr(self, "__pydantic_private__", None) is not None:
+            self.cleanup()
 
     def __enter__(self) -> "APIRemoteWorkspace":
         return self

--- a/tests/workspace/test_api_remote_workspace.py
+++ b/tests/workspace/test_api_remote_workspace.py
@@ -327,3 +327,17 @@ def test_api_remote_workspace_exit_sends_callback(monkeypatch):
         mock_client.post.assert_called_once()
         payload = mock_client.post.call_args.kwargs["json"]
         assert payload["status"] == "COMPLETED"
+
+
+def test_api_remote_workspace_del_on_partial_construction_is_safe():
+    """``__del__`` must not raise on a partially-constructed instance.
+
+    Mirrors the DockerWorkspace guard: if validation fails before
+    ``__pydantic_private__`` is initialised, ``__del__`` -> ``cleanup`` would
+    dereference ``_runtime_id`` and raise ``AttributeError``.
+    """
+    from openhands.workspace import APIRemoteWorkspace
+
+    workspace = object.__new__(APIRemoteWorkspace)
+    assert getattr(workspace, "__pydantic_private__", None) is None
+    workspace.__del__()

--- a/tests/workspace/test_docker_workspace.py
+++ b/tests/workspace/test_docker_workspace.py
@@ -270,3 +270,19 @@ def test_apptainer_workspace_startup_uses_health_check_timeout():
         mock_exec.return_value = Mock(returncode=0, stdout="", stderr="")
         ApptainerWorkspace(server_image="test:latest", health_check_timeout=45.0)
         mock_wait.assert_called_once_with(timeout=45.0)
+
+
+def test_docker_workspace_del_on_partial_construction_is_safe():
+    """``__del__`` must not raise on a partially-constructed instance.
+
+    When field validation fails (e.g. a wrong-typed field), pydantic raises
+    before ``__pydantic_private__`` is initialised. The orphaned instance is then
+    garbage collected and ``__del__`` -> ``cleanup`` dereferences ``_container_id``,
+    raising ``AttributeError`` (surfaced as "Exception ignored in __del__").
+    ``ApptainerWorkspace.__del__`` already guards this; ``DockerWorkspace`` must too.
+    """
+    workspace = object.__new__(DockerWorkspace)
+    # A partially-constructed instance has no pydantic private store.
+    assert getattr(workspace, "__pydantic_private__", None) is None
+    # Must be a no-op, not AttributeError.
+    workspace.__del__()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
Hit this myself when a workspace failed validation — del on the partial instance spammed "Exception ignored in del"; the guard matches the Apptainer/Cloud siblings.
<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

`DockerWorkspace.__del__` and `APIRemoteWorkspace.__del__` call `cleanup()`
unconditionally, and `cleanup()` dereferences pydantic `PrivateAttr`s
(`self._container_id` / `self._runtime_id`). When an instance is only
partially constructed — e.g. field validation fails before
`__pydantic_private__` is initialised — the orphaned instance's `__del__`
raises `AttributeError: ... object has no attribute '__pydantic_private__'`,
surfaced as a noisy "Exception ignored in __del__" during GC / interpreter
shutdown.

The sibling workspaces already guard exactly this case:
- `ApptainerWorkspace.__del__`: `if getattr(self, "__pydantic_private__", None) is not None: self.cleanup()` — comment *"Guard against accessing private attributes during interpreter shutdown"*.
- `CloudWorkspace.cleanup`: `try: ... except AttributeError: return` — comment *"Guard against __del__ on partially-constructed instances (e.g. when validation fails before all fields are initialised)"*.

Docker and APIRemote were the two outliers. This harmonises them to the
established pattern.

## Summary
- Guard `DockerWorkspace.__del__` and `APIRemoteWorkspace.__del__` with `if getattr(self, "__pydantic_private__", None) is not None:` before calling `cleanup()`, matching `ApptainerWorkspace`.
- Add a regression test for each, asserting `__del__` on a partially-constructed instance is a no-op instead of raising `AttributeError`.

## Issue Number
N/A

## How to Test

Install and run the new targeted tests:

```
uv pip install -e ./openhands-sdk -e ./openhands-workspace
uv run pytest \
  tests/workspace/test_docker_workspace.py::test_docker_workspace_del_on_partial_construction_is_safe \
  tests/workspace/test_api_remote_workspace.py::test_api_remote_workspace_del_on_partial_construction_is_safe -q
```

On `main` (before this change) both fail:
```
AttributeError: 'openhands.workspace.remote_api.workspace.APIRemoteWorkspace' object has no attribute '__pydantic_private__'
  .../remote_api/workspace.py:391: in cleanup -> if not self._runtime_id:
2 failed
```
With this change both pass (`2 passed`).

Realistic trigger without any test scaffolding (a field-type validation error
aborts construction before private attrs are set, then GC runs `__del__`):
```
uv run python -c "
from openhands.workspace import DockerWorkspace
import gc
try:
    DockerWorkspace(server_image='x', working_dir=123)
except Exception:
    pass
gc.collect()
"
```
On `main` this prints `Exception ignored in: <function DockerWorkspace.__del__ ...> AttributeError ...`; with the fix it is silent.

Full workspace regression: `uv run pytest tests/workspace/test_docker_workspace.py tests/workspace/test_api_remote_workspace.py tests/workspace/test_apptainer_workspace.py -q` → **33 passed**.

## Video/Screenshots
N/A — the change only affects destructor robustness to partial construction; covered by the red→green tests above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes
Semantics-preserving: no behaviour change on the happy path (a fully-constructed
workspace always has `__pydantic_private__` set, so `cleanup()` still runs). The
guard mirrors `ApptainerWorkspace.__del__` exactly. End-to-end container/VNC runs
were not exercised because the fix is confined to the destructor's robustness to
partial construction; the targeted tests plus the existing 33-test workspace
suite cover it.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.38s · commit 7c0a98c  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 4/4 hunks, 4/4 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 5.0% | No direct hunk selected |
| Weakened authentication | 3.0% | No direct hunk selected |
| Weakened authorization | 3.0% | No direct hunk selected |
| Contract regression | 8.0% | No direct hunk selected |
| Data loss | 4.0% | No direct hunk selected |
| Sensitive data disclosure | 2.0% | No direct hunk selected |
| Unexpected data transfer | 2.0% | No direct hunk selected |
| Credential misuse | 3.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 3.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 4.0% | No direct hunk selected |
| Security assessment bypass | 3.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 90.0% | No primary concern to locate |

</details>


<!-- jev-input-signature bc9aca210702e8fdd0ea36aa0d1028d89b3a6515b2d2c62662aa4faecbf808bf -->
<!-- jev-fast-audit:end -->
