### PR TITLE
feat: expose ephemeral per-run max_budget_per_run on Conversation

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -814,6 +814,7 @@ class EventService:
             callbacks=[self._callback_wrapper],
             token_callbacks=([_token_streaming_callback] if streaming_enabled else []),
             max_iteration_per_run=self.stored.max_iterations,
+            max_budget_per_run=self.stored.max_budget_per_run,
             stuck_detection=self.stored.stuck_detection,
             visualizer=None,
             secrets=self.stored.secrets,

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -72,6 +72,7 @@ class Conversation:
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
         max_iteration_per_run: int = 500,
+        max_budget_per_run: float | None = None,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
             StuckDetectionThresholds | Mapping[str, int] | None
@@ -100,6 +101,7 @@ class Conversation:
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
         max_iteration_per_run: int = 500,
+        max_budget_per_run: float | None = None,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
             StuckDetectionThresholds | Mapping[str, int] | None
@@ -128,6 +130,7 @@ class Conversation:
         token_callbacks: list[ConversationTokenCallbackType] | None = None,
         hook_config: HookConfig | None = None,
         max_iteration_per_run: int = 500,
+        max_budget_per_run: float | None = None,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
             StuckDetectionThresholds | Mapping[str, int] | None
@@ -147,6 +150,16 @@ class Conversation:
         from openhands.sdk.conversation.impl.remote_conversation import (
             RemoteConversation,
         )
+
+        # Match the gt=0 contract enforced on StartConversationRequest and
+        # AgentDefinition: a budget must be a positive cost or None. (A 0.0
+        # budget is only meaningful internally, where the sub-agent path
+        # constructs LocalConversation directly to signal an exhausted parent.)
+        if max_budget_per_run is not None and max_budget_per_run <= 0:
+            raise ValueError(
+                "max_budget_per_run must be a positive cost (USD) or None; "
+                f"got {max_budget_per_run}."
+            )
 
         if isinstance(workspace, RemoteWorkspace):
             # For RemoteConversation, persistence_dir should not be used.
@@ -188,6 +201,7 @@ class Conversation:
                 token_callbacks=token_callbacks,
                 hook_config=hook_config,
                 max_iteration_per_run=max_iteration_per_run,
+                max_budget_per_run=max_budget_per_run,
                 stuck_detection=stuck_detection,
                 stuck_detection_thresholds=stuck_detection_thresholds,
                 visualizer=visualizer,
@@ -209,6 +223,7 @@ class Conversation:
             token_callbacks=token_callbacks,
             hook_config=hook_config,
             max_iteration_per_run=max_iteration_per_run,
+            max_budget_per_run=max_budget_per_run,
             stuck_detection=stuck_detection,
             stuck_detection_thresholds=stuck_detection_thresholds,
             visualizer=visualizer,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -145,6 +145,11 @@ class LocalConversation(BaseConversation):
     delete_on_close: bool = True
     _arun_task: asyncio.Task[None] | None
     _cancel_token: CancellationToken | None
+    # Combined accumulated_cost captured at the start of the current run().
+    # max_budget_per_run measures spend relative to this baseline, so the budget
+    # resets on every run() call (same scope as the iteration counter) rather
+    # than tracking lifetime cost.
+    _run_cost_baseline: float
     # True while run()/arun() executes an agent step while holding the state
     # lock. A state-mutating tool (e.g. switch_llm) runs on a worker thread, so
     # it must skip re-acquiring the lock the run loop holds while blocked
@@ -242,6 +247,7 @@ class LocalConversation(BaseConversation):
         self._cleanup_initiated = False
         self._arun_task = None
         self._cancel_token = None
+        self._run_cost_baseline = 0.0
         self._step_holds_state_lock = False
 
         # Store plugin specs for lazy loading (no IO in constructor)
@@ -480,21 +486,49 @@ class LocalConversation(BaseConversation):
     def conversation_stats(self):
         return self._state.stats
 
+    def _run_spend(self) -> float:
+        """Cost accrued during the current run() (since the run baseline)."""
+        total = self.conversation_stats.get_combined_metrics().accumulated_cost
+        return total - self._run_cost_baseline
+
+    def _reset_run_budget_baseline(self) -> None:
+        """Capture the cost baseline at the start of a run().
+
+        max_budget_per_run measures spend since this baseline, so it resets on
+        every run() call — the same scope as the per-run iteration counter.
+        """
+        self._run_cost_baseline = (
+            self.conversation_stats.get_combined_metrics().accumulated_cost
+        )
+
     def _budget_exceeded_detail(self) -> str | None:
         """Error detail if the run has hit its cost budget, else None.
 
-        Bounds total spend across all of the run's LLMs (agent, condenser, ...),
-        complementing the iteration cap which only bounds step count.
+        Bounds spend across all of the run's LLMs (agent, condenser, ...) for the
+        current run() call, complementing the iteration cap which only bounds
+        step count. It measures spend since the baseline captured at the start of
+        run() (same scope as max_iteration_per_run), not lifetime cost.
         """
         if self.max_budget_per_run is None:
             return None
-        spent = self.conversation_stats.get_combined_metrics().accumulated_cost
+        spent = self._run_spend()
         if spent < self.max_budget_per_run:
             return None
         return (
             f"Agent reached maximum budget limit "
             f"(${self.max_budget_per_run:.4f}); accumulated cost ${spent:.4f}."
         )
+
+    @property
+    def remaining_budget_this_run(self) -> float | None:
+        """Budget left for the current run(), or None if no cap is set.
+
+        Used to spawn sub-agents with the parent's *remaining* budget rather
+        than its full budget.
+        """
+        if self.max_budget_per_run is None:
+            return None
+        return max(0.0, self.max_budget_per_run - self._run_spend())
 
     def _emit_run_limit_error(self, code: str, detail: str) -> None:
         """Mark the run failed with a run-limit ConversationErrorEvent."""
@@ -1220,6 +1254,7 @@ class LocalConversation(BaseConversation):
                 ConversationExecutionStatus.STUCK,
             ]:
                 self._state.execution_status = ConversationExecutionStatus.RUNNING
+            self._reset_run_budget_baseline()
 
         iteration = 0
         _run_start_event_count = len(self._state.events)
@@ -1421,6 +1456,7 @@ class LocalConversation(BaseConversation):
                 ConversationExecutionStatus.STUCK,
             ]:
                 self._state.execution_status = ConversationExecutionStatus.RUNNING
+            self._reset_run_budget_baseline()
             last_acp_prompt_user_message_id = self._state.agent_state.get(
                 ACP_LAST_PROMPT_USER_MESSAGE_ID
             )

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -644,6 +644,7 @@ class RemoteConversation(BaseConversation):
     agent: AgentBase
     _callbacks: list[ConversationCallbackType]
     max_iteration_per_run: int
+    max_budget_per_run: float | None
     workspace: RemoteWorkspace
     _client: httpx.Client
     _cleanup_initiated: bool
@@ -661,6 +662,7 @@ class RemoteConversation(BaseConversation):
         conversation_id: ConversationID | None = None,
         callbacks: list[ConversationCallbackType] | None = None,
         max_iteration_per_run: int = 500,
+        max_budget_per_run: float | None = None,
         stuck_detection: bool = True,
         stuck_detection_thresholds: (
             StuckDetectionThresholds | Mapping[str, int] | None
@@ -688,6 +690,8 @@ class RemoteConversation(BaseConversation):
             conversation_id: Optional existing conversation id to attach to
             callbacks: Optional callbacks to receive events (not yet streamed)
             max_iteration_per_run: Max iterations configured on server
+            max_budget_per_run: Ephemeral per-interaction cost ceiling (USD)
+                      enforced on the server. None disables the budget.
             stuck_detection: Whether to enable stuck detection on server
             stuck_detection_thresholds: Optional configuration for stuck detection
                       thresholds. Can be a StuckDetectionThresholds instance or
@@ -716,6 +720,7 @@ class RemoteConversation(BaseConversation):
         self.agent = agent
         self._callbacks = callbacks or []
         self.max_iteration_per_run = max_iteration_per_run
+        self.max_budget_per_run = max_budget_per_run
         self.workspace = workspace
         self._client = workspace.client
         self._conversation_info_base_path = LEGACY_CONVERSATIONS_PATH
@@ -776,6 +781,7 @@ class RemoteConversation(BaseConversation):
                 ),
                 "initial_message": None,
                 "max_iterations": max_iteration_per_run,
+                "max_budget_per_run": max_budget_per_run,
                 "stuck_detection": stuck_detection,
                 # We need to convert RemoteWorkspace to LocalWorkspace for the server
                 "workspace": LocalWorkspace(
@@ -1533,6 +1539,7 @@ class RemoteConversation(BaseConversation):
             workspace=self.workspace,
             conversation_id=fork_uuid,
             max_iteration_per_run=self.max_iteration_per_run,
+            max_budget_per_run=self.max_budget_per_run,
             delete_on_close=self.delete_on_close,
             tags=server_tags,
         )

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -120,6 +120,12 @@ class StartConversationRequest(BaseModel):
         description="If set, the max number of iterations the agent will run "
         "before stopping. This is useful to prevent infinite loops.",
     )
+    max_budget_per_run: float | None = Field(
+        default=None,
+        gt=0,
+        description="Ephemeral cost ceiling (USD) for a single interaction/run. "
+        "None disables the budget. Reset each interaction.",
+    )
     stuck_detection: bool = Field(
         default=True,
         description="If true, the conversation will use stuck detection to "

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -252,11 +252,14 @@ class TaskManager:
             if factory.definition.max_iteration_per_run
             else self.parent_conversation.max_iteration_per_run
         )
-        # Sub-agent budget: definition value, else inherit the parent's.
-        effective_max_budget = (
-            factory.definition.max_budget_per_run
-            or self.parent_conversation.max_budget_per_run
-        )
+        # Sub-agent budget: definition value, else inherit the parent's
+        # *remaining* budget for the current run. Use an explicit None check
+        # because a remaining budget of 0.0 is meaningful (parent exhausted) and
+        # `0.0 or X` would wrongly fall through to X.
+        if factory.definition.max_budget_per_run is not None:
+            effective_max_budget = factory.definition.max_budget_per_run
+        else:
+            effective_max_budget = self.parent_conversation.remaining_budget_this_run
 
         with self._tasks_lock:
             task_id, conversation_id = self._generate_ids()

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -75,6 +75,34 @@ def sample_stored_conversation():
     )
 
 
+def test_start_conversation_request_max_budget_per_run_roundtrip():
+    """max_budget_per_run defaults to None, survives JSON round-trip, rejects
+    non-positive values, and is inherited by StoredConversation."""
+    from pydantic import ValidationError
+
+    agent = Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[])
+    workspace = LocalWorkspace(working_dir="workspace/project")
+
+    assert (
+        StartConversationRequest(agent=agent, workspace=workspace).max_budget_per_run
+        is None
+    )
+
+    req = StartConversationRequest(
+        agent=agent, workspace=workspace, max_budget_per_run=2.0
+    )
+    restored = StartConversationRequest.model_validate_json(req.model_dump_json())
+    assert restored.max_budget_per_run == 2.0
+
+    with pytest.raises(ValidationError):
+        StartConversationRequest(agent=agent, workspace=workspace, max_budget_per_run=0)
+
+    stored = StoredConversation(
+        id=uuid4(), agent=agent, workspace=workspace, max_budget_per_run=1.5
+    )
+    assert stored.max_budget_per_run == 1.5
+
+
 def _create_running_terminal_action(tool_call_id: str = "call_1") -> ActionEvent:
     tool_call = MessageToolCall.from_chat_tool_call(
         ChatCompletionMessageToolCall(

--- a/tests/sdk/conversation/local/test_agent_status_transition.py
+++ b/tests/sdk/conversation/local/test_agent_status_transition.py
@@ -24,7 +24,7 @@ from typing import ClassVar
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.event import MessageEvent
+from openhands.sdk.event import ActionEvent, MessageEvent
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
 from openhands.sdk.llm import ImageContent, Message, MessageToolCall, TextContent
 from openhands.sdk.testing import TestLLM
@@ -543,17 +543,8 @@ def test_execution_status_finished_on_final_iteration():
     )
 
 
-def test_execution_status_error_on_max_budget(tmp_path):
-    """Run halts with ERROR + MaxBudgetReached when the cost budget is exceeded,
-    even before the iteration cap is reached."""
-    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
-    from openhands.sdk.llm.utils.metrics import Metrics
-
-    events_received: list = []
-    test_tool = StatusTransitionTestTool.create(executor=StatusCheckingExecutor([]))[0]
-    register_tool("test_tool", test_tool)
-
-    tool_call_message = Message(
+def _tool_call_message() -> Message:
+    return Message(
         role="assistant",
         content=[TextContent(text="")],
         tool_calls=[
@@ -565,7 +556,28 @@ def test_execution_status_error_on_max_budget(tmp_path):
             )
         ],
     )
-    llm = TestLLM.from_messages([tool_call_message] * 5)
+
+
+def test_execution_status_error_on_max_budget(tmp_path):
+    """Run halts with ERROR + MaxBudgetReached when spend accrued *during the
+    run* exceeds the budget, before the iteration cap is reached."""
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.llm.utils.metrics import Metrics
+
+    events_received: list = []
+    # TestLLM accrues no real cost; book spend when the agent acts (mid-run,
+    # while still RUNNING) to simulate an expensive step.
+    spend = Metrics(accumulated_cost=0.0)
+
+    def callback(event):
+        events_received.append(event)
+        if isinstance(event, ActionEvent):
+            spend.add_cost(5.0)
+
+    test_tool = StatusTransitionTestTool.create(executor=StatusCheckingExecutor([]))[0]
+    register_tool("test_tool", test_tool)
+
+    llm = TestLLM.from_messages([_tool_call_message()] * 5)
     agent = Agent(llm=llm, tools=[Tool(name="test_tool")])
     # High iteration cap so the BUDGET is what stops the run.
     conversation = LocalConversation(
@@ -575,14 +587,11 @@ def test_execution_status_error_on_max_budget(tmp_path):
         delete_on_close=False,
         max_iteration_per_run=10,
         max_budget_per_run=1.0,
-        callbacks=[lambda e: events_received.append(e)],
+        callbacks=[callback],
     )
+    conversation.conversation_stats.usage_to_metrics["spend"] = spend
     conversation.send_message(
         Message(role="user", content=[TextContent(text="Execute command")])
-    )
-    # Pre-seed spend over the budget (TestLLM accrues no real cost).
-    conversation.conversation_stats.usage_to_metrics["spend"] = Metrics(
-        accumulated_cost=5.0
     )
     conversation.run()
 
@@ -596,11 +605,20 @@ def test_execution_status_error_on_max_budget(tmp_path):
 
 
 def test_finished_preserved_even_when_over_budget(tmp_path):
-    """A run that finishes is kept FINISHED even if it is over budget."""
+    """A run that finishes is kept FINISHED even if it ends over budget."""
     from openhands.sdk.conversation.impl.local_conversation import LocalConversation
     from openhands.sdk.llm.utils.metrics import Metrics
 
     events_received: list = []
+    # Book over-budget spend exactly when the agent finishes, so the run is over
+    # budget at the very step it reaches FINISHED.
+    spend = Metrics(accumulated_cost=0.0)
+
+    def callback(event):
+        events_received.append(event)
+        if isinstance(event, MessageEvent) and event.source == "agent":
+            spend.add_cost(5.0)
+
     # Text-only response -> agent finishes on the first iteration.
     finish_message = Message(
         role="assistant", content=[TextContent(text="Task completed")]
@@ -614,14 +632,55 @@ def test_finished_preserved_even_when_over_budget(tmp_path):
         delete_on_close=False,
         max_iteration_per_run=10,
         max_budget_per_run=1.0,
-        callbacks=[lambda e: events_received.append(e)],
+        callbacks=[callback],
     )
+    conversation.conversation_stats.usage_to_metrics["spend"] = spend
     conversation.send_message(Message(role="user", content=[TextContent(text="Do it")]))
-    conversation.conversation_stats.usage_to_metrics["spend"] = Metrics(
-        accumulated_cost=5.0
-    )
     conversation.run()
 
     assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
     error_events = [e for e in events_received if isinstance(e, ConversationErrorEvent)]
     assert not any(e.code == "MaxBudgetReached" for e in error_events)
+    # Sanity: the run really did end over budget.
+    assert spend.accumulated_cost == 5.0
+
+
+def test_max_budget_baseline_resets_each_run(tmp_path):
+    """The budget window opens at run(): cost already on the books before the
+    run starts (lifetime spend, prior runs) is absorbed into the baseline and
+    does not count against the new run -- same per-run() scope as the
+    iteration cap."""
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.llm.utils.metrics import Metrics
+
+    events_received: list = []
+    test_tool = StatusTransitionTestTool.create(executor=StatusCheckingExecutor([]))[0]
+    register_tool("test_tool", test_tool)
+
+    finish_message = Message(role="assistant", content=[TextContent(text="Done")])
+    # A tool call keeps the run RUNNING so the budget check fires mid-run (not
+    # masked by the FINISHED guard); then the agent finishes.
+    llm = TestLLM.from_messages([_tool_call_message(), finish_message])
+    agent = Agent(llm=llm, tools=[Tool(name="test_tool")])
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+        delete_on_close=False,
+        max_iteration_per_run=10,
+        max_budget_per_run=1.0,
+        callbacks=[lambda e: events_received.append(e)],
+    )
+    conversation.send_message(Message(role="user", content=[TextContent(text="Go")]))
+    # Lifetime cost already exceeds the cap *before* this run starts.
+    conversation.conversation_stats.usage_to_metrics["spend"] = Metrics(
+        accumulated_cost=5.0
+    )
+    conversation.run()
+
+    # Baseline is captured at run() start (= 5.0), so the run itself spent 0:
+    # no breach, and the full budget remains available.
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+    error_events = [e for e in events_received if isinstance(e, ConversationErrorEvent)]
+    assert not any(e.code == "MaxBudgetReached" for e in error_events)
+    assert conversation.remaining_budget_this_run == 1.0

--- a/tests/sdk/conversation/test_conversation_factory.py
+++ b/tests/sdk/conversation/test_conversation_factory.py
@@ -86,6 +86,36 @@ def test_conversation_factory_forwards_local_parameters(agent):
     assert conversation.max_iteration_per_run == 100
 
 
+def test_conversation_factory_forwards_max_budget_per_run(agent):
+    """Factory forwards max_budget_per_run to LocalConversation."""
+    conversation = Conversation(
+        agent=agent,
+        max_budget_per_run=2.5,
+        visualizer=None,
+    )
+
+    assert isinstance(conversation, LocalConversation)
+    assert conversation.max_budget_per_run == 2.5
+
+
+@pytest.mark.parametrize("budget", [0, -5.0])
+def test_conversation_factory_rejects_non_positive_max_budget_local(agent, budget):
+    """Factory rejects a non-positive budget, matching the gt=0 contract on
+    StartConversationRequest / AgentDefinition (None stays allowed)."""
+    with pytest.raises(ValueError, match="max_budget_per_run must be a positive"):
+        Conversation(agent=agent, max_budget_per_run=budget, visualizer=None)
+
+
+@pytest.mark.parametrize("budget", [0, -5.0])
+@patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
+def test_conversation_factory_rejects_non_positive_max_budget_remote(
+    mock_ws_client, agent, remote_workspace, budget
+):
+    """The same guard applies before the remote branch is reached."""
+    with pytest.raises(ValueError, match="max_budget_per_run must be a positive"):
+        Conversation(agent=agent, workspace=remote_workspace, max_budget_per_run=budget)
+
+
 @patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
 def test_conversation_factory_forwards_remote_parameters(
     mock_ws_client, agent, remote_workspace
@@ -100,6 +130,24 @@ def test_conversation_factory_forwards_remote_parameters(
 
     assert isinstance(conversation, RemoteConversation)
     assert conversation.max_iteration_per_run == 200
+
+
+@patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
+def test_conversation_factory_forwards_remote_max_budget_to_payload(
+    mock_ws_client, agent, remote_workspace
+):
+    """RemoteConversation must send max_budget_per_run in the create request."""
+    conversation = Conversation(
+        agent=agent,
+        workspace=remote_workspace,
+        max_budget_per_run=3.0,
+    )
+
+    assert isinstance(conversation, RemoteConversation)
+    assert conversation.max_budget_per_run == 3.0
+    create_call = remote_workspace._client.request.call_args_list[0]
+    assert create_call.args[:2] == ("POST", "/api/conversations")
+    assert create_call.kwargs["json"]["max_budget_per_run"] == 3.0
 
 
 @patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -971,7 +971,27 @@ class TestTaskManagerBudget:
     """The per-subagent cost budget flows from the agent definition / parent
     into the spawned sub-conversation."""
 
-    def test_budget_from_agent_definition(self, tmp_path):
+    @staticmethod
+    def _parent_with_budget(
+        tmp_path, *, budget: float | None, spent: float = 0.0
+    ) -> LocalConversation:
+        from openhands.sdk.llm.utils.metrics import Metrics
+
+        parent = LocalConversation(
+            agent=Agent(llm=_make_llm(), tools=[]),
+            workspace=str(tmp_path),
+            visualizer=None,
+            delete_on_close=False,
+            max_budget_per_run=budget,
+        )
+        if spent:
+            parent.conversation_stats.usage_to_metrics["spend"] = Metrics(
+                accumulated_cost=spent
+            )
+        return parent
+
+    def test_budget_from_agent_definition_overrides_parent(self, tmp_path):
+        """A definition-level budget wins over the parent's remaining budget."""
         from openhands.sdk.subagent.registry import agent_definition_to_factory
 
         agent_def = AgentDefinition(
@@ -982,26 +1002,42 @@ class TestTaskManagerBudget:
             factory_func=agent_definition_to_factory(agent_def),
             description=agent_def,
         )
-        manager, _ = _manager_with_parent(tmp_path)
+        parent = self._parent_with_budget(tmp_path, budget=7.0, spent=2.0)
+        manager = TaskManager()
+        manager._ensure_parent(parent)
         task = manager._create_task(subagent_type="budgeted", description=None)
         assert task.conversation is not None
         assert task.conversation.max_budget_per_run == 4.0
 
-    def test_budget_inherits_from_parent(self, tmp_path):
+    def test_budget_inherits_parent_remaining(self, tmp_path):
+        """Sub-agent inherits the parent's *remaining* budget, not its full one."""
         register_builtins_agents()
-        agent = Agent(llm=_make_llm(), tools=[])
-        parent = LocalConversation(
-            agent=agent,
-            workspace=str(tmp_path),
-            visualizer=None,
-            delete_on_close=False,
-            max_budget_per_run=7.0,
-        )
+        # 7.0 cap, 2.0 already spent this run -> 5.0 remaining.
+        parent = self._parent_with_budget(tmp_path, budget=7.0, spent=2.0)
         manager = TaskManager()
         manager._ensure_parent(parent)
         task = manager._create_task(subagent_type="general-purpose", description=None)
         assert task.conversation is not None
-        assert task.conversation.max_budget_per_run == 7.0
+        assert task.conversation.max_budget_per_run == 5.0
+
+    def test_budget_zero_when_parent_exhausted(self, tmp_path):
+        """A parent that has spent its whole budget hands the sub-agent 0.0,
+        not the full budget (the explicit None check must not fall through)."""
+        register_builtins_agents()
+        parent = self._parent_with_budget(tmp_path, budget=3.0, spent=5.0)
+        manager = TaskManager()
+        manager._ensure_parent(parent)
+        task = manager._create_task(subagent_type="general-purpose", description=None)
+        assert task.conversation is not None
+        assert task.conversation.max_budget_per_run == 0.0
+
+    def test_budget_none_when_unbounded(self, tmp_path):
+        """No definition budget and no parent budget -> sub-agent is unbounded."""
+        register_builtins_agents()
+        manager, _ = _manager_with_parent(tmp_path)
+        task = manager._create_task(subagent_type="general-purpose", description=None)
+        assert task.conversation is not None
+        assert task.conversation.max_budget_per_run is None
 
 
 class TestRunErrorSurfacing:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Add a mx budget per run. Usefull for automation, where we want to have control on max $ spent.

---

AGENT:

## Why

`max_budget_per_run` already existed on `LocalConversation`, but it was a
constructor-only argument with three gaps for the automation use case:

1. **Not user-reachable** — it was not exposed on the public `Conversation(...)`
   factory, on `RemoteConversation`, or on `StartConversationRequest`, so a budget
   could not be set from the normal entry points (local or remote).
2. **Not ephemeral** — the check compared the conversation's *lifetime*
   `accumulated_cost` against the cap, so the budget never reset between runs.
3. **Sub-agents inherited the parent's *full* budget**, not what was left.

The goal is a cost ceiling that is scoped to a single `run()` — the **same scope
as `max_iteration_per_run`** (which resets its iteration counter each `run()`) —
works on both local and remote conversations, and is inherited by sub-agents as
the *remaining* budget.

## Summary

- Plumb `max_budget_per_run` through the public `Conversation(...)` factory,
  `RemoteConversation` (init/payload/fork), `StartConversationRequest`, and the
  agent server's `EventService`, so it is enforced on both local and remote paths.
- Make the budget **ephemeral, per-`run()`**: a cost baseline is captured at the
  start of each `run()`/`arun()` (alongside `iteration = 0`) and the check
  measures spend *since* that baseline instead of lifetime cost — same scope as
  `max_iteration_per_run`. Enforcement reuses the existing
  `_emit_run_limit_error` / `ConversationErrorEvent` / `ERROR` path unchanged.
- Sub-agents inherit the parent's **remaining** budget (explicit `is not None`
  check so an exhausted `0.0` is honored rather than falling through).
- Reject non-positive budgets at the factory, matching the `gt=0` contract
  already on `StartConversationRequest` and `AgentDefinition`.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `549581da572c` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1894,0 +1895 @@
+schema StartConversationRequest property max_budget_per_run optional schema=anyOf=[type="number" exclusiveMinimum=0.0,type="null"]
```
<!-- agent-server-rest-api-contract-summary:end -->

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `bac6aef8a727` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1895,0 +1896 @@
+schema StartConversationRequest property max_budget_per_run optional schema=anyOf=[type="number" exclusiveMinimum=0.0,type="null"]
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

N/A — no tracked issue.

## How to Test

End-to-end through the public `Conversation(...)` API (no network; a scripted
`TestLLM` drives the real run loop, cost is booked mid-run via a callback):

```
$ uv run python /tmp/budget_e2e.py   # script in the PR description / Notes
=== Scenario 1: budget halts a run end-to-end (public Conversation API) ===
status       : error
error code   : MaxBudgetReached
error detail : Agent reached maximum budget limit ($1.0000); accumulated cost $5.0000.

=== Scenario 2: next run() starts with a fresh budget (per-run scope) ===
lifetime accumulated_cost before run #2: 5.0
status            : finished
MaxBudgetReached? : False
remaining budget  : 1.0

=== Scenario 3: factory rejects non-positive budget ===
  budget=0: ValueError -> max_budget_per_run must be a positive cost (USD) or None; got 0.
  budget=-1.0: ValueError -> max_budget_per_run must be a positive cost (USD) or None; got -1.0.
```

Scenario 2 is the key one: lifetime cost (5.0) already exceeds the cap (1.0),
yet the next `run()` is not halted and the full budget is available again —
proving the per-`run()` reset.

Unit tests + lint:

```
uv run pytest tests/sdk/conversation/ tests/tools/task/ -q
# 685 passed

uv run pre-commit run   # against the staged change set
# Ruff format / Ruff lint / pycodestyle / pyright / import rules / tool registration: all Passed
```

New/updated tests: per-run budget enforcement (spend mid-run → `ERROR`),
`FINISHED` preserved when over budget, per-`run()` baseline reset, sub-agent
inherits remaining budget (incl. `0.0`-exhausted and `None`-unbounded), factory
forwarding (local + remote payload), factory rejection of non-positive budgets,
and `StartConversationRequest` (de)serialization.

## Video/Screenshots

No GUI surface — this is an SDK/agent-server change. The console transcript
under **How to Test** is the end-to-end evidence.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The exact `Conversation(...)` reproduction script used above:

```python
import tempfile
from collections.abc import Sequence
from typing import ClassVar
from openhands.sdk import Agent, Conversation
from openhands.sdk.event import ActionEvent
from openhands.sdk.event.conversation_error import ConversationErrorEvent
from openhands.sdk.llm import Message, MessageToolCall, TextContent
from openhands.sdk.llm.utils.metrics import Metrics
from openhands.sdk.testing import TestLLM
from openhands.sdk.tool import (
    Action, Observation, Tool, ToolDefinition, ToolExecutor, register_tool,
)

class A(Action):
    command: str
class O(Observation):
    result: str
    @property
    def to_llm_content(self): return [TextContent(text=self.result)]
class Exec(ToolExecutor):
    def __call__(self, action, conversation=None): return O(result="ok")
class T(ToolDefinition):
    name: ClassVar[str] = "noop_tool"
    @classmethod
    def create(cls, conv_state=None, *, executor, **kw) -> Sequence["T"]:
        return [cls(description="noop", action_type=A, observation_type=O, executor=executor)]
register_tool("noop_tool", T.create(executor=Exec())[0])

def tool_call():
    return Message(role="assistant", content=[TextContent(text="")],
        tool_calls=[MessageToolCall(id="c1", name="noop_tool", arguments='{"command":"x"}', origin="completion")])
done = Message(role="assistant", content=[TextContent(text="done")])

d = tempfile.mkdtemp()
llm = TestLLM.from_messages([tool_call(), tool_call(), done])
agent = Agent(llm=llm, tools=[Tool(name="noop_tool")])

events, charge = [], {"on": True}
spend = Metrics(accumulated_cost=0.0)
def cb(e):
    events.append(e)
    if isinstance(e, ActionEvent) and charge["on"]:
        spend.add_cost(5.0)

conv = Conversation(agent=agent, workspace=d, max_budget_per_run=1.0, visualizer=None, callbacks=[cb])
conv.conversation_stats.usage_to_metrics["spend"] = spend

conv.send_message(Message(role="user", content=[TextContent(text="go")]))
conv.run()                       # -> ERROR / MaxBudgetReached

charge["on"] = False             # run #2 accrues no new spend
conv.send_message(Message(role="user", content=[TextContent(text="again")]))
conv.run()                       # -> FINISHED, remaining budget 1.0
```

- Behavioral note: because the baseline resets every `run()` (to match
  `max_iteration_per_run`), a single prompt spanning multiple `run()` calls
  (confirmation mode, pause/resume) can spend up to N × `max_budget_per_run`
  total — exactly mirroring how the iteration cap behaves across those calls.
- Follow-up (out of scope): `max_budget_per_run` is not surfaced in
  `_ConversationInfoBase` conversation-info responses the way `max_iterations`
  is; can be added if info responses should expose it.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4b63adc-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4b63adc-python \
  ghcr.io/openhands/agent-server:4b63adc-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4b63adc-golang-amd64
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-golang-amd64
ghcr.io/openhands/agent-server:vasco-max-budget-golang-amd64
ghcr.io/openhands/agent-server:4b63adc-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4b63adc-golang-arm64
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-golang-arm64
ghcr.io/openhands/agent-server:vasco-max-budget-golang-arm64
ghcr.io/openhands/agent-server:4b63adc-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4b63adc-java-amd64
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-java-amd64
ghcr.io/openhands/agent-server:vasco-max-budget-java-amd64
ghcr.io/openhands/agent-server:4b63adc-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4b63adc-java-arm64
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-java-arm64
ghcr.io/openhands/agent-server:vasco-max-budget-java-arm64
ghcr.io/openhands/agent-server:4b63adc-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4b63adc-python-amd64
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-python-amd64
ghcr.io/openhands/agent-server:vasco-max-budget-python-amd64
ghcr.io/openhands/agent-server:4b63adc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4b63adc-python-arm64
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-python-arm64
ghcr.io/openhands/agent-server:vasco-max-budget-python-arm64
ghcr.io/openhands/agent-server:4b63adc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4b63adc-golang
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-golang
ghcr.io/openhands/agent-server:vasco-max-budget-golang
ghcr.io/openhands/agent-server:4b63adc-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4b63adc-java
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-java
ghcr.io/openhands/agent-server:vasco-max-budget-java
ghcr.io/openhands/agent-server:4b63adc-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4b63adc-python
ghcr.io/openhands/agent-server:4b63adcaad3fa151b0c0d3065812bec4a495d9bd-python
ghcr.io/openhands/agent-server:vasco-max-budget-python
ghcr.io/openhands/agent-server:4b63adc-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4b63adc-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4b63adc-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
