### PR TITLE
chore: remove unused httpx import in llm.py

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -10,7 +10,6 @@ from collections.abc import Callable, Sequence
 from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, get_args, get_origin
 
-import httpx  # noqa: F401
 from pydantic import (
     BaseModel,
     ConfigDict,


### PR DESCRIPTION
HUMAN:

Removing unused import.

---

AGENT:

## Why

`openhands-sdk/openhands/sdk/llm/llm.py` has an `import httpx  # noqa: F401` at the top that is never used. The only other `httpx` occurrence in the file is the **string** `module="httpx.*"` passed to `warnings.filterwarnings(...)`. That argument is matched as a regex against the originating warning's module `__name__` at warning-emit time — it does not reference the imported `httpx` symbol, so the import is dead. The `# noqa: F401` was merely suppressing the linter that would otherwise flag it.

## Summary

- Remove the unused `import httpx  # noqa: F401` from `openhands-sdk/openhands/sdk/llm/llm.py`.

## Issue Number

N/A

## How to Test

```
# only remaining httpx reference is the regex string in filterwarnings
grep -n "httpx" openhands-sdk/openhands/sdk/llm/llm.py
# -> 1864: ... module="httpx.*"

# module still compiles
python -m py_compile openhands-sdk/openhands/sdk/llm/llm.py   # -> no errors
```

The `warnings.filterwarnings(..., module="httpx.*")` call continues to work unchanged because it relies on the string pattern, not the import. No behavior change.

## Video/Screenshots

N/A — removal of a dead import; no runtime or UI behavior changes.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs / chore

## Notes

Pure cleanup. No functional impact.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8890cb9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8890cb9-python \
  ghcr.io/openhands/agent-server:8890cb9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8890cb9-golang-amd64
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-golang-amd64
ghcr.io/openhands/agent-server:remove-unused-httpx-import-golang-amd64
ghcr.io/openhands/agent-server:8890cb9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8890cb9-golang-arm64
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-golang-arm64
ghcr.io/openhands/agent-server:remove-unused-httpx-import-golang-arm64
ghcr.io/openhands/agent-server:8890cb9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8890cb9-java-amd64
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-java-amd64
ghcr.io/openhands/agent-server:remove-unused-httpx-import-java-amd64
ghcr.io/openhands/agent-server:8890cb9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8890cb9-java-arm64
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-java-arm64
ghcr.io/openhands/agent-server:remove-unused-httpx-import-java-arm64
ghcr.io/openhands/agent-server:8890cb9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8890cb9-python-amd64
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-python-amd64
ghcr.io/openhands/agent-server:remove-unused-httpx-import-python-amd64
ghcr.io/openhands/agent-server:8890cb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8890cb9-python-arm64
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-python-arm64
ghcr.io/openhands/agent-server:remove-unused-httpx-import-python-arm64
ghcr.io/openhands/agent-server:8890cb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8890cb9-golang
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-golang
ghcr.io/openhands/agent-server:remove-unused-httpx-import-golang
ghcr.io/openhands/agent-server:8890cb9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8890cb9-java
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-java
ghcr.io/openhands/agent-server:remove-unused-httpx-import-java
ghcr.io/openhands/agent-server:8890cb9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8890cb9-python
ghcr.io/openhands/agent-server:8890cb9f7837a56e6fff6a0ac71912579b45a99f-python
ghcr.io/openhands/agent-server:remove-unused-httpx-import-python
ghcr.io/openhands/agent-server:8890cb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8890cb9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8890cb9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->