### PR TITLE
Collapse integration report details in PR comments

### DIFF
--- a/tests/integration/utils/generate_markdown_report.py
+++ b/tests/integration/utils/generate_markdown_report.py
@@ -182,7 +182,8 @@ def generate_markdown_report(consolidated: ConsolidatedResults) -> str:
     if artifacts_available:
         report_lines.extend(
             [
-                "## 📁 Detailed Logs & Artifacts",
+                "<details>",
+                "<summary>📁 Detailed Logs & Artifacts</summary>",
                 "",
                 (
                     "Click the links below to access detailed agent/LLM logs showing "
@@ -221,6 +222,9 @@ def generate_markdown_report(consolidated: ConsolidatedResults) -> str:
             generate_detailed_results(consolidated.model_results),
         ]
     )
+
+    if artifacts_available:
+        report_lines.extend(["", "</details>"])
 
     return "\n".join(report_lines)
 

--- a/tests/integration/utils/test_generate_markdown_report.py
+++ b/tests/integration/utils/test_generate_markdown_report.py
@@ -1,0 +1,50 @@
+from datetime import datetime
+
+from tests.integration import schemas
+from tests.integration.utils.generate_markdown_report import generate_markdown_report
+
+
+def test_generate_markdown_report_collapses_artifacts_and_details():
+    model_result = schemas.ModelTestResults(
+        model_name="test-model",
+        run_suffix="test_run",
+        llm_config={},
+        timestamp=datetime(2026, 1, 1, 12, 0, 0),
+        test_instances=[
+            schemas.TestInstanceResult(
+                instance_id="t01_example",
+                test_result=schemas.TestResultData(success=True),
+                test_type="integration",
+                required=True,
+                cost=0.12,
+            )
+        ],
+        total_tests=1,
+        successful_tests=1,
+        skipped_tests=0,
+        success_rate=1.0,
+        total_cost=0.12,
+        total_token_usage=schemas.TokenUsageData(prompt_tokens=10, completion_tokens=5),
+        artifact_url="https://example.com/artifact",
+    )
+    consolidated = schemas.ConsolidatedResults(
+        timestamp=datetime(2026, 1, 1, 12, 30, 0),
+        total_models=1,
+        model_results=[model_result],
+        overall_success_rate=1.0,
+        total_cost_all_models=0.12,
+    )
+
+    report = generate_markdown_report(consolidated)
+
+    details_start = report.index("<details>")
+    details = report[details_start : report.index("</details>")]
+    visible_summary = report[:details_start]
+
+    assert "**Overall Success Rate**: 100.0%" in visible_summary
+    assert "**Total Cost**: $0.12" in visible_summary
+    assert "<summary>📁 Detailed Logs & Artifacts</summary>" in details
+    assert "[📥 View & Download Logs](https://example.com/artifact)" in details
+    assert "## 📊 Summary" in details
+    assert "## 📋 Detailed Results" in details
+    assert "## 📊 Summary" not in visible_summary


### PR DESCRIPTION
HUMAN:

Simplicity in comments so they're more readable 

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The release PR's integration-test and behavior-test label comments currently show the full report by default, including artifact links, the summary table, and detailed per-model results. That makes release PR comments long and harder to scan. Reviewers should see the top-level totals first and expand the detailed logs/artifacts only when needed.

## Summary

- Wrap the generated report content after the top-level totals in a collapsed GitHub `<details>` block labeled `📁 Detailed Logs & Artifacts`.
- Keep the summary table and detailed per-model results inside the collapsed section, so the unexpanded comment shows only the totals.
- Add a regression test covering the collapsed markdown layout.

## Issue Number

N/A

## How to Test

I ran the targeted regression test:

```bash
uv run pytest tests/integration/utils/test_generate_markdown_report.py
```

Result:

```text
collected 1 item

tests/integration/utils/test_generate_markdown_report.py::test_generate_markdown_report_collapses_artifacts_and_details PASSED [100%]

1 passed
```

I also ran pre-commit on the changed files:

```bash
uv run pre-commit run --files tests/integration/utils/generate_markdown_report.py tests/integration/utils/test_generate_markdown_report.py
```

Result:

```text
Ruff format..............................................................Passed
Ruff lint................................................................Passed
PEP8 style check (pycodestyle)...........................................Passed
Type check with pyright..................................................Passed
Check import dependency rules............................................Passed
Check Tool subclass registration.........................................Passed
```

End-to-end note: this change affects the markdown generated for GitHub PR comments. The regression test constructs real `ConsolidatedResults`/`ModelTestResults` schema objects and verifies that the top-level totals remain outside the `<details>` block while the artifact links, summary table, and detailed results are inside it.

## Video/Screenshots

N/A — this is a GitHub markdown comment formatting change. The generated markdown structure is covered by the regression test above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The `HUMAN:` section is intentionally left as the template placeholder for a human contributor to fill in.

This PR description update was generated by an AI agent (OpenHands) on behalf of the user.
