### PR TITLE
feat(agent-server): add workspace archive endpoint for git-delta/tar.gz (AGE-1871)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -9,7 +9,7 @@ import tarfile
 import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
-from typing import Annotated, Literal
+from typing import IO, Annotated, Literal
 from uuid import UUID
 
 from fastapi import (
@@ -501,7 +501,7 @@ class _ExactSizeReader:
     desynchronize no matter how the workspace mutates during capture.
     """
 
-    def __init__(self, fileobj: io.BufferedReader, size: int) -> None:
+    def __init__(self, fileobj: IO[bytes], size: int) -> None:
         self._fileobj = fileobj
         self._remaining = size
 

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -1,9 +1,13 @@
 import asyncio
+import fnmatch
+import io
+import json
 import os
 import subprocess
+import tarfile
 import tempfile
 import zipfile
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 from typing import Annotated, Literal
 from uuid import UUID
 
@@ -143,22 +147,28 @@ def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
         raise
 
 
-ArchiveFormat = Literal["git-delta"]
+ArchiveFormat = Literal["git-delta", "tar.gz"]
 
 _ARCHIVE_SUFFIX: dict[str, str] = {
     "git-delta": ".patch",
+    "tar.gz": ".tar.gz",
 }
 
 _ARCHIVE_MEDIA_TYPE: dict[str, str] = {
     "git-delta": "text/x-patch",
+    "tar.gz": "application/gzip",
 }
 
+ARCHIVE_MANIFEST_NAME = "archive_manifest.json"
 
-# Heavy / generated directories that bloat a delta without helping eval replay.
-# Applied via a scratch ``core.excludesFile`` so they are skipped even when the
-# repo itself does not ``.gitignore`` them (the repo's own .gitignore still
-# applies on top of this).
-_GIT_DELTA_DEFAULT_EXCLUDES = (
+
+# Heavy / generated directories that bloat an archive without helping eval
+# replay. For git-delta they are applied via a scratch ``core.excludesFile`` so
+# they are skipped even when the repo itself does not ``.gitignore`` them (the
+# repo's own .gitignore still applies on top of this). For tar.gz they prune the
+# walk. Shared by both formats and always applied (the ``exclude`` query param
+# only adds to these).
+_DEFAULT_ARCHIVE_EXCLUDES = (
     "node_modules/",
     ".venv/",
     "venv/",
@@ -174,17 +184,19 @@ _GIT_DELTA_DEFAULT_EXCLUDES = (
 )
 
 
-def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> str:
+def _create_git_delta(
+    root: Path, base_ref: str | None, output_path: Path, excludes: list[str]
+) -> str:
     """Write a git patch capturing the working-tree delta against a base.
 
     The delta covers tracked modifications, new (untracked) files, and
     deletions relative to ``base_ref`` (defaulting to the auto-detected
     comparison ref — origin branch, merge-base, or the empty tree for a fresh
     repo). A throwaway index (``GIT_INDEX_FILE``) is used so the repository's
-    real index is never touched. Heavy generated/dependency directories
-    (``_GIT_DELTA_DEFAULT_EXCLUDES``, e.g. ``node_modules/``) are excluded —
-    on top of the repo's own ``.gitignore`` — so the delta stays compact for
-    eval replay even if such a directory is present but not git-ignored.
+    real index is never touched. ``excludes`` (the default archive excludes plus
+    any caller-supplied patterns) are applied via a scratch ``core.excludesFile``
+    — on top of the repo's own ``.gitignore`` — so the delta stays compact for
+    eval replay even when such a directory is present but not git-ignored.
 
     Returns the full base commit SHA the patch applies against, or "" when the
     base is the empty tree (fresh repo) or cannot resolve to a commit.
@@ -198,7 +210,7 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> st
         raise ValueError(f"base_ref {base_ref!r} could not be resolved") from e
     index_path = output_path.with_name(output_path.name + ".index")
     excludes_path = output_path.with_name(output_path.name + ".excludes")
-    excludes_path.write_text("\n".join(_GIT_DELTA_DEFAULT_EXCLUDES) + "\n")
+    excludes_path.write_text("\n".join(excludes) + "\n")
     env = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
     try:
         # Seed the scratch index from the base ref, stage the working tree on
@@ -257,6 +269,77 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> st
         )
     except GitCommandError:
         return ""
+
+
+def _path_is_excluded(rel: PurePosixPath, patterns: list[str]) -> bool:
+    """True if any component of ``rel`` matches any glob in ``patterns``.
+
+    Patterns are matched per path component with ``fnmatch`` (a trailing ``/``,
+    used to denote directory excludes, is stripped first). Dependency-free so no
+    new package is pulled in.
+    """
+    stripped = [p.rstrip("/") for p in patterns]
+    for part in rel.parts:
+        for pattern in stripped:
+            if fnmatch.fnmatch(part, pattern):
+                return True
+    return False
+
+
+def _build_archive_manifest(
+    source: str, file_count: int, total_bytes: int, excludes: list[str]
+) -> bytes:
+    """Deterministic (timestamp-free) JSON manifest embedded in a tar.gz."""
+    manifest = {
+        "format": "tar.gz",
+        "source": source,
+        "file_count": file_count,
+        "total_bytes": total_bytes,
+        "excludes": excludes,
+    }
+    return json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+
+
+def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -> None:
+    """Stream a gzip tarball of ``root`` to ``output_path``.
+
+    Walks ``root`` without following symlinks, pruning excluded directories so
+    they are never descended into, and adds regular files only (symlinks are
+    skipped — same safety posture as the rest of the endpoint). Files are added
+    one at a time so the archive is never held in memory. A deterministic
+    manifest member (``ARCHIVE_MANIFEST_NAME``) records what was captured.
+    """
+    file_count = 0
+    total_bytes = 0
+    try:
+        with tarfile.open(output_path, "w:gz") as tar:
+            for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
+                base = PurePosixPath(Path(dirpath).relative_to(root).as_posix())
+                # Prune excluded directories in place so we never descend them.
+                dirnames[:] = [
+                    d for d in dirnames if not _path_is_excluded(base / d, excludes)
+                ]
+                for name in filenames:
+                    rel = base / name
+                    if _path_is_excluded(rel, excludes):
+                        continue
+                    file_path = Path(dirpath) / name
+                    if file_path.is_symlink() or not file_path.is_file():
+                        continue
+                    arcname = f"{root.name}/{rel}"
+                    tar.add(file_path, arcname=arcname, recursive=False)
+                    file_count += 1
+                    total_bytes += file_path.stat().st_size
+
+            manifest = _build_archive_manifest(
+                root.name, file_count, total_bytes, excludes
+            )
+            info = tarfile.TarInfo(f"{root.name}/{ARCHIVE_MANIFEST_NAME}")
+            info.size = len(manifest)
+            tar.addfile(info, io.BytesIO(manifest))
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
 
 
 @file_router.post("/upload")
@@ -468,7 +551,9 @@ async def archive_directory(
         Query(
             description=(
                 "Archive format: 'git-delta' for a git patch of the working-tree "
-                "changes against a base ref (requires a git repository)."
+                "changes against a base ref (requires a git repository); 'tar.gz' "
+                "for a full gzip tarball of the entire directory (works on "
+                "non-git directories too)."
             )
         ),
     ] = "git-delta",
@@ -478,7 +563,18 @@ async def archive_directory(
             description=(
                 "Only for format='git-delta': base ref to diff against. "
                 "Defaults to the auto-detected comparison ref (origin branch, "
-                "merge-base, or the empty tree for a fresh repo)."
+                "merge-base, or the empty tree for a fresh repo). Ignored for "
+                "format='tar.gz'."
+            )
+        ),
+    ] = None,
+    exclude: Annotated[
+        list[str] | None,
+        Query(
+            description=(
+                "Additional glob patterns to exclude (repeatable, e.g. "
+                "?exclude=foo&exclude=*.bin). Added on top of the built-in "
+                "default excludes, which always apply."
             )
         ),
     ] = None,
@@ -515,16 +611,25 @@ async def archive_directory(
         )
 
     target = target.resolve()
+    # Defaults always apply; the param only adds patterns (safe-by-default so
+    # the archive cannot explode on a heavy directory).
+    effective_excludes = list(_DEFAULT_ARCHIVE_EXCLUDES) + (exclude or [])
     # Build the archive outside the workspace so it is never included in itself
     # and leaves nothing behind in the archived tree.
     fd, tmp_name = tempfile.mkstemp(suffix=_ARCHIVE_SUFFIX[format])
     os.close(fd)
     output_path = Path(tmp_name)
 
+    base_commit = ""
     try:
-        base_commit = await asyncio.to_thread(
-            _create_git_delta, target, base_ref, output_path
-        )
+        if format == "git-delta":
+            base_commit = await asyncio.to_thread(
+                _create_git_delta, target, base_ref, output_path, effective_excludes
+            )
+        else:
+            await asyncio.to_thread(
+                _create_tar_gz_archive, target, output_path, effective_excludes
+            )
     except GitRepositoryError as e:
         output_path.unlink(missing_ok=True)
         raise HTTPException(

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -1,8 +1,13 @@
 import asyncio
+import io
+import json
 import os
+import subprocess
+import tarfile
+import tempfile
 import zipfile
 from pathlib import Path
-from typing import Annotated
+from typing import Annotated, Literal
 from uuid import UUID
 
 from fastapi import (
@@ -20,6 +25,12 @@ from starlette.background import BackgroundTask
 from openhands.agent_server.config import get_default_config
 from openhands.agent_server.models import Success
 from openhands.agent_server.server_details_router import update_last_execution_time
+from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
+from openhands.sdk.git.utils import (
+    GIT_EMPTY_TREE_HASH,
+    get_valid_ref,
+    validate_git_repository,
+)
 from openhands.sdk.logger import get_logger
 
 
@@ -132,6 +143,166 @@ def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
     except Exception:
         output_path.unlink(missing_ok=True)
         raise
+
+
+ArchiveFormat = Literal["tar.gz", "zip", "git-delta"]
+
+ARCHIVE_MANIFEST_NAME = "archive_manifest.json"
+
+_ARCHIVE_SUFFIX: dict[str, str] = {
+    "tar.gz": ".tar.gz",
+    "zip": ".zip",
+    "git-delta": ".patch",
+}
+
+_ARCHIVE_MEDIA_TYPE: dict[str, str] = {
+    "tar.gz": "application/gzip",
+    "zip": "application/zip",
+    "git-delta": "text/x-patch",
+}
+
+
+def _collect_workspace_files(root: Path) -> list[tuple[Path, Path]]:
+    """Regular files under ``root`` as ``(absolute_path, arcname)``, sorted.
+
+    ``os.walk(followlinks=False)`` never descends into symlinked directories,
+    and symlinked files are skipped, so a symlink cannot pull a file from
+    outside ``root`` into the archive and there is no risk of a symlink cycle.
+    """
+    files: list[tuple[Path, Path]] = []
+    for dirpath, _dirnames, filenames in os.walk(root, followlinks=False):
+        for name in filenames:
+            abs_path = Path(dirpath) / name
+            if abs_path.is_symlink():
+                continue
+            files.append((abs_path, abs_path.relative_to(root)))
+    files.sort(key=lambda pair: str(pair[1]))
+    return files
+
+
+def _build_archive_manifest(
+    root: Path, fmt: ArchiveFormat, files: list[tuple[Path, Path]]
+) -> bytes:
+    """Deterministic JSON manifest embedded at the archive root.
+
+    No timestamp is included so the manifest is reproducible for an identical
+    tree; callers that persist the archive record the capture time alongside
+    the stored object.
+    """
+    total_bytes = 0
+    for abs_path, _arcname in files:
+        try:
+            total_bytes += abs_path.stat().st_size
+        except OSError:
+            continue
+    manifest = {
+        "format": fmt,
+        "source": str(root),
+        "file_count": len(files),
+        "total_bytes": total_bytes,
+    }
+    return json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
+
+
+def _create_tar_gz_archive(
+    files: list[tuple[Path, Path]], manifest: bytes, output_path: Path
+) -> None:
+    try:
+        with tarfile.open(output_path, "w:gz") as tar:
+            for abs_path, arcname in files:
+                tar.add(abs_path, arcname=str(arcname), recursive=False)
+            info = tarfile.TarInfo(name=ARCHIVE_MANIFEST_NAME)
+            info.size = len(manifest)
+            tar.addfile(info, io.BytesIO(manifest))
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
+
+
+def _create_zip_archive(
+    files: list[tuple[Path, Path]], manifest: bytes, output_path: Path
+) -> None:
+    try:
+        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as archive:
+            for abs_path, arcname in files:
+                archive.write(abs_path, str(arcname))
+            archive.writestr(ARCHIVE_MANIFEST_NAME, manifest)
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
+
+
+def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> None:
+    """Write a git patch capturing the full working-tree delta against a base.
+
+    The delta covers tracked modifications, new (untracked) files, and
+    deletions relative to ``base_ref`` (defaulting to the auto-detected
+    comparison ref — origin branch, merge-base, or the empty tree for a fresh
+    repo). A throwaway index (``GIT_INDEX_FILE``) is used so the repository's
+    real index is never touched.
+    """
+    validate_git_repository(root)
+    ref = get_valid_ref(root, base_ref) or GIT_EMPTY_TREE_HASH
+    index_path = output_path.with_name(output_path.name + ".index")
+    env = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
+    try:
+        # Seed the scratch index from the base ref, stage the entire working
+        # tree on top of it, then diff: the result is everything that changed
+        # between the base and the workspace's current state.
+        subprocess.run(
+            ["git", "read-tree", ref],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            check=True,
+            timeout=60,
+        )
+        subprocess.run(
+            ["git", "add", "-A"],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            check=True,
+            timeout=300,
+        )
+        result = subprocess.run(
+            ["git", "diff", "--binary", "--cached", ref],
+            cwd=root,
+            env=env,
+            capture_output=True,
+            check=True,
+            timeout=300,
+        )
+        output_path.write_bytes(result.stdout)
+    except subprocess.CalledProcessError as e:
+        output_path.unlink(missing_ok=True)
+        stderr = e.stderr.decode("utf-8", "replace") if e.stderr else ""
+        raise GitCommandError(
+            message="Failed to generate git delta",
+            command=e.cmd if isinstance(e.cmd, list) else [str(e.cmd)],
+            exit_code=e.returncode,
+            stderr=stderr.strip(),
+        ) from e
+    except Exception:
+        output_path.unlink(missing_ok=True)
+        raise
+    finally:
+        index_path.unlink(missing_ok=True)
+
+
+def _build_workspace_archive(
+    root: Path, fmt: ArchiveFormat, base_ref: str | None, output_path: Path
+) -> None:
+    """Build the requested archive of ``root`` at ``output_path`` (blocking)."""
+    if fmt == "git-delta":
+        _create_git_delta(root, base_ref, output_path)
+        return
+    files = _collect_workspace_files(root)
+    manifest = _build_archive_manifest(root, fmt, files)
+    if fmt == "tar.gz":
+        _create_tar_gz_archive(files, manifest, output_path)
+    else:
+        _create_zip_archive(files, manifest, output_path)
 
 
 @file_router.post("/upload")
@@ -330,4 +501,100 @@ async def download_trajectory(
         filename=temp_file.name,
         media_type="application/octet-stream",
         background=BackgroundTask(temp_file.unlink),
+    )
+
+
+@file_router.get("/archive")
+async def archive_directory(
+    path: Annotated[
+        str, Query(description="Absolute path of the directory to archive")
+    ],
+    format: Annotated[
+        ArchiveFormat,
+        Query(
+            description=(
+                "Archive format: 'tar.gz' (default) or 'zip' for a full file "
+                "archive, or 'git-delta' for a git patch of the working-tree "
+                "changes against a base ref (requires a git repository)."
+            )
+        ),
+    ] = "tar.gz",
+    base_ref: Annotated[
+        str | None,
+        Query(
+            description=(
+                "Only for format='git-delta': base ref to diff against. "
+                "Defaults to the auto-detected comparison ref (origin branch, "
+                "merge-base, or the empty tree for a fresh repo)."
+            )
+        ),
+    ] = None,
+) -> FileResponse:
+    """Archive a workspace directory for persistence before runtime deletion.
+
+    Produces a downloadable archive of ``path``. Symlinks are never followed
+    out of the requested directory, so the archive cannot include files from
+    outside it. The temporary archive is created outside ``path`` and removed
+    after the response is sent.
+    """
+    update_last_execution_time()
+
+    target = Path(path)
+    if not target.is_absolute():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path must be absolute",
+        )
+    if not target.exists():
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Directory not found",
+        )
+    if not target.is_dir():
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="Path is not a directory",
+        )
+    if base_ref is not None and base_ref.startswith("-"):
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="base_ref must not start with '-'",
+        )
+
+    target = target.resolve()
+    # Build the archive outside the workspace so it is never included in itself
+    # and leaves nothing behind in the archived tree.
+    fd, tmp_name = tempfile.mkstemp(suffix=_ARCHIVE_SUFFIX[format])
+    os.close(fd)
+    output_path = Path(tmp_name)
+
+    try:
+        await asyncio.to_thread(
+            _build_workspace_archive, target, format, base_ref, output_path
+        )
+    except GitRepositoryError as e:
+        output_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Not a git repository: {e}",
+        )
+    except GitCommandError as e:
+        output_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to generate git delta: {e}",
+        )
+    except Exception as e:
+        output_path.unlink(missing_ok=True)
+        logger.error(f"Failed to archive {target}: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to archive directory: {str(e)}",
+        )
+
+    return FileResponse(
+        path=output_path,
+        filename=f"{target.name}{_ARCHIVE_SUFFIX[format]}",
+        media_type=_ARCHIVE_MEDIA_TYPE[format],
+        background=BackgroundTask(output_path.unlink, missing_ok=True),
     )

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -283,25 +283,44 @@ def _create_git_delta(
         return ""
 
 
-def _path_is_excluded(
-    rel: PurePosixPath, patterns: list[str], is_dir: bool
-) -> bool:
+def _path_is_excluded(rel: PurePosixPath, patterns: list[str], is_dir: bool) -> bool:
     """True if ``rel`` is excluded by any glob in ``patterns``.
 
-    A trailing ``/`` marks a directory-only pattern: it matches a directory
-    component but never a file's own name, so a ``build/`` pattern prunes a
-    ``build`` directory while keeping a file literally named ``build``. Other
-    patterns match any component. Dependency-free so no new package is pulled in.
+    Mirrors the git-delta path's gitignore semantics so the two formats agree:
+
+    - A trailing ``/`` marks a directory-only pattern: it matches a directory but
+      never a file's own name, so a ``build/`` pattern prunes a ``build``
+      directory while keeping a file literally named ``build``.
+    - A multi-segment pattern (one containing ``/``, e.g. ``secrets/prod``)
+      matches the full relative path or any prefix of it, so it drops both
+      ``secrets/prod`` and everything beneath it.
+    - A bare-name pattern (no ``/``, e.g. ``node_modules`` or ``*.pyc``) matches
+      any single path component, at any depth.
+
+    Dependency-free so no new package is pulled in.
     """
+    rel_str = rel.as_posix()
     parts = rel.parts
     for raw in patterns:
         pattern = raw.rstrip("/")
-        # For a dir-only pattern matched against a file, skip the basename so a
-        # file sharing a directory exclude's name is not dropped.
-        candidates = parts if (is_dir or not raw.endswith("/")) else parts[:-1]
-        for part in candidates:
-            if fnmatch.fnmatch(part, pattern):
+        dir_only = raw.endswith("/")
+        if "/" in pattern:
+            # Multi-segment: anchor against the full relative path, matching the
+            # path itself or anything nested under it (``secrets/prod`` drops
+            # ``secrets/prod`` and ``secrets/prod/key``). A dir-only pattern on a
+            # file still matches if the file lives *under* the excluded dir.
+            if fnmatch.fnmatch(rel_str, pattern) or fnmatch.fnmatch(
+                rel_str, f"{pattern}/*"
+            ):
                 return True
+        else:
+            # Bare name: match any single component. For a dir-only pattern on a
+            # file, skip the basename so a file sharing a directory exclude's
+            # name is not dropped.
+            candidates = parts if (is_dir or not dir_only) else parts[:-1]
+            for part in candidates:
+                if fnmatch.fnmatch(part, pattern):
+                    return True
     return False
 
 
@@ -330,6 +349,8 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
     """
     file_count = 0
     total_bytes = 0
+    manifest_arcname = f"{root.name}/{ARCHIVE_MANIFEST_NAME}"
+    manifest_collision = False
     try:
         with tarfile.open(output_path, "w:gz") as tar:
             for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
@@ -356,15 +377,26 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                     except OSError as e:
                         logger.warning(f"Skipping unreadable file {file_path}: {e}")
                         continue
+                    if arcname == manifest_arcname:
+                        manifest_collision = True
                     file_count += 1
                     total_bytes += size
 
-            manifest = _build_archive_manifest(
-                root.name, file_count, total_bytes, excludes
-            )
-            info = tarfile.TarInfo(f"{root.name}/{ARCHIVE_MANIFEST_NAME}")
-            info.size = len(manifest)
-            tar.addfile(info, io.BytesIO(manifest))
+            # Skip our synthetic capture manifest when the workspace already has a
+            # real file at that path: the user's data must win over our metadata.
+            if manifest_collision:
+                logger.warning(
+                    f"Workspace already contains {ARCHIVE_MANIFEST_NAME!r}; "
+                    "preserving the user's file and skipping the synthetic "
+                    "archive manifest."
+                )
+            else:
+                manifest = _build_archive_manifest(
+                    root.name, file_count, total_bytes, excludes
+                )
+                info = tarfile.TarInfo(manifest_arcname)
+                info.size = len(manifest)
+                tar.addfile(info, io.BytesIO(manifest))
     except Exception:
         output_path.unlink(missing_ok=True)
         raise

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -165,10 +165,10 @@ ARCHIVE_MANIFEST_NAME = "archive_manifest.json"
 # Heavy / generated directories that usually bloat an archive without helping
 # eval replay. These are the default excludes, not a minimum exclusion set:
 # callers can disable them with ``use_default_excludes=false`` when they need a
-# full workspace capture. For git-delta they are applied via a scratch
-# ``core.excludesFile`` so they are skipped even when the repo itself does not
-# ``.gitignore`` them (the repo's own .gitignore still applies on top of this).
-# For tar.gz they prune the walk.
+# full workspace capture. Both formats apply the same set: git-delta as
+# ``:(exclude)`` pathspecs (dropping tracked *and* untracked copies, on top of
+# the repo's own .gitignore) and tar.gz by pruning the walk — so the two
+# archives capture the same files.
 _DEFAULT_ARCHIVE_EXCLUDES = (
     ".git/",
     "node_modules/",
@@ -186,18 +186,37 @@ _DEFAULT_ARCHIVE_EXCLUDES = (
 )
 
 # Credential-bearing git internals that must NEVER be persisted to a shared
-# archive bucket, even when the caller disables the default excludes for a full
-# capture (``use_default_excludes=false``). A repo cloned with a tokenized
-# remote (``https://x-access-token:TOKEN@github.com/...``) keeps that token in
-# ``.git/config``; reflogs and saved credentials are equally sensitive. These
-# are stripped from every tar.gz regardless of the exclude settings. (git-delta
-# never includes ``.git`` — it is a working-tree diff — so this only matters for
-# the full-archive format.)
-_ALWAYS_EXCLUDE_TAR = (
-    ".git/config",
-    ".git/credentials",
-    ".git/logs/",
+# archive bucket, even for a full capture (``use_default_excludes=false``). A
+# tokenized clone (``https://x-access-token:TOKEN@github.com/...``) keeps that
+# token in ``.git/config`` and ``.git/FETCH_HEAD``; reflogs and saved
+# credentials are equally sensitive. These live under the superproject ``.git``
+# AND under ``.git/modules/<name>`` for submodules, so the match is by position
+# within any ``.git`` directory rather than a fixed top-level path. (git-delta
+# is a working-tree diff and never includes ``.git``, so this only matters for
+# tar.gz.)
+_SENSITIVE_GIT_INTERNALS = frozenset(
+    {"config", "config.worktree", "credentials", ".git-credentials", "FETCH_HEAD"}
 )
+
+
+def _is_sensitive_git_internal(rel: PurePosixPath) -> bool:
+    """True if ``rel`` is a credential-bearing file inside any ``.git`` dir.
+
+    Covers the superproject (``.git/...``) and submodules
+    (``.git/modules/<name>/...``) at any depth: the sensitive config/credential
+    files and every reflog under a ``logs/`` subtree.
+    """
+    parts = rel.parts
+    for i, part in enumerate(parts):
+        if part == ".git":
+            internal = parts[i + 1 :]
+            if not internal:
+                return False
+            if "logs" in internal:
+                return True
+            return internal[-1] in _SENSITIVE_GIT_INTERNALS
+    return False
+
 
 # Directory names never worth descending when auto-resolving the repo root under
 # a workspace path: they can legitimately contain vendored/nested git repos that
@@ -247,10 +266,39 @@ def _resolve_git_repo_root(target: Path, max_depth: int = 3) -> Path:
                 found.append(child)
                 if len(found) > 1:
                     # Ambiguous — don't guess which repo to archive.
+                    logger.warning(
+                        f"Multiple git repos under {target}; cannot pick one to "
+                        "archive — using the path as given. Caller should pass "
+                        "the repo path explicitly."
+                    )
                     return target
             else:
                 frontier.append((child, depth + 1))
     return found[0] if len(found) == 1 else target
+
+
+def _excludes_to_git_pathspecs(excludes: list[str]) -> list[str]:
+    """Translate the archive excludes into git ``:(exclude)`` pathspecs.
+
+    Using pathspecs instead of ``core.excludesFile`` drops excluded paths
+    whether they are tracked or untracked, so git-delta and tar.gz capture the
+    same file set. ``glob`` magic keeps ``*`` from crossing ``/`` while ``**``
+    spans directories, mirroring the tar.gz matcher's gitignore semantics: a
+    bare name matches at any depth; a multi-segment pattern is anchored at the
+    repo root.
+    """
+    specs: list[str] = []
+    for raw in excludes:
+        pat = raw.rstrip("/")
+        if not pat:
+            continue
+        if "/" in pat:
+            specs.append(f":(glob,exclude){pat}")
+            specs.append(f":(glob,exclude){pat}/**")
+        else:
+            specs.append(f":(glob,exclude)**/{pat}")
+            specs.append(f":(glob,exclude)**/{pat}/**")
+    return specs
 
 
 def _create_git_delta(
@@ -262,10 +310,11 @@ def _create_git_delta(
     deletions relative to ``base_ref`` (defaulting to the auto-detected
     comparison ref — origin branch, merge-base, or the empty tree for a fresh
     repo). A throwaway index (``GIT_INDEX_FILE``) is used so the repository's
-    real index is never touched. ``excludes`` are applied via a scratch
-    ``core.excludesFile`` — on top of the repo's own ``.gitignore`` — so callers
-    can keep the delta compact by default while still disabling the default
-    archive excludes when they intentionally want a fuller capture.
+    real index is never touched. ``excludes`` are applied as ``:(exclude)``
+    pathspecs — on top of the repo's own ``.gitignore`` — so excluded paths are
+    dropped whether tracked or untracked, matching the tar.gz format. Callers
+    can disable the default excludes when they intentionally want a fuller
+    capture.
 
     Returns the full base commit SHA the patch applies against, or "" when the
     base is the empty tree (fresh repo) or cannot resolve to a commit.
@@ -278,8 +327,7 @@ def _create_git_delta(
         # server fault; surface it so the caller gets a 4xx.
         raise ValueError(f"base_ref {base_ref!r} could not be resolved") from e
     index_path = output_path.with_name(output_path.name + ".index")
-    excludes_path = output_path.with_name(output_path.name + ".excludes")
-    excludes_path.write_text("\n".join(excludes) + "\n")
+    pathspecs = _excludes_to_git_pathspecs(excludes)
     env = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
     try:
         # Seed the scratch index from the base ref, stage the working tree on
@@ -296,7 +344,7 @@ def _create_git_delta(
             timeout=60,
         )
         subprocess.run(
-            ["git", "-c", f"core.excludesFile={excludes_path}", "add", "-A", "--", "."],
+            ["git", "add", "-A", "--", ".", *pathspecs],
             cwd=root,
             env=env,
             capture_output=True,
@@ -307,7 +355,7 @@ def _create_git_delta(
         # buffered in memory (OOM risk at pause/stop on a fat workspace).
         with open(output_path, "wb") as out:
             subprocess.run(
-                ["git", "diff", "--binary", "--cached", ref, "--", "."],
+                ["git", "diff", "--binary", "--cached", ref, "--", ".", *pathspecs],
                 cwd=root,
                 env=env,
                 stdout=out,
@@ -337,7 +385,6 @@ def _create_git_delta(
         raise
     finally:
         index_path.unlink(missing_ok=True)
-        excludes_path.unlink(missing_ok=True)
 
     if ref == GIT_EMPTY_TREE_HASH:
         return ""
@@ -382,6 +429,10 @@ def _path_is_excluded(rel: PurePosixPath, patterns: list[str], is_dir: bool) -> 
             if len(parts) >= len(pattern_parts) and all(
                 fnmatch.fnmatch(part, pat) for part, pat in zip(parts, pattern_parts)
             ):
+                # A dir-only pattern matches the directory and anything nested
+                # under it, but not a file whose own path equals the pattern.
+                if dir_only and not is_dir and len(parts) == len(pattern_parts):
+                    continue
                 return True
         else:
             # Bare name: match any single component. For a dir-only pattern on a
@@ -421,9 +472,6 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
     total_bytes = 0
     manifest_arcname = f"{root.name}/{ARCHIVE_MANIFEST_NAME}"
     manifest_collision = False
-    # Always strip credential-bearing git internals, even when the caller
-    # disabled the default excludes for a full capture.
-    excludes = list(excludes) + list(_ALWAYS_EXCLUDE_TAR)
     try:
         with tarfile.open(output_path, "w:gz") as tar:
             for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
@@ -433,6 +481,7 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                     d
                     for d in dirnames
                     if not _path_is_excluded(base / d, excludes, is_dir=True)
+                    and not _is_sensitive_git_internal(base / d)
                 ]
                 # Emit a directory member for every surviving directory so empty
                 # authored directories round-trip (the byte-for-byte full-capture
@@ -445,7 +494,9 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                     tar.add(dirpath, arcname=dir_arcname, recursive=False)
                 for name in filenames:
                     rel = base / name
-                    if _path_is_excluded(rel, excludes, is_dir=False):
+                    if _path_is_excluded(
+                        rel, excludes, is_dir=False
+                    ) or _is_sensitive_git_internal(rel):
                         continue
                     file_path = Path(dirpath) / name
                     if file_path.is_symlink() or not file_path.is_file():
@@ -784,13 +835,14 @@ async def archive_directory(
     os.close(fd)
     output_path = Path(tmp_name)
 
+    # The caller passes the workspace base, but a repo-backed conversation clones
+    # into a subdirectory; resolve to the actual repo so both formats root the
+    # archive at the repo (consistent paths across git-delta, tar.gz, and the
+    # initial snapshot) and git-delta does not 400 on the non-repo parent.
+    repo_root = await asyncio.to_thread(_resolve_git_repo_root, target)
     base_commit = ""
     try:
         if archive_format == "git-delta":
-            # The caller passes the workspace base, but a repo-backed conversation
-            # clones into a subdirectory; resolve to the actual repo so git-delta
-            # does not 400 on the non-repo parent (and capture nothing).
-            repo_root = await asyncio.to_thread(_resolve_git_repo_root, target)
             base_commit = await asyncio.to_thread(
                 _create_git_delta,
                 repo_root,
@@ -800,7 +852,7 @@ async def archive_directory(
             )
         else:
             await asyncio.to_thread(
-                _create_tar_gz_archive, target, output_path, effective_excludes
+                _create_tar_gz_archive, repo_root, output_path, effective_excludes
             )
     except GitRepositoryError as e:
         output_path.unlink(missing_ok=True)
@@ -838,7 +890,7 @@ async def archive_directory(
 
     return FileResponse(
         path=output_path,
-        filename=f"{target.name}{_ARCHIVE_SUFFIX[archive_format]}",
+        filename=f"{repo_root.name}{_ARCHIVE_SUFFIX[archive_format]}",
         media_type=_ARCHIVE_MEDIA_TYPE[archive_format],
         headers=headers,
         background=BackgroundTask(output_path.unlink, missing_ok=True),

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -235,15 +235,18 @@ def _create_git_delta(
             check=True,
             timeout=300,
         )
-        result = subprocess.run(
-            ["git", "diff", "--binary", "--cached", ref, "--", "."],
-            cwd=root,
-            env=env,
-            capture_output=True,
-            check=True,
-            timeout=300,
-        )
-        output_path.write_bytes(result.stdout)
+        # Stream the diff straight to disk so a large binary patch is never
+        # buffered in memory (OOM risk at pause/stop on a fat workspace).
+        with open(output_path, "wb") as out:
+            subprocess.run(
+                ["git", "diff", "--binary", "--cached", ref, "--", "."],
+                cwd=root,
+                env=env,
+                stdout=out,
+                stderr=subprocess.PIPE,
+                check=True,
+                timeout=300,
+            )
     except subprocess.CalledProcessError as e:
         output_path.unlink(missing_ok=True)
         stderr = e.stderr.decode("utf-8", "replace") if e.stderr else ""
@@ -252,6 +255,14 @@ def _create_git_delta(
             command=e.cmd if isinstance(e.cmd, list) else [str(e.cmd)],
             exit_code=e.returncode,
             stderr=stderr.strip(),
+        ) from e
+    except subprocess.TimeoutExpired as e:
+        output_path.unlink(missing_ok=True)
+        raise GitCommandError(
+            message="Timed out generating git delta",
+            command=e.cmd if isinstance(e.cmd, list) else [str(e.cmd)],
+            exit_code=-1,
+            stderr=f"timed out after {e.timeout}s",
         ) from e
     except Exception:
         output_path.unlink(missing_ok=True)
@@ -272,16 +283,23 @@ def _create_git_delta(
         return ""
 
 
-def _path_is_excluded(rel: PurePosixPath, patterns: list[str]) -> bool:
-    """True if any component of ``rel`` matches any glob in ``patterns``.
+def _path_is_excluded(
+    rel: PurePosixPath, patterns: list[str], is_dir: bool
+) -> bool:
+    """True if ``rel`` is excluded by any glob in ``patterns``.
 
-    Patterns are matched per path component with ``fnmatch`` (a trailing ``/``,
-    used to denote directory excludes, is stripped first). Dependency-free so no
-    new package is pulled in.
+    A trailing ``/`` marks a directory-only pattern: it matches a directory
+    component but never a file's own name, so a ``build/`` pattern prunes a
+    ``build`` directory while keeping a file literally named ``build``. Other
+    patterns match any component. Dependency-free so no new package is pulled in.
     """
-    stripped = [p.rstrip("/") for p in patterns]
-    for part in rel.parts:
-        for pattern in stripped:
+    parts = rel.parts
+    for raw in patterns:
+        pattern = raw.rstrip("/")
+        # For a dir-only pattern matched against a file, skip the basename so a
+        # file sharing a directory exclude's name is not dropped.
+        candidates = parts if (is_dir or not raw.endswith("/")) else parts[:-1]
+        for part in candidates:
             if fnmatch.fnmatch(part, pattern):
                 return True
     return False
@@ -318,19 +336,28 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                 base = PurePosixPath(Path(dirpath).relative_to(root).as_posix())
                 # Prune excluded directories in place so we never descend them.
                 dirnames[:] = [
-                    d for d in dirnames if not _path_is_excluded(base / d, excludes)
+                    d
+                    for d in dirnames
+                    if not _path_is_excluded(base / d, excludes, is_dir=True)
                 ]
                 for name in filenames:
                     rel = base / name
-                    if _path_is_excluded(rel, excludes):
+                    if _path_is_excluded(rel, excludes, is_dir=False):
                         continue
                     file_path = Path(dirpath) / name
                     if file_path.is_symlink() or not file_path.is_file():
                         continue
                     arcname = f"{root.name}/{rel}"
-                    tar.add(file_path, arcname=arcname, recursive=False)
+                    # Best-effort: the workspace may still be mutating, so a file
+                    # that vanishes between listing and add is skipped, not fatal.
+                    try:
+                        size = file_path.stat().st_size
+                        tar.add(file_path, arcname=arcname, recursive=False)
+                    except OSError as e:
+                        logger.warning(f"Skipping unreadable file {file_path}: {e}")
+                        continue
                     file_count += 1
-                    total_bytes += file_path.stat().st_size
+                    total_bytes += size
 
             manifest = _build_archive_manifest(
                 root.name, file_count, total_bytes, excludes

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -3,6 +3,7 @@ import fnmatch
 import io
 import json
 import os
+import stat
 import subprocess
 import tarfile
 import tempfile
@@ -286,19 +287,40 @@ def _excludes_to_git_pathspecs(excludes: list[str]) -> list[str]:
     spans directories, mirroring the tar.gz matcher's gitignore semantics: a
     bare name matches at any depth; a multi-segment pattern is anchored at the
     repo root.
+
+    A trailing ``/`` marks a directory-only pattern: we emit only the
+    contents form (``.../**``) and NOT the bare entry form, so a regular file
+    that happens to share the name (e.g. an authored file literally named
+    ``build``) is kept — matching ``_path_is_excluded``'s dir-only carve-out.
+    Emitting the bare entry too would silently drop such files from the
+    git-delta while the tar.gz keeps them.
     """
     specs: list[str] = []
     for raw in excludes:
+        dir_only = raw.endswith("/")
         pat = raw.rstrip("/")
         if not pat:
             continue
         if "/" in pat:
-            specs.append(f":(glob,exclude){pat}")
+            if not dir_only:
+                specs.append(f":(glob,exclude){pat}")
             specs.append(f":(glob,exclude){pat}/**")
         else:
-            specs.append(f":(glob,exclude)**/{pat}")
+            if not dir_only:
+                specs.append(f":(glob,exclude)**/{pat}")
             specs.append(f":(glob,exclude)**/{pat}/**")
     return specs
+
+
+def _head_is_detached(root: Path) -> bool:
+    """True if the repo at ``root`` has a detached HEAD (no current branch)."""
+    try:
+        branch = run_git_command(
+            ["git", "--no-pager", "rev-parse", "--abbrev-ref", "HEAD"], root
+        )
+    except GitCommandError:
+        return False
+    return branch.strip() == "HEAD"
 
 
 def _create_git_delta(
@@ -320,8 +342,15 @@ def _create_git_delta(
     base is the empty tree (fresh repo) or cannot resolve to a commit.
     """
     validate_git_repository(root)
+    effective_base = base_ref
+    if effective_base is None and _head_is_detached(root):
+        # A pinned base-commit checkout (e.g. a SWE-bench-style eval setup)
+        # leaves HEAD detached; get_valid_ref then skips the branch strategy and
+        # diffs against the remote default-branch TIP, polluting the patch with
+        # base..tip. The pinned HEAD commit is the right base, so request it.
+        effective_base = "HEAD"
     try:
-        ref = get_valid_ref(root, base_ref) or GIT_EMPTY_TREE_HASH
+        ref = get_valid_ref(root, effective_base) or GIT_EMPTY_TREE_HASH
     except GitCommandError as e:
         # An explicit base_ref that does not resolve is client error, not a
         # server fault; surface it so the caller gets a 4xx.
@@ -459,6 +488,65 @@ def _build_archive_manifest(
     return json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
 
 
+class _ExactSizeReader:
+    """File wrapper that always yields exactly ``size`` bytes.
+
+    ``tar.addfile`` writes the member header (declaring ``size``) and then copies
+    bytes from the file; if a concurrent writer truncates the file in between, a
+    short read would raise *mid-member*, after the header and a partial,
+    unpadded body are already on the gzip stream — silently misaligning every
+    member that follows (the trailing manifest included). By padding a short read
+    with NUL (file shrank) and stopping at ``size`` (file grew), the bytes handed
+    to ``addfile`` always match the declared size, so the stream can never
+    desynchronize no matter how the workspace mutates during capture.
+    """
+
+    def __init__(self, fileobj: io.BufferedReader, size: int) -> None:
+        self._fileobj = fileobj
+        self._remaining = size
+
+    def read(self, n: int = -1) -> bytes:
+        if self._remaining <= 0:
+            return b""
+        if n is None or n < 0 or n > self._remaining:
+            n = self._remaining
+        data = self._fileobj.read(n)
+        if len(data) < n:
+            data = data + b"\x00" * (n - len(data))
+        self._remaining -= len(data)
+        return data
+
+
+def _add_file_member(tar: tarfile.TarFile, file_path: Path, arcname: str) -> int | None:
+    """Add a regular file to ``tar`` without risking tar-stream corruption.
+
+    ``tar.add`` stats the file, writes a header for that size, then copies the
+    body — a concurrent truncate between the two desynchronizes the stream (see
+    ``_ExactSizeReader``). Instead, size the header from the OPEN fd and copy
+    exactly that many bytes via ``_ExactSizeReader``. Returns the byte count, or
+    ``None`` if the file could not be read / was not a regular file (skipped,
+    best-effort — the workspace may still be mutating).
+    """
+    try:
+        f = open(file_path, "rb")
+    except OSError as e:
+        logger.warning(f"Skipping unreadable file {file_path}: {e}")
+        return None
+    try:
+        st = os.fstat(f.fileno())
+        if not stat.S_ISREG(st.st_mode):
+            # Raced into a non-regular path (dir/fifo/socket); skip it.
+            return None
+        info = tar.gettarinfo(arcname=arcname, fileobj=f)
+        tar.addfile(info, _ExactSizeReader(f, info.size))
+        return info.size
+    except OSError as e:
+        logger.warning(f"Skipping unreadable file {file_path}: {e}")
+        return None
+    finally:
+        f.close()
+
+
 def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -> None:
     """Stream a gzip tarball of ``root`` to ``output_path``.
 
@@ -490,8 +578,14 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                 dir_arcname = (
                     root.name if base == PurePosixPath(".") else f"{root.name}/{base}"
                 )
-                if not (Path(dirpath).is_symlink()):
-                    tar.add(dirpath, arcname=dir_arcname, recursive=False)
+                if not Path(dirpath).is_symlink():
+                    # Guard like the per-file add below: a directory that vanishes
+                    # mid-capture (concurrent mutation) must skip its own member,
+                    # not abort the whole archive.
+                    try:
+                        tar.add(dirpath, arcname=dir_arcname, recursive=False)
+                    except OSError as e:
+                        logger.warning(f"Skipping unreadable directory {dirpath}: {e}")
                 for name in filenames:
                     rel = base / name
                     if _path_is_excluded(
@@ -502,13 +596,11 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                     if file_path.is_symlink() or not file_path.is_file():
                         continue
                     arcname = f"{root.name}/{rel}"
-                    # Best-effort: the workspace may still be mutating, so a file
-                    # that vanishes between listing and add is skipped, not fatal.
-                    try:
-                        size = file_path.stat().st_size
-                        tar.add(file_path, arcname=arcname, recursive=False)
-                    except OSError as e:
-                        logger.warning(f"Skipping unreadable file {file_path}: {e}")
+                    # Best-effort and corruption-proof: the workspace may still be
+                    # mutating, so a file that vanishes or is truncated mid-add is
+                    # skipped without desynchronizing the tar stream.
+                    size = _add_file_member(tar, file_path, arcname)
+                    if size is None:
                         continue
                     if arcname == manifest_arcname:
                         manifest_collision = True

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -29,6 +29,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import (
     GIT_EMPTY_TREE_HASH,
     get_valid_ref,
+    run_git_command,
     validate_git_repository,
 )
 from openhands.sdk.logger import get_logger
@@ -252,7 +253,7 @@ _GIT_DELTA_DEFAULT_EXCLUDES = (
 )
 
 
-def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> None:
+def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> str:
     """Write a git patch capturing the working-tree delta against a base.
 
     The delta covers tracked modifications, new (untracked) files, and
@@ -263,6 +264,9 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
     (``_GIT_DELTA_DEFAULT_EXCLUDES``, e.g. ``node_modules/``) are excluded —
     on top of the repo's own ``.gitignore`` — so the delta stays compact for
     eval replay even if such a directory is present but not git-ignored.
+
+    Returns the full base commit SHA the patch applies against, or "" when the
+    base is the empty tree (fresh repo) or cannot resolve to a commit.
     """
     validate_git_repository(root)
     try:
@@ -322,20 +326,35 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
         index_path.unlink(missing_ok=True)
         excludes_path.unlink(missing_ok=True)
 
+    if ref == GIT_EMPTY_TREE_HASH:
+        return ""
+    # Resolve the base to a full commit SHA so the artifact is self-describing.
+    try:
+        return run_git_command(
+            ["git", "--no-pager", "rev-parse", "--verify", f"{ref}^{{commit}}"],
+            root,
+        )
+    except GitCommandError:
+        return ""
+
 
 def _build_workspace_archive(
     root: Path, fmt: ArchiveFormat, base_ref: str | None, output_path: Path
-) -> None:
-    """Build the requested archive of ``root`` at ``output_path`` (blocking)."""
+) -> str | None:
+    """Build the requested archive of ``root`` at ``output_path`` (blocking).
+
+    Returns the git-delta base commit SHA (or "" if none), and None for the
+    tar.gz / zip formats.
+    """
     if fmt == "git-delta":
-        _create_git_delta(root, base_ref, output_path)
-        return
+        return _create_git_delta(root, base_ref, output_path)
     files = _collect_workspace_files(root)
     manifest = _build_archive_manifest(root, fmt, files)
     if fmt == "tar.gz":
         _create_tar_gz_archive(files, manifest, output_path)
     else:
         _create_zip_archive(files, manifest, output_path)
+    return None
 
 
 @file_router.post("/upload")
@@ -602,7 +621,7 @@ async def archive_directory(
     output_path = Path(tmp_name)
 
     try:
-        await asyncio.to_thread(
+        base_commit = await asyncio.to_thread(
             _build_workspace_archive, target, format, base_ref, output_path
         )
     except GitRepositoryError as e:
@@ -631,9 +650,18 @@ async def archive_directory(
             detail=f"Failed to archive directory: {str(e)}",
         )
 
+    headers: dict[str, str] | None = None
+    if base_commit:
+        # Make a git-delta self-describing so consumers can replay the patch.
+        headers = {
+            "X-Archive-Base-Commit": base_commit,
+            "X-Archive-Base-Ref": base_ref or "auto",
+        }
+
     return FileResponse(
         path=output_path,
         filename=f"{target.name}{_ARCHIVE_SUFFIX[format]}",
         media_type=_ARCHIVE_MEDIA_TYPE[format],
+        headers=headers,
         background=BackgroundTask(output_path.unlink, missing_ok=True),
     )

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -217,7 +217,7 @@ def _resolve_git_repo_root(target: Path, max_depth: int = 3) -> Path:
     exists for.
 
     If ``target`` is already a git work-tree, return it unchanged. Otherwise do a
-    bounded breadth-first search of its descendants (skipping hidden and
+    bounded depth-first search of its descendants (skipping hidden and
     vendored directories, and not descending into a repo once found) for git
     work-tree roots. Return the unique match if there is exactly one; if zero or
     several are found, return ``target`` unchanged so the existing not-a-git-repo

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -1,9 +1,6 @@
 import asyncio
-import io
-import json
 import os
 import subprocess
-import tarfile
 import tempfile
 import zipfile
 from pathlib import Path
@@ -146,91 +143,15 @@ def _create_zip_from_directory(source_dir: Path, output_path: Path) -> None:
         raise
 
 
-ArchiveFormat = Literal["tar.gz", "zip", "git-delta"]
-
-ARCHIVE_MANIFEST_NAME = "archive_manifest.json"
+ArchiveFormat = Literal["git-delta"]
 
 _ARCHIVE_SUFFIX: dict[str, str] = {
-    "tar.gz": ".tar.gz",
-    "zip": ".zip",
     "git-delta": ".patch",
 }
 
 _ARCHIVE_MEDIA_TYPE: dict[str, str] = {
-    "tar.gz": "application/gzip",
-    "zip": "application/zip",
     "git-delta": "text/x-patch",
 }
-
-
-def _collect_workspace_files(root: Path) -> list[tuple[Path, Path]]:
-    """Regular files under ``root`` as ``(absolute_path, arcname)``, sorted.
-
-    ``os.walk(followlinks=False)`` never descends into symlinked directories,
-    and symlinked files are skipped, so a symlink cannot pull a file from
-    outside ``root`` into the archive and there is no risk of a symlink cycle.
-    """
-    files: list[tuple[Path, Path]] = []
-    for dirpath, _dirnames, filenames in os.walk(root, followlinks=False):
-        for name in filenames:
-            abs_path = Path(dirpath) / name
-            if abs_path.is_symlink():
-                continue
-            files.append((abs_path, abs_path.relative_to(root)))
-    files.sort(key=lambda pair: str(pair[1]))
-    return files
-
-
-def _build_archive_manifest(
-    root: Path, fmt: ArchiveFormat, files: list[tuple[Path, Path]]
-) -> bytes:
-    """Deterministic JSON manifest embedded at the archive root.
-
-    No timestamp is included so the manifest is reproducible for an identical
-    tree; callers that persist the archive record the capture time alongside
-    the stored object.
-    """
-    total_bytes = 0
-    for abs_path, _arcname in files:
-        try:
-            total_bytes += abs_path.stat().st_size
-        except OSError:
-            continue
-    manifest = {
-        "format": fmt,
-        "source": str(root),
-        "file_count": len(files),
-        "total_bytes": total_bytes,
-    }
-    return json.dumps(manifest, indent=2, sort_keys=True).encode("utf-8")
-
-
-def _create_tar_gz_archive(
-    files: list[tuple[Path, Path]], manifest: bytes, output_path: Path
-) -> None:
-    try:
-        with tarfile.open(output_path, "w:gz") as tar:
-            for abs_path, arcname in files:
-                tar.add(abs_path, arcname=str(arcname), recursive=False)
-            info = tarfile.TarInfo(name=ARCHIVE_MANIFEST_NAME)
-            info.size = len(manifest)
-            tar.addfile(info, io.BytesIO(manifest))
-    except Exception:
-        output_path.unlink(missing_ok=True)
-        raise
-
-
-def _create_zip_archive(
-    files: list[tuple[Path, Path]], manifest: bytes, output_path: Path
-) -> None:
-    try:
-        with zipfile.ZipFile(output_path, "w", zipfile.ZIP_DEFLATED) as archive:
-            for abs_path, arcname in files:
-                archive.write(abs_path, str(arcname))
-            archive.writestr(ARCHIVE_MANIFEST_NAME, manifest)
-    except Exception:
-        output_path.unlink(missing_ok=True)
-        raise
 
 
 # Heavy / generated directories that bloat a delta without helping eval replay.
@@ -336,25 +257,6 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> st
         )
     except GitCommandError:
         return ""
-
-
-def _build_workspace_archive(
-    root: Path, fmt: ArchiveFormat, base_ref: str | None, output_path: Path
-) -> str | None:
-    """Build the requested archive of ``root`` at ``output_path`` (blocking).
-
-    Returns the git-delta base commit SHA (or "" if none), and None for the
-    tar.gz / zip formats.
-    """
-    if fmt == "git-delta":
-        return _create_git_delta(root, base_ref, output_path)
-    files = _collect_workspace_files(root)
-    manifest = _build_archive_manifest(root, fmt, files)
-    if fmt == "tar.gz":
-        _create_tar_gz_archive(files, manifest, output_path)
-    else:
-        _create_zip_archive(files, manifest, output_path)
-    return None
 
 
 @file_router.post("/upload")
@@ -565,12 +467,11 @@ async def archive_directory(
         ArchiveFormat,
         Query(
             description=(
-                "Archive format: 'tar.gz' (default) or 'zip' for a full file "
-                "archive, or 'git-delta' for a git patch of the working-tree "
+                "Archive format: 'git-delta' for a git patch of the working-tree "
                 "changes against a base ref (requires a git repository)."
             )
         ),
-    ] = "tar.gz",
+    ] = "git-delta",
     base_ref: Annotated[
         str | None,
         Query(
@@ -622,7 +523,7 @@ async def archive_directory(
 
     try:
         base_commit = await asyncio.to_thread(
-            _build_workspace_archive, target, format, base_ref, output_path
+            _create_git_delta, target, base_ref, output_path
         )
     except GitRepositoryError as e:
         output_path.unlink(missing_ok=True)

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -162,12 +162,13 @@ _ARCHIVE_MEDIA_TYPE: dict[str, str] = {
 ARCHIVE_MANIFEST_NAME = "archive_manifest.json"
 
 
-# Heavy / generated directories that bloat an archive without helping eval
-# replay. For git-delta they are applied via a scratch ``core.excludesFile`` so
-# they are skipped even when the repo itself does not ``.gitignore`` them (the
-# repo's own .gitignore still applies on top of this). For tar.gz they prune the
-# walk. Shared by both formats and always applied (the ``exclude`` query param
-# only adds to these).
+# Heavy / generated directories that usually bloat an archive without helping
+# eval replay. These are the default excludes, not a minimum exclusion set:
+# callers can disable them with ``use_default_excludes=false`` when they need a
+# full workspace capture. For git-delta they are applied via a scratch
+# ``core.excludesFile`` so they are skipped even when the repo itself does not
+# ``.gitignore`` them (the repo's own .gitignore still applies on top of this).
+# For tar.gz they prune the walk.
 _DEFAULT_ARCHIVE_EXCLUDES = (
     "node_modules/",
     ".venv/",
@@ -193,10 +194,10 @@ def _create_git_delta(
     deletions relative to ``base_ref`` (defaulting to the auto-detected
     comparison ref — origin branch, merge-base, or the empty tree for a fresh
     repo). A throwaway index (``GIT_INDEX_FILE``) is used so the repository's
-    real index is never touched. ``excludes`` (the default archive excludes plus
-    any caller-supplied patterns) are applied via a scratch ``core.excludesFile``
-    — on top of the repo's own ``.gitignore`` — so the delta stays compact for
-    eval replay even when such a directory is present but not git-ignored.
+    real index is never touched. ``excludes`` are applied via a scratch
+    ``core.excludesFile`` — on top of the repo's own ``.gitignore`` — so callers
+    can keep the delta compact by default while still disabling the default
+    archive excludes when they intentionally want a fuller capture.
 
     Returns the full base commit SHA the patch applies against, or "" when the
     base is the empty tree (fresh repo) or cannot resolve to a commit.
@@ -214,7 +215,7 @@ def _create_git_delta(
     env = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
     try:
         # Seed the scratch index from the base ref, stage the working tree on
-        # top of it (skipping the default excludes), then diff. The ``-- .``
+        # top of it (skipping the requested excludes), then diff. The ``-- .``
         # pathspec scopes staging and the diff to the requested directory, so a
         # ``path`` that is a subdirectory of a larger repo yields only that
         # subtree's delta rather than the whole repository's.
@@ -568,13 +569,25 @@ async def archive_directory(
             )
         ),
     ] = None,
+    use_default_excludes: Annotated[
+        bool,
+        Query(
+            description=(
+                "Whether to apply the built-in default exclude patterns "
+                "(node_modules/, .venv/, caches, build outputs, etc.). Defaults "
+                "to true for compact archives; set false to allow a full "
+                "workspace capture, including fat directories."
+            )
+        ),
+    ] = True,
     exclude: Annotated[
         list[str] | None,
         Query(
             description=(
                 "Additional glob patterns to exclude (repeatable, e.g. "
-                "?exclude=foo&exclude=*.bin). Added on top of the built-in "
-                "default excludes, which always apply."
+                "?exclude=foo&exclude=*.bin). Combined with the built-in "
+                "default excludes when use_default_excludes=true; used by "
+                "itself when use_default_excludes=false."
             )
         ),
     ] = None,
@@ -611,9 +624,9 @@ async def archive_directory(
         )
 
     target = target.resolve()
-    # Defaults always apply; the param only adds patterns (safe-by-default so
-    # the archive cannot explode on a heavy directory).
-    effective_excludes = list(_DEFAULT_ARCHIVE_EXCLUDES) + (exclude or [])
+    effective_excludes = (
+        list(_DEFAULT_ARCHIVE_EXCLUDES) if use_default_excludes else []
+    ) + (exclude or [])
     # Build the archive outside the workspace so it is never included in itself
     # and leaves nothing behind in the archived tree.
     fd, tmp_name = tempfile.mkstemp(suffix=_ARCHIVE_SUFFIX[format])

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -547,15 +547,16 @@ async def archive_directory(
     path: Annotated[
         str, Query(description="Absolute path of the directory to archive")
     ],
-    format: Annotated[
+    archive_format: Annotated[
         ArchiveFormat,
         Query(
+            alias="format",
             description=(
                 "Archive format: 'git-delta' for a git patch of the working-tree "
                 "changes against a base ref (requires a git repository); 'tar.gz' "
                 "for a full gzip tarball of the entire directory (works on "
                 "non-git directories too)."
-            )
+            ),
         ),
     ] = "git-delta",
     base_ref: Annotated[
@@ -629,13 +630,13 @@ async def archive_directory(
     ) + (exclude or [])
     # Build the archive outside the workspace so it is never included in itself
     # and leaves nothing behind in the archived tree.
-    fd, tmp_name = tempfile.mkstemp(suffix=_ARCHIVE_SUFFIX[format])
+    fd, tmp_name = tempfile.mkstemp(suffix=_ARCHIVE_SUFFIX[archive_format])
     os.close(fd)
     output_path = Path(tmp_name)
 
     base_commit = ""
     try:
-        if format == "git-delta":
+        if archive_format == "git-delta":
             base_commit = await asyncio.to_thread(
                 _create_git_delta, target, base_ref, output_path, effective_excludes
             )
@@ -679,8 +680,8 @@ async def archive_directory(
 
     return FileResponse(
         path=output_path,
-        filename=f"{target.name}{_ARCHIVE_SUFFIX[format]}",
-        media_type=_ARCHIVE_MEDIA_TYPE[format],
+        filename=f"{target.name}{_ARCHIVE_SUFFIX[archive_format]}",
+        media_type=_ARCHIVE_MEDIA_TYPE[archive_format],
         headers=headers,
         background=BackgroundTask(output_path.unlink, missing_ok=True),
     )

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -170,6 +170,7 @@ ARCHIVE_MANIFEST_NAME = "archive_manifest.json"
 # ``.gitignore`` them (the repo's own .gitignore still applies on top of this).
 # For tar.gz they prune the walk.
 _DEFAULT_ARCHIVE_EXCLUDES = (
+    ".git/",
     "node_modules/",
     ".venv/",
     "venv/",
@@ -183,6 +184,73 @@ _DEFAULT_ARCHIVE_EXCLUDES = (
     "target/",
     "*.pyc",
 )
+
+# Credential-bearing git internals that must NEVER be persisted to a shared
+# archive bucket, even when the caller disables the default excludes for a full
+# capture (``use_default_excludes=false``). A repo cloned with a tokenized
+# remote (``https://x-access-token:TOKEN@github.com/...``) keeps that token in
+# ``.git/config``; reflogs and saved credentials are equally sensitive. These
+# are stripped from every tar.gz regardless of the exclude settings. (git-delta
+# never includes ``.git`` — it is a working-tree diff — so this only matters for
+# the full-archive format.)
+_ALWAYS_EXCLUDE_TAR = (
+    ".git/config",
+    ".git/credentials",
+    ".git/logs/",
+)
+
+# Directory names never worth descending when auto-resolving the repo root under
+# a workspace path: they can legitimately contain vendored/nested git repos that
+# must not be mistaken for the workspace's own repo.
+_ARCHIVE_DESCENT_SKIP = frozenset({"node_modules", "venv", "site-packages", "vendor"})
+
+
+def _resolve_git_repo_root(target: Path, max_depth: int = 3) -> Path:
+    """Resolve the git work-tree to archive under ``target``.
+
+    Callers pass the workspace base (e.g. ``/workspace/project``), but a
+    repository-backed conversation clones into a subdirectory
+    (``{base}/[{group}/]{repo_name}``), so the base itself is usually *not* a git
+    repo. ``git rev-parse`` only searches upward, so archiving the base would
+    400 even though the repo sits one or two levels below it — silently
+    capturing nothing for exactly the repo-backed conversations the archive
+    exists for.
+
+    If ``target`` is already a git work-tree, return it unchanged. Otherwise do a
+    bounded breadth-first search of its descendants (skipping hidden and
+    vendored directories, and not descending into a repo once found) for git
+    work-tree roots. Return the unique match if there is exactly one; if zero or
+    several are found, return ``target`` unchanged so the existing not-a-git-repo
+    handling (HTTP 400) applies rather than guessing.
+    """
+    if (target / ".git").exists():
+        return target
+    found: list[Path] = []
+    frontier: list[tuple[Path, int]] = [(target, 0)]
+    while frontier:
+        current, depth = frontier.pop()
+        if depth >= max_depth:
+            continue
+        try:
+            children = sorted(current.iterdir())
+        except OSError:
+            continue
+        for child in children:
+            if child.name.startswith(".") or child.name in _ARCHIVE_DESCENT_SKIP:
+                continue
+            try:
+                if child.is_symlink() or not child.is_dir():
+                    continue
+            except OSError:
+                continue
+            if (child / ".git").exists():
+                found.append(child)
+                if len(found) > 1:
+                    # Ambiguous — don't guess which repo to archive.
+                    return target
+            else:
+                frontier.append((child, depth + 1))
+    return found[0] if len(found) == 1 else target
 
 
 def _create_git_delta(
@@ -299,18 +367,20 @@ def _path_is_excluded(rel: PurePosixPath, patterns: list[str], is_dir: bool) -> 
 
     Dependency-free so no new package is pulled in.
     """
-    rel_str = rel.as_posix()
     parts = rel.parts
     for raw in patterns:
         pattern = raw.rstrip("/")
         dir_only = raw.endswith("/")
         if "/" in pattern:
-            # Multi-segment: anchor against the full relative path, matching the
-            # path itself or anything nested under it (``secrets/prod`` drops
-            # ``secrets/prod`` and ``secrets/prod/key``). A dir-only pattern on a
-            # file still matches if the file lives *under* the excluded dir.
-            if fnmatch.fnmatch(rel_str, pattern) or fnmatch.fnmatch(
-                rel_str, f"{pattern}/*"
+            # Multi-segment: anchor against the relative path root and match
+            # per-segment so a ``*`` does NOT cross ``/`` (gitignore semantics,
+            # matching the git-delta path). The pattern matches the path itself
+            # or anything nested under it: ``secrets/prod`` drops ``secrets/prod``
+            # and ``secrets/prod/key``; ``*/test`` drops ``a/test`` but not
+            # ``a/b/test``; ``a/*/c`` drops ``a/x/c``.
+            pattern_parts = pattern.split("/")
+            if len(parts) >= len(pattern_parts) and all(
+                fnmatch.fnmatch(part, pat) for part, pat in zip(parts, pattern_parts)
             ):
                 return True
         else:
@@ -351,6 +421,9 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
     total_bytes = 0
     manifest_arcname = f"{root.name}/{ARCHIVE_MANIFEST_NAME}"
     manifest_collision = False
+    # Always strip credential-bearing git internals, even when the caller
+    # disabled the default excludes for a full capture.
+    excludes = list(excludes) + list(_ALWAYS_EXCLUDE_TAR)
     try:
         with tarfile.open(output_path, "w:gz") as tar:
             for dirpath, dirnames, filenames in os.walk(root, followlinks=False):
@@ -361,6 +434,15 @@ def _create_tar_gz_archive(root: Path, output_path: Path, excludes: list[str]) -
                     for d in dirnames
                     if not _path_is_excluded(base / d, excludes, is_dir=True)
                 ]
+                # Emit a directory member for every surviving directory so empty
+                # authored directories round-trip (the byte-for-byte full-capture
+                # contract). tar would otherwise only recreate parents implied by
+                # file members, dropping childless directories entirely.
+                dir_arcname = (
+                    root.name if base == PurePosixPath(".") else f"{root.name}/{base}"
+                )
+                if not (Path(dirpath).is_symlink()):
+                    tar.add(dirpath, arcname=dir_arcname, recursive=False)
                 for name in filenames:
                     rel = base / name
                     if _path_is_excluded(rel, excludes, is_dir=False):
@@ -687,17 +769,34 @@ async def archive_directory(
     effective_excludes = (
         list(_DEFAULT_ARCHIVE_EXCLUDES) if use_default_excludes else []
     ) + (exclude or [])
-    # Build the archive outside the workspace so it is never included in itself
-    # and leaves nothing behind in the archived tree.
-    fd, tmp_name = tempfile.mkstemp(suffix=_ARCHIVE_SUFFIX[archive_format])
+    # Build the archive on the same volume as the workspace (its parent dir, so
+    # it is never included in itself) rather than the system temp dir: a large
+    # tar.gz on a tmpfs /tmp would defeat the stream-to-disk OOM fix, and on a
+    # small container root it could trip the pod's ephemeral-storage limit. Fall
+    # back to the default temp location if the parent is not usable.
+    scratch_dir: str | None = None
+    parent = target.parent
+    if parent != target and os.access(parent, os.W_OK):
+        scratch_dir = str(parent)
+    fd, tmp_name = tempfile.mkstemp(
+        suffix=_ARCHIVE_SUFFIX[archive_format], dir=scratch_dir
+    )
     os.close(fd)
     output_path = Path(tmp_name)
 
     base_commit = ""
     try:
         if archive_format == "git-delta":
+            # The caller passes the workspace base, but a repo-backed conversation
+            # clones into a subdirectory; resolve to the actual repo so git-delta
+            # does not 400 on the non-repo parent (and capture nothing).
+            repo_root = await asyncio.to_thread(_resolve_git_repo_root, target)
             base_commit = await asyncio.to_thread(
-                _create_git_delta, target, base_ref, output_path, effective_excludes
+                _create_git_delta,
+                repo_root,
+                base_ref,
+                output_path,
+                effective_excludes,
             )
         else:
             await asyncio.to_thread(

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -265,16 +265,22 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
     eval replay even if such a directory is present but not git-ignored.
     """
     validate_git_repository(root)
-    ref = get_valid_ref(root, base_ref) or GIT_EMPTY_TREE_HASH
+    try:
+        ref = get_valid_ref(root, base_ref) or GIT_EMPTY_TREE_HASH
+    except GitCommandError as e:
+        # An explicit base_ref that does not resolve is client error, not a
+        # server fault; surface it so the caller gets a 4xx.
+        raise ValueError(f"base_ref {base_ref!r} could not be resolved") from e
     index_path = output_path.with_name(output_path.name + ".index")
     excludes_path = output_path.with_name(output_path.name + ".excludes")
     excludes_path.write_text("\n".join(_GIT_DELTA_DEFAULT_EXCLUDES) + "\n")
     env = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
     try:
         # Seed the scratch index from the base ref, stage the working tree on
-        # top of it (skipping the default excludes), then diff: the result is
-        # everything that changed between the base and the workspace's current
-        # state.
+        # top of it (skipping the default excludes), then diff. The ``-- .``
+        # pathspec scopes staging and the diff to the requested directory, so a
+        # ``path`` that is a subdirectory of a larger repo yields only that
+        # subtree's delta rather than the whole repository's.
         subprocess.run(
             ["git", "read-tree", ref],
             cwd=root,
@@ -284,7 +290,7 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
             timeout=60,
         )
         subprocess.run(
-            ["git", "-c", f"core.excludesFile={excludes_path}", "add", "-A"],
+            ["git", "-c", f"core.excludesFile={excludes_path}", "add", "-A", "--", "."],
             cwd=root,
             env=env,
             capture_output=True,
@@ -292,7 +298,7 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
             timeout=300,
         )
         result = subprocess.run(
-            ["git", "diff", "--binary", "--cached", ref],
+            ["git", "diff", "--binary", "--cached", ref, "--", "."],
             cwd=root,
             env=env,
             capture_output=True,
@@ -604,6 +610,12 @@ async def archive_directory(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Not a git repository: {e}",
+        )
+    except ValueError as e:
+        output_path.unlink(missing_ok=True)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=str(e),
         )
     except GitCommandError as e:
         output_path.unlink(missing_ok=True)

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -232,23 +232,49 @@ def _create_zip_archive(
         raise
 
 
+# Heavy / generated directories that bloat a delta without helping eval replay.
+# Applied via a scratch ``core.excludesFile`` so they are skipped even when the
+# repo itself does not ``.gitignore`` them (the repo's own .gitignore still
+# applies on top of this).
+_GIT_DELTA_DEFAULT_EXCLUDES = (
+    "node_modules/",
+    ".venv/",
+    "venv/",
+    "__pycache__/",
+    ".mypy_cache/",
+    ".pytest_cache/",
+    ".ruff_cache/",
+    "dist/",
+    "build/",
+    ".next/",
+    "target/",
+    "*.pyc",
+)
+
+
 def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> None:
-    """Write a git patch capturing the full working-tree delta against a base.
+    """Write a git patch capturing the working-tree delta against a base.
 
     The delta covers tracked modifications, new (untracked) files, and
     deletions relative to ``base_ref`` (defaulting to the auto-detected
     comparison ref — origin branch, merge-base, or the empty tree for a fresh
     repo). A throwaway index (``GIT_INDEX_FILE``) is used so the repository's
-    real index is never touched.
+    real index is never touched. Heavy generated/dependency directories
+    (``_GIT_DELTA_DEFAULT_EXCLUDES``, e.g. ``node_modules/``) are excluded —
+    on top of the repo's own ``.gitignore`` — so the delta stays compact for
+    eval replay even if such a directory is present but not git-ignored.
     """
     validate_git_repository(root)
     ref = get_valid_ref(root, base_ref) or GIT_EMPTY_TREE_HASH
     index_path = output_path.with_name(output_path.name + ".index")
+    excludes_path = output_path.with_name(output_path.name + ".excludes")
+    excludes_path.write_text("\n".join(_GIT_DELTA_DEFAULT_EXCLUDES) + "\n")
     env = {**os.environ, "GIT_INDEX_FILE": str(index_path)}
     try:
-        # Seed the scratch index from the base ref, stage the entire working
-        # tree on top of it, then diff: the result is everything that changed
-        # between the base and the workspace's current state.
+        # Seed the scratch index from the base ref, stage the working tree on
+        # top of it (skipping the default excludes), then diff: the result is
+        # everything that changed between the base and the workspace's current
+        # state.
         subprocess.run(
             ["git", "read-tree", ref],
             cwd=root,
@@ -258,7 +284,7 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
             timeout=60,
         )
         subprocess.run(
-            ["git", "add", "-A"],
+            ["git", "-c", f"core.excludesFile={excludes_path}", "add", "-A"],
             cwd=root,
             env=env,
             capture_output=True,
@@ -288,6 +314,7 @@ def _create_git_delta(root: Path, base_ref: str | None, output_path: Path) -> No
         raise
     finally:
         index_path.unlink(missing_ok=True)
+        excludes_path.unlink(missing_ok=True)
 
 
 def _build_workspace_archive(

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -768,3 +768,63 @@ def test_git_delta_on_non_repo_returns_400(client, workspace):
     )
     assert resp.status_code == 400
     assert "git repositor" in resp.json()["detail"].lower()
+
+
+def test_git_delta_response_includes_base_commit_header(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "a.txt").write_text("original\n", encoding="utf-8")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "init"], root)
+    head_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+    # Working-tree change so the delta is non-empty.
+    (root / "a.txt").write_text("changed\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(root), "format": "git-delta", "base_ref": "HEAD"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["x-archive-base-commit"] == head_sha
+    assert resp.headers["x-archive-base-ref"] == "HEAD"
+
+
+def test_git_delta_new_repo_has_no_base_commit_header(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "new_file.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    # Empty-tree base (no commits) is not a replayable commit, so no header.
+    assert "x-archive-base-commit" not in resp.headers
+
+
+def test_archive_tar_gz_has_no_base_commit_header(client, workspace):
+    resp = client.get("/api/file/archive", params={"path": str(workspace)})
+
+    assert resp.status_code == 200, resp.text
+    assert "x-archive-base-commit" not in resp.headers
+    assert "x-archive-base-ref" not in resp.headers
+
+
+def test_archive_zip_has_no_base_commit_header(client, workspace):
+    resp = client.get(
+        "/api/file/archive", params={"path": str(workspace), "format": "zip"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "x-archive-base-commit" not in resp.headers
+    assert "x-archive-base-ref" not in resp.headers

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -19,7 +19,7 @@ from fastapi.testclient import TestClient
 from openhands.agent_server import file_router as file_router_module
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
-from openhands.agent_server.file_router import _upload_file
+from openhands.agent_server.file_router import ARCHIVE_MANIFEST_NAME, _upload_file
 
 
 @pytest.fixture
@@ -923,3 +923,83 @@ def test_tar_gz_ignores_base_ref_without_error(client, workspace):
 
     assert resp.status_code == 200, resp.text
     assert "x-archive-base-commit" not in resp.headers
+
+
+def test_tar_gz_multi_segment_exclude_drops_nested_dir(client, tmp_path):
+    # A multi-segment exclude (containing '/') must be honored for tar.gz, the
+    # same way git-delta honors it via core.excludesFile. ``secrets/prod`` should
+    # drop only that nested dir, while a same-named dir elsewhere is kept.
+    root = tmp_path / "plain"
+    (root / "secrets" / "prod").mkdir(parents=True)
+    (root / "secrets" / "prod" / "token.txt").write_text("shh\n", encoding="utf-8")
+    (root / "secrets" / "dev").mkdir(parents=True)
+    (root / "secrets" / "dev" / "token.txt").write_text("ok\n", encoding="utf-8")
+    (root / "prod").mkdir()  # same basename, different path: must be kept
+    (root / "prod" / "keep.txt").write_text("keep\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(root), "format": "tar.gz", "exclude": "secrets/prod"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    # The nested secrets/prod subtree is gone...
+    assert not any("secrets/prod" in n for n in names)
+    # ...but the sibling secrets/dev and the unrelated top-level prod survive.
+    assert f"{root.name}/secrets/dev/token.txt" in names
+    assert f"{root.name}/prod/keep.txt" in names
+
+
+def test_tar_gz_bare_name_exclude_still_matches_any_component(client, tmp_path):
+    # Bare-name excludes (no '/') must keep matching any path component at any
+    # depth, so the multi-segment support does not regress node_modules-style
+    # pruning.
+    root = tmp_path / "plain"
+    (root / "a" / "node_modules").mkdir(parents=True)
+    (root / "a" / "node_modules" / "junk.js").write_text("// big\n", encoding="utf-8")
+    (root / "keep.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "tar.gz",
+            "use_default_excludes": "false",
+            "exclude": "node_modules",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert not any("node_modules" in n for n in names)
+    assert f"{root.name}/keep.py" in names
+
+
+def test_tar_gz_preserves_user_archive_manifest_file(client, tmp_path, caplog):
+    # If the workspace itself contains a top-level archive_manifest.json, the
+    # synthetic capture manifest must NOT clobber it: the user's bytes win and a
+    # warning is logged.
+    root = tmp_path / "plain"
+    root.mkdir()
+    user_payload = b'{"this": "is the user\'s real file"}'
+    (root / "archive_manifest.json").write_bytes(user_payload)
+    (root / "other.txt").write_text("x\n", encoding="utf-8")
+
+    with caplog.at_level("WARNING"):
+        resp = client.get(
+            "/api/file/archive", params={"path": str(root), "format": "tar.gz"}
+        )
+
+    assert resp.status_code == 200, resp.text
+    arcname = f"{root.name}/archive_manifest.json"
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        # Exactly one member at the path (no shadowing duplicate).
+        assert [n for n in tar.getnames() if n == arcname] == [arcname]
+        member = tar.extractfile(arcname)
+        assert member is not None
+        assert member.read() == user_payload
+
+    assert any(ARCHIVE_MANIFEST_NAME in record.message for record in caplog.records), (
+        "expected a warning about the archive_manifest.json collision"
+    )

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -659,6 +659,31 @@ def test_git_delta_excludes_node_modules_even_when_not_gitignored(client, tmp_pa
     assert "node_modules" not in patch
 
 
+def test_git_delta_can_disable_default_excludes(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "node_modules" / "pkg").mkdir(parents=True)
+    (root / "node_modules" / "pkg" / "big.js").write_text(
+        "// intentionally captured\n", encoding="utf-8"
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "git-delta",
+            "use_default_excludes": "false",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    patch = resp.content.decode("utf-8")
+    assert "app.py" in patch
+    assert "node_modules/pkg/big.js" in patch
+
+
 def test_git_delta_scoped_to_requested_subdirectory(client, tmp_path):
     root = tmp_path / "repo"
     root.mkdir()
@@ -796,6 +821,34 @@ def test_tar_gz_default_excludes_drop_node_modules(client, tmp_path):
     names = _tar_members(resp.content)
     assert f"{root.name}/src/main.py" in names
     assert not any("node_modules" in n for n in names)
+
+
+def test_tar_gz_can_disable_default_excludes(client, tmp_path):
+    root = tmp_path / "plain"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "main.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "node_modules" / "pkg").mkdir(parents=True)
+    (root / "node_modules" / "pkg" / "junk.js").write_text("// big\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "tar.gz",
+            "use_default_excludes": "false",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert f"{root.name}/src/main.py" in names
+    assert f"{root.name}/node_modules/pkg/junk.js" in names
+
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        member = tar.extractfile(f"{root.name}/archive_manifest.json")
+        assert member is not None
+        manifest = json.loads(member.read().decode("utf-8"))
+    assert "node_modules/" not in manifest["excludes"]
 
 
 def test_tar_gz_exclude_param_extends_defaults(client, tmp_path):

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -1203,6 +1203,63 @@ def test_tar_gz_strips_credentials_file_and_reflog_with_tokens(client, tmp_path)
         assert token not in resp.content
 
 
+def test_tar_gz_strips_fetch_head_and_submodule_credentials(client, tmp_path):
+    # enyst review (#3867): the strip must also cover .git/FETCH_HEAD (git writes
+    # the fetched URL — token and all — there) and submodule git dirs under
+    # .git/modules/<name>/, not just the top-level .git/config. Built by hand so
+    # those exact leak surfaces are exercised in a full capture.
+    root = tmp_path / "project"
+    git_dir = root / ".git"
+    sub = git_dir / "modules" / "libfoo"
+    (sub / "logs").mkdir(parents=True)
+    (root / "README.md").write_text("# p\n", encoding="utf-8")
+    (git_dir / "FETCH_HEAD").write_text(
+        "abc\tbranch 'main' of https://x-access-token:ghs_FETCHTOK@github.com/o/r\n",
+        encoding="utf-8",
+    )
+    (sub / "config").write_text(
+        '[remote "origin"]\n'
+        "\turl = https://x-access-token:ghs_SUBCFGTOK@github.com/o/sub\n",
+        encoding="utf-8",
+    )
+    (sub / "FETCH_HEAD").write_text(
+        "def\tbranch 'main' of "
+        "https://x-access-token:ghs_SUBFETCHTOK@github.com/o/sub\n",
+        encoding="utf-8",
+    )
+    (sub / "logs" / "HEAD").write_text(
+        "0 1 t <t@t.dev> 0 +0000\tclone: from "
+        "https://x-access-token:ghs_SUBLOGTOK@github.com/o/sub\n",
+        encoding="utf-8",
+    )
+    # A non-credential .git internal must still survive the strip.
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "tar.gz",
+            "use_default_excludes": "false",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert not any(n.endswith("/.git/FETCH_HEAD") for n in names)
+    assert not any("/.git/modules/" in n and n.endswith("/config") for n in names)
+    assert not any("/.git/modules/" in n and n.endswith("/FETCH_HEAD") for n in names)
+    assert not any("/.git/modules/libfoo/logs/" in n for n in names)
+    assert any(n.endswith("/.git/HEAD") for n in names)
+    for token in (
+        b"ghs_FETCHTOK",
+        b"ghs_SUBCFGTOK",
+        b"ghs_SUBFETCHTOK",
+        b"ghs_SUBLOGTOK",
+    ):
+        assert token not in resp.content
+
+
 # =============================================================================
 # Archive Tests - tar.gz empty-dir round-trip + per-segment exclude (infra#1444
 # L4 / L5)

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -2,6 +2,8 @@
 
 import asyncio
 import io
+import subprocess
+import tarfile
 import tempfile
 import time
 import zipfile
@@ -520,3 +522,180 @@ async def test_upload_does_not_block_event_loop_on_slow_storage(tmp_path, monkey
         f"upload (expected ≥ {expected_min}); event loop is blocked by "
         f"sync f.write() at file_router.py:65."
     )
+
+
+# =============================================================================
+# Archive Tests - GET /api/file/archive (AGE-1871)
+# =============================================================================
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    """A small nested workspace tree under ``tmp_path/project``."""
+    root = tmp_path / "project"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "main.py").write_text("print('hi')\n", encoding="utf-8")
+    (root / "README.md").write_text("# project\n", encoding="utf-8")
+    (root / "empty").mkdir()
+    return root
+
+
+def _git(args, cwd):
+    subprocess.run(
+        ["git", "-c", "user.email=t@t.dev", "-c", "user.name=t", *args],
+        cwd=cwd,
+        check=True,
+        capture_output=True,
+    )
+
+
+def test_archive_tar_gz_contains_nested_files_and_manifest(client, workspace):
+    resp = client.get("/api/file/archive", params={"path": str(workspace)})
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/gzip"
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        names = set(tar.getnames())
+    assert "src/main.py" in names
+    assert "README.md" in names
+    assert "archive_manifest.json" in names
+
+
+def test_archive_zip_contains_nested_files_and_manifest(client, workspace):
+    resp = client.get(
+        "/api/file/archive", params={"path": str(workspace), "format": "zip"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"] == "application/zip"
+    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
+        names = set(zf.namelist())
+        manifest = zf.read("archive_manifest.json").decode("utf-8")
+    assert "src/main.py" in names
+    assert "README.md" in names
+    assert '"file_count": 2' in manifest
+
+
+def test_archive_empty_directory_succeeds(client, tmp_path):
+    empty = tmp_path / "empty-ws"
+    empty.mkdir()
+
+    resp = client.get("/api/file/archive", params={"path": str(empty)})
+
+    assert resp.status_code == 200, resp.text
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        # Only the manifest — no workspace files.
+        assert tar.getnames() == ["archive_manifest.json"]
+
+
+def test_archive_does_not_follow_symlink_outside_root(client, tmp_path):
+    secret = tmp_path / "secret.txt"
+    secret.write_text("TOP SECRET", encoding="utf-8")
+    root = tmp_path / "ws"
+    root.mkdir()
+    (root / "ok.txt").write_text("ok", encoding="utf-8")
+    (root / "escape.txt").symlink_to(secret)
+
+    resp = client.get("/api/file/archive", params={"path": str(root)})
+
+    assert resp.status_code == 200, resp.text
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        names = set(tar.getnames())
+        contents = b"".join(
+            tar.extractfile(m).read()  # type: ignore[union-attr]
+            for m in tar.getmembers()
+            if m.isfile()
+        )
+    assert "ok.txt" in names
+    assert "escape.txt" not in names
+    assert b"TOP SECRET" not in contents
+
+
+def test_archive_missing_path_returns_404(client, tmp_path):
+    resp = client.get("/api/file/archive", params={"path": str(tmp_path / "nope")})
+    assert resp.status_code == 404
+
+
+def test_archive_file_path_returns_400(client, tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("x", encoding="utf-8")
+
+    resp = client.get("/api/file/archive", params={"path": str(f)})
+
+    assert resp.status_code == 400
+    assert "not a directory" in resp.json()["detail"].lower()
+
+
+def test_archive_relative_path_returns_400(client):
+    resp = client.get("/api/file/archive", params={"path": "relative/dir"})
+    assert resp.status_code == 400
+    assert "absolute" in resp.json()["detail"].lower()
+
+
+def test_archive_rejects_dashed_base_ref(client, workspace):
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(workspace), "format": "git-delta", "base_ref": "-x"},
+    )
+    assert resp.status_code == 400
+
+
+def test_archive_cleans_up_temp_file(client, workspace, tmp_path, monkeypatch):
+    # Force the archive temp file into an isolated dir we can inspect.
+    scratch = tmp_path / "scratch"
+    scratch.mkdir()
+    monkeypatch.setattr(tempfile, "tempdir", str(scratch))
+
+    resp = client.get("/api/file/archive", params={"path": str(workspace)})
+
+    assert resp.status_code == 200
+    # The BackgroundTask unlinks the archive once the response is fully sent.
+    assert list(scratch.iterdir()) == []
+
+
+def test_git_delta_new_repo_lists_files_as_additions(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "new_file.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/x-patch")
+    patch = resp.content.decode("utf-8")
+    assert "new_file.py" in patch
+    assert "new file mode" in patch
+
+
+def test_git_delta_captures_modifications_and_untracked_vs_head(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "a.txt").write_text("original\n", encoding="utf-8")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "init"], root)
+    # Mutate a tracked file and add an untracked one after the commit.
+    (root / "a.txt").write_text("changed\n", encoding="utf-8")
+    (root / "b.txt").write_text("brand new\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(root), "format": "git-delta", "base_ref": "HEAD"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    patch = resp.content.decode("utf-8")
+    assert "a.txt" in patch
+    assert "b.txt" in patch
+    assert "changed" in patch
+
+
+def test_git_delta_on_non_repo_returns_400(client, workspace):
+    resp = client.get(
+        "/api/file/archive", params={"path": str(workspace), "format": "git-delta"}
+    )
+    assert resp.status_code == 400
+    assert "git repositor" in resp.json()["detail"].lower()

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -3,7 +3,6 @@
 import asyncio
 import io
 import subprocess
-import tarfile
 import tempfile
 import time
 import zipfile
@@ -549,68 +548,6 @@ def _git(args, cwd):
     )
 
 
-def test_archive_tar_gz_contains_nested_files_and_manifest(client, workspace):
-    resp = client.get("/api/file/archive", params={"path": str(workspace)})
-
-    assert resp.status_code == 200, resp.text
-    assert resp.headers["content-type"] == "application/gzip"
-    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
-        names = set(tar.getnames())
-    assert "src/main.py" in names
-    assert "README.md" in names
-    assert "archive_manifest.json" in names
-
-
-def test_archive_zip_contains_nested_files_and_manifest(client, workspace):
-    resp = client.get(
-        "/api/file/archive", params={"path": str(workspace), "format": "zip"}
-    )
-
-    assert resp.status_code == 200, resp.text
-    assert resp.headers["content-type"] == "application/zip"
-    with zipfile.ZipFile(io.BytesIO(resp.content)) as zf:
-        names = set(zf.namelist())
-        manifest = zf.read("archive_manifest.json").decode("utf-8")
-    assert "src/main.py" in names
-    assert "README.md" in names
-    assert '"file_count": 2' in manifest
-
-
-def test_archive_empty_directory_succeeds(client, tmp_path):
-    empty = tmp_path / "empty-ws"
-    empty.mkdir()
-
-    resp = client.get("/api/file/archive", params={"path": str(empty)})
-
-    assert resp.status_code == 200, resp.text
-    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
-        # Only the manifest — no workspace files.
-        assert tar.getnames() == ["archive_manifest.json"]
-
-
-def test_archive_does_not_follow_symlink_outside_root(client, tmp_path):
-    secret = tmp_path / "secret.txt"
-    secret.write_text("TOP SECRET", encoding="utf-8")
-    root = tmp_path / "ws"
-    root.mkdir()
-    (root / "ok.txt").write_text("ok", encoding="utf-8")
-    (root / "escape.txt").symlink_to(secret)
-
-    resp = client.get("/api/file/archive", params={"path": str(root)})
-
-    assert resp.status_code == 200, resp.text
-    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
-        names = set(tar.getnames())
-        contents = b"".join(
-            tar.extractfile(m).read()  # type: ignore[union-attr]
-            for m in tar.getmembers()
-            if m.isfile()
-        )
-    assert "ok.txt" in names
-    assert "escape.txt" not in names
-    assert b"TOP SECRET" not in contents
-
-
 def test_archive_missing_path_returns_404(client, tmp_path):
     resp = client.get("/api/file/archive", params={"path": str(tmp_path / "nope")})
     assert resp.status_code == 404
@@ -640,13 +577,18 @@ def test_archive_rejects_dashed_base_ref(client, workspace):
     assert resp.status_code == 400
 
 
-def test_archive_cleans_up_temp_file(client, workspace, tmp_path, monkeypatch):
+def test_archive_cleans_up_temp_file(client, tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init"], repo)
+    (repo / "a.txt").write_text("x\n", encoding="utf-8")
+
     # Force the archive temp file into an isolated dir we can inspect.
     scratch = tmp_path / "scratch"
     scratch.mkdir()
     monkeypatch.setattr(tempfile, "tempdir", str(scratch))
 
-    resp = client.get("/api/file/archive", params={"path": str(workspace)})
+    resp = client.get("/api/file/archive", params={"path": str(repo)})
 
     assert resp.status_code == 200
     # The BackgroundTask unlinks the archive once the response is fully sent.
@@ -810,21 +752,3 @@ def test_git_delta_new_repo_has_no_base_commit_header(client, tmp_path):
     assert resp.status_code == 200, resp.text
     # Empty-tree base (no commits) is not a replayable commit, so no header.
     assert "x-archive-base-commit" not in resp.headers
-
-
-def test_archive_tar_gz_has_no_base_commit_header(client, workspace):
-    resp = client.get("/api/file/archive", params={"path": str(workspace)})
-
-    assert resp.status_code == 200, resp.text
-    assert "x-archive-base-commit" not in resp.headers
-    assert "x-archive-base-ref" not in resp.headers
-
-
-def test_archive_zip_has_no_base_commit_header(client, workspace):
-    resp = client.get(
-        "/api/file/archive", params={"path": str(workspace), "format": "zip"}
-    )
-
-    assert resp.status_code == 200, resp.text
-    assert "x-archive-base-commit" not in resp.headers
-    assert "x-archive-base-ref" not in resp.headers

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -2,7 +2,9 @@
 
 import asyncio
 import io
+import json
 import subprocess
+import tarfile
 import tempfile
 import time
 import zipfile
@@ -751,4 +753,120 @@ def test_git_delta_new_repo_has_no_base_commit_header(client, tmp_path):
 
     assert resp.status_code == 200, resp.text
     # Empty-tree base (no commits) is not a replayable commit, so no header.
+    assert "x-archive-base-commit" not in resp.headers
+
+
+# =============================================================================
+# Archive Tests - format=tar.gz (full-workspace archive)
+# =============================================================================
+
+
+def _tar_members(content: bytes) -> list[str]:
+    with tarfile.open(fileobj=io.BytesIO(content), mode="r:gz") as tar:
+        return tar.getnames()
+
+
+def test_tar_gz_on_non_git_directory_succeeds(client, workspace):
+    # The key differentiator: git-delta 400s on a non-git dir, tar.gz captures
+    # the whole tree.
+    resp = client.get(
+        "/api/file/archive", params={"path": str(workspace), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("application/gzip")
+    names = _tar_members(resp.content)
+    assert f"{workspace.name}/src/main.py" in names
+    assert f"{workspace.name}/README.md" in names
+    assert f"{workspace.name}/archive_manifest.json" in names
+
+
+def test_tar_gz_default_excludes_drop_node_modules(client, tmp_path):
+    root = tmp_path / "plain"
+    (root / "src").mkdir(parents=True)
+    (root / "src" / "main.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "node_modules" / "pkg").mkdir(parents=True)
+    (root / "node_modules" / "pkg" / "junk.js").write_text("// big\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert f"{root.name}/src/main.py" in names
+    assert not any("node_modules" in n for n in names)
+
+
+def test_tar_gz_exclude_param_extends_defaults(client, tmp_path):
+    root = tmp_path / "plain"
+    (root / "keep").mkdir(parents=True)
+    (root / "keep" / "a.txt").write_text("keep\n", encoding="utf-8")
+    (root / "secrets").mkdir()
+    (root / "secrets" / "token.txt").write_text("shh\n", encoding="utf-8")
+    # A default-excluded dir to confirm defaults still apply alongside the param.
+    (root / "__pycache__").mkdir()
+    (root / "__pycache__" / "x.pyc").write_text("bytecode\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(root), "format": "tar.gz", "exclude": "secrets"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert f"{root.name}/keep/a.txt" in names
+    assert not any("secrets" in n for n in names)
+    # Defaults still apply alongside the extra pattern.
+    assert not any("__pycache__" in n for n in names)
+
+
+def test_tar_gz_captures_gitignored_and_non_repo_files(client, tmp_path):
+    # tar.gz is byte-for-byte: it captures files git-delta would miss, including
+    # gitignored authored files (the dir need not even be a git repo).
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / ".gitignore").write_text("ignored.txt\n", encoding="utf-8")
+    (root / "ignored.txt").write_text("authored but gitignored\n", encoding="utf-8")
+    (root / "tracked.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert f"{root.name}/ignored.txt" in names
+    assert f"{root.name}/tracked.py" in names
+
+
+def test_tar_gz_manifest_records_format_and_excludes(client, workspace):
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(workspace), "format": "tar.gz", "exclude": "*.bin"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        member = tar.extractfile(f"{workspace.name}/archive_manifest.json")
+        assert member is not None
+        manifest = json.loads(member.read().decode("utf-8"))
+
+    assert manifest["format"] == "tar.gz"
+    assert manifest["source"] == workspace.name
+    assert manifest["file_count"] >= 2
+    # The applied excludes = defaults + the caller-supplied pattern.
+    assert "*.bin" in manifest["excludes"]
+    assert "node_modules/" in manifest["excludes"]
+
+
+def test_tar_gz_ignores_base_ref_without_error(client, workspace):
+    # base_ref applies only to git-delta; tar.gz must not error on it.
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(workspace), "format": "tar.gz", "base_ref": "HEAD"},
+    )
+
+    assert resp.status_code == 200, resp.text
     assert "x-archive-base-commit" not in resp.headers

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -1306,3 +1306,72 @@ def test_tar_gz_multi_segment_exclude_does_not_cross_slash(client, tmp_path):
     names = _tar_members(resp.content)
     assert f"{root.name}/a/secret.txt" not in names
     assert f"{root.name}/a/b/secret.txt" in names
+
+
+def test_exact_size_reader_pads_short_and_caps_long():
+    """_ExactSizeReader yields EXACTLY the declared size: pad short, cap long."""
+    reader = file_router_module._ExactSizeReader
+    short = reader(io.BytesIO(b"abc"), 5)
+    chunks = []
+    while chunk := short.read(2):
+        chunks.append(chunk)
+    assert b"".join(chunks) == b"abc\x00\x00"
+    long = reader(io.BytesIO(b"abcdefgh"), 4)
+    assert long.read(100) == b"abcd"
+    assert long.read(100) == b""
+
+
+def test_tar_stream_stays_aligned_when_source_shrinks(tmp_path):
+    """A file truncated mid-add must not corrupt the rest of the tar stream.
+
+    Regression for the catch-OSError-and-continue bug: tar.addfile writes the
+    header (declared size) before copying the body, so a short read used to
+    desync every following member and silently ship a corrupt archive.
+    _ExactSizeReader pads the short source so the bytes written always match the
+    header and the archive stays fully readable.
+    """
+    out = tmp_path / "a.tar.gz"
+    body2 = b"second member intact"
+    with tarfile.open(out, "w:gz") as tar:
+        # Member one: header claims 10 bytes but the source only yields 3 (a file
+        # truncated after its size was taken). The reader pads to 10.
+        info1 = tarfile.TarInfo("one")
+        info1.size = 10
+        tar.addfile(info1, file_router_module._ExactSizeReader(io.BytesIO(b"abc"), 10))
+        info2 = tarfile.TarInfo("two")
+        info2.size = len(body2)
+        tar.addfile(
+            info2, file_router_module._ExactSizeReader(io.BytesIO(body2), len(body2))
+        )
+    # Full readback must succeed (no ReadError) and member two must be intact.
+    with tarfile.open(out, "r:gz") as tar:
+        assert tar.getnames() == ["one", "two"]
+        member_two = tar.extractfile("two")
+        assert member_two is not None
+        assert member_two.read() == body2
+        member_one = tar.extractfile("one")
+        assert member_one is not None
+        assert member_one.read() == b"abc" + b"\x00" * 7
+
+
+def test_git_delta_dir_only_exclude_keeps_same_named_file(client, tmp_path):
+    """A 'build/' default exclude drops the build/ dir but KEEPS a file named
+    'build' — git-delta must match the tar.gz dir-only carve-out."""
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    # A regular file literally named 'build' must be KEPT...
+    (root / "build").write_text("authored marker\n", encoding="utf-8")
+    # ...while an actual build/ directory (the default 'build/' exclude) is dropped.
+    (root / "sub" / "build").mkdir(parents=True)
+    (root / "sub" / "build" / "out.o").write_text("compiled\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    patch = resp.content.decode("utf-8")
+    assert "diff --git a/build b/build" in patch  # the file is kept
+    assert "authored marker" in patch
+    assert "sub/build/out.o" not in patch  # the directory is excluded

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -579,22 +579,20 @@ def test_archive_rejects_dashed_base_ref(client, workspace):
     assert resp.status_code == 400
 
 
-def test_archive_cleans_up_temp_file(client, tmp_path, monkeypatch):
+def test_archive_cleans_up_temp_file(client, tmp_path):
     repo = tmp_path / "repo"
     repo.mkdir()
     _git(["init"], repo)
     (repo / "a.txt").write_text("x\n", encoding="utf-8")
 
-    # Force the archive temp file into an isolated dir we can inspect.
-    scratch = tmp_path / "scratch"
-    scratch.mkdir()
-    monkeypatch.setattr(tempfile, "tempdir", str(scratch))
-
     resp = client.get("/api/file/archive", params={"path": str(repo)})
 
     assert resp.status_code == 200
-    # The BackgroundTask unlinks the archive once the response is fully sent.
-    assert list(scratch.iterdir()) == []
+    # The scratch archive is built on the workspace volume (the target's parent)
+    # rather than the system temp dir, and the BackgroundTask unlinks it once the
+    # response is fully sent — so nothing is left behind next to the repo.
+    leftovers = [p for p in repo.parent.iterdir() if p.name != "repo"]
+    assert leftovers == []
 
 
 def test_git_delta_new_repo_lists_files_as_additions(client, tmp_path):
@@ -1003,3 +1001,206 @@ def test_tar_gz_preserves_user_archive_manifest_file(client, tmp_path, caplog):
     assert any(ARCHIVE_MANIFEST_NAME in record.message for record in caplog.records), (
         "expected a warning about the archive_manifest.json collision"
     )
+
+
+# =============================================================================
+# Archive Tests - git-delta auto-descend to the repo under the workspace base
+# (AGE-1871 / infra#1444 H1). A repo-backed conversation clones into
+# {base}/{repo_name}, so archiving the base itself must resolve down to the repo
+# instead of 400-ing on the non-repo parent and capturing nothing.
+# =============================================================================
+
+
+def test_git_delta_auto_descends_to_single_repo_under_base(client, tmp_path):
+    # The archive PATH points at the workspace base, but the git repo lives one
+    # level below at {base}/{repo_name}. git-delta must resolve to it.
+    base = tmp_path / "project"
+    repo = base / "my-repo"
+    repo.mkdir(parents=True)
+    _git(["init"], repo)
+    (repo / "app.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(base), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["content-type"].startswith("text/x-patch")
+    assert "app.py" in resp.content.decode("utf-8")
+
+
+def test_git_delta_auto_descends_two_levels_for_grouped_workspace(client, tmp_path):
+    # Under sandbox grouping the repo is at {base}/{group}/{repo_name} — two
+    # levels below the static base path runtime-api passes. Resolution is
+    # bounded-depth, so it still finds it.
+    base = tmp_path / "project"
+    repo = base / "deadbeef" / "my-repo"
+    repo.mkdir(parents=True)
+    _git(["init"], repo)
+    (repo / "app.py").write_text("y = 2\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(base), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "app.py" in resp.content.decode("utf-8")
+
+
+def test_git_delta_uses_base_directly_when_base_is_a_repo(client, tmp_path):
+    # If the base IS itself a repo, use it directly without descending (the
+    # resolver short-circuits), so a sibling subdir below it is irrelevant.
+    base = tmp_path / "project"
+    base.mkdir()
+    _git(["init"], base)
+    (base / "top.py").write_text("a = 1\n", encoding="utf-8")
+    (base / "docs").mkdir()
+    (base / "docs" / "guide.md").write_text("# guide\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(base), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    patch = resp.content.decode("utf-8")
+    assert "top.py" in patch
+    assert "guide.md" in patch
+
+
+def test_git_delta_ambiguous_multiple_repos_still_400s(client, tmp_path):
+    # Two candidate repos under the base is ambiguous — do not guess; fall back
+    # to the existing not-a-git-repo behavior (400) rather than archive a random
+    # one.
+    base = tmp_path / "project"
+    for name in ("repo-a", "repo-b"):
+        r = base / name
+        r.mkdir(parents=True)
+        _git(["init"], r)
+        (r / "f.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(base), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 400
+
+
+def test_git_delta_no_repo_under_base_still_400s(client, tmp_path):
+    base = tmp_path / "project"
+    (base / "src").mkdir(parents=True)
+    (base / "src" / "a.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(base), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 400
+
+
+# =============================================================================
+# Archive Tests - tar.gz never leaks .git credentials (infra#1444 H2)
+# =============================================================================
+
+
+def test_tar_gz_default_excludes_drop_dot_git(client, tmp_path):
+    # The full-archive default excludes must drop the entire .git tree so a clone
+    # token in .git/config never lands in the shared, indefinitely-retained
+    # archive bucket (and the object DB does not blow up the archive size).
+    root = tmp_path / "project"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "README.md").write_text("# p\n", encoding="utf-8")
+    # Simulate a tokenized clone remote persisted by git.
+    _git(
+        ["remote", "add", "origin", "https://x-access-token:ghs_SECRET@github.com/o/r"],
+        root,
+    )
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert not any("/.git/" in n or n.endswith("/.git") for n in names)
+    assert b"ghs_SECRET" not in resp.content
+    assert f"{root.name}/README.md" in names
+
+
+def test_tar_gz_full_capture_still_strips_git_credentials(client, tmp_path):
+    # Even with use_default_excludes=false (a deliberate full capture), the
+    # credential-bearing git internals must never be persisted.
+    root = tmp_path / "project"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "README.md").write_text("# p\n", encoding="utf-8")
+    _git(
+        ["remote", "add", "origin", "https://x-access-token:ghs_SECRET@github.com/o/r"],
+        root,
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "tar.gz",
+            "use_default_excludes": "false",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    # Full capture keeps most of .git (history/objects) for fidelity...
+    assert any("/.git/" in n for n in names)
+    # ...but never the secrets.
+    assert not any(n.endswith("/.git/config") for n in names)
+    assert not any("/.git/logs/" in n for n in names)
+    assert b"ghs_SECRET" not in resp.content
+
+
+# =============================================================================
+# Archive Tests - tar.gz empty-dir round-trip + per-segment exclude (infra#1444
+# L4 / L5)
+# =============================================================================
+
+
+def test_tar_gz_preserves_empty_directories(client, tmp_path):
+    # An authored-but-empty directory must round-trip (byte-for-byte capture).
+    root = tmp_path / "project"
+    (root / "outputs").mkdir(parents=True)  # empty, no files
+    (root / "src").mkdir()
+    (root / "src" / "main.py").write_text("x = 1\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    with tarfile.open(fileobj=io.BytesIO(resp.content), mode="r:gz") as tar:
+        outputs = tar.getmember(f"{root.name}/outputs")
+        assert outputs.isdir()
+
+
+def test_tar_gz_multi_segment_exclude_does_not_cross_slash(client, tmp_path):
+    # A '*' in a multi-segment exclude must not cross '/' (gitignore semantics,
+    # matching git-delta). '*/secret.txt' drops a depth-2 match but keeps a
+    # deeper one.
+    root = tmp_path / "project"
+    (root / "a").mkdir(parents=True)
+    (root / "a" / "secret.txt").write_text("drop\n", encoding="utf-8")
+    (root / "a" / "b").mkdir()
+    (root / "a" / "b" / "secret.txt").write_text("keep\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "tar.gz",
+            "exclude": "*/secret.txt",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert f"{root.name}/a/secret.txt" not in names
+    assert f"{root.name}/a/b/secret.txt" in names

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -1158,6 +1158,51 @@ def test_tar_gz_full_capture_still_strips_git_credentials(client, tmp_path):
     assert b"ghs_SECRET" not in resp.content
 
 
+def test_tar_gz_strips_credentials_file_and_reflog_with_tokens(client, tmp_path):
+    # Beyond .git/config: a synthetic .git/ carrying a token in .git/credentials
+    # and in a .git/logs/ reflog must never reach the archive bytes, even in a
+    # full capture. Built by hand (not `git init`) so .git/credentials and
+    # .git/logs/ — which git does not write on init — are exercised directly.
+    root = tmp_path / "project"
+    git_dir = root / ".git"
+    (git_dir / "logs").mkdir(parents=True)
+    (root / "README.md").write_text("# p\n", encoding="utf-8")
+    (git_dir / "config").write_text(
+        '[remote "origin"]\n'
+        "\turl = https://x-access-token:ghs_CONFIGTOK@github.com/o/r\n",
+        encoding="utf-8",
+    )
+    (git_dir / "credentials").write_text(
+        "https://x-access-token:ghs_CREDTOK@github.com\n", encoding="utf-8"
+    )
+    (git_dir / "logs" / "HEAD").write_text(
+        "0 1 t <t@t.dev> 0 +0000\tclone: from "
+        "https://x-access-token:ghs_LOGTOK@github.com/o/r\n",
+        encoding="utf-8",
+    )
+    # A non-credential .git internal must survive: proves the credential files
+    # are stripped specifically, not the whole .git tree.
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "tar.gz",
+            "use_default_excludes": "false",
+        },
+    )
+
+    assert resp.status_code == 200, resp.text
+    names = _tar_members(resp.content)
+    assert not any(n.endswith("/.git/config") for n in names)
+    assert not any(n.endswith("/.git/credentials") for n in names)
+    assert not any("/.git/logs/" in n for n in names)
+    assert any(n.endswith("/.git/HEAD") for n in names)
+    for token in (b"ghs_CONFIGTOK", b"ghs_CREDTOK", b"ghs_LOGTOK"):
+        assert token not in resp.content
+
+
 # =============================================================================
 # Archive Tests - tar.gz empty-dir round-trip + per-segment exclude (infra#1444
 # L4 / L5)

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -693,6 +693,28 @@ def test_git_delta_captures_modifications_and_untracked_vs_head(client, tmp_path
     assert "changed" in patch
 
 
+def test_git_delta_excludes_node_modules_even_when_not_gitignored(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    # New source file (should be in the delta) + a heavy untracked node_modules
+    # with NO .gitignore (should be excluded by the default excludes).
+    (root / "app.py").write_text("x = 1\n", encoding="utf-8")
+    (root / "node_modules" / "pkg").mkdir(parents=True)
+    (root / "node_modules" / "pkg" / "big.js").write_text(
+        "// huge\n" * 100, encoding="utf-8"
+    )
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(root), "format": "git-delta"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    patch = resp.content.decode("utf-8")
+    assert "app.py" in patch
+    assert "node_modules" not in patch
+
+
 def test_git_delta_on_non_repo_returns_400(client, workspace):
     resp = client.get(
         "/api/file/archive", params={"path": str(workspace), "format": "git-delta"}

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -715,6 +715,53 @@ def test_git_delta_excludes_node_modules_even_when_not_gitignored(client, tmp_pa
     assert "node_modules" not in patch
 
 
+def test_git_delta_scoped_to_requested_subdirectory(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "outside.txt").write_text("base\n", encoding="utf-8")
+    sub = root / "sub"
+    sub.mkdir()
+    (sub / "inside.txt").write_text("base\n", encoding="utf-8")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "init"], root)
+    # Change a file inside the subdir AND one outside it, after the commit.
+    (root / "outside.txt").write_text("changed-outside\n", encoding="utf-8")
+    (sub / "inside.txt").write_text("changed-inside\n", encoding="utf-8")
+
+    # Archiving the subdir must yield only the subdir's delta, not the repo's.
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(sub), "format": "git-delta", "base_ref": "HEAD"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    patch = resp.content.decode("utf-8")
+    assert "inside.txt" in patch
+    assert "outside.txt" not in patch
+
+
+def test_git_delta_invalid_base_ref_returns_400(client, tmp_path):
+    root = tmp_path / "repo"
+    root.mkdir()
+    _git(["init"], root)
+    (root / "a.txt").write_text("x\n", encoding="utf-8")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "init"], root)
+
+    resp = client.get(
+        "/api/file/archive",
+        params={
+            "path": str(root),
+            "format": "git-delta",
+            "base_ref": "does-not-exist-ref",
+        },
+    )
+
+    # A bad base_ref is client error, not a 500.
+    assert resp.status_code == 400
+
+
 def test_git_delta_on_non_repo_returns_400(client, workspace):
     resp = client.get(
         "/api/file/archive", params={"path": str(workspace), "format": "git-delta"}


### PR DESCRIPTION
HUMAN:

Reviewed and verified locally — this is the agent-server primitive for archiving a workspace before a runtime is deleted, used by the cloud archive-before-delete work (PLTF-3112 / APP-2403). Closes #3779.

AGENT:

Implemented by Claude (Opus 4.8) on Simon's machine. Ran the targeted tests + ruff + pyright locally (all green).

## Why

OpenHands Cloud loses workspace state when a runtime's PVC is reaped, which blocks building evals/datasets from real conversations. This adds a safe, reusable way to pull an archive of a workspace's files (or a compact git delta) out of a running sandbox before deletion, consumed by the runtime-api pause-time path (PLTF-3112) and the app-server explicit-delete path (APP-2403).

## Summary

Adds `GET /api/file/archive` to the agent-server `file_router`:

- `format=git-delta` (default): a git patch of the working-tree delta (tracked mods, untracked additions, deletions) against `base_ref` (auto-detected: origin branch / merge-base / empty tree), built with a throwaway `GIT_INDEX_FILE` so the repo's real index is untouched. The response includes `X-Archive-Base-Commit` so consumers can replay the patch.
- `format=tar.gz`: full-file archive of the directory, with a deterministic `archive_manifest.json` (format, source, file_count, total_bytes, applied excludes). This works for non-git directories and captures gitignored/non-repo files.
- `_DEFAULT_ARCHIVE_EXCLUDES` is a default, not a hard minimum. Heavy generated/dependency dirs (`node_modules/`, `.venv/`, `__pycache__/`, `dist/`, `build/`, …) are skipped by default for compact captures, but callers can set `use_default_excludes=false` to capture fat directories/full workspaces; repeatable `exclude` patterns still allow caller-specific pruning.
- Path validation (absolute / exists / is-dir → clear 4xx) and symlink-escape safety (`os.walk(followlinks=False)` + skipping symlinked files).
- Temp archive built outside the workspace, removed via `BackgroundTask`.
- Documented in the agent-server OpenAPI output.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `217b2cf83aab` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -27,0 +28 @@
+operation GET /api/file/archive operationId=archive_directory_api_file_archive_get
@@ -156,0 +158,5 @@
+parameter GET /api/file/archive query:base_ref required=false schema=anyOf=[type="string",type="null"]
+parameter GET /api/file/archive query:exclude required=false schema=anyOf=[type="array" items=type="string",type="null"]
+parameter GET /api/file/archive query:format required=false schema=type="string" enum=["git-delta","tar.gz"] default="git-delta"
+parameter GET /api/file/archive query:path required=true schema=type="string"
+parameter GET /api/file/archive query:use_default_excludes required=false schema=type="boolean" default=true
@@ -304,0 +311,2 @@
+response GET /api/file/archive 200 application/json schema={}
+response GET /api/file/archive 422 application/json schema=HTTPValidationError
@@ -1972,0 +1981 @@
+schema StartConversationRequest property observability_span_name optional schema=type="string" default="conversation"
```
<!-- agent-server-rest-api-contract-summary:end -->

## How to Test

```
uv run pytest tests/agent_server/test_file_router.py -v
uv run ruff check openhands-agent-server/openhands/agent_server/file_router.py tests/agent_server/test_file_router.py
uv run ruff format --check openhands-agent-server/openhands/agent_server/file_router.py tests/agent_server/test_file_router.py
```

Covers path validation, symlink-escape exclusion, temp cleanup, git-delta for fresh and committed repos, subdir scoping, invalid base refs, base commit headers, default exclude behavior, disabling default excludes, and tar.gz full-workspace archives for non-git/gitignored/fat-file cases. All 49 tests in `test_file_router.py` pass; `ruff`, `ruff format`, and `pyright` are clean.
















<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4d9ad33-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4d9ad33-python \
  ghcr.io/openhands/agent-server:4d9ad33-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4d9ad33-golang-amd64
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-golang-amd64
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-golang-amd64
ghcr.io/openhands/agent-server:4d9ad33-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4d9ad33-golang-arm64
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-golang-arm64
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-golang-arm64
ghcr.io/openhands/agent-server:4d9ad33-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4d9ad33-java-amd64
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-java-amd64
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-java-amd64
ghcr.io/openhands/agent-server:4d9ad33-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4d9ad33-java-arm64
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-java-arm64
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-java-arm64
ghcr.io/openhands/agent-server:4d9ad33-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4d9ad33-python-amd64
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-python-amd64
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-python-amd64
ghcr.io/openhands/agent-server:4d9ad33-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4d9ad33-python-arm64
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-python-arm64
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-python-arm64
ghcr.io/openhands/agent-server:4d9ad33-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4d9ad33-golang
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-golang
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-golang
ghcr.io/openhands/agent-server:4d9ad33-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4d9ad33-java
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-java
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-java
ghcr.io/openhands/agent-server:4d9ad33-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4d9ad33-python
ghcr.io/openhands/agent-server:4d9ad331b051596607b5ead4b52c5155ff08e436-python
ghcr.io/openhands/agent-server:age-1871-archive-endpoint-python
ghcr.io/openhands/agent-server:4d9ad33-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4d9ad33-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4d9ad33-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->





