### PR TITLE
fix(agent_server): honor OH_PERSISTENCE_DIR in meta-profiles router (#3835)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/meta_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/meta_profiles_router.py
@@ -4,6 +4,8 @@ Unlike LLM profiles, meta-profiles hold no secrets — they are plain JSON
 documents persisted via :class:`MetaProfileStore`.
 """
 
+import os
+import pathlib
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Annotated
@@ -35,6 +37,21 @@ MetaProfileName = Annotated[
     str,
     Path(min_length=1, max_length=64, pattern=PROFILE_NAME_PATTERN),
 ]
+
+
+def _get_meta_profile_store() -> MetaProfileStore:
+    """Resolve the meta-profile store under ``OH_PERSISTENCE_DIR``.
+
+    Mirrors how the LLM/agent profile stores resolve (``OH_PERSISTENCE_DIR``
+    when set, else ``~/.openhands``) so meta-profiles stay co-located with the
+    LLM profiles they reference by name, and an isolated agent-server (fresh
+    ``OH_PERSISTENCE_DIR``) doesn't read or write the host's
+    ``~/.openhands/meta-profiles``. A bare ``MetaProfileStore()`` ignores the
+    env var and always defaults to the host home dir.
+    """
+    env_dir = os.environ.get("OH_PERSISTENCE_DIR")
+    base = pathlib.Path(env_dir) if env_dir else pathlib.Path.home() / ".openhands"
+    return MetaProfileStore(base_dir=base / "meta-profiles")
 
 
 class MetaProfileInfo(BaseModel):
@@ -112,7 +129,7 @@ async def list_meta_profiles(request: Request) -> MetaProfileListResponse:
     settings_store = get_settings_store(config)
     settings = settings_store.load() or PersistedSettings()
 
-    store = MetaProfileStore()
+    store = _get_meta_profile_store()
     with _store_errors():
         summaries = store.list_summaries()
 
@@ -125,7 +142,7 @@ async def list_meta_profiles(request: Request) -> MetaProfileListResponse:
 @meta_profiles_router.get("/{name}", response_model=MetaProfileDetailResponse)
 async def get_meta_profile(name: MetaProfileName) -> MetaProfileDetailResponse:
     """Get a meta-profile's full configuration."""
-    store = MetaProfileStore()
+    store = _get_meta_profile_store()
     try:
         with _store_errors():
             meta_profile = store.load(name)
@@ -152,7 +169,7 @@ async def save_meta_profile(
     Returns 409 if creating a new meta-profile would exceed
     ``MAX_META_PROFILES``.
     """
-    store = MetaProfileStore()
+    store = _get_meta_profile_store()
     try:
         with _store_errors():
             store.save(name, body, max_profiles=MAX_META_PROFILES)
@@ -180,7 +197,7 @@ async def delete_meta_profile(
     If the deleted meta-profile is the active one, ``active_meta_profile`` is
     cleared.
     """
-    store = MetaProfileStore()
+    store = _get_meta_profile_store()
     with _store_errors():
         store.delete(name)
     if _set_active_meta_profile_if_matches(request, name, None):
@@ -205,7 +222,7 @@ async def activate_meta_profile(
     meta-profile does not exist.
     """
     # Verify the meta-profile exists (and is valid) before activating.
-    store = MetaProfileStore()
+    store = _get_meta_profile_store()
     try:
         with _store_errors():
             store.load(name)

--- a/tests/agent_server/test_meta_profiles_router.py
+++ b/tests/agent_server/test_meta_profiles_router.py
@@ -3,7 +3,6 @@
 import tempfile
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
-from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
@@ -16,14 +15,6 @@ from openhands.sdk.settings.model import OpenHandsAgentSettings
 
 
 @pytest.fixture
-def temp_meta_profiles_dir():
-    with tempfile.TemporaryDirectory() as tmpdir:
-        meta_dir = Path(tmpdir) / "meta-profiles"
-        meta_dir.mkdir(parents=True, exist_ok=True)
-        yield meta_dir
-
-
-@pytest.fixture
 def temp_settings_dir():
     with tempfile.TemporaryDirectory() as tmpdir:
         settings_dir = Path(tmpdir) / "settings"
@@ -32,16 +23,24 @@ def temp_settings_dir():
 
 
 @pytest.fixture
+def temp_meta_profiles_dir(temp_settings_dir):
+    # The router resolves meta-profiles at ``OH_PERSISTENCE_DIR/meta-profiles``,
+    # and the client fixture sets OH_PERSISTENCE_DIR to temp_settings_dir, so the
+    # store fixture must seed the same dir the router reads.
+    meta_dir = temp_settings_dir / "meta-profiles"
+    meta_dir.mkdir(parents=True, exist_ok=True)
+    yield meta_dir
+
+
+@pytest.fixture
 def client(temp_meta_profiles_dir, temp_settings_dir, monkeypatch):
     reset_stores()
     monkeypatch.setenv("OH_PERSISTENCE_DIR", str(temp_settings_dir))
     config = Config(static_files_path=None, session_api_keys=[], secret_key=None)
     app = create_app(config)
-    with patch(
-        "openhands.agent_server.meta_profiles_router.MetaProfileStore",
-        lambda: MetaProfileStore(base_dir=temp_meta_profiles_dir),
-    ):
-        yield TestClient(app)
+    # No MetaProfileStore patch needed: the router now honors OH_PERSISTENCE_DIR
+    # and resolves the same dir the store fixture seeds.
+    yield TestClient(app)
     reset_stores()
 
 
@@ -58,6 +57,33 @@ def _meta(classifier="minimax", default="gpt", classes=None) -> dict:
             "classes": classes or [{"description": "UI", "model": "deepseek"}],
         }
     ).model_dump(mode="json")
+
+
+# ── Persistence-dir resolution (regression for #3835) ────────────────────────
+
+
+def test_meta_profile_store_honors_persistence_dir(monkeypatch, tmp_path):
+    """The router resolves meta-profiles under OH_PERSISTENCE_DIR, not the host
+    ~/.openhands/meta-profiles, so isolated agent-servers stay isolated."""
+    from openhands.agent_server.meta_profiles_router import _get_meta_profile_store
+
+    monkeypatch.setenv("OH_PERSISTENCE_DIR", str(tmp_path))
+    store = _get_meta_profile_store()
+    assert store.base_dir == tmp_path / "meta-profiles"
+
+
+def test_meta_profile_store_falls_back_to_home(monkeypatch, tmp_path):
+    """Without OH_PERSISTENCE_DIR, fall back to ~/.openhands/meta-profiles so
+    meta-profiles stay co-located with the LLM profiles they reference by name
+    (not a workspace-relative dir)."""
+    from openhands.agent_server.meta_profiles_router import _get_meta_profile_store
+
+    monkeypatch.delenv("OH_PERSISTENCE_DIR", raising=False)
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    store = _get_meta_profile_store()
+    assert store.base_dir == fake_home / ".openhands" / "meta-profiles"
 
 
 # ── List ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
HUMAN:

Same OH_PERSISTENCE_DIR isolation leak as #3815/#3816, but for the meta-profiles router added in this PR. Fixing it on the #3744 branch so the leak never ships.
Fixes https://github.com/OpenHands/software-agent-sdk/issues/3835

---

AGENT:

## Why

`meta_profiles_router.py` (added by #3744) constructs `MetaProfileStore()` with no arguments in every handler (list/get/save/delete/activate), so it falls back to `_DEFAULT_META_PROFILE_DIR = Path.home() / ".openhands" / "meta-profiles"` and **ignores `OH_PERSISTENCE_DIR`**. This is the same isolation-leak class as #3815 (fixed for the LLM/agent profile stores by #3816): an agent-server started with a fresh `OH_PERSISTENCE_DIR` still reads and writes the host's `~/.openhands/meta-profiles`, so isolated instances (canvas CI/dev/QA rigs, multi-instance deployments) leak host state and can't get a known-empty server.

It is also a correctness issue, not just hygiene: meta-profiles reference LLM profiles **by name** (`MetaProfile.classifier_model`, `MetaProfile.default_model`, and each `MetaProfileClass.model`), resolved at runtime by `classify_and_switch_llm` against the LLM profile store. Since #3816 makes LLM profiles resolve via `OH_PERSISTENCE_DIR` (→ else `~/.openhands`), meta-profiles must resolve to the **same** base dir or those name references break under isolation.

## Summary

- Add `_get_meta_profile_store()` in `meta_profiles_router.py` that resolves the store dir the same way #3816 resolves the LLM/agent profile stores: `OH_PERSISTENCE_DIR` when set, else `~/.openhands`, then `/meta-profiles`. Switch all 5 handler call sites off the bare `MetaProfileStore()` constructor.
- The fix is contained entirely within `meta_profiles_router.py` + its test (both #3744-only files), so it does **not** touch `persistence/store.py` and won't conflict with #3816. Once #3816 lands, a trivial follow-up can DRY `_get_meta_profile_store()` to reuse `_get_profile_persistence_dir()`.
- Tests now rely on `OH_PERSISTENCE_DIR` (already set in the `client` fixture) instead of patching `MetaProfileStore` to inject a `base_dir` — that patch was itself a workaround for this leak. Added regression tests for both the env and home-fallback resolution paths.

## Issue Number

Fixes #3835.

## How to Test

```
pytest tests/agent_server/test_meta_profiles_router.py tests/agent_server/test_active_meta_profile.py -v
```

Both files pass (27 tests). The new `test_meta_profile_store_honors_persistence_dir` / `test_meta_profile_store_falls_back_to_home` lock the resolution behavior; `ruff check` and `pyright` are clean on the touched files.

## Notes

Out of scope (separate, deeper concern, flagged not fixed): `classify_and_switch_llm.py` falls back to a bare `MetaProfileStore()` when constructed without a `meta_profile_store`, so the **runtime tool** may also read `~/.openhands/meta-profiles` regardless of `OH_PERSISTENCE_DIR`. Its own comment treats home-dir resolution as intentional at the SDK/runtime layer — worth verifying how the tool is wired for isolated/cloud runtimes, but not changed here.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore
