### PR TITLE
Fix release Slack notification fallback

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -128,25 +128,38 @@ jobs:
                   echo "PR_URL=$PR_URL" >> $GITHUB_ENV
                   echo "pr_url=$PR_URL" >> $GITHUB_OUTPUT
 
-            - name: Check Slack token availability
-              id: slack_token
+            - name: Check Slack credentials availability
+              id: slack_credentials
               env:
                   SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+                  SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_SAAS_CHANNEL }}
               run: |
                   if [ -n "$SLACK_BOT_TOKEN" ]; then
-                    echo "available=true" >> "$GITHUB_OUTPUT"
+                    echo "mode=bot" >> "$GITHUB_OUTPUT"
+                  elif [ -n "$SLACK_WEBHOOK_URL" ]; then
+                    echo "mode=webhook" >> "$GITHUB_OUTPUT"
                   else
-                    echo "available=false" >> "$GITHUB_OUTPUT"
+                    echo "mode=none" >> "$GITHUB_OUTPUT"
+                    echo "::warning::Neither SLACK_BOT_TOKEN nor SLACK_WEBHOOK_SAAS_CHANNEL is configured; skipping Slack notification"
                   fi
 
-            - name: Notify Slack
-              if: steps.slack_token.outputs.available == 'true'
+            - name: Notify Slack via bot token
+              if: steps.slack_credentials.outputs.mode == 'bot'
               uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
               with:
                   method: chat.postMessage
                   token: ${{ secrets.SLACK_BOT_TOKEN }}
                   payload: |
                       channel: "#proj-agent"
+                      text: "🛠️ *SDK v${{ inputs.version }} release preparation started*\n\nRelease PR: <${{ steps.create_pr.outputs.pr_url }}|Release v${{ inputs.version }}>\nStarted by: <${{ github.server_url }}/${{ github.actor }}|@${{ github.actor }}>\nRepo: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
+
+            - name: Notify Slack via incoming webhook
+              if: steps.slack_credentials.outputs.mode == 'webhook'
+              uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
+              with:
+                  webhook: ${{ secrets.SLACK_WEBHOOK_SAAS_CHANNEL }}
+                  webhook-type: incoming-webhook
+                  payload: |
                       text: "🛠️ *SDK v${{ inputs.version }} release preparation started*\n\nRelease PR: <${{ steps.create_pr.outputs.pr_url }}|Release v${{ inputs.version }}>\nStarted by: <${{ github.server_url }}/${{ github.actor }}|@${{ github.actor }}>\nRepo: <${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
 
             - name: Summary


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
_This PR was created by an AI agent (OpenHands) on behalf of the user._

## Why

The SDK release-start Slack notification added for `prepare-release.yml` did not fire for release PR #3888. Investigation of Prepare Release run 28234560048 showed the workflow resolved `SLACK_BOT_TOKEN` to an empty value, so the Slack notification step was skipped.

I also checked the other Slack references:
- `.github/workflows/version-bump-prs.yml` uses the same `SLACK_BOT_TOKEN` secret and historical logs show that value is empty there too, so it is not a working pattern to copy.

## Summary

- Keep the existing `SLACK_BOT_TOKEN` path when the bot token is configured, preserving the explicit `#proj-agent` channel behavior.
- Emit a workflow warning when neither Slack credential is configured, so missing Slack credentials are visible instead of silently skipping notification.

## Issue Number

N/A — follow-up to PR #3888 comment: https://github.com/OpenHands/software-agent-sdk/pull/3888#issuecomment-4809426022

## How to Test

Ran:

```bash
uv run pre-commit run --files .github/workflows/prepare-release.yml
```

Result: passed.

Also parsed the workflow YAML successfully:

```bash
uv run python - <<'PY'
from pathlib import Path
import yaml
path = Path('.github/workflows/prepare-release.yml')
with path.open() as f:
    yaml.safe_load(f)
print(f'Parsed {path}')
PY
```

Result:

```text
Parsed .github/workflows/prepare-release.yml
```

I did not dispatch `prepare-release.yml` end-to-end because doing so would create another release branch/PR and could post to Slack from repository secrets.

## Video/Screenshots

N/A — workflow-only change.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR intentionally remains draft until a human updates the `HUMAN:` section in their own words.

@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/9e20843f-4680-49af-9bde-1cb49e55a5ef)
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:e26ecd6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-e26ecd6-python \
  ghcr.io/openhands/agent-server:e26ecd6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:e26ecd6-golang-amd64
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-golang-amd64
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-golang-amd64
ghcr.io/openhands/agent-server:e26ecd6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:e26ecd6-golang-arm64
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-golang-arm64
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-golang-arm64
ghcr.io/openhands/agent-server:e26ecd6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:e26ecd6-java-amd64
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-java-amd64
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-java-amd64
ghcr.io/openhands/agent-server:e26ecd6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:e26ecd6-java-arm64
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-java-arm64
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-java-arm64
ghcr.io/openhands/agent-server:e26ecd6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:e26ecd6-python-amd64
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-python-amd64
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-python-amd64
ghcr.io/openhands/agent-server:e26ecd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:e26ecd6-python-arm64
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-python-arm64
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-python-arm64
ghcr.io/openhands/agent-server:e26ecd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:e26ecd6-golang
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-golang
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-golang
ghcr.io/openhands/agent-server:e26ecd6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:e26ecd6-java
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-java
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-java
ghcr.io/openhands/agent-server:e26ecd6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:e26ecd6-python
ghcr.io/openhands/agent-server:e26ecd6bc81a07f808f33dedf393c1f700e6f155-python
ghcr.io/openhands/agent-server:fix-release-slack-webhook-fallback-python
ghcr.io/openhands/agent-server:e26ecd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `e26ecd6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `e26ecd6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->