### PR TITLE
fix(sdk): redact plugin and extension source credentials at the serialization boundary (#3752)

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/conversation.py
@@ -20,6 +20,7 @@ from openhands.sdk.logger import get_logger
 from openhands.sdk.plugin import PluginSource
 from openhands.sdk.secret import SecretValue
 from openhands.sdk.tool.client_tool import ClientToolSpec
+from openhands.sdk.utils.redact import redact_url_credentials
 from openhands.sdk.workspace import LocalWorkspace, RemoteWorkspace
 
 
@@ -174,7 +175,12 @@ class Conversation:
 
             # 2. Auto-generate plugins/skills tag from plugins parameter
             if plugins:
-                plugin_urls = [p.source_url for p in plugins if p.source_url]
+                # tags persist verbatim — mask inline creds (${VAR} refs survive).
+                plugin_urls = [
+                    redact_url_credentials(url, preserve_placeholders=True)
+                    for p in plugins
+                    if (url := p.source_url)
+                ]
                 if plugin_urls:
                     effective_tags["plugins"] = ",".join(plugin_urls)
                     logger.debug(f"Added plugins tag with {len(plugin_urls)} plugin(s)")

--- a/openhands-sdk/openhands/sdk/plugin/types.py
+++ b/openhands-sdk/openhands/sdk/plugin/types.py
@@ -6,7 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import frontmatter
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, Field, field_serializer, field_validator
 
 from openhands.sdk.utils.path import to_posix_path
 from openhands.sdk.utils.redact import redact_url_credentials
@@ -63,6 +63,15 @@ class PluginSource(BaseModel):
                 "repo_path cannot contain '..' (parent directory traversal)"
             )
         return v
+
+    @field_serializer("source", when_used="always")
+    def _redact_source(self, source: str) -> str:
+        """Mask inline URL credentials on dump; ${VAR} refs survive (not secrets).
+
+        The raw value stays on the attribute for fetch/clone — only serialized
+        forms (persisted state, the plugins tag, the remote payload) are masked.
+        """
+        return redact_url_credentials(source, preserve_placeholders=True)
 
     @property
     def source_url(self) -> str | None:

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -138,19 +138,17 @@ def http_error_log_content(response: httpx.Response) -> str | dict:
         return f"<non-JSON response body omitted ({body_len} chars)>"
 
 
-def redact_url_credentials(url: str) -> str:
+def redact_url_credentials(url: str, *, preserve_placeholders: bool = False) -> str:
     """Redact credentials embedded in a URL (e.g. https://user:token@host).
 
     Replaces the ``user:password`` or bare-token portion before the ``@`` with
     ``****`` so the URL is safe for logs, error messages, and persisted state.
     SSH URLs (``git@host``) and credential-free URLs are returned unchanged.
 
-    Args:
-        url: A URL that may contain embedded credentials.
-
-    Returns:
-        URL with the credential portion replaced by ``****``, or the original
-        URL if no embedded credentials are found.
+    With ``preserve_placeholders``, a userinfo holding a ``${VAR}`` reference is
+    left intact: it is expanded from the secret registry at fetch time and is
+    not itself a secret, so masking it would break the clone. Inline credentials
+    are still masked.
 
     Examples:
         >>> redact_url_credentials("https://oauth2:SECRET@gitlab.com/repo.git")
@@ -159,11 +157,17 @@ def redact_url_credentials(url: str) -> str:
         'https://github.com/owner/repo.git'
         >>> redact_url_credentials("git@github.com:owner/repo.git")
         'git@github.com:owner/repo.git'
+        >>> redact_url_credentials(
+        ...     "https://x-token-auth:${TOKEN}@host/r.git", preserve_placeholders=True
+        ... )
+        'https://x-token-auth:${TOKEN}@host/r.git'
     """
     match = re.match(r"^(https?://)([^@/]+)@(.+)$", url)
-    if match:
-        return f"{match.group(1)}****@{match.group(3)}"
-    return url
+    if not match:
+        return url
+    if preserve_placeholders and "${" in match.group(2):
+        return url
+    return f"{match.group(1)}****@{match.group(3)}"
 
 
 # Matches embedded ``http(s)://user:token@`` credentials anywhere within a

--- a/tests/sdk/conversation/remote/test_remote_conversation.py
+++ b/tests/sdk/conversation/remote/test_remote_conversation.py
@@ -256,6 +256,41 @@ class TestRemoteConversation:
     @patch(
         "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
     )
+    def test_remote_conversation_plugin_source_redacted_placeholder_kept(
+        self, mock_ws_client
+    ):
+        """The create payload masks inline plugin-source creds but keeps ${VAR}
+        placeholders, so the server clones private plugins via secret expansion
+        without raw credentials crossing the wire."""
+        from openhands.sdk.plugin import PluginSource
+
+        conversation_id = str(uuid.uuid4())
+        mock_client_instance = self.setup_mock_client(conversation_id=conversation_id)
+        mock_ws_client.return_value = Mock()
+
+        placeholder = "https://x-token-auth:${MY_TOKEN}@host/org/repo.git"
+        RemoteConversation(
+            agent=self.agent,
+            workspace=self.workspace,
+            plugins=[
+                PluginSource(source="https://oauth2:LEAKME@host/org/priv.git"),
+                PluginSource(source=placeholder),
+            ],
+        )
+
+        create_call = next(
+            call
+            for call in mock_client_instance.request.call_args_list
+            if call[0][0] == "POST" and call[0][1] == "/api/conversations"
+        )
+        sources = [p["source"] for p in create_call.kwargs["json"]["plugins"]]
+        assert "https://****@host/org/priv.git" in sources
+        assert placeholder in sources
+        assert "LEAKME" not in str(create_call.kwargs["json"]["plugins"])
+
+    @patch(
+        "openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient"
+    )
     def test_remote_conversation_user_id_none_sends_explicit_null(self, mock_ws_client):
         """user_id=None sends an explicit null key (not omitted) so the server
         receives a consistent payload regardless of whether user_id was supplied."""

--- a/tests/sdk/conversation/test_local_conversation_plugins.py
+++ b/tests/sdk/conversation/test_local_conversation_plugins.py
@@ -1463,3 +1463,37 @@ class TestAmbientPluginAutoLoad:
         assert "ambient-skill" in skill_names
         assert conversation.resolved_plugins is None
         conversation.close()
+
+    def test_plugin_load_log_never_leaks_credentials(
+        self, tmp_path: Path, basic_agent, caplog: pytest.LogCaptureFixture
+    ):
+        """Plugin-load logs must never contain the source credential. A serializer
+        covers model dumps, not f-string log lines, so this guards against anyone
+        re-adding spec.source to that log (issue #3752)."""
+        plugin_dir = create_test_plugin(
+            tmp_path / "plugin",
+            name="test-plugin",
+            skills=[{"name": "s", "content": "c"}],
+        )
+        workspace = tmp_path / "workspace"
+        workspace.mkdir()
+        conversation = LocalConversation(
+            agent=basic_agent,
+            workspace=workspace,
+            plugins=[
+                PluginSource(source="https://oauth2:LEAKME@host.example.com/o/r.git")
+            ],
+            visualizer=None,
+        )
+        with (
+            caplog.at_level(logging.DEBUG),
+            patch(
+                "openhands.sdk.conversation.impl.local_conversation."
+                "fetch_plugin_with_resolution",
+                return_value=(plugin_dir, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+            ),
+        ):
+            conversation._ensure_plugins_loaded()
+
+        assert "LEAKME" not in caplog.text
+        conversation.close()

--- a/tests/sdk/extensions/installation/test_installation_manager.py
+++ b/tests/sdk/extensions/installation/test_installation_manager.py
@@ -1,5 +1,6 @@
 import shutil
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 from pydantic import BaseModel
@@ -101,6 +102,29 @@ def test_install_from_local_path(
 
     metadata = InstallationMetadata.load_from_dir(installation_dir)
     assert mock_extension.name in metadata.extensions
+
+
+def test_update_reclones_with_credentialed_source(
+    manager: InstallationManager[MockExtension],
+    mock_extension_dir: Path,
+    mock_extension: MockExtension,
+):
+    """update() re-clones using the real credential recorded in .installed.json.
+
+    Extensions have no ${VAR} mechanism and the extensions layer has no cipher,
+    so the source is kept intact at rest; redacting it here would make a private
+    extension fail to re-clone on update (regression guard for issue #3752)."""
+    cred = "https://oauth2:SUPER_SECRET@github.com/org/repo.git"
+    with patch(
+        "openhands.sdk.extensions.installation.manager.fetch_with_resolution",
+        return_value=(mock_extension_dir, "abc123"),
+    ) as mock_fetch:
+        manager.install(source=cred, force=True)  # records cred in .installed.json
+        mock_fetch.reset_mock()
+        manager.update(mock_extension.name)  # re-fetch from the stored source
+
+    assert mock_fetch.call_count == 1
+    assert mock_fetch.call_args.kwargs["source"] == cred
 
 
 def test_install_already_exist_raises_error(

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -115,6 +115,20 @@ class TestRedactUrlCredentials:
         assert result == "https://****@github.com/repo.git"
         assert "user%40domain" not in result
 
+    def test_preserve_placeholders_keeps_var_reference(self):
+        """A ${VAR} userinfo is not a secret and must survive when asked."""
+        url = "https://x-token-auth:${MY_TOKEN}@host/repo.git"
+        assert redact_url_credentials(url, preserve_placeholders=True) == url
+        # Without the flag it is masked like any other userinfo.
+        assert redact_url_credentials(url) == "https://****@host/repo.git"
+
+    def test_preserve_placeholders_still_masks_inline_credentials(self):
+        """preserve_placeholders only spares ${VAR}; real inline creds are masked."""
+        url = "https://oauth2:SECRET@github.com/org/repo.git"
+        result = redact_url_credentials(url, preserve_placeholders=True)
+        assert result == "https://****@github.com/org/repo.git"
+        assert "SECRET" not in result
+
 
 class TestResolvedPluginSourceCredentialRedaction:
     """Tests for credential redaction in ResolvedPluginSource."""
@@ -192,6 +206,50 @@ class TestResolvedPluginSourceCredentialRedaction:
         json_str = resolved.model_dump_json()
         assert "SUPER_SECRET" not in json_str
         assert "****" in json_str
+
+
+class TestPluginSourceCredentialRedaction:
+    """PluginSource.source masks inline credentials at serialization time while
+    keeping the raw value in memory for fetch/clone and preserving ${VAR} refs."""
+
+    CRED = "https://oauth2:SUPER_SECRET@gitlab.com/org/repo.git"
+    REDACTED = "https://****@gitlab.com/org/repo.git"
+    PLACEHOLDER = "https://x-token-auth:${MY_TOKEN}@host/repo.git"
+
+    def test_default_dump_masks_only_the_credential(self):
+        ps = PluginSource(source=self.CRED)
+        # URL shape is kept (not a full ********** mask).
+        assert ps.model_dump()["source"] == self.REDACTED
+        assert "SUPER_SECRET" not in ps.model_dump_json()
+
+    def test_in_memory_value_is_raw_for_fetch(self):
+        # The attribute keeps the real URL so the plugin can still be cloned.
+        assert PluginSource(source=self.CRED).source == self.CRED
+
+    def test_placeholder_survives_dump(self):
+        # ${VAR} is not a secret; it is expanded from the secret registry at
+        # fetch time (incl. server-side), so it must survive every dump.
+        ps = PluginSource(source=self.PLACEHOLDER)
+        assert ps.model_dump()["source"] == self.PLACEHOLDER
+        assert ps.model_dump_json().count("${MY_TOKEN}") == 1
+
+    @pytest.mark.parametrize(
+        "source",
+        [
+            "github:owner/repo",
+            "/path/to/local/plugin",
+            "git@github.com:owner/repo.git",
+            "https://github.com/owner/repo.git",
+        ],
+    )
+    def test_non_credential_sources_unchanged(self, source):
+        assert PluginSource(source=source).model_dump()["source"] == source
+
+    def test_redacted_dump_round_trips(self):
+        # Reloading a redacted dump does not raise; the source stays redacted
+        # (resume of an inline-credentialed plugin relies on the resolved SHA).
+        dumped = PluginSource(source=self.CRED).model_dump()
+        assert PluginSource.model_validate(dumped).source == self.REDACTED
 
 
 class TestRedactUrlCredentialsCentralModule:

--- a/tests/workspace/test_cloud_workspace_automation_tags.py
+++ b/tests/workspace/test_cloud_workspace_automation_tags.py
@@ -375,6 +375,32 @@ class TestPluginsTagInConversation:
             )
             assert "https://github.com/OpenHands/review-skill" in plugin_urls
 
+    def test_credentials_redacted_in_plugins_tag(self):
+        """Inline creds must not reach the persisted plugins tag; ${VAR} survives."""
+        from unittest.mock import MagicMock
+
+        from openhands.sdk.conversation.conversation import Conversation
+        from openhands.sdk.plugin import PluginSource
+        from openhands.sdk.workspace import RemoteWorkspace
+
+        mock_workspace = MagicMock(spec=RemoteWorkspace)
+        mock_workspace.default_conversation_tags = {}
+
+        plugins = [
+            PluginSource(source="https://oauth2:SUPER_SECRET@github.com/org/repo.git"),
+            PluginSource(source="https://x-token-auth:${MY_TOKEN}@host/org/ext.git"),
+        ]
+        with patch(
+            "openhands.sdk.conversation.impl.remote_conversation.RemoteConversation"
+        ) as mock_convo_class:
+            mock_convo_class.return_value = MagicMock()
+            Conversation(agent=MagicMock(), workspace=mock_workspace, plugins=plugins)
+            tag = mock_convo_class.call_args.kwargs["tags"]["plugins"]
+
+        assert "SUPER_SECRET" not in tag
+        assert "https://****@github.com/org/repo.git" in tag.split(",")
+        assert "https://x-token-auth:${MY_TOKEN}@host/org/ext.git" in tag.split(",")
+
     def test_local_plugins_not_included_in_tags(self):
         """Should not include local path plugins in tags."""
         from unittest.mock import MagicMock


### PR DESCRIPTION
<!-- AI/LLM agents: Do not edit the HUMAN section. -->

HUMAN:

Taking over the stale community PR #3786 (thanks @haya-asif). After re-reading Vasco's review I went with the minimal version: one serializer that masks inline credentials but preserves `${VAR}` refs, instead of the secret-convention machinery (expose modes + encrypt-at-rest). Same security outcome for the paths that matter, far less surface area. Verified green locally on latest main.

---

AGENT:

## Why

Closes #3752. Supersedes #3786 (original work by @haya-asif).

Inline credentials in a plugin `source` URL (e.g. `https://oauth2:TOKEN@host/repo.git`)
leak into persisted state (conversation `meta.json`), the auto `plugins` tag, the
remote create payload, and ordinary model dumps, because `PluginSource.source`
serializes verbatim. This is the SDK-side sibling of APP-904
(OpenHands/OpenHands#14795, which added a `@field_serializer('source')` to the app
repo's `PluginSpec` with a `# TODO` to switch to the SDK's `redact_url_credentials`
once available — this closes that loop).

The one subtlety, per the #3786 / #2196 reviews: **`${VAR}` placeholders are not
secrets.** They are expanded from the secret registry at fetch time (including
server-side, where `_expand_plugin_source_ref` reads the registry), and they are
how private plugins are meant to authenticate. So they must survive serialization;
only genuine inline credentials should be masked.

## Summary

One choke point, no new secret API:

- **`redact_url_credentials(url, *, preserve_placeholders=False)`** gains a flag that
  leaves a `${VAR}`-bearing userinfo intact while still masking real inline
  credentials.
- **`PluginSource`** gets a single `@field_serializer("source")` that masks the
  userinfo (`https://****@host`) on every dump and keeps `${VAR}` refs. The raw value
  stays on the attribute, so fetch/clone is unaffected — only serialized forms
  (`meta.json`, the `plugins` tag, the remote payload) are masked. This covers all of
  Vasco's leak paths at once.
- The auto **`plugins` tag** is masked the same way.
- **`ResolvedPluginSource`** keeps redacting at construction, so direct attribute
  reads (example scripts, etc.) stay safe — no attribute-access leak introduced.

Deliberate non-changes:

- **Extensions (`.installed.json`) are left untouched.** `InstallationInfo.source`
  is serialized in exactly one place — `save_to_dir` → `.installed.json` — and
  `ExtensionManager.update()` re-clones from it. Extensions have no `${VAR}`
  mechanism and the layer has no cipher, so the source must stay intact at rest or
  private-extension updates break (Vasco's regression #2). Redacting it there would
  only break `update()` without closing the on-disk credential, so it's out of scope;
  a regression guard locks the re-clone behavior in. Encrypting extension metadata at
  rest is a separate follow-up.
- The plugin-load log leak (issue point 3) is already gone on `main` — the log sites
  print only `plugin.manifest.name` + `resolved_ref[:8]`. A guard test keeps it that
  way.

What this drops vs #3786: the `serialize_credential_url`/`validate_credential_url`
secret API, the `cipher` encrypt-at-rest mode, the before-validator decrypt, and the
`expose_secrets` plumbing on the remote payload and `save_to_dir`. The encrypt-at-rest
mode only helped *inline-credentialed* plugins survive a cacheless resume — but inline
credentials are exactly what we want out of persisted state, and `${VAR}` (which
survives) is the supported channel.

## Trade-off

An inline-credentialed *private* plugin will no longer re-clone on a remote/fresh-pod
resume — it must use a `${VAR}` reference instead. Those URLs were already leaking
their token into `meta.json`/tags/the payload before this PR, so the secure migration
is to `${VAR}`, which works end to end.

## Issue Number

Closes #3752.

## How to Test

```bash
uv run pytest tests/sdk/git/test_url_redaction.py tests/sdk/extensions/installation \
  tests/sdk/conversation/remote/test_remote_conversation.py \
  tests/sdk/conversation/test_local_conversation_plugins.py \
  tests/workspace/test_cloud_workspace_automation_tags.py
uv run ruff check . && uv run pyright
```

New tests cover each live path: `${VAR}` survives the default dump (the case #3786
never guarded), inline creds masked while the URL shape is kept, the in-memory value
stays raw, non-credential sources unchanged, the redacted `plugins` tag, the remote
payload (mask inline / keep `${VAR}`), the plugin-load log guard, and the
`update()` re-clone guard. Locally: targeted + full `tests/sdk` and the agent-server
persistence/plugin suites pass; ruff + pyright clean.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ce50187-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ce50187-python \
  ghcr.io/openhands/agent-server:ce50187-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ce50187-golang-amd64
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-golang-amd64
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-golang-amd64
ghcr.io/openhands/agent-server:ce50187-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ce50187-golang-arm64
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-golang-arm64
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-golang-arm64
ghcr.io/openhands/agent-server:ce50187-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ce50187-java-amd64
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-java-amd64
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-java-amd64
ghcr.io/openhands/agent-server:ce50187-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ce50187-java-arm64
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-java-arm64
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-java-arm64
ghcr.io/openhands/agent-server:ce50187-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ce50187-python-amd64
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-python-amd64
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-python-amd64
ghcr.io/openhands/agent-server:ce50187-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ce50187-python-arm64
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-python-arm64
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-python-arm64
ghcr.io/openhands/agent-server:ce50187-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ce50187-golang
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-golang
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-golang
ghcr.io/openhands/agent-server:ce50187-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ce50187-java
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-java
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-java
ghcr.io/openhands/agent-server:ce50187-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ce50187-python
ghcr.io/openhands/agent-server:ce50187ba047b2b4cbe8a057f133bb01c8fcd388-python
ghcr.io/openhands/agent-server:fix-redact-plugin-source-creds-python
ghcr.io/openhands/agent-server:ce50187-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ce50187-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ce50187-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->