### PR TITLE
ci: checkout eval model config with private-repo PAT

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -75,7 +75,7 @@ jobs:
               with:
                   repository: OpenHands/evaluation
                   ref: main
-                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH || github.token }}
+                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
                   path: .evaluation-model-config
                   sparse-checkout: |
                       eval-job/model-config


### PR DESCRIPTION
## What

Swap the token used by the integration-runner `setup-matrix` job to check out the private `OpenHands/evaluation` repo:

```diff
-    token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH || github.token }}
+    token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
```

## Why

PR #3843 moved model-config resolution into the private `OpenHands/evaluation` repo and added a "Checkout evaluation model config" step that **clones** it (needs `contents:read`). It authenticated with `OPENHANDS_BOT_GITHUB_PAT_EVAL_DISPATCH`, which is provisioned to **dispatch** eval workflows (used that way in `run-eval.yml` / `cancel-eval.yml`) and does not grant repo-contents read. The clone fails:

```
fatal: unable to access 'https://github.com/OpenHands/evaluation/': The requested URL returned error: 403
The process '/usr/bin/git' failed with exit code 128
```

`setup-matrix` then fails → `run-integration-tests` is skipped → `consolidate-results` fails. This has broken every integration-runner run (PRs, nightly schedule) since #3843 merged on 2026-06-23.

`OPENHANDS_BOT_GITHUB_PAT_PRIVATE` is the bot's private-repo access token (the naming convention is `_PUBLIC` / `_PRIVATE` / `_EVAL_DISPATCH` by purpose), which is the correct credential for reading a private repo. The `|| github.token` fallback is removed because it only masked the failure — `github.token` can never read a separate private repo, so it turned a missing/unscoped credential into a confusing 403.

## Preconditions for this to work
- `OPENHANDS_BOT_GITHUB_PAT_PRIVATE` must be available to this repo's Actions (org secret scoped to `software-agent-sdk`, or a repo secret).
- The token must have `contents:read` on `OpenHands/evaluation` and be unexpired.

## ⚠️ Note on scope
This PR targets `rel-1.29.3`. Because `integration-runner.yml` runs on **`pull_request_target`**, GitHub reads the workflow (and token) from the PR's **base branch**. The release PR #3888 has base `main`, so its integration checks run `main`'s workflow and **this change will not turn them green**. The same swap must also land on `main` to fix #3888, the nightly, and all other PRs.
