### PR TITLE
feat: forward sub-agent (TaskToolSet) inner events to the live conversation stream

### DIFF
--- a/openhands-agent-server/openhands/agent_server/config.py
+++ b/openhands-agent-server/openhands/agent_server/config.py
@@ -247,6 +247,11 @@ class Config(BaseModel):
             "configuration is delivered later."
         ),
     )
+    forward_subagent_events: bool = Field(
+        default=False,
+        description="Forward sub-agent inner events to the webhook (tagged with "
+        "parent_tool_use_id). Default off.",
+    )
     model_config: ClassVar[ConfigDict] = {"frozen": True}
 
     @property

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -676,6 +676,23 @@ class EventService:
         for llm in agent.get_all_llms():
             llm.telemetry.set_stats_update_callback(stats_callback)
 
+    def _make_subagent_event_sink(self):
+        """Create a publish-only sink for sub-agent inner events.
+
+        Mirrors _publish_stream_delta: publishes directly to _pub_sub so events
+        reach subscribers (e.g. WebhookSubscriber) but are NOT persisted to
+        ConversationState.events.
+        """
+        loop = self._main_loop
+        pub_sub = self._pub_sub
+
+        def _sink(event):
+            if not loop or not loop.is_running():
+                return
+            asyncio.run_coroutine_threadsafe(pub_sub(event), loop)
+
+        return _sink
+
     @staticmethod
     def _ensure_workspace_is_git_repo(working_dir: Path) -> None:
         """Initialize the workspace as a git repo if it isn't already one.
@@ -813,6 +830,11 @@ class EventService:
 
         # Register state change callback to automatically publish updates
         self._conversation._state.set_on_state_change(self._conversation._on_event)
+
+        # Wire sub-agent event sink when forwarding is enabled
+        from openhands.agent_server.config import get_default_config
+        if get_default_config().forward_subagent_events:
+            self._conversation._state.set_sub_event_sink(self._make_subagent_event_sink())
 
         # Setup LLM log streaming for remote execution
         self._setup_llm_log_streaming(self._conversation.agent)

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -1149,9 +1149,17 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
                 tool_name = extract_action_name(action_event)
                 observation: Observation = observe(name=tool_name, span_type="TOOL")(
                     tool
-                )(action_event.action, conversation)
+                )(
+                    action_event.action,
+                    conversation,
+                    parent_tool_use_id=action_event.tool_call.id,
+                )
             else:
-                observation = tool(action_event.action, conversation)
+                observation = tool(
+                    action_event.action,
+                    conversation,
+                    parent_tool_use_id=action_event.tool_call.id,
+                )
             assert isinstance(observation, Observation), (
                 f"Tool '{tool.name}' executor must return an Observation"
             )

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -228,6 +228,13 @@ class ConversationState(OpenHandsModel):
     )  # FIFO lock for thread safety
     _save_depth: int = PrivateAttr(default=0)  # context-manager nesting depth
     _dirty: bool = PrivateAttr(default=False)  # pending unsaved field changes
+    _sub_event_sink: "Callable[[Event], None] | None" = PrivateAttr(default=None)
+
+    def set_sub_event_sink(self, sink: "Callable[[Event], None] | None") -> None:
+        self._sub_event_sink = sink
+
+    def get_sub_event_sink(self) -> "Callable[[Event], None] | None":
+        return self._sub_event_sink
 
     @property
     def events(self) -> EventLog:

--- a/openhands-sdk/openhands/sdk/event/base.py
+++ b/openhands-sdk/openhands/sdk/event/base.py
@@ -30,6 +30,14 @@ class Event(DiscriminatedUnionMixin, ABC):
         description="Event timestamp",
     )  # consistent with V1
     source: SourceType = Field(..., description="The source of this event")
+    parent_tool_use_id: str | None = Field(
+        default=None,
+        description=(
+            "If set, this event was produced inside a sub-agent; the value is the "
+            "tool_call_id of the parent TaskAction that spawned it. None for "
+            "main-agent events. Mirrors Anthropic's parent_tool_use_id."
+        ),
+    )
 
     @property
     def visualize(self) -> Text:

--- a/openhands-sdk/openhands/sdk/tool/tool.py
+++ b/openhands-sdk/openhands/sdk/tool/tool.py
@@ -1,4 +1,5 @@
 import asyncio
+import inspect
 import re
 import threading
 from abc import ABC, abstractmethod
@@ -359,7 +360,11 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         return self.action_type.model_validate(arguments)
 
     def __call__(
-        self, action: ActionT, conversation: "LocalConversation | None" = None
+        self,
+        action: ActionT,
+        conversation: "LocalConversation | None" = None,
+        *,
+        parent_tool_use_id: str | None = None,
     ) -> Observation:
         """Validate input, execute, and coerce output.
 
@@ -369,8 +374,15 @@ class ToolDefinition[ActionT, ObservationT](DiscriminatedUnionMixin, ABC):
         if self.executor is None:
             raise NotImplementedError(f"Tool '{self.name}' has no executor")
 
-        # Execute
-        result = self.executor(action, conversation)
+        # Execute — pass parent_tool_use_id only to executors that accept it,
+        # so the ~dozen other tool executors are unaffected (no TypeError).
+        executor_params = inspect.signature(self.executor.__call__).parameters
+        if "parent_tool_use_id" in executor_params:
+            result = self.executor(
+                action, conversation, parent_tool_use_id=parent_tool_use_id
+            )
+        else:
+            result = self.executor(action, conversation)
 
         # Coerce output only if we declared a model; else wrap in base Observation
         if self.observation_type:

--- a/openhands-tools/openhands/tools/task/definition.py
+++ b/openhands-tools/openhands/tools/task/definition.py
@@ -245,7 +245,8 @@ class TaskToolSet(ToolDefinition[TaskAction, TaskObservation]):
             task_tool_examples=task_tool_examples,
         )
 
-        manager = TaskManager(confirmation_handler=confirmation_handler)
+        sink = conv_state.get_sub_event_sink() if hasattr(conv_state, "get_sub_event_sink") else None
+        manager = TaskManager(confirmation_handler=confirmation_handler, sub_event_sink=sink)
         task_executor = TaskExecutor(manager=manager)
 
         tools: list[ToolDefinition] = []

--- a/openhands-tools/openhands/tools/task/impl.py
+++ b/openhands-tools/openhands/tools/task/impl.py
@@ -27,6 +27,8 @@ class TaskExecutor(ToolExecutor):
         self,
         action: TaskAction,
         conversation: LocalConversation | None = None,
+        *,
+        parent_tool_use_id: str | None = None,
     ) -> TaskObservation:
         try:
             task = self._manager.start_task(
@@ -35,6 +37,7 @@ class TaskExecutor(ToolExecutor):
                 description=action.description,
                 resume=action.resume,
                 conversation=conversation,
+                parent_tool_use_id=parent_tool_use_id,
             )
             match task.status:
                 case TaskStatus.COMPLETED:

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -380,8 +380,10 @@ class TaskManager:
 
         def _forward(event):
             try:
-                event.parent_tool_use_id = parent_tool_use_id
-                sink(event)
+                # Event models are frozen (Pydantic frozen=True); use model_copy
+                # to produce a new instance with parent_tool_use_id stamped.
+                stamped = event.model_copy(update={"parent_tool_use_id": parent_tool_use_id})
+                sink(stamped)
             except Exception:
                 logger.warning("sub-agent event forwarding failed", exc_info=True)
 

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -36,9 +36,10 @@ from openhands.sdk.subagent.registry import AgentFactory, get_agent_factory
 
 
 if TYPE_CHECKING:
-    from openhands.sdk.event import ActionEvent
+    from openhands.sdk.event import ActionEvent, Event
 
 ConfirmationHandler = Callable[[str, list["ActionEvent"]], bool]
+SubEventSink = Callable[["Event"], None]
 
 
 logger = get_logger(__name__)
@@ -96,9 +97,11 @@ class TaskManager:
     def __init__(
         self,
         confirmation_handler: ConfirmationHandler | None = None,
+        sub_event_sink: "SubEventSink | None" = None,
     ):
         self._parent_conversation: LocalConversation | None = None
         self._confirmation_handler = confirmation_handler
+        self._sub_event_sink = sub_event_sink
 
         self._tasks: dict[str, Task] = {}
         self._tasks_lock = threading.Lock()
@@ -166,6 +169,7 @@ class TaskManager:
         resume: str | None = None,
         description: str | None = None,
         conversation: LocalConversation | None = None,
+        parent_tool_use_id: str | None = None,
     ) -> Task:
         """Start a blocking sub-agent task.
 
@@ -175,6 +179,8 @@ class TaskManager:
             resume: Task ID to resume (continues existing conversation).
             description: Short label for the task.
             conversation: Parent conversation (set on first call).
+            parent_tool_use_id: Tool-use ID of the calling tool invocation,
+                used for sub-event correlation (threaded to _run_task for Task 3).
 
         Returns:
             TaskState with the final result.
@@ -196,6 +202,7 @@ class TaskManager:
         return self._run_task(
             task=task,
             prompt=prompt,
+            parent_tool_use_id=parent_tool_use_id,
         )
 
     def _resume_task(self, resume: str, subagent_type: str) -> Task:
@@ -342,8 +349,19 @@ class TaskManager:
         )
         return sub_agent
 
-    def _run_task(self, task: Task, prompt: str) -> Task:
-        """Run a task synchronously."""
+    def _run_task(
+        self, task: Task, prompt: str, parent_tool_use_id: str | None = None
+    ) -> Task:
+        """Run a task synchronously.
+
+        Args:
+            task: The task to run.
+            prompt: The prompt to send to the sub-agent.
+            parent_tool_use_id: Tool-use ID of the calling tool invocation.
+                Stored for use by Task 3 (sub-event forwarding callback).
+        """
+        # Store for Task 3 to wire up the forwarding callback.
+        task._parent_tool_use_id = parent_tool_use_id  # type: ignore[attr-defined]
         if task.conversation is None:
             raise RuntimeError(f"Task '{task.id}' has no conversation to run.")
         # Get parent name for sender info

--- a/openhands-tools/openhands/tools/task/manager.py
+++ b/openhands-tools/openhands/tools/task/manager.py
@@ -192,11 +192,13 @@ class TaskManager:
             task = self._resume_task(
                 resume=resume,
                 subagent_type=subagent_type,
+                parent_tool_use_id=parent_tool_use_id,
             )
         else:
             task = self._create_task(
                 subagent_type=subagent_type,
                 description=description,
+                parent_tool_use_id=parent_tool_use_id,
             )
 
         return self._run_task(
@@ -205,7 +207,9 @@ class TaskManager:
             parent_tool_use_id=parent_tool_use_id,
         )
 
-    def _resume_task(self, resume: str, subagent_type: str) -> Task:
+    def _resume_task(
+        self, resume: str, subagent_type: str, parent_tool_use_id: str | None = None
+    ) -> Task:
         """Resume a sub-agent task."""
         with self._tasks_lock:
             if resume not in self._tasks:
@@ -217,6 +221,7 @@ class TaskManager:
             factory = get_agent_factory(subagent_type)
             worker_agent = self._get_sub_agent_from_factory(factory)
             conversation_id = self._tasks[resume].conversation_id
+            _fwd = self._make_forwarding_callback(parent_tool_use_id)
             conversation = LocalConversation(
                 agent=worker_agent,
                 workspace=self.parent_conversation.state.workspace.working_dir,
@@ -224,6 +229,7 @@ class TaskManager:
                 conversation_id=conversation_id,
                 hook_config=factory.definition.hooks,
                 delete_on_close=True,
+                callbacks=[_fwd] if _fwd else [],
             )
 
             self._set_confirmation_policy(
@@ -244,6 +250,7 @@ class TaskManager:
         self,
         subagent_type: str,
         description: str | None,
+        parent_tool_use_id: str | None = None,
     ) -> Task:
         """Create a fresh task.
 
@@ -276,6 +283,7 @@ class TaskManager:
                 worker_agent=worker_agent,
                 conversation_id=conversation_id,
                 hook_config=factory.definition.hooks,
+                parent_tool_use_id=parent_tool_use_id,
             )
 
             self._set_confirmation_policy(
@@ -300,6 +308,7 @@ class TaskManager:
         worker_agent: Agent,
         hook_config: HookConfig | None = None,
         max_budget_per_run: float | None = None,
+        parent_tool_use_id: str | None = None,
     ) -> LocalConversation:
         parent = self.parent_conversation
         parent_visualizer = parent._visualizer
@@ -309,6 +318,7 @@ class TaskManager:
             label = description or task_id
             visualizer = parent_visualizer.create_sub_visualizer(label)
 
+        _fwd = self._make_forwarding_callback(parent_tool_use_id)
         return LocalConversation(
             agent=worker_agent,
             workspace=parent.state.workspace.working_dir,
@@ -319,6 +329,7 @@ class TaskManager:
             max_budget_per_run=max_budget_per_run,
             hook_config=hook_config,
             delete_on_close=True,
+            callbacks=[_fwd] if _fwd else [],
         )
 
     def _get_sub_agent(self, subagent_type: str) -> Agent:
@@ -349,6 +360,33 @@ class TaskManager:
         )
         return sub_agent
 
+    def _make_forwarding_callback(self, parent_tool_use_id: str | None):
+        """Return a best-effort callback that stamps and forwards sub-agent events.
+
+        Returns None when no sink is configured so callers can skip attaching it.
+        The callback sets ``event.parent_tool_use_id`` and calls the sink.
+        It is publish-only: it does not read or mutate the parent conversation
+        (context-isolation invariant).
+
+        Args:
+            parent_tool_use_id: The tool-use ID to stamp on every forwarded event.
+
+        Returns:
+            A callable ``(event) -> None``, or ``None`` if no sink is configured.
+        """
+        sink = self._sub_event_sink
+        if sink is None:
+            return None
+
+        def _forward(event):
+            try:
+                event.parent_tool_use_id = parent_tool_use_id
+                sink(event)
+            except Exception:
+                logger.warning("sub-agent event forwarding failed", exc_info=True)
+
+        return _forward
+
     def _run_task(
         self, task: Task, prompt: str, parent_tool_use_id: str | None = None
     ) -> Task:
@@ -357,11 +395,9 @@ class TaskManager:
         Args:
             task: The task to run.
             prompt: The prompt to send to the sub-agent.
-            parent_tool_use_id: Tool-use ID of the calling tool invocation.
-                Stored for use by Task 3 (sub-event forwarding callback).
+            parent_tool_use_id: Tool-use ID of the calling tool invocation,
+                used to stamp forwarded sub-agent events.
         """
-        # Store for Task 3 to wire up the forwarding callback.
-        task._parent_tool_use_id = parent_tool_use_id  # type: ignore[attr-defined]
         if task.conversation is None:
             raise RuntimeError(f"Task '{task.id}' has no conversation to run.")
         # Get parent name for sender info

--- a/tests/agent_server/test_forward_subagent_flag.py
+++ b/tests/agent_server/test_forward_subagent_flag.py
@@ -1,0 +1,8 @@
+"""Tests for the forward_subagent_events config flag."""
+from openhands.agent_server.config import Config
+
+
+def test_forward_subagent_events_defaults_to_false():
+    """Config.forward_subagent_events must default to False."""
+    config = Config()
+    assert config.forward_subagent_events is False

--- a/tests/agent_server/test_subagent_event_sink.py
+++ b/tests/agent_server/test_subagent_event_sink.py
@@ -1,5 +1,6 @@
 """Tests that the subagent event sink publishes to pub_sub but does NOT persist."""
 import asyncio
+import threading
 from datetime import UTC, datetime
 from pathlib import Path
 from uuid import uuid4
@@ -67,3 +68,74 @@ async def test_sink_publishes_not_persists(stored, tmp_path):
 
     assert len(received) == 1
     assert received[0] is event
+
+
+@pytest.mark.asyncio
+async def test_sink_delivers_from_worker_thread(stored, tmp_path):
+    """Regression: sink called from a worker thread must reach _pub_sub subscribers.
+
+    This is the REAL path: sub-agent runs in a ThreadPoolExecutor worker thread
+    (LocalConversation._run_and_publish runs in run_in_executor). Before the fix
+    the forwarding callback tried to mutate a frozen Pydantic Event via setattr,
+    raising ValidationError (swallowed silently), so events never reached
+    pub_sub / WebhookSubscriber.
+    """
+    svc = EventService(
+        stored=stored,
+        conversations_dir=tmp_path,
+    )
+    loop = asyncio.get_running_loop()
+    svc._main_loop = loop
+
+    received: list[Event] = []
+
+    class ProbeSubscriber(Subscriber[Event]):
+        async def __call__(self, event: Event):
+            received.append(event)
+
+    svc._pub_sub.subscribe(ProbeSubscriber())
+
+    sink = svc._make_subagent_event_sink()
+
+    from openhands.sdk.event.llm_convertible.message import MessageEvent
+    from openhands.sdk.llm import Message
+    from openhands.tools.task.manager import TaskManager
+
+    # Wire the full forwarding path: TaskManager._make_forwarding_callback → sink
+    tool_call_id = "toolu_regression_worker_thread"
+    mgr = TaskManager(sub_event_sink=sink)
+    fwd = mgr._make_forwarding_callback(parent_tool_use_id=tool_call_id)
+    assert fwd is not None
+
+    # Build a real frozen Pydantic event (as the sub-agent actually emits)
+    event = MessageEvent(
+        source="agent",
+        llm_message=Message(role="assistant"),
+    )
+    assert event.parent_tool_use_id is None  # initially unset
+
+    # Call the forwarding callback from a real worker thread — the real path
+    worker_done = threading.Event()
+
+    def worker():
+        fwd(event)
+        worker_done.set()
+
+    t = threading.Thread(target=worker)
+    t.start()
+    t.join(timeout=2)
+    assert worker_done.is_set(), "worker thread did not finish"
+
+    # Give run_coroutine_threadsafe time to schedule and run on the loop
+    await asyncio.sleep(0.1)
+
+    # The stamped copy (not the original frozen instance) must reach the subscriber
+    assert len(received) == 1, f"Expected 1 event, got {len(received)}"
+    stamped = received[0]
+    assert stamped.parent_tool_use_id == tool_call_id, (
+        f"parent_tool_use_id not stamped: got {stamped.parent_tool_use_id!r}"
+    )
+    # The original event must be unmodified (model is frozen, copy was made)
+    assert event.parent_tool_use_id is None, (
+        "Original event was mutated — model_copy was not used"
+    )

--- a/tests/agent_server/test_subagent_event_sink.py
+++ b/tests/agent_server/test_subagent_event_sink.py
@@ -1,0 +1,69 @@
+"""Tests that the subagent event sink publishes to pub_sub but does NOT persist."""
+import asyncio
+from datetime import UTC, datetime
+from pathlib import Path
+from uuid import uuid4
+
+import pytest
+
+from openhands.agent_server.event_service import EventService
+from openhands.agent_server.models import StoredConversation
+from openhands.agent_server.pub_sub import Subscriber
+from openhands.sdk import LLM, Agent, Event
+from openhands.sdk.security.confirmation_policy import NeverConfirm
+from openhands.sdk.workspace import LocalWorkspace
+
+
+@pytest.fixture
+def stored():
+    return StoredConversation(
+        id=uuid4(),
+        agent=Agent(llm=LLM(model="gpt-4o", usage_id="test-llm"), tools=[]),
+        workspace=LocalWorkspace(working_dir="workspace/project"),
+        confirmation_policy=NeverConfirm(),
+        initial_message=None,
+        metrics=None,
+        created_at=datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC),
+        updated_at=datetime(2025, 1, 1, 12, 30, 0, tzinfo=UTC),
+    )
+
+
+@pytest.mark.asyncio
+async def test_sink_publishes_not_persists(stored, tmp_path):
+    """_make_subagent_event_sink publishes to _pub_sub but does NOT grow state.events."""
+    svc = EventService(
+        stored=stored,
+        conversations_dir=tmp_path,
+    )
+    # Set the main_loop (normally set in start())
+    svc._main_loop = asyncio.get_running_loop()
+
+    received = []
+
+    class ProbeSubscriber(Subscriber[Event]):
+        async def __call__(self, event: Event):
+            received.append(event)
+
+    # Subscribe a probe to pub_sub
+    svc._pub_sub.subscribe(ProbeSubscriber())
+
+    sink = svc._make_subagent_event_sink()
+
+    # Create a dummy event using a simple Event subclass
+    from openhands.sdk.event.llm_convertible.message import MessageEvent
+    from openhands.sdk.llm import Message
+
+    event = MessageEvent(
+        id="sub-evt-1",
+        source="user",
+        llm_message=Message(role="user"),
+    )
+
+    # Call sink (fires run_coroutine_threadsafe)
+    sink(event)
+
+    # Wait for the coroutine to complete
+    await asyncio.sleep(0.05)
+
+    assert len(received) == 1
+    assert received[0] is event

--- a/tests/sdk/conversation/test_sub_event_sink.py
+++ b/tests/sdk/conversation/test_sub_event_sink.py
@@ -1,0 +1,44 @@
+"""Tests for ConversationState sub_event_sink slot."""
+from uuid import uuid4
+
+import pytest
+from openhands.sdk import Agent, LLM
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.workspace import LocalWorkspace
+
+
+def _make_state(tmp_path):
+    llm = LLM(model="gpt-4o", usage_id="test")
+    agent = Agent(llm=llm, tools=[])
+    workspace = LocalWorkspace(working_dir=str(tmp_path))
+    return ConversationState.create(
+        id=uuid4(),
+        agent=agent,
+        workspace=workspace,
+        persistence_dir=str(tmp_path / "conversations"),
+    )
+
+
+def test_sub_event_sink_round_trip(tmp_path):
+    """set_sub_event_sink/get_sub_event_sink round-trip works."""
+    state = _make_state(tmp_path)
+
+    def my_sink(event):
+        pass
+
+    assert state.get_sub_event_sink() is None
+    state.set_sub_event_sink(my_sink)
+    assert state.get_sub_event_sink() is my_sink
+
+
+def test_sub_event_sink_not_serialized(tmp_path):
+    """The sink must NOT appear in model_dump() — it's a PrivateAttr."""
+    state = _make_state(tmp_path)
+
+    def my_sink(event):
+        pass
+
+    state.set_sub_event_sink(my_sink)
+    dumped = state.model_dump()
+    assert "_sub_event_sink" not in dumped
+    assert "sub_event_sink" not in dumped

--- a/tests/sdk/event/test_event_parent_tool_use_id.py
+++ b/tests/sdk/event/test_event_parent_tool_use_id.py
@@ -1,0 +1,16 @@
+"""Tests for Event.parent_tool_use_id field."""
+
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
+
+
+def test_parent_tool_use_id_defaults_none_and_roundtrips():
+    e = ConversationStateUpdateEvent(key="x", value=1, source="environment")
+    assert e.parent_tool_use_id is None
+    dumped = e.model_dump(mode="json")
+    assert "parent_tool_use_id" in dumped and dumped["parent_tool_use_id"] is None
+
+    e2 = ConversationStateUpdateEvent(
+        key="x", value=1, source="environment", parent_tool_use_id="toolu_123"
+    )
+    restored = type(e2).model_validate_json(e2.model_dump_json())
+    assert restored.parent_tool_use_id == "toolu_123"

--- a/tests/sdk/tool/test_tool_parent_tool_use_id.py
+++ b/tests/sdk/tool/test_tool_parent_tool_use_id.py
@@ -1,0 +1,223 @@
+"""Unit tests for Task 5: threading parent_tool_use_id through ToolDefinition.__call__
+and _execute_action_event.
+
+Test 1: ToolDefinition.__call__ forwards parent_tool_use_id to executors that accept it;
+        executors without the param still run fine.
+Test 2: _execute_action_event passes action_event.tool_call.id as parent_tool_use_id.
+"""
+
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Self
+from unittest.mock import MagicMock, patch
+
+import pytest
+from pydantic import Field
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.event import ActionEvent, ObservationEvent
+from openhands.sdk.llm import Message, MessageToolCall, TextContent
+from openhands.sdk.testing import TestLLM
+from openhands.sdk.tool import Action, Observation, Tool, ToolExecutor, register_tool
+from openhands.sdk.tool.tool import ToolDefinition
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.state import ConversationState
+
+
+# ---------------------------------------------------------------------------
+# Shared action / observation types
+# ---------------------------------------------------------------------------
+
+
+class SimpleAction(Action):
+    value: str = Field(default="")
+
+
+class SimpleObservation(Observation):
+    result: str = Field(default="")
+
+
+# ---------------------------------------------------------------------------
+# Test 1: ToolDefinition.__call__ forwards / ignores parent_tool_use_id correctly
+# ---------------------------------------------------------------------------
+
+
+class AwareExecutor(ToolExecutor):
+    """Executor that accepts parent_tool_use_id and records it."""
+
+    received_id: list[str | None]
+
+    def __init__(self):
+        self.received_id = []
+
+    def __call__(
+        self,
+        action: SimpleAction,
+        conversation=None,
+        *,
+        parent_tool_use_id: str | None = None,
+    ) -> SimpleObservation:
+        self.received_id.append(parent_tool_use_id)
+        return SimpleObservation(result="aware")
+
+
+class UnawareExecutor(ToolExecutor):
+    """Executor WITHOUT parent_tool_use_id param — must not receive it."""
+
+    called: list[bool]
+
+    def __init__(self):
+        self.called = []
+
+    def __call__(
+        self, action: SimpleAction, conversation=None
+    ) -> SimpleObservation:
+        self.called.append(True)
+        return SimpleObservation(result="unaware")
+
+
+class SimpleTool(ToolDefinition[SimpleAction, SimpleObservation]):
+    name = "simple_test_tool_ptuid"
+
+    @classmethod
+    def create(cls, conv_state=None, **params) -> Sequence["SimpleTool"]:
+        return [cls(**params)]
+
+
+def test_tool_definition_call_forwards_id_to_aware_executor():
+    """parent_tool_use_id is forwarded when executor.__call__ accepts it."""
+    executor = AwareExecutor()
+    tool = SimpleTool(
+        description="Test tool",
+        action_type=SimpleAction,
+        observation_type=SimpleObservation,
+        executor=executor,
+    )
+
+    action = SimpleAction(value="x")
+    result = tool(action, parent_tool_use_id="toolu_abc123")
+
+    assert isinstance(result, SimpleObservation)
+    assert executor.received_id == ["toolu_abc123"]
+
+
+def test_tool_definition_call_without_id_passes_none_to_aware_executor():
+    """When parent_tool_use_id is omitted it defaults to None."""
+    executor = AwareExecutor()
+    tool = SimpleTool(
+        description="Test tool",
+        action_type=SimpleAction,
+        observation_type=SimpleObservation,
+        executor=executor,
+    )
+
+    action = SimpleAction(value="x")
+    tool(action)
+
+    assert executor.received_id == [None]
+
+
+def test_tool_definition_call_does_not_break_unaware_executor():
+    """Passing parent_tool_use_id must not cause TypeError for executors without it."""
+    executor = UnawareExecutor()
+    tool = SimpleTool(
+        description="Test tool",
+        action_type=SimpleAction,
+        observation_type=SimpleObservation,
+        executor=executor,
+    )
+
+    action = SimpleAction(value="x")
+    # This must NOT raise TypeError even though parent_tool_use_id is supplied
+    result = tool(action, parent_tool_use_id="toolu_xyz")
+
+    assert isinstance(result, SimpleObservation)
+    assert executor.called == [True]
+
+
+# ---------------------------------------------------------------------------
+# Test 2: _execute_action_event passes action_event.tool_call.id
+# ---------------------------------------------------------------------------
+
+
+class CapturingExecutor(ToolExecutor):
+    """Executor that captures every parent_tool_use_id it receives."""
+
+    ids: list[str | None]
+
+    def __init__(self):
+        self.ids = []
+
+    def __call__(
+        self,
+        action: SimpleAction,
+        conversation=None,
+        *,
+        parent_tool_use_id: str | None = None,
+    ) -> SimpleObservation:
+        self.ids.append(parent_tool_use_id)
+        return SimpleObservation(result="captured")
+
+
+# Module-level executor so tests can inspect it after agent.step()
+_capturing_executor = CapturingExecutor()
+
+
+class CapturingTool(ToolDefinition[SimpleAction, SimpleObservation]):
+    name = "capturing_tool_ptuid"
+
+    @classmethod
+    def create(cls, conv_state: "ConversationState | None" = None) -> Sequence[Self]:
+        return [
+            cls(
+                description="Captures parent_tool_use_id",
+                action_type=SimpleAction,
+                observation_type=SimpleObservation,
+                executor=_capturing_executor,
+            )
+        ]
+
+
+register_tool("CapturingTool", CapturingTool)
+
+
+def test_execute_action_event_passes_tool_call_id():
+    """_execute_action_event must pass action_event.tool_call.id as parent_tool_use_id."""
+    expected_id = "toolu_test_call_99"
+    _capturing_executor.ids.clear()
+
+    llm = TestLLM.from_messages(
+        [
+            Message(
+                role="assistant",
+                content=[TextContent(text="")],
+                tool_calls=[
+                    MessageToolCall(
+                        id=expected_id,
+                        name="capturing_tool_ptuid",
+                        arguments='{"value": "hello"}',
+                        origin="completion",
+                    )
+                ],
+            ),
+            # Second response: finish
+            Message(role="assistant", content=[TextContent(text="Done")]),
+        ]
+    )
+
+    agent = Agent(llm=llm, tools=[Tool(name="CapturingTool")])
+
+    collected = []
+    conversation = Conversation(agent=agent, callbacks=[lambda e: collected.append(e)])
+    conversation.send_message(Message(role="user", content=[TextContent(text="Go")]))
+
+    # Run one step so the tool call is dispatched
+    agent.step(conversation, on_event=lambda e: collected.append(e))
+
+    assert len(_capturing_executor.ids) == 1, (
+        f"Expected 1 call, got {len(_capturing_executor.ids)}"
+    )
+    assert _capturing_executor.ids[0] == expected_id, (
+        f"Expected parent_tool_use_id={expected_id!r}, got {_capturing_executor.ids[0]!r}"
+    )

--- a/tests/tools/task/test_forwarding_callback.py
+++ b/tests/tools/task/test_forwarding_callback.py
@@ -1,0 +1,50 @@
+"""Tests for TaskManager._make_forwarding_callback (Task 3)."""
+
+import inspect
+
+from openhands.tools.task.manager import TaskManager
+
+
+def test_forwarding_callback_stamps_and_forwards(monkeypatch):
+    captured = []
+    mgr = TaskManager(sub_event_sink=lambda e: captured.append(e))
+    cb = mgr._make_forwarding_callback(parent_tool_use_id="toolu_abc")
+
+    class FakeEvent:
+        parent_tool_use_id = None
+
+    ev = FakeEvent()
+    cb(ev)
+
+    assert ev.parent_tool_use_id == "toolu_abc"
+    assert captured == [ev]
+
+
+def test_no_sink_means_no_callback():
+    mgr = TaskManager(sub_event_sink=None)
+    assert mgr._make_forwarding_callback(parent_tool_use_id="x") is None
+
+
+def test_forwarding_does_not_touch_parent_state():
+    # The callback only stamps + forwards; it must not reference parent state.
+    src = inspect.getsource(TaskManager._make_forwarding_callback)
+    assert "state.events" not in src and "append" not in src
+
+
+def test_forwarding_callback_swallows_sink_errors(monkeypatch):
+    """Best-effort: a failing sink must not crash the sub-agent run."""
+
+    def bad_sink(event):
+        raise RuntimeError("sink exploded")
+
+    mgr = TaskManager(sub_event_sink=bad_sink)
+    cb = mgr._make_forwarding_callback(parent_tool_use_id="toolu_xyz")
+
+    class FakeEvent:
+        parent_tool_use_id = None
+
+    ev = FakeEvent()
+    # Must not raise
+    cb(ev)
+    # stamp still applied even though sink raised
+    assert ev.parent_tool_use_id == "toolu_xyz"

--- a/tests/tools/task/test_forwarding_callback.py
+++ b/tests/tools/task/test_forwarding_callback.py
@@ -2,22 +2,38 @@
 
 import inspect
 
+import pytest
+
+from openhands.sdk.event.llm_convertible.message import MessageEvent
+from openhands.sdk.llm import Message
 from openhands.tools.task.manager import TaskManager
 
 
-def test_forwarding_callback_stamps_and_forwards(monkeypatch):
+def _make_event() -> MessageEvent:
+    """Return a real frozen Pydantic Event instance."""
+    return MessageEvent(
+        source="user",
+        llm_message=Message(role="user"),
+    )
+
+
+def test_forwarding_callback_stamps_and_forwards():
+    """Forwarding callback produces a stamped copy and delivers it to the sink."""
     captured = []
     mgr = TaskManager(sub_event_sink=lambda e: captured.append(e))
     cb = mgr._make_forwarding_callback(parent_tool_use_id="toolu_abc")
 
-    class FakeEvent:
-        parent_tool_use_id = None
-
-    ev = FakeEvent()
+    ev = _make_event()
     cb(ev)
 
-    assert ev.parent_tool_use_id == "toolu_abc"
-    assert captured == [ev]
+    # The original event must be unmodified (frozen model, immutable)
+    assert ev.parent_tool_use_id is None
+
+    # The stamped copy is delivered to the sink
+    assert len(captured) == 1
+    stamped = captured[0]
+    assert stamped is not ev
+    assert stamped.parent_tool_use_id == "toolu_abc"
 
 
 def test_no_sink_means_no_callback():
@@ -31,7 +47,7 @@ def test_forwarding_does_not_touch_parent_state():
     assert "state.events" not in src and "append" not in src
 
 
-def test_forwarding_callback_swallows_sink_errors(monkeypatch):
+def test_forwarding_callback_swallows_sink_errors():
     """Best-effort: a failing sink must not crash the sub-agent run."""
 
     def bad_sink(event):
@@ -40,11 +56,40 @@ def test_forwarding_callback_swallows_sink_errors(monkeypatch):
     mgr = TaskManager(sub_event_sink=bad_sink)
     cb = mgr._make_forwarding_callback(parent_tool_use_id="toolu_xyz")
 
-    class FakeEvent:
-        parent_tool_use_id = None
-
-    ev = FakeEvent()
-    # Must not raise
+    ev = _make_event()
+    # Must not raise even though the sink errors
     cb(ev)
-    # stamp still applied even though sink raised
-    assert ev.parent_tool_use_id == "toolu_xyz"
+
+
+def test_forwarding_callback_uses_model_copy_not_setattr():
+    """Regression: frozen Pydantic Event must be stamped via model_copy, not setattr.
+
+    Setting a field on a frozen model raises ValidationError. The forwarding
+    callback must use model_copy(update=...) to produce a new instance.
+    """
+    captured = []
+    mgr = TaskManager(sub_event_sink=lambda e: captured.append(e))
+    cb = mgr._make_forwarding_callback(parent_tool_use_id="toolu_frozen_test")
+
+    # Use a real frozen Pydantic event (parent_tool_use_id defaults to None)
+    ev = _make_event()
+    assert ev.parent_tool_use_id is None  # frozen, field is set at construction
+
+    # Must not raise (the old code raised ValidationError: frozen_instance)
+    cb(ev)
+
+    # The stamped copy reaches the sink
+    assert len(captured) == 1
+    stamped = captured[0]
+    assert stamped.parent_tool_use_id == "toolu_frozen_test"
+    # Original event is unchanged
+    assert ev.parent_tool_use_id is None
+
+
+def test_forwarding_callback_real_event_frozen_setattr_would_fail():
+    """Confirm that direct setattr on the frozen event raises, so model_copy is required."""
+    from pydantic import ValidationError
+
+    ev = _make_event()
+    with pytest.raises(ValidationError, match="frozen"):
+        ev.parent_tool_use_id = "x"  # type: ignore[misc]

--- a/tests/tools/task/test_sub_event_sink_wiring.py
+++ b/tests/tools/task/test_sub_event_sink_wiring.py
@@ -1,0 +1,20 @@
+"""Tests that sub_event_sink and parent_tool_use_id are threaded through the task tool."""
+import inspect
+
+from openhands.tools.task.manager import TaskManager
+from openhands.tools.task.impl import TaskExecutor
+
+
+def test_taskmanager_accepts_sub_event_sink():
+    sig = inspect.signature(TaskManager.__init__)
+    assert "sub_event_sink" in sig.parameters
+
+
+def test_start_task_accepts_parent_tool_use_id():
+    sig = inspect.signature(TaskManager.start_task)
+    assert "parent_tool_use_id" in sig.parameters
+
+
+def test_executor_call_accepts_parent_tool_use_id():
+    sig = inspect.signature(TaskExecutor.__call__)
+    assert "parent_tool_use_id" in sig.parameters

--- a/tests/tools/task/test_task_manager.py
+++ b/tests/tools/task/test_task_manager.py
@@ -539,7 +539,7 @@ class TestStartTask:
     def teardown_method(self):
         _reset_registry_for_tests()
 
-    def _fake_run_task(self, task: Task, prompt: str) -> Task:
+    def _fake_run_task(self, task: Task, prompt: str, parent_tool_use_id: str | None = None) -> Task:
         """Simulate a successful _run_task without hitting the LLM."""
         task.set_result(f"result for: {prompt}")
         return task

--- a/tests/tools/task/test_task_tool_use_id_threading.py
+++ b/tests/tools/task/test_task_tool_use_id_threading.py
@@ -1,0 +1,219 @@
+"""Integration test for Task 5: TaskAction tool_call_id is threaded through
+the full dispatch chain so forwarded sub-agent events carry the real
+parent_tool_use_id (not None).
+
+End-to-end proof:
+  Parent agent (TestLLM) calls the Task tool → TaskExecutor.__call__ receives
+  parent_tool_use_id == action_event.tool_call.id → TaskManager.start_task is
+  invoked with that id → _make_forwarding_callback stamps it on every forwarded
+  event → the sink captures events with the real, non-None id.
+
+  Parent state.events must NOT contain the sub-agent inner events (isolation).
+"""
+
+from collections.abc import Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Self
+from unittest.mock import patch
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk import Agent, LLM
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.event import ActionEvent, ObservationEvent
+from openhands.sdk.llm import Message, MessageToolCall, TextContent
+from openhands.sdk.subagent.registry import _reset_registry_for_tests
+from openhands.sdk.testing import TestLLM
+from openhands.sdk.tool import Tool, register_tool
+from openhands.tools.preset import register_builtins_agents
+from openhands.tools.task import TaskToolSet
+from openhands.tools.task.definition import TaskAction, TaskObservation
+from openhands.tools.task.impl import TaskExecutor
+from openhands.tools.task.manager import TaskManager, TaskStatus, Task
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_parent_conversation(tmp_path: Path) -> LocalConversation:
+    llm = LLM(model="gpt-4o", api_key=SecretStr("test-key"), usage_id="test-llm")
+    agent = Agent(llm=llm, tools=[])
+    return LocalConversation(
+        agent=agent,
+        workspace=str(tmp_path),
+        visualizer=None,
+        delete_on_close=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Integration test
+# ---------------------------------------------------------------------------
+
+
+class TestSubAgentEventForwarding:
+
+    def setup_method(self):
+        _reset_registry_for_tests()
+
+    def teardown_method(self):
+        _reset_registry_for_tests()
+
+    def test_forwarded_events_carry_real_parent_tool_use_id(self, tmp_path):
+        """
+        Full end-to-end proof:
+
+        1. A TestLLM instructs the parent agent to call the Task tool with a
+           specific tool_call_id ("toolu_task_integration_001").
+        2. The sink captures events; after the Task tool executes the sink must
+           have at least one event stamped with that exact id.
+        3. The parent conversation state.events must NOT contain those inner
+           sub-agent events.
+        """
+        register_builtins_agents()
+        parent_conv = _make_parent_conversation(tmp_path)
+
+        # --- Sink setup ---
+        captured_forwarded: list = []
+
+        def my_sink(event):
+            captured_forwarded.append(event)
+
+        # --- Build TaskManager with sink ---
+        manager = TaskManager(sub_event_sink=my_sink)
+        manager._ensure_parent(parent_conv)
+
+        # --- The tool_call_id the parent LLM will use ---
+        expected_tool_call_id = "toolu_task_integration_001"
+
+        # --- Simulate what TaskExecutor.__call__ does when wired up ---
+        # We mock _run_task so we don't need a real sub-agent LLM.
+        # But we DO let the forwarding callback machinery run so it stamps events.
+        def fake_run_task(task, prompt, parent_tool_use_id=None):
+            """Simulate sub-agent emitting 3 inner events via the forwarding callback."""
+            # Build the forwarding callback exactly as the real code does
+            fwd = manager._make_forwarding_callback(parent_tool_use_id)
+            if fwd is not None:
+                # Emit three fake inner events through the callback
+                for i in range(3):
+                    class _FakeEvent:
+                        parent_tool_use_id = None
+                    ev = _FakeEvent()
+                    fwd(ev)
+            task.set_result("task done")
+            return task
+
+        executor = TaskExecutor(manager=manager)
+
+        action = TaskAction(
+            prompt="do the sub-task",
+            subagent_type="general-purpose",
+        )
+
+        # Patch _run_task to avoid spawning a real sub-agent
+        with patch.object(manager, "_run_task", side_effect=fake_run_task):
+            obs = executor(
+                action=action,
+                conversation=parent_conv,
+                parent_tool_use_id=expected_tool_call_id,
+            )
+
+        # --- Assertions ---
+
+        # 1. The executor returned a successful observation
+        assert isinstance(obs, TaskObservation)
+        assert obs.status == TaskStatus.COMPLETED
+
+        # 2. The sink captured the inner events with the real, non-None id
+        assert len(captured_forwarded) == 3, (
+            f"Expected 3 forwarded events, got {len(captured_forwarded)}"
+        )
+        for ev in captured_forwarded:
+            assert ev.parent_tool_use_id == expected_tool_call_id, (
+                f"Forwarded event parent_tool_use_id must be {expected_tool_call_id!r}, "
+                f"got {ev.parent_tool_use_id!r}"
+            )
+
+        # 3. Parent state.events must NOT contain those inner sub-agent events
+        #    (isolation: sub-agent events are forwarded to the sink, not appended
+        #    to the parent conversation's event log)
+        parent_events = parent_conv.state.events
+        for fwd_ev in captured_forwarded:
+            assert fwd_ev not in parent_events, (
+                "Forwarded sub-agent event must NOT appear in parent state.events"
+            )
+
+    def test_tool_call_id_is_real_not_none_via_tool_definition_dispatch(self, tmp_path):
+        """
+        End-to-end via ToolDefinition.__call__ with the real TaskExecutor:
+
+        Calling tool(action, conversation, parent_tool_use_id=X) routes X
+        through TaskExecutor.__call__ → TaskManager.start_task → forwarding
+        callback → sink.  The captured events carry the real id, not None.
+        """
+        register_builtins_agents()
+        parent_conv = _make_parent_conversation(tmp_path)
+
+        expected_tool_call_id = "toolu_agent_dispatch_007"
+        captured_forwarded: list = []
+
+        def my_sink(event):
+            captured_forwarded.append(event)
+
+        manager = TaskManager(sub_event_sink=my_sink)
+        manager._ensure_parent(parent_conv)
+
+        # Build a ToolDefinition wrapping TaskExecutor (same as production path)
+        from openhands.tools.task.definition import TaskTool
+
+        def fake_run_task(task, prompt, parent_tool_use_id=None):
+            fwd = manager._make_forwarding_callback(parent_tool_use_id)
+            if fwd is not None:
+                for _ in range(2):
+                    class _FakeInnerEvent:
+                        parent_tool_use_id = None
+                    fwd(_FakeInnerEvent())
+            task.set_result("done")
+            return task
+
+        executor = TaskExecutor(manager=manager)
+
+        # description is minimal — just to satisfy TaskTool.create
+        tool_instances = TaskTool.create(executor=executor, description="test task tool")
+        assert len(tool_instances) == 1
+        task_tool = tool_instances[0]
+
+        action = TaskAction(
+            prompt="do the sub-task",
+            subagent_type="general-purpose",
+        )
+
+        with patch.object(manager, "_run_task", side_effect=fake_run_task):
+            obs = task_tool(
+                action,
+                parent_conv,
+                parent_tool_use_id=expected_tool_call_id,
+            )
+
+        # Executor returned successfully
+        assert isinstance(obs, TaskObservation)
+
+        # Sink captured events with the real, non-None id
+        assert len(captured_forwarded) == 2, (
+            f"Expected 2 forwarded events, got {len(captured_forwarded)}"
+        )
+        for ev in captured_forwarded:
+            assert ev.parent_tool_use_id == expected_tool_call_id, (
+                f"Expected {expected_tool_call_id!r}, got {ev.parent_tool_use_id!r}"
+            )
+
+        # Parent state must not contain those inner events
+        parent_events = parent_conv.state.events
+        for fwd_ev in captured_forwarded:
+            assert fwd_ev not in parent_events, (
+                "Forwarded sub-agent event must NOT appear in parent state.events"
+            )

--- a/tests/tools/task/test_task_tool_use_id_threading.py
+++ b/tests/tools/task/test_task_tool_use_id_threading.py
@@ -11,27 +11,19 @@ End-to-end proof:
   Parent state.events must NOT contain the sub-agent inner events (isolation).
 """
 
-from collections.abc import Sequence
 from pathlib import Path
-from typing import TYPE_CHECKING, Self
 from unittest.mock import patch
 
 import pytest
 from pydantic import SecretStr
 
 from openhands.sdk import Agent, LLM
-from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
-from openhands.sdk.event import ActionEvent, ObservationEvent
-from openhands.sdk.llm import Message, MessageToolCall, TextContent
 from openhands.sdk.subagent.registry import _reset_registry_for_tests
-from openhands.sdk.testing import TestLLM
-from openhands.sdk.tool import Tool, register_tool
 from openhands.tools.preset import register_builtins_agents
-from openhands.tools.task import TaskToolSet
 from openhands.tools.task.definition import TaskAction, TaskObservation
 from openhands.tools.task.impl import TaskExecutor
-from openhands.tools.task.manager import TaskManager, TaskStatus, Task
+from openhands.tools.task.manager import TaskManager, TaskStatus
 
 
 # ---------------------------------------------------------------------------
@@ -47,6 +39,17 @@ def _make_parent_conversation(tmp_path: Path) -> LocalConversation:
         workspace=str(tmp_path),
         visualizer=None,
         delete_on_close=False,
+    )
+
+
+def _make_real_event():
+    """Return a real frozen Pydantic Event instance for use in tests."""
+    from openhands.sdk.event.llm_convertible.message import MessageEvent
+    from openhands.sdk.llm import Message
+
+    return MessageEvent(
+        source="agent",
+        llm_message=Message(role="assistant"),
     )
 
 
@@ -98,11 +101,9 @@ class TestSubAgentEventForwarding:
             # Build the forwarding callback exactly as the real code does
             fwd = manager._make_forwarding_callback(parent_tool_use_id)
             if fwd is not None:
-                # Emit three fake inner events through the callback
+                # Emit three real frozen Pydantic events through the callback
                 for i in range(3):
-                    class _FakeEvent:
-                        parent_tool_use_id = None
-                    ev = _FakeEvent()
+                    ev = _make_real_event()
                     fwd(ev)
             task.set_result("task done")
             return task
@@ -174,9 +175,7 @@ class TestSubAgentEventForwarding:
             fwd = manager._make_forwarding_callback(parent_tool_use_id)
             if fwd is not None:
                 for _ in range(2):
-                    class _FakeInnerEvent:
-                        parent_tool_use_id = None
-                    fwd(_FakeInnerEvent())
+                    fwd(_make_real_event())
             task.set_result("done")
             return task
 

--- a/tests/tools/task/test_task_toolset_sink_wiring.py
+++ b/tests/tools/task/test_task_toolset_sink_wiring.py
@@ -1,0 +1,30 @@
+"""Tests that TaskToolSet.create passes sub_event_sink from conv_state to TaskManager."""
+from unittest.mock import MagicMock
+from openhands.tools.task import TaskToolSet
+from openhands.tools.task.impl import TaskExecutor
+
+
+def test_task_toolset_passes_sink_from_conv_state():
+    """When conv_state has a sub_event_sink, it's passed to TaskManager."""
+    my_sink = lambda event: None
+
+    mock_state = MagicMock()
+    mock_state.get_sub_event_sink.return_value = my_sink
+    # Ensure hasattr works for our guard
+
+    tools = TaskToolSet.create(conv_state=mock_state)
+    assert len(tools) == 1
+    tool = tools[0]
+
+    # The tool has an executor; the executor has a manager
+    assert isinstance(tool.executor, TaskExecutor)
+    assert tool.executor._manager._sub_event_sink is my_sink
+
+
+def test_task_toolset_none_sink_when_conv_state_none():
+    """When conv_state is None (legacy), sink is None."""
+    tools = TaskToolSet.create(conv_state=None)
+    assert len(tools) == 1
+    tool = tools[0]
+    assert isinstance(tool.executor, TaskExecutor)
+    assert tool.executor._manager._sub_event_sink is None


### PR DESCRIPTION
Refs OpenHands/software-agent-sdk#3907

## Why
Sub-agent (`TaskToolSet`) inner events never reach the parent conversation's live
stream — only `TaskAction` + `TaskObservation` do. Consumers of the agent-server
WebSocket can't show what a sub-agent is doing in real time and must poll the
on-disk `subagents/` dir. This adds opt-in forwarding of sub-agent events onto the
parent's live stream, tagged for correlation, **without** polluting the main
agent's LLM context.

## Summary
- `Event.parent_tool_use_id: str | None` (default `None`) — `None` = main-agent
  event; non-null = sub-agent event, value = spawning `TaskAction`'s `tool_call_id`
  (mirrors Anthropic's `parent_tool_use_id`).
- `task` tool / `TaskManager`: attach a forwarding callback to the sub-agent
  `LocalConversation` that stamps `parent_tool_use_id` and forwards via a sink —
  **publish-only, never appended to the parent's `state.events`** (delegation
  isolation preserved; reuses the `StreamingDeltaEvent` publish-not-persist path).
- Wire the sink from the agent-server through `conv_state` into the `TaskManager`;
  flag-gated by `OH_FORWARD_SUBAGENT_EVENTS` (default off).
- Thread the parent `TaskAction.tool_call_id` through tool dispatch so forwarded
  events carry the real id (not `None`).
- Fix: stamp via `model_copy(...)` (Event is a frozen Pydantic model).

## How to Test
1. Build/run an agent-server from this branch with `OH_FORWARD_SUBAGENT_EVENTS=true`.
2. Start a conversation; send a prompt that delegates to a sub-agent via the `task`
   tool (e.g. "use the task tool to delegate to the `code-explorer` sub-agent…").
3. Connect to the agent-server WS `/sockets/events/{conversation_id}`.
4. Observe: sub-agent inner events stream live, each with
   `parent_tool_use_id == <TaskAction tool_call_id>`; the parent stream still shows
   only `TaskAction` + `TaskObservation` (`parent_tool_use_id: null`); the main
   agent's `state.events` is unchanged.
- Unit tests added: `tests/sdk/event/...`, `tests/sdk/conversation/...`,
  `tests/sdk/tool/...`, `tests/tools/task/...`, `tests/agent_server/...`.
- Verified end-to-end with a built-in (`code-explorer`) and a plugin
  (`code-reviewer`) sub-agent.

## Type
- [x] Feature

## Notes
- **Default off** (`OH_FORWARD_SUBAGENT_EVENTS`) → no behavior change unless enabled.
- ⚠️ **Branch is based on `v1.29.0`; `main` is ~52 commits ahead.** Needs a rebase
  onto `main` (touches core files: `agent.py`, `tool.py`, `manager.py`, `state.py`,
  `event/base.py`) before merge — opening as **draft** for design discussion per #3907.
- A companion **OpenHands** app-server PR (separate-dir store + sub-stream endpoint)
  will follow once this is agreed/released.
