### PR TITLE
feat(terminal): allow clients to configure TerminalTool session env

### DIFF
--- a/openhands-tools/openhands/tools/terminal/README.md
+++ b/openhands-tools/openhands/tools/terminal/README.md
@@ -7,6 +7,7 @@ The Terminal Tool provides a persistent shell session for executing bash command
 - **Persistent session**: Environment variables, virtual environments, and working directory persist between commands
 - **Multiple backend support**: Auto-detects and uses tmux when available, falls back to subprocess-based PTY
 - **Configurable shell**: Support for custom shell binaries (useful on Nix, macOS, or custom environments)
+- **Client-configured environment**: Add SDK-provided session environment variables without exposing them as tool-call parameters
 - **Long-running command support**: Handle commands with soft timeouts and interrupt capabilities
 - **Terminal reset**: Ability to reset the terminal session if it becomes unresponsive
 
@@ -36,6 +37,31 @@ tools = TerminalTool.create(
 If no explicit `shell_path` is provided, the tool automatically finds bash in your PATH using the equivalent of `which bash`. This works like `#!/usr/bin/env bash` and is portable across different systems.
 
 If bash cannot be found in PATH, the tool will raise a clear error asking you to provide an explicit `shell_path`.
+
+## Environment Configuration
+
+SDK clients can provide extra environment variables when creating the terminal
+tool. These values are merged with the sanitized process environment and apply to
+the terminal session until it is reset or closed. They are not part of
+`TerminalAction` and are not exposed in the model-facing tool schema.
+
+```python
+from openhands.sdk import Conversation
+from openhands.tools.terminal.definition import TerminalTool
+
+conversation = Conversation()
+tools = TerminalTool.create(
+    conv_state=conversation.state,
+    env={
+        "UV_INDEX_URL": "https://example.internal/simple",
+        "UV_CACHE_DIR": "/workspace/.cache/uv",
+    },
+)
+```
+
+Raw secret values passed through `env` become session-scoped environment
+variables. Use the SDK secret registry when you need command-scoped secret
+injection behavior.
 
 ## Usage Examples
 
@@ -155,4 +181,4 @@ chmod +x /path/to/bash  # If needed
 
 - The `shell_path` configuration only affects the subprocess terminal type; tmux terminals will use whatever shell tmux is configured to use
 - The shell must be bash-compatible for proper operation
-- On reset, the terminal session will preserve the originally configured shell path
+- On reset, the terminal session will preserve the originally configured shell path and client environment

--- a/openhands-tools/openhands/tools/terminal/definition.py
+++ b/openhands-tools/openhands/tools/terminal/definition.py
@@ -2,7 +2,7 @@
 
 import os
 import platform
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import Field
@@ -287,6 +287,7 @@ class TerminalTool(ToolDefinition[TerminalAction, TerminalObservation]):
         no_change_timeout_seconds: int | None = None,
         terminal_type: Literal["tmux", "subprocess", "powershell"] | None = None,
         shell_path: str | None = None,
+        env: Mapping[str, str] | None = None,
         executor: ToolExecutor | None = None,
     ) -> Sequence["TerminalTool"]:
         """Initialize TerminalTool with executor parameters.
@@ -305,6 +306,9 @@ class TerminalTool(ToolDefinition[TerminalAction, TerminalObservation]):
             shell_path: Path to the shell binary. On Unix this applies to the
                        subprocess backend; on Windows it can point to a
                        PowerShell executable.
+            env: Extra environment variables to add to the terminal session.
+                 These are client-controlled session settings and are not part
+                 of the LLM-facing TerminalAction schema.
         """
         # Import here to avoid circular imports
         from openhands.tools.terminal.impl import TerminalExecutor
@@ -321,6 +325,7 @@ class TerminalTool(ToolDefinition[TerminalAction, TerminalObservation]):
                 no_change_timeout_seconds=no_change_timeout_seconds,
                 terminal_type=terminal_type,
                 shell_path=shell_path,
+                env=env,
                 full_output_save_dir=conv_state.env_observation_persistence_dir,
             )
 

--- a/openhands-tools/openhands/tools/terminal/definition.py
+++ b/openhands-tools/openhands/tools/terminal/definition.py
@@ -287,8 +287,9 @@ class TerminalTool(ToolDefinition[TerminalAction, TerminalObservation]):
         no_change_timeout_seconds: int | None = None,
         terminal_type: Literal["tmux", "subprocess", "powershell"] | None = None,
         shell_path: str | None = None,
-        env: Mapping[str, str] | None = None,
         executor: ToolExecutor | None = None,
+        *,
+        env: Mapping[str, str] | None = None,
     ) -> Sequence["TerminalTool"]:
         """Initialize TerminalTool with executor parameters.
 

--- a/openhands-tools/openhands/tools/terminal/env.py
+++ b/openhands-tools/openhands/tools/terminal/env.py
@@ -1,0 +1,39 @@
+"""Environment helpers for terminal backends."""
+
+import re
+from collections.abc import Mapping
+
+from openhands.sdk.utils import sanitized_env
+
+
+ENV_VAR_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
+
+
+def normalize_terminal_env(
+    extra_env: Mapping[str, str] | None,
+) -> dict[str, str] | None:
+    """Validate and copy client-provided terminal environment variables."""
+    if extra_env is None:
+        return None
+
+    normalized: dict[str, str] = {}
+    for key, value in extra_env.items():
+        if not isinstance(key, str) or not ENV_VAR_NAME_RE.match(key):
+            raise ValueError(f"Invalid terminal environment variable name: {key!r}")
+        if not isinstance(value, str):
+            raise TypeError(
+                "Terminal environment variable values must be strings: "
+                f"{key!r}={value!r}"
+            )
+        normalized[key] = value
+    return normalized
+
+
+def build_terminal_env(extra_env: Mapping[str, str] | None = None) -> dict[str, str]:
+    """Return the sanitized process environment plus client-provided overrides."""
+    env = sanitized_env()
+    normalized = normalize_terminal_env(extra_env)
+    if normalized:
+        env.update(normalized)
+        env = sanitized_env(env)
+    return env

--- a/openhands-tools/openhands/tools/terminal/impl.py
+++ b/openhands-tools/openhands/tools/terminal/impl.py
@@ -1,6 +1,6 @@
-import re
 import threading
 import time
+from collections.abc import Mapping
 from contextlib import suppress
 from typing import TYPE_CHECKING, Literal
 
@@ -19,6 +19,10 @@ from openhands.tools.terminal.definition import (
     TerminalAction,
     TerminalObservation,
     looks_like_python_literal_argument,
+)
+from openhands.tools.terminal.env import (
+    ENV_VAR_NAME_RE,
+    normalize_terminal_env,
 )
 from openhands.tools.terminal.terminal.factory import (
     _is_tmux_available,
@@ -55,10 +59,6 @@ _TMUX_RECOVERABLE_ERROR_MARKERS = (
 
 logger = get_logger(__name__)
 
-# Environment variable names must be alphanumeric + underscores, starting with
-# a letter or underscore. This guards against shell injection via key names.
-_ENV_VAR_NAME_RE = re.compile(r"^[a-zA-Z_][a-zA-Z0-9_]*$")
-
 
 class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
     shell_path: str | None
@@ -70,6 +70,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         no_change_timeout_seconds: int | None = None,
         terminal_type: Literal["tmux", "subprocess", "powershell"] | None = None,
         shell_path: str | None = None,
+        env: Mapping[str, str] | None = None,
         full_output_save_dir: str | None = None,
         max_panes: int = DEFAULT_MAX_PANES,
     ):
@@ -85,6 +86,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
             shell_path: Path to the shell binary. On Unix this applies to the
                        subprocess backend; on Windows it can point to a
                        PowerShell executable.
+            env: Extra environment variables to add to the terminal session.
             full_output_save_dir: Path to directory to save full output
                                   logs and files, used when truncation is needed.
             max_panes: Maximum number of concurrent panes in pool mode.
@@ -94,6 +96,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         self._username = username
         self._no_change_timeout_seconds = no_change_timeout_seconds
         self._terminal_type = terminal_type
+        self._env = normalize_terminal_env(env)
         self._max_panes = max_panes
         self.full_output_save_dir: str | None = full_output_save_dir
 
@@ -115,6 +118,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
                 no_change_timeout_seconds=no_change_timeout_seconds,
                 terminal_type=terminal_type,
                 shell_path=shell_path,
+                env=self._env,
             )
             self._session.initialize()
             logger.info(
@@ -134,6 +138,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
         self._pool = TmuxPanePool(
             self._working_dir,
             self._username,
+            env=self._env,
             max_panes=self._max_panes,
         )
         self._pool.initialize()
@@ -288,7 +293,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
     ) -> str:
         valid: dict[str, str] = {}
         for key, value in env_vars.items():
-            if _ENV_VAR_NAME_RE.match(key):
+            if ENV_VAR_NAME_RE.match(key):
                 valid[key] = value
             else:
                 logger.warning("Skipping secret with invalid env var name: %r", key)
@@ -400,6 +405,7 @@ class TerminalExecutor(ToolExecutor[TerminalAction, TerminalObservation]):
             no_change_timeout_seconds=original_no_change_timeout,
             terminal_type=None,
             shell_path=self.shell_path,
+            env=self._env,
         )
         self._session.initialize()
 

--- a/openhands-tools/openhands/tools/terminal/terminal/factory.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/factory.py
@@ -3,6 +3,7 @@
 import platform
 import subprocess
 import warnings
+from collections.abc import Mapping
 from typing import Literal
 
 from openhands.sdk.logger import get_logger
@@ -64,6 +65,7 @@ def _create_windows_terminal(
     username: str | None,
     no_change_timeout_seconds: int | None,
     shell_path: str | None,
+    env: Mapping[str, str] | None,
 ) -> TerminalSession:
     from openhands.tools.terminal.terminal.windows_terminal import WindowsTerminal
 
@@ -71,7 +73,12 @@ def _create_windows_terminal(
     if resolved_shell_path is None:
         raise RuntimeError("PowerShell is not available on this system")
 
-    terminal = WindowsTerminal(work_dir, username, shell_path=resolved_shell_path)
+    terminal = WindowsTerminal(
+        work_dir,
+        username,
+        shell_path=resolved_shell_path,
+        env=env,
+    )
     return TerminalSession(terminal, no_change_timeout_seconds)
 
 
@@ -81,6 +88,7 @@ def create_terminal_session(
     no_change_timeout_seconds: int | None = None,
     terminal_type: Literal["tmux", "subprocess", "powershell"] | None = None,
     shell_path: str | None = None,
+    env: Mapping[str, str] | None = None,
 ) -> TerminalSession:
     """Create an appropriate terminal session based on system capabilities.
 
@@ -92,6 +100,7 @@ def create_terminal_session(
             or 'powershell'). If None, auto-detect based on system capabilities.
         shell_path: Path to the shell binary. On Unix this is used for the
             subprocess backend; on Windows it can point to a PowerShell binary.
+        env: Extra environment variables to add to the terminal session.
 
     Returns:
         TerminalSession instance
@@ -106,7 +115,7 @@ def create_terminal_session(
             from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
             logger.info("Using forced TmuxTerminal")
-            terminal = TmuxTerminal(work_dir, username)
+            terminal = TmuxTerminal(work_dir, username, env=env)
             return TerminalSession(terminal, no_change_timeout_seconds)
 
         if terminal_type == "powershell":
@@ -116,6 +125,7 @@ def create_terminal_session(
                 username,
                 no_change_timeout_seconds,
                 shell_path,
+                env,
             )
 
         if terminal_type == "subprocess":
@@ -130,13 +140,14 @@ def create_terminal_session(
                     username,
                     no_change_timeout_seconds,
                     shell_path,
+                    env,
                 )
             from openhands.tools.terminal.terminal.subprocess_terminal import (
                 SubprocessTerminal,
             )
 
             logger.info("Using forced SubprocessTerminal")
-            terminal = SubprocessTerminal(work_dir, username, shell_path)
+            terminal = SubprocessTerminal(work_dir, username, shell_path, env=env)
             return TerminalSession(terminal, no_change_timeout_seconds)
 
         raise ValueError(f"Unknown session type: {terminal_type}")
@@ -148,13 +159,14 @@ def create_terminal_session(
             username,
             no_change_timeout_seconds,
             shell_path,
+            env,
         )
 
     if _is_tmux_available():
         from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
         logger.info("Auto-detected: Using TmuxTerminal (tmux available)")
-        terminal = TmuxTerminal(work_dir, username)
+        terminal = TmuxTerminal(work_dir, username, env=env)
         return TerminalSession(terminal, no_change_timeout_seconds)
 
     from openhands.tools.terminal.terminal.subprocess_terminal import (
@@ -168,5 +180,5 @@ def create_terminal_session(
     )
     logger.warning(_tmux_warning)
     warnings.warn(_tmux_warning, stacklevel=2)
-    terminal = SubprocessTerminal(work_dir, username, shell_path)
+    terminal = SubprocessTerminal(work_dir, username, shell_path, env=env)
     return TerminalSession(terminal, no_change_timeout_seconds)

--- a/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py
@@ -9,6 +9,7 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Mapping
 
 
 if platform.system() == "Windows":
@@ -22,11 +23,14 @@ import pty
 import select
 
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.constants import (
     CMD_OUTPUT_PS1_BEGIN,
     CMD_OUTPUT_PS1_END,
     HISTORY_LIMIT,
+)
+from openhands.tools.terminal.env import (
+    build_terminal_env,
+    normalize_terminal_env,
 )
 from openhands.tools.terminal.metadata import CmdOutputMetadata
 from openhands.tools.terminal.terminal import TerminalInterface
@@ -84,6 +88,7 @@ class SubprocessTerminal(TerminalInterface):
         work_dir: str,
         username: str | None = None,
         shell_path: str | None = None,
+        env: Mapping[str, str] | None = None,
     ):
         super().__init__(work_dir, username)
         self.PS1 = CmdOutputMetadata.to_ps1_prompt()
@@ -96,6 +101,7 @@ class SubprocessTerminal(TerminalInterface):
         self.reader_thread = None
         self._current_command_running = False
         self.shell_path = shell_path
+        self._env = normalize_terminal_env(env)
 
     # ------------------------- Lifecycle -------------------------
 
@@ -136,7 +142,7 @@ class SubprocessTerminal(TerminalInterface):
         logger.info(f"Using shell: {resolved_shell_path}")
 
         # Inherit environment variables from the parent process
-        env = sanitized_env()
+        env = build_terminal_env(self._env)
         # Disable interactive pagers (git, man, systemctl, ...) so commands that
         # auto-launch `less` on a TTY don't capture the PTY and wedge the session.
         env.setdefault("GIT_PAGER", "cat")

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py
@@ -10,7 +10,7 @@ import threading
 import time
 import uuid
 from collections import deque
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from contextlib import contextmanager, suppress
 from dataclasses import dataclass, field
 from typing import Final
@@ -18,12 +18,15 @@ from typing import Final
 import libtmux
 
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.constants import (
     HISTORY_LIMIT,
     TMUX_SESSION_HEIGHT,
     TMUX_SESSION_WIDTH,
     TMUX_SOCKET_NAME,
+)
+from openhands.tools.terminal.env import (
+    build_terminal_env,
+    normalize_terminal_env,
 )
 from openhands.tools.terminal.terminal.tmux_terminal import TmuxTerminal
 
@@ -80,6 +83,7 @@ class TmuxPanePool:
 
     work_dir: str
     username: str | None = None
+    env: Mapping[str, str] | None = None
     max_panes: int = DEFAULT_MAX_PANES
 
     # tmux handles
@@ -105,6 +109,7 @@ class TmuxPanePool:
     def __post_init__(self) -> None:
         if self.max_panes < 1:
             raise ValueError(f"max_panes must be >= 1, but got {self.max_panes}.")
+        self.env = normalize_terminal_env(self.env)
         self._semaphore = threading.Semaphore(self.max_panes)
 
     def initialize(self) -> None:
@@ -112,7 +117,7 @@ class TmuxPanePool:
         if self._initialized:
             return
 
-        env = sanitized_env()
+        env = build_terminal_env(self.env)
         self._server = libtmux.Server(socket_name=TMUX_SOCKET_NAME, environment=env)
         session_name = f"openhands-pool-{self.username}-{uuid.uuid4()}"
         self._session = self._server.new_session(
@@ -182,7 +187,11 @@ class TmuxPanePool:
 
         # Use PooledTmuxTerminal which overrides close() to only kill
         # this terminal's window instead of the entire shared tmux session.
-        terminal = PooledTmuxTerminal(work_dir=self.work_dir, username=self.username)
+        terminal = PooledTmuxTerminal(
+            work_dir=self.work_dir,
+            username=self.username,
+            env=self.env,
+        )
         terminal.server = self._server  # type: ignore[assignment]
         terminal.session = self._session
         terminal.window = window

--- a/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py
@@ -2,16 +2,20 @@
 
 import time
 import uuid
+from collections.abc import Mapping
 
 import libtmux
 
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.constants import (
     HISTORY_LIMIT,
     TMUX_SESSION_HEIGHT,
     TMUX_SESSION_WIDTH,
     TMUX_SOCKET_NAME,
+)
+from openhands.tools.terminal.env import (
+    build_terminal_env,
+    normalize_terminal_env,
 )
 from openhands.tools.terminal.metadata import CmdOutputMetadata
 from openhands.tools.terminal.terminal import TerminalInterface
@@ -57,16 +61,18 @@ class TmuxTerminal(TerminalInterface):
         self,
         work_dir: str,
         username: str | None = None,
+        env: Mapping[str, str] | None = None,
     ):
         super().__init__(work_dir, username)
         self.PS1 = CmdOutputMetadata.to_ps1_prompt()
+        self._env = normalize_terminal_env(env)
 
     def initialize(self) -> None:
         """Initialize the tmux terminal session."""
         if self._initialized:
             return
 
-        env = sanitized_env()
+        env = build_terminal_env(self._env)
         # Disable interactive pagers (git, man, systemctl, ...) so commands that
         # auto-launch `less` on a TTY don't capture the pane and wedge the session.
         env.setdefault("GIT_PAGER", "cat")

--- a/openhands-tools/openhands/tools/terminal/terminal/windows_terminal.py
+++ b/openhands-tools/openhands/tools/terminal/terminal/windows_terminal.py
@@ -10,13 +10,17 @@ import subprocess
 import threading
 import time
 from collections import deque
+from collections.abc import Mapping
 
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils import sanitized_env
 from openhands.tools.terminal.constants import (
     CMD_OUTPUT_PS1_BEGIN,
     CMD_OUTPUT_PS1_END,
     HISTORY_LIMIT,
+)
+from openhands.tools.terminal.env import (
+    build_terminal_env,
+    normalize_terminal_env,
 )
 from openhands.tools.terminal.terminal.interface import (
     TerminalInterface,
@@ -70,6 +74,7 @@ class WindowsTerminal(TerminalInterface):
         work_dir: str,
         username: str | None = None,
         shell_path: str = "powershell.exe",
+        env: Mapping[str, str] | None = None,
     ):
         super().__init__(work_dir, username)
         self.process = None
@@ -77,6 +82,7 @@ class WindowsTerminal(TerminalInterface):
         self.output_lock = threading.Lock()
         self.reader_thread = None
         self.shell_path = shell_path
+        self._env = normalize_terminal_env(env)
         self._command_running_event = threading.Event()
         self._stop_reader = threading.Event()
         self._decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
@@ -96,7 +102,7 @@ class WindowsTerminal(TerminalInterface):
             creationflags = getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0)
             creationflags |= getattr(subprocess, "CREATE_NO_WINDOW", 0)
 
-        env = sanitized_env()
+        env = build_terminal_env(self._env)
         env.setdefault("PYTHONIOENCODING", "utf-8")
         env.setdefault("PYTHONUTF8", "1")
 

--- a/tests/tools/terminal/test_conversation_cleanup.py
+++ b/tests/tools/terminal/test_conversation_cleanup.py
@@ -6,7 +6,7 @@ when conversations are closed or destroyed.
 """
 
 import tempfile
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, ClassVar, Literal
 from unittest.mock import Mock
 
@@ -39,6 +39,8 @@ class _InjectedExecutorTerminalTool(TerminalTool):
         terminal_type: Literal["tmux", "subprocess", "powershell"] | None = None,
         shell_path: str | None = None,
         executor: ToolExecutor | None = None,
+        *,
+        env: Mapping[str, str] | None = None,
     ) -> Sequence[TerminalTool]:
         tools = TerminalTool.create(
             conv_state,
@@ -47,6 +49,7 @@ class _InjectedExecutorTerminalTool(TerminalTool):
             terminal_type=terminal_type,
             shell_path=shell_path,
             executor=executor,
+            env=env,
         )
         return [
             tool.model_copy(update={"executor": cls.injected_executor})

--- a/tests/tools/terminal/test_terminal_tool.py
+++ b/tests/tools/terminal/test_terminal_tool.py
@@ -1,8 +1,10 @@
 """Tests for TerminalTool subclass."""
 
+import platform
 import tempfile
 from uuid import uuid4
 
+import pytest
 from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
@@ -105,3 +107,45 @@ def test_bash_tool_to_openai_tool():
         assert openai_tool["function"]["name"] == "terminal"
         assert "description" in openai_tool["function"]
         assert "parameters" in openai_tool["function"]
+
+
+@pytest.mark.skipif(
+    platform.system() == "Windows",
+    reason="This test uses POSIX shell environment variable syntax.",
+)
+def test_terminal_tool_client_env_is_session_scoped_and_schema_hidden(monkeypatch):
+    """Test that client env config reaches the shell without becoming action input."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        monkeypatch.setenv("OH_CLIENT_ENV_TEST", "parent-value")
+        conv_state = _create_test_conv_state(temp_dir)
+        tools = TerminalTool.create(
+            conv_state,
+            terminal_type="subprocess",
+            env={"OH_CLIENT_ENV_TEST": "client-value"},
+        )
+        tool = tools[0]
+        assert tool.executor is not None
+
+        properties = tool.action_type.model_json_schema()["properties"]
+        assert "env" not in properties
+
+        action = TerminalAction(command='printf "%s" "$OH_CLIENT_ENV_TEST"')
+        result = tool(action)
+        assert isinstance(result, TerminalObservation)
+        assert "client-value" in result.text
+        assert "parent-value" not in result.text
+
+        tool(TerminalAction(command="", reset=True))
+        result_after_reset = tool(action)
+        assert isinstance(result_after_reset, TerminalObservation)
+        assert "client-value" in result_after_reset.text
+
+        tool.executor.close()
+
+
+def test_terminal_tool_client_env_rejects_invalid_names():
+    """Test that client env keys must be valid shell environment names."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+        with pytest.raises(ValueError, match="Invalid terminal environment"):
+            TerminalTool.create(conv_state, env={"INVALID-NAME": "value"})


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
I tested this functionality. It does not break anything but adds useful enhancement to the TerminalTool.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<! AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

SDK clients currently have no supported way to configure non-LLM-controlled environment variables for `TerminalTool` sessions. The workaround is to ask the model to run `export ...` or prefix commands manually, which mixes client runtime setup with model-generated actions.

This PR adds a narrow client-side session configuration path while keeping `env` out of `TerminalAction` and out of the model-facing tool schema.

## Summary

- Adds client-configured `env` support to `TerminalTool.create()` / `TerminalExecutor`.
- Propagates the merged sanitized environment through subprocess, tmux, tmux pane pool, and PowerShell terminal backends.
- Adds regression coverage and README docs showing that env is session-scoped and not model-facing.

## Issue Number

Fixes #3812

## How to Test

Focused checks:

```bash
uv run pre-commit run --files openhands-tools/openhands/tools/terminal/env.py openhands-tools/openhands/tools/terminal/definition.py openhands-tools/openhands/tools/terminal/impl.py openhands-tools/openhands/tools/terminal/terminal/factory.py openhands-tools/openhands/tools/terminal/terminal/subprocess_terminal.py openhands-tools/openhands/tools/terminal/terminal/tmux_terminal.py openhands-tools/openhands/tools/terminal/terminal/tmux_pane_pool.py openhands-tools/openhands/tools/terminal/terminal/windows_terminal.py openhands-tools/openhands/tools/terminal/README.md tests/tools/terminal/test_terminal_tool.py
# passed
```

```bash
uv run pytest tests/tools/terminal/test_terminal_tool.py -q
# 7 passed in 16.38s
```

```bash
uv run pytest tests/tools/terminal/test_shell_path_configuration.py tests/tools/terminal/test_session_factory.py -q
# 16 passed, 1 warning in 8.60s
```

End-to-end smoke run:

```bash
uv run python - <<'PY'
import tempfile
from uuid import uuid4
from pydantic import SecretStr
from openhands.sdk.agent import Agent
from openhands.sdk.conversation.state import ConversationState
from openhands.sdk.llm import LLM
from openhands.sdk.workspace import LocalWorkspace
from openhands.tools.terminal import TerminalAction, TerminalTool

with tempfile.TemporaryDirectory() as temp_dir:
    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="smoke")
    agent = Agent(llm=llm, tools=[])
    state = ConversationState.create(
        id=uuid4(),
        agent=agent,
        workspace=LocalWorkspace(working_dir=temp_dir),
    )
    terminal = TerminalTool.create(
        state,
        terminal_type="subprocess",
        env={"OH_CLIENT_ENV_SMOKE": "smoke-value"},
    )[0]
    assert "env" not in terminal.action_type.model_json_schema()["properties"]
    obs = terminal(TerminalAction(command='printf "%s" "$OH_CLIENT_ENV_SMOKE"'))
    assert "smoke-value" in obs.text
    print("SMOKE_OK env_visible=True schema_contains_env=False")
    assert terminal.executor is not None
    terminal.executor.close()
PY
```

Observed output:

```text
SMOKE_OK env_visible=True schema_contains_env=False
```

## Video/Screenshots

N/A. This is a terminal/backend SDK change; the smoke run above exercises the behavior end-to-end through real `TerminalTool` creation and execution.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Example client usage:

```python
terminal = TerminalTool.create(
    state,
    terminal_type="subprocess",
    env={
        "VIRTUAL_ENV": "/workspace/.venv",
        "PIP_INDEX_URL": "https://example.internal/simple",
    },
)[0]

obs = terminal(TerminalAction(command='printf "%s" "$PIP_INDEX_URL"'))
```

This keeps session-level environment configuration under client control while leaving `env` out of `TerminalAction` and out of the model-facing tool schema.

Non-goals for this first slice:

- Does not add `env` to `TerminalAction`.
- Does not expose env control to the model-facing tool schema.
- Does not change command-scoped secret behavior.
- Does not change agent-server `/bash`.
- Does not touch `InteractiveTerminalToolSet`.

Co-authored-by: Codex
