### PR TITLE
Add vision helper tool for non-vision models

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -52,6 +52,7 @@ from openhands.sdk.event.condenser import (
 )
 from openhands.sdk.llm import (
     LLM,
+    ImageContent,
     LLMResponse,
     Message,
     MessageToolCall,
@@ -89,6 +90,7 @@ from openhands.sdk.tool.builtins import (
     FinishTool,
     ThinkAction,
 )
+from openhands.sdk.tool.builtins.vision_inspect import VISION_INSPECT_TOOL_NAME
 
 
 logger = get_logger(__name__)
@@ -136,6 +138,38 @@ def _non_multimodal_image_message(model: str) -> Message:
             )
         ],
     )
+
+
+def _replace_latest_user_images_with_references(
+    messages: list[Message],
+) -> list[Message]:
+    rewritten = list(messages)
+    for index in range(len(rewritten) - 1, -1, -1):
+        message = rewritten[index]
+        if message.role != "user" or not message.contains_image:
+            continue
+
+        image_index = 0
+        content: list[TextContent | ImageContent] = []
+        for item in message.content:
+            if isinstance(item, ImageContent):
+                for _ in item.image_urls:
+                    content.append(
+                        TextContent(
+                            text=(
+                                f"[Image {image_index} is attached to the latest "
+                                "user message. Use the inspect_image_with_vision "
+                                f"tool with image_index={image_index} to inspect it.]"
+                            )
+                        )
+                    )
+                    image_index += 1
+            else:
+                content.append(item)
+
+        rewritten[index] = message.model_copy(update={"content": content})
+        break
+    return rewritten
 
 
 def _should_handle_non_multimodal_image_input(
@@ -623,18 +657,27 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         _messages = _messages_or_condensation
 
         if _should_handle_non_multimodal_image_input(self.llm, _messages):
-            logger.info(
-                "Image input received while selected model does not support vision: %s",
-                self.llm.model,
-            )
-            on_event(
-                MessageEvent(
-                    source="agent",
-                    llm_message=_non_multimodal_image_message(self.llm.model),
+            if VISION_INSPECT_TOOL_NAME in self.tools_map:
+                logger.info(
+                    "Image input received by non-vision model %s; exposing "
+                    "image references and vision inspection tool",
+                    self.llm.model,
                 )
-            )
-            state.execution_status = ConversationExecutionStatus.FINISHED
-            return
+                _messages = _replace_latest_user_images_with_references(_messages)
+            else:
+                logger.info(
+                    "Image input received while selected model does not support "
+                    "vision: %s",
+                    self.llm.model,
+                )
+                on_event(
+                    MessageEvent(
+                        source="agent",
+                        llm_message=_non_multimodal_image_message(self.llm.model),
+                    )
+                )
+                state.execution_status = ConversationExecutionStatus.FINISHED
+                return
 
         logger.debug(
             "Sending messages to LLM: "
@@ -802,18 +845,27 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         _messages = _messages_or_condensation
 
         if _should_handle_non_multimodal_image_input(self.llm, _messages):
-            logger.info(
-                "Image input received while selected model does not support vision: %s",
-                self.llm.model,
-            )
-            on_event(
-                MessageEvent(
-                    source="agent",
-                    llm_message=_non_multimodal_image_message(self.llm.model),
+            if VISION_INSPECT_TOOL_NAME in self.tools_map:
+                logger.info(
+                    "Image input received by non-vision model %s; exposing "
+                    "image references and vision inspection tool",
+                    self.llm.model,
                 )
-            )
-            state.execution_status = ConversationExecutionStatus.FINISHED
-            return
+                _messages = _replace_latest_user_images_with_references(_messages)
+            else:
+                logger.info(
+                    "Image input received while selected model does not support "
+                    "vision: %s",
+                    self.llm.model,
+                )
+                on_event(
+                    MessageEvent(
+                        source="agent",
+                        llm_message=_non_multimodal_image_message(self.llm.model),
+                    )
+                )
+                state.execution_status = ConversationExecutionStatus.FINISHED
+                return
 
         logger.debug(
             "Sending messages to LLM: "

--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -42,6 +42,10 @@ from openhands.sdk.tool import (
     resolve_tool,
 )
 from openhands.sdk.tool.builtins import InvokeSkillTool
+from openhands.sdk.tool.builtins.vision_inspect import (
+    VisionInspectTool,
+    has_vision_profile_available,
+)
 from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
 from openhands.sdk.utils.models import DiscriminatedUnionMixin, get_handler_class_name
 
@@ -710,6 +714,16 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             logger.debug(
                 "Auto-attached %s (invocable AgentSkills-format skill present)",
                 InvokeSkillTool.__name__,
+            )
+        if (
+            not self.llm.vision_is_active()
+            and VisionInspectTool.__name__ not in default_tool_names
+            and has_vision_profile_available()
+        ):
+            default_tool_names.append(VisionInspectTool.__name__)
+            logger.debug(
+                "Auto-attached %s (vision profile available for non-vision model)",
+                VisionInspectTool.__name__,
             )
 
         for tool_name in default_tool_names:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1333,6 +1333,24 @@ class LocalConversation(BaseConversation):
             cached = loaded.model_copy(update={"usage_id": usage_id})
         self.switch_llm(cached)
 
+    def get_or_create_profile_llm(self, profile_name: str, usage_id: str) -> LLM:
+        """Return a saved profile LLM registered for this conversation.
+
+        Unlike :meth:`switch_profile`, this does not replace the active agent
+        model. It is intended for auxiliary one-off model calls from tools while
+        still routing token and cost accounting through ``llm_registry`` and
+        ``ConversationStats``.
+        """
+        try:
+            return self.llm_registry.get(usage_id)
+        except KeyError:
+            loaded = self._profile_store.load(profile_name, cipher=self._cipher)
+            llm = loaded.model_copy(update={"usage_id": usage_id})
+            llm = create_subscription_llm_from_config(llm)
+            self.llm_registry.add(llm)
+            self._bind_conversation_context(llm)
+            return llm
+
     def switch_acp_model(self, model: str) -> None:
         """Switch the model on an ACP conversation.
 

--- a/openhands-sdk/openhands/sdk/tool/builtins/__init__.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/__init__.py
@@ -29,6 +29,12 @@ from openhands.sdk.tool.builtins.think import (
     ThinkObservation,
     ThinkTool,
 )
+from openhands.sdk.tool.builtins.vision_inspect import (
+    VisionInspectAction,
+    VisionInspectExecutor,
+    VisionInspectObservation,
+    VisionInspectTool,
+)
 
 
 # Tools attached to every agent by default. `InvokeSkillTool` is deliberately
@@ -43,6 +49,7 @@ BUILT_IN_TOOL_CLASSES = {
     **{tool.__name__: tool for tool in BUILT_IN_TOOLS},
     InvokeSkillTool.__name__: InvokeSkillTool,
     SwitchLLMTool.__name__: SwitchLLMTool,
+    VisionInspectTool.__name__: VisionInspectTool,
 }
 
 __all__ = [
@@ -64,4 +71,8 @@ __all__ = [
     "ThinkAction",
     "ThinkObservation",
     "ThinkExecutor",
+    "VisionInspectTool",
+    "VisionInspectAction",
+    "VisionInspectObservation",
+    "VisionInspectExecutor",
 ]

--- a/openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py
@@ -69,6 +69,9 @@ class VisionInspectObservation(Observation):
     model: str | None = Field(
         default=None, description="Vision-capable model used for inspection."
     )
+    base_url: str | None = Field(
+        default=None, description="Vision-capable LLM endpoint used for inspection."
+    )
     answer: str | None = Field(
         default=None, description="Text answer returned by the vision model."
     )
@@ -262,6 +265,7 @@ class VisionInspectExecutor(ToolExecutor):
                 question=action.question,
                 profile_name=profile_name,
                 model=vision_llm.model,
+                base_url=vision_llm.base_url,
             )
 
         return VisionInspectObservation.from_text(
@@ -270,6 +274,7 @@ class VisionInspectExecutor(ToolExecutor):
             question=action.question,
             profile_name=profile_name,
             model=vision_llm.model,
+            base_url=vision_llm.base_url,
             answer=answer,
         )
 

--- a/openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py
+++ b/openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py
@@ -1,0 +1,323 @@
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, ClassVar, Self
+
+from pydantic import Field
+from rich.text import Text
+
+from openhands.sdk.llm import ImageContent, Message, TextContent
+from openhands.sdk.llm.llm import LLM
+from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.tool.tool import (
+    Action,
+    Observation,
+    ToolAnnotations,
+    ToolDefinition,
+    ToolExecutor,
+)
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+    from openhands.sdk.conversation.state import ConversationState
+
+
+VISION_INSPECT_TOOL_NAME = "inspect_image_with_vision"
+VISION_PROFILE_USAGE_PREFIX = "vision-profile"
+
+
+class VisionInspectAction(Action):
+    """Action for asking a vision model about an attached image."""
+
+    image_index: int = Field(
+        ge=0,
+        description=(
+            "Zero-based index of the image to inspect from the latest user message."
+        ),
+    )
+    question: str = Field(
+        min_length=1,
+        description="Question to ask the vision model about the selected image.",
+    )
+    profile_name: str | None = Field(
+        default=None,
+        description=(
+            "Optional saved vision-capable LLM profile name. If omitted, the first "
+            "available vision profile listed in the tool description is used."
+        ),
+    )
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        content.append("Inspect image with vision: ", style="bold magenta")
+        content.append(f"image {self.image_index}")
+        if self.profile_name:
+            content.append(f" via {self.profile_name}")
+        content.append("\nQuestion: ", style="bold")
+        content.append(self.question)
+        return content
+
+
+class VisionInspectObservation(Observation):
+    """Observation returned after a vision model inspects an image."""
+
+    image_index: int = Field(description="Image index that was inspected.")
+    question: str = Field(description="Question asked of the vision model.")
+    profile_name: str | None = Field(
+        default=None, description="Vision-capable profile used for inspection."
+    )
+    model: str | None = Field(
+        default=None, description="Vision-capable model used for inspection."
+    )
+    answer: str | None = Field(
+        default=None, description="Text answer returned by the vision model."
+    )
+
+    @property
+    def visualize(self) -> Text:
+        content = Text()
+        if self.is_error:
+            content.append("Failed to inspect image", style="bold red")
+        else:
+            content.append("Inspected image with vision", style="bold green")
+        content.append(f": image {self.image_index}")
+        if self.profile_name:
+            content.append(f" via {self.profile_name}")
+        if self.answer:
+            content.append("\n")
+            content.append(self.answer)
+        return content
+
+
+def _candidate_vision_profiles() -> list[str]:
+    """Return saved profile names that appear to support vision."""
+    profiles: list[str] = []
+    store = LLMProfileStore()
+    for summary in store.list_summaries():
+        name = summary.get("name")
+        model = summary.get("model")
+        if not isinstance(name, str) or not isinstance(model, str):
+            continue
+        try:
+            llm = LLM(model=model, base_url=summary.get("base_url"))
+        except Exception:
+            continue
+        if llm.vision_is_active():
+            profiles.append(name)
+            continue
+        try:
+            llm = store.load(name)
+        except Exception:
+            continue
+        if llm.vision_is_active():
+            profiles.append(name)
+    return sorted(profiles)
+
+
+def has_vision_profile_available() -> bool:
+    """Return True when at least one saved profile appears vision-capable."""
+    return bool(_candidate_vision_profiles())
+
+
+def _format_profiles(profile_names: Sequence[str]) -> str:
+    if not profile_names:
+        return "- No saved vision-capable LLM profiles are currently available."
+    return "\n".join(f"- {name}" for name in profile_names)
+
+
+def _latest_user_image_urls(conversation: "LocalConversation") -> list[str]:
+    from openhands.sdk.event import MessageEvent
+
+    for event in reversed(conversation.state.events):
+        if not isinstance(event, MessageEvent) or event.source != "user":
+            continue
+        urls: list[str] = []
+        for content in event.llm_message.content:
+            if isinstance(content, ImageContent):
+                urls.extend(content.image_urls)
+        if urls:
+            return urls
+    return []
+
+
+class VisionInspectExecutor(ToolExecutor):
+    def __init__(self, profile_names: Sequence[str]) -> None:
+        self._profile_names = tuple(profile_names)
+
+    def __call__(
+        self,
+        action: VisionInspectAction,
+        conversation: "LocalConversation | None" = None,
+    ) -> VisionInspectObservation:
+        if conversation is None:
+            return VisionInspectObservation.from_text(
+                text="Cannot inspect images without an active conversation.",
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+                profile_name=action.profile_name,
+            )
+
+        profile_name = action.profile_name or (
+            self._profile_names[0] if self._profile_names else None
+        )
+        if profile_name is None:
+            return VisionInspectObservation.from_text(
+                text="No vision-capable LLM profile is available.",
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+            )
+        if profile_name not in self._profile_names:
+            return VisionInspectObservation.from_text(
+                text=(
+                    f"Profile '{profile_name}' is not listed as a vision-capable "
+                    "profile for this conversation."
+                ),
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+                profile_name=profile_name,
+            )
+
+        image_urls = _latest_user_image_urls(conversation)
+        if action.image_index >= len(image_urls):
+            return VisionInspectObservation.from_text(
+                text=(
+                    f"Image index {action.image_index} is out of range. "
+                    f"The latest user message has {len(image_urls)} image(s)."
+                ),
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+                profile_name=profile_name,
+            )
+
+        try:
+            vision_llm = conversation.get_or_create_profile_llm(
+                profile_name=profile_name,
+                usage_id=f"{VISION_PROFILE_USAGE_PREFIX}:{profile_name}",
+            )
+        except Exception as exc:
+            return VisionInspectObservation.from_text(
+                text=(
+                    f"Failed to load vision profile '{profile_name}': "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+                profile_name=profile_name,
+            )
+
+        if not vision_llm.vision_is_active():
+            return VisionInspectObservation.from_text(
+                text=(
+                    f"Profile '{profile_name}' loaded model '{vision_llm.model}', "
+                    "which does not currently support vision."
+                ),
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+                profile_name=profile_name,
+                model=vision_llm.model,
+            )
+
+        messages = [
+            Message(
+                role="system",
+                content=[
+                    TextContent(
+                        text=(
+                            "Answer the user's question about the attached image. "
+                            "Return concise text only."
+                        )
+                    )
+                ],
+            ),
+            Message(
+                role="user",
+                content=[
+                    TextContent(text=action.question),
+                    ImageContent(image_urls=[image_urls[action.image_index]]),
+                ],
+            ),
+        ]
+        from openhands.sdk.agent.utils import make_llm_completion
+
+        response = make_llm_completion(vision_llm, messages, tools=[])
+        answer = next(
+            (
+                content.text
+                for content in response.message.content
+                if isinstance(content, TextContent)
+            ),
+            "",
+        )
+        if not answer:
+            return VisionInspectObservation.from_text(
+                text="The vision model returned no text answer.",
+                is_error=True,
+                image_index=action.image_index,
+                question=action.question,
+                profile_name=profile_name,
+                model=vision_llm.model,
+            )
+
+        return VisionInspectObservation.from_text(
+            text=answer,
+            image_index=action.image_index,
+            question=action.question,
+            profile_name=profile_name,
+            model=vision_llm.model,
+            answer=answer,
+        )
+
+
+_DESCRIPTION_TEMPLATE = (
+    "Ask a saved vision-capable LLM profile to inspect an image from the latest "
+    "user message and return a text answer.\n\n"
+    "Use this when the current model cannot understand images, the latest user "
+    "message includes an image, and visual details are needed to answer. The "
+    "current model should pass the image_index shown in the user message and a "
+    "specific question for the vision model. The cost of this vision model call "
+    "is tracked in the same conversation stats.\n\n"
+    "Available vision-capable profiles:\n"
+    "{profiles}"
+)
+
+
+class VisionInspectTool(ToolDefinition[VisionInspectAction, VisionInspectObservation]):
+    """Tool for one-off image inspection through a saved vision profile."""
+
+    name: ClassVar[str] = VISION_INSPECT_TOOL_NAME
+
+    @classmethod
+    def create(
+        cls,
+        conv_state: "ConversationState | None" = None,  # noqa: ARG003
+        **params,
+    ) -> Sequence[Self]:
+        if params:
+            raise ValueError("VisionInspectTool doesn't accept parameters")
+
+        profile_names = _candidate_vision_profiles()
+        if not profile_names:
+            return []
+
+        return [
+            cls(
+                description=_DESCRIPTION_TEMPLATE.format(
+                    profiles=_format_profiles(profile_names)
+                ),
+                action_type=VisionInspectAction,
+                observation_type=VisionInspectObservation,
+                executor=VisionInspectExecutor(profile_names),
+                annotations=ToolAnnotations(
+                    readOnlyHint=True,
+                    destructiveHint=False,
+                    idempotentHint=True,
+                    openWorldHint=True,
+                ),
+            )
+        ]

--- a/tests/sdk/agent/test_non_multimodal_image_input.py
+++ b/tests/sdk/agent/test_non_multimodal_image_input.py
@@ -1,13 +1,58 @@
+from collections.abc import Sequence
+from typing import TYPE_CHECKING, Any, cast
+
 import pytest
+from pydantic import PrivateAttr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.conversation import Conversation
 from openhands.sdk.conversation.impl.local_conversation import LocalConversation
 from openhands.sdk.conversation.state import ConversationExecutionStatus
-from openhands.sdk.event import MessageEvent
-from openhands.sdk.llm import ImageContent, Message, TextContent
+from openhands.sdk.event import MessageEvent, ObservationEvent
+from openhands.sdk.llm import (
+    ImageContent,
+    LLMResponse,
+    Message,
+    MessageToolCall,
+    TextContent,
+)
 from openhands.sdk.llm.router.impl.multimodal import MultimodalRouter
+from openhands.sdk.llm.streaming import TokenCallbackType
 from openhands.sdk.testing import TestLLM
+from openhands.sdk.tool import ToolDefinition
+from openhands.sdk.tool.builtins.vision_inspect import VISION_PROFILE_USAGE_PREFIX
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.llm.llm import LLMCallContext
+
+
+class CapturingTestLLM(TestLLM):
+    __test__ = False
+    _calls: list[tuple[list[Message], list]] = PrivateAttr(default_factory=list)
+
+    @property
+    def calls(self) -> list[tuple[list[Message], list]]:
+        return self._calls
+
+    def completion(
+        self,
+        messages: list[Message],
+        tools: Sequence[ToolDefinition] | None = None,
+        add_security_risk_prediction: bool = False,
+        on_token: TokenCallbackType | None = None,
+        call_context: "LLMCallContext | None" = None,
+        **kwargs: Any,
+    ) -> LLMResponse:
+        self._calls.append((messages, list(tools or [])))
+        return super().completion(
+            messages=messages,
+            tools=tools,
+            add_security_risk_prediction=add_security_risk_prediction,
+            on_token=on_token,
+            call_context=call_context,
+            **kwargs,
+        )
 
 
 def _image_message() -> Message:
@@ -32,7 +77,21 @@ def _agent_response_text(conversation: LocalConversation) -> str:
     return content.text
 
 
-def test_image_input_to_non_multimodal_model_returns_capability_message():
+def _last_agent_response_text(conversation: LocalConversation) -> str:
+    agent_messages = [
+        event
+        for event in conversation.state.events
+        if isinstance(event, MessageEvent) and event.source == "agent"
+    ]
+    content = agent_messages[-1].llm_message.content[0]
+    assert isinstance(content, TextContent)
+    return content.text
+
+
+def test_image_input_to_non_multimodal_model_returns_capability_message(monkeypatch):
+    monkeypatch.setattr(
+        "openhands.sdk.agent.base.has_vision_profile_available", lambda: False
+    )
     llm = TestLLM.from_messages(
         [],
         model="litellm_proxy/openrouter/z-ai/glm-4.7",
@@ -52,7 +111,12 @@ def test_image_input_to_non_multimodal_model_returns_capability_message():
 
 
 @pytest.mark.asyncio
-async def test_async_image_input_to_non_multimodal_model_returns_capability_message():
+async def test_async_image_input_to_non_multimodal_model_returns_capability_message(
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "openhands.sdk.agent.base.has_vision_profile_available", lambda: False
+    )
     llm = TestLLM.from_messages(
         [],
         model="litellm_proxy/openrouter/z-ai/glm-4.7",
@@ -70,7 +134,10 @@ async def test_async_image_input_to_non_multimodal_model_returns_capability_mess
     assert "does not support image understanding" in text
 
 
-def test_image_input_guard_does_not_preempt_multimodal_router():
+def test_image_input_guard_does_not_preempt_multimodal_router(monkeypatch):
+    monkeypatch.setattr(
+        "openhands.sdk.agent.base.has_vision_profile_available", lambda: False
+    )
     primary = TestLLM.from_messages(
         [Message(role="assistant", content=[TextContent(text="router handled image")])],
         model="claude-sonnet-4-5-20250929",
@@ -90,3 +157,114 @@ def test_image_input_guard_does_not_preempt_multimodal_router():
     assert primary.call_count == 1
     assert secondary.call_count == 0
     assert _agent_response_text(conversation) == "router handled image"
+
+
+def test_nonvision_model_can_use_vision_profile_tool(monkeypatch):
+    monkeypatch.setattr(
+        "openhands.sdk.agent.base.has_vision_profile_available", lambda: True
+    )
+    monkeypatch.setattr(
+        "openhands.sdk.tool.builtins.vision_inspect._candidate_vision_profiles",
+        lambda: ["vision-profile"],
+    )
+
+    parent = cast(
+        CapturingTestLLM,
+        CapturingTestLLM.from_messages(
+            [
+                Message(
+                    role="assistant",
+                    content=[TextContent(text="I will inspect the image.")],
+                    tool_calls=[
+                        MessageToolCall(
+                            id="call_vision",
+                            name="inspect_image_with_vision",
+                            arguments=(
+                                '{"image_index": 0, "question": "What is shown?"}'
+                            ),
+                            origin="completion",
+                        )
+                    ],
+                ),
+                Message(
+                    role="assistant",
+                    content=[TextContent(text="The image shows a cat.")],
+                ),
+            ],
+            model="text-only-model",
+            disable_vision=True,
+        ),
+    )
+    vision = TestLLM.from_messages(
+        [Message(role="assistant", content=[TextContent(text="It shows a cat.")])],
+        model="gpt-4o",
+    )
+
+    def fake_get_or_create_profile_llm(self, profile_name, usage_id):
+        assert profile_name == "vision-profile"
+        assert usage_id == f"{VISION_PROFILE_USAGE_PREFIX}:vision-profile"
+        return vision
+
+    monkeypatch.setattr(
+        LocalConversation,
+        "get_or_create_profile_llm",
+        fake_get_or_create_profile_llm,
+    )
+
+    conversation = Conversation(agent=Agent(llm=parent, tools=[]))
+    conversation.send_message(_image_message())
+    conversation.run()
+
+    assert conversation.state.execution_status == ConversationExecutionStatus.FINISHED
+    assert parent.call_count == 2
+    assert vision.call_count == 1
+    assert _last_agent_response_text(conversation) == "The image shows a cat."
+
+    first_parent_messages, first_parent_tools = parent.calls[0]
+    latest_user = next(
+        message for message in reversed(first_parent_messages) if message.role == "user"
+    )
+    assert not latest_user.contains_image
+    assert any(
+        isinstance(content, TextContent)
+        and "inspect_image_with_vision" in content.text
+        and "image_index=0" in content.text
+        for content in latest_user.content
+    )
+    assert any(tool.name == "inspect_image_with_vision" for tool in first_parent_tools)
+
+    observations = [
+        event
+        for event in conversation.state.events
+        if isinstance(event, ObservationEvent)
+        and event.tool_name == "inspect_image_with_vision"
+    ]
+    assert len(observations) == 1
+    observation_content = observations[0].observation.content[0]
+    assert isinstance(observation_content, TextContent)
+    assert "It shows a cat." in observation_content.text
+
+
+def test_profile_helper_registers_auxiliary_vision_llm(monkeypatch):
+    monkeypatch.setattr(
+        "openhands.sdk.agent.base.has_vision_profile_available", lambda: False
+    )
+    parent = TestLLM.from_messages([], model="text-only-model", disable_vision=True)
+    conversation = Conversation(agent=Agent(llm=parent, tools=[]))
+    conversation._ensure_agent_ready()
+
+    vision = TestLLM.from_messages(
+        [Message(role="assistant", content=[TextContent(text="vision answer")])],
+        model="gpt-4o",
+    )
+    monkeypatch.setattr(
+        conversation._profile_store,
+        "load",
+        lambda profile_name, cipher=None: vision,
+    )
+
+    usage_id = f"{VISION_PROFILE_USAGE_PREFIX}:vision-profile"
+    loaded = conversation.get_or_create_profile_llm("vision-profile", usage_id)
+
+    assert loaded is conversation.llm_registry.get(usage_id)
+    assert conversation.state.stats.usage_to_metrics[usage_id] is loaded.metrics

--- a/tests/sdk/agent/test_non_multimodal_image_input.py
+++ b/tests/sdk/agent/test_non_multimodal_image_input.py
@@ -198,6 +198,7 @@ def test_nonvision_model_can_use_vision_profile_tool(monkeypatch):
     vision = TestLLM.from_messages(
         [Message(role="assistant", content=[TextContent(text="It shows a cat.")])],
         model="gpt-4o",
+        base_url="https://vision.example.test/",
     )
 
     def fake_get_or_create_profile_llm(self, profile_name, usage_id):
@@ -240,6 +241,7 @@ def test_nonvision_model_can_use_vision_profile_tool(monkeypatch):
         and event.tool_name == "inspect_image_with_vision"
     ]
     assert len(observations) == 1
+    assert observations[0].observation.base_url == "https://vision.example.test/"
     observation_content = observations[0].observation.content[0]
     assert isinstance(observation_content, TextContent)
     assert "It shows a cat." in observation_content.text

--- a/tests/sdk/agent/test_non_multimodal_image_input.py
+++ b/tests/sdk/agent/test_non_multimodal_image_input.py
@@ -20,7 +20,10 @@ from openhands.sdk.llm.router.impl.multimodal import MultimodalRouter
 from openhands.sdk.llm.streaming import TokenCallbackType
 from openhands.sdk.testing import TestLLM
 from openhands.sdk.tool import ToolDefinition
-from openhands.sdk.tool.builtins.vision_inspect import VISION_PROFILE_USAGE_PREFIX
+from openhands.sdk.tool.builtins.vision_inspect import (
+    VISION_PROFILE_USAGE_PREFIX,
+    VisionInspectObservation,
+)
 
 
 if TYPE_CHECKING:
@@ -241,8 +244,9 @@ def test_nonvision_model_can_use_vision_profile_tool(monkeypatch):
         and event.tool_name == "inspect_image_with_vision"
     ]
     assert len(observations) == 1
-    assert observations[0].observation.base_url == "https://vision.example.test/"
-    observation_content = observations[0].observation.content[0]
+    observation = cast(VisionInspectObservation, observations[0].observation)
+    assert observation.base_url == "https://vision.example.test/"
+    observation_content = observation.content[0]
     assert isinstance(observation_content, TextContent)
     assert "It shows a cat." in observation_content.text
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

- [x] a human, me, juanmichelini, tested this. 

See screenshot:

<img width="1498" height="796" alt="image" src="https://github.com/user-attachments/assets/8e885b4e-5474-442b-90af-1eee9c0fe532" />



---

AGENT:

## Why

When the selected model does not support vision but the user sends an image, the SDK currently stops with a deterministic capability message. If a saved vision-capable profile is available, the non-vision model should be able to ask that model to inspect the image without switching the whole conversation.

## Summary

- Add an optional built-in `inspect_image_with_vision` tool that asks a saved vision-capable LLM profile about an image from the latest user message.
- Auto-attach the tool for non-vision agents when a vision-capable saved profile is available.
- Rewrite the latest image-containing user message into text image references before calling the non-vision model, so raw image content is not sent to a text-only model.
- Register auxiliary profile LLMs through `LocalConversation.llm_registry`, so the helper model's usage is included in regular conversation stats and combined cost.
- Preserve the existing deterministic warning when no vision helper is available.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `8473c0f5d69c` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -600 +600 @@
-schema Action oneOf=[MCPToolAction,FinishAction,InvokeSkillAction,SwitchLLMAction,ThinkAction,BrowserAction,BrowserClickAction,BrowserCloseTabAction,BrowserGetContentAction,BrowserGetStateAction,BrowserGetStorageAction,BrowserGoBackAction,BrowserListTabsAction,BrowserNavigateAction,BrowserScrollAction,BrowserSetStorageAction,BrowserStartRecordingAction,BrowserStopRecordingAction,BrowserSwitchTabAction,BrowserTypeAction,DelegateAction,FileEditorAction,EditAction,ListDirectoryAction,ReadFileAction,WriteFileAction,GlobAction,GrepAction,PlanningFileEditorAction,TaskAction,TaskTrackerAction,TerminalAction,WorkflowAction]
+schema Action oneOf=[MCPToolAction,FinishAction,InvokeSkillAction,SwitchLLMAction,ThinkAction,VisionInspectAction,BrowserAction,BrowserClickAction,BrowserCloseTabAction,BrowserGetContentAction,BrowserGetStateAction,BrowserGetStorageAction,BrowserGoBackAction,BrowserListTabsAction,BrowserNavigateAction,BrowserScrollAction,BrowserSetStorageAction,BrowserStartRecordingAction,BrowserStopRecordingAction,BrowserSwitchTabAction,BrowserTypeAction,DelegateAction,FileEditorAction,EditAction,ListDirectoryAction,ReadFileAction,WriteFileAction,GlobAction,GrepAction,PlanningFileEditorAction,TaskAction,TaskTrackerAction,TerminalAction,WorkflowAction]
@@ -1704 +1704 @@
-schema Observation oneOf=[MCPToolObservation,FinishObservation,InvokeSkillObservation,SwitchLLMObservation,ThinkObservation,ClientToolObservation,BrowserObservation,DelegateObservation,FileEditorObservation,EditObservation,ListDirectoryObservation,ReadFileObservation,WriteFileObservation,GlobObservation,GrepObservation,PlanningFileEditorObservation,TaskObservation,TaskTrackerObservation,TerminalObservation,WorkflowObservation]
+schema Observation oneOf=[MCPToolObservation,FinishObservation,InvokeSkillObservation,SwitchLLMObservation,ThinkObservation,VisionInspectObservation,ClientToolObservation,BrowserObservation,DelegateObservation,FileEditorObservation,EditObservation,ListDirectoryObservation,ReadFileObservation,WriteFileObservation,GlobObservation,GrepObservation,PlanningFileEditorObservation,TaskObservation,TaskTrackerObservation,TerminalObservation,WorkflowObservation]
@@ -2239 +2239 @@
-schema ToolDefinition oneOf=[MCPToolDefinition,FinishTool,InvokeSkillTool,SwitchLLMTool,ThinkTool,ClientTool,BrowserClickTool,BrowserCloseTabTool,BrowserGetContentTool,BrowserGetStateTool,BrowserGetStorageTool,BrowserGoBackTool,BrowserListTabsTool,BrowserNavigateTool,BrowserScrollTool,BrowserSetStorageTool,BrowserStartRecordingTool,BrowserStopRecordingTool,BrowserSwitchTabTool,BrowserToolSet,BrowserTypeTool,FileEditorTool,EditTool,ListDirectoryTool,ReadFileTool,WriteFileTool,GlobTool,GrepTool,PlanningFileEditorTool,TaskTool,TaskToolSet,TaskTrackerTool,TerminalTool,WorkflowTool,WorkflowToolSet]
+schema ToolDefinition oneOf=[MCPToolDefinition,FinishTool,InvokeSkillTool,SwitchLLMTool,ThinkTool,VisionInspectTool,ClientTool,BrowserClickTool,BrowserCloseTabTool,BrowserGetContentTool,BrowserGetStateTool,BrowserGetStorageTool,BrowserGoBackTool,BrowserListTabsTool,BrowserNavigateTool,BrowserScrollTool,BrowserSetStorageTool,BrowserStartRecordingTool,BrowserStopRecordingTool,BrowserSwitchTabTool,BrowserToolSet,BrowserTypeTool,FileEditorTool,EditTool,ListDirectoryTool,ReadFileTool,WriteFileTool,GlobTool,GrepTool,PlanningFileEditorTool,TaskTool,TaskToolSet,TaskTrackerTool,TerminalTool,WorkflowTool,WorkflowToolSet]
@@ -2287,0 +2288,23 @@
+schema VisionInspectAction property image_index required schema=type="integer" minimum=0.0
+schema VisionInspectAction property kind required schema=type="string" const="VisionInspectAction"
+schema VisionInspectAction property profile_name optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectAction property question required schema=type="string" minLength=1
+schema VisionInspectAction type="object" additionalProperties=false
+schema VisionInspectObservation property answer optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property base_url optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property content optional schema=type="array" items=anyOf=[TextContent,ImageContent]
+schema VisionInspectObservation property image_index required schema=type="integer"
+schema VisionInspectObservation property is_error optional schema=type="boolean" default=false
+schema VisionInspectObservation property kind required schema=type="string" const="VisionInspectObservation"
+schema VisionInspectObservation property model optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property profile_name optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property question required schema=type="string"
+schema VisionInspectObservation type="object" additionalProperties=false
+schema VisionInspectTool property action_type required schema=type="string"
+schema VisionInspectTool property annotations optional schema=anyOf=[openhands__sdk__tool__tool__ToolAnnotations,type="null"]
+schema VisionInspectTool property description required schema=type="string"
+schema VisionInspectTool property kind required schema=type="string" const="VisionInspectTool"
+schema VisionInspectTool property meta optional schema=anyOf=[type="object" additionalProperties=true,type="null"]
+schema VisionInspectTool property observation_type optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectTool property title required schema=type="string"
+schema VisionInspectTool type="object"
```
<!-- agent-server-rest-api-contract-summary:end -->

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `8473c0f5d69c` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -600 +600 @@
-schema Action oneOf=[MCPToolAction,FinishAction,InvokeSkillAction,SwitchLLMAction,ThinkAction,BrowserAction,BrowserClickAction,BrowserCloseTabAction,BrowserGetContentAction,BrowserGetStateAction,BrowserGetStorageAction,BrowserGoBackAction,BrowserListTabsAction,BrowserNavigateAction,BrowserScrollAction,BrowserSetStorageAction,BrowserStartRecordingAction,BrowserStopRecordingAction,BrowserSwitchTabAction,BrowserTypeAction,DelegateAction,FileEditorAction,EditAction,ListDirectoryAction,ReadFileAction,WriteFileAction,GlobAction,GrepAction,PlanningFileEditorAction,TaskAction,TaskTrackerAction,TerminalAction,WorkflowAction]
+schema Action oneOf=[MCPToolAction,FinishAction,InvokeSkillAction,SwitchLLMAction,ThinkAction,VisionInspectAction,BrowserAction,BrowserClickAction,BrowserCloseTabAction,BrowserGetContentAction,BrowserGetStateAction,BrowserGetStorageAction,BrowserGoBackAction,BrowserListTabsAction,BrowserNavigateAction,BrowserScrollAction,BrowserSetStorageAction,BrowserStartRecordingAction,BrowserStopRecordingAction,BrowserSwitchTabAction,BrowserTypeAction,DelegateAction,FileEditorAction,EditAction,ListDirectoryAction,ReadFileAction,WriteFileAction,GlobAction,GrepAction,PlanningFileEditorAction,TaskAction,TaskTrackerAction,TerminalAction,WorkflowAction]
@@ -1704 +1704 @@
-schema Observation oneOf=[MCPToolObservation,FinishObservation,InvokeSkillObservation,SwitchLLMObservation,ThinkObservation,ClientToolObservation,BrowserObservation,DelegateObservation,FileEditorObservation,EditObservation,ListDirectoryObservation,ReadFileObservation,WriteFileObservation,GlobObservation,GrepObservation,PlanningFileEditorObservation,TaskObservation,TaskTrackerObservation,TerminalObservation,WorkflowObservation]
+schema Observation oneOf=[MCPToolObservation,FinishObservation,InvokeSkillObservation,SwitchLLMObservation,ThinkObservation,VisionInspectObservation,ClientToolObservation,BrowserObservation,DelegateObservation,FileEditorObservation,EditObservation,ListDirectoryObservation,ReadFileObservation,WriteFileObservation,GlobObservation,GrepObservation,PlanningFileEditorObservation,TaskObservation,TaskTrackerObservation,TerminalObservation,WorkflowObservation]
@@ -2239 +2239 @@
-schema ToolDefinition oneOf=[MCPToolDefinition,FinishTool,InvokeSkillTool,SwitchLLMTool,ThinkTool,ClientTool,BrowserClickTool,BrowserCloseTabTool,BrowserGetContentTool,BrowserGetStateTool,BrowserGetStorageTool,BrowserGoBackTool,BrowserListTabsTool,BrowserNavigateTool,BrowserScrollTool,BrowserSetStorageTool,BrowserStartRecordingTool,BrowserStopRecordingTool,BrowserSwitchTabTool,BrowserToolSet,BrowserTypeTool,FileEditorTool,EditTool,ListDirectoryTool,ReadFileTool,WriteFileTool,GlobTool,GrepTool,PlanningFileEditorTool,TaskTool,TaskToolSet,TaskTrackerTool,TerminalTool,WorkflowTool,WorkflowToolSet]
+schema ToolDefinition oneOf=[MCPToolDefinition,FinishTool,InvokeSkillTool,SwitchLLMTool,ThinkTool,VisionInspectTool,ClientTool,BrowserClickTool,BrowserCloseTabTool,BrowserGetContentTool,BrowserGetStateTool,BrowserGetStorageTool,BrowserGoBackTool,BrowserListTabsTool,BrowserNavigateTool,BrowserScrollTool,BrowserSetStorageTool,BrowserStartRecordingTool,BrowserStopRecordingTool,BrowserSwitchTabTool,BrowserToolSet,BrowserTypeTool,FileEditorTool,EditTool,ListDirectoryTool,ReadFileTool,WriteFileTool,GlobTool,GrepTool,PlanningFileEditorTool,TaskTool,TaskToolSet,TaskTrackerTool,TerminalTool,WorkflowTool,WorkflowToolSet]
@@ -2287,0 +2288,23 @@
+schema VisionInspectAction property image_index required schema=type="integer" minimum=0.0
+schema VisionInspectAction property kind required schema=type="string" const="VisionInspectAction"
+schema VisionInspectAction property profile_name optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectAction property question required schema=type="string" minLength=1
+schema VisionInspectAction type="object" additionalProperties=false
+schema VisionInspectObservation property answer optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property base_url optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property content optional schema=type="array" items=anyOf=[TextContent,ImageContent]
+schema VisionInspectObservation property image_index required schema=type="integer"
+schema VisionInspectObservation property is_error optional schema=type="boolean" default=false
+schema VisionInspectObservation property kind required schema=type="string" const="VisionInspectObservation"
+schema VisionInspectObservation property model optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property profile_name optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectObservation property question required schema=type="string"
+schema VisionInspectObservation type="object" additionalProperties=false
+schema VisionInspectTool property action_type required schema=type="string"
+schema VisionInspectTool property annotations optional schema=anyOf=[openhands__sdk__tool__tool__ToolAnnotations,type="null"]
+schema VisionInspectTool property description required schema=type="string"
+schema VisionInspectTool property kind required schema=type="string" const="VisionInspectTool"
+schema VisionInspectTool property meta optional schema=anyOf=[type="object" additionalProperties=true,type="null"]
+schema VisionInspectTool property observation_type optional schema=anyOf=[type="string",type="null"]
+schema VisionInspectTool property title required schema=type="string"
+schema VisionInspectTool type="object"
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

N/A

## How to Test

```bash
uv run pytest tests/sdk/agent/test_non_multimodal_image_input.py
uv run pre-commit run --files openhands-sdk/openhands/sdk/tool/builtins/vision_inspect.py openhands-sdk/openhands/sdk/tool/builtins/__init__.py openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py openhands-sdk/openhands/sdk/agent/base.py openhands-sdk/openhands/sdk/agent/agent.py tests/sdk/agent/test_non_multimodal_image_input.py --show-diff-on-failure
```

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This is intentionally profile-based for the first pass, matching the existing `SwitchLLMTool` saved-profile workflow. The tool accepts an optional `profile_name`; otherwise it uses the first listed vision-capable profile deterministically.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:1c8ed83-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-1c8ed83-python \
  ghcr.io/openhands/agent-server:1c8ed83-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:1c8ed83-golang-amd64
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-golang-amd64
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-golang-amd64
ghcr.io/openhands/agent-server:1c8ed83-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:1c8ed83-golang-arm64
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-golang-arm64
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-golang-arm64
ghcr.io/openhands/agent-server:1c8ed83-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:1c8ed83-java-amd64
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-java-amd64
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-java-amd64
ghcr.io/openhands/agent-server:1c8ed83-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:1c8ed83-java-arm64
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-java-arm64
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-java-arm64
ghcr.io/openhands/agent-server:1c8ed83-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:1c8ed83-python-amd64
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-python-amd64
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-python-amd64
ghcr.io/openhands/agent-server:1c8ed83-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:1c8ed83-python-arm64
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-python-arm64
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-python-arm64
ghcr.io/openhands/agent-server:1c8ed83-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:1c8ed83-golang
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-golang
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-golang
ghcr.io/openhands/agent-server:1c8ed83-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:1c8ed83-java
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-java
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-java
ghcr.io/openhands/agent-server:1c8ed83-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:1c8ed83-python
ghcr.io/openhands/agent-server:1c8ed83a6e1e045d4b60e6b37c37be7e3f6473ca-python
ghcr.io/openhands/agent-server:vision-helper-tool-for-nonvision-models-python
ghcr.io/openhands/agent-server:1c8ed83-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `1c8ed83-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `1c8ed83-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->



