### PR TITLE
feat(marketplace): auto-load user-installed plugins from ~/.openhands (parity with load_user_skills)

### DIFF
--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -120,6 +120,18 @@ class AgentContext(BaseModel):
         ),
         json_schema_extra={"acp_compatible": True},
     )
+    load_user_plugins: bool = Field(
+        default=False,
+        description=(
+            "Whether to automatically load user-installed plugins from "
+            "~/.openhands/plugins/installed/ (managed via install_plugin / "
+            "uninstall_plugin) at conversation startup. This mirrors "
+            "load_user_skills for plugins: like load_project_skills, the flag is "
+            "resolved by LocalConversation on the first run()/send_message() "
+            "rather than by AgentContext itself."
+        ),
+        json_schema_extra={"acp_compatible": True},
+    )
     load_project_skills: bool = Field(
         default=False,
         description=(

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -61,6 +61,7 @@ from openhands.sdk.plugin import (
     PluginSource,
     ResolvedPluginSource,
     fetch_plugin_with_resolution,
+    load_installed_plugins,
 )
 from openhands.sdk.secret import StaticSecret
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
@@ -669,6 +670,17 @@ class LocalConversation(BaseConversation):
         # Track whether we have plugins or MCP config to process
         has_mcp_config = bool(merged_mcp)
 
+        def _merge_loaded_plugin(plugin: Plugin) -> None:
+            """Merge a loaded plugin's skills, MCP config, hooks, and agents."""
+            nonlocal merged_context, merged_mcp, has_mcp_config
+            merged_context = plugin.add_skills_to(merged_context)
+            merged_mcp = plugin.add_mcp_config_to(merged_mcp)
+            has_mcp_config = has_mcp_config or bool(merged_mcp)
+            if plugin.hooks and not plugin.hooks.is_empty():
+                all_plugin_hooks.append(plugin.hooks)
+            if plugin.agents:
+                all_plugin_agents.extend(plugin.agents)
+
         plugins_to_load: list[tuple[PluginSource, bool]] = []
         if merged_context is not None and merged_context.registered_marketplaces:
             registrations = [
@@ -745,19 +757,43 @@ class LocalConversation(BaseConversation):
                 )
 
                 # Merge plugin contents
-                merged_context = plugin.add_skills_to(merged_context)
-                merged_mcp = plugin.add_mcp_config_to(merged_mcp)
-                has_mcp_config = has_mcp_config or bool(merged_mcp)
-
-                # Collect hooks
-                if plugin.hooks and not plugin.hooks.is_empty():
-                    all_plugin_hooks.append(plugin.hooks)
-
-                # Collect agent definitions
-                if plugin.agents:
-                    all_plugin_agents.extend(plugin.agents)
+                _merge_loaded_plugin(plugin)
 
             logger.info(f"Loaded {len(plugins_to_load)} plugin(s) via Conversation")
+
+        # Auto-load user-installed plugins from ~/.openhands/plugins/installed/
+        # (parity with AgentContext.load_user_skills). These plugins are already
+        # on disk and version-pinned by install_plugin, so they are loaded
+        # directly rather than fetched, and are not added to _resolved_plugins.
+        # Best-effort: a failure to load/merge an installed plugin must not
+        # prevent the conversation from starting.
+        user_plugins_loaded = False
+        if merged_context is not None and merged_context.load_user_plugins:
+            try:
+                installed_plugins = load_installed_plugins()
+            except Exception:
+                logger.warning(
+                    "Failed to load user-installed plugins; continuing without them",
+                    exc_info=True,
+                )
+                installed_plugins = []
+            for plugin in installed_plugins:
+                try:
+                    _merge_loaded_plugin(plugin)
+                except Exception:
+                    logger.warning(
+                        "Failed to merge installed plugin '%s'; skipping",
+                        getattr(plugin, "name", "<unknown>"),
+                        exc_info=True,
+                    )
+                    continue
+                user_plugins_loaded = True
+            if installed_plugins:
+                logger.info(
+                    "Loaded %d user-installed plugin(s) from "
+                    "~/.openhands/plugins/installed/",
+                    len(installed_plugins),
+                )
 
         # Resolve project skills from the workspace. AgentContext can't do this
         # itself (the workspace path is unknown at validation time), so it is done
@@ -810,7 +846,12 @@ class LocalConversation(BaseConversation):
 
         # Update agent with merged content only if something changed.
         # Skip update otherwise to avoid unnecessary agent state mutations.
-        if plugins_to_load or has_mcp_config or project_skills_loaded:
+        if (
+            plugins_to_load
+            or has_mcp_config
+            or project_skills_loaded
+            or user_plugins_loaded
+        ):
             self.agent = self.agent.model_copy(
                 update={
                     "agent_context": merged_context,

--- a/tests/sdk/context/test_agent_context.py
+++ b/tests/sdk/context/test_agent_context.py
@@ -1123,3 +1123,14 @@ def test_agent_context_secrets_static_secret_still_masked():
     assert "static-secret" not in context.model_dump_json()
     exposed = context.model_dump(context={"expose_secrets": True})
     assert exposed["secrets"]["TOKEN"]["value"] == "static-secret"
+
+
+def test_load_user_plugins_defaults_false_and_is_settable():
+    """load_user_plugins mirrors load_user_skills: opt-in, default False."""
+    assert AgentContext().load_user_plugins is False
+    assert AgentContext(load_user_plugins=True).load_user_plugins is True
+    # Round-trips through serialization like the other plugin/skill flags.
+    restored = AgentContext.model_validate(
+        AgentContext(load_user_plugins=True).model_dump()
+    )
+    assert restored.load_user_plugins is True

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -14,7 +14,11 @@ from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.hooks.config import HookDefinition, HookMatcher
 from openhands.sdk.marketplace import MarketplaceRegistration
-from openhands.sdk.plugin import PluginSource
+from openhands.sdk.plugin import (
+    PluginSource,
+    install_plugin,
+    load_installed_plugins as real_load_installed_plugins,
+)
 from openhands.sdk.tool.builtins import ThinkTool
 
 
@@ -1353,5 +1357,129 @@ class TestPluginSourceSecretExpansion:
             conversation._ensure_plugins_loaded()
 
         assert captured["ref"] == "v1.2.3"
+
+        conversation.close()
+
+
+class TestLocalConversationUserPlugins:
+    """Tests for auto-loading user-installed plugins.
+
+    Mirrors AgentContext.load_user_skills, but for plugins installed under
+    ~/.openhands/plugins/installed/ (managed via install_plugin). The default
+    installed dir is monkeypatched to a temp dir so tests stay hermetic.
+    """
+
+    def _install_test_plugin(
+        self,
+        tmp_path: Path,
+        installed_dir: Path,
+        name: str,
+        skill_name: str,
+    ) -> None:
+        plugin_src = create_test_plugin(
+            tmp_path / f"src-{name}",
+            name=name,
+            skills=[{"name": skill_name, "content": f"{skill_name} content"}],
+        )
+        install_plugin(source=str(plugin_src), installed_dir=installed_dir)
+
+    def test_load_user_plugins_loads_installed_plugins(
+        self, tmp_path: Path, mock_llm, monkeypatch
+    ):
+        """load_user_plugins=True merges installed plugins' skills at startup."""
+        installed_dir = tmp_path / "installed"
+        installed_dir.mkdir()
+        self._install_test_plugin(tmp_path, installed_dir, "user-plugin", "user-skill")
+
+        monkeypatch.setattr(
+            local_conversation_impl,
+            "load_installed_plugins",
+            lambda: real_load_installed_plugins(installed_dir=installed_dir),
+        )
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(load_user_plugins=True),
+        )
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+        conversation._ensure_plugins_loaded()
+
+        assert conversation.agent.agent_context is not None
+        skill_names = [s.name for s in conversation.agent.agent_context.skills]
+        assert "user-skill" in skill_names
+        # Installed plugins are local and version-pinned on disk, so they are not
+        # tracked as resolved remote sources for deterministic resume.
+        assert not conversation.resolved_plugins
+
+        conversation.close()
+
+    def test_load_user_plugins_disabled_by_default(
+        self, tmp_path: Path, mock_llm, monkeypatch
+    ):
+        """With the default (False), installed plugins are not even queried."""
+        installed_dir = tmp_path / "installed"
+        installed_dir.mkdir()
+        self._install_test_plugin(tmp_path, installed_dir, "user-plugin", "user-skill")
+
+        calls = {"n": 0}
+
+        def _tracking_loader():
+            calls["n"] += 1
+            return real_load_installed_plugins(installed_dir=installed_dir)
+
+        monkeypatch.setattr(
+            local_conversation_impl, "load_installed_plugins", _tracking_loader
+        )
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(llm=mock_llm, tools=[], agent_context=AgentContext())
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+        conversation._ensure_plugins_loaded()
+
+        assert calls["n"] == 0
+        context = conversation.agent.agent_context
+        skill_names = [s.name for s in context.skills] if context else []
+        assert "user-skill" not in skill_names
+
+        conversation.close()
+
+    def test_load_user_plugins_best_effort_on_loader_error(
+        self, tmp_path: Path, mock_llm, monkeypatch
+    ):
+        """A failing installed-plugin load must not block conversation startup."""
+
+        def _boom():
+            raise RuntimeError("installed plugins unreadable")
+
+        monkeypatch.setattr(local_conversation_impl, "load_installed_plugins", _boom)
+
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        agent = Agent(
+            llm=mock_llm,
+            tools=[],
+            agent_context=AgentContext(load_user_plugins=True),
+        )
+        conversation = LocalConversation(
+            agent=agent,
+            workspace=workspace,
+            visualizer=None,
+        )
+
+        # Should not raise despite the loader error.
+        conversation._ensure_plugins_loaded()
+        assert conversation._plugins_loaded is True
 
         conversation.close()


### PR DESCRIPTION
## Why

The marketplace-registration stack (#3824–#3831) gave plugins a great deal of new loading machinery (registry, registered-marketplace auto-load, runtime `load_plugin`, agent-server APIs). But it left one asymmetry with **skills**: there is no startup path that auto-loads **user-installed** plugins from `~/.openhands/plugins/installed/` the way `AgentContext.load_user_skills` does for skills.

Today:

| Capability | Skills | Plugins (before this PR) |
|---|---|---|
| `install_*` → `~/.openhands/.../installed/` | ✅ | ✅ |
| `list/load_installed_*` API | ✅ | ✅ |
| Auto-loaded at conversation startup from home | ✅ (`load_user_skills`) | ❌ **missing** |
| Auto-load from registered marketplaces | ✅ | ✅ (this stack) |

`LocalConversation._ensure_plugins_loaded()` only loaded plugins from (1) `registered_marketplaces` with `auto_load=True` and (2) explicit `plugins=[...]` specs — it never read the installed-plugins home dir. The only callers of `load_installed_plugins()` were an example. This is the gap where Claude Code supports "drop a plugin in your home dir and it's picked up," and we did not.

## What changed

- **`AgentContext.load_user_plugins: bool`** (default `False`) — opt-in, mirroring `load_user_skills`. Like `load_project_skills`, it is resolved lazily by `LocalConversation` (the workspace/runtime context isn't known at `AgentContext` validation time).
- **`LocalConversation._ensure_plugins_loaded()`** — after marketplace/explicit plugin loading, if `load_user_plugins` is set, merge enabled installed plugins via `load_installed_plugins()`. Installed plugins are already on disk and version-pinned by `install_plugin`, so they are **loaded directly (not fetched)** and are **not** added to `_resolved_plugins` (which tracks remote sources for deterministic resume). Loading is **best-effort** so a single broken installed plugin can't block conversation startup (same guard pattern as `load_user_skills` / project-skills).
- Refactored the per-plugin merge (skills / MCP / hooks / agents) into a local `_merge_loaded_plugin` helper reused by both the fetched-plugin loop and the new installed-plugin path — no behavior change for existing plugin loading.

### Precedence / semantics
Installed plugins are merged after marketplace/explicit plugins using the same `add_skills_to` / `add_mcp_config_to` / hook / agent merge as fetched plugins, so behavior is consistent with the existing plugin path. Default is `False`, so this is fully opt-in and non-breaking.

## Tests

- `tests/sdk/conversation/test_local_conversation_plugins.py::TestLocalConversationUserPlugins`
  - `test_load_user_plugins_loads_installed_plugins` — installs a plugin into a temp installed dir and asserts its skill is merged into the agent context; confirms it is not tracked in `resolved_plugins`.
  - `test_load_user_plugins_disabled_by_default` — with the default flag the installed-plugins loader is **not even queried**.
  - `test_load_user_plugins_best_effort_on_loader_error` — a failing loader does not block startup.
- `tests/sdk/context/test_agent_context.py::test_load_user_plugins_defaults_false_and_is_settable` — default/serialization round-trip.

```bash
uv run pytest tests/sdk/conversation/test_local_conversation_plugins.py tests/sdk/context/test_agent_context.py -q
# broader: tests/sdk/context tests/sdk/marketplace tests/sdk/plugin tests/sdk/conversation all green (1247 passed)
uv run pre-commit run --files \
  openhands-sdk/openhands/sdk/context/agent_context.py \
  openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py \
  tests/sdk/conversation/test_local_conversation_plugins.py \
  tests/sdk/context/test_agent_context.py
```

## Notes / scope

- Based on `main` (the marketplace foundation #3824–#3826 is already merged and released in v1.29.2), so this can land independently as a sibling follow-up to the open stack rather than being stacked behind the in-flight PRs.
- No agent-server API surface added here (SDK-local parity only); exposing `load_user_plugins` through the `/api/skills`-style request models could be a natural follow-up, matching how `load_user_skills` is surfaced.

_This PR was created by an AI agent (OpenHands) on behalf of @jpshackelford._

@jpshackelford can click here to [continue refining the PR](https://app.all-hands.dev/conversations/94d97af6-b24a-4f3c-a84d-50735693826d)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:986e075-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-986e075-python \
  ghcr.io/openhands/agent-server:986e075-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:986e075-golang-amd64
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-golang-amd64
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-golang-amd64
ghcr.io/openhands/agent-server:986e075-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:986e075-golang-arm64
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-golang-arm64
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-golang-arm64
ghcr.io/openhands/agent-server:986e075-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:986e075-java-amd64
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-java-amd64
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-java-amd64
ghcr.io/openhands/agent-server:986e075-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:986e075-java-arm64
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-java-arm64
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-java-arm64
ghcr.io/openhands/agent-server:986e075-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:986e075-python-amd64
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-python-amd64
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-python-amd64
ghcr.io/openhands/agent-server:986e075-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:986e075-python-arm64
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-python-arm64
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-python-arm64
ghcr.io/openhands/agent-server:986e075-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:986e075-golang
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-golang
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-golang
ghcr.io/openhands/agent-server:986e075-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:986e075-java
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-java
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-java
ghcr.io/openhands/agent-server:986e075-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:986e075-python
ghcr.io/openhands/agent-server:986e0750ad165a582a7b313650d47eb7b68d34b4-python
ghcr.io/openhands/agent-server:feat-marketplace-load-user-plugins-python
ghcr.io/openhands/agent-server:986e075-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `986e075-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `986e075-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->