### PR TITLE
Add enable_switch_llm_tool to OpenHandsAgentProfile (per-agent)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -235,6 +235,7 @@ def _build_seed_profile(
         condenser=agent_settings.condenser,
         verification=_profile_verification(agent_settings.verification),
         enable_sub_agents=agent_settings.enable_sub_agents,
+        enable_switch_llm_tool=agent_settings.enable_switch_llm_tool,
         tool_concurrency_limit=agent_settings.tool_concurrency_limit,
         mcp_server_refs=None,
     )

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -140,6 +140,13 @@ class OpenHandsAgentProfile(AgentProfileBase):
         default=False,
         description="Enable sub-agent delegation via TaskToolSet.",
     )
+    enable_switch_llm_tool: bool = Field(
+        default=True,
+        description=(
+            "Enable the built-in switch_llm tool for switching between saved "
+            "LLM profiles."
+        ),
+    )
     tool_concurrency_limit: int = Field(
         default=1,
         ge=1,

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -222,6 +222,7 @@ def _build_openhands_settings(
         "condenser": profile.condenser,
         "verification": profile.verification.model_dump(),
         "enable_sub_agents": profile.enable_sub_agents,
+        "enable_switch_llm_tool": profile.enable_switch_llm_tool,
         "tool_concurrency_limit": profile.tool_concurrency_limit,
     }
     return validate_agent_settings(payload)

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -496,6 +496,7 @@ def test_seed_preserves_openhands_fields(client):
         json={
             "agent_settings_diff": {
                 "enable_sub_agents": True,
+                "enable_switch_llm_tool": False,
                 "tool_concurrency_limit": 3,
                 "agent_context": {"system_message_suffix": "be terse"},
                 "verification": {
@@ -509,6 +510,7 @@ def test_seed_preserves_openhands_fields(client):
 
     prof = client.get("/api/agent-profiles/default").json()["profile"]
     assert prof["enable_sub_agents"] is True
+    assert prof["enable_switch_llm_tool"] is False
     assert prof["tool_concurrency_limit"] == 3
     assert prof["system_message_suffix"] == "be terse"
     assert prof["verification"]["critic_enabled"] is True

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -40,6 +40,7 @@ def test_openhands_profile_round_trips() -> None:
         mcp_server_refs=["fetch"],
         system_message_suffix="be terse",
         enable_sub_agents=True,
+        enable_switch_llm_tool=False,
         tool_concurrency_limit=4,
     )
     reloaded = validate_agent_profile(profile.model_dump(mode="json"))
@@ -51,7 +52,13 @@ def test_openhands_profile_round_trips() -> None:
     assert reloaded.llm_profile_ref == "default"
     assert reloaded.revision == 3
     assert reloaded.mcp_server_refs == ["fetch"]
+    assert reloaded.enable_switch_llm_tool is False
     assert reloaded.tool_concurrency_limit == 4
+
+
+def test_openhands_profile_defaults_enable_switch_llm_tool_true() -> None:
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
+    assert profile.enable_switch_llm_tool is True
 
 
 def test_acp_profile_round_trips() -> None:

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -72,6 +72,7 @@ def test_openhands_resolves_to_settings_with_injected_llm(
         agent="CodeActAgent",
         system_message_suffix="be terse",
         enable_sub_agents=True,
+        enable_switch_llm_tool=False,
         tool_concurrency_limit=3,
         mcp_server_refs=["fetch"],
     )
@@ -82,6 +83,7 @@ def test_openhands_resolves_to_settings_with_injected_llm(
     assert isinstance(settings, OpenHandsAgentSettings)
     assert settings.agent == "CodeActAgent"
     assert settings.enable_sub_agents is True
+    assert settings.enable_switch_llm_tool is False
     assert settings.tool_concurrency_limit == 3
     assert settings.agent_context is not None
     assert settings.agent_context.system_message_suffix == "be terse"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

H:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Closes #3856.

Building the canvas per-profile agent editor (agent-canvas#1456 / #1463) surfaced a missing knob: the global `AgentSettingsConfig.enable_switch_llm_tool` toggle had no per-profile counterpart on `OpenHandsAgentProfile`, so a profile couldn't disable (or re-enable) the built-in `switch_llm` tool the way the global Settings page can.

Per the scope decision recorded in the issue on 2026-06-24, this PR addresses **only** that gap — gap 2 (`critic_api_key`) was dropped, since critic/verification stays a global service.

## Summary

- Add `enable_switch_llm_tool: bool` to `OpenHandsAgentProfile` (mirrors the `enable_sub_agents` field; defaults to `True` to match `AgentSettingsConfig`).
- Thread it through `resolve_agent_profile()` in `_build_openhands_settings(...)` so the resolved `OpenHandsAgentSettings` carries the per-profile value into `create_agent()`.
- In `agent_profiles_router._build_seed_profile`, propagate the existing global value when seeding the default OpenHands profile, so migrating users keep their current behavior.
- Tests: round-trip + default-true coverage in `tests/sdk/profiles/test_agent_profile.py`; resolver propagation in `tests/sdk/profiles/test_resolver.py`; seed fidelity in `tests/agent_server/test_agent_profiles_router.py`.

## Issue Number

Closes #3856.

## How to Test

```bash
make build
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/profiles/agent_profile.py \
  openhands-sdk/openhands/sdk/profiles/resolver.py \
  openhands-agent-server/openhands/agent_server/agent_profiles_router.py \
  tests/sdk/profiles/test_agent_profile.py \
  tests/sdk/profiles/test_resolver.py \
  tests/agent_server/test_agent_profiles_router.py
uv run pytest tests/sdk/profiles/ tests/agent_server/test_agent_profiles_router.py -q
```

Expected: pre-commit (ruff format / lint / pyright / import rules) all pass; 155 tests pass.

Functional check the tests assert:
1. `OpenHandsAgentProfile(name="oh", llm_profile_ref="default")` → `enable_switch_llm_tool is True` by default.
2. Constructing a profile with `enable_switch_llm_tool=False` and round-tripping through `validate_agent_profile(profile.model_dump(mode="json"))` preserves the value.
3. `resolve_agent_profile(profile, ...)` with `enable_switch_llm_tool=False` yields `OpenHandsAgentSettings` with `enable_switch_llm_tool is False`, which `create_agent()` then honors.
4. `PATCH /api/settings` with `enable_switch_llm_tool=False` followed by `GET /api/agent-profiles` then `GET /api/agent-profiles/default` returns a seed profile with `enable_switch_llm_tool: false`.

## Video/Screenshots

N/A — no UI / behavioral surface change beyond the new boolean field. Per-profile editor surfacing is the follow-up tracked in agent-canvas#1463 (after typescript-client regen).

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- The `AgentProfile` schema_version is still `1`. The new field has a default (`True`) that matches the existing `AgentSettingsConfig` default, so previously-persisted profiles validate unchanged and the resolved settings preserve current behavior.
- Follow-ups (out of scope here, called out in the issue): regen `@openhands/typescript-client`; agent-canvas surfaces the toggle in the per-profile editor (agent-canvas#1463).

_This PR was created by an AI agent (OpenHands) on behalf of the user._


@simonrosenberg can click here to [continue refining the PR](https://app.all-hands.dev/conversations/533bde5d-40bb-4bb4-9076-249198c7ce22)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:888bdb9-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-888bdb9-python \
  ghcr.io/openhands/agent-server:888bdb9-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:888bdb9-golang-amd64
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-golang-amd64
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-golang-amd64
ghcr.io/openhands/agent-server:888bdb9-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:888bdb9-golang-arm64
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-golang-arm64
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-golang-arm64
ghcr.io/openhands/agent-server:888bdb9-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:888bdb9-java-amd64
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-java-amd64
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-java-amd64
ghcr.io/openhands/agent-server:888bdb9-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:888bdb9-java-arm64
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-java-arm64
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-java-arm64
ghcr.io/openhands/agent-server:888bdb9-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:888bdb9-python-amd64
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-python-amd64
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-python-amd64
ghcr.io/openhands/agent-server:888bdb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:888bdb9-python-arm64
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-python-arm64
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-python-arm64
ghcr.io/openhands/agent-server:888bdb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:888bdb9-golang
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-golang
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-golang
ghcr.io/openhands/agent-server:888bdb9-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:888bdb9-java
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-java
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-java
ghcr.io/openhands/agent-server:888bdb9-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:888bdb9-python
ghcr.io/openhands/agent-server:888bdb986515ae844f23ae1ff539c9656c28db61-python
ghcr.io/openhands/agent-server:openhands-profile-enable-switch-llm-tool-python
ghcr.io/openhands/agent-server:888bdb9-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `888bdb9-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `888bdb9-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->