### PR TITLE
feat(marketplace): auto-load registered marketplace plugins

### DIFF
--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -216,6 +216,8 @@ class AgentContext(BaseModel):
     @model_validator(mode="after")
     def _load_auto_skills(self):
         """Load user and/or legacy public skills if enabled."""
+        # Any marketplace registration opts the context out of the legacy
+        # public-skills path, even when the registration is resolution-only.
         include_public = self.load_public_skills and not self.registered_marketplaces
         if not self.load_user_skills and not include_public:
             return self

--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -116,7 +116,7 @@ class AgentContext(BaseModel):
         default_factory=list,
         description=(
             "Marketplace registrations for plugin resolution. Registrations with "
-            "auto_load='all' are resolved by LocalConversation at startup."
+            "auto_load=True are resolved by LocalConversation at startup."
         ),
         json_schema_extra={"acp_compatible": True},
     )

--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -19,6 +19,7 @@ from openhands.sdk.context.prompts import render_template
 from openhands.sdk.llm import Message, TextContent
 from openhands.sdk.llm.utils.model_prompt_spec import get_model_prompt_spec
 from openhands.sdk.logger import get_logger
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.secret import SecretSource, SecretValue
 from openhands.sdk.skills import (
     Skill,
@@ -108,6 +109,14 @@ class AgentContext(BaseModel):
         description=(
             "Relative marketplace JSON path within the public skills repository. "
             "Set to None to load all public skills without marketplace filtering."
+        ),
+        json_schema_extra={"acp_compatible": True},
+    )
+    registered_marketplaces: list[MarketplaceRegistration] = Field(
+        default_factory=list,
+        description=(
+            "Marketplace registrations for plugin resolution. Registrations with "
+            "auto_load='all' are resolved by LocalConversation at startup."
         ),
         json_schema_extra={"acp_compatible": True},
     )
@@ -206,15 +215,16 @@ class AgentContext(BaseModel):
 
     @model_validator(mode="after")
     def _load_auto_skills(self):
-        """Load user and/or public skills if enabled."""
-        if not self.load_user_skills and not self.load_public_skills:
+        """Load user and/or legacy public skills if enabled."""
+        include_public = self.load_public_skills and not self.registered_marketplaces
+        if not self.load_user_skills and not include_public:
             return self
 
         auto_skills = load_available_skills(
             work_dir=None,
             include_user=self.load_user_skills,
             include_project=False,
-            include_public=self.load_public_skills,
+            include_public=include_public,
             marketplace_path=self.marketplace_path,
         )
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -685,7 +685,7 @@ class LocalConversation(BaseConversation):
                 expand_defaults=False,
             )
 
-        plugins_to_load: list[PluginSource] = []
+        plugins_to_load: list[tuple[PluginSource, bool]] = []
         if merged_context is not None and merged_context.registered_marketplaces:
             registrations = [
                 registration.model_copy(
@@ -712,20 +712,27 @@ class LocalConversation(BaseConversation):
                 for entry in marketplace.plugins:
                     source, ref, repo_path = marketplace.resolve_plugin_source(entry)
                     plugins_to_load.append(
-                        PluginSource(source=source, ref=ref, repo_path=repo_path)
+                        (
+                            PluginSource(source=source, ref=ref, repo_path=repo_path),
+                            True,
+                        )
                     )
 
         if self._plugin_specs:
-            plugins_to_load.extend(self._plugin_specs)
+            plugins_to_load.extend((spec, False) for spec in self._plugin_specs)
 
         # Load plugins if specified or registered for auto-load
         if plugins_to_load:
             logger.info(f"Loading {len(plugins_to_load)} plugin(s)...")
             self._resolved_plugins = []
 
-            for spec in plugins_to_load:
-                fetch_source = _expand_secret_refs(spec.source)
-                fetch_ref = _expand_secret_refs(spec.ref) if spec.ref else spec.ref
+            for spec, source_refs_expanded in plugins_to_load:
+                if source_refs_expanded:
+                    fetch_source = spec.source
+                    fetch_ref = spec.ref
+                else:
+                    fetch_source = _expand_secret_refs(spec.source)
+                    fetch_ref = _expand_secret_refs(spec.ref) if spec.ref else spec.ref
 
                 # Fetch plugin and get resolved commit SHA
                 path, resolved_ref = fetch_plugin_with_resolution(

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -53,6 +53,7 @@ from openhands.sdk.llm.auth.openai import create_subscription_llm_from_config
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
+from openhands.sdk.marketplace.registry import MarketplaceRegistry
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.plugin import (
     Plugin,
@@ -663,33 +664,66 @@ class LocalConversation(BaseConversation):
         # Track whether we have plugins or MCP config to process
         has_mcp_config = bool(merged_mcp)
 
-        # Load plugins if specified
+        # Expand ${VAR} placeholders in the source/ref using per-conversation
+        # secrets, so private plugins can be cloned with a token supplied via
+        # the secrets API, e.g. "https://x-token-auth:${MY_TOKEN}@host/repo.git".
+        #
+        # SECURITY: secrets only (check_env=False) -- never fold host
+        # environment variables into a URL sent to a remote git host.
+        # Braced-only (support_unbraced=False) avoids mangling a literal "$"
+        # that may legitimately appear in a token/password. expand_defaults
+        # is False so an unknown ${VAR} is left verbatim rather than silently
+        # defaulted inside a URL.
+        get_secret = self._state.secret_registry.get_secret_value
+
+        def _expand_secret_refs(value: str) -> str:
+            return expand_variable_references(
+                value,
+                get_secret=get_secret,
+                check_env=False,
+                support_unbraced=False,
+                expand_defaults=False,
+            )
+
+        plugins_to_load: list[PluginSource] = []
+        if merged_context is not None and merged_context.registered_marketplaces:
+            registrations = [
+                registration.model_copy(
+                    update={
+                        "source": _expand_secret_refs(registration.source),
+                        "ref": _expand_secret_refs(registration.ref)
+                        if registration.ref
+                        else None,
+                    }
+                )
+                for registration in merged_context.registered_marketplaces
+            ]
+            registry = MarketplaceRegistry(registrations)
+            for registration in registry.get_auto_load_registrations():
+                try:
+                    marketplace, _ = registry.get_marketplace(registration.name)
+                except Exception:
+                    logger.warning(
+                        "Failed to load marketplace '%s'; continuing without it",
+                        registration.name,
+                        exc_info=True,
+                    )
+                    continue
+                for entry in marketplace.plugins:
+                    source, ref, repo_path = marketplace.resolve_plugin_source(entry)
+                    plugins_to_load.append(
+                        PluginSource(source=source, ref=ref, repo_path=repo_path)
+                    )
+
         if self._plugin_specs:
-            logger.info(f"Loading {len(self._plugin_specs)} plugin(s)...")
+            plugins_to_load.extend(self._plugin_specs)
+
+        # Load plugins if specified or registered for auto-load
+        if plugins_to_load:
+            logger.info(f"Loading {len(plugins_to_load)} plugin(s)...")
             self._resolved_plugins = []
 
-            # Expand ${VAR} placeholders in the source/ref using per-conversation
-            # secrets, so private plugins can be cloned with a token supplied via
-            # the secrets API, e.g. "https://x-token-auth:${MY_TOKEN}@host/repo.git".
-            #
-            # SECURITY: secrets only (check_env=False) -- never fold host
-            # environment variables into a URL sent to a remote git host.
-            # Braced-only (support_unbraced=False) avoids mangling a literal "$"
-            # that may legitimately appear in a token/password. expand_defaults
-            # is False so an unknown ${VAR} is left verbatim rather than silently
-            # defaulted inside a URL.
-            get_secret = self._state.secret_registry.get_secret_value
-
-            def _expand_secret_refs(value: str) -> str:
-                return expand_variable_references(
-                    value,
-                    get_secret=get_secret,
-                    check_env=False,
-                    support_unbraced=False,
-                    expand_defaults=False,
-                )
-
-            for spec in self._plugin_specs:
+            for spec in plugins_to_load:
                 fetch_source = _expand_secret_refs(spec.source)
                 fetch_ref = _expand_secret_refs(spec.ref) if spec.ref else spec.ref
 
@@ -728,7 +762,7 @@ class LocalConversation(BaseConversation):
                 if plugin.agents:
                     all_plugin_agents.extend(plugin.agents)
 
-            logger.info(f"Loaded {len(self._plugin_specs)} plugin(s) via Conversation")
+            logger.info(f"Loaded {len(plugins_to_load)} plugin(s) via Conversation")
 
         # Resolve project skills from the workspace. AgentContext can't do this
         # itself (the workspace path is unknown at validation time), so it is done
@@ -781,7 +815,7 @@ class LocalConversation(BaseConversation):
 
         # Update agent with merged content only if something changed.
         # Skip update otherwise to avoid unnecessary agent state mutations.
-        if self._plugin_specs or has_mcp_config or project_skills_loaded:
+        if plugins_to_load or has_mcp_config or project_skills_loaded:
             self.agent = self.agent.model_copy(
                 update={
                     "agent_context": merged_context,

--- a/openhands-sdk/openhands/sdk/marketplace/__init__.py
+++ b/openhands-sdk/openhands/sdk/marketplace/__init__.py
@@ -26,7 +26,9 @@ Example marketplace.json:
 from importlib import import_module
 from typing import Any
 
-from openhands.sdk.marketplace.registration import MarketplaceRegistration
+from openhands.sdk.marketplace.registration import (
+    MarketplaceRegistration as MarketplaceRegistration,
+)
 
 
 _TYPE_EXPORTS = {
@@ -49,26 +51,7 @@ _REGISTRY_EXPORTS = {
 }
 
 
-__all__ = [
-    # Constants
-    "MARKETPLACE_MANIFEST_DIRS",
-    "MARKETPLACE_MANIFEST_FILE",
-    # Marketplace classes
-    "Marketplace",
-    "MarketplaceEntry",
-    "MarketplaceOwner",
-    "MarketplacePluginEntry",
-    "MarketplacePluginSource",
-    "MarketplaceMetadata",
-    "MarketplaceRegistration",
-    # Marketplace registry
-    "FetchedMarketplace",
-    "MarketplaceRegistry",
-    "PluginResolutionError",
-    "AmbiguousPluginError",
-    "PluginNotFoundError",
-    "MarketplaceNotFoundError",
-]
+__all__ = sorted(_TYPE_EXPORTS | _REGISTRY_EXPORTS | {"MarketplaceRegistration"})
 
 
 def __getattr__(name: str) -> Any:

--- a/openhands-sdk/openhands/sdk/marketplace/__init__.py
+++ b/openhands-sdk/openhands/sdk/marketplace/__init__.py
@@ -23,25 +23,30 @@ Example marketplace.json:
 ```
 """
 
-from openhands.sdk.marketplace.registry import (
-    AmbiguousPluginError,
-    FetchedMarketplace,
-    MarketplaceNotFoundError,
-    MarketplaceRegistry,
-    PluginNotFoundError,
-    PluginResolutionError,
-)
-from openhands.sdk.marketplace.types import (
-    MARKETPLACE_MANIFEST_DIRS,
-    MARKETPLACE_MANIFEST_FILE,
-    Marketplace,
-    MarketplaceEntry,
-    MarketplaceMetadata,
-    MarketplaceOwner,
-    MarketplacePluginEntry,
-    MarketplacePluginSource,
-    MarketplaceRegistration,
-)
+from importlib import import_module
+from typing import Any
+
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
+
+
+_TYPE_EXPORTS = {
+    "MARKETPLACE_MANIFEST_DIRS",
+    "MARKETPLACE_MANIFEST_FILE",
+    "Marketplace",
+    "MarketplaceEntry",
+    "MarketplaceMetadata",
+    "MarketplaceOwner",
+    "MarketplacePluginEntry",
+    "MarketplacePluginSource",
+}
+_REGISTRY_EXPORTS = {
+    "AmbiguousPluginError",
+    "FetchedMarketplace",
+    "MarketplaceNotFoundError",
+    "MarketplaceRegistry",
+    "PluginNotFoundError",
+    "PluginResolutionError",
+}
 
 
 __all__ = [
@@ -64,3 +69,11 @@ __all__ = [
     "PluginNotFoundError",
     "MarketplaceNotFoundError",
 ]
+
+
+def __getattr__(name: str) -> Any:
+    if name in _TYPE_EXPORTS:
+        return getattr(import_module("openhands.sdk.marketplace.types"), name)
+    if name in _REGISTRY_EXPORTS:
+        return getattr(import_module("openhands.sdk.marketplace.registry"), name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/openhands-sdk/openhands/sdk/marketplace/registration.py
+++ b/openhands-sdk/openhands/sdk/marketplace/registration.py
@@ -2,28 +2,9 @@
 
 from __future__ import annotations
 
-import re
-from pathlib import PurePosixPath
-from typing import Literal
+from pathlib import PurePosixPath, PureWindowsPath
 
 from pydantic import BaseModel, Field, field_validator
-
-
-_WINDOWS_DRIVE_PATH = re.compile(r"^[a-zA-Z]:[\\/]")
-
-
-def _validate_repo_path(value: str | None) -> str | None:
-    if value is None:
-        return None
-    if not value:
-        raise ValueError("repo_path must not be empty")
-    if "\\" in value:
-        raise ValueError("repo_path must use '/' separators")
-    if _WINDOWS_DRIVE_PATH.match(value) or PurePosixPath(value).is_absolute():
-        raise ValueError("repo_path must be relative, not absolute")
-    if ".." in PurePosixPath(value).parts:
-        raise ValueError("repo_path cannot contain '..' path traversal")
-    return value
 
 
 class MarketplaceRegistration(BaseModel):
@@ -44,15 +25,23 @@ class MarketplaceRegistration(BaseModel):
             "Only relevant for git sources."
         ),
     )
-    auto_load: Literal["all"] | None = Field(
-        default=None,
-        description=(
-            "Auto-load behavior for this marketplace. Use 'all' to load all "
-            "plugins at conversation start; None registers for resolution only."
-        ),
+    auto_load: bool = Field(
+        default=False,
+        description="Whether to load all marketplace plugins at conversation start.",
     )
 
     @field_validator("repo_path")
     @classmethod
     def _validate_repo_path(cls, value: str | None) -> str | None:
-        return _validate_repo_path(value)
+        if value is None:
+            return None
+        if not value:
+            raise ValueError("repo_path must not be empty")
+        if "\\" in value:
+            raise ValueError("repo_path must use '/' separators")
+        path = PurePosixPath(value)
+        if PureWindowsPath(value).drive or path.is_absolute():
+            raise ValueError("repo_path must be relative, not absolute")
+        if ".." in path.parts:
+            raise ValueError("repo_path cannot contain '..' path traversal")
+        return value

--- a/openhands-sdk/openhands/sdk/marketplace/registration.py
+++ b/openhands-sdk/openhands/sdk/marketplace/registration.py
@@ -1,0 +1,58 @@
+"""Marketplace registration model."""
+
+from __future__ import annotations
+
+import re
+from pathlib import PurePosixPath
+from typing import Literal
+
+from pydantic import BaseModel, Field, field_validator
+
+
+_WINDOWS_DRIVE_PATH = re.compile(r"^[a-zA-Z]:[\\/]")
+
+
+def _validate_repo_path(value: str | None) -> str | None:
+    if value is None:
+        return None
+    if not value:
+        raise ValueError("repo_path must not be empty")
+    if "\\" in value:
+        raise ValueError("repo_path must use '/' separators")
+    if _WINDOWS_DRIVE_PATH.match(value) or PurePosixPath(value).is_absolute():
+        raise ValueError("repo_path must be relative, not absolute")
+    if ".." in PurePosixPath(value).parts:
+        raise ValueError("repo_path cannot contain '..' path traversal")
+    return value
+
+
+class MarketplaceRegistration(BaseModel):
+    """Registration for a marketplace source used for plugin resolution."""
+
+    name: str = Field(description="Identifier for this marketplace registration")
+    source: str = Field(
+        description="Marketplace source: 'github:owner/repo', git URL, or local path"
+    )
+    ref: str | None = Field(
+        default=None,
+        description="Optional branch, tag, or commit for git sources",
+    )
+    repo_path: str | None = Field(
+        default=None,
+        description=(
+            "Subdirectory path within the git repository containing the marketplace. "
+            "Only relevant for git sources."
+        ),
+    )
+    auto_load: Literal["all"] | None = Field(
+        default=None,
+        description=(
+            "Auto-load behavior for this marketplace. Use 'all' to load all "
+            "plugins at conversation start; None registers for resolution only."
+        ),
+    )
+
+    @field_validator("repo_path")
+    @classmethod
+    def _validate_repo_path(cls, value: str | None) -> str | None:
+        return _validate_repo_path(value)

--- a/openhands-sdk/openhands/sdk/marketplace/registry.py
+++ b/openhands-sdk/openhands/sdk/marketplace/registry.py
@@ -97,7 +97,7 @@ class MarketplaceRegistry:
         return [
             registration
             for registration in self._registrations.values()
-            if registration.auto_load == "all"
+            if registration.auto_load
         ]
 
     def get_marketplace(self, name: str) -> tuple[Marketplace, Path]:

--- a/openhands-sdk/openhands/sdk/marketplace/registry.py
+++ b/openhands-sdk/openhands/sdk/marketplace/registry.py
@@ -6,7 +6,8 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from openhands.sdk.logger import get_logger
-from openhands.sdk.marketplace.types import Marketplace, MarketplaceRegistration
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
+from openhands.sdk.marketplace.types import Marketplace
 from openhands.sdk.plugin.fetch import fetch_plugin_with_resolution
 from openhands.sdk.plugin.types import PluginSource
 from openhands.sdk.utils.redact import redact_url_credentials

--- a/openhands-sdk/openhands/sdk/marketplace/types.py
+++ b/openhands-sdk/openhands/sdk/marketplace/types.py
@@ -3,9 +3,8 @@
 from __future__ import annotations
 
 import json
-import re
-from pathlib import Path, PurePosixPath
-from typing import Any, Literal
+from pathlib import Path
+from typing import Any
 
 from pydantic import BaseModel, Field, field_validator, model_validator
 
@@ -21,54 +20,6 @@ from openhands.sdk.plugin.types import (
 # Directories to check for marketplace manifest
 MARKETPLACE_MANIFEST_DIRS = [".plugin", ".claude-plugin"]
 MARKETPLACE_MANIFEST_FILE = "marketplace.json"
-
-_WINDOWS_DRIVE_PATH = re.compile(r"^[a-zA-Z]:[\\/]")
-
-
-def _validate_repo_path(value: str | None) -> str | None:
-    if value is None:
-        return None
-    if not value:
-        raise ValueError("repo_path must not be empty")
-    if "\\" in value:
-        raise ValueError("repo_path must use '/' separators")
-    if _WINDOWS_DRIVE_PATH.match(value) or PurePosixPath(value).is_absolute():
-        raise ValueError("repo_path must be relative, not absolute")
-    if ".." in PurePosixPath(value).parts:
-        raise ValueError("repo_path cannot contain '..' path traversal")
-    return value
-
-
-class MarketplaceRegistration(BaseModel):
-    """Registration for a marketplace source used for plugin resolution."""
-
-    name: str = Field(description="Identifier for this marketplace registration")
-    source: str = Field(
-        description="Marketplace source: 'github:owner/repo', git URL, or local path"
-    )
-    ref: str | None = Field(
-        default=None,
-        description="Optional branch, tag, or commit for git sources",
-    )
-    repo_path: str | None = Field(
-        default=None,
-        description=(
-            "Subdirectory path within the git repository containing the marketplace. "
-            "Only relevant for git sources."
-        ),
-    )
-    auto_load: Literal["all"] | None = Field(
-        default=None,
-        description=(
-            "Auto-load behavior for this marketplace. Use 'all' to load all "
-            "plugins at conversation start; None registers for resolution only."
-        ),
-    )
-
-    @field_validator("repo_path")
-    @classmethod
-    def _validate_repo_path(cls, value: str | None) -> str | None:
-        return _validate_repo_path(value)
 
 
 class MarketplaceOwner(BaseModel):

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -133,7 +133,7 @@ class TestLocalConversationPlugins:
                     MarketplaceRegistration(
                         name="auto",
                         source=str(marketplace_dir),
-                        auto_load="all",
+                        auto_load=True,
                     )
                 ]
             ),
@@ -153,6 +153,152 @@ class TestLocalConversationPlugins:
         assert len(conversation.resolved_plugins) == 1
 
         conversation.close()
+
+    def test_auto_load_marketplace_expands_registration_secret_refs(
+        self, tmp_path: Path, mock_llm
+    ):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "auto-plugin",
+                    "skills": [{"name": "auto-skill", "content": "Auto-loaded skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="private",
+                        source="https://${MARKETPLACE_TOKEN}@example.com/catalog.git",
+                        ref="${MARKETPLACE_REF}",
+                        repo_path="catalogs/team",
+                        auto_load=True,
+                    )
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+        conversation.update_secrets(
+            {
+                "MARKETPLACE_TOKEN": "token-value",
+                "MARKETPLACE_REF": "release-branch",
+            }
+        )
+
+        with patch(
+            "openhands.sdk.marketplace.registry.fetch_plugin_with_resolution",
+            return_value=(marketplace_dir, "abc123"),
+        ) as mock_fetch:
+            conversation._ensure_plugins_loaded()
+
+        mock_fetch.assert_called_once_with(
+            source="https://token-value@example.com/catalog.git",
+            ref="release-branch",
+            repo_path="catalogs/team",
+        )
+        assert conversation.agent.agent_context is not None
+        assert [skill.name for skill in conversation.agent.agent_context.skills] == [
+            "auto-skill"
+        ]
+        conversation.close()
+
+    def test_auto_load_marketplace_continues_after_fetch_failure(
+        self, tmp_path: Path, mock_llm, caplog: pytest.LogCaptureFixture
+    ):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "auto-plugin",
+                    "skills": [{"name": "auto-skill", "content": "Auto-loaded skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="broken",
+                        source=str(tmp_path / "missing-marketplace"),
+                        auto_load=True,
+                    ),
+                    MarketplaceRegistration(
+                        name="working",
+                        source=str(marketplace_dir),
+                        auto_load=True,
+                    ),
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+
+        with caplog.at_level(
+            "WARNING", logger="openhands.sdk.conversation.impl.local_conversation"
+        ):
+            conversation._ensure_plugins_loaded()
+
+        assert (
+            "Failed to load marketplace 'broken'; continuing without it" in caplog.text
+        )
+        assert conversation.agent.agent_context is not None
+        assert [skill.name for skill in conversation.agent.agent_context.skills] == [
+            "auto-skill"
+        ]
+        conversation.close()
+
+    def test_auto_load_marketplace_duplicate_names_fail(self, tmp_path: Path, mock_llm):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "auto-plugin",
+                    "skills": [{"name": "auto-skill", "content": "Auto-loaded skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="duplicate",
+                        source=str(marketplace_dir),
+                        auto_load=True,
+                    ),
+                    MarketplaceRegistration(
+                        name="duplicate",
+                        source=str(marketplace_dir),
+                        auto_load=True,
+                    ),
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+
+        try:
+            with pytest.raises(ValueError, match="Duplicate marketplace registration"):
+                conversation._ensure_plugins_loaded()
+        finally:
+            conversation.close()
 
     def test_registered_only_marketplace_does_not_auto_load(
         self, tmp_path: Path, mock_llm
@@ -220,7 +366,7 @@ class TestLocalConversationPlugins:
                     MarketplaceRegistration(
                         name="auto",
                         source=str(marketplace_dir),
-                        auto_load="all",
+                        auto_load=True,
                     )
                 ]
             ),
@@ -255,7 +401,7 @@ class TestLocalConversationPlugins:
                     MarketplaceRegistration(
                         name="auto",
                         source=str(tmp_path / "marketplace"),
-                        auto_load="all",
+                        auto_load=True,
                     )
                 ],
             )

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -7,10 +7,11 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import SecretStr
 
-from openhands.sdk import LLM, Agent, Conversation
+from openhands.sdk import LLM, Agent, AgentContext, Conversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.hooks.config import HookDefinition, HookMatcher
+from openhands.sdk.marketplace import MarketplaceRegistration
 from openhands.sdk.plugin import PluginSource
 
 
@@ -68,12 +69,198 @@ def create_test_plugin(
     return plugin_dir
 
 
+def create_test_marketplace(
+    marketplace_dir: Path,
+    plugins: list[dict],
+    name: str = "test-marketplace",
+) -> Path:
+    """Helper to create a test marketplace with local plugin entries."""
+    manifest_dir = marketplace_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+
+    entries = []
+    for plugin in plugins:
+        plugin_name = plugin["name"]
+        create_test_plugin(
+            marketplace_dir / "plugins" / plugin_name,
+            name=plugin_name,
+            skills=plugin.get("skills"),
+            mcp_config=plugin.get("mcp_config"),
+            hooks=plugin.get("hooks"),
+        )
+        entries.append(
+            {
+                "name": plugin_name,
+                "source": f"./plugins/{plugin_name}",
+                "description": f"Test plugin {plugin_name}",
+            }
+        )
+
+    manifest = {
+        "name": name,
+        "owner": {"name": "Test Team"},
+        "plugins": entries,
+    }
+    (manifest_dir / "marketplace.json").write_text(json.dumps(manifest))
+    return marketplace_dir
+
+
 class TestLocalConversationPlugins:
     """Tests for plugin loading in LocalConversation.
 
     Note: Plugins are lazy-loaded on first run()/send_message() call.
     Tests trigger _ensure_plugins_loaded() to verify loading behavior.
     """
+
+    def test_auto_load_marketplace_plugins(self, tmp_path: Path, mock_llm):
+        """Test marketplace registrations auto-load plugins at startup."""
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "auto-plugin",
+                    "skills": [{"name": "auto-skill", "content": "Auto-loaded skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="auto",
+                        source=str(marketplace_dir),
+                        auto_load="all",
+                    )
+                ]
+            ),
+        )
+
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+        conversation._ensure_plugins_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "auto-skill" in skill_names
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+
+        conversation.close()
+
+    def test_registered_only_marketplace_does_not_auto_load(
+        self, tmp_path: Path, mock_llm
+    ):
+        """Test registered marketplaces without auto_load stay resolution-only."""
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "manual-plugin",
+                    "skills": [{"name": "manual-skill", "content": "Manual skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+        conversation._ensure_plugins_loaded()
+
+        assert conversation.agent.agent_context is not None
+        assert conversation.agent.agent_context.skills == []
+        assert conversation.resolved_plugins is None
+
+        conversation.close()
+
+    def test_explicit_plugins_override_auto_loaded_marketplace_plugins(
+        self, tmp_path: Path, mock_llm
+    ):
+        """Test explicit plugins load after auto-loaded marketplace plugins."""
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "auto-plugin",
+                    "skills": [{"name": "shared", "content": "Auto content"}],
+                }
+            ],
+        )
+        explicit_plugin = create_test_plugin(
+            tmp_path / "explicit-plugin",
+            name="explicit-plugin",
+            skills=[{"name": "shared", "content": "Explicit content"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="auto",
+                        source=str(marketplace_dir),
+                        auto_load="all",
+                    )
+                ]
+            ),
+        )
+
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            plugins=[PluginSource(source=str(explicit_plugin))],
+            visualizer=None,
+        )
+        conversation._ensure_plugins_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skills = {s.name: s for s in conversation.agent.agent_context.skills}
+        assert skills["shared"].content == "Explicit content"
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 2
+
+        conversation.close()
+
+    def test_registered_marketplaces_skip_legacy_public_skill_loading(
+        self, tmp_path: Path
+    ):
+        """Test registered marketplaces suppress legacy public skill loading."""
+        with patch(
+            "openhands.sdk.context.agent_context.load_available_skills"
+        ) as mock_load_available_skills:
+            AgentContext(
+                load_public_skills=True,
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="auto",
+                        source=str(tmp_path / "marketplace"),
+                        auto_load="all",
+                    )
+                ],
+            )
+
+        mock_load_available_skills.assert_not_called()
 
     def test_create_conversation_with_plugins(self, tmp_path: Path, basic_agent):
         """Test creating LocalConversation with plugins parameter."""

--- a/tests/sdk/marketplace/test_marketplace_registry.py
+++ b/tests/sdk/marketplace/test_marketplace_registry.py
@@ -39,14 +39,14 @@ def test_marketplace_registration_accepts_all_fields() -> None:
         source="github:example/marketplaces",
         ref="v1.0.0",
         repo_path="marketplaces/team",
-        auto_load="all",
+        auto_load=True,
     )
 
     assert registration.name == "team"
     assert registration.source == "github:example/marketplaces"
     assert registration.ref == "v1.0.0"
     assert registration.repo_path == "marketplaces/team"
-    assert registration.auto_load == "all"
+    assert registration.auto_load
 
 
 @pytest.mark.parametrize(
@@ -79,7 +79,7 @@ def test_get_auto_load_registrations(tmp_path: Path) -> None:
     auto_registration = MarketplaceRegistration(
         name="auto",
         source=source,
-        auto_load="all",
+        auto_load=True,
     )
     manual_registration = MarketplaceRegistration(name="manual", source=source)
 


### PR DESCRIPTION
HUMAN:

Phase 2 of the marketplace revamp.

This PR folds the marketplace data classes introduced in the previous PR into the agent context plugin loading mechanism.

---

AGENT:

## Summary

Chunk 2 of the marketplace-registration reimplementation, stacked on #3824.

- Add `AgentContext.registered_marketplaces` using the typed `MarketplaceRegistration` model.
- Auto-load plugins from marketplace registrations marked `auto_load="all"` during `LocalConversation` startup.
- Preserve explicit plugin precedence by loading auto-loaded marketplace plugins before explicit `Conversation(..., plugins=[...])` entries.
- Suppress legacy public skill loading when registered marketplaces are present so `marketplace_path` does not pull from the default OpenHands extensions repo in the new path.
- Make marketplace package exports lazy so `AgentContext` can reference `MarketplaceRegistration` without introducing an import cycle.
- Add focused tests for auto-load behavior, registered-only no-op behavior, explicit plugin precedence, and legacy public-skill suppression.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `bac6aef8a727` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -612,0 +613 @@
+schema AgentContext-Input property registered_marketplaces optional schema=type="array" items=MarketplaceRegistration
@@ -622,0 +624 @@
+schema AgentContext-Output property registered_marketplaces optional schema=type="array" items=MarketplaceRegistration
@@ -1567,0 +1570,6 @@
+schema MarketplaceRegistration property auto_load optional schema=type="boolean" default=false
+schema MarketplaceRegistration property name required schema=type="string"
+schema MarketplaceRegistration property ref optional schema=anyOf=[type="string",type="null"]
+schema MarketplaceRegistration property repo_path optional schema=anyOf=[type="string",type="null"]
+schema MarketplaceRegistration property source required schema=type="string"
+schema MarketplaceRegistration type="object"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Scope

This PR intentionally does **not** add runtime `conversation.load_plugin(...)` or agent-server API support. Those are planned follow-up chunks.

## Tests

```bash
uv run pytest tests/sdk/conversation/test_local_conversation_plugins.py tests/sdk/marketplace/test_marketplace_registry.py -q
uv run pytest tests/sdk/conversation/test_local_conversation_plugins.py tests/sdk/marketplace -q
uv run pytest tests/sdk/context/test_agent_context.py tests/sdk/skills/test_load_public_skills.py -q
uv run pre-commit run --files openhands-sdk/openhands/sdk/context/agent_context.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-sdk/openhands/sdk/marketplace/__init__.py openhands-sdk/openhands/sdk/marketplace/types.py openhands-sdk/openhands/sdk/marketplace/registry.py openhands-sdk/openhands/sdk/marketplace/registration.py tests/sdk/conversation/test_local_conversation_plugins.py tests/sdk/marketplace/test_marketplace_registry.py
```

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@csmith49 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8dea99f4-c5ab-4cef-b9ff-d0dd7937ee13)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:339f257-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-339f257-python \
  ghcr.io/openhands/agent-server:339f257-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:339f257-golang-amd64
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-golang-amd64
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-golang-amd64
ghcr.io/openhands/agent-server:339f257-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:339f257-golang-arm64
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-golang-arm64
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-golang-arm64
ghcr.io/openhands/agent-server:339f257-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:339f257-java-amd64
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-java-amd64
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-java-amd64
ghcr.io/openhands/agent-server:339f257-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:339f257-java-arm64
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-java-arm64
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-java-arm64
ghcr.io/openhands/agent-server:339f257-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:339f257-python-amd64
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-python-amd64
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-python-amd64
ghcr.io/openhands/agent-server:339f257-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:339f257-python-arm64
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-python-arm64
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-python-arm64
ghcr.io/openhands/agent-server:339f257-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:339f257-golang
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-golang
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-golang
ghcr.io/openhands/agent-server:339f257-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:339f257-java
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-java
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-java
ghcr.io/openhands/agent-server:339f257-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:339f257-python
ghcr.io/openhands/agent-server:339f257fee115ac7a3c55e88cd0c32c5d866103c-python
ghcr.io/openhands/agent-server:feat-marketplace-autoload-registrations-python
ghcr.io/openhands/agent-server:339f257-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `339f257-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `339f257-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->