### PR TITLE
[codex] Fix subscription retry temperature handling

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py
@@ -50,7 +50,15 @@ class RetryMixin:
             if isinstance(exc, LLMNoResponseError):
                 kwargs = getattr(retry_state, "kwargs", None)
                 if isinstance(kwargs, dict):
-                    current_temp = kwargs.get("temperature", 0)
+                    current_temp = kwargs.get(
+                        "temperature", getattr(self, "temperature", None)
+                    )
+                    if current_temp is None:
+                        logger.warning(
+                            "LLMNoResponseError with no configured temperature, "
+                            "leaving temperature unset for next attempt."
+                        )
+                        return
                     if current_temp == 0:
                         kwargs["temperature"] = 1.0
                         logger.warning(

--- a/tests/sdk/llm/test_subscription_mode.py
+++ b/tests/sdk/llm/test_subscription_mode.py
@@ -157,7 +157,10 @@ def test_subscription_retry_does_not_add_temperature(mock_responses: Any):
         _make_responses_api_response("ok"),
     ]
 
-    llm.responses(messages=[Message(role="user", content=[TextContent(text="hi")])])
+    # Subscription auth loads OAuth credentials from disk; stub it out so the
+    # test does not depend on a real ChatGPT login being present.
+    with patch.object(llm, "_get_litellm_auth_values", return_value=(None, {})):
+        llm.responses(messages=[Message(role="user", content=[TextContent(text="hi")])])
 
     assert mock_responses.call_count == 2
     _, first_kwargs = mock_responses.call_args_list[0]

--- a/tests/sdk/llm/test_subscription_mode.py
+++ b/tests/sdk/llm/test_subscription_mode.py
@@ -5,6 +5,7 @@ Tests cover four bugs that made LLM.subscription_login() unusable:
 2. include/reasoning params cause silent empty output
 3. Streaming output items lost (response.completed has output=[])
 4. Reasoning item IDs cause 404 on follow-up requests (store=false)
+5. Retry path must not add unsupported temperature param
 
 See: https://github.com/OpenHands/software-agent-sdk/issues/2797
 """
@@ -12,13 +13,17 @@ See: https://github.com/OpenHands/software-agent-sdk/issues/2797
 import json
 from types import SimpleNamespace
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
+from litellm.types.llms.openai import ResponsesAPIResponse
+from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from openai.types.responses.response_function_tool_call import (
     ResponseFunctionToolCall,
 )
 
+from openhands.sdk.llm.exceptions import LLMNoResponseError
 from openhands.sdk.llm.llm import LLM
 from openhands.sdk.llm.message import (
     Message,
@@ -50,6 +55,26 @@ def _make_generic_output_item(**kwargs: Any) -> BaseLiteLLMOpenAIResponseObject:
     """Build a BaseLiteLLMOpenAIResponseObject (the type litellm uses for
     streaming output items) with the given attributes."""
     return BaseLiteLLMOpenAIResponseObject.model_construct(**kwargs)
+
+
+def _make_responses_api_response(text: str = "ok") -> ResponsesAPIResponse:
+    return ResponsesAPIResponse(
+        id="resp-1",
+        created_at=1,
+        output=[
+            ResponseOutputMessage(
+                id="msg-1",
+                type="message",
+                role="assistant",
+                status="completed",
+                content=[
+                    ResponseOutputText(type="output_text", text=text, annotations=[])
+                ],
+            )
+        ],
+        model="gpt-5.2-codex",
+        object="response",
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -107,6 +132,38 @@ def test_non_subscription_keeps_structured_param(param: str, check: Any):
     opts = select_responses_options(llm, {}, include=["text.output_text"], store=None)
     assert param in opts
     assert check(opts[param])
+
+
+# ---------------------------------------------------------------------------
+# Bug 5: Retry path must preserve omitted subscription params
+# ---------------------------------------------------------------------------
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_subscription_retry_does_not_add_temperature(mock_responses: Any):
+    """Subscription mode intentionally omits temperature.
+
+    A retry after LLMNoResponseError must not manufacture temperature=1.0,
+    because the ChatGPT subscription endpoint rejects the parameter.
+    """
+    llm = _make_subscription_llm()
+    llm.num_retries = 2
+    llm.retry_min_wait = 0
+    llm.retry_max_wait = 0
+    llm.stream = True
+
+    mock_responses.side_effect = [
+        LLMNoResponseError("empty response"),
+        _make_responses_api_response("ok"),
+    ]
+
+    llm.responses(messages=[Message(role="user", content=[TextContent(text="hi")])])
+
+    assert mock_responses.call_count == 2
+    _, first_kwargs = mock_responses.call_args_list[0]
+    _, second_kwargs = mock_responses.call_args_list[1]
+    assert "temperature" not in first_kwargs
+    assert "temperature" not in second_kwargs
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
HUMAN:
Fix the ChatGPT subscription retry path so an omitted `temperature` is not silently turned into `temperature=1.0`, which the Codex subscription endpoint rejects.

---

AGENT:
## Why

ChatGPT subscription mode intentionally omits `temperature` because the Codex subscription endpoint rejects that parameter. The `LLMNoResponseError` retry hook in `openhands-sdk/openhands/sdk/llm/utils/retry_mixin.py` used `kwargs.get("temperature", 0)`, so a retry with no retry kwargs was interpreted as temperature 0 and mutated to `temperature=1.0`. That caused the retry to fail with `Unsupported parameter: temperature`, making OpenHands agent conversations using ChatGPT subscription models unable to recover from an initial no-response.

## Summary

- Preserve an omitted LLM `temperature` during `LLMNoResponseError` retries instead of treating a missing value as `0`. When `temperature` is absent and `self.temperature` is `None`, the retry hook now logs a warning and returns without mutating kwargs.
- Keep the existing temperature 0 → 1.0 bump behavior for the API-key / non-subscription path where a temperature IS configured.
- Add a subscription-mode regression test (`test_subscription_retry_does_not_add_temperature`) proving neither the first nor the retry call adds `temperature` to ChatGPT subscription Responses calls after an `LLMNoResponseError`.

## Issue Number

Closes #3850 (tracking issue for this PR). Duplicate mirror issue: #3874.

## How to Test

1. `uv sync --group dev`
2. `uv run pytest tests/sdk/llm/test_subscription_mode.py -q` — all 19 tests pass, including the new `test_subscription_retry_does_not_add_temperature`.
3. `uv run pytest tests/sdk/llm/test_llm_no_response_retry.py tests/sdk/llm/test_llm_retry_telemetry.py tests/sdk/llm/test_api_connection_error_retry.py tests/sdk/llm/test_llm_fallback.py -q` — 40 tests pass, confirming the non-subscription temperature 0 → 1.0 mutation still works (`test_no_response_retry_bumps_temperature`, `test_responses_retry_bumps_temperature`, etc.).

## Video/Screenshots

N/A — pure logic fix verified by unit tests.

## Type

- [x] Bug fix

## Notes

Linear: AGE-4264. The GitHub mirror issue #3874 is a duplicate of the tracking issue #3850; #3874 will be closed as duplicate after this PR merges.

This PR description was prepared by an AI agent (OpenHands) on behalf of Graham Neubig.