### PR TITLE
More logging

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -247,6 +247,18 @@ class Config(BaseModel):
             "configuration is delivered later."
         ),
     )
+    lease_ttl_seconds: float = Field(
+        default=45.0,
+        ge=0.0,
+        description=(
+            "How long (in seconds) a conversation ownership lease remains valid "
+            "without renewal. The lease prevents two server instances from "
+            "concurrently owning the same conversation when storage is shared "
+            "across instances. Set to 0 to disable leasing entirely, which is "
+            "appropriate for single-instance deployments where concurrent "
+            "ownership is impossible."
+        ),
+    )
     model_config: ClassVar[ConfigDict] = {"frozen": True}
 
     @property

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -12,7 +12,10 @@ import httpx
 from pydantic import BaseModel
 
 from openhands.agent_server.config import Config, WebhookSpec
-from openhands.agent_server.conversation_lease import ConversationLeaseHeldError
+from openhands.agent_server.conversation_lease import (
+    DEFAULT_LEASE_TTL_SECONDS,
+    ConversationLeaseHeldError,
+)
 from openhands.agent_server.event_service import (
     LEASE_RENEW_INTERVAL_SECONDS,
     EventService,
@@ -441,6 +444,7 @@ class ConversationService:
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     max_concurrent_runs: int = 10
+    lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_webhook_subscribers: list["ConversationWebhookSubscriber"] = field(
         default_factory=list, init=False
@@ -1075,7 +1079,9 @@ class ConversationService:
             thread_name_prefix="conversation-run",
         )
         self._event_services = {}
-        logger.info(f"ConversationService:__aenter__:conversations_dir:{self.conversations_dir}")
+        logger.info(
+            f"ConversationService:__aenter__:conversations_dir:{self.conversations_dir}"
+        )
         for conversation_dir in self.conversations_dir.iterdir():
             stored: StoredConversation | None = None
             try:
@@ -1214,6 +1220,7 @@ class ConversationService:
             ),
             cipher=config.cipher,
             max_concurrent_runs=config.max_concurrent_runs,
+            lease_ttl_seconds=config.lease_ttl_seconds,
         )
 
     async def _start_event_service(self, stored: StoredConversation) -> EventService:
@@ -1226,6 +1233,7 @@ class ConversationService:
             conversations_dir=self.conversations_dir,
             cipher=self.cipher,
             owner_instance_id=self.owner_instance_id,
+            lease_ttl_seconds=self.lease_ttl_seconds,
         )
         # Lease renewal is handled by the centralized
         # _renew_all_leases_loop task on ConversationService.

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -1075,10 +1075,12 @@ class ConversationService:
             thread_name_prefix="conversation-run",
         )
         self._event_services = {}
+        logger.info(f"ConversationService:__aenter__:conversations_dir:{self.conversations_dir}")
         for conversation_dir in self.conversations_dir.iterdir():
             stored: StoredConversation | None = None
             try:
                 meta_file = conversation_dir / "meta.json"
+                logger.info(f"ConversationService:__aenter__:meta_file:{meta_file}")
                 if not meta_file.exists():
                     continue
                 json_str = meta_file.read_text()
@@ -1132,7 +1134,7 @@ class ConversationService:
                 conversation_id = (
                     stored.id if stored is not None else conversation_dir.name
                 )
-                logger.debug(
+                logger.info(
                     "Skipping active conversation %s owned by %s until %s",
                     conversation_id,
                     exc.owner_instance_id,

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 from pydantic import ValidationError
 
 from openhands.agent_server.conversation_lease import (
+    DEFAULT_LEASE_TTL_SECONDS,
     ConversationLease,
     ConversationOwnershipLostError,
 )
@@ -81,6 +82,7 @@ class EventService:
     conversations_dir: Path
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
+    lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _conversation: LocalConversation | None = field(default=None, init=False)
     _pub_sub: PubSub[Event] = field(
         default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
@@ -731,12 +733,14 @@ class EventService:
 
         # self.stored contains an Agent configuration we can instantiate
         self.conversation_dir.mkdir(parents=True, exist_ok=True)
-        self._lease = ConversationLease(
-            conversation_dir=self.conversation_dir,
-            owner_instance_id=self.owner_instance_id,
-        )
-        lease_claim = self._lease.claim()
-        self._lease_generation = lease_claim.generation
+        if self.lease_ttl_seconds > 0:
+            self._lease = ConversationLease(
+                conversation_dir=self.conversation_dir,
+                owner_instance_id=self.owner_instance_id,
+                ttl_seconds=self.lease_ttl_seconds,
+            )
+            lease_claim = self._lease.claim()
+            self._lease_generation = lease_claim.generation
         workspace = self.stored.workspace
         assert isinstance(workspace, LocalWorkspace)
         working_dir = Path(workspace.working_dir)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

<!-- Describe problem, motivation, etc.-->

## Summary

<!-- 1-3 bullets describing what changed. -->
-

## Issue Number
<!-- Required if there is a relevant issue to this PR. -->

## How to Test

<!--
Required. Share the steps for the reviewer to be able to test your PR. e.g. You can test by running `npm install` then `npm build dev`.

If you could not test this, say why.
-->

## Video/Screenshots

<!--
Provide a video or screenshots of testing your PR. e.g. you added a new feature to the gui, show us the video of you testing it successfully.

-->

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

<!-- Optional: config changes, rollout concerns, follow-ups, or anything reviewers should know. -->



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:55623be-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-55623be-python \
  ghcr.io/openhands/agent-server:55623be-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:55623be-golang-amd64
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-golang-amd64
ghcr.io/openhands/agent-server:debug-conversation-service-golang-amd64
ghcr.io/openhands/agent-server:55623be-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:55623be-golang-arm64
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-golang-arm64
ghcr.io/openhands/agent-server:debug-conversation-service-golang-arm64
ghcr.io/openhands/agent-server:55623be-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:55623be-java-amd64
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-java-amd64
ghcr.io/openhands/agent-server:debug-conversation-service-java-amd64
ghcr.io/openhands/agent-server:55623be-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:55623be-java-arm64
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-java-arm64
ghcr.io/openhands/agent-server:debug-conversation-service-java-arm64
ghcr.io/openhands/agent-server:55623be-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:55623be-python-amd64
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-python-amd64
ghcr.io/openhands/agent-server:debug-conversation-service-python-amd64
ghcr.io/openhands/agent-server:55623be-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:55623be-python-arm64
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-python-arm64
ghcr.io/openhands/agent-server:debug-conversation-service-python-arm64
ghcr.io/openhands/agent-server:55623be-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:55623be-golang
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-golang
ghcr.io/openhands/agent-server:debug-conversation-service-golang
ghcr.io/openhands/agent-server:55623be-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:55623be-java
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-java
ghcr.io/openhands/agent-server:debug-conversation-service-java
ghcr.io/openhands/agent-server:55623be-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:55623be-python
ghcr.io/openhands/agent-server:55623bec41f78116e0911ead68858f7c2e73462d-python
ghcr.io/openhands/agent-server:debug-conversation-service-python
ghcr.io/openhands/agent-server:55623be-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `55623be-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `55623be-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->