### PR TITLE
feat(marketplace): support runtime local plugin loading

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -901,6 +901,11 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # Drive the traversal from self
         yield from _walk(self)
 
+    def reset_runtime_tools(self) -> None:
+        """Clear initialized runtime tools so they can be rebuilt from config."""
+        self._tools = {}
+        self._initialized = False
+
     @property
     def tools_map(self) -> dict[str, ToolDefinition]:
         """Get the initialized tools map.

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Generator, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Literal
@@ -901,10 +902,41 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # Drive the traversal from self
         yield from _walk(self)
 
-    def reset_runtime_tools(self) -> None:
-        """Clear initialized runtime tools so they can be rebuilt from config."""
-        self._tools = {}
-        self._initialized = False
+    def _close_tool_executor(self, tool: ToolDefinition) -> None:
+        try:
+            executable_tool = tool.as_executable()
+            executable_tool.executor.close()
+        except NotImplementedError:
+            return
+        except Exception as exc:
+            logger.warning("Error closing executor for tool '%s': %s", tool.name, exc)
+
+    def add_runtime_tools(self, tools: Sequence[ToolDefinition]) -> None:
+        if not self._initialized:
+            logger.warning(
+                "add_runtime_tools called before agent initialization; "
+                "tools will not be registered"
+            )
+            return
+        for tool in tools:
+            if not isinstance(tool, ToolDefinition):
+                raise ValueError(
+                    f"Tool {tool} is not an instance of 'ToolDefinition'. "
+                    f"Got type: {type(tool)}"
+                )
+
+        tool_names = [tool.name for tool in tools]
+        if len(tool_names) != len(set(tool_names)):
+            duplicates = {
+                name for name, count in Counter(tool_names).items() if count > 1
+            }
+            raise ValueError(f"Duplicate runtime tool names found: {duplicates}")
+
+        for tool in tools:
+            previous_tool = self._tools.get(tool.name)
+            if previous_tool is not None:
+                self._close_tool_executor(previous_tool)
+            self._tools[tool.name] = tool
 
     @property
     def tools_map(self) -> dict[str, ToolDefinition]:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -939,15 +939,16 @@ class LocalConversation(BaseConversation):
         self._hook_processor.set_conversation_state(self._state)
         self._hook_processor.run_session_start()
 
-    def _runtime_tools_for_plugin(
+    def _runtime_mcp_tools_for_plugin(
         self, plugin_mcp_config: dict[str, Any] | None
     ) -> list[ToolDefinition]:
-        runtime_tools: list[ToolDefinition] = []
-        if plugin_mcp_config:
-            runtime_tools.extend(
-                create_mcp_tools(plugin_mcp_config, _RUNTIME_MCP_TIMEOUT_SECS).tools
-            )
+        if not plugin_mcp_config:
+            return []
+        return list(
+            create_mcp_tools(plugin_mcp_config, _RUNTIME_MCP_TIMEOUT_SECS).tools
+        )
 
+    def _runtime_skill_tools_for_agent(self) -> list[ToolDefinition]:
         agent_context = self.agent.agent_context
         has_invocable_skills = bool(
             agent_context
@@ -957,8 +958,21 @@ class LocalConversation(BaseConversation):
             )
         )
         if has_invocable_skills and InvokeSkillTool.name not in self.agent.tools_map:
-            runtime_tools.extend(InvokeSkillTool.create(self._state))
-        return runtime_tools
+            return list(InvokeSkillTool.create(self._state))
+        return []
+
+    def _close_runtime_tools(self, tools: Sequence[ToolDefinition]) -> None:
+        for tool in tools:
+            try:
+                tool.as_executable().executor.close()
+            except NotImplementedError:
+                continue
+            except Exception as exc:
+                logger.warning(
+                    "Error closing runtime tool executor for tool '%s': %s",
+                    tool.name,
+                    exc,
+                )
 
     def load_plugin(self, plugin_ref: str) -> None:
         """Load a plugin from the conversation's registered marketplaces."""
@@ -1000,6 +1014,11 @@ class LocalConversation(BaseConversation):
                 get_secret=get_secret,
                 expand_defaults=True,
             )
+        runtime_mcp_tools = (
+            self._runtime_mcp_tools_for_plugin(runtime_plugin_mcp)
+            if self._agent_ready
+            else []
+        )
 
         with self._state:
             self.agent = self.agent.model_copy(
@@ -1024,9 +1043,15 @@ class LocalConversation(BaseConversation):
 
             self._state.agent = self.agent
             if self._agent_ready:
-                self.agent.add_runtime_tools(
-                    self._runtime_tools_for_plugin(runtime_plugin_mcp)
-                )
+                runtime_tools = [
+                    *runtime_mcp_tools,
+                    *self._runtime_skill_tools_for_agent(),
+                ]
+                try:
+                    self.agent.add_runtime_tools(runtime_tools)
+                except Exception:
+                    self._close_runtime_tools(runtime_mcp_tools)
+                    raise
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -664,34 +664,13 @@ class LocalConversation(BaseConversation):
         # Track whether we have plugins or MCP config to process
         has_mcp_config = bool(merged_mcp)
 
-        # Expand ${VAR} placeholders in the source/ref using per-conversation
-        # secrets, so private plugins can be cloned with a token supplied via
-        # the secrets API, e.g. "https://x-token-auth:${MY_TOKEN}@host/repo.git".
-        #
-        # SECURITY: secrets only (check_env=False) -- never fold host
-        # environment variables into a URL sent to a remote git host.
-        # Braced-only (support_unbraced=False) avoids mangling a literal "$"
-        # that may legitimately appear in a token/password. expand_defaults
-        # is False so an unknown ${VAR} is left verbatim rather than silently
-        # defaulted inside a URL.
-        get_secret = self._state.secret_registry.get_secret_value
-
-        def _expand_secret_refs(value: str) -> str:
-            return expand_variable_references(
-                value,
-                get_secret=get_secret,
-                check_env=False,
-                support_unbraced=False,
-                expand_defaults=False,
-            )
-
         plugins_to_load: list[tuple[PluginSource, bool]] = []
         if merged_context is not None and merged_context.registered_marketplaces:
             registrations = [
                 registration.model_copy(
                     update={
-                        "source": _expand_secret_refs(registration.source),
-                        "ref": _expand_secret_refs(registration.ref)
+                        "source": self._expand_plugin_source_ref(registration.source),
+                        "ref": self._expand_plugin_source_ref(registration.ref)
                         if registration.ref
                         else None,
                     }
@@ -731,8 +710,12 @@ class LocalConversation(BaseConversation):
                     fetch_source = spec.source
                     fetch_ref = spec.ref
                 else:
-                    fetch_source = _expand_secret_refs(spec.source)
-                    fetch_ref = _expand_secret_refs(spec.ref) if spec.ref else spec.ref
+                    fetch_source = self._expand_plugin_source_ref(spec.source)
+                    fetch_ref = (
+                        self._expand_plugin_source_ref(spec.ref)
+                        if spec.ref
+                        else spec.ref
+                    )
 
                 # Fetch plugin and get resolved commit SHA
                 path, resolved_ref = fetch_plugin_with_resolution(
@@ -880,6 +863,127 @@ class LocalConversation(BaseConversation):
             self._hook_processor.run_session_start()
 
         self._plugins_loaded = True
+
+    def _expand_plugin_source_ref(self, value: str) -> str:
+        return expand_variable_references(
+            value,
+            get_secret=self._state.secret_registry.get_secret_value,
+            check_env=False,
+            support_unbraced=False,
+            expand_defaults=False,
+        )
+
+    def _marketplace_registry_from_context(self) -> MarketplaceRegistry:
+        agent_context = self.agent.agent_context
+        if agent_context is None:
+            raise ValueError(
+                "No agent context available. Configure agent_context with "
+                "registered_marketplaces to use load_plugin()."
+            )
+        registrations = agent_context.registered_marketplaces
+        if not registrations:
+            raise ValueError(
+                "No marketplaces registered. Configure registered_marketplaces "
+                "in AgentContext to use load_plugin()."
+            )
+        return MarketplaceRegistry(
+            [
+                registration.model_copy(
+                    update={
+                        "source": self._expand_plugin_source_ref(registration.source),
+                        "ref": self._expand_plugin_source_ref(registration.ref)
+                        if registration.ref
+                        else None,
+                    }
+                )
+                for registration in registrations
+            ]
+        )
+
+    def _merge_runtime_plugin_hooks(self, plugin_hooks: HookConfig) -> None:
+        existing_config = self._state.hook_config
+        merged_config = (
+            HookConfig.merge([existing_config, plugin_hooks])
+            if existing_config is not None
+            else plugin_hooks
+        )
+        if merged_config is None:
+            return
+
+        hook_persistence_dir = (
+            str(Path(self._state.persistence_dir).parent)
+            if self._state.persistence_dir is not None
+            else None
+        )
+        self._state.hook_config = merged_config
+        self._pending_hook_config = merged_config
+        self._hook_processor, self._on_event = create_hook_callback(
+            hook_config=merged_config,
+            working_dir=str(self.workspace.working_dir),
+            session_id=str(self._state.id),
+            original_callback=self._base_callback,
+            llm_getter=lambda: self.agent.llm,
+            persistence_dir=hook_persistence_dir,
+            visualizer=self._visualizer,
+            conversation_stats=self._state.stats,
+        )
+        self._hook_processor.set_conversation_state(self._state)
+
+    def load_plugin(self, plugin_ref: str) -> None:
+        """Load a plugin from the conversation's registered marketplaces."""
+        self._ensure_plugins_loaded()
+        spec = self._marketplace_registry_from_context().resolve_plugin(plugin_ref)
+
+        fetch_source = self._expand_plugin_source_ref(spec.source)
+        fetch_ref = self._expand_plugin_source_ref(spec.ref) if spec.ref else spec.ref
+        path, resolved_ref = fetch_plugin_with_resolution(
+            source=fetch_source,
+            ref=fetch_ref,
+            repo_path=spec.repo_path,
+        )
+        plugin = Plugin.load(path)
+        logger.info(
+            f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
+            + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
+        )
+
+        merged_context = plugin.add_skills_to(self.agent.agent_context)
+        merged_mcp = plugin.add_mcp_config_to(
+            dict(self.agent.mcp_config) if self.agent.mcp_config else {}
+        )
+        if merged_mcp:
+            merged_mcp = expand_mcp_variables(
+                merged_mcp,
+                {},
+                get_secret=self._state.secret_registry.get_secret_value,
+                expand_defaults=True,
+            )
+
+        self.agent = self.agent.model_copy(
+            update={
+                "agent_context": merged_context,
+                "mcp_config": merged_mcp,
+            }
+        )
+
+        if plugin.agents:
+            register_plugin_agents(
+                agents=plugin.agents,
+                work_dir=self.workspace.working_dir,
+            )
+        if plugin.hooks and not plugin.hooks.is_empty():
+            self._merge_runtime_plugin_hooks(plugin.hooks)
+
+        resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
+        if self._resolved_plugins is None:
+            self._resolved_plugins = []
+        self._resolved_plugins.append(resolved)
+
+        with self._state:
+            self._state.agent = self.agent
+            if self._agent_ready:
+                self.agent.reset_runtime_tools()
+                self.agent.init_state(self._state, on_event=self._on_event)
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -54,6 +54,7 @@ from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace.registry import MarketplaceRegistry
+from openhands.sdk.mcp import create_mcp_tools
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.plugin import (
     Plugin,
@@ -76,6 +77,8 @@ from openhands.sdk.subagent import (
     register_file_agents,
     register_plugin_agents,
 )
+from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.tool.builtins import InvokeSkillTool
 from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.utils.cipher import Cipher
@@ -87,6 +90,8 @@ logger = get_logger(__name__)
 ACP_LAST_PROMPT_USER_MESSAGE_ID = "acp_last_prompt_user_message_id"
 ACP_INFLIGHT_PROMPT_USER_MESSAGE_ID = "acp_inflight_prompt_user_message_id"
 ACP_SUPERSEDE_INFLIGHT_PROMPT = "acp_supersede_inflight_prompt"
+_RUNTIME_MCP_TIMEOUT_SECS = 30
+
 ACP_STOP_HOOK_FEEDBACK_PREFIX = "[Stop hook feedback]"
 
 
@@ -735,7 +740,7 @@ class LocalConversation(BaseConversation):
                 # Load the plugin
                 plugin = Plugin.load(path)
                 logger.debug(
-                    f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
+                    f"Loaded plugin '{plugin.manifest.name}'"
                     + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
                 )
 
@@ -915,6 +920,10 @@ class LocalConversation(BaseConversation):
             if self._state.persistence_dir is not None
             else None
         )
+        previous_processor = self._hook_processor
+        if previous_processor is not None:
+            previous_processor.run_session_end()
+
         self._state.hook_config = merged_config
         self._pending_hook_config = merged_config
         self._hook_processor, self._on_event = create_hook_callback(
@@ -928,6 +937,28 @@ class LocalConversation(BaseConversation):
             conversation_stats=self._state.stats,
         )
         self._hook_processor.set_conversation_state(self._state)
+        self._hook_processor.run_session_start()
+
+    def _runtime_tools_for_plugin(
+        self, plugin_mcp_config: dict[str, Any] | None
+    ) -> list[ToolDefinition]:
+        runtime_tools: list[ToolDefinition] = []
+        if plugin_mcp_config:
+            runtime_tools.extend(
+                create_mcp_tools(plugin_mcp_config, _RUNTIME_MCP_TIMEOUT_SECS).tools
+            )
+
+        agent_context = self.agent.agent_context
+        has_invocable_skills = bool(
+            agent_context
+            and any(
+                skill.is_agentskills_format and not skill.disable_model_invocation
+                for skill in agent_context.skills
+            )
+        )
+        if has_invocable_skills and InvokeSkillTool.name not in self.agent.tools_map:
+            runtime_tools.extend(InvokeSkillTool.create(self._state))
+        return runtime_tools
 
     def load_plugin(self, plugin_ref: str) -> None:
         """Load a plugin from the conversation's registered marketplaces."""
@@ -943,10 +974,21 @@ class LocalConversation(BaseConversation):
         )
         plugin = Plugin.load(path)
         logger.info(
-            f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
+            f"Loaded plugin '{plugin.manifest.name}'"
             + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
         )
 
+        get_secret = self._state.secret_registry.get_secret_value
+        runtime_plugin_mcp = (
+            expand_mcp_variables(
+                plugin.mcp_config,
+                {},
+                get_secret=get_secret,
+                expand_defaults=True,
+            )
+            if plugin.mcp_config
+            else None
+        )
         merged_context = plugin.add_skills_to(self.agent.agent_context)
         merged_mcp = plugin.add_mcp_config_to(
             dict(self.agent.mcp_config) if self.agent.mcp_config else {}
@@ -955,35 +997,36 @@ class LocalConversation(BaseConversation):
             merged_mcp = expand_mcp_variables(
                 merged_mcp,
                 {},
-                get_secret=self._state.secret_registry.get_secret_value,
+                get_secret=get_secret,
                 expand_defaults=True,
             )
 
-        self.agent = self.agent.model_copy(
-            update={
-                "agent_context": merged_context,
-                "mcp_config": merged_mcp,
-            }
-        )
-
-        if plugin.agents:
-            register_plugin_agents(
-                agents=plugin.agents,
-                work_dir=self.workspace.working_dir,
-            )
-        if plugin.hooks and not plugin.hooks.is_empty():
-            self._merge_runtime_plugin_hooks(plugin.hooks)
-
-        resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
-        if self._resolved_plugins is None:
-            self._resolved_plugins = []
-        self._resolved_plugins.append(resolved)
-
         with self._state:
+            self.agent = self.agent.model_copy(
+                update={
+                    "agent_context": merged_context,
+                    "mcp_config": merged_mcp,
+                }
+            )
+
+            if plugin.agents:
+                register_plugin_agents(
+                    agents=plugin.agents,
+                    work_dir=self.workspace.working_dir,
+                )
+            if plugin.hooks and not plugin.hooks.is_empty():
+                self._merge_runtime_plugin_hooks(plugin.hooks)
+
+            resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
+            if self._resolved_plugins is None:
+                self._resolved_plugins = []
+            self._resolved_plugins.append(resolved)
+
             self._state.agent = self.agent
             if self._agent_ready:
-                self.agent.reset_runtime_tools()
-                self.agent.init_state(self._state, on_event=self._on_event)
+                self.agent.add_runtime_tools(
+                    self._runtime_tools_for_plugin(runtime_plugin_mcp)
+                )
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -564,13 +564,6 @@ class TestLocalConversationPlugins:
             def __init__(self):
                 self.tools = [runtime_tool]
 
-        def mock_create_mcp_tools(config, timeout):
-            mcp_tools_created.append(config)
-            return RuntimeMCPClient()
-
-        monkeypatch.setattr(
-            local_conversation_impl, "create_mcp_tools", mock_create_mcp_tools
-        )
         marketplace_dir = create_test_marketplace(
             tmp_path / "marketplace",
             plugins=[
@@ -599,6 +592,14 @@ class TestLocalConversationPlugins:
         conversation._ensure_agent_ready()
         existing_tools = dict(conversation.agent.tools_map)
 
+        def mock_create_mcp_tools(config, timeout):
+            mcp_tools_created.append((config, conversation.state.locked()))
+            return RuntimeMCPClient()
+
+        monkeypatch.setattr(
+            local_conversation_impl, "create_mcp_tools", mock_create_mcp_tools
+        )
+
         conversation.load_plugin("mcp-plugin")
 
         for name, tool in existing_tools.items():
@@ -607,7 +608,9 @@ class TestLocalConversationPlugins:
         assert conversation.agent.mcp_config is not None
         assert "runtime-server" in conversation.agent.mcp_config["mcpServers"]
         assert len(mcp_tools_created) == 1
-        assert "runtime-server" in mcp_tools_created[0]["mcpServers"]
+        created_config, state_locked = mcp_tools_created[0]
+        assert not state_locked
+        assert "runtime-server" in created_config["mcpServers"]
 
         conversation.close()
 

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -440,6 +440,112 @@ class TestLocalConversationPlugins:
 
         conversation.close()
 
+    def test_load_plugin_from_registered_marketplace(self, tmp_path: Path, mock_llm):
+        """Test runtime plugin loading from a registered marketplace."""
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "manual-plugin",
+                    "skills": [{"name": "manual-skill", "content": "Manual skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+
+        conversation.load_plugin("manual-plugin@manual")
+
+        assert conversation.agent.agent_context is not None
+        skills = {
+            skill.name: skill for skill in conversation.agent.agent_context.skills
+        }
+        assert skills["manual-skill"].content == "Manual skill"
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+
+        conversation.close()
+
+    def test_load_plugin_reinitializes_tools_after_agent_ready(
+        self, tmp_path: Path, mock_llm, monkeypatch
+    ):
+        """Test runtime MCP plugins rebuild initialized tool state."""
+        mcp_tools_created = []
+
+        def mock_create_mcp_tools(config, timeout):
+            mcp_tools_created.append(config)
+            return []
+
+        import openhands.sdk.agent.base
+
+        monkeypatch.setattr(
+            openhands.sdk.agent.base, "create_mcp_tools", mock_create_mcp_tools
+        )
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "mcp-plugin",
+                    "mcp_config": {
+                        "mcpServers": {"runtime-server": {"command": "runtime"}}
+                    },
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+        conversation._ensure_agent_ready()
+
+        conversation.load_plugin("mcp-plugin")
+
+        assert conversation.agent.mcp_config is not None
+        assert "runtime-server" in conversation.agent.mcp_config["mcpServers"]
+        assert len(mcp_tools_created) == 1
+        assert "runtime-server" in mcp_tools_created[0]["mcpServers"]
+
+        conversation.close()
+
+    def test_load_plugin_requires_registered_marketplaces(
+        self, tmp_path: Path, basic_agent
+    ):
+        """Test runtime plugin loading requires registered marketplaces."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+
+        with pytest.raises(ValueError, match="registered_marketplaces"):
+            conversation.load_plugin("missing-plugin")
+
+        conversation.close()
+
     def test_conversation_with_multiple_plugins(self, tmp_path: Path, basic_agent):
         """Test loading multiple plugins via LocalConversation."""
         plugin1 = create_test_plugin(

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -1,18 +1,21 @@
 """Tests for plugin loading via LocalConversation and Conversation factory."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
 
+import openhands.sdk.conversation.impl.local_conversation as local_conversation_impl
 from openhands.sdk import LLM, Agent, AgentContext, Conversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.hooks.config import HookDefinition, HookMatcher
 from openhands.sdk.marketplace import MarketplaceRegistration
 from openhands.sdk.plugin import PluginSource
+from openhands.sdk.tool.builtins import ThinkTool
 
 
 @pytest.fixture
@@ -88,13 +91,16 @@ def create_test_marketplace(
             mcp_config=plugin.get("mcp_config"),
             hooks=plugin.get("hooks"),
         )
-        entries.append(
-            {
-                "name": plugin_name,
-                "source": f"./plugins/{plugin_name}",
-                "description": f"Test plugin {plugin_name}",
-            }
-        )
+        entry = {
+            "name": plugin_name,
+            "source": plugin.get("source", f"./plugins/{plugin_name}"),
+            "description": f"Test plugin {plugin_name}",
+        }
+        if "ref" in plugin:
+            entry["ref"] = plugin["ref"]
+        if "repo_path" in plugin:
+            entry["repo_path"] = plugin["repo_path"]
+        entries.append(entry)
 
     manifest = {
         "name": name,
@@ -478,20 +484,92 @@ class TestLocalConversationPlugins:
 
         conversation.close()
 
-    def test_load_plugin_reinitializes_tools_after_agent_ready(
+    def test_load_plugin_expands_resolved_plugin_source_secret_refs(
+        self,
+        tmp_path: Path,
+        mock_llm,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "private-plugin",
+                    "source": {
+                        "source": "url",
+                        "url": "https://${PLUGIN_TOKEN}@example.com/private.git",
+                        "ref": "${PLUGIN_REF}",
+                        "path": "plugins/private-plugin",
+                    },
+                    "skills": [{"name": "private-skill", "content": "Private skill"}],
+                }
+            ],
+        )
+        plugin_dir = marketplace_dir / "plugins" / "private-plugin"
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+        conversation.update_secrets(
+            {"PLUGIN_TOKEN": "token-value", "PLUGIN_REF": "release-branch"}
+        )
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch(
+                "openhands.sdk.conversation.impl.local_conversation."
+                "fetch_plugin_with_resolution",
+                return_value=(plugin_dir, "abc123"),
+            ) as mock_fetch,
+        ):
+            conversation.load_plugin("private-plugin")
+
+        assert "token-value" not in caplog.text
+        assert "https://" not in caplog.text
+        mock_fetch.assert_called_once_with(
+            source="https://token-value@example.com/private.git",
+            ref="release-branch",
+            repo_path="plugins/private-plugin",
+        )
+        assert conversation.agent.agent_context is not None
+        assert [skill.name for skill in conversation.agent.agent_context.skills] == [
+            "private-skill"
+        ]
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+
+        conversation.close()
+
+    def test_load_plugin_adds_runtime_tools_without_reinitializing_existing_tools(
         self, tmp_path: Path, mock_llm, monkeypatch
     ):
-        """Test runtime MCP plugins rebuild initialized tool state."""
         mcp_tools_created = []
+
+        class RuntimeOnlyTool(ThinkTool):
+            name = "runtime_only"
+
+        runtime_tool = RuntimeOnlyTool.create()[0]
+
+        class RuntimeMCPClient:
+            def __init__(self):
+                self.tools = [runtime_tool]
 
         def mock_create_mcp_tools(config, timeout):
             mcp_tools_created.append(config)
-            return []
-
-        import openhands.sdk.agent.base
+            return RuntimeMCPClient()
 
         monkeypatch.setattr(
-            openhands.sdk.agent.base, "create_mcp_tools", mock_create_mcp_tools
+            local_conversation_impl, "create_mcp_tools", mock_create_mcp_tools
         )
         marketplace_dir = create_test_marketplace(
             tmp_path / "marketplace",
@@ -519,13 +597,99 @@ class TestLocalConversationPlugins:
             agent=agent, workspace=workspace, visualizer=None
         )
         conversation._ensure_agent_ready()
+        existing_tools = dict(conversation.agent.tools_map)
 
         conversation.load_plugin("mcp-plugin")
 
+        for name, tool in existing_tools.items():
+            assert conversation.agent.tools_map[name] is tool
+        assert conversation.agent.tools_map[runtime_tool.name] is runtime_tool
         assert conversation.agent.mcp_config is not None
         assert "runtime-server" in conversation.agent.mcp_config["mcpServers"]
         assert len(mcp_tools_created) == 1
         assert "runtime-server" in mcp_tools_created[0]["mcpServers"]
+
+        conversation.close()
+
+    def test_load_plugin_merges_runtime_hooks_and_restarts_processor(
+        self, tmp_path: Path, mock_llm
+    ):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "hook-plugin",
+                    "hooks": {
+                        "hooks": {
+                            "PreToolUse": [
+                                {
+                                    "matcher": "runtime-*",
+                                    "hooks": [{"command": "runtime-cmd"}],
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        explicit_hooks = HookConfig(
+            pre_tool_use=[
+                HookMatcher(
+                    matcher="explicit-*", hooks=[HookDefinition(command="explicit-cmd")]
+                )
+            ]
+        )
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            hook_config=explicit_hooks,
+            visualizer=None,
+        )
+        initial_processor = MagicMock()
+        initial_processor.on_event = MagicMock()
+        runtime_processor = MagicMock()
+        runtime_processor.on_event = MagicMock()
+
+        callback_lock_owned: list[bool] = []
+
+        def mock_create_hook_callback(*args, **kwargs):
+            callback_lock_owned.append(conversation.state._lock.owned())
+            if len(callback_lock_owned) == 1:
+                return initial_processor, initial_processor.on_event
+            return runtime_processor, runtime_processor.on_event
+
+        with patch(
+            "openhands.sdk.conversation.impl.local_conversation.create_hook_callback",
+            side_effect=mock_create_hook_callback,
+        ) as mock_create_hook_callback:
+            conversation.load_plugin("hook-plugin")
+
+        assert conversation.state.hook_config is not None
+        assert [
+            matcher.matcher for matcher in conversation.state.hook_config.pre_tool_use
+        ] == ["explicit-*", "runtime-*"]
+        assert mock_create_hook_callback.call_count == 2
+        assert callback_lock_owned[1]
+        initial_processor.set_conversation_state.assert_called_once_with(
+            conversation.state
+        )
+        initial_processor.run_session_start.assert_called_once()
+        initial_processor.run_session_end.assert_called_once()
+        runtime_processor.set_conversation_state.assert_called_once_with(
+            conversation.state
+        )
+        runtime_processor.run_session_start.assert_called_once()
 
         conversation.close()
 


### PR DESCRIPTION
HUMAN:

Phase 3 of the marketplace implementation changes. This PR tightly integrates the marketplace data classes into the plugin loading machinery for local conversations.

---

AGENT:

## Summary

Chunk 3 of the marketplace-registration reimplementation, stacked after #3825.

- Add `LocalConversation.load_plugin(plugin_ref)` for resolving and loading plugins from registered marketplaces at runtime.
- Support both `plugin-name` and `plugin-name@marketplace-name` references through `MarketplaceRegistry`.
- Merge runtime plugin skills, MCP config, hooks, and plugin agent definitions into the conversation.
- Reset and rebuild initialized agent tools when runtime plugin loading changes MCP config, so newly loaded MCP tools are available after `_ensure_agent_ready()` has already run.
- Add focused tests for runtime plugin loading, MCP/tool reinitialization, and missing registration errors.

## Why

Runtime marketplace plugin loading lets local conversations opt into additional plugin capabilities after startup without reinitializing the whole conversation.

## Scope

This is SDK-local runtime loading only. Agent-server routes and `RemoteConversation.load_plugin(...)` are planned for later chunks in this stack.

## How to Test

```bash
uv run pytest tests/sdk/conversation/test_local_conversation_plugins.py -q
uv run pre-commit run --files openhands-sdk/openhands/sdk/agent/base.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py tests/sdk/conversation/test_local_conversation_plugins.py
```

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@csmith49 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8dea99f4-c5ab-4cef-b9ff-d0dd7937ee13)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4135dc7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4135dc7-python \
  ghcr.io/openhands/agent-server:4135dc7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4135dc7-golang-amd64
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-golang-amd64
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-golang-amd64
ghcr.io/openhands/agent-server:4135dc7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4135dc7-golang-arm64
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-golang-arm64
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-golang-arm64
ghcr.io/openhands/agent-server:4135dc7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4135dc7-java-amd64
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-java-amd64
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-java-amd64
ghcr.io/openhands/agent-server:4135dc7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4135dc7-java-arm64
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-java-arm64
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-java-arm64
ghcr.io/openhands/agent-server:4135dc7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4135dc7-python-amd64
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-python-amd64
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-python-amd64
ghcr.io/openhands/agent-server:4135dc7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4135dc7-python-arm64
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-python-arm64
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-python-arm64
ghcr.io/openhands/agent-server:4135dc7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4135dc7-golang
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-golang
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-golang
ghcr.io/openhands/agent-server:4135dc7-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4135dc7-java
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-java
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-java
ghcr.io/openhands/agent-server:4135dc7-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4135dc7-python
ghcr.io/openhands/agent-server:4135dc726c3a4d708181efdfe23689fefa84576d-python
ghcr.io/openhands/agent-server:feat-marketplace-runtime-load-plugin-python
ghcr.io/openhands/agent-server:4135dc7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4135dc7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4135dc7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->