### PR TITLE
docs(examples): show registered marketplace plugins

### DIFF
--- a/examples/05_skills_and_plugins/05_registered_marketplace_plugins/main.py
+++ b/examples/05_skills_and_plugins/05_registered_marketplace_plugins/main.py
@@ -1,0 +1,124 @@
+"""Example: Registered Marketplaces and Runtime Plugin Loading
+
+This example demonstrates the registered marketplace flow:
+
+1. Register multiple marketplace catalogs on AgentContext.
+2. Auto-load plugins from a marketplace with ``auto_load='all'``.
+3. Load an additional plugin at runtime by marketplace-qualified name.
+
+The example builds two temporary local marketplaces so it can run without network
+access or external credentials.
+"""
+
+import json
+import tempfile
+from pathlib import Path
+
+from pydantic import SecretStr
+
+from openhands.sdk import LLM, Agent, AgentContext, Conversation
+from openhands.sdk.marketplace import MarketplaceRegistration
+
+
+def write_plugin(plugin_dir: Path, plugin_name: str, skill_name: str) -> None:
+    manifest_dir = plugin_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps(
+            {
+                "name": plugin_name,
+                "version": "1.0.0",
+                "description": f"Example plugin {plugin_name}",
+            }
+        )
+    )
+
+    skills_dir = plugin_dir / "skills"
+    skills_dir.mkdir()
+    (skills_dir / f"{skill_name}.md").write_text(
+        f"---\nname: {skill_name}\ndescription: Example skill\n---\n"
+        f"Use {skill_name} when demonstrating registered marketplace plugins."
+    )
+
+
+def write_marketplace(marketplace_dir: Path, plugin_name: str, skill_name: str) -> None:
+    write_plugin(marketplace_dir / "plugins" / plugin_name, plugin_name, skill_name)
+    manifest_dir = marketplace_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": marketplace_dir.name,
+                "owner": {"name": "Example Team"},
+                "plugins": [
+                    {
+                        "name": plugin_name,
+                        "source": f"./plugins/{plugin_name}",
+                        "description": f"Example marketplace plugin {plugin_name}",
+                    }
+                ],
+            }
+        )
+    )
+
+
+with tempfile.TemporaryDirectory() as tmpdir:
+    tmp_path = Path(tmpdir)
+    team_marketplace = tmp_path / "team-marketplace"
+    specialists_marketplace = tmp_path / "specialists-marketplace"
+    write_marketplace(team_marketplace, "review-bot", "review-checklist")
+    write_marketplace(specialists_marketplace, "incident-bot", "incident-brief")
+
+    agent = Agent(
+        llm=LLM(model="test/model", api_key=SecretStr("not-used")),
+        tools=[],
+        agent_context=AgentContext(
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="team",
+                    source=str(team_marketplace),
+                    auto_load="all",
+                ),
+                MarketplaceRegistration(
+                    name="specialists",
+                    source=str(specialists_marketplace),
+                ),
+            ]
+        ),
+    )
+
+    conversation = Conversation(
+        agent=agent,
+        workspace=str(tmp_path / "workspace"),
+    )
+
+    conversation.load_plugin("incident-bot@specialists")
+
+    agent_context = conversation.agent.agent_context
+    assert agent_context is not None
+    skill_names = sorted(skill.name for skill in agent_context.skills or [])
+    resolved_sources = [plugin.source for plugin in conversation.resolved_plugins or []]
+
+    print("Registered marketplaces:")
+    for registration in agent_context.registered_marketplaces:
+        print(f"  - {registration.name}: auto_load={registration.auto_load}")
+
+    print("Loaded skills:")
+    for skill_name in skill_names:
+        print(f"  - {skill_name}")
+
+    print("Resolved plugins:")
+    for source in resolved_sources:
+        print(f"  - {source}")
+
+    assert skill_names == ["incident-brief", "review-checklist"]
+    assert any(
+        source.endswith("team-marketplace/plugins/review-bot")
+        for source in resolved_sources
+    )
+    assert any(
+        source.endswith("specialists-marketplace/plugins/incident-bot")
+        for source in resolved_sources
+    )
+
+print("EXAMPLE_COST: 0")

--- a/examples/05_skills_and_plugins/05_registered_marketplace_plugins/main.py
+++ b/examples/05_skills_and_plugins/05_registered_marketplace_plugins/main.py
@@ -14,10 +14,9 @@ import json
 import tempfile
 from pathlib import Path
 
-from pydantic import SecretStr
-
-from openhands.sdk import LLM, Agent, AgentContext, Conversation
+from openhands.sdk import Agent, AgentContext, Conversation
 from openhands.sdk.marketplace import MarketplaceRegistration
+from openhands.sdk.testing import TestLLM
 
 
 def write_plugin(plugin_dir: Path, plugin_name: str, skill_name: str) -> None:
@@ -70,7 +69,7 @@ with tempfile.TemporaryDirectory() as tmpdir:
     write_marketplace(specialists_marketplace, "incident-bot", "incident-brief")
 
     agent = Agent(
-        llm=LLM(model="test/model", api_key=SecretStr("not-used")),
+        llm=TestLLM.from_messages([]),
         tools=[],
         agent_context=AgentContext(
             registered_marketplaces=[

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -13,6 +13,7 @@ from openhands.agent_server.env_parser import (
     get_env_parser,
     merge,
 )
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.utils.cipher import Cipher
 
 
@@ -234,6 +235,13 @@ class Config(BaseModel):
         default_factory=_default_web_url,
         description=(
             "The URL where this agent server instance is available externally"
+        ),
+    )
+    registered_marketplaces: list[MarketplaceRegistration] = Field(
+        default_factory=list,
+        description=(
+            "Default marketplace registrations for plugin and skill loading. "
+            "Can be configured with OH_REGISTERED_MARKETPLACES as a JSON list."
         ),
     )
     deferred_init: bool = Field(

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -21,6 +21,7 @@ from openhands.agent_server._secrets_exposure import (
 )
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.dependencies import get_conversation_service
+from openhands.agent_server.event_service import InactiveServiceError
 from openhands.agent_server.models import (
     INCLUDE_SKILLS_PARAM_TITLE,
     AgentResponseResult,
@@ -519,6 +520,11 @@ async def load_conversation_plugin(
     except PluginResolutionError as e:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except InactiveServiceError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
             detail=str(e),
         )
     except ValueError as e:

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -42,6 +42,7 @@ from openhands.agent_server.models import (
 )
 from openhands.sdk import LLM, Agent, TextContent
 from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.marketplace.registry import PluginResolutionError
 from openhands.sdk.profiles.resolver import DanglingMcpServerRef, ProfileNotFound
 from openhands.sdk.tool.client_tool import ClientToolRegistrationError
 from openhands.sdk.workspace import LocalWorkspace
@@ -494,6 +495,37 @@ async def switch_conversation_llm(
     if cipher is not None:
         llm = decrypt_incoming_llm_secrets(llm, cipher)
     conversation.switch_llm(llm)
+    return Success()
+
+
+@conversation_router.post(
+    "/{conversation_id}/load_plugin",
+    responses={
+        400: {"description": "Invalid plugin reference or inactive conversation"},
+        404: {"description": "Conversation or plugin not found"},
+    },
+)
+async def load_conversation_plugin(
+    conversation_id: UUID,
+    plugin_ref: str = Body(..., embed=True),
+    conversation_service: ConversationService = Depends(get_conversation_service),
+) -> Success:
+    """Load a plugin from the conversation's registered marketplaces."""
+    event_service = await conversation_service.get_event_service(conversation_id)
+    if event_service is None:
+        raise HTTPException(status.HTTP_404_NOT_FOUND)
+    try:
+        await event_service.load_plugin(plugin_ref)
+    except PluginResolutionError as e:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=str(e),
+        )
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
+        )
     return Success()
 
 

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1360,6 +1360,13 @@ class EventService:
             None, self._conversation.set_security_analyzer, security_analyzer
         )
 
+    async def load_plugin(self, plugin_ref: str) -> None:
+        """Load a marketplace plugin into the active conversation."""
+        if self._conversation is None:
+            raise ValueError("inactive_service")
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._conversation.load_plugin, plugin_ref)
+
     async def switch_acp_model(self, model: str) -> None:
         """Switch the model on an ACP conversation.
 

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -70,6 +70,10 @@ INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
 logger = get_logger(__name__)
 
 
+class InactiveServiceError(ValueError):
+    """Raised when an operation targets an inactive event service."""
+
+
 @dataclass
 class EventService:
     """
@@ -1363,7 +1367,7 @@ class EventService:
     async def load_plugin(self, plugin_ref: str) -> None:
         """Load a marketplace plugin into the active conversation."""
         if self._conversation is None:
-            raise ValueError("inactive_service")
+            raise InactiveServiceError("inactive_service")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, self._conversation.load_plugin, plugin_ref)
 

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -24,6 +24,7 @@ from openhands.agent_server.skills_service import (
     sync_public_skills,
 )
 from openhands.sdk.extensions.fetch import ExtensionFetchError
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     SkillFetchError,
@@ -99,6 +100,14 @@ class SkillsRequest(BaseModel):
             "Set to null to load all public skills."
         ),
     )
+    registered_marketplaces: list[MarketplaceRegistration] = Field(
+        default_factory=list,
+        description=(
+            "Marketplace registrations for plugin-based skill loading. When set, "
+            "registrations with auto_load='all' replace legacy public skills."
+        ),
+    )
+
     project_dir: str | None = Field(
         default=None, description="Workspace directory path for project skills"
     )
@@ -295,6 +304,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
         org_repos=org_repos,
         sandbox_exposed_urls=sandbox_urls,
         marketplace_path=request.marketplace_path,
+        registered_marketplaces=request.registered_marketplaces,
     )
 
     # Convert Skill objects to SkillInfo for response

--- a/openhands-agent-server/openhands/agent_server/skills_router.py
+++ b/openhands-agent-server/openhands/agent_server/skills_router.py
@@ -6,7 +6,7 @@ Business logic is delegated to skills_service.py.
 
 from typing import Annotated, Literal
 
-from fastapi import APIRouter, HTTPException, Path
+from fastapi import APIRouter, HTTPException, Path, Request
 from pydantic import BaseModel, Field
 
 from openhands.agent_server.skills_service import (
@@ -260,8 +260,21 @@ class MarketplaceCatalogResponse(BaseModel):
     skills: list[MarketplaceSkillInfo]
 
 
+def _merge_registered_marketplaces(
+    server_registrations: list[MarketplaceRegistration],
+    request_registrations: list[MarketplaceRegistration],
+) -> list[MarketplaceRegistration]:
+    registrations_by_name = {
+        registration.name: registration for registration in server_registrations
+    }
+    registrations_by_name.update(
+        {registration.name: registration for registration in request_registrations}
+    )
+    return list(registrations_by_name.values())
+
+
 @skills_router.post("", response_model=SkillsResponse)
-def get_skills(request: SkillsRequest) -> SkillsResponse:
+def get_skills(request: SkillsRequest, http_request: Request) -> SkillsResponse:
     """Load and merge skills from all configured sources.
 
     Skills are loaded from multiple sources and merged with the following
@@ -294,6 +307,13 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
     elif "org_config" in request.model_fields_set and request.org_config:
         org_repos = [(request.org_config.org_repo_url, request.org_config.org_name)]
 
+    config = getattr(http_request.app.state, "config", None)
+    server_registrations = config.registered_marketplaces if config is not None else []
+    registered_marketplaces = _merge_registered_marketplaces(
+        server_registrations,
+        request.registered_marketplaces,
+    )
+
     # Call the service
     result = load_all_skills(
         load_public=request.load_public,
@@ -304,7 +324,7 @@ def get_skills(request: SkillsRequest) -> SkillsResponse:
         org_repos=org_repos,
         sandbox_exposed_urls=sandbox_urls,
         marketplace_path=request.marketplace_path,
-        registered_marketplaces=request.registered_marketplaces,
+        registered_marketplaces=registered_marketplaces,
     )
 
     # Convert Skill objects to SkillInfo for response

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -26,6 +26,9 @@ from pydantic import BaseModel, ValidationError
 
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace import Marketplace
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
+from openhands.sdk.marketplace.registry import MarketplaceRegistry
+from openhands.sdk.plugin import Plugin
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     Skill,
@@ -290,6 +293,45 @@ def merge_skills(skill_lists: list[list[Skill]]) -> list[Skill]:
     return list(skills_by_name.values())
 
 
+def load_registered_marketplace_skills(
+    registered_marketplaces: list[MarketplaceRegistration],
+) -> list[Skill]:
+    """Load skills from auto-load plugins in registered marketplaces."""
+    if not registered_marketplaces:
+        return []
+
+    registry = MarketplaceRegistry(registered_marketplaces)
+    all_skills: list[Skill] = []
+    for registration in registry.get_auto_load_registrations():
+        try:
+            marketplace, _ = registry.get_marketplace(registration.name)
+        except Exception:
+            logger.warning(
+                "Failed to load marketplace '%s'; continuing without it",
+                registration.name,
+                exc_info=True,
+            )
+            continue
+
+        for entry in marketplace.plugins:
+            try:
+                source, ref, repo_path = marketplace.resolve_plugin_source(entry)
+                plugin_path = Plugin.fetch(
+                    source=source,
+                    ref=ref,
+                    repo_path=repo_path,
+                )
+                all_skills.extend(Plugin.load(plugin_path).get_all_skills())
+            except Exception:
+                logger.warning(
+                    "Failed to load plugin '%s' from marketplace '%s'",
+                    entry.name,
+                    registration.name,
+                    exc_info=True,
+                )
+    return all_skills
+
+
 def load_all_skills(
     load_public: bool = True,
     load_user: bool = True,
@@ -299,6 +341,7 @@ def load_all_skills(
     org_repos: list[tuple[str, str]] | None = None,
     sandbox_exposed_urls: list[ExposedUrlData] | None = None,
     marketplace_path: str | None = DEFAULT_MARKETPLACE_PATH,
+    registered_marketplaces: list[MarketplaceRegistration] | None = None,
 ) -> SkillLoadResult:
     """Load and merge skills from all configured sources.
 
@@ -321,6 +364,8 @@ def load_all_skills(
         sandbox_exposed_urls: List of exposed URLs from sandbox.
         marketplace_path: Relative marketplace JSON path for public skills.
             Pass None to load all public skills without marketplace filtering.
+        registered_marketplaces: Marketplace registrations whose auto-load plugins
+            replace legacy public skills when provided.
 
     Returns:
         SkillLoadResult containing merged skills and source counts.
@@ -337,12 +382,20 @@ def load_all_skills(
     sources["sandbox"] = len(sandbox_skills)
     skill_lists.append(sandbox_skills)
 
-    # 2-3. Load public + user skills via helper (no project yet — org sits between)
+    marketplace_skills: list[Skill] = []
+    if load_public and registered_marketplaces:
+        marketplace_skills = load_registered_marketplace_skills(registered_marketplaces)
+    sources["registered_marketplaces"] = len(marketplace_skills)
+    skill_lists.append(marketplace_skills)
+
+    # 2-3. Load legacy public + user skills via helper (no project yet — org sits
+    # between). Registered marketplaces replace legacy public skills, while user
+    # skills keep their existing precedence above the public marketplace tier.
     sdk_base = load_available_skills(
         work_dir=None,
         include_user=load_user,
         include_project=False,
-        include_public=load_public,
+        include_public=load_public and not registered_marketplaces,
         marketplace_path=marketplace_path,
     )
     sources["sdk_base"] = len(sdk_base)

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -901,6 +901,11 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # Drive the traversal from self
         yield from _walk(self)
 
+    def reset_runtime_tools(self) -> None:
+        """Clear initialized runtime tools so they can be rebuilt from config."""
+        self._tools = {}
+        self._initialized = False
+
     @property
     def tools_map(self) -> dict[str, ToolDefinition]:
         """Get the initialized tools map.

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -6,6 +6,7 @@ import os
 import re
 import sys
 from abc import ABC, abstractmethod
+from collections import Counter
 from collections.abc import Generator, Iterable, Sequence
 from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING, Any, Literal
@@ -901,10 +902,41 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # Drive the traversal from self
         yield from _walk(self)
 
-    def reset_runtime_tools(self) -> None:
-        """Clear initialized runtime tools so they can be rebuilt from config."""
-        self._tools = {}
-        self._initialized = False
+    def _close_tool_executor(self, tool: ToolDefinition) -> None:
+        try:
+            executable_tool = tool.as_executable()
+            executable_tool.executor.close()
+        except NotImplementedError:
+            return
+        except Exception as exc:
+            logger.warning("Error closing executor for tool '%s': %s", tool.name, exc)
+
+    def add_runtime_tools(self, tools: Sequence[ToolDefinition]) -> None:
+        if not self._initialized:
+            logger.warning(
+                "add_runtime_tools called before agent initialization; "
+                "tools will not be registered"
+            )
+            return
+        for tool in tools:
+            if not isinstance(tool, ToolDefinition):
+                raise ValueError(
+                    f"Tool {tool} is not an instance of 'ToolDefinition'. "
+                    f"Got type: {type(tool)}"
+                )
+
+        tool_names = [tool.name for tool in tools]
+        if len(tool_names) != len(set(tool_names)):
+            duplicates = {
+                name for name, count in Counter(tool_names).items() if count > 1
+            }
+            raise ValueError(f"Duplicate runtime tool names found: {duplicates}")
+
+        for tool in tools:
+            previous_tool = self._tools.get(tool.name)
+            if previous_tool is not None:
+                self._close_tool_executor(previous_tool)
+            self._tools[tool.name] = tool
 
     @property
     def tools_map(self) -> dict[str, ToolDefinition]:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -939,15 +939,16 @@ class LocalConversation(BaseConversation):
         self._hook_processor.set_conversation_state(self._state)
         self._hook_processor.run_session_start()
 
-    def _runtime_tools_for_plugin(
+    def _runtime_mcp_tools_for_plugin(
         self, plugin_mcp_config: dict[str, Any] | None
     ) -> list[ToolDefinition]:
-        runtime_tools: list[ToolDefinition] = []
-        if plugin_mcp_config:
-            runtime_tools.extend(
-                create_mcp_tools(plugin_mcp_config, _RUNTIME_MCP_TIMEOUT_SECS).tools
-            )
+        if not plugin_mcp_config:
+            return []
+        return list(
+            create_mcp_tools(plugin_mcp_config, _RUNTIME_MCP_TIMEOUT_SECS).tools
+        )
 
+    def _runtime_skill_tools_for_agent(self) -> list[ToolDefinition]:
         agent_context = self.agent.agent_context
         has_invocable_skills = bool(
             agent_context
@@ -957,8 +958,21 @@ class LocalConversation(BaseConversation):
             )
         )
         if has_invocable_skills and InvokeSkillTool.name not in self.agent.tools_map:
-            runtime_tools.extend(InvokeSkillTool.create(self._state))
-        return runtime_tools
+            return list(InvokeSkillTool.create(self._state))
+        return []
+
+    def _close_runtime_tools(self, tools: Sequence[ToolDefinition]) -> None:
+        for tool in tools:
+            try:
+                tool.as_executable().executor.close()
+            except NotImplementedError:
+                continue
+            except Exception as exc:
+                logger.warning(
+                    "Error closing runtime tool executor for tool '%s': %s",
+                    tool.name,
+                    exc,
+                )
 
     def load_plugin(self, plugin_ref: str) -> None:
         """Load a plugin from the conversation's registered marketplaces."""
@@ -1000,6 +1014,11 @@ class LocalConversation(BaseConversation):
                 get_secret=get_secret,
                 expand_defaults=True,
             )
+        runtime_mcp_tools = (
+            self._runtime_mcp_tools_for_plugin(runtime_plugin_mcp)
+            if self._agent_ready
+            else []
+        )
 
         with self._state:
             self.agent = self.agent.model_copy(
@@ -1024,9 +1043,15 @@ class LocalConversation(BaseConversation):
 
             self._state.agent = self.agent
             if self._agent_ready:
-                self.agent.add_runtime_tools(
-                    self._runtime_tools_for_plugin(runtime_plugin_mcp)
-                )
+                runtime_tools = [
+                    *runtime_mcp_tools,
+                    *self._runtime_skill_tools_for_agent(),
+                ]
+                try:
+                    self.agent.add_runtime_tools(runtime_tools)
+                except Exception:
+                    self._close_runtime_tools(runtime_mcp_tools)
+                    raise
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -664,34 +664,13 @@ class LocalConversation(BaseConversation):
         # Track whether we have plugins or MCP config to process
         has_mcp_config = bool(merged_mcp)
 
-        # Expand ${VAR} placeholders in the source/ref using per-conversation
-        # secrets, so private plugins can be cloned with a token supplied via
-        # the secrets API, e.g. "https://x-token-auth:${MY_TOKEN}@host/repo.git".
-        #
-        # SECURITY: secrets only (check_env=False) -- never fold host
-        # environment variables into a URL sent to a remote git host.
-        # Braced-only (support_unbraced=False) avoids mangling a literal "$"
-        # that may legitimately appear in a token/password. expand_defaults
-        # is False so an unknown ${VAR} is left verbatim rather than silently
-        # defaulted inside a URL.
-        get_secret = self._state.secret_registry.get_secret_value
-
-        def _expand_secret_refs(value: str) -> str:
-            return expand_variable_references(
-                value,
-                get_secret=get_secret,
-                check_env=False,
-                support_unbraced=False,
-                expand_defaults=False,
-            )
-
         plugins_to_load: list[tuple[PluginSource, bool]] = []
         if merged_context is not None and merged_context.registered_marketplaces:
             registrations = [
                 registration.model_copy(
                     update={
-                        "source": _expand_secret_refs(registration.source),
-                        "ref": _expand_secret_refs(registration.ref)
+                        "source": self._expand_plugin_source_ref(registration.source),
+                        "ref": self._expand_plugin_source_ref(registration.ref)
                         if registration.ref
                         else None,
                     }
@@ -731,8 +710,12 @@ class LocalConversation(BaseConversation):
                     fetch_source = spec.source
                     fetch_ref = spec.ref
                 else:
-                    fetch_source = _expand_secret_refs(spec.source)
-                    fetch_ref = _expand_secret_refs(spec.ref) if spec.ref else spec.ref
+                    fetch_source = self._expand_plugin_source_ref(spec.source)
+                    fetch_ref = (
+                        self._expand_plugin_source_ref(spec.ref)
+                        if spec.ref
+                        else spec.ref
+                    )
 
                 # Fetch plugin and get resolved commit SHA
                 path, resolved_ref = fetch_plugin_with_resolution(
@@ -880,6 +863,127 @@ class LocalConversation(BaseConversation):
             self._hook_processor.run_session_start()
 
         self._plugins_loaded = True
+
+    def _expand_plugin_source_ref(self, value: str) -> str:
+        return expand_variable_references(
+            value,
+            get_secret=self._state.secret_registry.get_secret_value,
+            check_env=False,
+            support_unbraced=False,
+            expand_defaults=False,
+        )
+
+    def _marketplace_registry_from_context(self) -> MarketplaceRegistry:
+        agent_context = self.agent.agent_context
+        if agent_context is None:
+            raise ValueError(
+                "No agent context available. Configure agent_context with "
+                "registered_marketplaces to use load_plugin()."
+            )
+        registrations = agent_context.registered_marketplaces
+        if not registrations:
+            raise ValueError(
+                "No marketplaces registered. Configure registered_marketplaces "
+                "in AgentContext to use load_plugin()."
+            )
+        return MarketplaceRegistry(
+            [
+                registration.model_copy(
+                    update={
+                        "source": self._expand_plugin_source_ref(registration.source),
+                        "ref": self._expand_plugin_source_ref(registration.ref)
+                        if registration.ref
+                        else None,
+                    }
+                )
+                for registration in registrations
+            ]
+        )
+
+    def _merge_runtime_plugin_hooks(self, plugin_hooks: HookConfig) -> None:
+        existing_config = self._state.hook_config
+        merged_config = (
+            HookConfig.merge([existing_config, plugin_hooks])
+            if existing_config is not None
+            else plugin_hooks
+        )
+        if merged_config is None:
+            return
+
+        hook_persistence_dir = (
+            str(Path(self._state.persistence_dir).parent)
+            if self._state.persistence_dir is not None
+            else None
+        )
+        self._state.hook_config = merged_config
+        self._pending_hook_config = merged_config
+        self._hook_processor, self._on_event = create_hook_callback(
+            hook_config=merged_config,
+            working_dir=str(self.workspace.working_dir),
+            session_id=str(self._state.id),
+            original_callback=self._base_callback,
+            llm_getter=lambda: self.agent.llm,
+            persistence_dir=hook_persistence_dir,
+            visualizer=self._visualizer,
+            conversation_stats=self._state.stats,
+        )
+        self._hook_processor.set_conversation_state(self._state)
+
+    def load_plugin(self, plugin_ref: str) -> None:
+        """Load a plugin from the conversation's registered marketplaces."""
+        self._ensure_plugins_loaded()
+        spec = self._marketplace_registry_from_context().resolve_plugin(plugin_ref)
+
+        fetch_source = self._expand_plugin_source_ref(spec.source)
+        fetch_ref = self._expand_plugin_source_ref(spec.ref) if spec.ref else spec.ref
+        path, resolved_ref = fetch_plugin_with_resolution(
+            source=fetch_source,
+            ref=fetch_ref,
+            repo_path=spec.repo_path,
+        )
+        plugin = Plugin.load(path)
+        logger.info(
+            f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
+            + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
+        )
+
+        merged_context = plugin.add_skills_to(self.agent.agent_context)
+        merged_mcp = plugin.add_mcp_config_to(
+            dict(self.agent.mcp_config) if self.agent.mcp_config else {}
+        )
+        if merged_mcp:
+            merged_mcp = expand_mcp_variables(
+                merged_mcp,
+                {},
+                get_secret=self._state.secret_registry.get_secret_value,
+                expand_defaults=True,
+            )
+
+        self.agent = self.agent.model_copy(
+            update={
+                "agent_context": merged_context,
+                "mcp_config": merged_mcp,
+            }
+        )
+
+        if plugin.agents:
+            register_plugin_agents(
+                agents=plugin.agents,
+                work_dir=self.workspace.working_dir,
+            )
+        if plugin.hooks and not plugin.hooks.is_empty():
+            self._merge_runtime_plugin_hooks(plugin.hooks)
+
+        resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
+        if self._resolved_plugins is None:
+            self._resolved_plugins = []
+        self._resolved_plugins.append(resolved)
+
+        with self._state:
+            self._state.agent = self.agent
+            if self._agent_ready:
+                self.agent.reset_runtime_tools()
+                self.agent.init_state(self._state, on_event=self._on_event)
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -54,6 +54,7 @@ from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.llm.llm_registry import LLMRegistry
 from openhands.sdk.logger import get_logger
 from openhands.sdk.marketplace.registry import MarketplaceRegistry
+from openhands.sdk.mcp import create_mcp_tools
 from openhands.sdk.observability.laminar import observe
 from openhands.sdk.plugin import (
     Plugin,
@@ -76,6 +77,8 @@ from openhands.sdk.subagent import (
     register_file_agents,
     register_plugin_agents,
 )
+from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.tool.builtins import InvokeSkillTool
 from openhands.sdk.tool.client_tool import ClientToolSpec
 from openhands.sdk.tool.schema import Action, Observation
 from openhands.sdk.utils.cipher import Cipher
@@ -87,6 +90,8 @@ logger = get_logger(__name__)
 ACP_LAST_PROMPT_USER_MESSAGE_ID = "acp_last_prompt_user_message_id"
 ACP_INFLIGHT_PROMPT_USER_MESSAGE_ID = "acp_inflight_prompt_user_message_id"
 ACP_SUPERSEDE_INFLIGHT_PROMPT = "acp_supersede_inflight_prompt"
+_RUNTIME_MCP_TIMEOUT_SECS = 30
+
 ACP_STOP_HOOK_FEEDBACK_PREFIX = "[Stop hook feedback]"
 
 
@@ -735,7 +740,7 @@ class LocalConversation(BaseConversation):
                 # Load the plugin
                 plugin = Plugin.load(path)
                 logger.debug(
-                    f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
+                    f"Loaded plugin '{plugin.manifest.name}'"
                     + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
                 )
 
@@ -915,6 +920,10 @@ class LocalConversation(BaseConversation):
             if self._state.persistence_dir is not None
             else None
         )
+        previous_processor = self._hook_processor
+        if previous_processor is not None:
+            previous_processor.run_session_end()
+
         self._state.hook_config = merged_config
         self._pending_hook_config = merged_config
         self._hook_processor, self._on_event = create_hook_callback(
@@ -928,6 +937,28 @@ class LocalConversation(BaseConversation):
             conversation_stats=self._state.stats,
         )
         self._hook_processor.set_conversation_state(self._state)
+        self._hook_processor.run_session_start()
+
+    def _runtime_tools_for_plugin(
+        self, plugin_mcp_config: dict[str, Any] | None
+    ) -> list[ToolDefinition]:
+        runtime_tools: list[ToolDefinition] = []
+        if plugin_mcp_config:
+            runtime_tools.extend(
+                create_mcp_tools(plugin_mcp_config, _RUNTIME_MCP_TIMEOUT_SECS).tools
+            )
+
+        agent_context = self.agent.agent_context
+        has_invocable_skills = bool(
+            agent_context
+            and any(
+                skill.is_agentskills_format and not skill.disable_model_invocation
+                for skill in agent_context.skills
+            )
+        )
+        if has_invocable_skills and InvokeSkillTool.name not in self.agent.tools_map:
+            runtime_tools.extend(InvokeSkillTool.create(self._state))
+        return runtime_tools
 
     def load_plugin(self, plugin_ref: str) -> None:
         """Load a plugin from the conversation's registered marketplaces."""
@@ -943,10 +974,21 @@ class LocalConversation(BaseConversation):
         )
         plugin = Plugin.load(path)
         logger.info(
-            f"Loaded plugin '{plugin.manifest.name}' from {spec.source}"
+            f"Loaded plugin '{plugin.manifest.name}'"
             + (f" @ {resolved_ref[:8]}" if resolved_ref else "")
         )
 
+        get_secret = self._state.secret_registry.get_secret_value
+        runtime_plugin_mcp = (
+            expand_mcp_variables(
+                plugin.mcp_config,
+                {},
+                get_secret=get_secret,
+                expand_defaults=True,
+            )
+            if plugin.mcp_config
+            else None
+        )
         merged_context = plugin.add_skills_to(self.agent.agent_context)
         merged_mcp = plugin.add_mcp_config_to(
             dict(self.agent.mcp_config) if self.agent.mcp_config else {}
@@ -955,35 +997,36 @@ class LocalConversation(BaseConversation):
             merged_mcp = expand_mcp_variables(
                 merged_mcp,
                 {},
-                get_secret=self._state.secret_registry.get_secret_value,
+                get_secret=get_secret,
                 expand_defaults=True,
             )
 
-        self.agent = self.agent.model_copy(
-            update={
-                "agent_context": merged_context,
-                "mcp_config": merged_mcp,
-            }
-        )
-
-        if plugin.agents:
-            register_plugin_agents(
-                agents=plugin.agents,
-                work_dir=self.workspace.working_dir,
-            )
-        if plugin.hooks and not plugin.hooks.is_empty():
-            self._merge_runtime_plugin_hooks(plugin.hooks)
-
-        resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
-        if self._resolved_plugins is None:
-            self._resolved_plugins = []
-        self._resolved_plugins.append(resolved)
-
         with self._state:
+            self.agent = self.agent.model_copy(
+                update={
+                    "agent_context": merged_context,
+                    "mcp_config": merged_mcp,
+                }
+            )
+
+            if plugin.agents:
+                register_plugin_agents(
+                    agents=plugin.agents,
+                    work_dir=self.workspace.working_dir,
+                )
+            if plugin.hooks and not plugin.hooks.is_empty():
+                self._merge_runtime_plugin_hooks(plugin.hooks)
+
+            resolved = ResolvedPluginSource.from_plugin_source(spec, resolved_ref)
+            if self._resolved_plugins is None:
+                self._resolved_plugins = []
+            self._resolved_plugins.append(resolved)
+
             self._state.agent = self.agent
             if self._agent_ready:
-                self.agent.reset_runtime_tools()
-                self.agent.init_state(self._state, on_event=self._on_event)
+                self.agent.add_runtime_tools(
+                    self._runtime_tools_for_plugin(runtime_plugin_mcp)
+                )
 
     def _register_file_based_agents(self) -> None:
         """Discover and register file-based agents into the agent registry.

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -1372,6 +1372,14 @@ class RemoteConversation(BaseConversation):
             f"{self._conversation_action_base_path}/{self._id}/interrupt",
         )
 
+    def load_plugin(self, plugin_ref: str) -> None:
+        _send_request(
+            self._client,
+            "POST",
+            f"{self._conversation_action_base_path}/{self._id}/load_plugin",
+            json={"plugin_ref": plugin_ref},
+        )
+
     def update_secrets(self, secrets: Mapping[str, SecretValue]) -> None:
         from openhands.sdk.secret.secrets import SecretSource
 

--- a/openhands-sdk/openhands/sdk/marketplace/registration.py
+++ b/openhands-sdk/openhands/sdk/marketplace/registration.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from pathlib import PurePosixPath, PureWindowsPath
+from typing import Literal
 
 from pydantic import BaseModel, Field, field_validator
 
@@ -25,7 +26,7 @@ class MarketplaceRegistration(BaseModel):
             "Only relevant for git sources."
         ),
     )
-    auto_load: bool = Field(
+    auto_load: bool | Literal["all"] = Field(
         default=False,
         description="Whether to load all marketplace plugins at conversation start.",
     )

--- a/tests/agent_server/test_config.py
+++ b/tests/agent_server/test_config.py
@@ -1,0 +1,32 @@
+import json
+
+from openhands.agent_server.config import CONFIG_PATH_ENV, load_config
+
+
+def test_load_config_reads_registered_marketplaces_from_env(monkeypatch, tmp_path):
+    config_path = tmp_path / "missing.json"
+    monkeypatch.setenv(CONFIG_PATH_ENV, str(config_path))
+    monkeypatch.setenv(
+        "OH_REGISTERED_MARKETPLACES",
+        json.dumps(
+            [
+                {
+                    "name": "team",
+                    "source": "https://github.com/org/marketplace",
+                    "ref": "main",
+                    "repo_path": "marketplace",
+                    "auto_load": "all",
+                }
+            ]
+        ),
+    )
+
+    config = load_config()
+
+    assert len(config.registered_marketplaces) == 1
+    registration = config.registered_marketplaces[0]
+    assert registration.name == "team"
+    assert registration.source == "https://github.com/org/marketplace"
+    assert registration.ref == "main"
+    assert registration.repo_path == "marketplace"
+    assert registration.auto_load == "all"

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -12,7 +12,7 @@ from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_router import conversation_router
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.dependencies import get_conversation_service
-from openhands.agent_server.event_service import EventService
+from openhands.agent_server.event_service import EventService, InactiveServiceError
 from openhands.agent_server.models import (
     ACPConversationInfo,
     ConversationInfo,
@@ -2234,6 +2234,30 @@ def test_load_conversation_plugin_conversation_not_found(
         )
 
         assert response.status_code == 404
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_load_conversation_plugin_inactive_service_returns_400(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """The /load_plugin endpoint maps inactive runtime state to 400."""
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.load_plugin.side_effect = InactiveServiceError(
+        "inactive_service"
+    )
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/load_plugin",
+            json={"plugin_ref": "review-bot@team"},
+        )
+
+        assert response.status_code == 400
+        assert "inactive_service" in response.json()["detail"]
     finally:
         client.app.dependency_overrides.clear()
 

--- a/tests/agent_server/test_conversation_router.py
+++ b/tests/agent_server/test_conversation_router.py
@@ -27,6 +27,7 @@ from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.llm import llm_profile_store
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.marketplace.registry import PluginNotFoundError
 from openhands.sdk.security.llm_analyzer import LLMSecurityAnalyzer
 from openhands.sdk.settings import AGENT_SETTINGS_SCHEMA_VERSION
 from openhands.sdk.workspace import LocalWorkspace
@@ -2170,6 +2171,69 @@ def test_switch_conversation_profile_corrupted_profile(
         assert response.status_code == 400
         assert "Invalid profile format" in response.json()["detail"]
         mock_conversation.switch_profile.assert_called_once_with("corrupted")
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_load_conversation_plugin_success(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """The /load_plugin endpoint forwards the plugin ref to EventService."""
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/load_plugin",
+            json={"plugin_ref": "review-bot@team"},
+        )
+
+        assert response.status_code == 200
+        mock_event_service.load_plugin.assert_awaited_once_with("review-bot@team")
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_load_conversation_plugin_not_found(
+    client, mock_conversation_service, mock_event_service, sample_conversation_id
+):
+    """The /load_plugin endpoint maps plugin resolution errors to 404."""
+    mock_conversation_service.get_event_service.return_value = mock_event_service
+    mock_event_service.load_plugin.side_effect = PluginNotFoundError("missing")
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/load_plugin",
+            json={"plugin_ref": "missing"},
+        )
+
+        assert response.status_code == 404
+        assert "missing" in response.json()["detail"]
+    finally:
+        client.app.dependency_overrides.clear()
+
+
+def test_load_conversation_plugin_conversation_not_found(
+    client, mock_conversation_service, sample_conversation_id
+):
+    """The /load_plugin endpoint returns 404 when the conversation is missing."""
+    mock_conversation_service.get_event_service.return_value = None
+    client.app.dependency_overrides[get_conversation_service] = lambda: (
+        mock_conversation_service
+    )
+
+    try:
+        response = client.post(
+            f"/api/conversations/{sample_conversation_id}/load_plugin",
+            json={"plugin_ref": "review-bot@team"},
+        )
+
+        assert response.status_code == 404
     finally:
         client.app.dependency_overrides.clear()
 

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -14,7 +14,7 @@ import pytest
 import pytest_asyncio
 
 from openhands.agent_server.conversation_service import ConversationService
-from openhands.agent_server.event_service import EventService
+from openhands.agent_server.event_service import EventService, InactiveServiceError
 from openhands.agent_server.models import (
     ConfirmationResponseRequest,
     EventPage,
@@ -1366,7 +1366,7 @@ class TestEventServiceSendMessage:
         """Runtime plugin loads require an active conversation."""
         event_service._conversation = None
 
-        with pytest.raises(ValueError, match="inactive_service"):
+        with pytest.raises(InactiveServiceError, match="inactive_service"):
             await event_service.load_plugin("plugin@team")
 
 

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1343,6 +1343,32 @@ class TestEventServiceSendMessage:
                 None, conversation.send_message, system_message
             )
 
+    @pytest.mark.asyncio
+    async def test_load_plugin_delegates_to_conversation(self, event_service):
+        """Runtime plugin loads are delegated through the executor."""
+        conversation = MagicMock()
+        conversation.load_plugin = MagicMock()
+        event_service._conversation = conversation
+
+        with patch("asyncio.get_running_loop") as mock_get_loop:
+            mock_loop = MagicMock()
+            mock_get_loop.return_value = mock_loop
+            mock_loop.run_in_executor.side_effect = lambda *args: self._mock_executor()
+
+            await event_service.load_plugin("plugin@team")
+
+        mock_loop.run_in_executor.assert_called_once_with(
+            None, conversation.load_plugin, "plugin@team"
+        )
+
+    @pytest.mark.asyncio
+    async def test_load_plugin_inactive_service(self, event_service):
+        """Runtime plugin loads require an active conversation."""
+        event_service._conversation = None
+
+        with pytest.raises(ValueError, match="inactive_service"):
+            await event_service.load_plugin("plugin@team")
+
 
 class TestEventServiceRespondToConfirmation:
     """Test cases for confirmation responses and rejection handling."""

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -10,6 +10,7 @@ from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.skills_service import MarketplaceSkillInfo, SkillLoadResult
 from openhands.sdk.extensions.fetch import ExtensionFetchError
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.skills import (
     InstalledSkillInfo,
     KeywordTrigger,
@@ -168,6 +169,73 @@ class TestGetSkillsEndpoint:
             assert registrations[0].ref == "main"
             assert registrations[0].repo_path == "marketplace"
             assert registrations[0].auto_load == "all"
+
+    def test_get_skills_merges_server_registered_marketplaces(self):
+        """Server default marketplaces are included with request marketplaces."""
+        config = Config(
+            session_api_keys=[],
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="default",
+                    source="https://github.com/org/default-marketplace",
+                    auto_load="all",
+                )
+            ],
+        )
+        client = TestClient(create_app(config), raise_server_exceptions=False)
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.return_value = SkillLoadResult(skills=[], sources={})
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "registered_marketplaces": [
+                        {
+                            "name": "team",
+                            "source": "https://github.com/org/team-marketplace",
+                        }
+                    ]
+                },
+            )
+
+        assert response.status_code == 200
+        registrations = mock_load.call_args[1]["registered_marketplaces"]
+        assert [registration.name for registration in registrations] == [
+            "default",
+            "team",
+        ]
+
+    def test_get_skills_request_marketplace_overrides_server_default(self):
+        """Request registrations override same-named server defaults."""
+        config = Config(
+            session_api_keys=[],
+            registered_marketplaces=[
+                MarketplaceRegistration(
+                    name="team",
+                    source="https://github.com/org/default-marketplace",
+                )
+            ],
+        )
+        client = TestClient(create_app(config), raise_server_exceptions=False)
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.return_value = SkillLoadResult(skills=[], sources={})
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "registered_marketplaces": [
+                        {
+                            "name": "team",
+                            "source": "https://github.com/org/request-marketplace",
+                        }
+                    ]
+                },
+            )
+
+        assert response.status_code == 200
+        registrations = mock_load.call_args[1]["registered_marketplaces"]
+        assert len(registrations) == 1
+        assert registrations[0].source == "https://github.com/org/request-marketplace"
 
     def test_get_skills_with_sandbox_config(self, client):
         """Test skills request with sandbox configuration."""

--- a/tests/agent_server/test_skills_router.py
+++ b/tests/agent_server/test_skills_router.py
@@ -140,6 +140,35 @@ class TestGetSkillsEndpoint:
                 ("https://github.com/hieptl/.agents", "hieptl"),
             ]
 
+    def test_get_skills_with_registered_marketplaces(self, client):
+        """Registered marketplaces are forwarded to the skills service."""
+        with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:
+            mock_load.return_value = SkillLoadResult(skills=[], sources={})
+
+            response = client.post(
+                "/api/skills",
+                json={
+                    "registered_marketplaces": [
+                        {
+                            "name": "team",
+                            "source": "https://github.com/org/marketplace",
+                            "ref": "main",
+                            "repo_path": "marketplace",
+                            "auto_load": "all",
+                        }
+                    ]
+                },
+            )
+
+            assert response.status_code == 200
+            registrations = mock_load.call_args[1]["registered_marketplaces"]
+            assert len(registrations) == 1
+            assert registrations[0].name == "team"
+            assert registrations[0].source == "https://github.com/org/marketplace"
+            assert registrations[0].ref == "main"
+            assert registrations[0].repo_path == "marketplace"
+            assert registrations[0].auto_load == "all"
+
     def test_get_skills_with_sandbox_config(self, client):
         """Test skills request with sandbox configuration."""
         with patch("openhands.agent_server.skills_router.load_all_skills") as mock_load:

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -344,6 +344,7 @@ class TestLoadAllSkills:
             assert result.sources["sandbox"] == 0
             assert result.sources["org"] == 0
             assert result.sources["project"] == 0
+            assert result.sources["registered_marketplaces"] == 0
 
     def test_load_all_skills_passes_marketplace_path_to_sdk_base(self):
         """Test that marketplace_path is forwarded to SDK public skill loading."""

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -1,5 +1,6 @@
 """Tests for skills service."""
 
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -11,10 +12,48 @@ from openhands.agent_server.skills_service import (
     create_sandbox_skill,
     load_all_skills,
     load_org_skills_from_url,
+    load_registered_marketplace_skills,
     merge_skills,
     sync_public_skills,
 )
+from openhands.sdk.marketplace.registration import MarketplaceRegistration
 from openhands.sdk.skills import Skill
+
+
+def _create_test_plugin(plugin_dir: Path, name: str, skill_name: str) -> Path:
+    manifest_dir = plugin_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "plugin.json").write_text(
+        json.dumps({"name": name, "version": "1.0.0"})
+    )
+    skills_dir = plugin_dir / "skills"
+    skills_dir.mkdir()
+    (skills_dir / f"{skill_name}.md").write_text(
+        f"---\nname: {skill_name}\n---\n{skill_name} content"
+    )
+    return plugin_dir
+
+
+def _create_test_marketplace(marketplace_dir: Path) -> Path:
+    _create_test_plugin(marketplace_dir / "plugins" / "auto", "auto", "auto-skill")
+    _create_test_plugin(
+        marketplace_dir / "plugins" / "manual", "manual", "manual-skill"
+    )
+    manifest_dir = marketplace_dir / ".plugin"
+    manifest_dir.mkdir(parents=True, exist_ok=True)
+    (manifest_dir / "marketplace.json").write_text(
+        json.dumps(
+            {
+                "name": "test-marketplace",
+                "owner": {"name": "Test Team"},
+                "plugins": [
+                    {"name": "auto", "source": "./plugins/auto"},
+                    {"name": "manual", "source": "./plugins/manual"},
+                ],
+            }
+        )
+    )
+    return marketplace_dir
 
 
 class TestExposedUrlData:
@@ -216,6 +255,56 @@ class TestLoadAllSkills:
     """Tests for load_all_skills function."""
 
     _PATCH_TARGET = "openhands.agent_server.skills_service.load_available_skills"
+
+    def test_load_all_skills_registered_marketplaces_replace_legacy_public(
+        self, tmp_path: Path
+    ):
+        """Registered marketplaces load public-tier plugin skills."""
+        marketplace_dir = _create_test_marketplace(tmp_path / "marketplace")
+        user_skill = Skill(name="user-skill", content="user", trigger=None)
+
+        with patch(
+            self._PATCH_TARGET, side_effect=[{"user-skill": user_skill}, {}]
+        ) as mock_avail:
+            result = load_all_skills(
+                load_public=True,
+                load_user=True,
+                load_project=False,
+                load_org=False,
+                registered_marketplaces=[
+                    MarketplaceRegistration(
+                        name="test",
+                        source=str(marketplace_dir),
+                        auto_load="all",
+                    )
+                ],
+            )
+
+        skill_names = {skill.name for skill in result.skills}
+        assert "auto-skill" in skill_names
+        assert "manual-skill" in skill_names
+        assert "user-skill" in skill_names
+        assert result.sources["registered_marketplaces"] == 2
+        assert mock_avail.call_args_list[0].kwargs["include_public"] is False
+
+    def test_load_registered_marketplace_skills_uses_auto_load_registrations(
+        self, tmp_path: Path
+    ):
+        """Only registrations marked auto_load='all' contribute plugin skills."""
+        marketplace_dir = _create_test_marketplace(tmp_path / "marketplace")
+
+        skills = load_registered_marketplace_skills(
+            [
+                MarketplaceRegistration(
+                    name="test",
+                    source=str(marketplace_dir),
+                    auto_load="all",
+                ),
+                MarketplaceRegistration(name="manual", source=str(marketplace_dir)),
+            ]
+        )
+
+        assert {skill.name for skill in skills} == {"auto-skill", "manual-skill"}
 
     def test_load_all_skills_returns_skill_load_result(self):
         """Test that load_all_skills returns a SkillLoadResult."""

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -306,6 +306,35 @@ class TestLoadAllSkills:
 
         assert {skill.name for skill in skills} == {"auto-skill", "manual-skill"}
 
+    def test_load_registered_marketplace_skills_uses_registration_fetch_fields(
+        self, tmp_path: Path
+    ):
+        """Marketplace source, ref, and repo_path drive registry fetching."""
+        marketplace_dir = _create_test_marketplace(tmp_path / "marketplace")
+
+        with patch(
+            "openhands.sdk.marketplace.registry.fetch_plugin_with_resolution",
+            return_value=(marketplace_dir, "abc123"),
+        ) as mock_fetch:
+            skills = load_registered_marketplace_skills(
+                [
+                    MarketplaceRegistration(
+                        name="custom",
+                        source="github:example/marketplaces",
+                        ref="feature-branch",
+                        repo_path="catalogs/public",
+                        auto_load="all",
+                    )
+                ]
+            )
+
+        assert {skill.name for skill in skills} == {"auto-skill", "manual-skill"}
+        mock_fetch.assert_called_once_with(
+            source="github:example/marketplaces",
+            ref="feature-branch",
+            repo_path="catalogs/public",
+        )
+
     def test_load_all_skills_returns_skill_load_result(self):
         """Test that load_all_skills returns a SkillLoadResult."""
         with patch(self._PATCH_TARGET, return_value={}):

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -33,6 +33,7 @@ _TARGET_DIRECTORIES = (
     EXAMPLES_ROOT / "05_skills_and_plugins" / "01_loading_agentskills",
     EXAMPLES_ROOT / "05_skills_and_plugins" / "02_loading_plugins",
     EXAMPLES_ROOT / "05_skills_and_plugins" / "04_mixed_marketplace_skills",
+    EXAMPLES_ROOT / "05_skills_and_plugins" / "05_registered_marketplace_plugins",
 )
 
 # LLM-specific examples that require model overrides
@@ -105,6 +106,12 @@ def test_directory_example_is_discovered() -> None:
         EXAMPLES_ROOT
         / "05_skills_and_plugins"
         / "04_mixed_marketplace_skills"
+        / "main.py"
+    ) in EXAMPLES
+    assert (
+        EXAMPLES_ROOT
+        / "05_skills_and_plugins"
+        / "05_registered_marketplace_plugins"
         / "main.py"
     ) in EXAMPLES
 

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -1602,6 +1602,29 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_remote_conversation_load_plugin(self, mock_ws_client):
+        """load_plugin() POSTs the plugin reference to the server."""
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+
+        mock_ws_instance = Mock()
+        mock_ws_client.return_value = mock_ws_instance
+
+        conversation = RemoteConversation(agent=self.agent, workspace=self.workspace)
+        conversation.load_plugin("review-bot@team")
+
+        matching_calls = [
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "POST"
+            and f"/api/conversations/{conversation_id}/load_plugin" in call[0][1]
+        ]
+        assert len(matching_calls) == 1
+        assert matching_calls[0].kwargs["json"] == {"plugin_ref": "review-bot@team"}
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_remote_conversation_update_secrets(self, mock_ws_client):
         """Test updating secrets."""
         # Setup mocks

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -564,13 +564,6 @@ class TestLocalConversationPlugins:
             def __init__(self):
                 self.tools = [runtime_tool]
 
-        def mock_create_mcp_tools(config, timeout):
-            mcp_tools_created.append(config)
-            return RuntimeMCPClient()
-
-        monkeypatch.setattr(
-            local_conversation_impl, "create_mcp_tools", mock_create_mcp_tools
-        )
         marketplace_dir = create_test_marketplace(
             tmp_path / "marketplace",
             plugins=[
@@ -599,6 +592,14 @@ class TestLocalConversationPlugins:
         conversation._ensure_agent_ready()
         existing_tools = dict(conversation.agent.tools_map)
 
+        def mock_create_mcp_tools(config, timeout):
+            mcp_tools_created.append((config, conversation.state.locked()))
+            return RuntimeMCPClient()
+
+        monkeypatch.setattr(
+            local_conversation_impl, "create_mcp_tools", mock_create_mcp_tools
+        )
+
         conversation.load_plugin("mcp-plugin")
 
         for name, tool in existing_tools.items():
@@ -607,7 +608,9 @@ class TestLocalConversationPlugins:
         assert conversation.agent.mcp_config is not None
         assert "runtime-server" in conversation.agent.mcp_config["mcpServers"]
         assert len(mcp_tools_created) == 1
-        assert "runtime-server" in mcp_tools_created[0]["mcpServers"]
+        created_config, state_locked = mcp_tools_created[0]
+        assert not state_locked
+        assert "runtime-server" in created_config["mcpServers"]
 
         conversation.close()
 

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -440,6 +440,112 @@ class TestLocalConversationPlugins:
 
         conversation.close()
 
+    def test_load_plugin_from_registered_marketplace(self, tmp_path: Path, mock_llm):
+        """Test runtime plugin loading from a registered marketplace."""
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "manual-plugin",
+                    "skills": [{"name": "manual-skill", "content": "Manual skill"}],
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+
+        conversation.load_plugin("manual-plugin@manual")
+
+        assert conversation.agent.agent_context is not None
+        skills = {
+            skill.name: skill for skill in conversation.agent.agent_context.skills
+        }
+        assert skills["manual-skill"].content == "Manual skill"
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+
+        conversation.close()
+
+    def test_load_plugin_reinitializes_tools_after_agent_ready(
+        self, tmp_path: Path, mock_llm, monkeypatch
+    ):
+        """Test runtime MCP plugins rebuild initialized tool state."""
+        mcp_tools_created = []
+
+        def mock_create_mcp_tools(config, timeout):
+            mcp_tools_created.append(config)
+            return []
+
+        import openhands.sdk.agent.base
+
+        monkeypatch.setattr(
+            openhands.sdk.agent.base, "create_mcp_tools", mock_create_mcp_tools
+        )
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "mcp-plugin",
+                    "mcp_config": {
+                        "mcpServers": {"runtime-server": {"command": "runtime"}}
+                    },
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+        conversation._ensure_agent_ready()
+
+        conversation.load_plugin("mcp-plugin")
+
+        assert conversation.agent.mcp_config is not None
+        assert "runtime-server" in conversation.agent.mcp_config["mcpServers"]
+        assert len(mcp_tools_created) == 1
+        assert "runtime-server" in mcp_tools_created[0]["mcpServers"]
+
+        conversation.close()
+
+    def test_load_plugin_requires_registered_marketplaces(
+        self, tmp_path: Path, basic_agent
+    ):
+        """Test runtime plugin loading requires registered marketplaces."""
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+
+        with pytest.raises(ValueError, match="registered_marketplaces"):
+            conversation.load_plugin("missing-plugin")
+
+        conversation.close()
+
     def test_conversation_with_multiple_plugins(self, tmp_path: Path, basic_agent):
         """Test loading multiple plugins via LocalConversation."""
         plugin1 = create_test_plugin(

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -1,18 +1,21 @@
 """Tests for plugin loading via LocalConversation and Conversation factory."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
 from pydantic import SecretStr
 
+import openhands.sdk.conversation.impl.local_conversation as local_conversation_impl
 from openhands.sdk import LLM, Agent, AgentContext, Conversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.hooks.config import HookDefinition, HookMatcher
 from openhands.sdk.marketplace import MarketplaceRegistration
 from openhands.sdk.plugin import PluginSource
+from openhands.sdk.tool.builtins import ThinkTool
 
 
 @pytest.fixture
@@ -88,13 +91,16 @@ def create_test_marketplace(
             mcp_config=plugin.get("mcp_config"),
             hooks=plugin.get("hooks"),
         )
-        entries.append(
-            {
-                "name": plugin_name,
-                "source": f"./plugins/{plugin_name}",
-                "description": f"Test plugin {plugin_name}",
-            }
-        )
+        entry = {
+            "name": plugin_name,
+            "source": plugin.get("source", f"./plugins/{plugin_name}"),
+            "description": f"Test plugin {plugin_name}",
+        }
+        if "ref" in plugin:
+            entry["ref"] = plugin["ref"]
+        if "repo_path" in plugin:
+            entry["repo_path"] = plugin["repo_path"]
+        entries.append(entry)
 
     manifest = {
         "name": name,
@@ -478,20 +484,92 @@ class TestLocalConversationPlugins:
 
         conversation.close()
 
-    def test_load_plugin_reinitializes_tools_after_agent_ready(
+    def test_load_plugin_expands_resolved_plugin_source_secret_refs(
+        self,
+        tmp_path: Path,
+        mock_llm,
+        caplog: pytest.LogCaptureFixture,
+    ):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "private-plugin",
+                    "source": {
+                        "source": "url",
+                        "url": "https://${PLUGIN_TOKEN}@example.com/private.git",
+                        "ref": "${PLUGIN_REF}",
+                        "path": "plugins/private-plugin",
+                    },
+                    "skills": [{"name": "private-skill", "content": "Private skill"}],
+                }
+            ],
+        )
+        plugin_dir = marketplace_dir / "plugins" / "private-plugin"
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        conversation = LocalConversation(
+            agent=agent, workspace=workspace, visualizer=None
+        )
+        conversation.update_secrets(
+            {"PLUGIN_TOKEN": "token-value", "PLUGIN_REF": "release-branch"}
+        )
+
+        with (
+            caplog.at_level(logging.INFO),
+            patch(
+                "openhands.sdk.conversation.impl.local_conversation."
+                "fetch_plugin_with_resolution",
+                return_value=(plugin_dir, "abc123"),
+            ) as mock_fetch,
+        ):
+            conversation.load_plugin("private-plugin")
+
+        assert "token-value" not in caplog.text
+        assert "https://" not in caplog.text
+        mock_fetch.assert_called_once_with(
+            source="https://token-value@example.com/private.git",
+            ref="release-branch",
+            repo_path="plugins/private-plugin",
+        )
+        assert conversation.agent.agent_context is not None
+        assert [skill.name for skill in conversation.agent.agent_context.skills] == [
+            "private-skill"
+        ]
+        assert conversation.resolved_plugins is not None
+        assert len(conversation.resolved_plugins) == 1
+
+        conversation.close()
+
+    def test_load_plugin_adds_runtime_tools_without_reinitializing_existing_tools(
         self, tmp_path: Path, mock_llm, monkeypatch
     ):
-        """Test runtime MCP plugins rebuild initialized tool state."""
         mcp_tools_created = []
+
+        class RuntimeOnlyTool(ThinkTool):
+            name = "runtime_only"
+
+        runtime_tool = RuntimeOnlyTool.create()[0]
+
+        class RuntimeMCPClient:
+            def __init__(self):
+                self.tools = [runtime_tool]
 
         def mock_create_mcp_tools(config, timeout):
             mcp_tools_created.append(config)
-            return []
-
-        import openhands.sdk.agent.base
+            return RuntimeMCPClient()
 
         monkeypatch.setattr(
-            openhands.sdk.agent.base, "create_mcp_tools", mock_create_mcp_tools
+            local_conversation_impl, "create_mcp_tools", mock_create_mcp_tools
         )
         marketplace_dir = create_test_marketplace(
             tmp_path / "marketplace",
@@ -519,13 +597,99 @@ class TestLocalConversationPlugins:
             agent=agent, workspace=workspace, visualizer=None
         )
         conversation._ensure_agent_ready()
+        existing_tools = dict(conversation.agent.tools_map)
 
         conversation.load_plugin("mcp-plugin")
 
+        for name, tool in existing_tools.items():
+            assert conversation.agent.tools_map[name] is tool
+        assert conversation.agent.tools_map[runtime_tool.name] is runtime_tool
         assert conversation.agent.mcp_config is not None
         assert "runtime-server" in conversation.agent.mcp_config["mcpServers"]
         assert len(mcp_tools_created) == 1
         assert "runtime-server" in mcp_tools_created[0]["mcpServers"]
+
+        conversation.close()
+
+    def test_load_plugin_merges_runtime_hooks_and_restarts_processor(
+        self, tmp_path: Path, mock_llm
+    ):
+        marketplace_dir = create_test_marketplace(
+            tmp_path / "marketplace",
+            plugins=[
+                {
+                    "name": "hook-plugin",
+                    "hooks": {
+                        "hooks": {
+                            "PreToolUse": [
+                                {
+                                    "matcher": "runtime-*",
+                                    "hooks": [{"command": "runtime-cmd"}],
+                                }
+                            ]
+                        }
+                    },
+                }
+            ],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(
+                registered_marketplaces=[
+                    MarketplaceRegistration(name="manual", source=str(marketplace_dir))
+                ]
+            ),
+        )
+        explicit_hooks = HookConfig(
+            pre_tool_use=[
+                HookMatcher(
+                    matcher="explicit-*", hooks=[HookDefinition(command="explicit-cmd")]
+                )
+            ]
+        )
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            hook_config=explicit_hooks,
+            visualizer=None,
+        )
+        initial_processor = MagicMock()
+        initial_processor.on_event = MagicMock()
+        runtime_processor = MagicMock()
+        runtime_processor.on_event = MagicMock()
+
+        callback_lock_owned: list[bool] = []
+
+        def mock_create_hook_callback(*args, **kwargs):
+            callback_lock_owned.append(conversation.state._lock.owned())
+            if len(callback_lock_owned) == 1:
+                return initial_processor, initial_processor.on_event
+            return runtime_processor, runtime_processor.on_event
+
+        with patch(
+            "openhands.sdk.conversation.impl.local_conversation.create_hook_callback",
+            side_effect=mock_create_hook_callback,
+        ) as mock_create_hook_callback:
+            conversation.load_plugin("hook-plugin")
+
+        assert conversation.state.hook_config is not None
+        assert [
+            matcher.matcher for matcher in conversation.state.hook_config.pre_tool_use
+        ] == ["explicit-*", "runtime-*"]
+        assert mock_create_hook_callback.call_count == 2
+        assert callback_lock_owned[1]
+        initial_processor.set_conversation_state.assert_called_once_with(
+            conversation.state
+        )
+        initial_processor.run_session_start.assert_called_once()
+        initial_processor.run_session_end.assert_called_once()
+        runtime_processor.set_conversation_state.assert_called_once_with(
+            conversation.state
+        )
+        runtime_processor.run_session_start.assert_called_once()
 
         conversation.close()
 

--- a/tests/sdk/marketplace/test_marketplace_registry.py
+++ b/tests/sdk/marketplace/test_marketplace_registry.py
@@ -47,6 +47,14 @@ def test_marketplace_registration_accepts_all_fields() -> None:
     assert registration.ref == "v1.0.0"
     assert registration.repo_path == "marketplaces/team"
     assert registration.auto_load
+    assert (
+        MarketplaceRegistration(
+            name="team",
+            source="github:example/marketplaces",
+            auto_load="all",
+        ).auto_load
+        == "all"
+    )
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Chunk 7 of the marketplace-registration reimplementation, stacked on #3829.

- Add a no-network example that creates two local registered marketplaces in a temp directory.
- Demonstrate `auto_load="all"` for one marketplace and runtime `Conversation.load_plugin("plugin@marketplace")` for another.
- Register the new directory-based example in `tests/examples/test_examples.py`.

## Tests

```bash
uv run pre-commit run --files examples/05_skills_and_plugins/05_registered_marketplace_plugins/main.py tests/examples/test_examples.py
uv run pytest tests/examples/test_examples.py::test_directory_example_is_discovered -q
uv run pytest tests/examples/test_examples.py --run-examples -q -k registered_marketplace
```

_This PR was created by an AI agent (OpenHands) on behalf of the user._

@csmith49 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8dea99f4-c5ab-4cef-b9ff-d0dd7937ee13)