### PR TITLE
fix(agent-server): update FastAPI root_path when /api/init delivers a web_url

### DIFF
--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -213,17 +213,11 @@ class InitService:
             self._entered_service = service
             self._app.state.config = new_config
             self._app.state.conversation_service = service
-            # FastAPI sets root_path once at construction; dormant servers
-            # boot without a web_url, so re-derive it from the merged config
-            # so OpenAPI / Swagger / ReDoc URLs and ASGI scope root_path
-            # reflect the per-user mount path. Stand-in test apps may not
-            # expose ``root_path``; skip the update in that case.
+            # Re-derive root_path from the merged config so Doc URLS are valid
             from openhands.agent_server.api import _get_root_path
 
             new_root_path = _get_root_path(new_config)
-            current_root_path = getattr(self._app, "root_path", None)
-            if current_root_path is not None and current_root_path != new_root_path:
-                self._app.root_path = new_root_path
+            self._app.root_path = new_root_path
             mark_initialization_complete()
             self._state = "ready"
             logger.info("deferred_init: server transitioned to ready")

--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -213,6 +213,17 @@ class InitService:
             self._entered_service = service
             self._app.state.config = new_config
             self._app.state.conversation_service = service
+            # FastAPI sets root_path once at construction; dormant servers
+            # boot without a web_url, so re-derive it from the merged config
+            # so OpenAPI / Swagger / ReDoc URLs and ASGI scope root_path
+            # reflect the per-user mount path. Stand-in test apps may not
+            # expose ``root_path``; skip the update in that case.
+            from openhands.agent_server.api import _get_root_path
+
+            new_root_path = _get_root_path(new_config)
+            current_root_path = getattr(self._app, "root_path", None)
+            if current_root_path is not None and current_root_path != new_root_path:
+                self._app.root_path = new_root_path
             mark_initialization_complete()
             self._state = "ready"
             logger.info("deferred_init: server transitioned to ready")

--- a/tests/agent_server/test_init_router.py
+++ b/tests/agent_server/test_init_router.py
@@ -246,6 +246,41 @@ class TestEndToEndOverLifespan:
             finally:
                 _reset_conversation_singleton()
 
+    def test_root_path_updates_from_init_web_url(self, tmp_path):
+        """When /api/init delivers a ``web_url``, the FastAPI ``root_path``
+        must be re-derived from it so OpenAPI/Swagger/ReDoc URLs reflect the
+        external mount path (e.g. behind a reverse proxy)."""
+        _reset_conversation_singleton()
+        cfg = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "convs",
+            bash_events_dir=tmp_path / "bash",
+        )
+        app = create_app(cfg)
+        with TestClient(app) as client:
+            try:
+                # Dormant server has no web_url → empty root_path.
+                assert app.root_path == ""
+
+                resp = client.post(
+                    "/api/init",
+                    json={
+                        "web_url": "https://example.com/agent-server-123/agent-server/",
+                        "conversations_path": str(tmp_path / "u" / "convs"),
+                        "bash_events_dir": str(tmp_path / "u" / "bash"),
+                    },
+                )
+                assert resp.status_code == 200
+
+                # The FastAPI app's root_path must now match the prefix from
+                # the per-user web_url so OpenAPI doc URLs and Swagger asset
+                # links are correct under the reverse-proxy mount path.
+                assert app.root_path == "/agent-server-123/agent-server", (
+                    f"root_path was not updated after /api/init: {app.root_path!r}"
+                )
+            finally:
+                _reset_conversation_singleton()
+
     def test_init_api_key_required_when_configured(self, tmp_path):
         _reset_conversation_singleton()
         cfg = Config(


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fixing openapi docs when using path based routing

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

When `Config.deferred_init=True`, the agent-server boots in *dormant* mode and
`POST /api/init` later delivers a per-user `web_url` (used to derive the FastAPI
`root_path` for OpenAPI / Swagger / ReDoc URLs on servers mounted behind a
reverse proxy under a sub-path, e.g. `/agent-server-123/agent-server/`).

`InitService.initialize` already swaps the merged config onto `app.state.config`,
but never updated `app.root_path`. Because FastAPI writes `scope["root_path"] =
self.root_path` on every request (`FastAPI.__call__`), the OpenAPI doc handlers
served `servers` entries derived from the dormant `""` root_path — regardless of
the per-user mount path. Docs and Swagger UI links were broken on warm-pool
servers that actually initialize.

## Summary

- Re-derive FastAPI `root_path` from the merged config inside `InitService.initialize`, right before flipping state to `ready`, so OpenAPI / Swagger / ReDoc URLs and the ASGI scope `root_path` reflect the per-user mount path on the very first request after `/api/init`.
- Add `test_root_path_updates_from_init_web_url` covering the dormant→init transition through the real FastAPI app + TestClient.

## Issue Number

<!-- Required if there is a relevant issue to this PR. -->

## How to Test

Unit tests:
```
uv run pytest tests/agent_server/test_init_router.py tests/agent_server/test_api.py -v
```

End-to-end against a real `uvicorn` server (`OH_DEFERRED_INIT=true`, then `POST /api/init` with `web_url="https://example.com/agent-server-123/agent-server/"`, then `GET /openapi.json`):

```
Before /api/init:
  GET /openapi.json status=200
  openapi.servers=None

POST /api/init status=200 body={'state': 'ready', 'error': None}

After /api/init:
  GET /openapi.json status=200
  openapi.servers=[{'url': '/agent-server-123/agent-server'}]

PASS: root_path was updated from /api/init web_url
```

Pre-fix the post-init line read `openapi.servers=None` (or `[]`); the per-user prefix only appeared in the schema after the FastAPI app was rebuilt.

## Video/Screenshots

In the screen shot below, see that an agent server started in deferred init mode shows the openapi docs when initialized with path based routing
<img width="1756" height="799" alt="image" src="https://github.com/user-attachments/assets/432250c5-3593-4b9b-9582-fc29f29e5d61" />


## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `_get_root_path` import is local to `initialize` to avoid an `api.py` ↔ `init_router.py` circular import (`api.py` already imports `InitService` / `init_router` at module load).
- The `getattr(self._app, "root_path", None)` guard keeps existing unit tests that substitute a `SimpleNamespace` for the FastAPI app working without modification.
- No public API changes; no migration needed.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:b1e462e-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-b1e462e-python \
  ghcr.io/openhands/agent-server:b1e462e-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:b1e462e-golang-amd64
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-golang-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-golang-amd64
ghcr.io/openhands/agent-server:b1e462e-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:b1e462e-golang-arm64
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-golang-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-golang-arm64
ghcr.io/openhands/agent-server:b1e462e-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:b1e462e-java-amd64
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-java-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-java-amd64
ghcr.io/openhands/agent-server:b1e462e-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:b1e462e-java-arm64
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-java-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-java-arm64
ghcr.io/openhands/agent-server:b1e462e-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:b1e462e-python-amd64
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-python-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-python-amd64
ghcr.io/openhands/agent-server:b1e462e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:b1e462e-python-arm64
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-python-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-python-arm64
ghcr.io/openhands/agent-server:b1e462e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:b1e462e-golang
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-golang
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-golang
ghcr.io/openhands/agent-server:b1e462e-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:b1e462e-java
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-java
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-java
ghcr.io/openhands/agent-server:b1e462e-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:b1e462e-python
ghcr.io/openhands/agent-server:b1e462e6d54dfaa4c9d08e1056bc326115ce32c1-python
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-python
ghcr.io/openhands/agent-server:b1e462e-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `b1e462e-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `b1e462e-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->