### PR TITLE
fix(agent-server): make webhook retry sleep patchable per-instance

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1,6 +1,7 @@
 import asyncio
 import importlib
 import logging
+from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
 from dataclasses import dataclass, field
@@ -1367,6 +1368,12 @@ class WebhookSubscriber(Subscriber):
     session_api_key: str | None = None
     queue: list[Event] = field(default_factory=list)
     _flush_timer: asyncio.Task | None = field(default=None, init=False)
+    # Per-instance sleep seam so tests override delays without patching the
+    # global asyncio.sleep. default_factory (not default) keeps it an instance
+    # attribute, else the function would be descriptor-bound as a method.
+    _sleep: Callable[[float], Awaitable[None]] = field(
+        default_factory=lambda: asyncio.sleep, init=False
+    )
 
     async def __call__(self, event: Event):
         """Add event to queue and post to webhook when buffer size is reached."""
@@ -1437,7 +1444,7 @@ class WebhookSubscriber(Subscriber):
             except Exception as e:
                 logger.warning(f"Webhook post attempt {attempt + 1} failed: {e}")
                 if attempt < self.spec.num_retries:
-                    await asyncio.sleep(self.spec.retry_delay)
+                    await self._sleep(self.spec.retry_delay)
                 else:
                     logger.error(
                         f"Failed to post events to webhook {events_url} "
@@ -1462,7 +1469,7 @@ class WebhookSubscriber(Subscriber):
     async def _flush_after_delay(self):
         """Wait for flush_delay seconds then flush events if any exist."""
         try:
-            await asyncio.sleep(self.spec.flush_delay)
+            await self._sleep(self.spec.flush_delay)
             # Only flush if there are events in the queue
             if self.queue:
                 await self._post_events()
@@ -1479,6 +1486,10 @@ class ConversationWebhookSubscriber:
 
     spec: WebhookSpec
     session_api_key: str | None = None
+    # Per-instance sleep seam; see WebhookSubscriber._sleep.
+    _sleep: Callable[[float], Awaitable[None]] = field(
+        default_factory=lambda: asyncio.sleep, init=False
+    )
 
     async def post_conversation_info(self, conversation_info: BaseModel):
         """Post conversation info to the webhook immediately (no batching)."""
@@ -1516,7 +1527,7 @@ class ConversationWebhookSubscriber:
                     f"Conversation webhook post attempt {attempt + 1} failed: {e}"
                 )
                 if attempt < self.spec.num_retries:
-                    await asyncio.sleep(self.spec.retry_delay)
+                    await self._sleep(self.spec.retry_delay)
                 else:
                     # Log response content for debugging failures
                     response_content = (

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -492,21 +492,18 @@ class TestWebhookSubscriberPostEvents:
         async def mock_sleep(delay):
             sleep_calls.append(delay)
 
+        subscriber._sleep = mock_sleep
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.request = mock_request
             mock_client_class.return_value.__aenter__.return_value = mock_client
 
-            with patch("asyncio.sleep", side_effect=mock_sleep):
-                await subscriber._post_events()
+            await subscriber._post_events()
 
         # Verify retries were attempted
         assert len(retry_attempts) == 3
-        # patch("asyncio.sleep") replaces the global, so background tasks
-        # leaked from prior tests (e.g. other subscribers' flush timers) can
-        # also append entries. Filter to the retry_delay we care about.
-        retry_sleeps = [d for d in sleep_calls if d == webhook_spec.retry_delay]
-        assert len(retry_sleeps) == 2  # Sleep between retries
+        # Only this instance's delays are recorded — no global-sleep pollution.
+        assert sleep_calls == [webhook_spec.retry_delay] * 2
 
         # Verify queue is cleared after success
         assert subscriber.queue == []
@@ -540,21 +537,18 @@ class TestWebhookSubscriberPostEvents:
         async def mock_sleep(delay):
             sleep_calls.append(delay)
 
+        subscriber._sleep = mock_sleep
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.request = mock_request
             mock_client_class.return_value.__aenter__.return_value = mock_client
 
-            with patch("asyncio.sleep", side_effect=mock_sleep):
-                await subscriber._post_events()
+            await subscriber._post_events()
 
         # Verify all retries were attempted (num_retries + 1 = 3 total attempts)
         assert len(retry_attempts) == 3
-        # patch("asyncio.sleep") replaces the global, so background tasks
-        # leaked from prior tests (e.g. other subscribers' flush timers) can
-        # also append entries. Filter to the retry_delay we care about.
-        retry_sleeps = [d for d in sleep_calls if d == webhook_spec.retry_delay]
-        assert len(retry_sleeps) == 2
+        # Only this instance's delays are recorded — no global-sleep pollution.
+        assert sleep_calls == [webhook_spec.retry_delay] * 2
 
         # Verify events are re-queued after failure
         assert len(subscriber.queue) == 2
@@ -819,17 +813,18 @@ class TestWebhookSubscriberErrorHandling:
 
         subscriber.queue = sample_events[:2]
 
-        with patch("asyncio.sleep") as mock_sleep:
-            await subscriber._post_events()
+        # Record on the instance's own seam, not the global asyncio.sleep.
+        sleep_calls: list[float] = []
+
+        async def record_sleep(delay):
+            sleep_calls.append(delay)
+
+        subscriber._sleep = record_sleep
+        await subscriber._post_events()
 
         # Verify retries were attempted
         assert mock_client.request.call_count == 3  # num_retries + 1
-        retry_sleeps = [
-            call.args[0]
-            for call in mock_sleep.await_args_list
-            if call.args and call.args[0] == webhook_spec.retry_delay
-        ]
-        assert len(retry_sleeps) == 2
+        assert sleep_calls == [webhook_spec.retry_delay] * 2
 
         # Events should be re-queued after failure
         assert len(subscriber.queue) == 2
@@ -858,17 +853,18 @@ class TestWebhookSubscriberErrorHandling:
 
         subscriber.queue = sample_events[:1]
 
-        with patch("asyncio.sleep") as mock_sleep:
-            await subscriber._post_events()
+        # Record on the instance's own seam, not the global asyncio.sleep.
+        sleep_calls: list[float] = []
+
+        async def record_sleep(delay):
+            sleep_calls.append(delay)
+
+        subscriber._sleep = record_sleep
+        await subscriber._post_events()
 
         # Verify retries were attempted
         assert mock_client.request.call_count == 3
-        retry_sleeps = [
-            call.args[0]
-            for call in mock_sleep.await_args_list
-            if call.args and call.args[0] == webhook_spec.retry_delay
-        ]
-        assert len(retry_sleeps) == 2
+        assert sleep_calls == [webhook_spec.retry_delay] * 2
 
         # Events should be re-queued after failure
         assert len(subscriber.queue) == 1
@@ -1235,18 +1231,18 @@ class TestConversationWebhookSubscriber:
         async def mock_sleep(delay):
             sleep_calls.append(delay)
 
+        subscriber._sleep = mock_sleep
         with patch("httpx.AsyncClient") as mock_client_class:
             mock_client = AsyncMock()
             mock_client.request = mock_request
             mock_client_class.return_value.__aenter__.return_value = mock_client
 
-            with patch("asyncio.sleep", side_effect=mock_sleep):
-                await subscriber.post_conversation_info(conversation_info)
+            await subscriber.post_conversation_info(conversation_info)
 
         # Verify retries were attempted
         assert len(retry_attempts) == 3
-        assert len(sleep_calls) == 2  # Sleep between retries
-        assert all(delay == webhook_spec.retry_delay for delay in sleep_calls)
+        # Only this instance's delays are recorded — no global-sleep pollution.
+        assert sleep_calls == [webhook_spec.retry_delay] * 2
 
 
 class TestWebhookSubscriberTimerBehavior:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small fix for the webhook issue.

---

AGENT:

## Why

`tests/agent_server/test_webhook_subscriber.py::TestWebhookSubscriberErrorHandling::test_timeout_error_handling`
is flaky in the full agent-server suite (issue #3791). It patches the
**process-global** `asyncio.sleep` and asserts on the raw mock call count:

```
AssertionError: assert 1594 == 2
  where 1594 = <AsyncMock name='sleep'>.call_count
```

`WebhookSubscriber._post_events` (retry delay) and `_flush_after_delay`
(flush timer) both `await asyncio.sleep(...)`. Other tests create
`_flush_after_delay()` background tasks and never await/cancel them; when those
leaked tasks are still alive during this test they call the **same** patched
global, so their sleeps are counted too. The test passes in isolation and only
fails under the full xdist suite — classic suite-order/background-task
pollution.

A previous mitigation (filter recorded sleeps to `== retry_delay`) is already on
`main` but cannot fix this: `retry_delay == 1`, and both a leaked flush timer
(`test_timer_cancelled_when_buffer_full` sets `flush_delay = 1.0`) and any
leaked webhook subscriber's own retry sleep also use the value `1`, so they slip
straight through the filter. The root problem is asserting on a process-global,
not the value matching.

## Summary

- Add an injectable `_sleep` seam (`Callable[[float], Awaitable[None]]`,
  defaulting to `asyncio.sleep` via `default_factory`) to `WebhookSubscriber`
  and `ConversationWebhookSubscriber`; the retry/flush paths now await
  `self._sleep(...)`.
- Update the four retry tests to record on the subscriber's **own** `_sleep`
  instead of patching the global `asyncio.sleep`, so only that instance's
  delays are observed. Drops the fragile global-patch + value-filter entirely.

`default_factory` keeps `_sleep` an instance attribute — a plain-function class
default would be descriptor-bound as a method and receive `self`.

## Issue Number

Closes #3791

## How to Test

Run the previously-flaky file plus the full agent-server suite under xdist (the
configuration that flaked):

```bash
uv run pytest tests/agent_server/test_webhook_subscriber.py -q
# -> 39 passed

uv run pytest tests/agent_server -q
```

Evidence on this branch (the full suite ran twice, both green):

```
tests/agent_server/test_webhook_subscriber.py ... 39 passed in 1.78s

# full suite, two consecutive runs:
1296 passed, 14 deselected, 39 warnings in 76.18s
1296 passed, 14 deselected, 39 warnings in 76.21s
```

`ruff check`, `ruff format --check`, and `pyright` all pass on the two changed
files.

Note: `tests/agent_server` also contains one unrelated, pre-existing failure,
`TestAutoTitle::test_autotitle_sets_title_on_first_user_message`, which fails on
clean `origin/main` in isolation as well (an `AsyncMock(spec=EventService).stored`
issue, nothing to do with sleep/webhooks). It is deselected in the runs above
and is out of scope for this PR.

## Video/Screenshots

N/A — test-only flakiness fix; evidence is the pytest output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No behavior change in production: `_sleep` defaults to `asyncio.sleep`, so
runtime retry/flush timing is identical; the field only adds a per-instance test
seam.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fd9ad8a-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fd9ad8a-python \
  ghcr.io/openhands/agent-server:fd9ad8a-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fd9ad8a-golang-amd64
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-golang-amd64
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-golang-amd64
ghcr.io/openhands/agent-server:fd9ad8a-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fd9ad8a-golang-arm64
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-golang-arm64
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-golang-arm64
ghcr.io/openhands/agent-server:fd9ad8a-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fd9ad8a-java-amd64
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-java-amd64
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-java-amd64
ghcr.io/openhands/agent-server:fd9ad8a-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fd9ad8a-java-arm64
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-java-arm64
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-java-arm64
ghcr.io/openhands/agent-server:fd9ad8a-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fd9ad8a-python-amd64
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-python-amd64
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-python-amd64
ghcr.io/openhands/agent-server:fd9ad8a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:fd9ad8a-python-arm64
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-python-arm64
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-python-arm64
ghcr.io/openhands/agent-server:fd9ad8a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:fd9ad8a-golang
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-golang
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-golang
ghcr.io/openhands/agent-server:fd9ad8a-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:fd9ad8a-java
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-java
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-java
ghcr.io/openhands/agent-server:fd9ad8a-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:fd9ad8a-python
ghcr.io/openhands/agent-server:fd9ad8a04e58774ad07d7cfef3fb3a34a4b06411-python
ghcr.io/openhands/agent-server:fix-webhook-sleep-seam-python
ghcr.io/openhands/agent-server:fd9ad8a-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fd9ad8a-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fd9ad8a-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->