### PR TITLE
fix(mcp): log the failing server name and error when MCP setup fails

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/utils.py
+++ b/openhands-sdk/openhands/sdk/mcp/utils.py
@@ -78,6 +78,27 @@ def create_mcp_tools(
         raise MCPTimeoutError(
             error_msg, timeout=timeout, config=config.model_dump()
         ) from e
+    except Exception as e:
+        # Surface *why* MCP setup failed (e.g. a 401 from an OAuth-required
+        # server, or a bad command) together with the configured server name(s),
+        # instead of letting it propagate unlogged and surface to the user as
+        # silently-missing tools (#9805).
+        server_names = (
+            list(config.mcpServers.keys()) if config.mcpServers else ["unknown"]
+        )
+        logger.error(
+            "Failed to set up MCP tools for server(s) %s: %s",
+            ", ".join(server_names),
+            e,
+            exc_info=True,
+        )
+        try:
+            client.sync_close()
+        except Exception as close_exc:
+            logger.warning(
+                "Failed to close MCP client during error cleanup", exc_info=close_exc
+            )
+        raise
     except BaseException:
         try:
             client.sync_close()

--- a/tests/sdk/mcp/test_create_mcp_tool.py
+++ b/tests/sdk/mcp/test_create_mcp_tool.py
@@ -358,6 +358,36 @@ def test_create_mcp_tools_connection_to_nonexistent_server():
         pass  # Expected connection errors are acceptable
 
 
+def test_create_mcp_tools_logs_server_name_on_failure():
+    """A failed MCP setup logs the server name + underlying error instead of
+    propagating unlogged and surfacing to the user as silently-missing tools.
+
+    Regression test for #9805 (e.g. an OAuth server returning 401).
+    """
+    from openhands.sdk.mcp import utils as mcp_utils
+
+    config = {
+        "mcpServers": {
+            "linear": {"transport": "http", "url": "http://127.0.0.1:59999/mcp"}
+        }
+    }
+
+    async def _boom(client):
+        raise ValueError("401 Unauthorized")
+
+    with (
+        patch.object(mcp_utils, "_connect_and_list_tools", _boom),
+        patch.object(mcp_utils.logger, "error") as mock_error,
+    ):
+        with pytest.raises(ValueError, match="401 Unauthorized"):
+            create_mcp_tools(config, timeout=5.0)
+
+    mock_error.assert_called_once()
+    args = mock_error.call_args.args
+    assert "Failed to set up MCP tools" in args[0]
+    assert "linear" in args  # the configured server name is surfaced
+
+
 def test_create_mcp_tools_stdio_server():
     """Test creating MCP tools with dict configuration (not MCPConfig object)."""
     mcp_config = {


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

When `create_mcp_tools()` fails for a non-timeout reason — e.g. an OAuth-required server returning `401`, or a bad stdio command — the exception propagated out of `_resolve_tools` with **no log of which server failed or why**. From the user's side the MCP tools just silently don't appear, with nothing actionable in the logs. This is the core of `OpenHands/OpenHands#9805` (maintainer confirmed it's an ongoing issue with OAuth-required MCP servers).

## Summary

- In `openhands/sdk/mcp/utils.py`, add an `except Exception` branch that logs an `ERROR` naming the configured MCP server(s) and the underlying error before re-raising.
- Control flow is unchanged (still re-raises; `TimeoutError` keeps its existing detailed `MCPTimeoutError`; `BaseException`/cleanup path preserved).
- Adds a regression test asserting the server name is surfaced on failure.

## Issue Number

Addresses OpenHands/OpenHands#9805 (surfaces the failure; the broader UI status/retry work is separate).

## How to Test

```bash
uv run pytest tests/sdk/mcp/test_create_mcp_tool.py \
  -k "logs_server_name_on_failure or connection_to_nonexistent"
```

Output:

```
2 passed, 11 deselected in 17.48s
```

The new test (`test_create_mcp_tools_logs_server_name_on_failure`) forces `_connect_and_list_tools` to raise `ValueError("401 Unauthorized")` and asserts `logger.error` is called with the configured server name (`linear`) before the error re-raises. `ruff format --check` + `ruff check` pass on both files.

Note: this is a targeted logging change; a full end-to-end repro (a live agent against an OAuth MCP server returning 401) isn't reproducible in this environment, so the evidence is the deterministic unit test that asserts the new log on the failure path.

## Video/Screenshots

N/A — log-only change on the MCP setup-failure path.
