### PR TITLE
Use provider-fetchable icon URL in image examples

### DIFF
--- a/examples/01_standalone_sdk/17_image_input.py
+++ b/examples/01_standalone_sdk/17_image_input.py
@@ -83,7 +83,7 @@ conversation = Conversation(
 )
 
 # ── Part 1: single URL image ──────────────────────────────────────────────
-IMAGE_URL = "https://github.com/OpenHands/docs/raw/main/openhands/static/img/logo.png"
+IMAGE_URL = "https://www.python.org/static/opengraph-icon-200x200.png"
 
 conversation.send_message(
     Message(

--- a/examples/01_standalone_sdk/40_acp_agent_example.py
+++ b/examples/01_standalone_sdk/40_acp_agent_example.py
@@ -21,7 +21,7 @@ from openhands.sdk.agent import ACPAgent
 from openhands.sdk.conversation import Conversation
 
 
-IMAGE_URL = "https://github.com/OpenHands/docs/raw/main/openhands/static/img/logo.png"
+IMAGE_URL = "https://www.python.org/static/opengraph-icon-200x200.png"
 
 agent = ACPAgent(acp_command=["npx", "-y", "@agentclientprotocol/claude-agent-acp"])
 

--- a/tests/integration/tests/t08_image_file_viewing.py
+++ b/tests/integration/tests/t08_image_file_viewing.py
@@ -9,12 +9,12 @@ from tests.integration.base import BaseIntegrationTest, SkipTest, TestResult
 
 
 INSTRUCTION = (
-    "Please view the logo.png file in the current directory and tell me what "
-    "colors you see in it. Is the logo blue, yellow, or green? Please analyze "
+    "Please view the python_icon.png file in the current directory and tell me "
+    "what colors you see in it. Does the icon contain yellow? Please analyze "
     "the image and provide your answer."
 )
 
-IMAGE_URL = "https://github.com/OpenHands/docs/raw/main/openhands/static/img/logo.png"
+IMAGE_URL = "https://www.python.org/static/opengraph-icon-200x200.png"
 
 logger = get_logger(__name__)
 
@@ -26,7 +26,7 @@ class ImageFileViewingTest(BaseIntegrationTest):
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
-        self.logo_path: str = os.path.join(self.workspace, "logo.png")
+        self.icon_path: str = os.path.join(self.workspace, "python_icon.png")
 
         # Verify that the LLM supports vision
         if not self.llm.vision_is_active():
@@ -36,19 +36,19 @@ class ImageFileViewingTest(BaseIntegrationTest):
             )
 
     def setup(self) -> None:
-        """Download the OpenHands logo for the agent to analyze."""
+        """Download a Python icon for the agent to analyze."""
         try:
-            urllib.request.urlretrieve(IMAGE_URL, self.logo_path)
-            logger.info(f"Downloaded test logo to: {self.logo_path}")
+            urllib.request.urlretrieve(IMAGE_URL, self.icon_path)
+            logger.info(f"Downloaded test icon to: {self.icon_path}")
         except Exception as e:
-            logger.error(f"Failed to download logo: {e}")
+            logger.error(f"Failed to download icon: {e}")
             raise
 
     def verify_result(self) -> TestResult:
-        """Verify that the agent identified yellow as one of the logo colors."""
-        if not os.path.exists(self.logo_path):
+        """Verify that the agent identified yellow as one of the icon colors."""
+        if not os.path.exists(self.icon_path):
             return TestResult(
-                success=False, reason="Logo file not found after agent execution"
+                success=False, reason="Icon file not found after agent execution"
             )
 
         # Get the final response from agent (handles both MessageEvent and FinishAction)
@@ -57,13 +57,13 @@ class ImageFileViewingTest(BaseIntegrationTest):
         if "yellow" in final_response:
             return TestResult(
                 success=True,
-                reason="Agent successfully identified yellow color in the logo",
+                reason="Agent successfully identified yellow color in the icon",
             )
         else:
             return TestResult(
                 success=False,
                 reason=(
-                    f"Agent did not identify yellow color in the logo. "
+                    f"Agent did not identify yellow color in the icon. "
                     f"Response: {final_response[:500]}"
                 ),
             )


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
This PR proposes to replace the image URL because github robots.txt doesn't allow access.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

The release PR example run failed because Anthropic rejected the previous GitHub-hosted OpenHands logo URL as disallowed by robots.txt. This follows up on PR #3863 and replaces that URL with an internet-hosted icon URL that is available from python.org.

## Summary

- Replace the GitHub-hosted logo URL in the image input examples with the Python.org OpenGraph icon.
- Update the image integration test to download and ask about the new icon.

## Issue Number

Follow-up to https://github.com/OpenHands/software-agent-sdk/pull/3863#issuecomment-4783868576

## How to Test

- Verified the new URL downloads with Python's standard library:
  `python - <<'PY' ... urllib.request.urlretrieve('https://www.python.org/static/opengraph-icon-200x200.png', path) ... PY`
  Result: downloaded `image/png` with `Content-Length: 7821`.
- Ran pre-commit on all modified files:
  `uv run pre-commit run --files examples/01_standalone_sdk/17_image_input.py examples/01_standalone_sdk/40_acp_agent_example.py tests/integration/tests/t08_image_file_viewing.py`
  Result: passed Ruff format, Ruff lint, pycodestyle, pyright, import dependency rules, and tool registration checks.

I did not run the full LLM-backed examples locally because they require provider credentials and the ACP subprocess flow; this change is limited to the external image URL they pass to the provider.

## Video/Screenshots

N/A — URL/test maintenance change, no UI change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR was created by an AI agent (OpenHands) on behalf of the user.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9dbfb78b-5ad7-4a28-9ef9-2eb04c333839)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a1348cd-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a1348cd-python \
  ghcr.io/openhands/agent-server:a1348cd-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a1348cd-golang-amd64
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-golang-amd64
ghcr.io/openhands/agent-server:replace-example-image-url-golang-amd64
ghcr.io/openhands/agent-server:a1348cd-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a1348cd-golang-arm64
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-golang-arm64
ghcr.io/openhands/agent-server:replace-example-image-url-golang-arm64
ghcr.io/openhands/agent-server:a1348cd-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a1348cd-java-amd64
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-java-amd64
ghcr.io/openhands/agent-server:replace-example-image-url-java-amd64
ghcr.io/openhands/agent-server:a1348cd-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a1348cd-java-arm64
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-java-arm64
ghcr.io/openhands/agent-server:replace-example-image-url-java-arm64
ghcr.io/openhands/agent-server:a1348cd-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a1348cd-python-amd64
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-python-amd64
ghcr.io/openhands/agent-server:replace-example-image-url-python-amd64
ghcr.io/openhands/agent-server:a1348cd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a1348cd-python-arm64
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-python-arm64
ghcr.io/openhands/agent-server:replace-example-image-url-python-arm64
ghcr.io/openhands/agent-server:a1348cd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a1348cd-golang
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-golang
ghcr.io/openhands/agent-server:replace-example-image-url-golang
ghcr.io/openhands/agent-server:a1348cd-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a1348cd-java
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-java
ghcr.io/openhands/agent-server:replace-example-image-url-java
ghcr.io/openhands/agent-server:a1348cd-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a1348cd-python
ghcr.io/openhands/agent-server:a1348cdce2a53342d7e4950ff329f7695120dc83-python
ghcr.io/openhands/agent-server:replace-example-image-url-python
ghcr.io/openhands/agent-server:a1348cd-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a1348cd-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a1348cd-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->