### PR TITLE
chore: drop redundant TYPE_CHECKING SystemPromptEvent import in critic.py

### DIFF
--- a/openhands-sdk/openhands/sdk/critic/impl/api/critic.py
+++ b/openhands-sdk/openhands/sdk/critic/impl/api/critic.py
@@ -12,7 +12,7 @@ from openhands.sdk.critic.impl.api.taxonomy import categorize_features
 
 
 if TYPE_CHECKING:
-    from openhands.sdk.event import LLMConvertibleEvent, SystemPromptEvent
+    from openhands.sdk.event import LLMConvertibleEvent
 
 
 def _format_feature_list(features: list[dict[str, Any]]) -> str:


### PR DESCRIPTION
HUMAN:

Removed unused type hint.

---

AGENT:

## Why

In `openhands-sdk/openhands/sdk/critic/impl/api/critic.py`, `SystemPromptEvent` was imported twice:

- Module-level under `TYPE_CHECKING` (line 15).
- Inside `APIBasedCritic.evaluate` as a local import (line 65), needed at runtime for `isinstance(event, SystemPromptEvent)`.

`SystemPromptEvent` is only ever referenced inside the function body (the local annotation and the runtime `isinstance`), never at module scope, so the `TYPE_CHECKING` copy is redundant. (`LLMConvertibleEvent` is kept in both places: the module-level import resolves the `evaluate` signature annotation `Sequence[LLMConvertibleEvent]`, and the local import is used at runtime via `LLMConvertibleEvent.events_to_messages(...)`.)

## Summary

- Remove `SystemPromptEvent` from the module-level `TYPE_CHECKING` import, keeping the function-body import that is required at runtime.

## Issue Number

N/A

## How to Test

```
# module still compiles
python -m py_compile openhands-sdk/openhands/sdk/critic/impl/api/critic.py   # -> no errors

# SystemPromptEvent now imported only in the function body (runtime), not at module scope
grep -n "SystemPromptEvent" openhands-sdk/openhands/sdk/critic/impl/api/critic.py
```

The runtime `isinstance(event, SystemPromptEvent)` check still resolves via the retained local import, so `evaluate` behavior is unchanged.

## Video/Screenshots

N/A — import cleanup; no runtime or UI behavior changes.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [x] Docs / chore

## Notes

Pure cleanup. No functional impact.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:337b180-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-337b180-python \
  ghcr.io/openhands/agent-server:337b180-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:337b180-golang-amd64
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-golang-amd64
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-golang-amd64
ghcr.io/openhands/agent-server:337b180-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:337b180-golang-arm64
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-golang-arm64
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-golang-arm64
ghcr.io/openhands/agent-server:337b180-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:337b180-java-amd64
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-java-amd64
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-java-amd64
ghcr.io/openhands/agent-server:337b180-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:337b180-java-arm64
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-java-arm64
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-java-arm64
ghcr.io/openhands/agent-server:337b180-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:337b180-python-amd64
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-python-amd64
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-python-amd64
ghcr.io/openhands/agent-server:337b180-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:337b180-python-arm64
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-python-arm64
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-python-arm64
ghcr.io/openhands/agent-server:337b180-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:337b180-golang
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-golang
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-golang
ghcr.io/openhands/agent-server:337b180-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:337b180-java
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-java
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-java
ghcr.io/openhands/agent-server:337b180-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:337b180-python
ghcr.io/openhands/agent-server:337b180cc50183160d61d78b80e680dcaa0a1689-python
ghcr.io/openhands/agent-server:dedup-systempromptevent-import-python
ghcr.io/openhands/agent-server:337b180-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `337b180-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `337b180-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->