### PR TITLE
Notify proj-agent when SDK release prep starts

### DIFF
--- a/.agents/skills/sdk-release/SKILL.md
+++ b/.agents/skills/sdk-release/SKILL.md
@@ -4,13 +4,13 @@ description: >-
   This skill should be used when the user asks to "release the SDK",
   "prepare a release", "publish a new version", "cut a release",
   "do a release", or mentions the SDK release checklist or release process.
-  Guides through the full software-agent-sdk release workflow
+  Guides through the full agent-sdk release workflow
   from version bump to PyPI publication, emphasizing human checkpoints.
 ---
 
 # SDK Release Guide
 
-This skill walks through the software-agent-sdk release process step by step.
+This skill walks through the agent-sdk release process step by step.
 
 > **🚨 CRITICAL**: NEVER merge the release PR or create/publish a GitHub
 > release without the human's explicit approval. Release is the last line
@@ -26,7 +26,7 @@ automatically.
 ### Via GitHub UI
 
 Navigate to
-<https://github.com/OpenHands/software-agent-sdk/actions/workflows/prepare-release.yml>,
+<https://github.com/OpenHands/agent-sdk/actions/workflows/prepare-release.yml>,
 click **Run workflow**, enter the version (e.g. `1.16.0`), and run it.
 
 ### Via GitHub API
@@ -35,7 +35,7 @@ click **Run workflow**, enter the version (e.g. `1.16.0`), and run it.
 curl -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/OpenHands/software-agent-sdk/actions/workflows/prepare-release.yml/dispatches" \
+  "https://api.github.com/repos/OpenHands/agent-sdk/actions/workflows/prepare-release.yml/dispatches" \
   -d '{
     "ref": "main",
     "inputs": {
@@ -51,13 +51,14 @@ The workflow will:
 4. Update the `sdk_ref` default in the eval workflow
 5. Open a PR titled **"Release v\<version\>"** with labels
    `integration-test`, `behavior-test`, and `test-examples`
+6. Notify `#proj-agent` with the release PR link and workflow actor
 
 ### ⏸ Checkpoint — Confirm PR Created
 
 Verify the PR exists and the version changes look correct before continuing.
 
 ```bash
-gh pr list --repo OpenHands/software-agent-sdk \
+gh pr list --repo OpenHands/agent-sdk \
   --head "rel-<version>" --json number,title,url
 ```
 
@@ -86,7 +87,7 @@ The release PR triggers three labeled test suites. **All three must pass.**
 Monitor status:
 
 ```bash
-gh pr checks <PR_NUMBER> --repo OpenHands/software-agent-sdk
+gh pr checks <PR_NUMBER> --repo OpenHands/agent-sdk
 ```
 
 ### ⏸ Checkpoint — Human Judgment on Failures
@@ -101,11 +102,11 @@ Re-run failed jobs:
 
 ```bash
 # Find the run ID
-gh run list --repo OpenHands/software-agent-sdk \
+gh run list --repo OpenHands/agent-sdk \
   --branch "rel-<version>" --limit 5
 
 # Re-run failed jobs
-gh run rerun <RUN_ID> --repo OpenHands/software-agent-sdk --failed
+gh run rerun <RUN_ID> --repo OpenHands/agent-sdk --failed
 ```
 
 ## Phase 4: Run Evaluation (Optional but Recommended)
@@ -118,7 +119,7 @@ details.
 curl -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/OpenHands/software-agent-sdk/actions/workflows/run-eval.yml/dispatches" \
+  "https://api.github.com/repos/OpenHands/agent-sdk/actions/workflows/run-eval.yml/dispatches" \
   -d '{
     "ref": "main",
     "inputs": {
@@ -146,7 +147,7 @@ drops should block the release.
 Once the human approves:
 
 ```bash
-gh pr merge <PR_NUMBER> --repo OpenHands/software-agent-sdk --merge
+gh pr merge <PR_NUMBER> --repo OpenHands/agent-sdk --merge
 ```
 
 ## Phase 6: Automated Release Pipeline (no action needed)
@@ -188,7 +189,7 @@ Version bump PRs:
 • <https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands>
 • <https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands-CLI>
 
-Release: <https://github.com/OpenHands/software-agent-sdk/releases/tag/v<version>|v<version>>
+Release: <https://github.com/OpenHands/agent-sdk/releases/tag/v<version>|v<version>>
 ```
 
 See `references/post-release-checklist.md` for details on reviewing

--- a/.agents/skills/sdk-release/SKILL.md
+++ b/.agents/skills/sdk-release/SKILL.md
@@ -4,13 +4,13 @@ description: >-
   This skill should be used when the user asks to "release the SDK",
   "prepare a release", "publish a new version", "cut a release",
   "do a release", or mentions the SDK release checklist or release process.
-  Guides through the full agent-sdk release workflow
+  Guides through the full software-agent-sdk release workflow
   from version bump to PyPI publication, emphasizing human checkpoints.
 ---
 
 # SDK Release Guide
 
-This skill walks through the agent-sdk release process step by step.
+This skill walks through the software-agent-sdk release process step by step.
 
 > **🚨 CRITICAL**: NEVER merge the release PR or create/publish a GitHub
 > release without the human's explicit approval. Release is the last line
@@ -26,7 +26,7 @@ automatically.
 ### Via GitHub UI
 
 Navigate to
-<https://github.com/OpenHands/agent-sdk/actions/workflows/prepare-release.yml>,
+<https://github.com/OpenHands/software-agent-sdk/actions/workflows/prepare-release.yml>,
 click **Run workflow**, enter the version (e.g. `1.16.0`), and run it.
 
 ### Via GitHub API
@@ -35,7 +35,7 @@ click **Run workflow**, enter the version (e.g. `1.16.0`), and run it.
 curl -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/OpenHands/agent-sdk/actions/workflows/prepare-release.yml/dispatches" \
+  "https://api.github.com/repos/OpenHands/software-agent-sdk/actions/workflows/prepare-release.yml/dispatches" \
   -d '{
     "ref": "main",
     "inputs": {
@@ -58,7 +58,7 @@ The workflow will:
 Verify the PR exists and the version changes look correct before continuing.
 
 ```bash
-gh pr list --repo OpenHands/agent-sdk \
+gh pr list --repo OpenHands/software-agent-sdk \
   --head "rel-<version>" --json number,title,url
 ```
 
@@ -87,7 +87,7 @@ The release PR triggers three labeled test suites. **All three must pass.**
 Monitor status:
 
 ```bash
-gh pr checks <PR_NUMBER> --repo OpenHands/agent-sdk
+gh pr checks <PR_NUMBER> --repo OpenHands/software-agent-sdk
 ```
 
 ### ⏸ Checkpoint — Human Judgment on Failures
@@ -102,11 +102,11 @@ Re-run failed jobs:
 
 ```bash
 # Find the run ID
-gh run list --repo OpenHands/agent-sdk \
+gh run list --repo OpenHands/software-agent-sdk \
   --branch "rel-<version>" --limit 5
 
 # Re-run failed jobs
-gh run rerun <RUN_ID> --repo OpenHands/agent-sdk --failed
+gh run rerun <RUN_ID> --repo OpenHands/software-agent-sdk --failed
 ```
 
 ## Phase 4: Run Evaluation (Optional but Recommended)
@@ -119,7 +119,7 @@ details.
 curl -X POST \
   -H "Authorization: token $GITHUB_TOKEN" \
   -H "Accept: application/vnd.github+json" \
-  "https://api.github.com/repos/OpenHands/agent-sdk/actions/workflows/run-eval.yml/dispatches" \
+  "https://api.github.com/repos/OpenHands/software-agent-sdk/actions/workflows/run-eval.yml/dispatches" \
   -d '{
     "ref": "main",
     "inputs": {
@@ -147,7 +147,7 @@ drops should block the release.
 Once the human approves:
 
 ```bash
-gh pr merge <PR_NUMBER> --repo OpenHands/agent-sdk --merge
+gh pr merge <PR_NUMBER> --repo OpenHands/software-agent-sdk --merge
 ```
 
 ## Phase 6: Automated Release Pipeline (no action needed)
@@ -189,7 +189,7 @@ Version bump PRs:
 • <https://github.com/All-Hands-AI/OpenHands/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands>
 • <https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-<version>|OpenHands-CLI>
 
-Release: <https://github.com/OpenHands/agent-sdk/releases/tag/v<version>|v<version>>
+Release: <https://github.com/OpenHands/software-agent-sdk/releases/tag/v<version>|v<version>>
 ```
 
 See `references/post-release-checklist.md` for details on reviewing

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,6 +12,8 @@ on:
 jobs:
     prepare-release:
         runs-on: ubuntu-24.04
+        env:
+            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         steps:
             - name: Validate version format
               env:
@@ -78,19 +80,24 @@ jobs:
                   echo "✅ Branch pushed: $BRANCH_NAME"
 
             - name: Create Pull Request
+              id: create_pr
               env:
                   GH_TOKEN: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PUBLIC }}
+                  GITHUB_ACTOR: ${{ github.actor }}
                   INPUTS_VERSION: ${{ inputs.version }}
               run: |
                   python3 << 'PY'
                   import os
                   from pathlib import Path
 
+                  actor = os.environ["GITHUB_ACTOR"]
                   version = os.environ["INPUTS_VERSION"]
                   Path("pr_body.txt").write_text(
                       f"""## Release v{version}
 
                   This PR prepares the release for version **{version}**.
+
+                  **Started by:** @{actor}
 
                   ### Release Checklist
                   - [x] Version set to {version}
@@ -126,6 +133,17 @@ jobs:
                   PR_URL=$(gh pr view "$BRANCH_NAME" --json url --jq '.url')
                   echo "🔗 PR URL: $PR_URL"
                   echo "PR_URL=$PR_URL" >> $GITHUB_ENV
+                  echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
+
+            - name: Notify Slack
+              if: env.SLACK_BOT_TOKEN != ''
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                  method: chat.postMessage
+                  token: ${{ env.SLACK_BOT_TOKEN }}
+                  payload: |
+                      channel: "#proj-agent"
+                      text: "🛠️ *SDK v${{ inputs.version }} release preparation started*\n\nRelease PR: <${{ steps.create_pr.outputs.pr_url }}|Release v${{ inputs.version }}>\nStarted by: <${{ github.server_url }}/${{ github.actor }}|@${{ github.actor }}>\nRepo: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
 
             - name: Summary
               env:

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -12,8 +12,6 @@ on:
 jobs:
     prepare-release:
         runs-on: ubuntu-24.04
-        env:
-            SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
         steps:
             - name: Validate version format
               env:
@@ -135,12 +133,23 @@ jobs:
                   echo "PR_URL=$PR_URL" >> $GITHUB_ENV
                   echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
+            - name: Check Slack token availability
+              id: slack_token
+              env:
+                  SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+              run: |
+                  if [ -n "$SLACK_BOT_TOKEN" ]; then
+                    echo "available=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "available=false" >> "$GITHUB_OUTPUT"
+                  fi
+
             - name: Notify Slack
-              if: env.SLACK_BOT_TOKEN != ''
+              if: steps.slack_token.outputs.available == 'true'
               uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
                   method: chat.postMessage
-                  token: ${{ env.SLACK_BOT_TOKEN }}
+                  token: ${{ secrets.SLACK_BOT_TOKEN }}
                   payload: |
                       channel: "#proj-agent"
                       text: "🛠️ *SDK v${{ inputs.version }} release preparation started*\n\nRelease PR: <${{ steps.create_pr.outputs.pr_url }}|Release v${{ inputs.version }}>\nStarted by: <${{ github.server_url }}/${{ github.actor }}|@${{ github.actor }}>\nRepo: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
This PR proposes to add a Slack message to `#proj-agent` when a release preparation workflow is started.

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
_This PR was created by an AI agent (OpenHands) on behalf of the user._

## Why

Release preparation currently creates the release PR, but the project channel does not get a notification until later in the release process. The team asked to notify `#proj-agent` as soon as an agent-sdk release starts preparation, including the release PR and the person who triggered the workflow.

## Summary

- Post a Slack message to `#proj-agent` after `prepare-release.yml` creates the release PR.
- Include the release PR link, repository link, and `github.actor` so the notification captures the human workflow dispatcher (for example, `tofarr` on the most recent release prep run).
- Add `Started by: @<actor>` to the generated release PR body and update the SDK release skill docs for the notification and `agent-sdk` repo references.

## Issue Number

N/A

## How to Test

Ran:

```bash
uv run pre-commit run --files .github/workflows/prepare-release.yml .agents/skills/sdk-release/SKILL.md
```

Result: passed.

I also inspected the most recent release PR (#3853) and its `prepare-release.yml` workflow run through the GitHub API. The PR author was `all-hands-bot`, while the workflow actor was `tofarr`, confirming that `github.actor` captures the starter we want to report.

## Video/Screenshots

N/A — workflow-only change.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

The PR description check still needs a human-authored note in the `HUMAN:` section before it can pass; the repository template explicitly instructs AI agents not to edit that section.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a344ad7-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a344ad7-python \
  ghcr.io/openhands/agent-server:a344ad7-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a344ad7-golang-amd64
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-golang-amd64
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-golang-amd64
ghcr.io/openhands/agent-server:a344ad7-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a344ad7-golang-arm64
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-golang-arm64
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-golang-arm64
ghcr.io/openhands/agent-server:a344ad7-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a344ad7-java-amd64
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-java-amd64
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-java-amd64
ghcr.io/openhands/agent-server:a344ad7-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a344ad7-java-arm64
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-java-arm64
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-java-arm64
ghcr.io/openhands/agent-server:a344ad7-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a344ad7-python-amd64
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-python-amd64
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-python-amd64
ghcr.io/openhands/agent-server:a344ad7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a344ad7-python-arm64
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-python-arm64
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-python-arm64
ghcr.io/openhands/agent-server:a344ad7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a344ad7-golang
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-golang
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-golang
ghcr.io/openhands/agent-server:a344ad7-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a344ad7-java
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-java
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-java
ghcr.io/openhands/agent-server:a344ad7-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a344ad7-python
ghcr.io/openhands/agent-server:a344ad7eea8719cd1ff15c685b14b58a6ce9cc80-python
ghcr.io/openhands/agent-server:notify-sdk-release-prep-slack-python
ghcr.io/openhands/agent-server:a344ad7-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a344ad7-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a344ad7-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->