### PR TITLE
feat: add OH_LEASE_TTL_SECONDS to make conversation lease TTL configurable

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -6,6 +6,7 @@ from typing import Any, ClassVar
 
 from pydantic import BaseModel, ConfigDict, Field, SecretStr
 
+from openhands.agent_server.conversation_lease import DEFAULT_LEASE_TTL_SECONDS
 from openhands.agent_server.env_parser import (
     MISSING,
     _get_default_parsers,
@@ -248,7 +249,7 @@ class Config(BaseModel):
         ),
     )
     lease_ttl_seconds: float = Field(
-        default=45.0,
+        default=DEFAULT_LEASE_TTL_SECONDS,
         ge=0.0,
         description=(
             "How long (in seconds) a conversation ownership lease remains valid "
@@ -256,7 +257,9 @@ class Config(BaseModel):
             "concurrently owning the same conversation when storage is shared "
             "across instances. Set to 0 to disable leasing entirely, which is "
             "appropriate for single-instance deployments where concurrent "
-            "ownership is impossible."
+            "ownership is impossible. Values between 0 and "
+            "LEASE_RENEW_INTERVAL_SECONDS (15 s) are valid but cause the lease "
+            "to expire before the first renewal, effectively making it one-shot."
         ),
     )
     model_config: ClassVar[ConfigDict] = {"frozen": True}

--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -247,6 +247,18 @@ class Config(BaseModel):
             "configuration is delivered later."
         ),
     )
+    lease_ttl_seconds: float = Field(
+        default=45.0,
+        ge=0.0,
+        description=(
+            "How long (in seconds) a conversation ownership lease remains valid "
+            "without renewal. The lease prevents two server instances from "
+            "concurrently owning the same conversation when storage is shared "
+            "across instances. Set to 0 to disable leasing entirely, which is "
+            "appropriate for single-instance deployments where concurrent "
+            "ownership is impossible."
+        ),
+    )
     model_config: ClassVar[ConfigDict] = {"frozen": True}
 
     @property

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -13,7 +13,10 @@ import httpx
 from pydantic import BaseModel
 
 from openhands.agent_server.config import Config, WebhookSpec
-from openhands.agent_server.conversation_lease import ConversationLeaseHeldError
+from openhands.agent_server.conversation_lease import (
+    DEFAULT_LEASE_TTL_SECONDS,
+    ConversationLeaseHeldError,
+)
 from openhands.agent_server.event_service import (
     LEASE_RENEW_INTERVAL_SECONDS,
     EventService,
@@ -442,6 +445,7 @@ class ConversationService:
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
     max_concurrent_runs: int = 10
+    lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _event_services: dict[UUID, EventService] | None = field(default=None, init=False)
     _conversation_webhook_subscribers: list["ConversationWebhookSubscriber"] = field(
         default_factory=list, init=False
@@ -1213,6 +1217,7 @@ class ConversationService:
             ),
             cipher=config.cipher,
             max_concurrent_runs=config.max_concurrent_runs,
+            lease_ttl_seconds=config.lease_ttl_seconds,
         )
 
     async def _start_event_service(self, stored: StoredConversation) -> EventService:
@@ -1225,6 +1230,7 @@ class ConversationService:
             conversations_dir=self.conversations_dir,
             cipher=self.cipher,
             owner_instance_id=self.owner_instance_id,
+            lease_ttl_seconds=self.lease_ttl_seconds,
         )
         # Lease renewal is handled by the centralized
         # _renew_all_leases_loop task on ConversationService.

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -9,6 +9,7 @@ from uuid import UUID, uuid4
 from pydantic import ValidationError
 
 from openhands.agent_server.conversation_lease import (
+    DEFAULT_LEASE_TTL_SECONDS,
     ConversationLease,
     ConversationOwnershipLostError,
 )
@@ -81,6 +82,7 @@ class EventService:
     conversations_dir: Path
     cipher: Cipher | None = None
     owner_instance_id: str = field(default_factory=lambda: uuid4().hex)
+    lease_ttl_seconds: float = DEFAULT_LEASE_TTL_SECONDS
     _conversation: LocalConversation | None = field(default=None, init=False)
     _pub_sub: PubSub[Event] = field(
         default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
@@ -733,12 +735,14 @@ class EventService:
 
         # self.stored contains an Agent configuration we can instantiate
         self.conversation_dir.mkdir(parents=True, exist_ok=True)
-        self._lease = ConversationLease(
-            conversation_dir=self.conversation_dir,
-            owner_instance_id=self.owner_instance_id,
-        )
-        lease_claim = self._lease.claim()
-        self._lease_generation = lease_claim.generation
+        if self.lease_ttl_seconds > 0:
+            self._lease = ConversationLease(
+                conversation_dir=self.conversation_dir,
+                owner_instance_id=self.owner_instance_id,
+                ttl_seconds=self.lease_ttl_seconds,
+            )
+            lease_claim = self._lease.claim()
+            self._lease_generation = lease_claim.generation
         workspace = self.stored.workspace
         assert isinstance(workspace, LocalWorkspace)
         working_dir = Path(workspace.working_dir)

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -735,6 +735,8 @@ class EventService:
 
         # self.stored contains an Agent configuration we can instantiate
         self.conversation_dir.mkdir(parents=True, exist_ok=True)
+        # lease_ttl_seconds=0 disables leasing for single-instance deployments
+        # where shared-storage stale leases would otherwise block pod restarts.
         if self.lease_ttl_seconds > 0:
             self._lease = ConversationLease(
                 conversation_dir=self.conversation_dir,

--- a/tests/agent_server/test_env_parser.py
+++ b/tests/agent_server/test_env_parser.py
@@ -22,6 +22,7 @@ import pytest
 from pydantic import BaseModel, Field
 
 from openhands.agent_server.config import Config, load_config
+from openhands.agent_server.conversation_lease import DEFAULT_LEASE_TTL_SECONDS
 from openhands.agent_server.env_parser import (
     MISSING,
     BoolEnvParser,
@@ -1428,3 +1429,14 @@ def test_discriminated_union_single_empty_kind_no_variables(clean_env):
     # because there's no indication that this entry is configured
     result = parser.from_env("TEST")
     assert result is MISSING
+
+
+def test_config_lease_ttl_seconds_default(clean_env):
+    config = from_env(Config, "OH")
+    assert config.lease_ttl_seconds == DEFAULT_LEASE_TTL_SECONDS
+
+
+def test_config_lease_ttl_seconds_env_var(clean_env):
+    os.environ["OH_LEASE_TTL_SECONDS"] = "0"
+    config = from_env(Config, "OH")
+    assert config.lease_ttl_seconds == 0.0

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 import pytest
 import pytest_asyncio
 
+from openhands.agent_server.conversation_lease import LEASE_FILE_NAME
 from openhands.agent_server.conversation_service import ConversationService
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import (
@@ -3250,3 +3251,64 @@ def test_llm_log_callback_swallows_emit_failures(
     emit_mock = cast(MagicMock, event_service._emit_event_from_thread)
     emit_mock.assert_called_once()
     assert "Failed to emit LLM completion log event" in caplog.text
+
+
+def _make_stored(tmp_path: Path) -> StoredConversation:
+    return StoredConversation(
+        id=uuid4(),
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test"), tools=[]),
+        workspace=LocalWorkspace(working_dir=str(tmp_path)),
+        confirmation_policy=NeverConfirm(),
+        initial_message=None,
+        metrics=None,
+    )
+
+
+def _make_mock_conv() -> MagicMock:
+    mock_conv = MagicMock()
+    mock_state = MagicMock()
+    mock_state.execution_status = ConversationExecutionStatus.IDLE
+    mock_state.events = []
+    mock_state.stats = MagicMock()
+    mock_conv.agent.get_all_llms.return_value = []
+    mock_conv._state = mock_state
+    mock_conv.state = mock_state
+    mock_conv._on_event = MagicMock()
+    return mock_conv
+
+
+@pytest.mark.asyncio
+async def test_event_service_skips_lease_when_ttl_is_zero(tmp_path: Path) -> None:
+    stored = _make_stored(tmp_path)
+    service = EventService(
+        stored=stored,
+        conversations_dir=tmp_path,
+        lease_ttl_seconds=0,
+    )
+    with patch(
+        "openhands.agent_server.event_service.LocalConversation",
+        return_value=_make_mock_conv(),
+    ):
+        await service.start()
+
+    assert service._lease is None
+    assert not (tmp_path / stored.id.hex / LEASE_FILE_NAME).exists()
+
+
+@pytest.mark.asyncio
+async def test_event_service_creates_lease_with_custom_ttl(tmp_path: Path) -> None:
+    stored = _make_stored(tmp_path)
+    service = EventService(
+        stored=stored,
+        conversations_dir=tmp_path,
+        lease_ttl_seconds=10.0,
+    )
+    with patch(
+        "openhands.agent_server.event_service.LocalConversation",
+        return_value=_make_mock_conv(),
+    ):
+        await service.start()
+
+    assert service._lease is not None
+    assert service._lease._ttl_seconds == 10.0
+    assert (tmp_path / stored.id.hex / LEASE_FILE_NAME).exists()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

This fixes an issue I found in the K8s environment, where only a single server runs in the container and the lease is unnecessary - before this change I found that if I rapidly stopped and restarted a server I would get a lease error.

---

AGENT:

## Why

In single-instance Kubernetes deployments with NFS-mounted conversation storage, stale lease files left by the previous pod (due to K8s grace-period expiry, SIGKILL, or NFS attribute-cache lag) block the new pod from resuming conversations until the full 45-second TTL expires — or indefinitely if the new pod starts within that window. The cross-host liveness check in `_owner_is_dead()` always returns `False` when pod hostnames differ, so the new pod has no way to detect the old pod is dead and must wait out the TTL.

In a single-pod deployment, multi-instance ownership coordination is impossible by design, making the lease mechanism pure overhead with no benefit.

## Summary

- Add `lease_ttl_seconds: float` to `Config` (default `45.0`, `ge=0.0`), exposed as `OH_LEASE_TTL_SECONDS` via the existing `OH_*` env-var prefix parser
- Thread `lease_ttl_seconds` from `Config` → `ConversationService` → `EventService`
- Gate lease creation in `EventService.start()` on `lease_ttl_seconds > 0`; setting it to `0` skips all lease file operations (claim, renew, release) — the existing `if self._lease is not None` guards in `renew_lease()`, `_renew_lease_loop()`, and `close()` make those paths no-ops automatically

## Issue Number

N/A

## How to Test

HUMAN:

I tested this by taking the arm image and loading it into my local kind cluster and started and stopped and resumed pods. Previously I would get a skipped conversation on restart, but no longer! 

## Video/Screenshots

When using the new network mount I no longer get an error when rapidly restarting a conversation:
<img width="1086" height="884" alt="image" src="https://github.com/user-attachments/assets/40094dba-9928-4e9b-b363-eaa4ce8cd3de" />

AGENT:

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Setting `OH_LEASE_TTL_SECONDS=0` is the recommended configuration for single-pod Kubernetes deployments with shared NFS storage.
- No changes to `ConversationLease` itself — the TTL is already a constructor parameter (`ttl_seconds`), it just was not previously surfaced to `Config`.
- The `ge=0.0` constraint on the field prevents negative values.

_This PR was created by an AI agent (OpenHands) on behalf of the user._
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dcd6924-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dcd6924-python \
  ghcr.io/openhands/agent-server:dcd6924-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dcd6924-golang-amd64
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-golang-amd64
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-golang-amd64
ghcr.io/openhands/agent-server:dcd6924-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dcd6924-golang-arm64
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-golang-arm64
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-golang-arm64
ghcr.io/openhands/agent-server:dcd6924-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dcd6924-java-amd64
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-java-amd64
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-java-amd64
ghcr.io/openhands/agent-server:dcd6924-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dcd6924-java-arm64
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-java-arm64
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-java-arm64
ghcr.io/openhands/agent-server:dcd6924-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dcd6924-python-amd64
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-python-amd64
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-python-amd64
ghcr.io/openhands/agent-server:dcd6924-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dcd6924-python-arm64
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-python-arm64
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-python-arm64
ghcr.io/openhands/agent-server:dcd6924-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dcd6924-golang
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-golang
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-golang
ghcr.io/openhands/agent-server:dcd6924-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:dcd6924-java
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-java
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-java
ghcr.io/openhands/agent-server:dcd6924-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:dcd6924-python
ghcr.io/openhands/agent-server:dcd69244df214ec7bcb6fe51d11fac574e3cff9a-python
ghcr.io/openhands/agent-server:fix-lease-ttl-configurable-python
ghcr.io/openhands/agent-server:dcd6924-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dcd6924-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dcd6924-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->