### PR TITLE
fix(llm): bound model-info discovery with a timeout to prevent deadlocks

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -5,6 +5,7 @@ from contextlib import contextmanager
 from typing import Annotated, Any
 
 from fastapi import APIRouter, HTTPException, Path, Request, status
+from fastapi.concurrency import run_in_threadpool
 from pydantic import BaseModel, Field, SecretStr
 
 from openhands.agent_server._secrets_exposure import (
@@ -165,7 +166,10 @@ async def get_profile(request: Request, name: ProfileName) -> ProfileDetailRespo
     store = get_llm_profile_store()
     try:
         with _store_errors():
-            llm = store.load(name, cipher=cipher)
+            # Loading constructs an ``LLM``, which may perform a synchronous,
+            # network-bound model-info probe. Run it in a worker thread so a
+            # slow or unreachable endpoint can never block the event loop.
+            llm = await run_in_threadpool(store.load, name, cipher=cipher)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
@@ -326,7 +330,8 @@ async def activate_profile(
     profile_store = get_llm_profile_store()
     try:
         with _store_errors():
-            llm = profile_store.load(name, cipher=cipher)
+            # See ``get_profile``: keep the network-bound load off the loop.
+            llm = await run_in_threadpool(profile_store.load, name, cipher=cipher)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,

--- a/openhands-sdk/openhands/sdk/llm/utils/model_info.py
+++ b/openhands-sdk/openhands/sdk/llm/utils/model_info.py
@@ -1,4 +1,6 @@
 import time
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, TimeoutError as FutureTimeoutError
 from functools import lru_cache
 from logging import getLogger
 
@@ -11,6 +13,52 @@ from openhands.sdk.llm.utils.openhands_provider import litellm_call_kwargs
 
 
 logger = getLogger(__name__)
+
+# Model-info discovery must never block LLM construction indefinitely.
+#
+# Some providers (self-hosted / OpenAI-compatible such as ``lemonade``,
+# ``ollama`` and ``vllm``) resolve model info by making a live HTTP request to
+# the model server rather than reading a static cost map. litellm performs that
+# request synchronously with no timeout, so if the endpoint is unreachable -- or
+# accidentally points back at the caller (e.g. a reverse proxy that forwards to
+# this very process) -- the call hangs forever. Because ``LLM`` construction is
+# synchronous and runs this probe in ``_post_init``, an indefinite hang freezes
+# any caller, including an async server's event loop.
+#
+# Bound every probe with this deadline. ``model_info`` is an optional
+# enhancement (callers already handle ``None``), so timing out degrades
+# gracefully instead of deadlocking.
+MODEL_INFO_DISCOVERY_TIMEOUT = 10.0
+
+_discovery_executor = ThreadPoolExecutor(
+    max_workers=4, thread_name_prefix="model-info-discovery"
+)
+
+
+def _run_with_deadline[T](
+    func: Callable[..., T],
+    *args,
+    timeout: float | None = None,
+    **kwargs,
+) -> T | None:
+    """Run a (possibly network-bound, non-cancellable) sync call with a deadline.
+
+    Returns ``None`` if the call does not finish within ``timeout`` so that
+    model-info discovery never blocks the caller indefinitely. A timed-out
+    worker thread is abandoned (it cannot be cancelled) but is bounded by
+    litellm's own socket timeout and does not block the caller.
+    """
+    if timeout is None:
+        timeout = MODEL_INFO_DISCOVERY_TIMEOUT
+    future = _discovery_executor.submit(func, *args, **kwargs)
+    try:
+        return future.result(timeout=timeout)
+    except FutureTimeoutError:
+        logger.warning(
+            "Timed out after %ss while fetching model info; continuing without it.",
+            timeout,
+        )
+        return None
 
 
 @lru_cache
@@ -28,7 +76,11 @@ def _get_model_info_from_litellm_proxy(
         if secret_api_key:
             headers["Authorization"] = f"Bearer {secret_api_key}"
 
-        response = httpx.get(f"{base_url}/v1/model/info", headers=headers)
+        response = httpx.get(
+            f"{base_url}/v1/model/info",
+            headers=headers,
+            timeout=MODEL_INFO_DISCOVERY_TIMEOUT,
+        )
         data = response.json().get("data", [])
         # Match against either the public alias (`model_name`) or the
         # underlying provider/model_name form (`litellm_params.model`). The proxy itself
@@ -69,7 +121,7 @@ def get_litellm_model_info(
     # Try to get model info via openrouter or litellm proxy first
     try:
         if model.startswith("openrouter"):
-            model_info = get_model_info(model)
+            model_info = _run_with_deadline(get_model_info, model)
             if model_info:
                 return model_info
     except Exception as e:
@@ -90,13 +142,13 @@ def get_litellm_model_info(
 
     # Fallbacks: try base name variants
     try:
-        model_info = get_model_info(model.split(":")[0])
+        model_info = _run_with_deadline(get_model_info, model.split(":")[0])
         if model_info:
             return model_info
     except Exception:
         pass
     try:
-        model_info = get_model_info(model.split("/")[-1])
+        model_info = _run_with_deadline(get_model_info, model.split("/")[-1])
         if model_info:
             return model_info
     except Exception:

--- a/tests/sdk/llm/test_model_info_discovery_timeout.py
+++ b/tests/sdk/llm/test_model_info_discovery_timeout.py
@@ -1,0 +1,67 @@
+"""Model-info discovery must never block the caller indefinitely.
+
+Some providers (self-hosted / OpenAI-compatible such as ``lemonade``,
+``ollama`` and ``vllm``) resolve model info via a live HTTP request to the
+model server. litellm makes that request synchronously with no timeout, so an
+unreachable endpoint -- or one that loops back to the caller through a reverse
+proxy -- hangs forever. Because ``LLM`` construction runs this probe in
+``_post_init``, that previously froze any caller, including an async server's
+event loop.
+
+These tests pin the bounded behavior: discovery returns ``None`` within the
+deadline instead of hanging.
+"""
+
+import time
+
+from openhands.sdk.llm.utils import model_info
+from openhands.sdk.llm.utils.model_info import (
+    _run_with_deadline,
+    get_litellm_model_info,
+)
+
+
+def test_run_with_deadline_returns_none_on_timeout():
+    def _hang(*_a, **_kw):
+        time.sleep(30)
+        return "never"
+
+    started = time.time()
+    result = _run_with_deadline(_hang, timeout=0.2)
+    elapsed = time.time() - started
+
+    assert result is None
+    # Returned promptly rather than waiting for the (abandoned) call.
+    assert elapsed < 5
+
+
+def test_run_with_deadline_returns_value_when_fast():
+    assert _run_with_deadline(lambda: 42, timeout=5) == 42
+
+
+def test_get_litellm_model_info_does_not_hang_on_slow_probe(monkeypatch):
+    """A self-hosted model whose model-info probe hangs must not block.
+
+    Regression test for the deadlock where ``litellm.get_model_info`` for an
+    unreachable self-hosted endpoint blocked ``LLM`` construction (and any
+    async caller) forever.
+    """
+
+    def _hang(*_a, **_kw):
+        time.sleep(30)
+        raise AssertionError("should have been abandoned by the deadline")
+
+    monkeypatch.setattr(model_info, "get_model_info", _hang)
+    monkeypatch.setattr(model_info, "MODEL_INFO_DISCOVERY_TIMEOUT", 0.2)
+
+    started = time.time()
+    info = get_litellm_model_info(
+        secret_api_key=None,
+        base_url="http://localhost:9",
+        model="lemonade/some-self-hosted-model",
+    )
+    elapsed = time.time() - started
+
+    assert info is None
+    # Two bounded fallback probes at ~0.2s each must still return promptly.
+    assert elapsed < 5


### PR DESCRIPTION
HUMAN:

This all started because when filling out the LLM profile, I put a couple of backslashes in the URL field by accident. From then on, the UI would crash and deadlock, and I couldn't do anything.

<img width="1520" height="1291" alt="image" src="https://github.com/user-attachments/assets/d58f93c5-08d8-4593-8605-64cb8d1d992f" />


---

AGENT:

## Why

Model-info discovery for self-hosted / OpenAI-compatible providers (e.g.
`lemonade`, `ollama`, `vllm`) is resolved by a **synchronous HTTP request with no
timeout** inside LiteLLM. `LLM` construction triggers this probe eagerly in
`_post_init` (`_init_model_info_and_caps` → `get_litellm_model_info`). If the
model endpoint is unreachable — or, in a topology where a reverse proxy forwards
the provider's *default* port back to the server itself, loops back to the
caller — the request hangs forever.

Because the agent-server constructs `LLM`s on its asyncio event loop (e.g.
`GET /profiles/{name}` → `store.load()`), one hung probe **freezes the entire
server**: every subsequent request (server_info, settings, delete, …) times out.

Captured hang (py-spy) of the agent-server's main thread:

```
read (httpcore/_backends/sync.py:128)          # blocked, no timeout
...
get_model_info (litellm/.../lemonade/chat/transformation.py:182)
get_litellm_model_info (openhands/sdk/llm/utils/model_info.py:93)
_init_model_info_and_caps (openhands/sdk/llm/llm.py:2091)
_post_init → load (llm_profile_store.py:206) → get_profile (profiles_router.py:168)
```

## Summary

- `openhands-sdk/.../llm/utils/model_info.py`: bound every model-info network
  probe with a deadline (`MODEL_INFO_DISCOVERY_TIMEOUT`, default `10s`). On
  timeout, discovery returns `None` — a state callers already handle, since
  model info is an optional enhancement. Also pass an explicit `timeout` to the
  litellm-proxy `httpx.get`.
- `openhands-agent-server/.../profiles_router.py`: run the blocking profile
  `store.load()` off the event loop via `run_in_threadpool` in `get_profile`
  and `activate_profile`, so a slow probe can never block the loop.

## Issue Number

Related to #4263 (model-info probe makes an unvalidated, un-timed `httpx.get`
at LLM init). This PR bounds that probe with a deadline so it can no longer
hang LLM construction or the agent-server event loop.

## How to Test

```
uv run pytest tests/sdk/llm/test_model_info_discovery_timeout.py \
              tests/agent_server/test_profiles_router.py
```

New test `test_model_info_discovery_timeout.py` simulates a hanging probe and
asserts discovery returns within the deadline instead of blocking. All 77
existing `test_profiles_router.py` tests still pass.

Manual repro (agent-server): create a self-hosted profile whose model-info
endpoint is unreachable (or loops back through the ingress). Before: the first
`GET /api/profiles/{name}` hangs and every later request times out. After: it
returns promptly and the server stays responsive.

## Video/Screenshots

py-spy stack above is the captured deadlock. Local test run: `8 passed`
(discovery-timeout + existing proxy-lookup), `77 passed` (profiles router).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

`model_info == None` is already handled throughout the codebase; this change
only makes that fallback reachable on a hang rather than blocking forever. The
deadline uses a small `ThreadPoolExecutor`; a timed-out probe thread is
abandoned (uncancellable) but bounded by litellm's own socket timeout and does
not block the caller.

<!-- jev-fast-audit:start -->
## Jev-Fast-Audit

⚡ **Jev fast audit** · estimates · 0.48s · commit dd2dde9  
**Strongest signal:** No primary concern selected.  
**Evidence:** No primary concern to locate.  
**Coverage:** complete supplied coverage; 9/9 hunks, 3/3 files.

<details>
<summary>All estimates and evidence</summary>

| Estimate | Likelihood / value | Direct evidence |
| --- | --- | --- |
| SQL injection | 3.0% | No direct hunk selected |
| Command injection | 3.0% | No direct hunk selected |
| Weakened authentication | 4.0% | No direct hunk selected |
| Weakened authorization | 6.0% | No direct hunk selected |
| Contract regression | 14.0% | No direct hunk selected |
| Data loss | 3.0% | No direct hunk selected |
| Sensitive data disclosure | 4.0% | No direct hunk selected |
| Unexpected data transfer | 4.0% | No direct hunk selected |
| Credential misuse | 8.0% | No direct hunk selected |
| Untrusted instruction authority | 2.0% | No direct hunk selected |
| Package source redirection | 4.0% | No direct hunk selected |
| Unverified remote execution | 2.0% | No direct hunk selected |
| Privileged environment access | 3.0% | No direct hunk selected |
| Security assessment bypass | 4.0% | No direct hunk selected |
| Prohibited workload | 2.0% | No direct hunk selected |
| Primary concern | None selected; confidence 83.0% | No primary concern to locate |

</details>


<!-- jev-input-signature ed07d6e42f77708e0770ff6d807ac0e4acaf79df542d46570e4b1b3aecc685c5 -->
<!-- jev-fast-audit:end -->
