### PR TITLE
fix(sdk): disable streaming for summarizer LLM call (#3902)

### DIFF
--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -188,10 +188,19 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
 
+        # Force non-streaming: the summary is consumed whole and no on_token
+        # callback is passed, which a streaming LLM would require. Sharing the
+        # same usage_id/metrics keeps summary tokens counted (model_copy is
+        # non-mutating; unlike sub-agents we do not reset_metrics here).
+        summarizing_llm = (
+            self.llm.model_copy(update={"stream": False})
+            if self.llm.stream
+            else self.llm
+        )
         # Do not pass extra_body explicitly. The LLM handles forwarding
         # litellm_extra_body only when it is non-empty.
         try:
-            llm_response = self.llm.completion(
+            llm_response = summarizing_llm.completion(
                 messages=messages,
             )
         except Exception as e:
@@ -384,8 +393,14 @@ class LLMSummarizingCondenser(RollingCondenser):
         )
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
+        # Force non-streaming for the summary (see _generate_condensation).
+        summarizing_llm = (
+            self.llm.model_copy(update={"stream": False})
+            if self.llm.stream
+            else self.llm
+        )
         try:
-            llm_response = await self.llm.acompletion(messages=messages)
+            llm_response = await summarizing_llm.acompletion(messages=messages)
         except Exception as e:
             raise NoCondensationAvailableException(
                 f"Summarization LLM call failed: {e}"

--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -80,6 +80,17 @@ class LLMSummarizingCondenser(RollingCondenser):
             )
         return self
 
+    @model_validator(mode="after")
+    def _disable_streaming_for_summary(self):
+        # Summaries are consumed whole with no on_token callback, which a
+        # streaming LLM requires (#3902). Disable streaming once so every
+        # summary path is covered. model_copy is non-mutating and shares
+        # usage_id/metrics, so summary tokens stay attributed to the
+        # conversation.
+        if self.llm.stream:
+            self.llm = self.llm.model_copy(update={"stream": False})
+        return self
+
     def handles_condensation_requests(self) -> bool:
         return True
 
@@ -188,19 +199,10 @@ class LLMSummarizingCondenser(RollingCondenser):
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
 
-        # Force non-streaming: the summary is consumed whole and no on_token
-        # callback is passed, which a streaming LLM would require. Sharing the
-        # same usage_id/metrics keeps summary tokens counted (model_copy is
-        # non-mutating; unlike sub-agents we do not reset_metrics here).
-        summarizing_llm = (
-            self.llm.model_copy(update={"stream": False})
-            if self.llm.stream
-            else self.llm
-        )
         # Do not pass extra_body explicitly. The LLM handles forwarding
         # litellm_extra_body only when it is non-empty.
         try:
-            llm_response = summarizing_llm.completion(
+            llm_response = self.llm.completion(
                 messages=messages,
             )
         except Exception as e:
@@ -393,14 +395,8 @@ class LLMSummarizingCondenser(RollingCondenser):
         )
 
         messages = [Message(role="user", content=[TextContent(text=prompt)])]
-        # Force non-streaming for the summary (see _generate_condensation).
-        summarizing_llm = (
-            self.llm.model_copy(update={"stream": False})
-            if self.llm.stream
-            else self.llm
-        )
         try:
-            llm_response = await summarizing_llm.acompletion(messages=messages)
+            llm_response = await self.llm.acompletion(messages=messages)
         except Exception as e:
             raise NoCondensationAvailableException(
                 f"Summarization LLM call failed: {e}"

--- a/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
+++ b/openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
@@ -83,10 +83,9 @@ class LLMSummarizingCondenser(RollingCondenser):
     @model_validator(mode="after")
     def _disable_streaming_for_summary(self):
         # Summaries are consumed whole with no on_token callback, which a
-        # streaming LLM requires (#3902). Disable streaming once so every
-        # summary path is covered. model_copy is non-mutating and shares
-        # usage_id/metrics, so summary tokens stay attributed to the
-        # conversation.
+        # streaming LLM requires. Disable streaming once so every summary path
+        # is covered. model_copy is non-mutating and shares usage_id/metrics,
+        # so summary tokens stay attributed to the conversation.
         if self.llm.stream:
             self.llm = self.llm.model_copy(update={"stream": False})
         return self

--- a/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
+++ b/tests/sdk/context/condenser/test_llm_summarizing_condenser.py
@@ -1,8 +1,14 @@
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from litellm.types.utils import ModelResponse
+from litellm.types.utils import (
+    Choices,
+    Message as LiteLLMMessage,
+    ModelResponse,
+    Usage,
+)
+from pydantic import SecretStr
 
 from openhands.sdk.context.condenser.base import (
     CondensationRequirement,
@@ -76,6 +82,9 @@ def mock_llm() -> LLM:
     mock_llm.reasoning_effort = None
     mock_llm.litellm_extra_body = {}
     mock_llm.temperature = 0.0
+    # Streaming is off by default (matches LLM.stream's default), so the
+    # condenser uses this LLM directly without copying it.
+    mock_llm.stream = False
 
     # Explicitly set pricing attributes required by LLM -> Telemetry wiring
     mock_llm.input_cost_per_token = None
@@ -871,3 +880,110 @@ def test_llm_error_triggers_hard_context_reset(mock_llm: LLM) -> None:
     assert isinstance(result, Condensation)
     assert result.summary == "Summary of forgotten events"
     assert cast(MagicMock, mock_llm.completion).call_count == 2
+
+
+def _streaming_llm() -> LLM:
+    """A real LLM with streaming enabled, as a long-running conversation has."""
+    return LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test-key"),
+        usage_id="summarizer-test",
+        stream=True,
+    )
+
+
+def _summary_response(content: str = "A summary") -> ModelResponse:
+    return ModelResponse(
+        id="resp-id",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(content=content, role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+@patch("openhands.sdk.llm.llm.LLM._transport_call", autospec=True)
+def test_summarization_disables_streaming_when_llm_streams(mock_transport) -> None:
+    """Regression test for issue #3902: a ``stream=True`` LLM must still summarize
+    even though the condenser passes no ``on_token`` callback."""
+    mock_transport.return_value = _summary_response("A summary")
+
+    llm = _streaming_llm()
+    condenser = LLMSummarizingCondenser(llm=llm, max_size=10, keep_first=3)
+
+    events: list[Event] = [message_event(f"Event {i}") for i in range(11)]
+    view = View.from_events(events)
+
+    result = condenser.condense(view)
+
+    assert isinstance(result, Condensation)
+    assert result.summary == "A summary"
+    mock_transport.assert_called_once()
+    # Streaming was disabled on a copy, not the agent's own LLM (autospec =>
+    # self is the first positional arg).
+    assert mock_transport.call_args.kwargs["enable_streaming"] is False
+    assert mock_transport.call_args.kwargs["on_token"] is None
+    summarizing_llm = mock_transport.call_args.args[0]
+    assert summarizing_llm is not llm
+    assert summarizing_llm.stream is False
+    assert llm.stream is True  # original untouched (model_copy is non-mutating)
+    # Token usage is still counted: the copy shares the original's metrics.
+    usage = llm.metrics.accumulated_token_usage
+    assert usage is not None
+    assert usage.prompt_tokens == 10
+    assert usage.completion_tokens == 5
+
+
+@pytest.mark.asyncio
+@patch("openhands.sdk.llm.llm.LLM._atransport_call", new_callable=AsyncMock)
+async def test_async_summarization_disables_streaming_when_llm_streams(
+    mock_atransport,
+) -> None:
+    """Async variant of the issue #3902 regression test (aget_condensation)."""
+    mock_atransport.return_value = _summary_response("A summary")
+
+    llm = _streaming_llm()
+    condenser = LLMSummarizingCondenser(llm=llm, max_size=10, keep_first=3)
+
+    events: list[Event] = [message_event(f"Event {i}") for i in range(11)]
+    view = View.from_events(events)
+
+    result = await condenser.aget_condensation(view)
+
+    assert isinstance(result, Condensation)
+    assert result.summary == "A summary"
+    mock_atransport.assert_awaited_once()
+    assert mock_atransport.call_args.kwargs["enable_streaming"] is False
+    assert mock_atransport.call_args.kwargs["on_token"] is None
+    assert llm.stream is True
+
+
+@patch("openhands.sdk.llm.llm.LLM._transport_call", autospec=True)
+def test_summarization_uses_llm_as_is_when_not_streaming(mock_transport) -> None:
+    """When streaming is off, the condenser summarizes with the LLM unchanged."""
+    mock_transport.return_value = _summary_response("A summary")
+
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test-key"),
+        usage_id="summarizer-test",
+        stream=False,
+    )
+    condenser = LLMSummarizingCondenser(llm=llm, max_size=10, keep_first=3)
+
+    events: list[Event] = [message_event(f"Event {i}") for i in range(11)]
+    view = View.from_events(events)
+
+    result = condenser.condense(view)
+
+    assert isinstance(result, Condensation)
+    assert result.summary == "A summary"
+    # The exact same LLM instance is used (no copy when not streaming).
+    assert mock_transport.call_args.args[0] is llm


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Fixing a bug with condenser and streaming.

---

AGENT:

## Why

Long-running conversations using the standard OpenHands agent crash with a
server-side error once they grow large enough to trigger summarization:

```
Summarization LLM call failed: Streaming requires an on_token callback
```

After it fires the conversation stops progressing and becomes unrecoverable
(downstream `search_subdirs` 400s and events-WebSocket handshake failures are
secondary symptoms). Reported in #3902 (originally surfaced from
`OpenHands/agent-canvas#1514`).

Root cause: `LLMSummarizingCondenser` calls `self.llm.completion()` /
`self.llm.acompletion()` **without** an `on_token` callback. When the
conversation's LLM is configured with `stream=True` (e.g. the agent-canvas
`dev:automation` stack), `LLM.completion()` enables streaming because
`enable_streaming = bool(kwargs.get("stream", False)) or self.stream`, and then
raises `ValueError("Streaming requires an on_token callback")`. The condenser
re-wraps that as `Summarization LLM call failed: ...`.

Every other auxiliary (non-interactive) LLM call in the SDK already guards
against this by forcing non-streaming — e.g. `conversation/goal/judge.py`
(`judge_llm.model_copy(update={"stream": False})`) and the delegated
sub-agent paths (`tests/tools/delegate/test_delegation.py::test_spawn_disables_streaming_for_sub_agents`).
The summarizer was the one caller that was missed.

## Summary

- Force a non-streaming copy of the LLM for the summary completion in both
  `_generate_condensation` (sync) and `_agenerate_condensation` (async),
  mirroring the existing `judge.py` idiom. The copy is only made when
  `self.llm.stream` is `True`, so non-streaming setups are unaffected.
- The agent's own LLM is left untouched — `model_copy` is non-mutating and the
  copy keeps the same `usage_id` and shares the underlying `_metrics`/
  `_telemetry` object (we deliberately do **not** `reset_metrics()` here, unlike
  the sub-agent path which wants independent tracking), so summary token usage
  is still attributed to the conversation.
- Add regression tests covering the streaming (sync + async) and non-streaming
  paths, including an assertion that summary token usage is recorded on the
  original LLM's metrics.

## Issue Number

Fixes #3902

## How to Test

```bash
uv sync --dev
# Full condenser suite (39 tests, includes the new ones):
uv run pytest tests/sdk/context/condenser/test_llm_summarizing_condenser.py -q
```

To confirm the new tests actually reproduce the bug, revert the source change
and run only the streaming regression tests — they fail with the exact
production error before the fix:

```bash
git stash push -- openhands-sdk/openhands/sdk/context/condenser/llm_summarizing_condenser.py
uv run pytest tests/sdk/context/condenser/test_llm_summarizing_condenser.py \
  -q -k streaming
git stash pop
```

## Video/Screenshots

Deterministic CLI reproduction (no GUI involved). Captured locally:

**1. New regression tests FAIL on `main` (fix reverted) — exact issue error:**

```
tests/.../test_llm_summarizing_condenser.py:390: in _agenerate_condensation
    raise NoCondensationAvailableException(
E   NoCondensationAvailableException: Summarization LLM call failed: Streaming requires an on_token callback
...
FAILED ...::test_summarization_disables_streaming_when_llm_streams
FAILED ...::test_async_summarization_disables_streaming_when_llm_streams
2 failed, 1 passed, 36 deselected
```

**2. With the fix — full condenser suite passes:**

```
collected 39 items
tests/sdk/context/condenser/test_llm_summarizing_condenser.py ............................. [100%]
39 passed in 0.24s
```

**3. Token usage is still counted (no metrics loss):** running the real
`completion()` path through the stream-disabled copy records the response's
`Usage(prompt_tokens=10, completion_tokens=5)` onto the **original** LLM's
`metrics.accumulated_token_usage`, with `usage_id` preserved. Asserted in
`test_summarization_disables_streaming_when_llm_streams`.

**4. Broader sweep + hooks green:**

```
tests/sdk/context/  ->  406 passed
pre-commit (Ruff format, Ruff lint, pycodestyle, pyright, import rules) -> all Passed
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- A truly live end-to-end repro (full agent-canvas dev stack + a real provider
  key, driving a conversation until it auto-summarizes) was **not** run here —
  it needs provider credentials and a long conversation. Instead the bug is
  reproduced deterministically at the SDK layer: the regression tests use a
  real `LLM(stream=True)` with the transport mocked, so the genuine streaming
  guard in `completion()`/`acompletion()` executes and raises the identical
  error without the fix.
- Metrics pattern note: the sub-agent path (`subagent/registry.py`) copies the
  condenser LLM with a **distinct** `usage_id` and calls `reset_metrics()` on
  purpose, so a sub-agent's condenser cost is tracked independently. This PR
  intentionally does the opposite (same `usage_id`, shared metrics), matching
  `judge.py`, so summarization cost rolls up to the conversation that incurred
  it rather than being split into a separate bucket.
- The fix is intentionally minimal and local to the condenser. An alternative
  is to disable streaming once where the condenser's LLM is constructed
  (agent-server wiring), but that is broader and not guaranteed to cover every
  code path that builds a condenser.
