### PR TITLE
fix(llm): recover softly from Anthropic content-policy blocks

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -609,11 +609,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             on_event(error_message)
             return
         except LLMContentPolicyViolationError as e:
-            # The provider's content filter blocked this completion. It is
-            # deterministic, so re-sending the same request is futile; instead
-            # nudge the model with a user message and let the run loop continue.
-            # A model that keeps tripping the filter is bounded by the stuck
-            # detector rather than emitting a fatal ConversationErrorEvent.
+            # Content-policy blocks are deterministic; nudge the model and let the
+            # run loop continue instead of emitting a fatal error.
             logger.warning(f"LLM output blocked by content filter: {e}")
             on_event(
                 MessageEvent(
@@ -774,11 +771,8 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             on_event(error_message)
             return
         except LLMContentPolicyViolationError as e:
-            # The provider's content filter blocked this completion. It is
-            # deterministic, so re-sending the same request is futile; instead
-            # nudge the model with a user message and let the run loop continue.
-            # A model that keeps tripping the filter is bounded by the stuck
-            # detector rather than emitting a fatal ConversationErrorEvent.
+            # Content-policy blocks are deterministic; nudge the model and let the
+            # run loop continue instead of emitting a fatal error.
             logger.warning(f"LLM output blocked by content filter: {e}")
             on_event(
                 MessageEvent(

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -61,6 +61,7 @@ from openhands.sdk.llm import (
 )
 from openhands.sdk.llm.exceptions import (
     FunctionCallValidationError,
+    LLMContentPolicyViolationError,
     LLMContextWindowExceedError,
     LLMMalformedConversationHistoryError,
 )
@@ -607,6 +608,31 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
             )
             on_event(error_message)
             return
+        except LLMContentPolicyViolationError as e:
+            # The provider's content filter blocked this completion. It is
+            # deterministic, so re-sending the same request is futile; instead
+            # nudge the model with a user message and let the run loop continue.
+            # A model that keeps tripping the filter is bounded by the stuck
+            # detector rather than emitting a fatal ConversationErrorEvent.
+            logger.warning(f"LLM output blocked by content filter: {e}")
+            on_event(
+                MessageEvent(
+                    source="user",
+                    llm_message=Message(
+                        role="user",
+                        content=[
+                            TextContent(
+                                text=(
+                                    "Your previous response was blocked by the "
+                                    "model's content filter. Please continue, "
+                                    "rephrasing to avoid the flagged content."
+                                )
+                            )
+                        ],
+                    ),
+                )
+            )
+            return
         except LLMMalformedConversationHistoryError as e:
             # The provider rejected the current message history as structurally
             # invalid (for example, broken tool_use/tool_result pairing). Route
@@ -746,6 +772,31 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                 ),
             )
             on_event(error_message)
+            return
+        except LLMContentPolicyViolationError as e:
+            # The provider's content filter blocked this completion. It is
+            # deterministic, so re-sending the same request is futile; instead
+            # nudge the model with a user message and let the run loop continue.
+            # A model that keeps tripping the filter is bounded by the stuck
+            # detector rather than emitting a fatal ConversationErrorEvent.
+            logger.warning(f"LLM output blocked by content filter: {e}")
+            on_event(
+                MessageEvent(
+                    source="user",
+                    llm_message=Message(
+                        role="user",
+                        content=[
+                            TextContent(
+                                text=(
+                                    "Your previous response was blocked by the "
+                                    "model's content filter. Please continue, "
+                                    "rephrasing to avoid the flagged content."
+                                )
+                            )
+                        ],
+                    ),
+                )
+            )
             return
         except LLMMalformedConversationHistoryError as e:
             # The provider rejected the current message history as

--- a/openhands-sdk/openhands/sdk/llm/exceptions/__init__.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/__init__.py
@@ -1,4 +1,5 @@
 from .classifier import (
+    is_content_policy_violation,
     is_context_window_exceeded,
     is_prompt_cache_too_small,
     looks_like_auth_error,
@@ -11,6 +12,7 @@ from .types import (
     FunctionCallValidationError,
     LLMAuthenticationError,
     LLMBadRequestError,
+    LLMContentPolicyViolationError,
     LLMContextWindowExceedError,
     LLMContextWindowTooSmallError,
     LLMError,
@@ -40,6 +42,7 @@ __all__ = [
     "LLMContextWindowExceedError",
     "LLMMalformedConversationHistoryError",
     "LLMContextWindowTooSmallError",
+    "LLMContentPolicyViolationError",
     "LLMAuthenticationError",
     "LLMRateLimitError",
     "LLMTimeoutError",
@@ -48,6 +51,7 @@ __all__ = [
     "UserCancelledError",
     "OperationCancelled",
     # Helpers
+    "is_content_policy_violation",
     "is_context_window_exceeded",
     "is_prompt_cache_too_small",
     "looks_like_auth_error",

--- a/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
@@ -20,7 +20,7 @@ from .types import (
 
 
 # Minimal, provider-agnostic context-window detection
-LONG_PROMPT_PATTERNS: list[str] = [
+LONG_PROMPT_PATTERNS: Final[list[str]] = [
     "contextwindowexceedederror",
     "prompt is too long",
     "input length and `max_tokens` exceed context limit",
@@ -35,7 +35,7 @@ LONG_PROMPT_PATTERNS: list[str] = [
 # provider. They are tracked separately from true context-window errors so the
 # logs and agent control flow can preserve that distinction while still routing
 # into condensation-based recovery.
-MALFORMED_HISTORY_PATTERNS: list[str] = [
+MALFORMED_HISTORY_PATTERNS: Final[list[str]] = [
     "tool_use ids were found without `tool_result` blocks immediately after",
     # Anthropic backtick variant
     "`tool_use` ids were found without `tool_result` blocks immediately after",
@@ -55,6 +55,30 @@ MALFORMED_HISTORY_PATTERNS: list[str] = [
     # OpenAI-compatible providers may reject replayed assistant tool calls whose
     # arguments are not valid JSON.
     "failed to parse tool call arguments as json",
+]
+
+# Vertex AI (Gemini) rejects context-caching requests when the cached content
+# is below the provider's minimum token threshold (currently 4096 tokens).
+# Example error: "The cached content is of 1171 tokens. The minimum token
+# count to start caching is 4096." — the `.lower()` comparison handles case
+# variation across providers but won't match reworded messages; update this
+# pattern if the API phrasing changes.
+PROMPT_CACHE_TOO_SMALL_PATTERNS: Final[list[str]] = [
+    "minimum token count to start caching",
+]
+
+AUTH_PATTERNS: Final[list[str]] = [
+    "invalid api key",
+    "unauthorized",
+    "missing api key",
+    "invalid authentication",
+    "access denied",
+]
+
+CONTENT_POLICY_PATTERNS: Final[list[str]] = [
+    "content_policy",
+    "content filtering policy",
+    "output blocked by content filtering",
 ]
 
 
@@ -89,25 +113,6 @@ def looks_like_malformed_conversation_history_error(exception: Exception) -> boo
     return any(p in s for p in MALFORMED_HISTORY_PATTERNS)
 
 
-# Vertex AI (Gemini) rejects context-caching requests when the cached content
-# is below the provider's minimum token threshold (currently 4096 tokens).
-# Example error: "The cached content is of 1171 tokens. The minimum token
-# count to start caching is 4096." — the `.lower()` comparison handles case
-# variation across providers but won't match reworded messages; update this
-# pattern if the API phrasing changes.
-PROMPT_CACHE_TOO_SMALL_PATTERNS: list[str] = [
-    "minimum token count to start caching",
-]
-
-AUTH_PATTERNS: list[str] = [
-    "invalid api key",
-    "unauthorized",
-    "missing api key",
-    "invalid authentication",
-    "access denied",
-]
-
-
 def is_prompt_cache_too_small(exception: Exception) -> bool:
     """Return True if the error indicates the prompt cache content is too small.
 
@@ -137,16 +142,6 @@ def looks_like_auth_error(exception: Exception) -> bool:
         if code in s:
             return True
     return False
-
-
-# Output/input content-policy blocks. Anthropic raises this as a 400 with
-# "Output blocked by content filtering policy"; the typed class may be flattened
-# to a plain BadRequestError by proxies/aliased providers, hence the text fallback.
-CONTENT_POLICY_PATTERNS: Final[list[str]] = [
-    "content_policy",
-    "content filtering policy",
-    "output blocked by content filtering",
-]
 
 
 def is_content_policy_violation(exception: Exception) -> bool:

--- a/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Final
+
 from litellm.exceptions import (
     APIConnectionError,
     AuthenticationError,
@@ -140,7 +142,7 @@ def looks_like_auth_error(exception: Exception) -> bool:
 # Output/input content-policy blocks. Anthropic raises this as a 400 with
 # "Output blocked by content filtering policy"; the typed class may be flattened
 # to a plain BadRequestError by proxies/aliased providers, hence the text fallback.
-CONTENT_POLICY_PATTERNS: list[str] = [
+CONTENT_POLICY_PATTERNS: Final[list[str]] = [
     "content_policy",
     "content filtering policy",
     "output blocked by content filtering",

--- a/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/classifier.py
@@ -4,6 +4,7 @@ from litellm.exceptions import (
     APIConnectionError,
     AuthenticationError,
     BadRequestError,
+    ContentPolicyViolationError,
     ContextWindowExceededError,
     InternalServerError,
     OpenAIError,
@@ -134,3 +135,22 @@ def looks_like_auth_error(exception: Exception) -> bool:
         if code in s:
             return True
     return False
+
+
+# Output/input content-policy blocks. Anthropic raises this as a 400 with
+# "Output blocked by content filtering policy"; the typed class may be flattened
+# to a plain BadRequestError by proxies/aliased providers, hence the text fallback.
+CONTENT_POLICY_PATTERNS: list[str] = [
+    "content_policy",
+    "content filtering policy",
+    "output blocked by content filtering",
+]
+
+
+def is_content_policy_violation(exception: Exception) -> bool:
+    if isinstance(exception, ContentPolicyViolationError):
+        return True
+    if not isinstance(exception, (BadRequestError, OpenAIError)):
+        return False
+    s = str(exception).lower()
+    return any(p in s for p in CONTENT_POLICY_PATTERNS)

--- a/openhands-sdk/openhands/sdk/llm/exceptions/mapping.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/mapping.py
@@ -10,6 +10,7 @@ from litellm.exceptions import (
 )
 
 from .classifier import (
+    is_content_policy_violation,
     is_context_window_exceeded,
     looks_like_auth_error,
     looks_like_malformed_conversation_history_error,
@@ -17,6 +18,7 @@ from .classifier import (
 from .types import (
     LLMAuthenticationError,
     LLMBadRequestError,
+    LLMContentPolicyViolationError,
     LLMContextWindowExceedError,
     LLMMalformedConversationHistoryError,
     LLMRateLimitError,
@@ -55,6 +57,11 @@ def map_provider_exception(exception: Exception) -> Exception:
         exception, (APIConnectionError, ServiceUnavailableError, InternalServerError)
     ):
         return LLMServiceUnavailableError(str(exception))
+
+    # Content-policy blocks are deterministic 4xx; distinguish them from generic
+    # bad requests so the agent can recover softly instead of hard-erroring.
+    if is_content_policy_violation(exception):
+        return LLMContentPolicyViolationError(str(exception))
 
     # Generic client-side 4xx errors
     if isinstance(exception, BadRequestError):

--- a/openhands-sdk/openhands/sdk/llm/exceptions/types.py
+++ b/openhands-sdk/openhands/sdk/llm/exceptions/types.py
@@ -131,6 +131,20 @@ class LLMBadRequestError(LLMError):
         super().__init__(message)
 
 
+class LLMContentPolicyViolationError(LLMBadRequestError):
+    """Provider blocked the request/response via its content filter.
+
+    Subclasses LLMBadRequestError for back-compat. Deterministic in
+    (messages, model): a bare retry trips the same filter, so recovery
+    requires changing the request, not re-sending it.
+    """
+
+    def __init__(
+        self, message: str = "Output blocked by content filtering policy"
+    ) -> None:
+        super().__init__(message)
+
+
 # Other
 class UserCancelledError(Exception):
     def __init__(self, message: str = "User cancelled the request") -> None:

--- a/tests/sdk/agent/test_agent_content_policy_violation.py
+++ b/tests/sdk/agent/test_agent_content_policy_violation.py
@@ -1,0 +1,83 @@
+"""Content-policy blocks recover softly instead of hard-erroring.
+
+See https://github.com/OpenHands/software-agent-sdk/issues/3798. An Anthropic
+output content-policy block surfaces as ``LLMContentPolicyViolationError``. The
+agent should emit a non-fatal user nudge and return so the run loop continues,
+rather than letting it escape ``step``/``astep`` and become a fatal
+``ConversationErrorEvent``.
+"""
+
+import pytest
+from pydantic import PrivateAttr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.event import MessageEvent
+from openhands.sdk.event.conversation_error import ConversationErrorEvent
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.exceptions import LLMContentPolicyViolationError
+
+
+class ContentPolicyRaisingLLM(LLM):
+    _force_responses: bool = PrivateAttr(default=False)
+
+    def __init__(self, *, model: str = "test-model", force_responses: bool = False):
+        super().__init__(model=model, usage_id="test-llm")
+        self._force_responses = force_responses
+
+    def uses_responses_api(self) -> bool:  # override gating
+        return self._force_responses
+
+    def completion(self, *, messages, tools=None, **kwargs):  # type: ignore[override]
+        raise LLMContentPolicyViolationError()
+
+    async def acompletion(self, *, messages, tools=None, **kwargs):  # type: ignore[override]
+        raise LLMContentPolicyViolationError()
+
+    def responses(self, *, messages, tools=None, **kwargs):  # type: ignore[override]
+        raise LLMContentPolicyViolationError()
+
+    async def aresponses(self, *, messages, tools=None, **kwargs):  # type: ignore[override]
+        raise LLMContentPolicyViolationError()
+
+
+def _content_policy_nudges(events: list) -> list[MessageEvent]:
+    return [
+        e
+        for e in events
+        if isinstance(e, MessageEvent)
+        and e.source == "user"
+        and any(
+            "content filter" in getattr(c, "text", "") for c in e.llm_message.content
+        )
+    ]
+
+
+@pytest.mark.parametrize("force_responses", [True, False])
+def test_step_emits_soft_nudge_on_content_policy(force_responses: bool):
+    llm = ContentPolicyRaisingLLM(force_responses=force_responses)
+    agent = Agent(llm=llm, tools=[])
+    convo = Conversation(agent=agent)
+    convo._ensure_agent_ready()
+
+    seen: list = []
+    # Must not raise — a content-policy block is recoverable.
+    agent.step(convo, on_event=seen.append)
+
+    assert len(_content_policy_nudges(seen)) == 1
+    assert not any(isinstance(e, ConversationErrorEvent) for e in seen)
+
+
+@pytest.mark.parametrize("force_responses", [True, False])
+@pytest.mark.asyncio
+async def test_astep_emits_soft_nudge_on_content_policy(force_responses: bool):
+    llm = ContentPolicyRaisingLLM(force_responses=force_responses)
+    agent = Agent(llm=llm, tools=[])
+    convo = Conversation(agent=agent)
+    convo._ensure_agent_ready()
+
+    seen: list = []
+    await agent.astep(convo, on_event=seen.append)
+
+    assert len(_content_policy_nudges(seen)) == 1
+    assert not any(isinstance(e, ConversationErrorEvent) for e in seen)

--- a/tests/sdk/llm/test_exception_mapping.py
+++ b/tests/sdk/llm/test_exception_mapping.py
@@ -2,6 +2,7 @@ import httpx
 from litellm.exceptions import (
     AuthenticationError,
     BadRequestError,
+    ContentPolicyViolationError,
     InternalServerError,
     PermissionDeniedError,
 )
@@ -9,6 +10,7 @@ from litellm.exceptions import (
 from openhands.sdk.llm.exceptions import (
     LLMAuthenticationError,
     LLMBadRequestError,
+    LLMContentPolicyViolationError,
     LLMMalformedConversationHistoryError,
     map_provider_exception,
 )
@@ -80,10 +82,33 @@ def test_map_openai_tool_argument_parse_internal_server_error():
     assert isinstance(mapped, LLMMalformedConversationHistoryError)
 
 
+def test_map_typed_content_policy_violation():
+    e = ContentPolicyViolationError(
+        "Output blocked by content filtering policy", MODEL, PROVIDER
+    )
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMContentPolicyViolationError)
+    # Subtype of LLMBadRequestError keeps back-compat for existing handlers.
+    assert isinstance(mapped, LLMBadRequestError)
+
+
+def test_map_content_policy_violation_text_fallback():
+    # Proxied/aliased providers may flatten the typed class to a plain 400.
+    e = BadRequestError(
+        "AnthropicException - Output blocked by content filtering policy",
+        MODEL,
+        PROVIDER,
+    )
+    mapped = map_provider_exception(e)
+    assert isinstance(mapped, LLMContentPolicyViolationError)
+
+
 def test_map_generic_bad_request():
     e = BadRequestError("Some client-side error not related to auth", MODEL, PROVIDER)
     mapped = map_provider_exception(e)
     assert isinstance(mapped, LLMBadRequestError)
+    # A generic 400 must NOT be misclassified as content-policy.
+    assert not isinstance(mapped, LLMContentPolicyViolationError)
 
 
 def test_passthrough_unknown_exception():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

add error for policy error

---

AGENT:

## Why

An Anthropic **output** content-policy block (`litellm.ContentPolicyViolationError`,
HTTP 400 "Output blocked by content filtering policy") currently terminates a
conversation with a fatal `ConversationErrorEvent` (`execution_status=error`).
The run is actually recoverable — the user can send another message — but the UX
is a scary hard error.

Root cause: `ContentPolicyViolationError` subclasses `litellm.BadRequestError`, so
it is **not distinguished** from any other deterministic 400. It is correctly
excluded from retries (`LLM_RETRY_EXCEPTIONS`) and SDK fallback
(`_LLM_FALLBACK_EXCEPTIONS`), but `map_provider_exception` collapses it into the
generic `LLMBadRequestError`, which is none of the typed exceptions `astep`/`step`
catch. It therefore falls through to the `arun`/`run` catch-all that sets `ERROR`
and emits a fatal event.

A bare retry cannot fix it: the block is deterministic in `(messages, model)`, so
re-sending the identical request trips the same output classifier and only burns
tokens. Recovery requires *changing* the request.

## Summary

- Add `LLMContentPolicyViolationError(LLMBadRequestError)` — the subtype keeps
  back-compat for anything catching `LLMBadRequestError` — and
  `is_content_policy_violation()` (typed `isinstance` check + a text-pattern
  fallback for proxied/aliased providers whose typed class is flattened).
- Map content-policy **before** the generic `BadRequestError` branch in
  `map_provider_exception`.
- Handle it in both `step` and `astep` exactly like a malformed function call:
  emit a soft user-message nudge and `return`, so the run loop stays `RUNNING`
  and auto-resumes with a changed request. A model that keeps tripping the filter
  is bounded by the existing stuck detector rather than a fatal event.

## Issue Number

Closes #3798

## How to Test

```
uv run pytest \
  tests/sdk/llm/test_exception_mapping.py \
  tests/sdk/agent/test_agent_content_policy_violation.py -q
```

Result: `14 passed`. The new agent tests assert that a content-policy error in
`step`/`astep` (both Chat and Responses APIs) produces a single soft user-message
nudge containing "content filter" and **no** `ConversationErrorEvent`, and that
`step`/`astep` do not raise. The mapping tests cover the typed exception, the
text-fallback path, and that a generic 400 is *not* misclassified.

Regression check (no behavior change to neighboring exception handling):

```
uv run pytest \
  tests/sdk/llm/test_exception_classifier.py \
  tests/sdk/llm/test_exception.py \
  tests/sdk/agent/test_agent_context_window_condensation.py -q
```

Result: `44 passed`. `pre-commit` (ruff, pycodestyle, pyright, import rules)
passes on all changed files.

**Limitation / not yet done end-to-end:** a live reproduction requires actually
tripping Anthropic's output content filter (the original report observed it while
the agent generated a `CODE_OF_CONDUCT.md`), which is non-deterministic and needs
a real provider key. The change is exercised here by injecting the typed
exception at the LLM boundary, which is the exact point where litellm raises it.
A reviewer with a live Anthropic key can confirm the end-to-end UX by running a
task that reliably trips the filter and verifying the conversation continues
instead of surfacing a hard error.

## Video/Screenshots

N/A — backend-only change; evidence is the test output above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Minimal, provider-independent SDK fix. It does **not** add an LLM-level
  `content_policy_fallbacks` config; that is a separate, optional mitigation best
  filed against `OpenHands/OpenHands-Cloud`, with the caveat that it is **inert
  for single-Anthropic installs** (the fallback target is another `claude-*`
  model that hits the same output filter).
- Applies to both the async (`astep`/`arun`) and sync (`step`/`run`) paths.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f767244-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f767244-python \
  ghcr.io/openhands/agent-server:f767244-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f767244-golang-amd64
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-golang-amd64
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-golang-amd64
ghcr.io/openhands/agent-server:f767244-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f767244-golang-arm64
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-golang-arm64
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-golang-arm64
ghcr.io/openhands/agent-server:f767244-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f767244-java-amd64
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-java-amd64
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-java-amd64
ghcr.io/openhands/agent-server:f767244-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f767244-java-arm64
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-java-arm64
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-java-arm64
ghcr.io/openhands/agent-server:f767244-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f767244-python-amd64
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-python-amd64
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-python-amd64
ghcr.io/openhands/agent-server:f767244-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f767244-python-arm64
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-python-arm64
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-python-arm64
ghcr.io/openhands/agent-server:f767244-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f767244-golang
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-golang
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-golang
ghcr.io/openhands/agent-server:f767244-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f767244-java
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-java
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-java
ghcr.io/openhands/agent-server:f767244-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f767244-python
ghcr.io/openhands/agent-server:f7672441a5be0c78b29da910d1e65fae2e17295d-python
ghcr.io/openhands/agent-server:fix-content-policy-soft-recovery-python
ghcr.io/openhands/agent-server:f767244-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f767244-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f767244-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->