### PR TITLE
feat(marketplace): configure server marketplace defaults

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -14,6 +14,7 @@ from openhands.agent_server.env_parser import (
     get_env_parser,
     merge,
 )
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.utils.cipher import Cipher
 
 
@@ -235,6 +236,13 @@ class Config(BaseModel):
         default_factory=_default_web_url,
         description=(
             "The URL where this agent server instance is available externally"
+        ),
+    )
+    registered_marketplaces: list[MarketplaceRegistration] = Field(
+        default_factory=list,
+        description=(
+            "Default marketplace registrations for plugin and skill loading. "
+            "Can be configured with OH_REGISTERED_MARKETPLACES as a JSON list."
         ),
     )
     deferred_init: bool = Field(

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -6,7 +6,7 @@ Business logic is delegated to skills_service.py.
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, HTTPException, Path, Request
 from pydantic import BaseModel, Field
 
 from openhands.agent_server.skills_service import (
@@ -261,8 +261,21 @@ class MarketplaceCatalogResponse(BaseModel):
     skills: list[MarketplaceSkillInfo]
 
 
+def _merge_registered_marketplaces(
+    server_registrations: list[MarketplaceRegistration],
+    request_registrations: list[MarketplaceRegistration],
+) -> list[MarketplaceRegistration]:
+    registrations_by_name = {
+        registration.name: registration for registration in server_registrations
+    }
+    registrations_by_name.update(
+        {registration.name: registration for registration in request_registrations}
+    )
+    return list(registrations_by_name.values())
+
+
 @skills_router.post("", response_model=SkillsResponse)
-def get_skills(request: SkillsRequest) -> SkillsResponse:
+def get_skills(request: SkillsRequest, http_request: Request) -> SkillsResponse:
     """Load and merge skills from all configured sources.
 
     Skills are loaded from multiple sources and merged with the following
@@ -295,6 +308,13 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
     elif "org_config" in request.model_fields_set and request.org_config:
         org_repos = [(request.org_config.org_repo_url, request.org_config.org_name)]
 
+    config = getattr(http_request.app.state, "config", None)
+    server_registrations = config.registered_marketplaces if config is not None else []
+    registered_marketplaces = _merge_registered_marketplaces(
+        server_registrations,
+        request.registered_marketplaces,
+    )
+
     # Call the service
     result = load_all_skills(
         load_public=request.load_public,
@@ -305,7 +325,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
         org_repos=org_repos,
         sandbox_exposed_urls=sandbox_urls,
         marketplace_path=request.marketplace_path,
-        registered_marketplaces=request.registered_marketplaces,
+        registered_marketplaces=registered_marketplaces,
     )
 
     # Convert Skill objects to SkillInfo for response

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -15,7 +15,7 @@ def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_pat
                     "source": "https://github.com/org/marketplace",
                     "ref": "main",
                     "repo_path": "marketplace",
-                    "auto_load": "all",
+                    "auto_load": True,
                 }
             ]
         ),
@@ -29,4 +29,4 @@ def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_pat
     assert registration.source == "https://github.com/org/marketplace"
     assert registration.ref == "main"
     assert registration.repo_path == "marketplace"
-    assert registration.auto_load == "all"
+    assert registration.auto_load is True

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -1,0 +1,32 @@
+import json
+
+from openhands.agent_server.config import CONFIG_PATH_ENV, load_config
+
+
+def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_path):
+    config_path = tmp_path / "missing.json"
+    monkeypatch.setenv(CONFIG_PATH_ENV, str(config_path))
+    monkeypatch.setenv(
+        "OH_REGISTERED_MARKETPLACES",
+        json.dumps(
+            [
+                {
+                    "name": "team",
+                    "source": "https://github.com/org/marketplace",
+                    "ref": "main",
+                    "repo_path": "marketplace",
+                    "auto_load": "all",
+                }
+            ]
+        ),
+    )
+
+    config = load_config()
+
+    assert len(config.registered_marketplaces) == 1
+    registration = config.registered_marketplaces[0]
+    assert registration.name == "team"
+    assert registration.source == "https://github.com/org/marketplace"
+    assert registration.ref == "main"
+    assert registration.repo_path == "marketplace"
+    assert registration.auto_load == "all"

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -228,6 +228,39 @@ class TestGetSkillsEndpoint:
             "team",
         ]
 
+    def test_get_skills_server_manual_marketplace_keeps_public_skills(self):
+        config = Config(
+            session_api_keys=[],
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="manual",
+                    source="https://github.com/org/manual-marketplace",
+                )
+            ],
+        )
+        client = TestClient(create_app(config), raise_server_exceptions=False)
+        public_skill = Skill(name="public-skill", content="public", trigger=None)
+
+        with patch(
+            "openhands.agent_server.skills_service.load_available_skills",
+            side_effect=[{"public-skill": public_skill}, {}],
+        ) as mock_load_available:
+            response = client.post(
+                "/api/skills",
+                json={
+                    "load_user": False,
+                    "load_project": False,
+                    "load_org": False,
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert [skill["name"] for skill in data["skills"]] == ["public-skill"]
+        assert data["sources"]["registered_marketplaces"] == 0
+        assert data["sources"]["sdk_base"] == 1
+        assert mock_load_available.call_args_list[0].kwargs["include_public"] is True
+
     def test_get_skills_request_marketplace_overrides_server_default(self):
         """Request registrations override same-named server defaults."""
         config = Config(

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -10,6 +10,7 @@ from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.skills_service import MarketplaceSkillInfo, SkillLoadResult
 from openhands.sdk.extensions.fetch import ExtensionFetchError
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     KeywordTrigger,
@@ -191,6 +192,73 @@ class TestGetSkillsEndpoint:
             registrations = mock_load.call_args[1]["registered_marketplaces"]
             assert len(registrations) == 1
             assert registrations[0].auto_load == ["formatter", "linter"]
+
+    def test_get_skills_merges_server_registered_marketplaces(self):
+        """Server default marketplaces are included with request marketplaces."""
+        config = Config(
+            session_api_keys=[],
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="default",
+                    source="https://github.com/org/default-marketplace",
+                    auto_load=True,
+                )
+            ],
+        )
+        client = TestClient(create_app(config), raise_server_exceptions=False)
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.return_value = SkillLoadResult(skills=[], sources={})
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "registered_marketplaces": [
+                        {
+                            "name": "team",
+                            "source": "https://github.com/org/team-marketplace",
+                        }
+                    ]
+                },
+            )
+
+        assert response.status_code == 200
+        registrations = mock_load.call_args[1]["registered_marketplaces"]
+        assert [registration.name for registration in registrations] == [
+            "default",
+            "team",
+        ]
+
+    def test_get_skills_request_marketplace_overrides_server_default(self):
+        """Request registrations override same-named server defaults."""
+        config = Config(
+            session_api_keys=[],
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="team",
+                    source="https://github.com/org/default-marketplace",
+                )
+            ],
+        )
+        client = TestClient(create_app(config), raise_server_exceptions=False)
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.return_value = SkillLoadResult(skills=[], sources={})
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "registered_marketplaces": [
+                        {
+                            "name": "team",
+                            "source": "https://github.com/org/request-marketplace",
+                        }
+                    ]
+                },
+            )
+
+        assert response.status_code == 200
+        registrations = mock_load.call_args[1]["registered_marketplaces"]
+        assert len(registrations) == 1
+        assert registrations[0].source == "https://github.com/org/request-marketplace"
 
     def test_get_skills_with_sandbox_config(self, client):
         """Test skills request with sandbox configuration."""


### PR DESCRIPTION
HUMAN:

Enables us to construct server-level registered marketplace defaults.

---

AGENT:

## Summary

Chunk 5 of the marketplace-registration reimplementation, stacked on #3827.

- Add `Config.registered_marketplaces` for server-level marketplace defaults.
- Support `OH_REGISTERED_MARKETPLACES` JSON-list parsing through the existing env parser.
- Merge server default registrations with `/api/skills` request registrations.
- Let request registrations override same-named server defaults before calling `load_all_skills(...)`.
- Add config and router tests for env parsing, merging, and override behavior.

## Why

Server-level marketplace defaults let deployments configure common marketplace registrations once while still allowing request-specific overrides.

## How to Test

```bash
uv run pytest tests/agent_server/test_config.py tests/agent_server/test_skills_router.py -q
uv run pre-commit run --files openhands-agent-server/openhands/agent_server/config.py openhands-agent-server/openhands/agent_server/skills_router.py tests/agent_server/test_config.py tests/agent_server/test_skills_router.py
```

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@csmith49 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8dea99f4-c5ab-4cef-b9ff-d0dd7937ee13)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:9e4785e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-9e4785e-python \
  ghcr.io/openhands/agent-server:9e4785e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:9e4785e-golang-amd64
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-golang-amd64
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-golang-amd64
ghcr.io/openhands/agent-server:9e4785e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:9e4785e-golang-arm64
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-golang-arm64
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-golang-arm64
ghcr.io/openhands/agent-server:9e4785e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:9e4785e-java-amd64
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-java-amd64
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-java-amd64
ghcr.io/openhands/agent-server:9e4785e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:9e4785e-java-arm64
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-java-arm64
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-java-arm64
ghcr.io/openhands/agent-server:9e4785e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:9e4785e-python-amd64
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-python-amd64
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-python-amd64
ghcr.io/openhands/agent-server:9e4785e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:9e4785e-python-arm64
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-python-arm64
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-python-arm64
ghcr.io/openhands/agent-server:9e4785e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:9e4785e-golang
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-golang
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-golang
ghcr.io/openhands/agent-server:9e4785e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:9e4785e-java
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-java
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-java
ghcr.io/openhands/agent-server:9e4785e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:9e4785e-python
ghcr.io/openhands/agent-server:9e4785e291f5659f70a27d27293c31e6171063e6-python
ghcr.io/openhands/agent-server:feat-marketplace-server-defaults-python
ghcr.io/openhands/agent-server:9e4785e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `9e4785e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `9e4785e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->