### PR TITLE
fix(agent-server): read services from app.state in WebSocket handlers for deferred-init

### DIFF
--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -234,6 +234,13 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
         mark_initialization_complete()
         logger.info("Server initialization complete - ready to serve requests")
 
+        bash_svc = get_default_bash_event_service()
+        # Register on app.state so the websocket handlers (and any other
+        # per-request code) see the same instance configured at startup
+        # rather than the module-level default that may have been built
+        # at import time from a different config.
+        api.state.bash_event_service = bash_svc
+
         async with service:
             api.state.conversation_service = service
 
@@ -241,7 +248,7 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
             retention_task: asyncio.Task | None = None
             if config.bash_events_retention_seconds is not None:
                 retention_task = asyncio.create_task(
-                    get_default_bash_event_service().run_retention_cleanup_loop(
+                    bash_svc.run_retention_cleanup_loop(
                         config.bash_events_retention_seconds
                     )
                 )

--- a/openhands-agent-server/openhands/agent_server/api.py
+++ b/openhands-agent-server/openhands/agent_server/api.py
@@ -235,10 +235,6 @@ async def api_lifespan(api: FastAPI) -> AsyncIterator[None]:
         logger.info("Server initialization complete - ready to serve requests")
 
         bash_svc = get_default_bash_event_service()
-        # Register on app.state so the websocket handlers (and any other
-        # per-request code) see the same instance configured at startup
-        # rather than the module-level default that may have been built
-        # at import time from a different config.
         api.state.bash_event_service = bash_svc
 
         async with service:

--- a/openhands-agent-server/openhands/agent_server/bash_router.py
+++ b/openhands-agent-server/openhands/agent_server/bash_router.py
@@ -7,12 +7,14 @@ from uuid import UUID
 
 from fastapi import (
     APIRouter,
+    Depends,
     HTTPException,
     Query,
     status,
 )
 
-from openhands.agent_server.bash_service import get_default_bash_event_service
+from openhands.agent_server.bash_service import BashEventService
+from openhands.agent_server.dependencies import get_bash_event_service
 from openhands.agent_server.models import (
     BashCommand,
     BashEventBase,
@@ -25,7 +27,6 @@ from openhands.agent_server.server_details_router import update_last_execution_t
 
 
 bash_router = APIRouter(prefix="/bash", tags=["Bash"])
-bash_event_service = get_default_bash_event_service()
 logger = logging.getLogger(__name__)
 
 
@@ -53,6 +54,7 @@ async def search_bash_events(
         int,
         Query(title="The max number of results in the page", gt=0, lte=100),
     ] = 100,
+    bash_event_service: BashEventService = Depends(get_bash_event_service),
 ) -> BashEventPage:
     """Search / List bash event events"""
     assert limit > 0
@@ -73,7 +75,10 @@ async def search_bash_events(
 @bash_router.get(
     "/bash_events/{event_id}", responses={404: {"description": "Item not found"}}
 )
-async def get_bash_event(event_id: str) -> BashEventBase:
+async def get_bash_event(
+    event_id: str,
+    bash_event_service: BashEventService = Depends(get_bash_event_service),
+) -> BashEventBase:
     """Get a bash event event given an id"""
     event = await bash_event_service.get_bash_event(event_id)
     if event is None:
@@ -84,6 +89,7 @@ async def get_bash_event(event_id: str) -> BashEventBase:
 @bash_router.get("/bash_events/")
 async def batch_get_bash_events(
     event_ids: list[str],
+    bash_event_service: BashEventService = Depends(get_bash_event_service),
 ) -> list[BashEventBase | None]:
     """Get a batch of bash event events given their ids, returning null for any
     missing item."""
@@ -92,7 +98,10 @@ async def batch_get_bash_events(
 
 
 @bash_router.post("/start_bash_command")
-async def start_bash_command(request: ExecuteBashRequest) -> BashCommand:
+async def start_bash_command(
+    request: ExecuteBashRequest,
+    bash_event_service: BashEventService = Depends(get_bash_event_service),
+) -> BashCommand:
     """Execute a bash command in the background"""
     update_last_execution_time()
     command, _ = await bash_event_service.start_bash_command(request)
@@ -100,7 +109,10 @@ async def start_bash_command(request: ExecuteBashRequest) -> BashCommand:
 
 
 @bash_router.post("/execute_bash_command")
-async def execute_bash_command(request: ExecuteBashRequest) -> BashOutput:
+async def execute_bash_command(
+    request: ExecuteBashRequest,
+    bash_event_service: BashEventService = Depends(get_bash_event_service),
+) -> BashOutput:
     """Execute a bash command and wait for a result"""
     update_last_execution_time()
     command, task = await bash_event_service.start_bash_command(request)
@@ -111,7 +123,9 @@ async def execute_bash_command(request: ExecuteBashRequest) -> BashOutput:
 
 
 @bash_router.delete("/bash_events")
-async def clear_all_bash_events() -> dict[str, int]:
+async def clear_all_bash_events(
+    bash_event_service: BashEventService = Depends(get_bash_event_service),
+) -> dict[str, int]:
     """Clear all bash events from storage"""
     count = await bash_event_service.clear_all_events()
     return {"cleared_count": count}

--- a/openhands-agent-server/openhands/agent_server/dependencies.py
+++ b/openhands-agent-server/openhands/agent_server/dependencies.py
@@ -3,6 +3,7 @@ from uuid import UUID
 from fastapi import Depends, HTTPException, Request, status
 from fastapi.security import APIKeyCookie, APIKeyHeader
 
+from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.event_service import EventService
@@ -59,18 +60,22 @@ def check_workspace_session(
     raise HTTPException(status.HTTP_401_UNAUTHORIZED)
 
 
-def get_conversation_service(request: Request):
-    """Get the conversation service from app state.
-
-    This dependency ensures that the conversation service is properly initialized
-    through the application lifespan context manager.
-    """
-
+def get_conversation_service(request: Request) -> ConversationService:
     service = getattr(request.app.state, "conversation_service", None)
     if service is None:
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Conversation service is not available",
+        )
+    return service
+
+
+def get_bash_event_service(request: Request) -> BashEventService:
+    service = getattr(request.app.state, "bash_event_service", None)
+    if service is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Bash event service is not available",
         )
     return service
 

--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -211,18 +211,9 @@ class InitService:
             service = ConversationService.get_instance(new_config)
             cs_mod._conversation_service = service
 
-            # Build a BashEventService from the merged config so the bash
-            # events websocket (and any other consumer) sees the per-user
-            # bash_events_dir delivered by /api/init, not the import-time
-            # default.
             bash_svc = BashEventService(bash_events_dir=new_config.bash_events_dir)
             await bash_svc.__aenter__()
             self._entered_bash_service = bash_svc
-            # Reset the module-level bash singleton so bash_router (which
-            # uses the module-level default) also sees the new instance.
-            from openhands.agent_server import bash_service as bash_mod
-
-            bash_mod._bash_event_service = bash_svc
 
             await service.__aenter__()
             self._entered_service = service

--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -213,6 +213,17 @@ class InitService:
             self._entered_service = service
             self._app.state.config = new_config
             self._app.state.conversation_service = service
+            # FastAPI sets root_path once at construction; dormant servers
+            # boot without a web_url, so re-derive it from the merged config
+            # so OpenAPI / Swagger / ReDoc URLs and ASGI scope root_path
+            # reflect the per-user mount path. Stand-in test apps may not
+            # expose ``root_path``; skip the update in that case.
+            from openhands.agent_server.api import _get_root_path
+
+            new_root_path = _get_root_path(new_config)
+            current_root_path = getattr(self._app, "root_path", None)
+            if current_root_path is not None and current_root_path != new_root_path:
+                self._app.root_path = new_root_path
             mark_initialization_complete()
             self._state = "ready"
             logger.info("deferred_init: server transitioned to ready")

--- a/openhands-agent-server/openhands/agent_server/init_router.py
+++ b/openhands-agent-server/openhands/agent_server/init_router.py
@@ -21,6 +21,7 @@ from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request, status
 from fastapi.security import APIKeyHeader
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
+from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config, WebhookSpec
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.server_details_router import mark_initialization_complete
@@ -175,6 +176,7 @@ class InitService:
         self._error: str | None = None
         self._lock = asyncio.Lock()
         self._entered_service: ConversationService | None = None
+        self._entered_bash_service: BashEventService | None = None
 
     @property
     def state(self) -> InitState:
@@ -209,10 +211,24 @@ class InitService:
             service = ConversationService.get_instance(new_config)
             cs_mod._conversation_service = service
 
+            # Build a BashEventService from the merged config so the bash
+            # events websocket (and any other consumer) sees the per-user
+            # bash_events_dir delivered by /api/init, not the import-time
+            # default.
+            bash_svc = BashEventService(bash_events_dir=new_config.bash_events_dir)
+            await bash_svc.__aenter__()
+            self._entered_bash_service = bash_svc
+            # Reset the module-level bash singleton so bash_router (which
+            # uses the module-level default) also sees the new instance.
+            from openhands.agent_server import bash_service as bash_mod
+
+            bash_mod._bash_event_service = bash_svc
+
             await service.__aenter__()
             self._entered_service = service
             self._app.state.config = new_config
             self._app.state.conversation_service = service
+            self._app.state.bash_event_service = bash_svc
             # FastAPI sets root_path once at construction; dormant servers
             # boot without a web_url, so re-derive it from the merged config
             # so OpenAPI / Swagger / ReDoc URLs and ASGI scope root_path
@@ -246,6 +262,9 @@ class InitService:
         if self._entered_service is not None:
             await self._entered_service.__aexit__(None, None, None)
             self._entered_service = None
+        if self._entered_bash_service is not None:
+            await self._entered_bash_service.__aexit__(None, None, None)
+            self._entered_bash_service = None
 
 
 def get_init_service(request: Request) -> InitService:

--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -28,9 +28,13 @@ from fastapi import (
 )
 from starlette.websockets import WebSocketState
 
-from openhands.agent_server.bash_service import get_default_bash_event_service
+from openhands.agent_server.bash_service import (
+    BashEventService,
+    get_default_bash_event_service,
+)
 from openhands.agent_server.config import Config, get_default_config
 from openhands.agent_server.conversation_service import (
+    ConversationService,
     get_default_conversation_service,
 )
 from openhands.agent_server.event_router import normalize_datetime_to_server_timezone
@@ -46,6 +50,11 @@ from openhands.sdk.utils.paging import page_iterator
 
 
 sockets_router = APIRouter(prefix="/sockets", tags=["WebSockets"])
+# Module-level defaults for the case where ``app.state`` does not have a
+# service registered (e.g. unit tests, library usage without a lifespan).
+# In normal operation the per-app instances registered on ``app.state`` at
+# lifespan time (or by ``POST /api/init`` in deferred-init mode) take
+# precedence; see ``_get_conversation_service`` and ``_get_bash_event_service``.
 conversation_service = get_default_conversation_service()
 bash_event_service = get_default_bash_event_service()
 logger = logging.getLogger(__name__)
@@ -62,6 +71,38 @@ def _get_config(websocket: WebSocket) -> Config:
     if isinstance(config, Config):
         return config
     return get_default_config()
+
+
+def _get_conversation_service(websocket: WebSocket) -> ConversationService:
+    """Return the ConversationService for this FastAPI app instance.
+
+    Looks up ``app.state.conversation_service`` at request time so that the
+    service delivered via ``POST /api/init`` (deferred-init / dormant mode)
+    is used instead of the module-level default captured at import. When
+    ``app.state`` is not configured (e.g. when sockets.py is imported as a
+    library without a lifespan), falls back to the module-level singleton,
+    which keeps the behaviour of existing tests that patch the module-level
+    variable.
+    """
+    service = getattr(websocket.app.state, "conversation_service", None)
+    if isinstance(service, ConversationService):
+        return service
+    return conversation_service
+
+
+def _get_bash_event_service(websocket: WebSocket) -> BashEventService:
+    """Return the BashEventService for this FastAPI app instance.
+
+    Looks up ``app.state.bash_event_service`` at request time so that the
+    service delivered via ``POST /api/init`` (deferred-init / dormant mode)
+    is used instead of the module-level default captured at import. When
+    ``app.state`` is not configured (e.g. when sockets.py is imported as a
+    library without a lifespan), falls back to the module-level singleton.
+    """
+    service = getattr(websocket.app.state, "bash_event_service", None)
+    if isinstance(service, BashEventService):
+        return service
+    return bash_event_service
 
 
 def _resolve_websocket_session_api_key(
@@ -242,7 +283,11 @@ async def events_socket(
         return
 
     logger.info(f"Event Websocket Connected: {conversation_id}")
-    event_service = await conversation_service.get_event_service(conversation_id)
+    # Resolve the per-app ConversationService (set by the lifespan or by
+    # POST /api/init) so deferred-init mode uses the up-to-date instance
+    # rather than the module-level singleton captured at import time.
+    conv_service = _get_conversation_service(websocket)
+    event_service = await conv_service.get_event_service(conversation_id)
     if event_service is None:
         logger.warning(f"Converation not found: {conversation_id}")
         await websocket.close(code=4004, reason="Conversation not found")
@@ -372,9 +417,14 @@ async def bash_events_socket(
     if not await _accept_authenticated_websocket(websocket, session_api_key):
         return
 
+    # Resolve the per-app BashEventService (set by the lifespan or by
+    # POST /api/init) so deferred-init mode uses the up-to-date instance
+    # rather than the module-level singleton captured at import time.
+    bash_service = _get_bash_event_service(websocket)
+
     logger.info("Bash Websocket Connected")
     try:
-        subscriber_id = await bash_event_service.subscribe_to_events(
+        subscriber_id = await bash_service.subscribe_to_events(
             _BashWebSocketSubscriber(websocket)
         )
     except MaxSubscribersError:
@@ -392,7 +442,7 @@ async def bash_events_socket(
         # Resend all existing events if requested
         if effective_mode == "all":
             logger.info("Resending bash events")
-            async for event in page_iterator(bash_event_service.search_bash_events):
+            async for event in page_iterator(bash_service.search_bash_events):
                 await _send_bash_event(event, websocket)
 
         while True:
@@ -401,7 +451,7 @@ async def bash_events_socket(
                 data = await websocket.receive_json()
                 logger.info("Received bash request")
                 request = ExecuteBashRequest.model_validate(data)
-                await bash_event_service.start_bash_command(request)
+                await bash_service.start_bash_command(request)
             except WebSocketDisconnect:
                 logger.info("Bash websocket disconnected")
                 return
@@ -428,7 +478,7 @@ async def bash_events_socket(
                     await _safe_close_websocket(websocket)
                     return
     finally:
-        await bash_event_service.unsubscribe_from_events(subscriber_id)
+        await bash_service.unsubscribe_from_events(subscriber_id)
 
 
 async def _send_event(event: Event, websocket: WebSocket):

--- a/openhands-agent-server/openhands/agent_server/sockets.py
+++ b/openhands-agent-server/openhands/agent_server/sockets.py
@@ -50,11 +50,6 @@ from openhands.sdk.utils.paging import page_iterator
 
 
 sockets_router = APIRouter(prefix="/sockets", tags=["WebSockets"])
-# Module-level defaults for the case where ``app.state`` does not have a
-# service registered (e.g. unit tests, library usage without a lifespan).
-# In normal operation the per-app instances registered on ``app.state`` at
-# lifespan time (or by ``POST /api/init`` in deferred-init mode) take
-# precedence; see ``_get_conversation_service`` and ``_get_bash_event_service``.
 conversation_service = get_default_conversation_service()
 bash_event_service = get_default_bash_event_service()
 logger = logging.getLogger(__name__)
@@ -283,9 +278,6 @@ async def events_socket(
         return
 
     logger.info(f"Event Websocket Connected: {conversation_id}")
-    # Resolve the per-app ConversationService (set by the lifespan or by
-    # POST /api/init) so deferred-init mode uses the up-to-date instance
-    # rather than the module-level singleton captured at import time.
     conv_service = _get_conversation_service(websocket)
     event_service = await conv_service.get_event_service(conversation_id)
     if event_service is None:
@@ -417,11 +409,7 @@ async def bash_events_socket(
     if not await _accept_authenticated_websocket(websocket, session_api_key):
         return
 
-    # Resolve the per-app BashEventService (set by the lifespan or by
-    # POST /api/init) so deferred-init mode uses the up-to-date instance
-    # rather than the module-level singleton captured at import time.
     bash_service = _get_bash_event_service(websocket)
-
     logger.info("Bash Websocket Connected")
     try:
         subscriber_id = await bash_service.subscribe_to_events(

--- a/tests/agent_server/stress/conftest.py
+++ b/tests/agent_server/stress/conftest.py
@@ -50,20 +50,11 @@ async def conversation_service(tmp_path: Path) -> AsyncIterator[ConversationServ
 
 
 @pytest_asyncio.fixture
-async def bash_service(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> AsyncIterator[BashEventService]:
-    """Per-test BashEventService, monkeypatched into the bash router.
-
-    The bash router stores its service as a module-level global
-    (``bash_router.bash_event_service``) initialized at import time, so we
-    can't isolate it via FastAPI dependency injection — we have to swap the
-    attribute. monkeypatch restores the original on teardown.
-    """
+async def bash_service(tmp_path: Path) -> AsyncIterator[BashEventService]:
+    """Per-test BashEventService scoped to tmp_path/bash_events."""
     bash_dir = tmp_path / "bash_events"
     bash_dir.mkdir(parents=True, exist_ok=True)
     service = BashEventService(bash_events_dir=bash_dir)
-    monkeypatch.setattr(bash_router_module, "bash_event_service", service)
     async with service:
         yield service
 
@@ -85,6 +76,7 @@ def app(
     """
     fastapi_app = FastAPI()
     fastapi_app.state.config = Config()
+    fastapi_app.state.bash_event_service = bash_service
     fastapi_app.include_router(server_details_router)
     fastapi_app.include_router(conversation_router, prefix="/api")
     fastapi_app.include_router(event_router, prefix="/api")

--- a/tests/agent_server/test_bash_service.py
+++ b/tests/agent_server/test_bash_service.py
@@ -24,13 +24,9 @@ from openhands.agent_server.server_details_router import (
 
 
 @pytest_asyncio.fixture
-async def bash_service(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> AsyncIterator[BashEventService]:
+async def bash_service(tmp_path: Path) -> AsyncIterator[BashEventService]:
     service = BashEventService(bash_events_dir=tmp_path / "bash_events")
     async with service:
-        # bash_router holds its service as a module-level global; swap it.
-        monkeypatch.setattr(bash_router_module, "bash_event_service", service)
         yield service
 
 
@@ -38,6 +34,7 @@ async def bash_service(
 async def client(bash_service: BashEventService) -> AsyncIterator[httpx.AsyncClient]:
     app = FastAPI()
     app.state.config = Config()
+    app.state.bash_event_service = bash_service
     app.include_router(server_details_router)
     app.include_router(bash_router_module.bash_router, prefix="/api")
     mark_initialization_complete()

--- a/tests/agent_server/test_init_router.py
+++ b/tests/agent_server/test_init_router.py
@@ -46,6 +46,13 @@ def _reset_conversation_singleton():
     cs_mod._conversation_service = None
 
 
+def _reset_bash_singleton():
+    """Reset the module-level BashEventService cache so each test starts fresh."""
+    from openhands.agent_server import bash_service as bash_mod
+
+    bash_mod._bash_event_service = None
+
+
 class TestConfigDefaults:
     def test_deferred_init_defaults_false(self):
         assert Config().deferred_init is False
@@ -116,6 +123,9 @@ class TestInitServiceTransitions:
     @pytest.mark.asyncio
     async def test_init_transitions_dormant_to_ready(self, tmp_path):
         _reset_conversation_singleton()
+        _reset_bash_singleton()
+        from openhands.agent_server.bash_service import BashEventService
+
         base = Config(
             deferred_init=True,
             conversations_path=tmp_path / "convs",
@@ -139,9 +149,25 @@ class TestInitServiceTransitions:
             assert app.state.config.deferred_init is False
             assert app.state.config.session_api_keys == ["user-key"]
             assert app.state.conversation_service is not None
+            # BashEventService is registered on app.state so the bash
+            # websocket handler picks up the per-user bash_events_dir
+            # rather than the import-time default.
+            assert isinstance(
+                getattr(app.state, "bash_event_service", None), BashEventService
+            )
+            assert (
+                app.state.bash_event_service.bash_events_dir
+                == tmp_path / "user" / "bash"
+            )
+            # And the module-level default is also refreshed so bash_router
+            # (which reads the module-level singleton) uses the new dir.
+            from openhands.agent_server import bash_service as bash_mod
+
+            assert bash_mod._bash_event_service is app.state.bash_event_service
         finally:
             await svc.teardown()
             _reset_conversation_singleton()
+            _reset_bash_singleton()
 
     @pytest.mark.asyncio
     async def test_second_init_rejected_with_400(self, tmp_path):
@@ -197,6 +223,71 @@ class TestInitServiceTransitions:
             await svc.teardown()
             monkeypatch.delenv("DEFERRED_INIT_TEST_VAR", raising=False)
             _reset_conversation_singleton()
+
+    @pytest.mark.asyncio
+    async def test_init_bash_service_uses_user_supplied_dir(self, tmp_path):
+        """The bash events websocket and bash_router must observe the
+        bash_events_dir supplied via /api/init, not the import-time default."""
+        _reset_conversation_singleton()
+        _reset_bash_singleton()
+        from openhands.agent_server import bash_service as bash_mod
+        from openhands.agent_server.bash_service import BashEventService
+
+        base = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "convs",
+            bash_events_dir=tmp_path / "boot" / "bash",
+        )
+        app = SimpleNamespace(state=SimpleNamespace(config=base))
+        svc = InitService(app, base_config=base)  # type: ignore[arg-type]
+
+        # Make sure no stale module-level instance leaks in from elsewhere.
+        bash_mod._bash_event_service = None
+
+        user_dir = tmp_path / "user" / "bash"
+        await svc.initialize(
+            InitRequest(
+                conversations_path=tmp_path / "user" / "convs",
+                bash_events_dir=user_dir,
+            )
+        )
+        try:
+            bash_svc = app.state.bash_event_service
+            assert isinstance(bash_svc, BashEventService)
+            assert bash_svc.bash_events_dir == user_dir
+            # bash_router reads through get_default_bash_event_service(),
+            # which uses the module-level cache, so it must be refreshed too.
+            assert bash_mod.get_default_bash_event_service().bash_events_dir == user_dir
+        finally:
+            await svc.teardown()
+            _reset_conversation_singleton()
+            _reset_bash_singleton()
+
+    @pytest.mark.asyncio
+    async def test_init_teardown_releases_bash_service(self, tmp_path):
+        """When /api/init is followed by teardown, the bash service must also
+        be exited so its background tasks are released."""
+        _reset_conversation_singleton()
+        _reset_bash_singleton()
+        base = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "convs",
+            bash_events_dir=tmp_path / "bash",
+        )
+        app = SimpleNamespace(state=SimpleNamespace(config=base))
+        svc = InitService(app, base_config=base)  # type: ignore[arg-type]
+
+        await svc.initialize(
+            InitRequest(
+                conversations_path=tmp_path / "u" / "convs",
+                bash_events_dir=tmp_path / "u" / "bash",
+            )
+        )
+        assert svc._entered_bash_service is not None
+        await svc.teardown()
+        assert svc._entered_bash_service is None
+        _reset_conversation_singleton()
+        _reset_bash_singleton()
 
 
 class TestEndToEndOverLifespan:
@@ -393,6 +484,7 @@ async def test_lifespan_teardown_releases_conversation_service_after_init(
     """If /api/init succeeds, the lifespan finally clause must release the
     conversation service. If /api/init never runs, teardown is a no-op."""
     _reset_conversation_singleton()
+    _reset_bash_singleton()
     cfg = Config(
         deferred_init=True,
         conversations_path=tmp_path / "convs",
@@ -413,4 +505,7 @@ async def test_lifespan_teardown_releases_conversation_service_after_init(
     # After lifespan exit the conversation service should have been torn
     # down — i.e. _entered_service is cleared.
     assert init_svc._entered_service is None
+    # Same for the bash service: it must be torn down on lifespan exit.
+    assert init_svc._entered_bash_service is None
     _reset_conversation_singleton()
+    _reset_bash_singleton()

--- a/tests/agent_server/test_init_router.py
+++ b/tests/agent_server/test_init_router.py
@@ -159,11 +159,6 @@ class TestInitServiceTransitions:
                 app.state.bash_event_service.bash_events_dir
                 == tmp_path / "user" / "bash"
             )
-            # And the module-level default is also refreshed so bash_router
-            # (which reads the module-level singleton) uses the new dir.
-            from openhands.agent_server import bash_service as bash_mod
-
-            assert bash_mod._bash_event_service is app.state.bash_event_service
         finally:
             await svc.teardown()
             _reset_conversation_singleton()
@@ -226,11 +221,10 @@ class TestInitServiceTransitions:
 
     @pytest.mark.asyncio
     async def test_init_bash_service_uses_user_supplied_dir(self, tmp_path):
-        """The bash events websocket and bash_router must observe the
-        bash_events_dir supplied via /api/init, not the import-time default."""
+        """After /api/init, app.state.bash_event_service uses the
+        bash_events_dir supplied in the InitRequest."""
         _reset_conversation_singleton()
         _reset_bash_singleton()
-        from openhands.agent_server import bash_service as bash_mod
         from openhands.agent_server.bash_service import BashEventService
 
         base = Config(
@@ -240,9 +234,6 @@ class TestInitServiceTransitions:
         )
         app = SimpleNamespace(state=SimpleNamespace(config=base))
         svc = InitService(app, base_config=base)  # type: ignore[arg-type]
-
-        # Make sure no stale module-level instance leaks in from elsewhere.
-        bash_mod._bash_event_service = None
 
         user_dir = tmp_path / "user" / "bash"
         await svc.initialize(
@@ -255,9 +246,6 @@ class TestInitServiceTransitions:
             bash_svc = app.state.bash_event_service
             assert isinstance(bash_svc, BashEventService)
             assert bash_svc.bash_events_dir == user_dir
-            # bash_router reads through get_default_bash_event_service(),
-            # which uses the module-level cache, so it must be refreshed too.
-            assert bash_mod.get_default_bash_event_service().bash_events_dir == user_dir
         finally:
             await svc.teardown()
             _reset_conversation_singleton()

--- a/tests/agent_server/test_init_router.py
+++ b/tests/agent_server/test_init_router.py
@@ -246,6 +246,41 @@ class TestEndToEndOverLifespan:
             finally:
                 _reset_conversation_singleton()
 
+    def test_root_path_updates_from_init_web_url(self, tmp_path):
+        """When /api/init delivers a ``web_url``, the FastAPI ``root_path``
+        must be re-derived from it so OpenAPI/Swagger/ReDoc URLs reflect the
+        external mount path (e.g. behind a reverse proxy)."""
+        _reset_conversation_singleton()
+        cfg = Config(
+            deferred_init=True,
+            conversations_path=tmp_path / "convs",
+            bash_events_dir=tmp_path / "bash",
+        )
+        app = create_app(cfg)
+        with TestClient(app) as client:
+            try:
+                # Dormant server has no web_url → empty root_path.
+                assert app.root_path == ""
+
+                resp = client.post(
+                    "/api/init",
+                    json={
+                        "web_url": "https://example.com/agent-server-123/agent-server/",
+                        "conversations_path": str(tmp_path / "u" / "convs"),
+                        "bash_events_dir": str(tmp_path / "u" / "bash"),
+                    },
+                )
+                assert resp.status_code == 200
+
+                # The FastAPI app's root_path must now match the prefix from
+                # the per-user web_url so OpenAPI doc URLs and Swagger asset
+                # links are correct under the reverse-proxy mount path.
+                assert app.root_path == "/agent-server-123/agent-server", (
+                    f"root_path was not updated after /api/init: {app.root_path!r}"
+                )
+            finally:
+                _reset_conversation_singleton()
+
     def test_init_api_key_required_when_configured(self, tmp_path):
         _reset_conversation_singleton()
         cfg = Config(

--- a/tests/agent_server/test_sockets_service_getters.py
+++ b/tests/agent_server/test_sockets_service_getters.py
@@ -1,0 +1,205 @@
+"""Tests for the per-app service getters in sockets.py.
+
+The websocket handlers must read ``ConversationService`` and
+``BashEventService`` from ``app.state`` (set by the lifespan or by
+``POST /api/init`` in deferred-init mode) rather than the module-level
+singletons captured at import time. These helpers encapsulate that lookup
+and gracefully fall back to the module-level default when ``app.state``
+is not configured (e.g. when sockets.py is imported as a library without
+a lifespan).
+"""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+import openhands.agent_server.sockets as sockets_mod
+from openhands.agent_server.bash_service import BashEventService
+from openhands.agent_server.config import Config
+from openhands.agent_server.conversation_service import ConversationService
+from openhands.agent_server.event_service import EventService
+from openhands.agent_server.sockets import (
+    _get_bash_event_service,
+    _get_conversation_service,
+)
+
+
+def _make_ws(state: dict[str, object] | None = None) -> MagicMock:
+    """Build a mock WebSocket whose ``app.state`` exposes ``state``."""
+    ws = MagicMock()
+    ws.app.state = SimpleNamespace()
+    if state is not None:
+        ws.app.state = SimpleNamespace(**state)
+    return ws
+
+
+@pytest.fixture
+def conv_service():
+    return MagicMock(spec=ConversationService)
+
+
+@pytest.fixture
+def bash_service():
+    return MagicMock(spec=BashEventService)
+
+
+# -- _get_conversation_service --
+
+
+def test_get_conversation_service_prefers_app_state(conv_service):
+    """When the app registers a service, that one is returned (not the
+    module-level singleton)."""
+    ws = _make_ws({"conversation_service": conv_service})
+    assert _get_conversation_service(ws) is conv_service
+
+
+def test_get_conversation_service_falls_back_to_module_singleton():
+    """When ``app.state`` has no conversation service, the module-level
+    default is returned (preserves the behaviour of tests that patch the
+    module-level singleton)."""
+    ws = _make_ws()
+    assert _get_conversation_service(ws) is sockets_mod.conversation_service
+
+
+def test_get_conversation_service_ignores_wrong_type():
+    """If ``app.state.conversation_service`` is set to something that is not
+    a ConversationService (e.g. None or some other object), fall back to the
+    module-level default rather than blow up."""
+    for bogus in (None, "not a service", 42):
+        ws = _make_ws({"conversation_service": bogus})
+        # Must not raise — just return the module-level default.
+        result = _get_conversation_service(ws)
+        assert isinstance(result, ConversationService)
+
+
+# -- _get_bash_event_service --
+
+
+def test_get_bash_event_service_prefers_app_state(bash_service):
+    ws = _make_ws({"bash_event_service": bash_service})
+    assert _get_bash_event_service(ws) is bash_service
+
+
+def test_get_bash_event_service_falls_back_to_module_singleton():
+    ws = _make_ws()
+    assert _get_bash_event_service(ws) is sockets_mod.bash_event_service
+
+
+def test_get_bash_event_service_ignores_wrong_type():
+    for bogus in (None, "not a service", 42):
+        ws = _make_ws({"bash_event_service": bogus})
+        result = _get_bash_event_service(ws)
+        assert isinstance(result, BashEventService)
+
+
+# -- Integration with Config --
+
+
+def test_get_conversation_service_handles_real_config(tmp_path):
+    """Sanity check: the helper returns a real ConversationService built
+    from a Config on ``app.state`` rather than the import-time default."""
+    from openhands.agent_server import conversation_service as cs_mod
+
+    original_default = sockets_mod.conversation_service
+    cs_mod._conversation_service = None
+    try:
+        new_service = ConversationService(
+            conversations_dir=tmp_path / "convs",
+        )
+        cfg = Config(
+            conversations_path=tmp_path / "convs",
+            bash_events_dir=tmp_path / "bash",
+        )
+        ws = _make_ws({"conversation_service": new_service, "config": cfg})
+        assert _get_conversation_service(ws) is new_service
+        assert _get_conversation_service(ws) is not original_default
+    finally:
+        cs_mod._conversation_service = None
+
+
+def test_get_bash_event_service_handles_real_config(tmp_path):
+    """Sanity check: the helper returns a real BashEventService built
+    from a Config on ``app.state`` rather than the import-time default."""
+    from openhands.agent_server import bash_service as bash_mod
+
+    original_default = sockets_mod.bash_event_service
+    bash_mod._bash_event_service = None
+    try:
+        new_service = BashEventService(bash_events_dir=tmp_path / "user" / "bash")
+        cfg = Config(
+            conversations_path=tmp_path / "convs",
+            bash_events_dir=tmp_path / "user" / "bash",
+        )
+        ws = _make_ws({"bash_event_service": new_service, "config": cfg})
+        assert _get_bash_event_service(ws) is new_service
+        assert _get_bash_event_service(ws) is not original_default
+    finally:
+        bash_mod._bash_event_service = None
+
+
+# -- End-to-end: WebSocket handlers use per-app services after /api/init --
+
+
+@pytest.mark.asyncio
+async def test_events_socket_uses_app_state_conversation_service():
+    """events_socket must use app.state.conversation_service (set by /api/init)
+    rather than the module-level singleton captured at import time."""
+    from openhands.agent_server.sockets import events_socket
+
+    mock_event_svc = MagicMock(spec=EventService)
+    mock_event_svc.subscribe_to_events = AsyncMock(return_value=uuid4())
+    mock_event_svc.unsubscribe_from_events = AsyncMock(return_value=True)
+
+    per_app_conv_svc = MagicMock(spec=ConversationService)
+    per_app_conv_svc.get_event_service = AsyncMock(return_value=mock_event_svc)
+
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.receive_text = AsyncMock()
+    ws.receive_json = AsyncMock(side_effect=WebSocketDisconnect())
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    ws.headers = {}
+    # Simulate app.state after /api/init delivers a per-user service.
+    ws.app.state = SimpleNamespace(
+        conversation_service=per_app_conv_svc,
+        config=Config(),  # empty session_api_keys → no auth check
+    )
+
+    await events_socket(uuid4(), ws, session_api_key=None)
+
+    per_app_conv_svc.get_event_service.assert_called_once()
+    mock_event_svc.subscribe_to_events.assert_called_once()
+    mock_event_svc.unsubscribe_from_events.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_bash_events_socket_uses_app_state_bash_event_service():
+    """bash_events_socket must use app.state.bash_event_service (set by /api/init)
+    rather than the module-level singleton captured at import time."""
+    from openhands.agent_server.sockets import bash_events_socket
+
+    per_app_bash_svc = MagicMock(spec=BashEventService)
+    per_app_bash_svc.subscribe_to_events = AsyncMock(return_value=uuid4())
+    per_app_bash_svc.unsubscribe_from_events = AsyncMock(return_value=True)
+
+    ws = MagicMock()
+    ws.accept = AsyncMock()
+    ws.receive_text = AsyncMock()
+    ws.receive_json = AsyncMock(side_effect=WebSocketDisconnect())
+    ws.send_json = AsyncMock()
+    ws.close = AsyncMock()
+    ws.headers = {}
+    # Simulate app.state after /api/init delivers a per-user service.
+    ws.app.state = SimpleNamespace(
+        bash_event_service=per_app_bash_svc,
+        config=Config(),  # empty session_api_keys → no auth check
+    )
+
+    await bash_events_socket(ws, session_api_key=None)
+
+    per_app_bash_svc.subscribe_to_events.assert_called_once()
+    per_app_bash_svc.unsubscribe_from_events.assert_called_once()

--- a/tests/agent_server/test_terminal_router.py
+++ b/tests/agent_server/test_terminal_router.py
@@ -2,7 +2,7 @@
 
 import tempfile
 from pathlib import Path
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
@@ -10,6 +10,7 @@ from fastapi.testclient import TestClient
 from openhands.agent_server.api import create_app
 from openhands.agent_server.bash_service import BashEventService
 from openhands.agent_server.config import Config
+from openhands.agent_server.dependencies import get_bash_event_service
 from openhands.agent_server.models import BashCommand
 
 
@@ -30,34 +31,38 @@ def client():
     return TestClient(create_app(config))
 
 
-@pytest.mark.asyncio
-async def test_clear_all_bash_events_empty_storage():
+def test_clear_all_bash_events_empty_storage():
     """Test clearing bash events when storage is empty."""
-    with patch("openhands.agent_server.bash_router.bash_event_service") as mock_service:
-        mock_service.clear_all_events = AsyncMock(return_value=0)
+    mock_service = MagicMock(spec=BashEventService)
+    mock_service.clear_all_events = AsyncMock(return_value=0)
 
-        config = Config(session_api_keys=[])  # Disable authentication
-        client = TestClient(create_app(config))
-        response = client.delete("/api/bash/bash_events")
+    config = Config(session_api_keys=[])
+    app = create_app(config)
+    app.dependency_overrides[get_bash_event_service] = lambda: mock_service
 
-        assert response.status_code == 200
-        assert response.json() == {"cleared_count": 0}
-        mock_service.clear_all_events.assert_called_once()
+    client = TestClient(app)
+    response = client.delete("/api/bash/bash_events")
+
+    assert response.status_code == 200
+    assert response.json() == {"cleared_count": 0}
+    mock_service.clear_all_events.assert_called_once()
 
 
-@pytest.mark.asyncio
-async def test_clear_all_bash_events_with_data():
+def test_clear_all_bash_events_with_data():
     """Test clearing bash events when storage contains data."""
-    with patch("openhands.agent_server.bash_router.bash_event_service") as mock_service:
-        mock_service.clear_all_events = AsyncMock(return_value=5)
+    mock_service = MagicMock(spec=BashEventService)
+    mock_service.clear_all_events = AsyncMock(return_value=5)
 
-        config = Config(session_api_keys=[])  # Disable authentication
-        client = TestClient(create_app(config))
-        response = client.delete("/api/bash/bash_events")
+    config = Config(session_api_keys=[])
+    app = create_app(config)
+    app.dependency_overrides[get_bash_event_service] = lambda: mock_service
 
-        assert response.status_code == 200
-        assert response.json() == {"cleared_count": 5}
-        mock_service.clear_all_events.assert_called_once()
+    client = TestClient(app)
+    response = client.delete("/api/bash/bash_events")
+
+    assert response.status_code == 200
+    assert response.json() == {"cleared_count": 5}
+    mock_service.clear_all_events.assert_called_once()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

socket.py was still using the original service from application startup.

---

AGENT:

## Why

The WebSocket handlers in `sockets.py` read `conversation_service` and `bash_event_service` from module-level singletons captured at import time. In deferred-init mode (`OH_DEFERRED_INIT=true`), `POST /api/init` registers new per-user services on `app.state` after import — so the WebSocket handlers kept using the stale import-time instances, ignoring whatever `bash_events_dir` (and other config) was delivered at init time.

This mirrors the same bug that was already fixed for REST routes in `dependencies.py`, which always reads services from `request.app.state` at request time.

## Summary

- Added `_get_conversation_service(websocket)` and `_get_bash_event_service(websocket)` helpers in `sockets.py` that read from `websocket.app.state` at request time (falling back to module-level defaults for library/test usage without a lifespan); `events_socket` and `bash_events_socket` now use these instead of the module globals directly.
- `api.py` (non-deferred lifespan): registers `bash_event_service` on `api.state` so the websocket helpers always find it there.
- `init_router.py` (deferred path): `InitService.initialize()` builds a fresh `BashEventService` from the merged config and writes it to `app.state.bash_event_service`; `teardown()` exits it alongside the conversation service.

## Issue Number

<!-- No specific issue number -->

## How to Test

Run the unit test suite for all affected files:

```
uv run pytest tests/agent_server/test_sockets_service_getters.py tests/agent_server/test_init_router.py tests/agent_server/test_websocket_first_message_auth.py -v
```

All 43 tests pass. Key new/updated tests:
- `test_events_socket_uses_app_state_conversation_service` — calls `events_socket` with `ws.app.state.conversation_service` wired to a spec-d mock; asserts that mock (not the module-level singleton) was used for `get_event_service`.
- `test_bash_events_socket_uses_app_state_bash_event_service` — same pattern for the bash handler.
- `test_init_bash_service_uses_user_supplied_dir` — after `InitService.initialize()`, verifies `app.state.bash_event_service.bash_events_dir` matches the user-supplied dir from `InitRequest`.
- `test_init_teardown_releases_bash_service` — verifies `_entered_bash_service is None` after `teardown()`.

```
============================= test session starts ==============================
collected 43 items

tests/agent_server/test_sockets_service_getters.py::test_get_conversation_service_prefers_app_state PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_conversation_service_falls_back_to_module_singleton PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_conversation_service_ignores_wrong_type PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_bash_event_service_prefers_app_state PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_bash_event_service_falls_back_to_module_singleton PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_bash_event_service_ignores_wrong_type PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_conversation_service_handles_real_config PASSED
tests/agent_server/test_sockets_service_getters.py::test_get_bash_event_service_handles_real_config PASSED
tests/agent_server/test_sockets_service_getters.py::test_events_socket_uses_app_state_conversation_service PASSED
tests/agent_server/test_sockets_service_getters.py::test_bash_events_socket_uses_app_state_bash_event_service PASSED
tests/agent_server/test_init_router.py::TestInitServiceTransitions::test_init_transitions_dormant_to_ready PASSED
tests/agent_server/test_init_router.py::TestInitServiceTransitions::test_init_bash_service_uses_user_supplied_dir PASSED
tests/agent_server/test_init_router.py::TestInitServiceTransitions::test_init_teardown_releases_bash_service PASSED
tests/agent_server/test_init_router.py::test_lifespan_teardown_releases_conversation_service_after_init PASSED
... 43 passed in 3.79s
```

Pre-commit checks (ruff, pyright, import rules) all pass.

## Video/Screenshots

Websockets now connect when using servers which were started in deferred mode:
<img width="1098" height="759" alt="image" src="https://github.com/user-attachments/assets/02de7c9d-c2ee-4430-bff5-8edc50b9fd62" />

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

The fallback to the module-level singleton is intentional and preserved: it keeps existing tests that patch `sockets.conversation_service` working without changes, and also supports usage of `sockets.py` as a library without a full FastAPI lifespan.

_This PR was created by an AI agent (OpenHands) on behalf of the user._





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:22b137a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-22b137a-python \
  ghcr.io/openhands/agent-server:22b137a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:22b137a-golang-amd64
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-golang-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-golang-amd64
ghcr.io/openhands/agent-server:22b137a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:22b137a-golang-arm64
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-golang-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-golang-arm64
ghcr.io/openhands/agent-server:22b137a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:22b137a-java-amd64
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-java-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-java-amd64
ghcr.io/openhands/agent-server:22b137a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:22b137a-java-arm64
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-java-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-java-arm64
ghcr.io/openhands/agent-server:22b137a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:22b137a-python-amd64
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-python-amd64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-python-amd64
ghcr.io/openhands/agent-server:22b137a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:22b137a-python-arm64
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-python-arm64
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-python-arm64
ghcr.io/openhands/agent-server:22b137a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:22b137a-golang
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-golang
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-golang
ghcr.io/openhands/agent-server:22b137a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:22b137a-java
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-java
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-java
ghcr.io/openhands/agent-server:22b137a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:22b137a-python
ghcr.io/openhands/agent-server:22b137a0ea1b627d1004473b454d48d6c49640f5-python
ghcr.io/openhands/agent-server:fix-deferred-init-root-path-python
ghcr.io/openhands/agent-server:22b137a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `22b137a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `22b137a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->