### PR TITLE
Document OpenRouter attribution URL stability

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -280,6 +280,8 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         default=None,
     )
 
+    # OpenRouter uses HTTP-Referer as the app identity for rankings.
+    # Keep this stable unless the OpenRouter app attribution is migrated.
     openrouter_site_url: str = Field(
         default="https://docs.all-hands.dev/",
     )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
This PR initially proposes to change the OpenHands URL for OpenRouter, but on further thought, my agent found that OpenRouter uses the URL as identifier of the app, so we’d likely lose history/rankings on change.

So instead, we’re documenting this, for future agents to surface it if the issue ever comes up again.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<! AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

OpenRouter uses the `HTTP-Referer` header as the app URL and primary ranking identity. During review of the old OpenHands docs URL default, we verified that changing this value could split OpenRouter app attribution/rankings. This PR documents why the default must remain stable unless the OpenRouter attribution identity is migrated first.

Official OpenRouter source checked: https://openrouter.ai/docs/app-attribution

Relevant quote from that page:

> The HTTP-Referer header identifies your app’s URL and is used as the primary identifier for rankings. This header is required for app attribution — without it, no app page will be created and your usage will not appear in rankings. Your app’s URL becomes its unique identifier in the system.

## Summary

- Preserve the existing OpenRouter `HTTP-Referer` default (`https://docs.all-hands.dev/`).
- Add a short SDK code note explaining that the value is intentionally stable for OpenRouter rankings/app attribution.

## Issue Number

N/A

## How to Test

I verified the change with targeted SDK checks from the repository root.

Pre-commit on the touched files:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/config/test_llm_config.py tests/sdk/context/condenser/test_llm_summarizing_condenser.py examples/01_standalone_sdk/37_llm_profile_store/profiles/fast.json
```

Result:

```text
Format YAML files....................................(no files to check)Skipped
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
Check import dependency rules............................................Passed
Check Tool subclass registration.........................................Passed
```

Focused tests covering the OpenRouter default and per-call header forwarding:

```bash
uv run pytest tests/sdk/config/test_llm_config.py::test_llm_config_openrouter_defaults tests/sdk/llm/test_chat_options.py::test_chat_options_injects_openrouter_headers_via_extra_headers tests/sdk/llm/test_chat_options.py::test_chat_options_user_extra_headers_win_over_openrouter_defaults -q
```

Result:

```text
3 passed, 5 warnings in 0.35s
```

Whitespace check:

```bash
git diff --check
```

Result: passed with no output.

End-to-end behavior note: this PR intentionally does not change runtime behavior. The existing OpenRouter header path remains covered by the focused tests above, which exercise `LLM.openrouter_site_url` and `select_chat_options()` header injection/override behavior through the real SDK code path.

## Video/Screenshots

N/A — this is an SDK code-comment-only change with no UI behavior.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR was updated after verifying OpenRouter’s official App Attribution documentation. Changing the default URL would risk splitting the app identity used for rankings, so the code now documents why the old URL is intentionally preserved.

_This PR was updated by an AI agent (OpenHands) on behalf of the user._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2e44660-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2e44660-python \
  ghcr.io/openhands/agent-server:2e44660-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2e44660-golang-amd64
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-golang-amd64
ghcr.io/openhands/agent-server:update-openrouter-site-url-golang-amd64
ghcr.io/openhands/agent-server:2e44660-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2e44660-golang-arm64
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-golang-arm64
ghcr.io/openhands/agent-server:update-openrouter-site-url-golang-arm64
ghcr.io/openhands/agent-server:2e44660-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2e44660-java-amd64
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-java-amd64
ghcr.io/openhands/agent-server:update-openrouter-site-url-java-amd64
ghcr.io/openhands/agent-server:2e44660-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2e44660-java-arm64
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-java-arm64
ghcr.io/openhands/agent-server:update-openrouter-site-url-java-arm64
ghcr.io/openhands/agent-server:2e44660-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2e44660-python-amd64
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-python-amd64
ghcr.io/openhands/agent-server:update-openrouter-site-url-python-amd64
ghcr.io/openhands/agent-server:2e44660-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2e44660-python-arm64
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-python-arm64
ghcr.io/openhands/agent-server:update-openrouter-site-url-python-arm64
ghcr.io/openhands/agent-server:2e44660-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2e44660-golang
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-golang
ghcr.io/openhands/agent-server:update-openrouter-site-url-golang
ghcr.io/openhands/agent-server:2e44660-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2e44660-java
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-java
ghcr.io/openhands/agent-server:update-openrouter-site-url-java
ghcr.io/openhands/agent-server:2e44660-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2e44660-python
ghcr.io/openhands/agent-server:2e4466066f21185e8f37ef41a7a185fddbe27723-python
ghcr.io/openhands/agent-server:update-openrouter-site-url-python
ghcr.io/openhands/agent-server:2e44660-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2e44660-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2e44660-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->