### PR TITLE
fix(sdk): load user skills by default

### DIFF
--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -90,7 +90,7 @@ class AgentContext(BaseModel):
         json_schema_extra={"acp_compatible": True},
     )
     load_user_skills: bool = Field(
-        default=False,
+        default=True,
         description=(
             "Whether to automatically load user skills from ~/.openhands/skills/ "
             "and ~/.openhands/microagents/ (for backward compatibility). "

--- a/tests/sdk/skills/test_load_user_skills.py
+++ b/tests/sdk/skills/test_load_user_skills.py
@@ -241,7 +241,7 @@ def test_agent_context_loads_user_skills_by_default(temp_user_skills_dir):
     original_dirs = skill.USER_SKILLS_DIRS
     try:
         skill.USER_SKILLS_DIRS = [skills_dir]
-        context = AgentContext(load_user_skills=True)
+        context = AgentContext()
         skill_names = [s.name for s in context.skills]
         assert "auto_skill" in skill_names
     finally:


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

_This PR was created by an AI agent (OpenHands) on behalf of the user._

## Why

The PR that originally added `AgentContext.load_user_skills` is OpenHands/software-agent-sdk#950. Its description did not give a reason for defaulting the field to `False`; it actually described the default as enabled/`True`. This change aligns the SDK default with that documented intent and makes global user skills load automatically unless callers explicitly opt out.

## Summary

- Set `AgentContext.load_user_skills` to default to `True`.
- Updated the existing default-loading test to rely on `AgentContext()` rather than explicitly passing `load_user_skills=True`.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `224b71798af2` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -661 +661 @@
-schema AgentContext-Input property load_user_skills optional schema=type="boolean" default=false
+schema AgentContext-Input property load_user_skills optional schema=type="boolean" default=true
@@ -672 +672 @@
-schema AgentContext-Output property load_user_skills optional schema=type="boolean" default=false
+schema AgentContext-Output property load_user_skills optional schema=type="boolean" default=true
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

N/A

## How to Test

Ran focused unit coverage:

```bash
cd /workspace/project/software-agent-sdk
uv run pytest tests/sdk/skills/test_load_user_skills.py
```

Result: `14 passed, 5 warnings in 0.08s`.

Ran pre-commit on the changed files:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/context/agent_context.py tests/sdk/skills/test_load_user_skills.py
```

Result: all hooks passed (`Ruff format`, `Ruff lint`, `PEP8 style check`, `pyright`, dependency rules, tool subclass registration).

Ran a direct SDK behavior smoke check that creates a temporary user skill, constructs `AgentContext()` without passing `load_user_skills`, and confirms the skill is loaded:

```bash
uv run python - <<'PY'
from pathlib import Path
from tempfile import TemporaryDirectory

from openhands.sdk.context.agent_context import AgentContext
from openhands.sdk.skills import skill

with TemporaryDirectory() as tmp:
    skills_dir = Path(tmp) / '.openhands' / 'skills'
    skills_dir.mkdir(parents=True)
    (skills_dir / 'browser-screenshots.md').write_text(
        '---\nname: browser-screenshots\n---\nAlways request screenshots.\n'
    )
    original_dirs = skill.USER_SKILLS_DIRS
    try:
        skill.USER_SKILLS_DIRS = [skills_dir]
        context = AgentContext()
        print([loaded.name for loaded in context.skills])
    finally:
        skill.USER_SKILLS_DIRS = original_dirs
PY
```

Observed output included:

```text
['browser-screenshots']
```

## Video/Screenshots

Not applicable; this is SDK default behavior with command-line verification above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This preserves the explicit opt-out path: callers can still pass `load_user_skills=False`.


@enyst can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8584ba07-1f9c-4dbe-ae76-5db414159a86)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:fadd82c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-fadd82c-python \
  ghcr.io/openhands/agent-server:fadd82c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:fadd82c-golang-amd64
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-golang-amd64
ghcr.io/openhands/agent-server:flip-user-skills-default-golang-amd64
ghcr.io/openhands/agent-server:fadd82c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:fadd82c-golang-arm64
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-golang-arm64
ghcr.io/openhands/agent-server:flip-user-skills-default-golang-arm64
ghcr.io/openhands/agent-server:fadd82c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:fadd82c-java-amd64
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-java-amd64
ghcr.io/openhands/agent-server:flip-user-skills-default-java-amd64
ghcr.io/openhands/agent-server:fadd82c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:fadd82c-java-arm64
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-java-arm64
ghcr.io/openhands/agent-server:flip-user-skills-default-java-arm64
ghcr.io/openhands/agent-server:fadd82c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:fadd82c-python-amd64
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-python-amd64
ghcr.io/openhands/agent-server:flip-user-skills-default-python-amd64
ghcr.io/openhands/agent-server:fadd82c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:fadd82c-python-arm64
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-python-arm64
ghcr.io/openhands/agent-server:flip-user-skills-default-python-arm64
ghcr.io/openhands/agent-server:fadd82c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:fadd82c-golang
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-golang
ghcr.io/openhands/agent-server:flip-user-skills-default-golang
ghcr.io/openhands/agent-server:fadd82c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:fadd82c-java
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-java
ghcr.io/openhands/agent-server:flip-user-skills-default-java
ghcr.io/openhands/agent-server:fadd82c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:fadd82c-python
ghcr.io/openhands/agent-server:fadd82c822228204822a1a667319bf262ab07f13-python
ghcr.io/openhands/agent-server:flip-user-skills-default-python
ghcr.io/openhands/agent-server:fadd82c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `fadd82c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `fadd82c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->