### PR TITLE
fix(agent-server): recover stale run tasks when status is idle

### DIFF
--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -68,6 +68,7 @@ class EventService:
         default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
     )
     _run_task: asyncio.Task | None = field(default=None, init=False)
+    _run_finalizing_task: asyncio.Task | None = field(default=None, init=False)
     # Set when a send_message(run=True) is rejected because a run is still
     # wrapping up; consumed by _run_and_publish to re-run the stranded message.
     _rerun_requested: bool = field(default=False, init=False)
@@ -752,15 +753,16 @@ class EventService:
 
         # Use lock to make check-and-set atomic, preventing race conditions
         async with self._run_lock:
-            if (
-                await self._get_execution_status()
-                == ConversationExecutionStatus.RUNNING
-            ):
+            execution_status = await self._get_execution_status()
+            if execution_status == ConversationExecutionStatus.RUNNING:
                 raise ValueError("conversation_already_running")
 
             # Check if there's already a running task
             if self._run_task is not None and not self._run_task.done():
-                raise ValueError("conversation_already_running")
+                if self._run_finalizing_task is self._run_task:
+                    raise ValueError("conversation_already_running")
+                self._run_task.cancel()
+                self._run_task = None
 
             # Capture conversation reference for the closure
             conversation = self._conversation
@@ -769,6 +771,7 @@ class EventService:
             loop = asyncio.get_running_loop()
 
             async def _run_and_publish():
+                current_task = asyncio.current_task()
                 try:
                     # Prefer the native async path when available so the event
                     # loop is free during LLM I/O.  Fall back to thread-pool
@@ -804,13 +807,17 @@ class EventService:
                     # This prevents a race condition where the conversation status
                     # becomes FINISHED before agent events (MessageEvent, ActionEvent,
                     # etc.) are published to WebSocket subscribers.
+                    self._run_finalizing_task = current_task
                     if self._callback_wrapper:
                         await loop.run_in_executor(
                             None, self._callback_wrapper.wait_for_pending, 30.0
                         )
 
                     # Clear task reference and publish state update
-                    self._run_task = None
+                    if self._run_task is current_task:
+                        self._run_task = None
+                    if self._run_finalizing_task is current_task:
+                        self._run_finalizing_task = None
                     await self._publish_state_update()
 
                     # Re-arm a run for input stranded while this task was

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -1187,8 +1187,8 @@ class TestEventServiceRun:
             await event_service.run()
 
     @pytest.mark.asyncio
-    async def test_run_already_running_by_task(self, event_service):
-        """Test that run raises ValueError when there's an active run task."""
+    async def test_run_already_running_by_finalizing_task(self, event_service):
+        """Test that run raises ValueError when a run task is finalizing."""
         conversation = MagicMock(spec=Conversation)
         state = MagicMock(spec=ConversationState)
         state.execution_status = ConversationExecutionStatus.IDLE
@@ -1202,9 +1202,51 @@ class TestEventServiceRun:
         mock_task = MagicMock()
         mock_task.done.return_value = False
         event_service._run_task = mock_task
+        event_service._run_finalizing_task = mock_task
 
         with pytest.raises(ValueError, match="conversation_already_running"):
             await event_service.run()
+
+    @pytest.mark.asyncio
+    async def test_run_recovers_stale_task_when_status_is_idle(self, event_service):
+        """Test that run recovers when status is IDLE but a stale task remains."""
+        conversation = MagicMock(spec=Conversation)
+        state = MagicMock(spec=ConversationState)
+        state.execution_status = ConversationExecutionStatus.IDLE
+        state.__enter__ = MagicMock(return_value=state)
+        state.__exit__ = MagicMock(return_value=None)
+        conversation._state = state
+        conversation.run = MagicMock()
+
+        event_service._conversation = conversation
+        event_service._publish_state_update = AsyncMock()
+
+        stale_task_started = asyncio.Event()
+        stale_task_cancelled = asyncio.Event()
+
+        async def stale_run_task():
+            try:
+                stale_task_started.set()
+                await asyncio.Event().wait()
+            finally:
+                stale_task_cancelled.set()
+
+        stale_task = asyncio.create_task(stale_run_task())
+        await stale_task_started.wait()
+        event_service._run_task = stale_task
+
+        await event_service.run()
+
+        replacement_task = event_service._run_task
+        assert replacement_task is not None
+        assert replacement_task is not stale_task
+
+        with suppress(asyncio.CancelledError):
+            await stale_task
+        assert stale_task_cancelled.is_set()
+
+        await replacement_task
+        conversation.run.assert_called_once()
 
     @pytest.mark.asyncio
     async def test_run_starts_background_task(self, event_service):


### PR DESCRIPTION
## Why

Fixes #3842.

`EventService.run()` could reject a new run with
`conversation_already_running` whenever `_run_task` was still alive, even if the
persisted conversation status was already `IDLE`. That leaves the agent-server
in the wedged state described in the issue: the conversation looks idle, new
messages are accepted, but `POST /run` returns 409 until the process is
restarted.

## Summary

- Distinguish a legitimate cleanup-tail task from a stale non-running task with
  `_run_finalizing_task`.
- Keep the existing protection for `RUNNING` conversations and for tasks that
  are still finalizing callback publication.
- Cancel and replace a stale run task when the conversation status is no longer
  running.
- Guard cleanup so an older task cannot clear a newer replacement task.
- Add regression coverage for the idle-status/stale-task recovery path and the
  cleanup-tail protection.

## Changes

- Updated `EventService.run()` to cancel and replace a stale `_run_task` when
  the persisted execution status is no longer `RUNNING`.
- Tracked the currently finalizing run task by identity so cleanup-tail
  behavior remains protected.
- Added regression tests covering both stale-task recovery and finalizing-task
  rejection.

## Issue Number

Fixes #3842

## Verification

I reproduced the unit-level failure before the fix:

```text
uv run pytest tests/agent_server/test_event_service.py::TestEventServiceRun::test_run_already_running_by_finalizing_task tests/agent_server/test_event_service.py::TestEventServiceRun::test_run_recovers_stale_task_when_status_is_idle -q
```

Observed before the fix: `test_run_recovers_stale_task_when_status_is_idle`
failed with `ValueError: conversation_already_running`.

After the fix:

```text
uv run pytest tests/agent_server/test_event_service.py::TestEventServiceRun::test_run_already_running_by_finalizing_task tests/agent_server/test_event_service.py::TestEventServiceRun::test_run_recovers_stale_task_when_status_is_idle -q
```

Observed after the fix: `2 passed in 0.19s`.

Related run/send-message cleanup-tail regression coverage:

```text
uv run pytest tests/agent_server/test_event_service.py::TestEventServiceSendMessage tests/agent_server/test_event_service.py::TestEventServiceRun tests/agent_server/test_event_service.py::test_message_in_run_cleanup_tail_is_not_stranded tests/agent_server/test_event_service.py::test_run_false_message_in_cleanup_tail_is_not_run -q
```

Observed result: `16 passed in 0.78s`.

Full event service file:

```text
uv run pytest tests/agent_server/test_event_service.py -q
```

Observed result: `85 passed in 16.97s`.

Static checks:

```text
uv run ruff format --check openhands-agent-server/openhands/agent_server/event_service.py tests/agent_server/test_event_service.py

uv run ruff check openhands-agent-server/openhands/agent_server/event_service.py tests/agent_server/test_event_service.py
```

Observed result: `2 files already formatted`; `All checks passed!`.

## How to Test

Run the verification commands above from the repository root.

## Video/Screenshots

Not applicable. This is agent-server run-task state reconciliation covered by
unit/regression tests.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- [ ] A human has tested these changes.

I did not run a live WebSocket/drop scenario. The regression test exercises the
core state that identifies the wedge: `execution_status == IDLE` while a stale
`_run_task` is still alive.
