### PR TITLE
fix(file_editor): preserve new_str whitespace in str_replace fallback

### DIFF
--- a/openhands-tools/openhands/tools/file_editor/editor.py
+++ b/openhands-tools/openhands/tools/file_editor/editor.py
@@ -214,9 +214,11 @@ class FileEditor:
         if not occurrences:
             # We found no occurrences, possibly because of extra white spaces at
             # either the front or back of the string.
-            # Remove the white spaces and try again.
+            # Strip old_str to retry the *match* only. Do NOT strip new_str: it
+            # is the replacement content, and stripping it would silently drop
+            # meaningful leading/trailing whitespace (e.g. a Markdown hard line
+            # break or intentional indentation) the caller asked to write.
             old_str = old_str.strip()
-            new_str = new_str.strip()
             pattern = re.escape(old_str)
             occurrences = [
                 (

--- a/tests/tools/file_editor/test_file_editor_tool.py
+++ b/tests/tools/file_editor/test_file_editor_tool.py
@@ -337,3 +337,62 @@ def test_file_editor_tool_image_viewing_line_with_vision_disabled():
         # Check that the image viewing line is NOT included in description
         assert "is an image file" not in tool.description
         assert "displays the image content" not in tool.description
+
+
+def test_str_replace_fallback_preserves_new_str_whitespace():
+    """When the whitespace-tolerant fallback is used (old_str not verbatim),
+    meaningful leading/trailing whitespace in new_str must be preserved.
+
+    Regression test: previously the fallback stripped new_str as well as
+    old_str, silently dropping intentional whitespace (e.g. a Markdown hard
+    line break) while reporting success.
+    """
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+        tool = FileEditorTool.create(conv_state)[0]
+
+        test_file = os.path.join(temp_dir, "test.md")
+        with open(test_file, "w") as f:
+            f.write("hello world\nsecond line\n")
+
+        # Leading space in old_str -> exact match fails -> fallback runs.
+        # Trailing spaces in new_str are meaningful (Markdown hard line break).
+        action = FileEditorAction(
+            command="str_replace",
+            path=test_file,
+            old_str=" hello world",
+            new_str="HELLO WORLD  ",
+        )
+        result = tool(action)
+
+        assert result is not None
+        assert not result.is_error
+        with open(test_file) as f:
+            content = f.read()
+        assert content == "HELLO WORLD  \nsecond line\n"
+
+
+def test_str_replace_exact_match_preserves_new_str_whitespace():
+    """The exact-match path (no fallback) must also preserve new_str
+    whitespace. Guards against regressions in the normal code path."""
+    with tempfile.TemporaryDirectory() as temp_dir:
+        conv_state = _create_test_conv_state(temp_dir)
+        tool = FileEditorTool.create(conv_state)[0]
+
+        test_file = os.path.join(temp_dir, "test.md")
+        with open(test_file, "w") as f:
+            f.write("hello world\nsecond line\n")
+
+        action = FileEditorAction(
+            command="str_replace",
+            path=test_file,
+            old_str="hello world",
+            new_str="HELLO WORLD  ",
+        )
+        result = tool(action)
+
+        assert result is not None
+        assert not result.is_error
+        with open(test_file) as f:
+            content = f.read()
+        assert content == "HELLO WORLD  \nsecond line\n"


### PR DESCRIPTION
**HUMAN:** In `str_replace`, when `old_str` isn't found verbatim, a fallback strips surrounding whitespace and retries. It strips *both* `old_str` and `new_str`. Stripping `old_str` (for re-matching) is fine, but stripping `new_str` mutates the *replacement content*: meaningful leading/trailing whitespace (e.g. a Markdown hard line break, intentional indentation) is silently dropped, and the tool still reports success. This PR removes only the `new_str` strip; the existing match-tolerance behavior is unchanged.

- [x] A human has tested these changes.

## Problem

`str_replace` matches exactly first, then falls back to a whitespace-tolerant retry:

```python
if not occurrences:
    old_str = old_str.strip()
    new_str = new_str.strip()   # mutates the content to be written
```

`old_str.strip()` only affects *locating* the match. `new_str.strip()` changes what is **written to the file**. When `new_str` has meaningful surrounding whitespace, it is silently lost and the edit is reported as successful (`is_error=None`).

**Triggers when both hold:** (1) `old_str` doesn't match verbatim — common, since LLMs frequently get surrounding whitespace slightly wrong, so the fallback runs; and (2) `new_str` has meaningful leading/trailing whitespace. The exact-match path is unaffected, so whether whitespace survives depends on whether `old_str` happened to match — unpredictable to the caller, and silent on failure.

## Reproduction

```python
# file: "hello world\n"
editor(command="str_replace", path=p,
       old_str=" hello world",     # leading space -> exact match fails -> fallback
       new_str="HELLO WORLD  ")    # trailing 2 spaces (Markdown hard line break)
# expected: "HELLO WORLD  \n"
# actual:   "HELLO WORLD\n"        # trailing spaces lost, is_error=None
```

## Why this is a bug, not whitespace cleanup

The trailing whitespace might be unintentional — but the tool can't tell intentional from accidental whitespace, and the costs are asymmetric: dropping intentional whitespace is silent, unrecoverable content corruption, while keeping accidental whitespace is harmless and self-correctable by the agent. The tool should write `new_str` faithfully and leave intent to the agent.

This matches comparable implementations: the original Anthropic `text_editor` (cited in this file's header) and OpenAI Codex's `seek_sequence` (which applies *more* aggressive match leniency) only relax whitespace for *locating*, never for the written content.

## Fix

Remove `new_str = new_str.strip()`; keep `old_str.strip()` so match tolerance is unchanged.

*Note: the fallback's whitespace tolerance on `old_str` is itself a design choice; this PR is scoped only to the uncontroversial `new_str` side and does not change matching behavior.*

## Tests

Added regression tests: (a) fallback path with trailing whitespace in `new_str` -> preserved; (b) exact-match path with trailing whitespace -> still works (no regression). Full `file_editor` suite passes (157), `ruff` clean.
