### PR TITLE
Skip integration setup for unrelated labels

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -4,8 +4,8 @@ run-name: >-
     Run Integration Tests ${{ inputs.reason || github.event.label.name || 'scheduled' }}
 
 on:
-    # Use pull_request_target to access secrets even on fork PRs
-    # This is safe because we only run when the 'integration-test' label is added by a maintainer
+    # Use pull_request_target to access secrets even on fork PRs.
+    # Labeled PR runs are gated per job to integration-test and behavior-test.
     pull_request_target:
         types:
             - labeled
@@ -54,6 +54,10 @@ env:
 
 jobs:
     setup-matrix:
+        if: >-
+            github.event_name != 'pull_request_target' ||
+            github.event.label.name == 'integration-test' ||
+            github.event.label.name == 'behavior-test'
         runs-on: ubuntu-latest
         outputs:
             matrix: ${{ steps.resolve-models.outputs.matrix }}


### PR DESCRIPTION
HUMAN:

Please skip integration setup for unrelated labels before it checks out evaluation.

---

AGENT:
_This PR was created by an AI agent (OpenHands) on behalf of the user._

## Why

The `Run Integration Tests` workflow triggers on every `pull_request_target` labeled event. Adding an unrelated label like `review-this` starts the workflow and currently lets `setup-matrix` try to checkout `OpenHands/evaluation`, which can fail before the workflow reaches later label-specific skips.

## Summary

- Gate the `setup-matrix` job so pull-request label events only proceed for `integration-test` or `behavior-test`.
- Keep workflow_dispatch and scheduled runs unaffected.
- Update the top-level workflow comment to match the actual per-job label gating.

## Issue Number

N/A

## How to Test

Ran:

```bash
uv run pre-commit run --files .github/workflows/integration-runner.yml
git diff --check
```

Both passed. `actionlint` is not installed in this environment, so it could not be run locally.

## Video/Screenshots

N/A — workflow-only change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This should make labels such as `review-this` skip the integration workflow faster, before any evaluation checkout or model setup work runs.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8d84f04c-ecd8-471a-9909-ee4ea5251ac2)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:41d982c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-41d982c-python \
  ghcr.io/openhands/agent-server:41d982c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:41d982c-golang-amd64
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-golang-amd64
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-golang-amd64
ghcr.io/openhands/agent-server:41d982c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:41d982c-golang-arm64
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-golang-arm64
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-golang-arm64
ghcr.io/openhands/agent-server:41d982c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:41d982c-java-amd64
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-java-amd64
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-java-amd64
ghcr.io/openhands/agent-server:41d982c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:41d982c-java-arm64
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-java-arm64
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-java-arm64
ghcr.io/openhands/agent-server:41d982c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:41d982c-python-amd64
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-python-amd64
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-python-amd64
ghcr.io/openhands/agent-server:41d982c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:41d982c-python-arm64
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-python-arm64
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-python-arm64
ghcr.io/openhands/agent-server:41d982c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:41d982c-golang
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-golang
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-golang
ghcr.io/openhands/agent-server:41d982c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:41d982c-java
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-java
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-java
ghcr.io/openhands/agent-server:41d982c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:41d982c-python
ghcr.io/openhands/agent-server:41d982ca9a45b5c7d3305cdefbf951ed53474a86-python
ghcr.io/openhands/agent-server:fix-integration-runner-label-gate-python
ghcr.io/openhands/agent-server:41d982c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `41d982c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `41d982c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->