### PR TITLE
refactor(sdk): port planning prompt to the registry, retire system_prompt_planning.j2

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -27,7 +27,7 @@ from openhands.sdk.agent.utils import (
     parse_tool_call_arguments,
     prepare_llm_messages,
 )
-from openhands.sdk.context.prompts.presets import create_registry
+from openhands.sdk.context.prompts.presets import PromptPreset, create_registry
 from openhands.sdk.conversation import (
     CancellationToken,
     ConversationCallbackType,
@@ -474,7 +474,10 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         secret_infos = state.secret_registry.get_secret_infos()
 
         ctx = self._build_prompt_context(additional_secret_infos=secret_infos)
-        return create_registry().build(ctx).dynamic
+        # The dynamic tier is preset-independent; fall back to the default tier for a
+        # custom Jinja template (preset None), as before.
+        preset = self._prompt_preset or PromptPreset.DEFAULT
+        return create_registry(preset).build(ctx).dynamic
 
     def _execute_actions(
         self,

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -26,7 +26,7 @@ from pydantic import (
 
 from openhands.sdk.context.agent_context import AgentContext
 from openhands.sdk.context.condenser import CondenserBase
-from openhands.sdk.context.prompts.presets import create_registry
+from openhands.sdk.context.prompts.presets import PromptPreset, create_registry
 from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.context.prompts.section import Platform, PromptContext
 from openhands.sdk.critic.base import CriticBase
@@ -111,11 +111,20 @@ _DEFAULT_SOUL = (
     " with a computer to solve tasks."
 )
 
-# Built-in prompt dir. The registry only stands in for the default prompt here; a
-# subclass with its own prompts/system_prompt.j2 keeps the Jinja render path.
+# Built-in prompt dir. The registry only stands in for built-in prompts here; a
+# subclass with its own prompts/ keeps the Jinja render path.
 _BUILTIN_PROMPT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), "prompts")
 )
+
+# Built-in ``system_prompt_filename`` values are back-compat sentinels (the .j2 files
+# were removed) that select a registry preset. ``system_prompt_planning.j2`` keeps its
+# historical name so ``get_planning_agent`` needs no change. Any other filename -- or a
+# subclass's own ``prompt_dir`` -- falls through to the Jinja escape hatch.
+_PRESET_BY_FILENAME: dict[str, PromptPreset] = {
+    "system_prompt.j2": PromptPreset.DEFAULT,
+    "system_prompt_planning.j2": PromptPreset.PLANNING,
+}
 
 
 def _load_soul_md() -> str:
@@ -462,6 +471,18 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         return self.__class__.__name__
 
     @property
+    def _prompt_preset(self) -> PromptPreset | None:
+        """The registry preset for this agent's built-in prompt.
+
+        ``None`` means "take the Jinja escape hatch": a subclass with its own
+        ``prompt_dir``, or a ``system_prompt_filename`` that is not a known built-in
+        sentinel (e.g. a custom relative name or an absolute path).
+        """
+        if os.path.realpath(self.prompt_dir) != _BUILTIN_PROMPT_DIR:
+            return None
+        return _PRESET_BY_FILENAME.get(self.system_prompt_filename)
+
+    @property
     def static_system_message(self) -> str:
         """Compute the static portion of the system message.
 
@@ -469,10 +490,11 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         per-conversation context. This static portion can be cached and reused
         across conversations for better prompt caching efficiency.
 
-        The default prompt is assembled from the typed section registry, which also
-        resolves a custom ``security_policy_filename``. Escape hatches keep the Jinja
-        path: an inline ``system_prompt`` is returned verbatim; a custom
-        ``system_prompt_filename`` or subclass ``prompt_dir`` renders its own template.
+        Built-in prompts (the ``default`` and ``planning`` presets) are assembled from
+        the typed section registry, which also resolves a custom
+        ``security_policy_filename``. Escape hatches keep the Jinja path: an inline
+        ``system_prompt`` is returned verbatim; a custom ``system_prompt_filename`` or
+        subclass ``prompt_dir`` renders its own template.
 
         Returns:
             The static system prompt without dynamic context.
@@ -482,17 +504,15 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
 
         # Escape hatch: a custom filename or a subclass's own prompt_dir renders its
         # own Jinja template; everything else (incl. custom policies) uses the registry.
-        if (
-            self.system_prompt_filename != "system_prompt.j2"
-            or os.path.realpath(self.prompt_dir) != _BUILTIN_PROMPT_DIR
-        ):
+        preset = self._prompt_preset
+        if preset is None:
             return render_template(
                 prompt_dir=self.prompt_dir,
                 template_name=self.system_prompt_filename,
                 **self._resolved_template_kwargs(),
             )
 
-        return create_registry().build(self._build_prompt_context()).static
+        return create_registry(preset).build(self._build_prompt_context()).static
 
     def _resolved_template_kwargs(self) -> dict[str, object]:
         """Resolve the system-prompt template kwargs.
@@ -640,7 +660,10 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         """
         if not self.agent_context:
             return None
-        return create_registry().build(self._build_prompt_context()).dynamic
+        # The dynamic tier is preset-independent, so a custom Jinja template (preset
+        # None) still gets the default dynamic block, exactly as before.
+        preset = self._prompt_preset or PromptPreset.DEFAULT
+        return create_registry(preset).build(self._build_prompt_context()).dynamic
 
     def init_state(
         self,

--- a/openhands-sdk/openhands/sdk/context/prompts/presets.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/presets.py
@@ -1,14 +1,20 @@
 """Named :class:`PromptRegistry` presets -- ready-to-use section compositions.
 
-``create_registry()`` registers the static-tier sections in the exact order
-``agent/prompts/system_prompt.j2`` emits them, so ``registry.build(ctx).static``
-reproduces ``AgentBase.static_system_message``. The dynamic-tier sections are
-appended separately. It will gain a ``preset``
-flag to select among prompt variants (interactive, planning, ...) over the same
-engine; today it returns the default composition.
+``create_registry()`` selects a section composition over the same engine. The
+``"default"`` preset registers the static-tier sections in the exact order
+``agent/prompts/system_prompt.j2`` emitted them, so ``registry.build(ctx).static``
+reproduces ``AgentBase.static_system_message``. The ``"planning"`` preset is a
+distinct standalone composition (ported from ``system_prompt_planning.j2``) that
+omits the default OpenHands sections. The dynamic-tier sections are **shared** --
+datetime/repo/skills/suffix/secrets are preset-independent -- so a planning agent
+with an ``agent_context`` still gets its dynamic block.
 """
 
+from enum import StrEnum
+from typing import Final
+
 from openhands.sdk.context.prompts.registry import PromptRegistry
+from openhands.sdk.context.prompts.section import PromptSection
 from openhands.sdk.context.prompts.sections.dynamic import (
     AvailableSkillsSection,
     CustomSecretsSection,
@@ -16,6 +22,7 @@ from openhands.sdk.context.prompts.sections.dynamic import (
     DateTimeSection,
     RepoContextSection,
 )
+from openhands.sdk.context.prompts.sections.planning import PlanningSection
 from openhands.sdk.context.prompts.sections.static import (
     BrowserSection,
     CodeQualitySection,
@@ -38,34 +45,65 @@ from openhands.sdk.context.prompts.sections.static import (
 )
 
 
-__all__ = ["create_registry"]
+__all__ = ["PromptPreset", "create_registry"]
 
 
-def create_registry() -> PromptRegistry:
+class PromptPreset(StrEnum):
+    """Names a :func:`create_registry` section composition."""
+
+    DEFAULT = "default"
+    PLANNING = "planning"
+
+
+_DEFAULT_STATIC_SECTIONS: Final[tuple[PromptSection, ...]] = (
+    SoulSection(),
+    RoleSection(),
+    MemorySection(),
+    EfficiencySection(),
+    FileSystemSection(),
+    CodeQualitySection(),
+    VersionControlSection(),
+    PullRequestsSection(),
+    ProblemSolvingSection(),
+    SelfDocumentationSection(),
+    SecuritySection(),  # guard: security_policy_filename set
+    SecurityRiskAssessmentSection(),  # guard: llm_security_analyzer
+    BrowserSection(),  # guard: ctx.enable_browser
+    ExternalServicesSection(),
+    EnvironmentSetupSection(),
+    TroubleshootingSection(),
+    ProcessManagementSection(),
+    ModelSpecificSection(),  # guard: model_family resolved
+)
+
+_PLANNING_STATIC_SECTIONS: Final[tuple[PromptSection, ...]] = (PlanningSection(),)
+
+_DYNAMIC_SECTIONS: Final[tuple[PromptSection, ...]] = (
+    DateTimeSection(),
+    RepoContextSection(),  # guard: gated repo skills present
+    AvailableSkillsSection(),  # guard: available_skills_prompt
+    CustomSuffixSection(),  # guard: system_message_suffix
+    CustomSecretsSection(),  # guard: secret_infos present
+)
+
+
+def create_registry(preset: PromptPreset = PromptPreset.DEFAULT) -> PromptRegistry:
+    """Build the section registry for ``preset``.
+
+    ``DEFAULT`` is the standard OpenHands composition; ``PLANNING`` is the read-only
+    analysis composition (no ``<SECURITY>``/``<SOUL>``/``<MEMORY>`` ...). Both share
+    the dynamic tier. Sections are stateless, so the per-preset sequences are reused
+    across calls.
+    """
+    match preset:
+        case PromptPreset.PLANNING:
+            static_sections = _PLANNING_STATIC_SECTIONS
+        case PromptPreset.DEFAULT:
+            static_sections = _DEFAULT_STATIC_SECTIONS
+        case _:
+            raise ValueError(f"Unknown prompt preset: {preset!r}")
+
     r = PromptRegistry()
-    # static tier -- ported verbatim from system_prompt.j2 (#3610)
-    r.register(SoulSection())
-    r.register(RoleSection())
-    r.register(MemorySection())
-    r.register(EfficiencySection())
-    r.register(FileSystemSection())
-    r.register(CodeQualitySection())
-    r.register(VersionControlSection())
-    r.register(PullRequestsSection())
-    r.register(ProblemSolvingSection())
-    r.register(SelfDocumentationSection())
-    r.register(SecuritySection())  # guard: security_policy_filename set
-    r.register(SecurityRiskAssessmentSection())  # guard: llm_security_analyzer
-    r.register(BrowserSection())  # guard: ctx.enable_browser
-    r.register(ExternalServicesSection())
-    r.register(EnvironmentSetupSection())
-    r.register(TroubleshootingSection())
-    r.register(ProcessManagementSection())
-    r.register(ModelSpecificSection())  # guard: model_family resolved
-    # dynamic tier (#3610)
-    r.register(DateTimeSection())
-    r.register(RepoContextSection())  # guard: gated repo skills present
-    r.register(AvailableSkillsSection())  # guard: available_skills_prompt
-    r.register(CustomSuffixSection())  # guard: system_message_suffix
-    r.register(CustomSecretsSection())  # guard: secret_infos present
+    for section in (*static_sections, *_DYNAMIC_SECTIONS):
+        r.register(section)
     return r

--- a/openhands-sdk/openhands/sdk/context/prompts/sections/__init__.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/__init__.py
@@ -3,7 +3,8 @@
 Sections are pure, synchronous functions of a :class:`PromptContext` -- no Jinja
 environment, no filesystem loader, no ``render_template`` bootstrap -- so each one
 unit-tests in isolation. The static tier (ported from ``system_prompt.j2``) lives
-in :mod:`.static`.
+in :mod:`.static`; the standalone planning composition (ported from
+``system_prompt_planning.j2``) in :mod:`.planning`.
 """
 
 from openhands.sdk.context.prompts.sections.dynamic import (
@@ -13,6 +14,7 @@ from openhands.sdk.context.prompts.sections.dynamic import (
     DateTimeSection,
     RepoContextSection,
 )
+from openhands.sdk.context.prompts.sections.planning import PlanningSection
 from openhands.sdk.context.prompts.sections.static import (
     BrowserSection,
     CodeQualitySection,
@@ -48,6 +50,7 @@ __all__ = [
     "FileSystemSection",
     "MemorySection",
     "ModelSpecificSection",
+    "PlanningSection",
     "ProblemSolvingSection",
     "ProcessManagementSection",
     "PullRequestsSection",

--- a/openhands-sdk/openhands/sdk/context/prompts/sections/planning.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/planning.py
@@ -1,3 +1,34 @@
+"""The planning system prompt, ported verbatim from ``agent/prompts/system_prompt_planning.j2``.
+
+Unlike the default composition -- whose blocks each carry a guard and can be overridden
+individually -- the planning prompt is a single standalone STATIC block with no
+per-section guards, so it is one section. The only substitution is ``plan_structure``;
+``tests/sdk/context/prompts/test_planning_registry.py`` pins the output against a golden
+snapshot. No ``_refine``: the text mentions no ``bash``/``terminal`` (its ``<EFFICIENCY>``
+says ``glob and grep``), so the Windows shell substitution is a no-op.
+"""
+
+# The body is verbatim long-form prompt text; wrapping a line would change the rendered
+# bytes, so line-length (E501) is disabled for this whole file.
+# ruff: noqa: E501
+
+from openhands.sdk.context.prompts.section import CacheTier, PromptContext
+
+
+__all__ = ["PlanningSection"]
+
+
+class PlanningSection:
+    """The full planning system prompt as one STATIC block.
+
+    The only substitution is ``plan_structure`` (an empty value reproduces the
+    template's ``<PLAN_STRUCTURE>\\n\\n</PLAN_STRUCTURE>`` output verbatim).
+    """
+
+    name = "planning"
+    cache_tier = CacheTier.STATIC
+
+    _BODY = """\
 You are a Planning Agent that analyzes codebases and helps the user make a detailed plan for their requested changes.
 
 <ROLE>
@@ -92,5 +123,12 @@ Follow this enhanced planning workflow to create well-researched, user-aligned p
 </PLAN_SCOPE>
 
 <PLAN_STRUCTURE>
-{{plan_structure}}
-</PLAN_STRUCTURE>
+{plan_structure}
+</PLAN_STRUCTURE>"""
+
+    def guard(self, ctx: PromptContext) -> bool:  # noqa: ARG002
+        return True
+
+    def render(self, ctx: PromptContext) -> str | None:
+        plan_structure = str(ctx.template_kwargs.get("plan_structure", ""))
+        return self._BODY.replace("{plan_structure}", plan_structure)

--- a/openhands-sdk/openhands/sdk/context/prompts/sections/planning.py
+++ b/openhands-sdk/openhands/sdk/context/prompts/sections/planning.py
@@ -1,4 +1,4 @@
-"""The planning system prompt, ported verbatim from ``agent/prompts/system_prompt_planning.j2``.
+"""The planning system prompt.
 
 Unlike the default composition -- whose blocks each carry a guard and can be overridden
 individually -- the planning prompt is a single standalone STATIC block with no

--- a/tests/sdk/agent/test_system_prompt.py
+++ b/tests/sdk/agent/test_system_prompt.py
@@ -9,7 +9,7 @@ import pytest
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.agent.base import AgentBase
-from openhands.sdk.context.prompts.presets import create_registry
+from openhands.sdk.context.prompts.presets import PromptPreset, create_registry
 from openhands.sdk.llm import LLM
 
 
@@ -104,6 +104,58 @@ def test_builtin_default_prompt_uses_registry() -> None:
     agent = Agent(llm=_make_llm(), tools=[])
     expected = create_registry().build(agent._build_prompt_context()).static
     assert agent.static_system_message == expected
+
+
+# --- planning preset (sentinel-filename routing) ---
+
+
+def test_prompt_preset_resolves_from_builtin_filename(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Built-in sentinel filenames map to a preset; anything else escapes to Jinja."""
+    assert Agent(llm=_make_llm(), tools=[])._prompt_preset is PromptPreset.DEFAULT
+    planning = Agent(
+        llm=_make_llm(),
+        tools=[],
+        system_prompt_filename="system_prompt_planning.j2",
+        system_prompt_kwargs={"plan_structure": "X"},
+    )
+    assert planning._prompt_preset is PromptPreset.PLANNING
+    # A non-sentinel filename takes the Jinja escape hatch (preset None).
+    assert (
+        Agent(
+            llm=_make_llm(), tools=[], system_prompt_filename="custom.j2"
+        )._prompt_preset
+        is None
+    )
+    # So does a subclass with its own prompt_dir, even with a sentinel filename.
+    prompts = tmp_path / "prompts"
+    prompts.mkdir()
+    monkeypatch.setattr(_CustomPromptDirAgent, "custom_prompt_dir", str(prompts))
+    sub = _CustomPromptDirAgent(
+        llm=_make_llm(), tools=[], system_prompt_filename="system_prompt_planning.j2"
+    )
+    assert sub._prompt_preset is None
+
+
+def test_planning_filename_routes_through_registry() -> None:
+    """The planning sentinel renders the planning registry preset, not the default."""
+    agent = Agent(
+        llm=_make_llm(),
+        tools=[],
+        system_prompt_filename="system_prompt_planning.j2",
+        system_prompt_kwargs={"plan_structure": "1. OBJECTIVE"},
+    )
+    static = agent.static_system_message
+    expected = (
+        create_registry(PromptPreset.PLANNING)
+        .build(agent._build_prompt_context())
+        .static
+    )
+    assert static == expected
+    assert static.startswith("You are a Planning Agent")
+    # Standalone composition: the default OpenHands identity must not leak in.
+    assert "<SOUL>" not in static
 
 
 def test_custom_security_policy_is_resolved_by_registry(tmp_path: Path) -> None:

--- a/tests/sdk/context/prompts/snapshots/planning__default.txt
+++ b/tests/sdk/context/prompts/snapshots/planning__default.txt
@@ -1,0 +1,102 @@
+You are a Planning Agent that analyzes codebases and helps the user make a detailed plan for their requested changes.
+
+<ROLE>
+* Your primary role is to assist users by creating a comprehensive step-by-step implementation plan. You should be thorough, methodical, and prioritize quality over speed.
+* If the user asks a question, like "why is X happening", just give an answer to the question.
+</ROLE>
+
+<IMPORTANT_PRINCIPLES>
+* **Don't make large assumptions about user intent.** The goal is to present a well-researched plan and tie any loose ends before implementation begins.
+* **Ask clarifying questions when needed.** At any point in this workflow, feel free to ask the user questions or seek clarifications. This is especially important when:
+  - The request is ambiguous in a way that materially changes the result
+  - You cannot disambiguate by reading the repository
+  - There are significant tradeoffs that the user should weigh in on
+* **Professional objectivity:** Prioritize technical accuracy over validating the user's beliefs. Focus on facts and problem-solving, providing direct, objective technical info. It is best for the user if you honestly apply rigorous standards and disagree when necessary.
+</IMPORTANT_PRINCIPLES>
+
+<EFFICIENCY>
+* Each action you take is somewhat expensive. Wherever possible, combine multiple actions into a single action, e.g. using sed and grep to view multiple files at once.
+* When exploring the codebase, use efficient tools like glob and grep with appropriate filters to minimize unnecessary operations.
+</EFFICIENCY>
+
+<FILE_SYSTEM_GUIDELINES>
+* When a user provides a file path, do NOT assume it's relative to the current working directory. First explore the file system to locate the file before working on it.
+</FILE_SYSTEM_GUIDELINES>
+
+<PLANNING_WORKFLOW>
+Follow this enhanced planning workflow to create well-researched, user-aligned plans:
+
+## Phase 1: Initial Understanding
+
+**Goal:** Gain a comprehensive understanding of the user's request by reading through code and asking them questions.
+
+1. **Understand the user's request thoroughly.** Read it carefully and identify what they're trying to accomplish.
+
+2. **Explore the codebase efficiently.** Use glob and grep to search for relevant files, existing implementations, related components, and testing patterns. Focus your exploration on areas directly relevant to the request.
+
+3. **Clarify ambiguities up front.** If the user's request is vague, ambiguous, or underspecified in ways that would materially affect the plan, ask concise, targeted clarifying questions BEFORE proceeding with detailed planning.
+
+   **General principle:** Ask when ambiguity materially affects the approach.
+
+   Examples of ambiguities that materially affect the plan:
+   - **Tech stack:** "Build me a todo app" (React vs Vue? REST vs GraphQL? SQL vs NoSQL?)
+   - **Auth method:** "Add authentication" (OAuth vs password vs SSO? Session vs JWT?)
+   - **Expected behavior:** "Fix the bug" (What should happen vs what is happening?)
+
+## Phase 2: Planning
+
+**Goal:** Come up with an approach to solve the problem identified in Phase 1.
+
+1. **Evaluate multiple approaches** if applicable, considering tradeoffs between complexity, maintainability, and alignment with existing patterns.
+
+2. **Consult the user on significant tradeoffs.** If several approaches appear equally viable or have meaningful tradeoffs, ask the user to choose their preferred direction before committing to a plan.
+
+3. **Design the implementation plan.** Think carefully about:
+   - Dividing work into logical phases
+   - Determining optimal implementation order
+   - Identifying dependencies between steps
+   - Anticipating potential challenges
+
+## Phase 3: Synthesis & User Alignment
+
+**Goal:** Ensure the plan aligns with the user's intentions.
+
+1. **Write the initial plan to the configured PLAN.md file.** By default, this
+   file is `.agents_tmp/PLAN.md` under the workspace root. The file already
+   contains the required section headers - fill in the content under each section.
+
+2. **Ask the user about any remaining tradeoffs** or decisions that could affect the implementation.
+
+3. **Briefly summarize your plan** to the user and ask if it matches their expectations.
+
+## Phase 4: Refinement
+
+**Goal:** Iterate on the plan based on user feedback.
+
+1. **Incorporate user feedback** to adjust scope, structure, or priorities as needed.
+
+2. **When the user requests a change:**
+   - Update the plan if the change is reasonable
+   - If not feasible, respectfully explain why and propose better alternatives
+
+3. **Keep the plan consistent.** When editing, ensure all affected sections stay aligned.
+
+4. **Summarize changes** after each update so the user can easily verify what changed.
+</PLANNING_WORKFLOW>
+
+<PLAN_SCOPE>
+* The plan must stay strictly within scope and avoid adding extra features, enhancements, or unrelated ideas.
+* No need to mention security or performance considerations unless they are directly relevant to the user's request.
+* No need to mention general knowledge or good practices if they aren't directly relevant to the plan.
+* Don't add anything out-of-scope except if it's directly relevant to the plan.
+</PLAN_SCOPE>
+
+<PLAN_STRUCTURE>
+The plan must follow this structure exactly:
+
+1. OBJECTIVE
+   * Summarize the goal of the plan in one or two sentences.
+
+2. IMPLEMENTATION STEPS
+   * Provide a step-by-step plan for execution.
+</PLAN_STRUCTURE>

--- a/tests/sdk/context/prompts/test_planning_registry.py
+++ b/tests/sdk/context/prompts/test_planning_registry.py
@@ -1,0 +1,103 @@
+"""Planning preset: the byte-for-byte port of ``system_prompt_planning.j2``.
+
+The ``.j2`` was deleted once parity was confirmed, so the planning composition is now
+pinned against a golden snapshot (regenerate with ``REGEN_PROMPT_SNAPSHOTS=1``). The
+planning prompt is a single standalone section, so the unit tests exercise that one
+section directly -- no Agent, no Jinja environment.
+"""
+
+import os
+from pathlib import Path
+from typing import Final
+
+from openhands.sdk.context.prompts.presets import PromptPreset, create_registry
+from openhands.sdk.context.prompts.section import Platform, PromptContext
+from openhands.sdk.context.prompts.sections.planning import PlanningSection
+
+
+SNAPSHOT_DIR: Final[Path] = Path(__file__).parent / "snapshots"
+REGEN: Final[bool] = os.environ.get("REGEN_PROMPT_SNAPSHOTS") == "1"
+
+# A representative plan_structure (the template's only substitution). Kept inline so the
+# SDK test does not depend on openhands-tools' format_plan_structure().
+PLAN_STRUCTURE: Final[str] = (
+    "The plan must follow this structure exactly:\n\n"
+    "1. OBJECTIVE\n   * Summarize the goal of the plan in one or two sentences.\n\n"
+    "2. IMPLEMENTATION STEPS\n   * Provide a step-by-step plan for execution."
+)
+
+
+def _ctx(
+    platform: Platform = Platform.LINUX, **template_kwargs: object
+) -> PromptContext:
+    return PromptContext(template_kwargs=template_kwargs, platform=platform)
+
+
+def _check_snapshot(name: str, content: str) -> None:
+    path = SNAPSHOT_DIR / f"{name}.txt"
+    if REGEN:
+        SNAPSHOT_DIR.mkdir(parents=True, exist_ok=True)
+        path.write_text(content, encoding="utf-8")
+        return
+    assert path.exists(), (
+        f"Missing snapshot {path}. Regenerate with REGEN_PROMPT_SNAPSHOTS=1."
+    )
+    assert content == path.read_text(encoding="utf-8"), (
+        f"Planning prompt for '{name}' diverged from its committed snapshot. If the "
+        "change is intentional, regenerate with REGEN_PROMPT_SNAPSHOTS=1."
+    )
+
+
+def test_planning_registry_static_snapshot() -> None:
+    ctx = _ctx(plan_structure=PLAN_STRUCTURE)
+    blocks = create_registry(PromptPreset.PLANNING).build(ctx)
+    # The planning preset registers no dynamic data here, so the dynamic block is empty.
+    assert blocks.dynamic is None
+    _check_snapshot("planning__default", blocks.static)
+
+
+def test_planning_is_standalone_composition() -> None:
+    ctx = _ctx(plan_structure=PLAN_STRUCTURE)
+    static = create_registry(PromptPreset.PLANNING).build(ctx).static
+    assert static.startswith("You are a Planning Agent")
+    # Standalone: none of the default OpenHands sections leak in.
+    for tag in ("<SOUL>", "<SECURITY>", "<MEMORY>", "<VERSION_CONTROL>", "<IMPORTANT>"):
+        assert tag not in static
+    for tag in ("<ROLE>", "<PLANNING_WORKFLOW>", "<PLAN_SCOPE>", "<PLAN_STRUCTURE>"):
+        assert tag in static
+
+
+def test_planning_section_is_unguarded() -> None:
+    assert PlanningSection().guard(_ctx()) is True
+
+
+def test_planning_section_substitutes_plan_structure() -> None:
+    out = PlanningSection().render(_ctx(plan_structure="STEP ONE")) or ""
+    assert "<PLAN_STRUCTURE>\nSTEP ONE\n</PLAN_STRUCTURE>" in out
+    # An empty plan_structure reproduces the template's blank-line body verbatim.
+    empty = PlanningSection().render(_ctx()) or ""
+    assert empty.endswith("<PLAN_STRUCTURE>\n\n</PLAN_STRUCTURE>")
+
+
+def test_planning_uses_glob_grep_and_is_platform_invariant() -> None:
+    # The planning <EFFICIENCY> says "glob and grep" (not bash/git), so the Windows
+    # shell substitution is a no-op and the prompt is identical across platforms.
+    posix = PlanningSection().render(_ctx(platform=Platform.LINUX)) or ""
+    windows = PlanningSection().render(_ctx(platform=Platform.WINDOWS)) or ""
+    assert "glob and grep" in posix
+    assert "bash" not in posix and "powershell" not in posix
+    assert windows == posix
+
+
+def test_planning_dynamic_tier_is_shared_with_default() -> None:
+    # The dynamic tier is preset-independent: the same context yields the same block.
+    ctx = PromptContext(
+        now="2025-01-01T00:00:00+00:00",
+        custom_suffix="Follow conventions.",
+        secret_infos=(("GITHUB_TOKEN", None),),
+        template_kwargs={"plan_structure": PLAN_STRUCTURE},
+    )
+    planning = create_registry(PromptPreset.PLANNING).build(ctx).dynamic
+    default = create_registry(PromptPreset.DEFAULT).build(ctx).dynamic
+    assert planning == default
+    assert "<CURRENT_DATETIME>" in (planning or "")

--- a/tests/sdk/context/test_prompt_absolute_path.py
+++ b/tests/sdk/context/test_prompt_absolute_path.py
@@ -12,23 +12,23 @@ from openhands.sdk.llm import LLM
 
 
 def test_render_template_with_relative_path():
-    """Test that render_template works with relative paths (existing behavior)."""
-    # Use the agent's default prompts directory
-    agent_prompts_dir = os.path.join(
-        os.path.dirname(os.path.dirname(os.path.dirname(__file__))),
-        "../openhands-sdk/openhands/sdk/agent/prompts",
-    )
-    agent_prompts_dir = os.path.abspath(agent_prompts_dir)
+    """Test that render_template resolves a relative name against prompt_dir.
 
-    # system_prompt_planning.j2 is the surviving built-in Jinja template.
-    result = render_template(
-        prompt_dir=agent_prompts_dir,
-        template_name="system_prompt_planning.j2",
-    )
+    The built-in .j2 templates were ported into the prompt registry, so this uses a
+    throwaway template in a temp dir to exercise relative-path resolution.
+    """
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        template_name = "relative_template.j2"
+        with open(os.path.join(tmp_dir, template_name), "w") as f:
+            f.write("Relative render of {{ subject }}.")
 
-    # Verify result is a non-empty string
-    assert isinstance(result, str)
-    assert len(result) > 0
+        result = render_template(
+            prompt_dir=tmp_dir,
+            template_name=template_name,
+            subject="a template",
+        )
+
+    assert result == "Relative render of a template."
 
 
 def test_render_template_with_absolute_path():


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Retirng the planning prompt in favour of the new registry.

---

AGENT:

## Why

`system_prompt_planning.j2` was the **last surviving built-in Jinja system-prompt
template** after the default-registry port (#3796). Keeping one template alive means the
system prompt still has two rendering paths (the Jinja escape hatch *and* the typed
registry). This ports the planning prompt into the registry and deletes the template, so
every built-in prompt is assembled by one engine.

## Summary

- Add `PromptPreset` (StrEnum) and `create_registry(preset=...)`. The `planning` preset
  is a single standalone `PlanningSection` (the prompt has no per-section guards); the
  dynamic tier (datetime/repo/skills/suffix/secrets) is **shared** across presets.
- Route `AgentBase` through a sentinel-filename map
  (`system_prompt_planning.j2` → `planning`) before the Jinja escape hatch, so
  `get_planning_agent` is **unchanged** and the filename stays a back-compat sentinel
  (the same pattern as `security_policy.j2`).
- Delete `system_prompt_planning.j2`. Output is **byte-for-byte preserved** (verified
  against the live template, then frozen as a golden snapshot).

## Issue Number

Prompt-registry port follow-up (#3610 / #3796). No dedicated issue.

## How to Test

End-to-end (not just unit tests): render a real planning agent and confirm it matches the
old template output.

```
$ uv run python -c "
from pydantic import SecretStr
from openhands.sdk.llm import LLM
from openhands.tools.preset.planning import get_planning_agent
a = get_planning_agent(LLM(model='gpt-4o-mini', api_key=SecretStr('x'), usage_id='p'))
s = a.static_system_message
print('preset =', a._prompt_preset, '| len =', len(s))
print('first line:', s.splitlines()[0][:55])
print('ends with </PLAN_STRUCTURE>:', s.rstrip().endswith('</PLAN_STRUCTURE>'))
"
preset = planning | len = 6235
first line: You are a Planning Agent that analyzes codebases and he
ends with </PLAN_STRUCTURE>: True
```

Byte-parity against the live `.j2` **before** deleting it (registry vs `render_template`):

```
[populated] old=6235 new=6235 identical=True
[empty]     old=5249 new=5249 identical=True
[custom]    old=5274 new=5274 identical=True
ALL IDENTICAL: True
```

Test suites:

```
$ uv run pytest tests/sdk/agent/ tests/sdk/context/ -q
====================== 1150 passed, 38 warnings in 18.41s ======================

# New/updated coverage:
#  tests/sdk/context/prompts/test_planning_registry.py  (section + golden snapshot + shared dynamic tier)
#  tests/sdk/agent/test_system_prompt.py                (_prompt_preset resolution + planning routes through registry)
#  tests/sdk/context/test_prompt_absolute_path.py       (rewritten: no longer uses the deleted .j2 as a fixture)
```

`uv run pre-commit run` passes (ruff format/lint, pycodestyle, pyright, import-dep rules,
tool-registration check).

## Video/Screenshots

N/A — this is a system-prompt rendering change; the byte-parity and length evidence above
stand in for a screenshot.

## Type

- [ ] Bug fix
- [ ] Feature
- [x] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Deleting the last template empties `openhands-sdk/openhands/sdk/agent/prompts/`.
  Harmless: `_BUILTIN_PROMPT_DIR` is only a `realpath` anchor for the sentinel check (it
  does not need the dir to exist), and packaging globs `*.j2` (matches nothing there, no
  error).
- The planning prompt is a **standalone** composition: it intentionally omits the default
  OpenHands sections (`<SOUL>`/`<SECURITY>`/`<MEMORY>` ...) — this preserves today's
  behavior. Adding a security policy to planning agents would be a separate, explicit
  change.
- This PR also converts the default composition's `register(...)` calls into extracted
  section sequences + a registration loop. Behavior is unchanged (frozen by the existing
  default snapshots); happy to split that out if reviewers prefer a smaller diff.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:897f591-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-897f591-python \
  ghcr.io/openhands/agent-server:897f591-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:897f591-golang-amd64
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-golang-amd64
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-golang-amd64
ghcr.io/openhands/agent-server:897f591-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:897f591-golang-arm64
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-golang-arm64
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-golang-arm64
ghcr.io/openhands/agent-server:897f591-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:897f591-java-amd64
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-java-amd64
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-java-amd64
ghcr.io/openhands/agent-server:897f591-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:897f591-java-arm64
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-java-arm64
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-java-arm64
ghcr.io/openhands/agent-server:897f591-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:897f591-python-amd64
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-python-amd64
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-python-amd64
ghcr.io/openhands/agent-server:897f591-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:897f591-python-arm64
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-python-arm64
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-python-arm64
ghcr.io/openhands/agent-server:897f591-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:897f591-golang
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-golang
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-golang
ghcr.io/openhands/agent-server:897f591-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:897f591-java
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-java
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-java
ghcr.io/openhands/agent-server:897f591-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:897f591-python
ghcr.io/openhands/agent-server:897f5911cafd0e6d89ed7ad9514a6319a89c9534-python
ghcr.io/openhands/agent-server:vasco-retire-planning-prompt-python
ghcr.io/openhands/agent-server:897f591-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `897f591-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `897f591-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->