### PR TITLE
Expose conversation observability span names on agent server

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -823,6 +823,7 @@ class EventService:
             user_id=self.stored.user_id,
             observability_metadata=self.stored.observability_metadata,
             observability_tags=self.stored.observability_tags,
+            observability_span_name=self.stored.observability_span_name,
         )
 
         conversation.set_confirmation_policy(self.stored.confirmation_policy)

--- a/openhands-agent-server/openhands/agent_server/openai/router.py
+++ b/openhands-agent-server/openhands/agent_server/openai/router.py
@@ -1,11 +1,13 @@
 """OpenAI-compatible gateway routes for the agent server."""
 
+import json
 from typing import Annotated
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response, status
 from fastapi.responses import StreamingResponse
 from fastapi.security import APIKeyHeader, HTTPAuthorizationCredentials, HTTPBearer
+from pydantic import TypeAdapter, ValidationError
 
 from openhands.agent_server.config import Config
 from openhands.agent_server.conversation_service import ConversationService
@@ -20,12 +22,20 @@ from openhands.agent_server.openai.service import (
     list_openai_models,
     run_chat_completion,
 )
+from openhands.sdk.conversation.types import (
+    ConversationObservabilityMetadata,
+    ConversationObservabilitySpanName,
+    ConversationObservabilityTags,
+)
 
 
 openai_router = APIRouter(tags=["OpenAI Compatibility"])
 
 _SESSION_API_KEY_HEADER = APIKeyHeader(name="X-Session-API-Key", auto_error=False)
 _AUTHORIZATION_HEADER = HTTPBearer(auto_error=False)
+_OBSERVABILITY_SPAN_NAME_ADAPTER = TypeAdapter(ConversationObservabilitySpanName)
+_OBSERVABILITY_TAGS_ADAPTER = TypeAdapter(ConversationObservabilityTags)
+_OBSERVABILITY_METADATA_ADAPTER = TypeAdapter(ConversationObservabilityMetadata)
 
 
 def check_openai_api_key(
@@ -66,6 +76,41 @@ def _get_config(request: Request) -> Config:
     return config
 
 
+def _parse_observability_overrides(
+    *,
+    span_name: str | None,
+    tags: str | None,
+    metadata: str | None,
+) -> dict[str, object]:
+    overrides: dict[str, object] = {}
+    try:
+        if span_name:
+            overrides["observability_span_name"] = (
+                _OBSERVABILITY_SPAN_NAME_ADAPTER.validate_python(span_name)
+            )
+        if tags:
+            tag_values = [tag.strip() for tag in tags.split(",") if tag.strip()]
+            overrides["observability_tags"] = (
+                _OBSERVABILITY_TAGS_ADAPTER.validate_python(tag_values)
+            )
+        if metadata:
+            metadata_payload = json.loads(metadata)
+            overrides["observability_metadata"] = (
+                _OBSERVABILITY_METADATA_ADAPTER.validate_python(metadata_payload)
+            )
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail="X-OpenHands-Observability-Metadata must be a JSON object",
+        ) from exc
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail=exc.errors(),
+        ) from exc
+    return overrides
+
+
 @openai_router.get("/v1/models", response_model=OpenAIModelListResponse)
 async def get_openai_models(request: Request) -> OpenAIModelListResponse:
     _get_config(request)
@@ -84,6 +129,15 @@ async def create_chat_completion(
     x_openhands_server_conversation_id: Annotated[
         UUID | None, Header(alias="X-OpenHands-ServerConversation-ID")
     ] = None,
+    x_openhands_observability_span_name: Annotated[
+        str | None, Header(alias="X-OpenHands-Observability-Span-Name")
+    ] = None,
+    x_openhands_observability_tags: Annotated[
+        str | None, Header(alias="X-OpenHands-Observability-Tags")
+    ] = None,
+    x_openhands_observability_metadata: Annotated[
+        str | None, Header(alias="X-OpenHands-Observability-Metadata")
+    ] = None,
     conversation_service: ConversationService = Depends(get_conversation_service),
 ) -> OpenAIChatCompletionResponse | StreamingResponse:
     result = await run_chat_completion(
@@ -91,6 +145,11 @@ async def create_chat_completion(
         config=_get_config(request),
         conversation_service=conversation_service,
         reusable_conversation_id=x_openhands_server_conversation_id,
+        observability_overrides=_parse_observability_overrides(
+            span_name=x_openhands_observability_span_name,
+            tags=x_openhands_observability_tags,
+            metadata=x_openhands_observability_metadata,
+        ),
     )
     conversation_id = str(result.conversation_id)
     if body.stream:

--- a/openhands-agent-server/openhands/agent_server/openai/router.py
+++ b/openhands-agent-server/openhands/agent_server/openai/router.py
@@ -106,7 +106,7 @@ def _parse_observability_overrides(
     except ValidationError as exc:
         raise HTTPException(
             status_code=422,
-            detail=exc.errors(),
+            detail=exc.errors(include_context=False),
         ) from exc
     return overrides
 

--- a/openhands-agent-server/openhands/agent_server/openai/service.py
+++ b/openhands-agent-server/openhands/agent_server/openai/service.py
@@ -398,6 +398,7 @@ async def run_chat_completion(
     config: Config,
     conversation_service: ConversationService,
     reusable_conversation_id: UUID | None,
+    observability_overrides: dict[str, object] | None = None,
 ) -> OpenAIChatCompletionResult:
     if request.stream:
         # SSE streaming needs incremental agent-event forwarding; add it separately.
@@ -411,6 +412,8 @@ async def run_chat_completion(
         config=config,
         conversation_id=reusable_conversation_id,
     )
+    if observability_overrides:
+        start_request = start_request.model_copy(update=observability_overrides)
     event_service = None
     conversation_id = reusable_conversation_id
     min_event_count: int | None = None

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -173,7 +173,8 @@ class BaseConversation(ABC):
         """End the observability span if it hasn't been ended already."""
         if self._span_ended:
             return
-        end_root_span(self._observability_root_span)
+        if self._observability_root_span is not None:
+            end_root_span(self._observability_root_span)
         self._observability_root_span = None
         self._span_ended = True
 

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -139,6 +139,7 @@ class BaseConversation(ABC):
     def _start_observability_span(
         self,
         session_id: str,
+        span_name: str = "conversation",
         user_id: str | None = None,
         metadata: dict[str, TraceMetadataValue] | None = None,
         tags: list[str] | None = None,
@@ -148,6 +149,7 @@ class BaseConversation(ABC):
 
         Args:
             session_id: The session ID to associate with the trace
+            span_name: Name for the root span. Keep this low-cardinality.
             user_id: Optional user ID to associate with the trace
             metadata: Optional trace-level metadata to attach to observability backends
             tags: Optional span tags to attach to the conversation root span
@@ -159,7 +161,7 @@ class BaseConversation(ABC):
             # Idempotent: never start two roots for one conversation.
             return
         self._observability_root_span = start_root_span(
-            "conversation",
+            span_name,
             session_id=session_id,
             user_id=user_id,
             metadata=metadata,

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -18,6 +18,7 @@ from openhands.sdk.observability.laminar import (
     RootSpan,
     end_root_span,
     should_enable_observability,
+    start_child_span,
     start_root_span,
 )
 from openhands.sdk.security.analyzer import SecurityAnalyzerBase
@@ -149,7 +150,7 @@ class BaseConversation(ABC):
 
         Args:
             session_id: The session ID to associate with the trace
-            span_name: Name for the root span. Keep this low-cardinality.
+            span_name: Optional child span name to emit under the conversation root.
             user_id: Optional user ID to associate with the trace
             metadata: Optional trace-level metadata to attach to observability backends
             tags: Optional span tags to attach to the conversation root span
@@ -161,13 +162,15 @@ class BaseConversation(ABC):
             # Idempotent: never start two roots for one conversation.
             return
         self._observability_root_span = start_root_span(
-            span_name,
+            "conversation",
             session_id=session_id,
             user_id=user_id,
             metadata=metadata,
             tags=tags,
             attributes=_conversation_tag_attributes(conversation_tags),
         )
+        if span_name != "conversation":
+            start_child_span(self._observability_root_span, span_name, tags=tags)
 
     def _end_observability_span(self) -> None:
         """End the observability span if it hasn't been ended already."""

--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -86,6 +86,7 @@ class Conversation:
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
+        observability_span_name: str = "conversation",
     ) -> "LocalConversation": ...
 
     @overload
@@ -114,6 +115,7 @@ class Conversation:
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
+        observability_span_name: str = "conversation",
     ) -> "RemoteConversation": ...
 
     def __new__(
@@ -142,6 +144,7 @@ class Conversation:
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
+        observability_span_name: str = "conversation",
     ) -> BaseConversation:
         from openhands.sdk.conversation.impl.local_conversation import LocalConversation
         from openhands.sdk.conversation.impl.remote_conversation import (
@@ -199,6 +202,7 @@ class Conversation:
                 client_tools=client_tools,
                 observability_metadata=observability_metadata,
                 observability_tags=observability_tags,
+                observability_span_name=observability_span_name,
             )
 
         return LocalConversation(
@@ -221,4 +225,5 @@ class Conversation:
             client_tools=client_tools,
             observability_metadata=observability_metadata,
             observability_tags=observability_tags,
+            observability_span_name=observability_span_name,
         )

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -190,6 +190,7 @@ class LocalConversation(BaseConversation):
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
+        observability_span_name: str = "conversation",
         # Appended at the end (not grouped with max_iteration_per_run) to avoid
         # shifting the position of any existing positional argument.
         max_budget_per_run: float | None = None,
@@ -242,6 +243,7 @@ class LocalConversation(BaseConversation):
                   (e.g. a frontend) observing the emitted ActionEvent.
             observability_metadata: Optional trace metadata for observability backends.
             observability_tags: Optional root span tags for observability backends.
+            observability_span_name: Optional root span name for observability backends.
         """
         super().__init__()  # Initialize with span tracking
         # Mark cleanup as initiated as early as possible to avoid races or partially
@@ -422,6 +424,7 @@ class LocalConversation(BaseConversation):
         atexit.register(self.close)
         self._start_observability_span(
             str(desired_id),
+            span_name=observability_span_name,
             user_id=user_id,
             metadata=observability_metadata,
             tags=observability_tags,

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -190,10 +190,10 @@ class LocalConversation(BaseConversation):
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
-        observability_span_name: str = "conversation",
         # Appended at the end (not grouped with max_iteration_per_run) to avoid
         # shifting the position of any existing positional argument.
         max_budget_per_run: float | None = None,
+        observability_span_name: str = "conversation",
         **_: object,
     ):
         """Initialize the conversation.

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -243,7 +243,8 @@ class LocalConversation(BaseConversation):
                   (e.g. a frontend) observing the emitted ActionEvent.
             observability_metadata: Optional trace metadata for observability backends.
             observability_tags: Optional root span tags for observability backends.
-            observability_span_name: Optional root span name for observability backends.
+            observability_span_name: Optional child span name for observability
+                  backends. The root span remains named "conversation".
         """
         super().__init__()  # Initialize with span tracking
         # Mark cleanup as initiated as early as possible to avoid races or partially

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -712,7 +712,8 @@ class RemoteConversation(BaseConversation):
                       handles execution via callbacks.
             observability_metadata: Optional trace metadata for observability backends.
             observability_tags: Optional root span tags for observability backends.
-            observability_span_name: Optional root span name for observability backends.
+            observability_span_name: Optional child span name for observability
+                      backends. The root span remains named "conversation".
         """
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -676,6 +676,7 @@ class RemoteConversation(BaseConversation):
         client_tools: list[ClientToolSpec] | None = None,
         observability_metadata: dict[str, TraceMetadataValue] | None = None,
         observability_tags: list[str] | None = None,
+        observability_span_name: str = "conversation",
         **_: object,
     ) -> None:
         """Remote conversation proxy that talks to an agent server.
@@ -711,6 +712,7 @@ class RemoteConversation(BaseConversation):
                       handles execution via callbacks.
             observability_metadata: Optional trace metadata for observability backends.
             observability_tags: Optional root span tags for observability backends.
+            observability_span_name: Optional root span name for observability backends.
         """
         super().__init__()  # Initialize base class with span tracking
         self.agent = agent
@@ -803,6 +805,7 @@ class RemoteConversation(BaseConversation):
                 "observability_tags": observability_tags
                 if observability_tags is not None
                 else [],
+                "observability_span_name": observability_span_name,
                 "user_id": user_id,
             }
             if user_id:
@@ -973,6 +976,7 @@ class RemoteConversation(BaseConversation):
 
         self._start_observability_span(
             str(self._id),
+            span_name=observability_span_name,
             user_id=user_id,
             metadata=observability_metadata,
             tags=observability_tags,

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -25,6 +25,7 @@ from openhands.sdk.agent.agent import Agent as Agent
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.types import (
     ConversationObservabilityMetadata,
+    ConversationObservabilitySpanName,
     ConversationObservabilityTags,
     ConversationTags,
 )
@@ -211,6 +212,14 @@ class StartConversationRequest(BaseModel):
     observability_tags: ConversationObservabilityTags = Field(
         default_factory=list,
         description="Tags to attach to the conversation root observability span.",
+    )
+    observability_span_name: ConversationObservabilitySpanName = Field(
+        default="conversation",
+        description=(
+            "Name for the conversation root observability span. Use stable, "
+            "low-cardinality names because observability backends may use span "
+            "names for grouping or signal routing."
+        ),
     )
     autotitle: bool = Field(
         default=True,

--- a/openhands-sdk/openhands/sdk/conversation/request.py
+++ b/openhands-sdk/openhands/sdk/conversation/request.py
@@ -216,9 +216,9 @@ class StartConversationRequest(BaseModel):
     observability_span_name: ConversationObservabilitySpanName = Field(
         default="conversation",
         description=(
-            "Name for the conversation root observability span. Use stable, "
-            "low-cardinality names because observability backends may use span "
-            "names for grouping or signal routing."
+            "Optional named child span to emit under the conversation root. Use "
+            "stable, low-cardinality names because observability backends may use "
+            "span names for grouping or signal routing."
         ),
     )
     autotitle: bool = Field(

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -130,7 +130,7 @@ ConversationObservabilitySpanName = Annotated[
     str,
     BeforeValidator(_validate_observability_span_name),
 ]
-"""Validated Laminar/OTel root span name for a conversation."""
+"""Validated Laminar/OTel span name for conversation observability."""
 
 
 class StuckDetectionThresholds(BaseModel):

--- a/openhands-sdk/openhands/sdk/conversation/types.py
+++ b/openhands-sdk/openhands/sdk/conversation/types.py
@@ -104,6 +104,35 @@ ConversationObservabilityTags = Annotated[
 """Validated list of Laminar/OTel span tags for a conversation."""
 
 
+OBSERVABILITY_SPAN_NAME_PATTERN = re.compile(r"^[A-Za-z0-9._:/-]+$")
+OBSERVABILITY_SPAN_NAME_MAX_LENGTH = 128
+
+
+def _validate_observability_span_name(v: Any) -> str:
+    if v is None:
+        return "conversation"
+    if not isinstance(v, str) or not v:
+        raise ValueError("Observability span name must be a non-empty string")
+    if len(v) > OBSERVABILITY_SPAN_NAME_MAX_LENGTH:
+        raise ValueError(
+            "Observability span name exceeds maximum length of "
+            f"{OBSERVABILITY_SPAN_NAME_MAX_LENGTH} characters"
+        )
+    if not OBSERVABILITY_SPAN_NAME_PATTERN.match(v):
+        raise ValueError(
+            "Observability span name may only contain letters, numbers, dots, "
+            "underscores, colons, slashes, and hyphens"
+        )
+    return v
+
+
+ConversationObservabilitySpanName = Annotated[
+    str,
+    BeforeValidator(_validate_observability_span_name),
+]
+"""Validated Laminar/OTel root span name for a conversation."""
+
+
 class StuckDetectionThresholds(BaseModel):
     """Configuration for stuck detection thresholds.
 

--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -336,6 +336,29 @@ def end_root_span(root: RootSpan | None) -> None:
     root.end()
 
 
+def start_child_span(
+    root: RootSpan | None,
+    name: str,
+    tags: list[str] | None = None,
+) -> None:
+    """Create and immediately end a child span under a conversation root span."""
+    if root is None or root.span is None:
+        return
+    try:
+        from lmnr import Laminar
+
+        with Laminar.use_span(
+            root.span,
+            record_exception=False,
+            set_status_on_exception=False,
+        ):
+            with Laminar.start_as_current_span(name=name):
+                if tags:
+                    Laminar.set_span_tags(tags)
+    except Exception:
+        logger.debug("Failed to create observability child span", exc_info=True)
+
+
 @contextlib.contextmanager
 def _maybe_use_root_span(args: tuple[Any, ...]) -> Iterator[None]:
     """If the first positional arg owns a ``RootSpan``, re-attach it.

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -38,6 +38,7 @@ from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.conversation.request import SendMessageRequest
 from openhands.sdk.conversation.types import (
     ConversationObservabilityMetadata,
+    ConversationObservabilitySpanName,
     ConversationObservabilityTags,
 )
 from openhands.sdk.hooks import HookConfig
@@ -796,6 +797,11 @@ class ConversationSettings(BaseModel):
         exclude=True,
         description="Tags for the conversation root observability span.",
     )
+    observability_span_name: ConversationObservabilitySpanName | None = Field(
+        default=None,
+        exclude=True,
+        description="Name for the conversation root observability span.",
+    )
 
     # --- persisted fields ---------------------------------------------------
     max_iterations: int = Field(
@@ -920,6 +926,8 @@ class ConversationSettings(BaseModel):
             payload.setdefault("observability_metadata", self.observability_metadata)
         if self.observability_tags is not None:
             payload.setdefault("observability_tags", self.observability_tags)
+        if self.observability_span_name is not None:
+            payload.setdefault("observability_span_name", self.observability_span_name)
 
         # --- persisted defaults ---------------------------------------------
         payload.setdefault("confirmation_policy", self._build_confirmation_policy())

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -800,7 +800,7 @@ class ConversationSettings(BaseModel):
     observability_span_name: ConversationObservabilitySpanName | None = Field(
         default=None,
         exclude=True,
-        description="Name for the conversation root observability span.",
+        description="Optional named child span to emit under the conversation root.",
     )
 
     # --- persisted fields ---------------------------------------------------

--- a/tests/agent_server/test_api_authentication.py
+++ b/tests/agent_server/test_api_authentication.py
@@ -9,6 +9,7 @@ from fastapi.testclient import TestClient
 
 from openhands.agent_server.api import _find_http_exception, create_app
 from openhands.agent_server.config import Config
+from openhands.agent_server.openai.router import _parse_observability_overrides
 
 
 @pytest.fixture
@@ -139,6 +140,34 @@ def test_openai_routes_accept_bearer_session_key(client_with_auth, monkeypatch):
         "/v1/models", headers={"X-Session-API-Key": "test-key-123"}
     )
     assert response.status_code == 200
+
+
+def test_openai_observability_headers_parse_to_conversation_overrides():
+    overrides = _parse_observability_overrides(
+        span_name="pr_review_evaluation",
+        tags="pr-review,evaluation",
+        metadata='{"repo":"OpenHands/software-agent-sdk","pr_number":123}',
+    )
+
+    assert overrides == {
+        "observability_span_name": "pr_review_evaluation",
+        "observability_tags": ["pr-review", "evaluation"],
+        "observability_metadata": {
+            "repo": "OpenHands/software-agent-sdk",
+            "pr_number": 123,
+        },
+    }
+
+
+def test_openai_observability_headers_reject_invalid_span_name():
+    with pytest.raises(HTTPException) as exc_info:
+        _parse_observability_overrides(
+            span_name="bad span name",
+            tags=None,
+            metadata=None,
+        )
+
+    assert exc_info.value.status_code == 422
 
 
 def test_api_protected_endpoints_require_auth(client_with_auth):

--- a/tests/agent_server/test_api_authentication.py
+++ b/tests/agent_server/test_api_authentication.py
@@ -3,12 +3,15 @@ Integration tests for API authentication using dependency-based authentication.
 Tests the complete authentication flow through the FastAPI application.
 """
 
+import json
+
 import pytest
 from fastapi import HTTPException
 from fastapi.testclient import TestClient
 
 from openhands.agent_server.api import _find_http_exception, create_app
 from openhands.agent_server.config import Config
+from openhands.agent_server.dependencies import get_conversation_service
 from openhands.agent_server.openai.router import _parse_observability_overrides
 
 
@@ -168,6 +171,32 @@ def test_openai_observability_headers_reject_invalid_span_name():
         )
 
     assert exc_info.value.status_code == 422
+    json.dumps(exc_info.value.detail)
+
+
+def test_openai_route_invalid_observability_header_returns_422(monkeypatch):
+    async def fail_if_called(*args, **kwargs):
+        raise AssertionError("run_chat_completion should not run for invalid headers")
+
+    monkeypatch.setattr(
+        "openhands.agent_server.openai.router.run_chat_completion",
+        fail_if_called,
+    )
+    app = create_app(Config(session_api_keys=[]))
+    app.dependency_overrides[get_conversation_service] = lambda: object()
+    client = TestClient(app, raise_server_exceptions=False)
+
+    response = client.post(
+        "/v1/chat/completions",
+        headers={"X-OpenHands-Observability-Span-Name": "bad span name"},
+        json={
+            "model": "openhands/test",
+            "messages": [{"role": "user", "content": "hello"}],
+        },
+    )
+
+    assert response.status_code == 422
+    assert "Observability span name" in response.text
 
 
 def test_api_protected_endpoints_require_auth(client_with_auth):

--- a/tests/agent_server/test_conversation_tags.py
+++ b/tests/agent_server/test_conversation_tags.py
@@ -274,7 +274,7 @@ async def test_event_service_start_forwards_tags_to_local_conversation(tmp_path)
 
 @pytest.mark.asyncio
 async def test_event_service_start_forwards_observability_span_name(tmp_path):
-    """EventService.start() must pass stored root span names to LocalConversation."""
+    """EventService.start() must pass stored child span names to LocalConversation."""
     stored = StoredConversation(
         id=uuid4(),
         agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),

--- a/tests/agent_server/test_conversation_tags.py
+++ b/tests/agent_server/test_conversation_tags.py
@@ -270,3 +270,43 @@ async def test_event_service_start_forwards_tags_to_local_conversation(tmp_path)
         MockConversation.assert_called_once()
         call_kwargs = MockConversation.call_args.kwargs
         assert call_kwargs["tags"] == tags
+
+
+@pytest.mark.asyncio
+async def test_event_service_start_forwards_observability_span_name(tmp_path):
+    """EventService.start() must pass stored root span names to LocalConversation."""
+    stored = StoredConversation(
+        id=uuid4(),
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(tmp_path)),
+        confirmation_policy=NeverConfirm(),
+        observability_span_name="pr_review_evaluation",
+        created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        updated_at=datetime(2025, 1, 1, 12, 30, 0, tzinfo=UTC),
+    )
+
+    event_service = EventService(
+        stored=stored,
+        conversations_dir=tmp_path / "conversations",
+    )
+
+    with patch(
+        "openhands.agent_server.event_service.LocalConversation"
+    ) as MockConversation:
+        mock_conv = MagicMock()
+        mock_state = MagicMock()
+        mock_state.execution_status = ConversationExecutionStatus.IDLE
+        mock_state.events = []
+        mock_agent = MagicMock()
+        mock_agent.get_all_llms.return_value = []
+        mock_conv._state = mock_state
+        mock_conv.state = mock_state
+        mock_conv.agent = mock_agent
+        mock_conv._on_event = MagicMock()
+        MockConversation.return_value = mock_conv
+
+        await event_service.start()
+
+        MockConversation.assert_called_once()
+        call_kwargs = MockConversation.call_args.kwargs
+        assert call_kwargs["observability_span_name"] == "pr_review_evaluation"

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -232,6 +232,7 @@ class TestRemoteConversation:
             workspace=self.workspace,
             observability_metadata={"repo": "OpenHands/software-agent-sdk"},
             observability_tags=["sdk", "remote"],
+            observability_span_name="pr_review_evaluation",
             user_id="test-user-42",
         )
 
@@ -249,6 +250,7 @@ class TestRemoteConversation:
             "repo": "OpenHands/software-agent-sdk"
         }
         assert payload["observability_tags"] == ["sdk", "remote"]
+        assert payload["observability_span_name"] == "pr_review_evaluation"
         assert payload["user_id"] == "test-user-42"
 
     @patch(

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -160,8 +160,8 @@ def test_base_conversation_passes_observability_metadata_and_tag_attributes():
         )
 
 
-def test_base_conversation_uses_custom_observability_span_name():
-    """Conversation root span names can be overridden by callers."""
+def test_base_conversation_uses_custom_observability_span_name_as_child_span():
+    """Custom span names are emitted as child spans under the conversation root."""
     conversation = MockConversation()
 
     with (
@@ -170,6 +170,7 @@ def test_base_conversation_uses_custom_observability_span_name():
             return_value=True,
         ),
         patch("openhands.sdk.conversation.base.start_root_span") as mock_start_span,
+        patch("openhands.sdk.conversation.base.start_child_span") as mock_child_span,
     ):
         conversation._start_observability_span(
             "test-session-id",
@@ -177,12 +178,17 @@ def test_base_conversation_uses_custom_observability_span_name():
         )
 
         mock_start_span.assert_called_once_with(
-            "pr_review_evaluation",
+            "conversation",
             session_id="test-session-id",
             user_id=None,
             metadata=None,
             tags=None,
             attributes=None,
+        )
+        mock_child_span.assert_called_once_with(
+            mock_start_span.return_value,
+            "pr_review_evaluation",
+            tags=None,
         )
 
 

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -208,11 +208,10 @@ def test_base_conversation_span_management_disabled():
         assert conversation._span_ended is False
         assert conversation._observability_root_span is None
 
-        # End is always called (it's a no-op for None) and marks ended.
-        # The important property is that no observability call is made when
-        # observability is disabled.
+        # Ending without a started root span is a no-op and marks ended.
         conversation._end_observability_span()
-        mock_end_span.assert_called_once_with(None)
+        mock_end_span.assert_not_called()
+        assert conversation._span_ended is True
 
 
 def test_base_conversation_no_span_warnings(caplog):

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -160,6 +160,32 @@ def test_base_conversation_passes_observability_metadata_and_tag_attributes():
         )
 
 
+def test_base_conversation_uses_custom_observability_span_name():
+    """Conversation root span names can be overridden by callers."""
+    conversation = MockConversation()
+
+    with (
+        patch(
+            "openhands.sdk.conversation.base.should_enable_observability",
+            return_value=True,
+        ),
+        patch("openhands.sdk.conversation.base.start_root_span") as mock_start_span,
+    ):
+        conversation._start_observability_span(
+            "test-session-id",
+            span_name="pr_review_evaluation",
+        )
+
+        mock_start_span.assert_called_once_with(
+            "pr_review_evaluation",
+            session_id="test-session-id",
+            user_id=None,
+            metadata=None,
+            tags=None,
+            attributes=None,
+        )
+
+
 def test_base_conversation_span_management_disabled():
     """Test that BaseConversation doesn't perform span operations when observability is disabled."""  # noqa: E501
 

--- a/tests/sdk/conversation/test_conversation_factory.py
+++ b/tests/sdk/conversation/test_conversation_factory.py
@@ -61,6 +61,7 @@ def test_conversation_factory_creates_local_by_default(agent):
     conversation = Conversation(agent=agent)
 
     assert isinstance(conversation, LocalConversation)
+    conversation.close()
 
 
 @patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
@@ -84,6 +85,27 @@ def test_conversation_factory_forwards_local_parameters(agent):
 
     assert isinstance(conversation, LocalConversation)
     assert conversation.max_iteration_per_run == 100
+    conversation.close()
+
+
+def test_conversation_factory_forwards_local_observability_span_name(agent):
+    with (
+        patch(
+            "openhands.sdk.conversation.base.should_enable_observability",
+            return_value=True,
+        ),
+        patch("openhands.sdk.conversation.base.start_root_span") as mock_start_span,
+        patch("openhands.sdk.conversation.base.end_root_span"),
+    ):
+        conversation = Conversation(
+            agent=agent,
+            visualizer=None,
+            observability_span_name="pr_review_evaluation",
+        )
+        assert isinstance(conversation, LocalConversation)
+        mock_start_span.assert_called_once()
+        assert mock_start_span.call_args.args[0] == "pr_review_evaluation"
+        conversation.close()
 
 
 @patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
@@ -112,6 +134,7 @@ def test_conversation_factory_forwards_remote_user_id_to_create_payload(
         workspace=remote_workspace,
         tags={"automationid": "auto-1"},
         user_id="user-42",
+        observability_span_name="pr_review_evaluation",
     )
 
     assert isinstance(conversation, RemoteConversation)
@@ -120,6 +143,7 @@ def test_conversation_factory_forwards_remote_user_id_to_create_payload(
     payload = create_call.kwargs["json"]
     assert payload["user_id"] == "user-42"
     assert payload["tags"] == {"automationid": "auto-1"}
+    assert payload["observability_span_name"] == "pr_review_evaluation"
 
 
 def test_conversation_factory_string_workspace_creates_local(agent):
@@ -127,6 +151,7 @@ def test_conversation_factory_string_workspace_creates_local(agent):
     conversation = Conversation(agent=agent, workspace="")
 
     assert isinstance(conversation, LocalConversation)
+    conversation.close()
 
 
 @patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
@@ -137,3 +162,4 @@ def test_conversation_factory_type_inference(mock_ws_client, agent, remote_works
 
     assert isinstance(local_conv, LocalConversation)
     assert isinstance(remote_conv, RemoteConversation)
+    local_conv.close()

--- a/tests/sdk/conversation/test_conversation_factory.py
+++ b/tests/sdk/conversation/test_conversation_factory.py
@@ -95,6 +95,7 @@ def test_conversation_factory_forwards_local_observability_span_name(agent):
             return_value=True,
         ),
         patch("openhands.sdk.conversation.base.start_root_span") as mock_start_span,
+        patch("openhands.sdk.conversation.base.start_child_span") as mock_child_span,
         patch("openhands.sdk.conversation.base.end_root_span"),
     ):
         conversation = Conversation(
@@ -104,7 +105,12 @@ def test_conversation_factory_forwards_local_observability_span_name(agent):
         )
         assert isinstance(conversation, LocalConversation)
         mock_start_span.assert_called_once()
-        assert mock_start_span.call_args.args[0] == "pr_review_evaluation"
+        assert mock_start_span.call_args.args[0] == "conversation"
+        mock_child_span.assert_called_once_with(
+            mock_start_span.return_value,
+            "pr_review_evaluation",
+            tags=None,
+        )
         conversation.close()
 
 


### PR DESCRIPTION
HUMAN:

- [x]  This was tested by a human, me, @juanmichelini 

evidence:

curl + span logged

<img width="1512" height="799" alt="image" src="https://github.com/user-attachments/assets/420afce0-d708-4ec5-b4aa-bb124504ba50" />

signal settings that captures mySpanName

<img width="1512" height="799" alt="image" src="https://github.com/user-attachments/assets/1bd8c07c-3653-4e59-8b6e-949089a3cf2a" />

mySpanName captured by signal

<img width="1512" height="799" alt="image" src="https://github.com/user-attachments/assets/d28b54aa-9c55-479f-aaa3-1b5ccbdb9d70" />

AGENT:

## Why
Conversation traces should keep the standard root span name `conversation`, but SDK and gateway callers still need a stable, low-cardinality span name that downstream observability tooling can route on. Emitting the requested name as a child span gives callers that signal without changing the root trace shape.

## Summary
- add a validated `observability_span_name` field to conversation start/settings payloads
- keep the conversation root span named `conversation`
- emit the configured `observability_span_name` as an immediate child span under the conversation root
- forward observability span name, tags, and metadata through `LocalConversation`, `RemoteConversation`, the public `Conversation(...)` factory, and OpenAI-compatible gateway headers
- return a client-facing 422 for invalid observability headers instead of a 500 serialization failure
- keep `LocalConversation.__init__` positional compatibility by appending the new parameter after `max_budget_per_run`

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `217b2cf83aab` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1972,0 +1973 @@
+schema StartConversationRequest property observability_span_name optional schema=type="string" default="conversation"
```
<!-- agent-server-rest-api-contract-summary:end -->

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `afd248fe7de3` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -1972,0 +1973 @@
+schema StartConversationRequest property observability_span_name optional schema=type="string" default="conversation"
```
<!-- agent-server-rest-api-contract-summary:end -->

## How to Test
- `uv run pytest tests/agent_server/test_api_authentication.py tests/agent_server/test_conversation_tags.py tests/sdk/conversation/test_conversation_factory.py tests/sdk/conversation/remote/test_remote_conversation.py::TestRemoteConversation::test_remote_conversation_sends_observability_fields tests/sdk/conversation/test_base_span_management.py`
- `uv run ruff format --check openhands-sdk/openhands/sdk/conversation/base.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py openhands-sdk/openhands/sdk/conversation/request.py openhands-sdk/openhands/sdk/conversation/types.py openhands-sdk/openhands/sdk/observability/laminar.py openhands-sdk/openhands/sdk/settings/model.py tests/agent_server/test_conversation_tags.py tests/sdk/conversation/test_base_span_management.py tests/sdk/conversation/test_conversation_factory.py`
- `uv run ruff check openhands-sdk/openhands/sdk/conversation/base.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py openhands-sdk/openhands/sdk/conversation/request.py openhands-sdk/openhands/sdk/conversation/types.py openhands-sdk/openhands/sdk/observability/laminar.py openhands-sdk/openhands/sdk/settings/model.py tests/agent_server/test_conversation_tags.py tests/sdk/conversation/test_base_span_management.py tests/sdk/conversation/test_conversation_factory.py`
- `uv run pyright openhands-sdk/openhands/sdk/observability/laminar.py openhands-sdk/openhands/sdk/conversation openhands-agent-server/openhands/agent_server/openai openhands-agent-server/openhands/agent_server/event_service.py openhands-sdk/openhands/sdk/settings/model.py tests/agent_server/test_api_authentication.py tests/agent_server/test_conversation_tags.py tests/sdk/conversation/test_conversation_factory.py tests/sdk/conversation/remote/test_remote_conversation.py tests/sdk/conversation/test_base_span_management.py`

## Evidence
- Focused pytest run passed: `45 passed in 2.95s`
- Ruff format check passed: `10 files already formatted`
- Ruff check passed: `All checks passed!`
- Pyright passed: `0 errors, 0 warnings, 0 informations`
- Manual local verification against agent-server on port 9000 confirmed the root span remains `conversation` and the configured name is emitted as a child span.



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:44ea585-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-44ea585-python \
  ghcr.io/openhands/agent-server:44ea585-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:44ea585-golang-amd64
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-golang-amd64
ghcr.io/openhands/agent-server:agent-server-observability-span-name-golang-amd64
ghcr.io/openhands/agent-server:44ea585-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:44ea585-golang-arm64
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-golang-arm64
ghcr.io/openhands/agent-server:agent-server-observability-span-name-golang-arm64
ghcr.io/openhands/agent-server:44ea585-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:44ea585-java-amd64
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-java-amd64
ghcr.io/openhands/agent-server:agent-server-observability-span-name-java-amd64
ghcr.io/openhands/agent-server:44ea585-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:44ea585-java-arm64
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-java-arm64
ghcr.io/openhands/agent-server:agent-server-observability-span-name-java-arm64
ghcr.io/openhands/agent-server:44ea585-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:44ea585-python-amd64
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-python-amd64
ghcr.io/openhands/agent-server:agent-server-observability-span-name-python-amd64
ghcr.io/openhands/agent-server:44ea585-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:44ea585-python-arm64
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-python-arm64
ghcr.io/openhands/agent-server:agent-server-observability-span-name-python-arm64
ghcr.io/openhands/agent-server:44ea585-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:44ea585-golang
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-golang
ghcr.io/openhands/agent-server:agent-server-observability-span-name-golang
ghcr.io/openhands/agent-server:44ea585-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:44ea585-java
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-java
ghcr.io/openhands/agent-server:agent-server-observability-span-name-java
ghcr.io/openhands/agent-server:44ea585-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:44ea585-python
ghcr.io/openhands/agent-server:44ea5858f3d1cc69ee09a5df9d2ea2cf131faeed-python
ghcr.io/openhands/agent-server:agent-server-observability-span-name-python
ghcr.io/openhands/agent-server:44ea585-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `44ea585-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `44ea585-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

