### PR TITLE
Release v1.29.3

### DIFF
--- a/openhands-agent-server/pyproject.toml
+++ b/openhands-agent-server/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-agent-server"
-version = "1.29.2"
+version = "1.29.3"
 description = "OpenHands Agent Server - REST/WebSocket interface for OpenHands AI Agent"
 
 requires-python = ">=3.12"

--- a/openhands-sdk/pyproject.toml
+++ b/openhands-sdk/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-sdk"
-version = "1.29.2"
+version = "1.29.3"
 description = "OpenHands SDK - Core functionality for building AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-tools/pyproject.toml
+++ b/openhands-tools/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-tools"
-version = "1.29.2"
+version = "1.29.3"
 description = "OpenHands Tools - Runtime tools for AI agents"
 
 requires-python = ">=3.12"

--- a/openhands-workspace/pyproject.toml
+++ b/openhands-workspace/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "openhands-workspace"
-version = "1.29.2"
+version = "1.29.3"
 description = "OpenHands Workspace - Docker and container-based workspace implementations"
 
 requires-python = ">=3.12"

--- a/uv.lock
+++ b/uv.lock
@@ -2653,7 +2653,7 @@ wheels = [
 
 [[package]]
 name = "openhands-agent-server"
-version = "1.29.2"
+version = "1.29.3"
 source = { editable = "openhands-agent-server" }
 dependencies = [
     { name = "aiosqlite" },
@@ -2686,7 +2686,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-sdk"
-version = "1.29.2"
+version = "1.29.3"
 source = { editable = "openhands-sdk" }
 dependencies = [
     { name = "agent-client-protocol" },
@@ -2742,7 +2742,7 @@ provides-extras = ["boto3", "vertex"]
 
 [[package]]
 name = "openhands-tools"
-version = "1.29.2"
+version = "1.29.3"
 source = { editable = "openhands-tools" }
 dependencies = [
     { name = "binaryornot" },
@@ -2773,7 +2773,7 @@ requires-dist = [
 
 [[package]]
 name = "openhands-workspace"
-version = "1.29.2"
+version = "1.29.3"
 source = { editable = "openhands-workspace" }
 dependencies = [
     { name = "openhands-agent-server" },


### PR DESCRIPTION
## Release v1.29.3

This PR prepares the release for version **1.29.3**.

### Release Checklist
- [x] Version set to 1.29.3
- [ ] Fix any deprecation deadlines if they exist
- [ ] Integration tests pass (tagged with `integration-test`)
- [ ] Behavior tests pass (tagged with `behavior-test`)
- [ ] Example tests pass (tagged with `test-examples`)
- [ ] Evaluation on OpenHands Index
- [ ] Confirm any `release-note-required` PRs are accurately called out in the final release notes

### What happens on merge
When this PR is merged, the `create-release.yml` workflow will automatically:
1. Create a GitHub release with tag `v1.29.3` and auto-generated notes, plus an explicit preamble for merged `release-note-required` PRs
2. Trigger `pypi-release.yml` to publish all packages to PyPI
3. Trigger `version-bump-prs.yml` to create downstream version bump PRs


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cc928bb-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cc928bb-python \
  ghcr.io/openhands/agent-server:cc928bb-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cc928bb-golang-amd64
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-golang-amd64
ghcr.io/openhands/agent-server:rel-1.29.3-golang-amd64
ghcr.io/openhands/agent-server:cc928bb-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cc928bb-golang-arm64
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-golang-arm64
ghcr.io/openhands/agent-server:rel-1.29.3-golang-arm64
ghcr.io/openhands/agent-server:cc928bb-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cc928bb-java-amd64
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-java-amd64
ghcr.io/openhands/agent-server:rel-1.29.3-java-amd64
ghcr.io/openhands/agent-server:cc928bb-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cc928bb-java-arm64
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-java-arm64
ghcr.io/openhands/agent-server:rel-1.29.3-java-arm64
ghcr.io/openhands/agent-server:cc928bb-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cc928bb-python-amd64
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-python-amd64
ghcr.io/openhands/agent-server:rel-1.29.3-python-amd64
ghcr.io/openhands/agent-server:cc928bb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cc928bb-python-arm64
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-python-arm64
ghcr.io/openhands/agent-server:rel-1.29.3-python-arm64
ghcr.io/openhands/agent-server:cc928bb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cc928bb-golang
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-golang
ghcr.io/openhands/agent-server:rel-1.29.3-golang
ghcr.io/openhands/agent-server:cc928bb-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:cc928bb-java
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-java
ghcr.io/openhands/agent-server:rel-1.29.3-java
ghcr.io/openhands/agent-server:cc928bb-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:cc928bb-python
ghcr.io/openhands/agent-server:cc928bb586a1be4474939990b9591b362f5d4291-python
ghcr.io/openhands/agent-server:rel-1.29.3-python
ghcr.io/openhands/agent-server:cc928bb-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cc928bb-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cc928bb-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->