### PR TITLE
feat: add OH_LEASE_TTL_SECONDS to make conversation lease TTL configurable

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -247,6 +247,18 @@ class Config(BaseModel):
             "configuration is delivered later."
         ),
     )
+    lease_ttl_seconds: float = Field(
+        default=45.0,
+        ge=0.0,
+        description=(
+            "How long (in seconds) a conversation ownership lease remains valid "
+            "without renewal. The lease prevents two server instances from "
+            "concurrently owning the same conversation when storage is shared "
+            "across instances. Set to 0 to disable leasing entirely, which is "
+            "appropriate for single-instance deployments where concurrent "
+            "ownership is impossible."
+        ),
+    )
     model_config: ClassVar[ConfigDict] = {"frozen": True}
 
     @property

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -13,7 +13,10 @@ import httpx
 from pydantic import BaseModel
 
 from openhands.agent_server.config import Config, WebhookSpec
-from openhands.agent_server.conversation_lease import ConversationLeaseHeldError
+from openhands.agent_server.conversation_lease import (
+    DEFAULT_LEASE_TTL_SECONDS,
+    ConversationLeaseHeldError,
+)
 from openhands.agent_server.event_service import (
     LEASE_RENEW_INTERVAL_SECONDS,
     EventService,
@@ -442,6 +445,7 @@ class ConversationService:
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     max_concurrent_runs: int = 10
+    lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_webhook_subscribers: list["ConversationWebhookSubscriber"] = field(
         default_factory=list, init=False
@@ -1213,6 +1217,7 @@ class ConversationService:
             ),
             cipher=config.cipher,
             max_concurrent_runs=config.max_concurrent_runs,
+            lease_ttl_seconds=config.lease_ttl_seconds,
         )
 
     async def _start_event_service(self, stored: StoredConversation) -> EventService:
@@ -1225,6 +1230,7 @@ class ConversationService:
             conversations_dir=self.conversations_dir,
             cipher=self.cipher,
             owner_instance_id=self.owner_instance_id,
+            lease_ttl_seconds=self.lease_ttl_seconds,
         )
         # Lease renewal is handled by the centralized
         # _renew_all_leases_loop task on ConversationService.

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 from pydantic import ValidationError
 
 from openhands.agent_server.conversation_lease import (
+    DEFAULT_LEASE_TTL_SECONDS,
     ConversationLease,
     ConversationOwnershipLostError,
 )
@@ -81,6 +82,7 @@ class EventService:
     conversations_dir: Path
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
+    lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _conversation: LocalConversation | None = field(default=None, init=False)
     _pub_sub: PubSub[Event] = field(
         default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
@@ -733,12 +735,14 @@ class EventService:
 
         # self.stored contains an Agent configuration we can instantiate
         self.conversation_dir.mkdir(parents=True, exist_ok=True)
-        self._lease = ConversationLease(
-            conversation_dir=self.conversation_dir,
-            owner_instance_id=self.owner_instance_id,
-        )
-        lease_claim = self._lease.claim()
-        self._lease_generation = lease_claim.generation
+        if self.lease_ttl_seconds > 0:
+            self._lease = ConversationLease(
+                conversation_dir=self.conversation_dir,
+                owner_instance_id=self.owner_instance_id,
+                ttl_seconds=self.lease_ttl_seconds,
+            )
+            lease_claim = self._lease.claim()
+            self._lease_generation = lease_claim.generation
         workspace = self.stored.workspace
         assert isinstance(workspace, LocalWorkspace)
         working_dir = Path(workspace.working_dir)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

In single-instance Kubernetes deployments with NFS-mounted conversation storage, stale lease files left by the previous pod (due to K8s grace-period expiry, SIGKILL, or NFS attribute-cache lag) block the new pod from resuming conversations until the full 45-second TTL expires — or indefinitely if the new pod starts within that window. The cross-host liveness check in `_owner_is_dead()` always returns `False` when pod hostnames differ, so the new pod has no way to detect the old pod is dead and must wait out the TTL.

In a single-pod deployment, multi-instance ownership coordination is impossible by design, making the lease mechanism pure overhead with no benefit.

## Summary

- Add `lease_ttl_seconds: float` to `Config` (default `45.0`, `ge=0.0`), exposed as `OH_LEASE_TTL_SECONDS` via the existing `OH_*` env-var prefix parser
- Thread `lease_ttl_seconds` from `Config` → `ConversationService` → `EventService`
- Gate lease creation in `EventService.start()` on `lease_ttl_seconds > 0`; setting it to `0` skips all lease file operations (claim, renew, release) — the existing `if self._lease is not None` guards in `renew_lease()`, `_renew_lease_loop()`, and `close()` make those paths no-ops automatically

## Issue Number

N/A

## How to Test

I was unable to test this against a live Kubernetes + NFS environment from within this sandbox. The change can be validated manually as follows:

1. **Default behaviour unchanged**: Start the server without setting `OH_LEASE_TTL_SECONDS`. Confirm lease files (`owner_lease.json`) are still written to conversation directories as before.

2. **Lease disabled**: Set `OH_LEASE_TTL_SECONDS=0` and start the server. Confirm no `owner_lease.json` files are created in conversation directories, and that conversations can be loaded/resumed normally.

3. **Configurable TTL**: Set `OH_LEASE_TTL_SECONDS=10` and confirm lease files are written with a 10-second expiry (`expires_at`) and that a second server instance is blocked for only ~10 seconds before it can take over.

## Video/Screenshots

Not applicable — no UI changes.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Setting `OH_LEASE_TTL_SECONDS=0` is the recommended configuration for single-pod Kubernetes deployments with shared NFS storage.
- No changes to `ConversationLease` itself — the TTL is already a constructor parameter (`ttl_seconds`), it just was not previously surfaced to `Config`.
- The `ge=0.0` constraint on the field prevents negative values.

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:7bf53ad-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-7bf53ad-python \
  ghcr.io/openhands/agent-server:7bf53ad-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:7bf53ad-golang-amd64
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-golang-amd64
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-golang-amd64
ghcr.io/openhands/agent-server:7bf53ad-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:7bf53ad-golang-arm64
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-golang-arm64
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-golang-arm64
ghcr.io/openhands/agent-server:7bf53ad-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:7bf53ad-java-amd64
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-java-amd64
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-java-amd64
ghcr.io/openhands/agent-server:7bf53ad-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:7bf53ad-java-arm64
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-java-arm64
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-java-arm64
ghcr.io/openhands/agent-server:7bf53ad-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:7bf53ad-python-amd64
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-python-amd64
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-python-amd64
ghcr.io/openhands/agent-server:7bf53ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:7bf53ad-python-arm64
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-python-arm64
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-python-arm64
ghcr.io/openhands/agent-server:7bf53ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:7bf53ad-golang
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-golang
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-golang
ghcr.io/openhands/agent-server:7bf53ad-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:7bf53ad-java
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-java
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-java
ghcr.io/openhands/agent-server:7bf53ad-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:7bf53ad-python
ghcr.io/openhands/agent-server:7bf53ad7eec6361a805742476a88d7549989357a-python
ghcr.io/openhands/agent-server:feat-configurable-lease-ttl-python
ghcr.io/openhands/agent-server:7bf53ad-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `7bf53ad-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `7bf53ad-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->