### PR TITLE
feat(sdk): conversation history tree (parent_id, leaf HEAD, fork-from-event, navigate)

### DIFF
--- a/examples/01_standalone_sdk/48_conversation_fork.py
+++ b/examples/01_standalone_sdk/48_conversation_fork.py
@@ -15,6 +15,7 @@ A/B-testing prompts, fork-on-tool-change, edit-a-past-turn-and-re-run.
 import os
 
 from openhands.sdk import LLM, Agent, Conversation, Tool
+from openhands.sdk.event import MessageEvent
 from openhands.tools.terminal import TerminalTool
 
 
@@ -97,9 +98,6 @@ print(f"Fork events : {len(fork_alt.state.events)}")
 # =================================================================
 # Fork from the first user message: copies only path_to_root(event) and sets
 # the fork's HEAD there.
-from openhands.sdk.event import MessageEvent  # noqa: E402
-
-
 cut_event_id = next(
     e.id
     for e in source.state.events

--- a/examples/01_standalone_sdk/48_conversation_fork.py
+++ b/examples/01_standalone_sdk/48_conversation_fork.py
@@ -1,16 +1,15 @@
-"""Fork a conversation to branch off for follow-up exploration.
+"""Branch a conversation. The conversation is a tree (every event has a
+``parent_id``; the HEAD is ``leaf_event_id``), exposing three primitives:
 
-``Conversation.fork()`` deep-copies a conversation — events, agent config,
-workspace metadata — into a new conversation with its own ID.  The fork
-starts in ``idle`` status and retains full event memory of the source, so
-calling ``run()`` picks up right where the original left off.
+  - ``fork()`` — deep-copy the whole conversation into a new one; ``run()``
+    resumes with full event memory.
+  - ``fork(from_event_id=...)`` — fork only the branch up to a chosen event;
+    the fork's HEAD is that event.
+  - ``navigate_to(event_id)`` — move HEAD within one conversation; appending
+    after navigating creates a sibling branch, abandoned events stay on disk.
 
-Use cases:
-  - CI agents that produced a wrong patch — engineer forks to debug
-    without losing the original run's audit trail
-  - A/B-testing prompts — fork at a given turn, change one variable,
-    compare downstream
-  - Swapping tools mid-conversation (fork-on-tool-change)
+Use cases: debugging a wrong CI patch off the original's audit trail,
+A/B-testing prompts, fork-on-tool-change, edit-a-past-turn-and-re-run.
 """
 
 import os
@@ -92,6 +91,53 @@ fork_alt.send_message("What command did you run earlier? Just tell me, no tools.
 fork_alt.run()
 
 print(f"Fork events : {len(fork_alt.state.events)}")
+
+# =================================================================
+# 4. Branch-slice fork: fork from a chosen past event
+# =================================================================
+# Fork from the first user message: copies only path_to_root(event) and sets
+# the fork's HEAD there.
+from openhands.sdk.event import MessageEvent  # noqa: E402
+
+
+cut_event_id = next(
+    e.id
+    for e in source.state.events
+    if isinstance(e, MessageEvent) and e.source == "user"
+)
+
+fork_slice = source.fork(from_event_id=cut_event_id, title="Branch from first turn")
+
+print("\n--- Branch-slice fork (from_event_id) ---")
+print(f"Cut event id          : {cut_event_id}")
+print(f"Source events (full)  : {len(source.state.events)}")
+print(f"Fork events (sliced)  : {len(fork_slice.state.events)}")
+print(f"Fork HEAD             : {fork_slice.state.leaf_event_id}")
+
+# The slice contains only the branch up to the cut point.
+assert len(fork_slice.state.events) <= len(source.state.events)
+assert fork_slice.state.leaf_event_id == cut_event_id
+
+fork_slice.send_message("Given only my first request, run `echo sliced-branch`.")
+fork_slice.run()
+print(f"Fork events after run : {len(fork_slice.state.events)}")
+
+# =================================================================
+# 5. In-conversation navigation: move HEAD and create a sibling branch
+# =================================================================
+# Move HEAD back to the cut point and send a new message: a sibling branch.
+# The abandoned branch stays on disk but leaves the agent's active context.
+events_before_nav = len(source.state.events)
+
+source.navigate_to(cut_event_id)
+print("\n--- navigate_to (in-conversation branching) ---")
+print(f"HEAD moved to         : {source.state.leaf_event_id}")
+print(f"Active branch length  : {len(source.state.view.events)} events in context")
+print(f"Events still on disk  : {events_before_nav}")
+
+source.send_message("Actually, instead run `echo sibling-branch`.")
+source.run()
+print(f"Events on disk now     : {len(source.state.events)} (old branch retained)")
 
 # =================================================================
 # Summary

--- a/examples/01_standalone_sdk/48_conversation_fork.py
+++ b/examples/01_standalone_sdk/48_conversation_fork.py
@@ -118,9 +118,10 @@ print(f"Fork HEAD             : {fork_slice.state.leaf_event_id}")
 assert len(fork_slice.state.events) <= len(source.state.events)
 assert fork_slice.state.leaf_event_id == cut_event_id
 
-fork_slice.send_message("Given only my first request, run `echo sliced-branch`.")
+fork_slice.send_message("Run `echo sliced-branch` in the terminal.")
 fork_slice.run()
 print(f"Fork events after run : {len(fork_slice.state.events)}")
+assert any("sliced-branch" in str(e) for e in fork_slice.state.events)
 
 # =================================================================
 # 5. In-conversation navigation: move HEAD and create a sibling branch

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -863,6 +863,11 @@ class EventService:
         state = self._conversation.state
         if state.execution_status == ConversationExecutionStatus.RUNNING:
             state.execution_status = ConversationExecutionStatus.ERROR
+            # Crash recovery scans the full log, not the active branch: the
+            # process may have died between writing an event file and persisting
+            # the advanced HEAD, so the leaf can lag the on-disk events. (Remote
+            # branching is unsupported — #3749 — so there are no abandoned
+            # branches to exclude here anyway.)
             unmatched_actions = ConversationState.get_unmatched_actions(state.events)
             if unmatched_actions:
                 first_action = unmatched_actions[0]

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -585,7 +585,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         state = conversation.state
         # Check for pending actions (implicit confirmation)
         # and execute them before sampling new actions.
-        pending_actions = ConversationState.get_unmatched_actions(state.events)
+        pending_actions = ConversationState.get_unmatched_actions(state.active_branch())
         if pending_actions:
             logger.info(
                 "Confirmation mode: Executing %d pending action(s)",
@@ -769,7 +769,7 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         """
         state = conversation.state
         # Check for pending actions (implicit confirmation)
-        pending_actions = ConversationState.get_unmatched_actions(state.events)
+        pending_actions = ConversationState.get_unmatched_actions(state.active_branch())
         if pending_actions:
             logger.info(
                 "Confirmation mode: Executing %d pending action(s)",

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -12,6 +12,7 @@ from openhands.sdk.conversation.types import (
     ConversationTokenCallbackType,
     TraceMetadataValue,
 )
+from openhands.sdk.event.types import EventID
 from openhands.sdk.llm.llm import LLM
 from openhands.sdk.llm.message import Message
 from openhands.sdk.observability.laminar import (
@@ -393,6 +394,7 @@ class BaseConversation(ABC):
         title: str | None = None,
         tags: dict[str, str] | None = None,
         reset_metrics: bool = True,
+        from_event_id: EventID | None = None,
     ) -> "BaseConversation":
         """Deep-copy this conversation with a new ID.
 
@@ -409,10 +411,29 @@ class BaseConversation(ABC):
             tags: Optional tags for the forked conversation.
             reset_metrics: If ``True`` (default), cost/token stats start
                 fresh on the fork.
+            from_event_id: If set, copy only the branch up to this event and set
+                the fork's HEAD there. If ``None`` (default), full copy.
 
         Returns:
             A new conversation that shares the same event history but has
             its own identity and independent state going forward.
+        """
+        ...
+
+    @abstractmethod
+    def navigate_to(self, event_id: EventID | None) -> None:
+        """Move the conversation HEAD to an existing event within this conversation.
+
+        Re-roots the active branch in place: the agent's next context becomes
+        ``path_to_root(event_id)``. All branches stay on disk; unlike
+        :meth:`fork`, no new conversation is created.
+
+        Args:
+            event_id: Event to make the new HEAD, or ``None`` for the empty tree.
+
+        Raises:
+            ValueError: If ``event_id`` is not ``None`` and not in this
+                conversation.
         """
         ...
 

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -88,10 +88,6 @@ class EventLog(EventsListBase):
             return item.id in self._id_to_idx
         return item in self._id_to_idx
 
-    def get_by_id(self, event_id: EventID) -> Event:
-        """Return the event with the given id (raises KeyError if absent)."""
-        return self[self.get_index(event_id)]
-
     def _effective_parent_id(self, idx: int, event: Event) -> EventID | None:
         """Resolve the parent of ``event`` (at ``idx``) for tree traversal.
 
@@ -128,17 +124,6 @@ class EventLog(EventsListBase):
             chain.append(evt := self[idx])
             cur_id = self._effective_parent_id(idx, evt)
         return chain[::-1]
-
-    def children_of(self, event_id: EventID | None) -> list[EventID]:
-        """Ids of events whose effective parent is ``event_id``.
-
-        ``None`` returns the root(s); 2+ children are sibling branches.
-        """
-        return [
-            evt.id
-            for idx, evt in enumerate(self)
-            if self._effective_parent_id(idx, evt) == event_id
-        ]
 
     @overload
     def __getitem__(self, idx: int) -> Event: ...

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -72,6 +72,63 @@ class EventLog(EventsListBase):
             raise IndexError("Event index out of range")
         return self._idx_to_id[idx]
 
+    def __contains__(self, item: object) -> bool:
+        """Whether the log contains a given event id or ``Event`` (by id).
+
+        Checking by id (not the ``Sequence`` default of value-equality) keeps
+        ``event in events`` true after the event is stamped with a ``parent_id``
+        on append, and avoids hashing unhashable event payloads.
+        """
+        if isinstance(item, Event):
+            return item.id in self._id_to_idx
+        return item in self._id_to_idx
+
+    def get_by_id(self, event_id: EventID) -> Event:
+        """Return the event with the given id (raises KeyError if absent)."""
+        return self[self.get_index(event_id)]
+
+    def _effective_parent_id(self, idx: int, event: Event) -> EventID | None:
+        """Resolve the parent of ``event`` (at ``idx``) for tree traversal.
+
+        Legacy events predating the tree have no ``parent_id``; they fall back to
+        the linear chain (event ``idx - 1``) so old conversations load unbranched
+        with no disk rewrite.
+        """
+        if event.parent_id is not None:
+            return event.parent_id  # explicit (new events)
+        if idx == 0:
+            return None  # genuine root
+        return self.get_id(idx - 1)  # legacy linear chain (back-compat)
+
+    def path_to_root(self, leaf_id: EventID | None) -> list[Event]:
+        """The active branch ``leaf -> ... -> root``, returned root-first.
+
+        ``leaf_id=None`` yields ``[]``. Raises ValueError on a cycle, KeyError if
+        ``leaf_id`` or an ancestor is missing.
+        """
+        chain: list[Event] = []
+        seen: set[EventID] = set()
+        cur_id: EventID | None = leaf_id
+        while cur_id is not None:
+            if cur_id in seen:
+                raise ValueError(f"Cycle in event tree at {cur_id}")
+            seen.add(cur_id)
+            idx = self.get_index(cur_id)
+            chain.append(evt := self[idx])
+            cur_id = self._effective_parent_id(idx, evt)
+        return chain[::-1]
+
+    def children_of(self, event_id: EventID | None) -> list[EventID]:
+        """Ids of events whose effective parent is ``event_id``.
+
+        ``None`` returns the root(s); 2+ children are sibling branches.
+        """
+        return [
+            evt.id
+            for idx, evt in enumerate(self)
+            if self._effective_parent_id(idx, evt) == event_id
+        ]
+
     @overload
     def __getitem__(self, idx: int) -> Event: ...
 

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -107,16 +107,20 @@ class EventLog(EventsListBase):
             return None  # genuine root
         return self.get_id(idx - 1)  # legacy linear chain (back-compat)
 
-    def path_to_root(self, leaf_id: EventID | None) -> list[Event]:
+    def path_to_root(
+        self, leaf_id: EventID | None, limit: int | None = None
+    ) -> list[Event]:
         """The active branch ``leaf -> ... -> root``, returned root-first.
 
-        ``leaf_id=None`` yields ``[]``. Raises ValueError on a cycle, KeyError if
-        ``leaf_id`` or an ancestor is missing.
+        ``leaf_id=None`` yields ``[]``. ``limit`` keeps only the last ``limit``
+        events (walking back from the leaf), so callers wanting a recent window
+        stay O(limit) instead of O(branch). Raises ValueError on a cycle, KeyError
+        if ``leaf_id`` or an ancestor is missing.
         """
         chain: list[Event] = []
         seen: set[EventID] = set()
         cur_id: EventID | None = leaf_id
-        while cur_id is not None:
+        while cur_id is not None and (limit is None or len(chain) < limit):
             if cur_id in seen:
                 raise ValueError(f"Cycle in event tree at {cur_id}")
             seen.add(cur_id)

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -2,7 +2,7 @@
 import operator
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, nullcontext
-from typing import SupportsIndex, overload
+from typing import Final, SupportsIndex, overload
 
 from openhands.sdk.conversation.events_list_base import EventsListBase
 from openhands.sdk.conversation.persistence_const import (
@@ -20,6 +20,11 @@ logger = get_logger(__name__)
 
 LOCK_FILE_NAME = ".eventlog.lock"
 LOCK_TIMEOUT_SECONDS = 30
+
+# Marks a feature-created root at a non-zero index (e.g. navigate_to(None) then
+# emit), where parent_id=None is ambiguous with a legacy event. Reserved value:
+# never collides with a real id (event ids are uuid4).
+ROOT_PARENT_ID: Final = "__root__"
 
 
 class EventLog(EventsListBase):
@@ -94,6 +99,8 @@ class EventLog(EventsListBase):
         the linear chain (event ``idx - 1``) so old conversations load unbranched
         with no disk rewrite.
         """
+        if event.parent_id == ROOT_PARENT_ID:
+            return None  # explicit root (feature-created root at idx > 0)
         if event.parent_id is not None:
             return event.parent_id  # explicit (new events)
         if idx == 0:

--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -2,7 +2,7 @@
 import operator
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, nullcontext
-from typing import Final, SupportsIndex, overload
+from typing import SupportsIndex, overload
 
 from openhands.sdk.conversation.events_list_base import EventsListBase
 from openhands.sdk.conversation.persistence_const import (
@@ -11,6 +11,7 @@ from openhands.sdk.conversation.persistence_const import (
     EVENTS_DIR,
 )
 from openhands.sdk.event import Event, EventID
+from openhands.sdk.event.types import ROOT_PARENT_ID
 from openhands.sdk.io import FileStore
 from openhands.sdk.logger import get_logger
 from openhands.sdk.utils.path import posix_path_name
@@ -21,10 +22,9 @@ logger = get_logger(__name__)
 LOCK_FILE_NAME = ".eventlog.lock"
 LOCK_TIMEOUT_SECONDS = 30
 
-# Marks a feature-created root at a non-zero index (e.g. navigate_to(None) then
-# emit), where parent_id=None is ambiguous with a legacy event. Reserved value:
-# never collides with a real id (event ids are uuid4).
-ROOT_PARENT_ID: Final = "__root__"
+# ROOT_PARENT_ID now lives in event.types (single source of truth); it is used
+# below in _effective_parent_id and re-exported here so existing
+# ``from event_store import ROOT_PARENT_ID`` importers keep working.
 
 
 class EventLog(EventsListBase):

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -14,7 +14,7 @@ from openhands.sdk.context.condenser import CondenserBase, LLMSummarizingCondens
 from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.cancellation import CancellationToken
-from openhands.sdk.conversation.event_store import ROOT_PARENT_ID, EventLog
+from openhands.sdk.conversation.event_store import EventLog
 from openhands.sdk.conversation.exceptions import ConversationRunError
 from openhands.sdk.conversation.secret_registry import SecretValue
 from openhands.sdk.conversation.state import (
@@ -47,7 +47,6 @@ from openhands.sdk.event import (
     UserRejectObservation,
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
-from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.hooks import HookConfig, HookEventProcessor, create_hook_callback
 from openhands.sdk.io import LocalFileStore
 from openhands.sdk.llm import LLM, Message, TextContent, content_to_str
@@ -328,15 +327,9 @@ class LocalConversation(BaseConversation):
             # This callback runs while holding the conversation state's lock
             # (see BaseConversation.compose_callbacks usage inside `with self._state:`
             # regions), so updating state here is thread-safe.
-            self._state.events.append(e)
-            # Advance HEAD to the just-appended event (parent_id was stamped
-            # upstream by _tree_stamping). This is the single append site, so the
-            # leaf always names a real event even when a hook swaps the in-flight
-            # one. ConversationStateUpdateEvent is excluded: it is a state-sync
-            # artifact, not a tree node, and advancing the leaf for it recurses
-            # (moving the leaf re-emits a ConversationStateUpdateEvent here).
-            if not isinstance(e, ConversationStateUpdateEvent):
-                self._state.leaf_event_id = e.id
+            # Single chokepoint: stamps parent_id (catching any event a hook
+            # swapped in downstream of _tree_stamping) and advances HEAD.
+            self._state.append_event(e)
             # Track user MessageEvent IDs here so hook callbacks (which may
             # synthesize or alter user messages) are captured in one place.
             if isinstance(e, MessageEvent) and e.source == "user":
@@ -452,27 +445,15 @@ class LocalConversation(BaseConversation):
     def _tree_stamping(
         self, inner: ConversationCallbackType
     ) -> ConversationCallbackType:
-        """Wrap an event callback so every emitted event is placed in the tree.
+        """Wrap a callback so in-flight subscribers see a lineage-bearing event.
 
-        Stamps ``parent_id`` (to the current active leaf) on any event lacking
-        one, then forwards it to ``inner``. Stamping at the front of the chain
-        lets every subscriber and persistence see the same lineage-bearing event.
-
-        HEAD is advanced where the event is actually appended
-        (``_default_callback``), not here, so the leaf always names a real event
-        even when a hook swaps the in-flight one.
+        Convenience only: the authoritative stamp is
+        ``ConversationState.append_event``, which re-stamps anything a hook swaps
+        in downstream. HEAD advances at the append site, not here.
         """
 
         def wrapped(event: Event) -> None:
-            if event.parent_id is None:
-                parent = self._state._resolve_active_leaf()
-                # An empty HEAD over a non-empty log is a deliberate new root
-                # (e.g. after navigate_to(None)); mark it explicitly so it is
-                # not misread as a legacy event chained to its storage neighbour.
-                if parent is None and len(self._state.events) > 0:
-                    parent = ROOT_PARENT_ID
-                event = event.model_copy(update={"parent_id": parent})
-            inner(event)
+            inner(self._state._stamp_parent_id(event))
 
         return cast(ConversationCallbackType, wrapped)
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -659,6 +659,11 @@ class LocalConversation(BaseConversation):
             for event in source_events:
                 fork_conv._state.events.append(_copy_event_for_fork(event))
             fork_conv._state.leaf_event_id = fork_leaf
+            # A full fork inherits the source's empty-HEAD state; a branch slice
+            # roots HEAD at a real event (from_event_id), so it is never empty.
+            fork_conv._state.head_is_empty = (
+                self._state.head_is_empty if from_event_id is None else False
+            )
             # Full rebuild: the copied events may need property enforcement
             # (same posture as cold load).
             fork_conv._state.rebuild_view()
@@ -712,6 +717,10 @@ class LocalConversation(BaseConversation):
             if event_id is not None and event_id not in self._state.events:
                 raise ValueError(f"Unknown event_id: {event_id}")
             self._state.leaf_event_id = event_id  # autosaves base_state.json
+            # Mark an explicit empty HEAD so it is not misread as a legacy/unset
+            # leaf (which would resolve back to the last event). See
+            # ConversationState._resolve_active_leaf.
+            self._state.head_is_empty = event_id is None
             self._state.rebuild_view()
 
     def _ensure_plugins_loaded(self) -> None:
@@ -1844,7 +1853,7 @@ class LocalConversation(BaseConversation):
 
                         acp_prompt_messages = [
                             event
-                            for event in self._state.events
+                            for event in self._state.active_branch()
                             if _is_acp_prompt_message(event)
                         ]
                         if last_acp_prompt_user_message_id is None:
@@ -1959,7 +1968,7 @@ class LocalConversation(BaseConversation):
                     with self._state:
                         acp_prompt_messages = [
                             event
-                            for event in self._state.events
+                            for event in self._state.active_branch()
                             if _is_acp_prompt_message(event)
                         ]
                         latest_acp_prompt_message_id = (
@@ -2057,7 +2066,7 @@ class LocalConversation(BaseConversation):
 
                     acp_prompt_messages = [
                         event
-                        for event in self._state.events
+                        for event in self._state.active_branch()
                         if _is_acp_prompt_message(event)
                     ]
                     latest_acp_prompt_message_id = (
@@ -2471,7 +2480,9 @@ class LocalConversation(BaseConversation):
         """
         effective_llm = llm if llm is not None else self.agent.llm
         return generate_conversation_title(
-            events=self._state.events, llm=effective_llm, max_length=max_length
+            events=self._state.active_branch(),
+            llm=effective_llm,
+            max_length=max_length,
         )
 
     def condense(self) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -6,7 +6,7 @@ import json
 import uuid
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, TypeGuard
+from typing import Any, TypeGuard, cast
 
 from openhands.sdk.agent.acp_agent import ACPAgent
 from openhands.sdk.agent.base import AgentBase
@@ -39,6 +39,7 @@ from openhands.sdk.event import (
     AgentErrorEvent,
     CondensationRequest,
     Event,
+    EventID,
     InterruptEvent,
     MessageEvent,
     ObservationEvent,
@@ -46,6 +47,7 @@ from openhands.sdk.event import (
     UserRejectObservation,
 )
 from openhands.sdk.event.conversation_error import ConversationErrorEvent
+from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.hooks import HookConfig, HookEventProcessor, create_hook_callback
 from openhands.sdk.io import LocalFileStore
 from openhands.sdk.llm import LLM, Message, TextContent, content_to_str
@@ -321,6 +323,14 @@ class LocalConversation(BaseConversation):
             # (see BaseConversation.compose_callbacks usage inside `with self._state:`
             # regions), so updating state here is thread-safe.
             self._state.events.append(e)
+            # Advance HEAD to the just-appended event (parent_id was stamped
+            # upstream by _tree_stamping). This is the single append site, so the
+            # leaf always names a real event even when a hook swaps the in-flight
+            # one. ConversationStateUpdateEvent is excluded: it is a state-sync
+            # artifact, not a tree node, and advancing the leaf for it recurses
+            # (moving the leaf re-emits a ConversationStateUpdateEvent here).
+            if not isinstance(e, ConversationStateUpdateEvent):
+                self._state.leaf_event_id = e.id
             # Track user MessageEvent IDs here so hook callbacks (which may
             # synthesize or alter user messages) are captured in one place.
             if isinstance(e, MessageEvent) and e.source == "user":
@@ -359,7 +369,7 @@ class LocalConversation(BaseConversation):
         # This runs on first run()/send_message() call and handles both
         # explicit hooks and plugin hooks in one place
         self._hook_processor = None
-        self._on_event = base_callback
+        self._on_event = self._tree_stamping(base_callback)
         self._on_token = (
             BaseConversation.compose_callbacks(token_callbacks)
             if token_callbacks
@@ -432,6 +442,29 @@ class LocalConversation(BaseConversation):
             conversation_tags=tags,
         )
         self.delete_on_close = delete_on_close
+
+    def _tree_stamping(
+        self, inner: ConversationCallbackType
+    ) -> ConversationCallbackType:
+        """Wrap an event callback so every emitted event is placed in the tree.
+
+        Stamps ``parent_id`` (to the current active leaf) on any event lacking
+        one, then forwards it to ``inner``. Stamping at the front of the chain
+        lets every subscriber and persistence see the same lineage-bearing event.
+
+        HEAD is advanced where the event is actually appended
+        (``_default_callback``), not here, so the leaf always names a real event
+        even when a hook swaps the in-flight one.
+        """
+
+        def wrapped(event: Event) -> None:
+            if event.parent_id is None:
+                event = event.model_copy(
+                    update={"parent_id": self._state._resolve_active_leaf()}
+                )
+            inner(event)
+
+        return cast(ConversationCallbackType, wrapped)
 
     def _recover_persisted_client_tools(
         self,
@@ -551,6 +584,7 @@ class LocalConversation(BaseConversation):
         title: str | None = None,
         tags: dict[str, str] | None = None,
         reset_metrics: bool = True,
+        from_event_id: EventID | None = None,
     ) -> "LocalConversation":
         """Deep-copy this conversation with a new ID.
 
@@ -567,10 +601,16 @@ class LocalConversation(BaseConversation):
             tags: Optional tags for the forked conversation.
             reset_metrics: If ``True`` (default), cost/token stats start
                 fresh on the fork.
+            from_event_id: If set, copy only the branch up to this event
+                (``path_to_root``) and set the fork's HEAD there. If ``None``
+                (default), copy the whole log and keep the source's HEAD.
 
         Returns:
             A new ``LocalConversation`` that shares the same event history
             but has its own identity and independent state going forward.
+
+        Raises:
+            ValueError: If ``from_event_id`` is not an event in this conversation.
         """
         fork_id = conversation_id or uuid.uuid4()
         # Always deep-copy the agent (supplied or source) so the fork owns
@@ -612,8 +652,22 @@ class LocalConversation(BaseConversation):
                 tags=tags,
             )
 
-            for event in self._state.events:
+            # Branch slice copies path_to_root(event) (root-first, re-rootable);
+            # a full fork copies the whole log and inherits the source's HEAD.
+            if from_event_id is not None:
+                if from_event_id not in self._state.events:
+                    raise ValueError(f"Unknown from_event_id: {from_event_id}")
+                source_events: list[Event] = self._state.events.path_to_root(
+                    from_event_id
+                )
+                fork_leaf: EventID | None = from_event_id
+            else:
+                source_events = list(self._state.events)
+                fork_leaf = self._state.leaf_event_id
+
+            for event in source_events:
                 fork_conv._state.events.append(_copy_event_for_fork(event))
+            fork_conv._state.leaf_event_id = fork_leaf
             # Full rebuild: the copied events may need property enforcement
             # (same posture as cold load).
             fork_conv._state.rebuild_view()
@@ -638,14 +692,36 @@ class LocalConversation(BaseConversation):
             if not reset_metrics:
                 fork_conv._state.stats = self._state.stats.model_copy(deep=True)
 
-            event_count = len(self._state.events)
+            event_count = len(source_events)
 
         logger.info(
             f"Forked conversation {self.id} → {fork_id} "
             f"({event_count} events copied, "
-            f"reset_metrics={reset_metrics})"
+            f"reset_metrics={reset_metrics}, "
+            f"from_event_id={from_event_id})"
         )
         return fork_conv
+
+    def navigate_to(self, event_id: EventID | None) -> None:
+        """Move the conversation HEAD within this conversation (no new fork).
+
+        Re-roots the active branch: the agent's next context becomes
+        ``path_to_root(event_id)``. All branches stay on disk — appending after
+        navigating creates a sibling; abandoned events stay in the log but drop
+        out of ``state.view``.
+
+        Args:
+            event_id: Event to make the new HEAD, or ``None`` for the empty tree.
+
+        Raises:
+            ValueError: If ``event_id`` is not ``None`` and not in this
+                conversation.
+        """
+        with self._state:
+            if event_id is not None and event_id not in self._state.events:
+                raise ValueError(f"Unknown event_id: {event_id}")
+            self._state.leaf_event_id = event_id  # autosaves base_state.json
+            self._state.rebuild_view()
 
     def _ensure_plugins_loaded(self) -> None:
         """Lazy load plugins and set up hooks on first use.
@@ -915,7 +991,7 @@ class LocalConversation(BaseConversation):
                 else None
             )
 
-            self._hook_processor, self._on_event = create_hook_callback(
+            self._hook_processor, raw_on_event = create_hook_callback(
                 hook_config=final_hook_config,
                 working_dir=str(self.workspace.working_dir),
                 session_id=str(self._state.id),
@@ -927,6 +1003,7 @@ class LocalConversation(BaseConversation):
                 visualizer=self._visualizer,
                 conversation_stats=self._state.stats,
             )
+            self._on_event = self._tree_stamping(raw_on_event)
             self._hook_processor.set_conversation_state(self._state)
             self._hook_processor.run_session_start()
 
@@ -989,7 +1066,7 @@ class LocalConversation(BaseConversation):
 
         self._state.hook_config = merged_config
         self._pending_hook_config = merged_config
-        self._hook_processor, self._on_event = create_hook_callback(
+        self._hook_processor, raw_on_event = create_hook_callback(
             hook_config=merged_config,
             working_dir=str(self.workspace.working_dir),
             session_id=str(self._state.id),
@@ -999,6 +1076,7 @@ class LocalConversation(BaseConversation):
             visualizer=self._visualizer,
             conversation_stats=self._state.stats,
         )
+        self._on_event = self._tree_stamping(raw_on_event)
         self._hook_processor.set_conversation_state(self._state)
         self._hook_processor.run_session_start()
 

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -2200,7 +2200,9 @@ class LocalConversation(BaseConversation):
         This is a non-invasive method to reject actions between run() calls.
         Also clears the agent_waiting_for_confirmation flag.
         """
-        pending_actions = ConversationState.get_unmatched_actions(self._state.events)
+        pending_actions = ConversationState.get_unmatched_actions(
+            self._state.active_branch()
+        )
 
         with self._state:
             # Always clear the agent_waiting_for_confirmation flag
@@ -2236,7 +2238,7 @@ class LocalConversation(BaseConversation):
 
         Must be called while holding ``self._state``.
         """
-        orphans = ConversationState.get_unmatched_actions(self._state.events)
+        orphans = ConversationState.get_unmatched_actions(self._state.active_branch())
         for ae in orphans:
             logger.info(
                 "Emitting synthetic error for orphaned action %s (%s)",

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -14,7 +14,7 @@ from openhands.sdk.context.condenser import CondenserBase, LLMSummarizingCondens
 from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.cancellation import CancellationToken
-from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.conversation.event_store import ROOT_PARENT_ID, EventLog
 from openhands.sdk.conversation.exceptions import ConversationRunError
 from openhands.sdk.conversation.secret_registry import SecretValue
 from openhands.sdk.conversation.state import (
@@ -465,9 +465,13 @@ class LocalConversation(BaseConversation):
 
         def wrapped(event: Event) -> None:
             if event.parent_id is None:
-                event = event.model_copy(
-                    update={"parent_id": self._state._resolve_active_leaf()}
-                )
+                parent = self._state._resolve_active_leaf()
+                # An empty HEAD over a non-empty log is a deliberate new root
+                # (e.g. after navigate_to(None)); mark it explicitly so it is
+                # not misread as a legacy event chained to its storage neighbour.
+                if parent is None and len(self._state.events) > 0:
+                    parent = ROOT_PARENT_ID
+                event = event.model_copy(update={"parent_id": parent})
             inner(event)
 
         return cast(ConversationCallbackType, wrapped)

--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -46,6 +46,7 @@ from openhands.sdk.event.conversation_state import (
     ConversationStateUpdateEvent,
 )
 from openhands.sdk.event.llm_completion_log import LLMCompletionLogEvent
+from openhands.sdk.event.types import EventID
 from openhands.sdk.hooks import HookConfig
 from openhands.sdk.llm import LLM, Message, TextContent
 from openhands.sdk.logger import DEBUG, get_logger
@@ -1477,6 +1478,7 @@ class RemoteConversation(BaseConversation):
         title: str | None = None,
         tags: dict[str, str] | None = None,
         reset_metrics: bool = True,
+        from_event_id: EventID | None = None,
     ) -> "RemoteConversation":
         """Fork this conversation on the remote agent server.
 
@@ -1493,18 +1495,27 @@ class RemoteConversation(BaseConversation):
             tags: Optional tags for the forked conversation.
             reset_metrics: If ``True`` (default), cost/token stats start
                 fresh on the fork.
+            from_event_id: **Not yet supported remotely** — a non-``None`` value
+                raises ``NotImplementedError`` (tracked separately). Use
+                ``LocalConversation.fork(from_event_id=...)`` for now.
 
         Returns:
             A new ``RemoteConversation`` backed by the forked server-side
             conversation.
 
         Raises:
-            NotImplementedError: If ``agent`` is provided.
+            NotImplementedError: If ``agent`` or ``from_event_id`` is provided.
         """
         if agent is not None:
             raise NotImplementedError(
                 "Agent replacement is not supported for remote conversation "
                 "forks. Use LocalConversation.fork(agent=...) instead."
+            )
+        if from_event_id is not None:
+            raise NotImplementedError(
+                "fork(from_event_id=...) is not yet supported for remote "
+                "conversations. Use LocalConversation.fork(from_event_id=...) "
+                "instead."
             )
 
         body: dict[str, object] = {"reset_metrics": reset_metrics}
@@ -1540,6 +1551,19 @@ class RemoteConversation(BaseConversation):
             max_iteration_per_run=self.max_iteration_per_run,
             delete_on_close=self.delete_on_close,
             tags=server_tags,
+        )
+
+    def navigate_to(self, event_id: EventID | None) -> None:
+        """Move the conversation HEAD within this conversation.
+
+        Not yet supported remotely (tracked separately); use
+        ``LocalConversation.navigate_to`` for now.
+
+        Raises:
+            NotImplementedError: Always.
+        """
+        raise NotImplementedError(
+            "navigate_to is not yet supported for RemoteConversation."
         )
 
     def execute_tool(self, tool_name: str, action: "Action") -> "Observation":

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -12,7 +12,7 @@ from pydantic import Field, PrivateAttr
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.context.view import View
 from openhands.sdk.conversation.conversation_stats import ConversationStats
-from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.conversation.event_store import ROOT_PARENT_ID, EventLog
 from openhands.sdk.conversation.fifo_lock import FIFOLock
 from openhands.sdk.conversation.persistence_const import BASE_STATE, EVENTS_DIR
 from openhands.sdk.conversation.secret_registry import SecretRegistry
@@ -260,6 +260,36 @@ class ConversationState(OpenHandsModel):
         if self._events[n - 1].parent_id is not None:
             return None
         return self._events.get_id(n - 1)
+
+    def _stamp_parent_id(self, event: Event) -> Event:
+        """Return ``event`` with ``parent_id`` set to the active leaf if unset."""
+        if event.parent_id is not None:
+            return event
+        parent = self._resolve_active_leaf()
+        # Empty HEAD over a non-empty log = deliberate new root (navigate_to(None));
+        # mark it so it is not misread as a legacy event chained to its neighbour.
+        if parent is None and len(self._events) > 0:
+            parent = ROOT_PARENT_ID
+        return event.model_copy(update={"parent_id": parent})
+
+    def append_event(self, event: Event) -> Event:
+        """Single storage chokepoint: stamp parent_id, append, advance HEAD.
+
+        Stamping here (not only at the emit callback) ensures no event enters the
+        log unstamped, even one a hook swaps in downstream. ``fork`` copies
+        pre-stamped events and sets HEAD itself, so it bypasses this.
+        """
+        event = self._stamp_parent_id(event)
+        self._events.append(event)
+        # ConversationStateUpdateEvent is a state-sync artifact, not a tree node;
+        # advancing HEAD for it would recurse (moving HEAD re-emits one).
+        from openhands.sdk.event.conversation_state import (
+            ConversationStateUpdateEvent,
+        )
+
+        if not isinstance(event, ConversationStateUpdateEvent):
+            self.leaf_event_id = event.id
+        return event
 
     @property
     def view(self) -> View:

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -163,6 +163,16 @@ class ConversationState(OpenHandsModel):
         ),
     )
 
+    # Movable HEAD of the conversation tree.
+    leaf_event_id: EventID | None = Field(
+        default=None,
+        description=(
+            "HEAD of the conversation tree: the parent of the next appended "
+            "event. None means an empty tree (or, pre-feature, the linear tail; "
+            "see _resolve_active_leaf). Moving it re-roots the active branch."
+        ),
+    )
+
     # Conversation statistics for LLM usage tracking
     stats: ConversationStats = Field(
         default_factory=ConversationStats,
@@ -207,11 +217,13 @@ class ConversationState(OpenHandsModel):
     # ===== Private attrs (NOT Fields) =====
     _fs: FileStore = PrivateAttr()  # filestore for persistence
     _events: EventLog = PrivateAttr()  # now the storage for events
-    # Cached projection of `_events`, lazily updated on read via a
-    # watermark.  Derived state — never persisted, never serialized.
+    # Cached projection of `_events` for the *active branch*, lazily updated on
+    # read. Derived state — never persisted. `_view_branch_leaf` is the resolved
+    # leaf the cache reflects: equal to the active leaf -> reuse; an ancestor ->
+    # extend with the tail; otherwise -> rebuild (branch switch).
     # See https://github.com/OpenHands/software-agent-sdk/issues/3053.
     _view: View = PrivateAttr(default_factory=View)
-    _view_watermark: int = PrivateAttr(default=0)
+    _view_branch_leaf: EventID | None = PrivateAttr(default=None)
     _view_lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)
     _cipher: Cipher | None = PrivateAttr(default=None)  # cipher for secret encryption
     _autosave_enabled: bool = PrivateAttr(
@@ -233,65 +245,82 @@ class ConversationState(OpenHandsModel):
     def events(self) -> EventLog:
         return self._events
 
+    def _resolve_active_leaf(self) -> EventID | None:
+        """The effective HEAD, resolving a ``None`` ``leaf_event_id`` by lineage.
+
+        A set leaf is returned as-is. A ``None`` leaf falls back to the last
+        event only for pre-feature conversations (last event has no
+        ``parent_id``), so legacy history loads unbranched; once events are
+        stamped, ``None`` is a deliberate empty HEAD (e.g. ``navigate_to(None)``).
+        """
+        if self.leaf_event_id is not None:
+            return self.leaf_event_id
+        if (n := len(self._events)) == 0:
+            return None
+        if self._events[n - 1].parent_id is not None:
+            return None
+        return self._events.get_id(n - 1)
+
     @property
     def view(self) -> View:
-        """Lazily-updated, incrementally-maintained ``View`` of the events.
+        """Lazily-maintained ``View`` of the active branch (``path_to_root(leaf)``).
 
-        The view is brought up to date by replaying only the events
-        appended since the last read (tracked by an internal watermark).
-        This is O(k) where k is the number of new events — typically 2–4
-        per agent step — rather than O(n) over the entire history.
+        Abandoned branches (from navigation/forking) are excluded. A linear
+        append replays only the new tail — O(k), preserving the incremental
+        optimization (#3053); a branch switch rebuilds once, O(n).
+        ``enforce_properties`` runs only on rebuild (``rebuild_view()``).
 
-        ``enforce_properties`` is *not* run on the incremental path.
-        Full enforcement happens only via ``rebuild_view()``, which is
-        called on cold load, fork, and error recovery.
-
-        Callers must treat the returned view as read-only.  This
-        reference is also invalidated by any call to ``rebuild_view()``;
-        re-read ``state.view`` after any rebuild if you need a fresh
-        snapshot.
+        The returned view is read-only and is invalidated by ``rebuild_view()``;
+        re-read ``state.view`` after any rebuild.
         """
         with self._view_lock:
-            n = len(self._events)
-            for i in range(self._view_watermark, n):
-                try:
-                    self._view.append_event(self._events[i])
-                    self._view_watermark = i + 1
-                except Exception:
-                    logger.warning(
-                        "Incremental view append failed at index %d; "
-                        "rebuilding from scratch.",
-                        i,
-                        exc_info=True,
-                    )
-                    self._view = View.from_events(self._events)
-                    self._view_watermark = len(self._events)
-                    break
+            leaf = self._resolve_active_leaf()
+            if leaf == self._view_branch_leaf:
+                return self._view
+
+            # Fast path: cached leaf is an ancestor of the new leaf (linear
+            # append) → replay only the tail. Also covers first populate (cached
+            # leaf None, cached view empty), avoiding the enforce_properties pass.
+            try:
+                tail: list[Event] = []
+                cur_id: EventID | None = leaf
+                while cur_id is not None and cur_id != self._view_branch_leaf:
+                    idx = self._events.get_index(cur_id)
+                    evt = self._events[idx]
+                    tail.append(evt)
+                    cur_id = self._events._effective_parent_id(idx, evt)
+                if cur_id == self._view_branch_leaf:
+                    for evt in reversed(tail):
+                        self._view.append_event(evt)
+                    self._view_branch_leaf = leaf
+                    return self._view
+            except Exception:
+                logger.warning(
+                    "Incremental view append failed for leaf %s; "
+                    "rebuilding from the active branch.",
+                    leaf,
+                    exc_info=True,
+                )
+
+            # Diverged branch (navigation/fork), first populate, or recovery
+            # from the failure above → full rebuild from the active branch.
+            self._view = View.from_events(self._events.path_to_root(leaf))
+            self._view_branch_leaf = leaf
             return self._view
 
     def rebuild_view(self) -> None:
-        """Re-derive the cached view from the full event log.
+        """Re-derive the cached view from the active branch, with full enforcement.
 
-        Runs ``View.from_events`` which applies all view-property
-        enforcement.  This is the recovery / cold-load path described
-        in ``ViewPropertyBase`` and should be called only on:
-
-        - Cold load (resuming a persisted ``ConversationState``).
-        - Fork creation, after deep-copying events from the source.
-        - Explicit error recovery (e.g. malformed-history retry).
-
-        Any ``View`` reference previously returned by ``state.view``
-        is invalidated after this call and must not be used — it
-        will never reflect new events or the rebuilt state.
-
-        If ``View.from_events`` raises (e.g. due to corrupted events),
-        the cache is left unchanged and the exception propagates to
-        the caller.  ``state.view`` continues to serve the pre-rebuild
-        state until a successful ``rebuild_view()`` call.
+        Runs ``View.from_events`` over ``path_to_root(leaf)``. Called on cold
+        load, fork, navigation, and error recovery. Invalidates any prior
+        ``state.view`` reference. If ``View.from_events`` raises, the cache is
+        left unchanged and the exception propagates.
         """
         with self._view_lock:
-            self._view = View.from_events(self._events)
-            self._view_watermark = len(self._events)
+            leaf = self._resolve_active_leaf()
+            branch = self._events.path_to_root(leaf)
+            self._view = View.from_events(branch)
+            self._view_branch_leaf = leaf
 
     @property
     def env_observation_persistence_dir(self) -> str | None:
@@ -497,9 +526,15 @@ class ConversationState(OpenHandsModel):
                     logger.exception("Auto-persist base_state failed", exc_info=True)
                     raise e
 
-            # Call state change callback if set
+            # Call state change callback if set. leaf_event_id is skipped: it
+            # changes every event and the server persists broadcasts, so it would
+            # ~double the log — and the new HEAD is the just-appended event's id.
             callback = getattr(self, "_on_state_change", None)
-            if callback is not None and old is not _sentinel:
+            if (
+                callback is not None
+                and old is not _sentinel
+                and name != "leaf_event_id"
+            ):
                 try:
                     # Import here to avoid circular imports
                     from openhands.sdk.event.conversation_state import (

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -173,6 +173,12 @@ class ConversationState(OpenHandsModel):
         ),
     )
 
+    # Distinguishes a deliberate empty HEAD (navigate_to(None)) from an unset
+    # ``leaf_event_id``, which triggers legacy back-compat. Without it, emptying a
+    # single-root tree is indistinguishable from a pre-tree conversation. Persisted
+    # so the empty HEAD survives a save/reload. See _resolve_active_leaf.
+    head_is_empty: bool = Field(default=False)
+
     # Conversation statistics for LLM usage tracking
     stats: ConversationStats = Field(
         default_factory=ConversationStats,
@@ -248,13 +254,15 @@ class ConversationState(OpenHandsModel):
     def _resolve_active_leaf(self) -> EventID | None:
         """The effective HEAD, resolving a ``None`` ``leaf_event_id`` by lineage.
 
-        A set leaf is returned as-is. A ``None`` leaf falls back to the last
-        event only for pre-feature conversations (last event has no
-        ``parent_id``), so legacy history loads unbranched; once events are
-        stamped, ``None`` is a deliberate empty HEAD (e.g. ``navigate_to(None)``).
+        A set leaf is returned as-is. ``head_is_empty`` marks a deliberate empty
+        HEAD (``navigate_to(None)``) -> no active branch. Otherwise a ``None`` leaf
+        falls back to the last event only for pre-feature conversations (last
+        event has no ``parent_id``), so legacy history loads unbranched.
         """
         if self.leaf_event_id is not None:
             return self.leaf_event_id
+        if self.head_is_empty:
+            return None
         if (n := len(self._events)) == 0:
             return None
         if self._events[n - 1].parent_id is not None:
@@ -298,6 +306,8 @@ class ConversationState(OpenHandsModel):
 
         if not isinstance(event, ConversationStateUpdateEvent):
             self.leaf_event_id = event.id
+            if self.head_is_empty:  # HEAD now points at a real event again
+                self.head_is_empty = False
         return event
 
     @property
@@ -565,14 +575,15 @@ class ConversationState(OpenHandsModel):
                     logger.exception("Auto-persist base_state failed", exc_info=True)
                     raise e
 
-            # Call state change callback if set. leaf_event_id is skipped: it
-            # changes every event and the server persists broadcasts, so it would
-            # ~double the log — and the new HEAD is the just-appended event's id.
+            # Call state change callback if set. leaf_event_id/head_is_empty are
+            # skipped: they are internal HEAD bookkeeping (leaf_event_id changes
+            # every event, so broadcasting it would ~double the persisted log) and
+            # the HEAD is recoverable from the just-appended event.
             callback = getattr(self, "_on_state_change", None)
             if (
                 callback is not None
                 and old is not _sentinel
-                and name != "leaf_event_id"
+                and name not in ("leaf_event_id", "head_is_empty")
             ):
                 try:
                     # Import here to avoid circular imports

--- a/openhands-sdk/openhands/sdk/conversation/state.py
+++ b/openhands-sdk/openhands/sdk/conversation/state.py
@@ -261,6 +261,15 @@ class ConversationState(OpenHandsModel):
             return None
         return self._events.get_id(n - 1)
 
+    def active_branch(self, limit: int | None = None) -> list[Event]:
+        """Raw events on the active branch (``path_to_root(leaf)``), root-first.
+
+        Excludes abandoned branches, so consumers reasoning about the *current*
+        conversation (stuck detection, pending actions) see only the live path.
+        ``limit`` returns just the last ``limit`` events, kept O(limit).
+        """
+        return self._events.path_to_root(self._resolve_active_leaf(), limit=limit)
+
     def _stamp_parent_id(self, event: Event) -> Event:
         """Return ``event`` with ``parent_id`` set to the active leaf if unset."""
         if event.parent_id is not None:

--- a/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
+++ b/openhands-sdk/openhands/sdk/conversation/stuck_detector.py
@@ -63,11 +63,12 @@ class StuckDetector:
         """Check if the agent is currently stuck.
 
         Note: To avoid materializing potentially large file-backed event histories,
-        only the last MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION events are analyzed.
-        If a user message exists within this window, only events after it are checked.
-        Otherwise, all events in the window are analyzed.
+        only the last MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION events of the active
+        branch are analyzed (abandoned branches are excluded). If a user message
+        exists within this window, only events after it are checked. Otherwise, all
+        events in the window are analyzed.
         """
-        events = list(self.state.events[-MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION:])
+        events = self.state.active_branch(limit=MAX_EVENTS_TO_SCAN_FOR_STUCK_DETECTION)
 
         # Only look at history after the last user message
         last_user_msg_index = next(

--- a/openhands-sdk/openhands/sdk/event/base.py
+++ b/openhands-sdk/openhands/sdk/event/base.py
@@ -30,6 +30,14 @@ class Event(DiscriminatedUnionMixin, ABC):
         description="Event timestamp",
     )  # consistent with V1
     source: SourceType = Field(..., description="The source of this event")
+    parent_id: EventID | None = Field(
+        default=None,
+        description=(
+            "Parent event id in the conversation tree. None for the root, or for "
+            "legacy events predating the tree (see EventLog's effective-parent "
+            "rule). Events sharing a parent_id are sibling branches."
+        ),
+    )
 
     @property
     def visualize(self) -> Text:

--- a/openhands-sdk/openhands/sdk/event/base.py
+++ b/openhands-sdk/openhands/sdk/event/base.py
@@ -3,10 +3,10 @@ from abc import ABC, abstractmethod
 from datetime import datetime
 from typing import TYPE_CHECKING, ClassVar
 
-from pydantic import ConfigDict, Field
+from pydantic import ConfigDict, Field, field_validator
 from rich.text import Text
 
-from openhands.sdk.event.types import EventID, SourceType
+from openhands.sdk.event.types import ROOT_PARENT_ID, EventID, SourceType
 from openhands.sdk.llm import ImageContent, Message, TextContent
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
@@ -38,6 +38,15 @@ class Event(DiscriminatedUnionMixin, ABC):
             "rule). Events sharing a parent_id are sibling branches."
         ),
     )
+
+    @field_validator("id")
+    @classmethod
+    def _reject_reserved_id(cls, v: EventID) -> EventID:
+        # ROOT_PARENT_ID is a reserved parent_id sentinel; an event whose id
+        # equalled it would make its children look parentless in the tree.
+        if v == ROOT_PARENT_ID:
+            raise ValueError(f"Event id may not equal reserved sentinel {v!r}")
+        return v
 
     @property
     def visualize(self) -> Text:

--- a/openhands-sdk/openhands/sdk/event/types.py
+++ b/openhands-sdk/openhands/sdk/event/types.py
@@ -1,4 +1,4 @@
-from typing import Literal
+from typing import Final, Literal
 
 
 EventType = Literal["action", "observation", "message", "system_prompt", "agent_error"]
@@ -6,6 +6,13 @@ SourceType = Literal["agent", "user", "environment", "hook"]
 
 EventID = str
 """Type alias for event IDs."""
+
+ROOT_PARENT_ID: Final = "__root__"
+"""Reserved ``parent_id`` marking a tree root created after ``navigate_to(None)``.
+
+No event ``id`` may equal it (enforced by a validator on ``Event``), so a
+``parent_id == ROOT_PARENT_ID`` unambiguously means "root", never "child of the
+event whose id is ``__root__``"."""
 
 ToolCallID = str
 """Type alias for tool call IDs."""

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -2703,6 +2703,9 @@ class TestEventServiceClose:
             def fork(self, **kwargs):
                 return mock.fork(**kwargs)
 
+            def navigate_to(self, event_id):
+                return mock.navigate_to(event_id)
+
         conv = SyncOnlyConversation()
         event_service._conversation = conv  # type: ignore[assignment]
 

--- a/tests/cross/test_stuck_detector.py
+++ b/tests/cross/test_stuck_detector.py
@@ -95,6 +95,12 @@ class _SpyState:
     def __init__(self, events):
         self.events = events
 
+    def active_branch(self, limit=None):
+        # A linear conversation's active branch is the whole log; ``limit`` takes
+        # the tail. Mirrored via the spy slice so the "only the last N events are
+        # touched" assertions still hold.
+        return list(self.events[-limit:] if limit is not None else self.events)
+
 
 def test_is_stuck_uses_only_recent_event_window():
     llm = LLM(model="gpt-4o-mini", usage_id="test-llm")

--- a/tests/cross/test_stuck_detector_config.py
+++ b/tests/cross/test_stuck_detector_config.py
@@ -51,11 +51,13 @@ def test_custom_action_observation_threshold():
         )
         return action, observation
 
-    # Add 4 pairs (would trigger default threshold of 4)
+    # Add 4 pairs (would trigger default threshold of 4). Emit through the
+    # real chokepoint so HEAD advances, as it does in a live run.
     for _ in range(4):
         action, observation = create_action_obs()
-        conv._state.events.append(action)
-        conv._state.events.append(observation)
+        with conv._state:
+            conv._state.append_event(action)
+            conv._state.append_event(observation)
 
     # Should NOT be stuck with threshold=6
     assert conv._stuck_detector is not None
@@ -64,8 +66,9 @@ def test_custom_action_observation_threshold():
     # Add 2 more pairs to reach threshold of 6
     for _ in range(2):
         action, observation = create_action_obs()
-        conv._state.events.append(action)
-        conv._state.events.append(observation)
+        with conv._state:
+            conv._state.append_event(action)
+            conv._state.append_event(observation)
 
     # Now should be stuck
     assert conv._stuck_detector.is_stuck()

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -346,3 +346,26 @@ def test_fork_from_event_on_an_abandoned_branch():
         assert [e.id for e in fork.state.events] == [e0.id, e1.id, e2.id]
         assert fork.state.leaf_event_id == e2.id
         assert _view_ids(fork) == _ground_truth_view_ids(fork) == [e0.id, e1.id, e2.id]
+
+
+def test_append_event_stamps_swapped_event_to_active_leaf_not_storage_tail():
+    """An unstamped event (as a hook swaps in downstream of _tree_stamping) is
+    stamped to the active leaf at append_event — not left to the idx-1 fallback,
+    which after a navigate would chain it onto the abandoned branch.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        _emit(conv, _msg("a1"))
+        _emit(conv, _msg("a2"))  # branch A (abandoned); a2 is the storage tail
+
+        conv.navigate_to(e0.id)  # active leaf is e0, but storage tail is a2
+
+        swapped = _msg("swapped")  # brand-new event, parent_id is None
+        with conv._state:
+            conv._state.append_event(swapped)
+
+        stored = conv.state.events.get_by_id(swapped.id)
+        assert stored.parent_id == e0.id  # active leaf, not a2 (idx - 1)
+        assert conv.state.leaf_event_id == swapped.id
+        assert _view_ids(conv) == [e0.id, swapped.id]  # branch A stays off-view

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -154,6 +154,35 @@ def test_navigate_to_none_empties_the_active_branch():
         assert _view_ids(conv) == []
 
 
+def test_navigate_to_none_then_emit_starts_a_fresh_root():
+    """After navigate_to(None), the next event is a genuine root — not silently
+    re-parented onto the abandoned branch's leaf.
+
+    A stamped root landing at a non-zero storage index has parent_id=None, the
+    same shape as a legacy event; without an explicit marker the effective-parent
+    rule would treat it as a legacy child (idx-1) and resurrect the whole
+    abandoned branch into the active view.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        _emit(conv, _msg("a1"))  # branch A: root -> a1, then abandoned
+
+        conv.navigate_to(None)  # deliberate empty HEAD
+        assert _view_ids(conv) == []
+
+        fresh = _emit(conv, _msg("fresh"))  # a new root over a non-empty log
+
+        events = conv.state.events
+        stored = events.get_by_id(fresh.id)
+        # Effective parent is None: a genuine root, not chained to a1.
+        assert events._effective_parent_id(events.get_index(fresh.id), stored) is None
+        # Active branch is exactly the fresh root; branch A stays off-view.
+        assert _view_ids(conv) == [fresh.id]
+        # Both roots hang off None as siblings.
+        assert set(events.children_of(None)) == {e0.id, fresh.id}
+
+
 def test_fork_from_event_slices_the_branch():
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -7,16 +7,21 @@ from collections.abc import Callable
 from pathlib import Path
 
 import pytest
+from litellm import ChatCompletionMessageToolCall
+from litellm.types.utils import Function
 from pydantic import SecretStr
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.context.view import View
 from openhands.sdk.conversation import Conversation, LocalConversation
+from openhands.sdk.conversation.state import ConversationState
+from openhands.sdk.event import ActionEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.condenser import Condensation
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.event.types import SourceType
-from openhands.sdk.llm import LLM, Message, TextContent
+from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
+from openhands.sdk.tool.schema import Action
 
 
 def _agent() -> Agent:
@@ -369,3 +374,60 @@ def test_append_event_stamps_swapped_event_to_active_leaf_not_storage_tail():
         assert stored.parent_id == e0.id  # active leaf, not a2 (idx - 1)
         assert conv.state.leaf_event_id == swapped.id
         assert _view_ids(conv) == [e0.id, swapped.id]  # branch A stays off-view
+
+
+class _MockAction(Action):
+    command: str
+
+
+def _action_event(call_id: str = "call_1") -> ActionEvent:
+    """A minimal executable ActionEvent — pending until a matching observation."""
+    tool_call = ChatCompletionMessageToolCall(
+        id=call_id,
+        type="function",
+        function=Function(name="test_tool", arguments='{"command": "x"}'),
+    )
+    return ActionEvent(
+        source="agent",
+        thought=[TextContent(text="t")],
+        action=_MockAction(command="x"),
+        tool_name="test_tool",
+        tool_call_id=call_id,
+        tool_call=MessageToolCall.from_chat_tool_call(tool_call),
+        llm_response_id="resp-1",
+    )
+
+
+def test_active_branch_returns_live_path_and_tail():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        _emit(conv, _msg("a1"))
+        _emit(conv, _msg("a2"))  # branch A, to be abandoned
+        conv.navigate_to(e0.id)
+        e3 = _emit(conv, _msg("b1"))  # branch B
+
+        # Only the live path; abandoned a1/a2 excluded.
+        assert [e.id for e in conv.state.active_branch()] == [e0.id, e3.id]
+        # limit walks back from the leaf.
+        assert [e.id for e in conv.state.active_branch(limit=1)] == [e3.id]
+
+
+def test_pending_actions_ignore_abandoned_branch():
+    """get_unmatched_actions over the active branch drops an abandoned branch's
+    orphaned action — so navigating away can't leave phantom pending actions.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        pending = _emit(conv, _action_event("call_A"))  # unmatched on branch A
+
+        conv.navigate_to(e0.id)  # abandon branch A
+
+        # The full log still shows the orphaned action...
+        assert [
+            a.id
+            for a in ConversationState.get_unmatched_actions(list(conv.state.events))
+        ] == [pending.id]
+        # ...but the active branch (what the consumers now read) does not.
+        assert ConversationState.get_unmatched_actions(conv.state.active_branch()) == []

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -1,0 +1,337 @@
+"""Integration tests for the conversation tree: stamping, leaf, view, navigate,
+and branch-slice fork through a real LocalConversation (no LLM). (#3747, #3748)
+"""
+
+import tempfile
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from pydantic import SecretStr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.context.view import View
+from openhands.sdk.conversation import Conversation, LocalConversation
+from openhands.sdk.event.base import Event
+from openhands.sdk.event.condenser import Condensation
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.event.types import SourceType
+from openhands.sdk.llm import LLM, Message, TextContent
+
+
+def _agent() -> Agent:
+    return Agent(
+        llm=LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test"),
+        tools=[],
+    )
+
+
+def _conversation(tmpdir: str, **kwargs) -> LocalConversation:
+    conv = Conversation(
+        agent=_agent(),
+        persistence_dir=tmpdir,
+        workspace=tmpdir,
+        visualizer=None,
+        **kwargs,
+    )
+    assert isinstance(conv, LocalConversation)
+    return conv
+
+
+def _emit(conv: LocalConversation, event: Event) -> Event:
+    """Emit through the stamping pipeline; return the event (id is preserved)."""
+    with conv._state:
+        conv._on_event(event)
+    return event
+
+
+def _msg(text: str, source: SourceType = "user") -> MessageEvent:
+    role = "user" if source == "user" else "assistant"
+    return MessageEvent(
+        source=source,
+        llm_message=Message(role=role, content=[TextContent(text=text)]),
+    )
+
+
+def _view_ids(conv: LocalConversation) -> list[str]:
+    return [e.id for e in conv.state.view.events]
+
+
+def _ground_truth_view_ids(conv: LocalConversation) -> list[str]:
+    """The view computed from scratch — independent of the cached/incremental one."""
+    leaf = conv.state._resolve_active_leaf()
+    branch = conv.state.events.path_to_root(leaf)
+    return [e.id for e in View.from_events(branch).events]
+
+
+# --------------------------------------------------------------------------- #
+# parent_id stamping + leaf advance  (#3747)
+# --------------------------------------------------------------------------- #
+def test_parent_id_stamped_and_leaf_advances():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("first"))
+        e1 = _emit(conv, _msg("second"))
+        e2 = _emit(conv, _msg("third"))
+
+        stored = {e.id: e for e in conv.state.events}
+        assert stored[e0.id].parent_id is None  # root
+        assert stored[e1.id].parent_id == e0.id  # chains to previous leaf
+        assert stored[e2.id].parent_id == e1.id
+        assert conv.state.leaf_event_id == e2.id
+
+
+def test_leaf_event_id_round_trips_through_base_state():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        _emit(conv, _msg("a"))
+        e1 = _emit(conv, _msg("b"))
+        conv_id = conv.id
+        conv.close()
+
+        resumed = _conversation(tmp, conversation_id=conv_id)
+        assert resumed.state.leaf_event_id == e1.id
+        # Active branch is restored intact.
+        assert _view_ids(resumed) == [e.id for e in resumed.state.events]
+
+
+def test_view_reflects_only_the_active_branch():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        e1 = _emit(conv, _msg("a1"))
+        e2 = _emit(conv, _msg("a2"))
+        assert _view_ids(conv) == [e0.id, e1.id, e2.id]
+
+
+# --------------------------------------------------------------------------- #
+# navigate_to  (#3748)
+# --------------------------------------------------------------------------- #
+def test_navigate_then_emit_creates_sibling_branch():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        e1 = _emit(conv, _msg("a1"))
+        e2 = _emit(conv, _msg("a2"))  # branch A: root -> a1 -> a2
+
+        conv.navigate_to(e0.id)  # move HEAD back to the root
+        assert conv.state.leaf_event_id == e0.id
+        assert _view_ids(conv) == [e0.id]
+
+        e3 = _emit(conv, _msg("b1"))  # branch B forks off the root
+        assert conv.state.events.get_by_id(e3.id).parent_id == e0.id
+
+        # Abandoned branch A is still on disk...
+        assert e1.id in conv.state.events
+        assert e2.id in conv.state.events
+        # ...but absent from the active view.
+        view_ids = _view_ids(conv)
+        assert e1.id not in view_ids and e2.id not in view_ids
+        assert view_ids == [e0.id, e3.id]
+
+        # Both branches hang off the root as siblings.
+        assert set(conv.state.events.children_of(e0.id)) == {e1.id, e3.id}
+
+
+@pytest.mark.parametrize(
+    "operation",
+    [
+        lambda conv: conv.navigate_to("nope"),
+        lambda conv: conv.fork(from_event_id="nope"),
+    ],
+    ids=["navigate_to", "fork"],
+)
+def test_unknown_event_id_raises(operation: Callable[[LocalConversation], object]):
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        _emit(conv, _msg("root"))
+        with pytest.raises(ValueError, match="nope"):
+            operation(conv)
+
+
+def test_navigate_to_none_empties_the_active_branch():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        _emit(conv, _msg("root"))
+        _emit(conv, _msg("a1"))
+
+        conv.navigate_to(None)
+        assert conv.state.leaf_event_id is None
+        assert _view_ids(conv) == []
+
+
+# --------------------------------------------------------------------------- #
+# fork(from_event_id=...)  (#3748)
+# --------------------------------------------------------------------------- #
+def test_fork_from_event_slices_the_branch():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        e1 = _emit(conv, _msg("a"))
+        _emit(conv, _msg("b"))  # e2, not on the sliced branch
+
+        fork = conv.fork(from_event_id=e1.id)
+
+        # Exactly path_to_root(e1) is copied, HEAD set at the cut point.
+        assert [e.id for e in fork.state.events] == [e0.id, e1.id]
+        assert fork.state.leaf_event_id == e1.id
+        assert _view_ids(fork) == [e0.id, e1.id]
+
+        # Source conversation is untouched.
+        assert len(conv.state.events) == 3
+
+        # Running the fork continues from the cut point.
+        e3 = _emit(fork, _msg("c"))
+        assert fork.state.events.get_by_id(e3.id).parent_id == e1.id
+
+
+def test_fork_after_condensation_replays_correctly():
+    """Forking from a condensation event replays it on the sliced branch."""
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("m0"))
+        e1 = _emit(conv, _msg("m1"))
+        e2 = _emit(conv, _msg("m2"))
+
+        cond = Condensation(
+            forgotten_event_ids={e0.id},
+            summary="dropped m0",
+            llm_response_id="resp-1",
+        )
+        _emit(conv, cond)
+
+        # On the source, the active view already reflects the condensation.
+        assert e0.id not in _view_ids(conv)
+
+        fork = conv.fork(from_event_id=cond.id)
+
+        # The whole branch up to and including the condensation is copied...
+        assert len(fork.state.events) == 4
+        # ...and replaying it drops the forgotten event while keeping the rest.
+        fork_view_ids = _view_ids(fork)
+        assert e0.id not in fork_view_ids
+        assert e1.id in fork_view_ids and e2.id in fork_view_ids
+
+
+def test_default_fork_is_unchanged_full_copy():
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        e1 = _emit(conv, _msg("a1"))
+        _emit(conv, _msg("a2"))
+        conv.navigate_to(e0.id)  # diverge the HEAD before forking
+
+        fork = conv.fork()  # no from_event_id -> full copy, HEAD preserved
+
+        assert len(fork.state.events) == len(conv.state.events) == 3
+        assert fork.state.leaf_event_id == e0.id  # source HEAD is inherited
+        assert _view_ids(fork) == [e0.id]
+        assert e1.id in fork.state.events  # abandoned branch copied too
+
+
+# --------------------------------------------------------------------------- #
+# Correctness invariants (not just the happy path)
+# --------------------------------------------------------------------------- #
+def test_incremental_view_matches_ground_truth_across_branch_switches():
+    """The cached/incremental ``state.view`` must equal a from-scratch rebuild.
+
+    Reading the view between every mutation exercises the incremental fast path
+    (linear append, first-populate, ancestor detection) and the full-rebuild
+    path (branch switch); both are pinned against ``View.from_events`` so a
+    fast-path bug cannot pass silently.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+
+        e0 = _emit(conv, _msg("root"))
+        assert _view_ids(conv) == _ground_truth_view_ids(conv)  # first populate
+        e1 = _emit(conv, _msg("a1"))
+        e2 = _emit(conv, _msg("a2"))
+        assert _view_ids(conv) == _ground_truth_view_ids(conv)  # linear fast path
+
+        conv.navigate_to(e0.id)  # branch switch -> full rebuild
+        assert _view_ids(conv) == _ground_truth_view_ids(conv) == [e0.id]
+
+        _emit(conv, _msg("b1"))  # extend sibling branch via fast path off e0
+        assert _view_ids(conv) == _ground_truth_view_ids(conv)
+
+        conv.navigate_to(e2.id)  # back to the abandoned branch's leaf
+        assert _view_ids(conv) == _ground_truth_view_ids(conv) == [e0.id, e1.id, e2.id]
+
+
+def test_legacy_conversation_resumes_and_continues():
+    """Events persisted without parent_id load as one linear branch and continue.
+
+    The headline back-compat guarantee, exercised through the real cold-load
+    (resume) path rather than an in-memory EventLog.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        # Append directly to the log: bypasses the stamping chokepoint, so these
+        # events get no parent_id and never advance the leaf — exactly the shape
+        # of data written before the tree feature existed.
+        legacy = [_msg(f"legacy-{i}") for i in range(3)]
+        for ev in legacy:
+            conv.state.events.append(ev)
+        conv_id = conv.id
+        conv.close()
+
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+        # No persisted leaf, no parent_ids on disk...
+        assert resumed.state.leaf_event_id is None
+        assert all(e.parent_id is None for e in resumed.state.events)
+        # ...yet the full linear history is the active branch.
+        assert _view_ids(resumed) == [e.id for e in legacy]
+        assert _ground_truth_view_ids(resumed) == [e.id for e in legacy]
+
+        # A new event seamlessly continues the chain off the last legacy event.
+        new = _emit(resumed, _msg("after-resume"))
+        assert resumed.state.events.get_by_id(new.id).parent_id == legacy[-1].id
+        assert resumed.state.leaf_event_id == new.id
+        assert [e.id for e in resumed.state.events.path_to_root(new.id)] == [
+            *(e.id for e in legacy),
+            new.id,
+        ]
+
+
+def test_parent_id_round_trips_on_disk_and_root_omits_it():
+    """parent_id survives persistence; the root event's JSON omits it (additive)."""
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        e0 = _emit(conv, _msg("root"))
+        e1 = _emit(conv, _msg("child"))
+        conv_id = conv.id
+        persist = Path(conv.state.persistence_dir)  # type: ignore[arg-type]
+        conv.close()
+
+        # Byte-additive: a root event (parent_id None) is serialized without the
+        # key at all; a child event carries parent_id pointing at its parent.
+        root_json = next(persist.rglob(f"event-*-{e0.id}.json")).read_text()
+        child_json = next(persist.rglob(f"event-*-{e1.id}.json")).read_text()
+        assert '"parent_id"' not in root_json
+        assert '"parent_id"' in child_json
+        assert e0.id in child_json
+
+        # And it survives the round-trip back into memory.
+        resumed = _conversation(tmp, conversation_id=conv_id, delete_on_close=False)
+        stored = {e.id: e for e in resumed.state.events}
+        assert stored[e0.id].parent_id is None
+        assert stored[e1.id].parent_id == e0.id
+
+
+def test_fork_from_event_on_an_abandoned_branch():
+    """from_event_id slices by lineage, even off a branch that is not the HEAD."""
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        e1 = _emit(conv, _msg("a1"))
+        e2 = _emit(conv, _msg("a2"))  # branch A (will be abandoned)
+
+        conv.navigate_to(e0.id)
+        _emit(conv, _msg("b1"))  # HEAD now on branch B, A is abandoned
+
+        # Fork from a2 (on the abandoned branch) — independent of the live HEAD.
+        fork = conv.fork(from_event_id=e2.id)
+        assert [e.id for e in fork.state.events] == [e0.id, e1.id, e2.id]
+        assert fork.state.leaf_event_id == e2.id
+        assert _view_ids(fork) == _ground_truth_view_ids(fork) == [e0.id, e1.id, e2.id]

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -431,3 +431,88 @@ def test_pending_actions_ignore_abandoned_branch():
         ] == [pending.id]
         # ...but the active branch (what the consumers now read) does not.
         assert ConversationState.get_unmatched_actions(conv.state.active_branch()) == []
+
+
+def test_navigate_to_none_empties_single_root_tree():
+    """navigate_to(None) must empty even a one-event tree, and the next event must
+    be a fresh root — not chained onto the abandoned one. (The legacy fallback in
+    _resolve_active_leaf used to resurrect a lone root.)
+    """
+    from openhands.sdk.conversation.event_store import ROOT_PARENT_ID
+
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        _emit(conv, _msg("only"))
+        conv.navigate_to(None)
+        assert conv.state.leaf_event_id is None
+        assert conv.state.head_is_empty is True
+        assert _view_ids(conv) == []
+
+        fresh = _emit(conv, _msg("fresh"))
+        assert conv.state.events.get_by_id(fresh.id).parent_id == ROOT_PARENT_ID
+        assert _view_ids(conv) == [fresh.id]
+
+
+def test_empty_head_survives_reload():
+    """A deliberate empty HEAD persists across save/reload (head_is_empty), instead
+    of being resurrected by the legacy fallback on cold load.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp, delete_on_close=False)
+        _emit(conv, _msg("only"))
+        conv.navigate_to(None)
+        cid = conv.id
+        conv.close()
+
+        resumed = _conversation(tmp, conversation_id=cid, delete_on_close=False)
+        assert resumed.state.head_is_empty is True
+        assert resumed.state.leaf_event_id is None
+        assert _view_ids(resumed) == []
+
+
+def test_generate_title_reads_active_branch(monkeypatch):
+    """generate_title() extracts the first user message from the active branch, not
+    an abandoned branch's message.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        _emit(conv, _msg("old root"))
+        _emit(conv, _msg("reply", "agent"))  # 2-event prefix so navigate empties
+        conv.navigate_to(None)
+        _emit(conv, _msg("fresh root"))
+
+        captured: dict = {}
+
+        def _fake_generate(events, llm, max_length=50):
+            captured["events"] = list(events)
+            return "title"
+
+        monkeypatch.setattr(
+            "openhands.sdk.conversation.impl.local_conversation."
+            "generate_conversation_title",
+            _fake_generate,
+        )
+        conv.generate_title()
+
+        texts = [
+            c.text
+            for e in captured["events"]
+            if isinstance(e, MessageEvent)
+            for c in e.llm_message.content
+            if isinstance(c, TextContent)
+        ]
+        assert texts == ["fresh root"]
+
+
+def test_fork_preserves_empty_head():
+    """A full fork of an empty-HEAD conversation stays empty (head_is_empty is
+    copied), instead of the legacy fallback resurrecting the last event.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        _emit(conv, _msg("only"))
+        conv.navigate_to(None)
+
+        fork = conv.fork()
+        assert fork.state.head_is_empty is True
+        assert _view_ids(fork) == []

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -19,7 +19,7 @@ from openhands.sdk.event import ActionEvent
 from openhands.sdk.event.base import Event
 from openhands.sdk.event.condenser import Condensation
 from openhands.sdk.event.llm_convertible import MessageEvent
-from openhands.sdk.event.types import SourceType
+from openhands.sdk.event.types import ROOT_PARENT_ID, SourceType
 from openhands.sdk.llm import LLM, Message, MessageToolCall, TextContent
 from openhands.sdk.tool.schema import Action
 
@@ -56,6 +56,11 @@ def _msg(text: str, source: SourceType = "user") -> MessageEvent:
         source=source,
         llm_message=Message(role=role, content=[TextContent(text=text)]),
     )
+
+
+def _by_id(events, event_id: str) -> Event:
+    """Look up a stored event by id."""
+    return next(e for e in events if e.id == event_id)
 
 
 def _view_ids(conv: LocalConversation) -> list[str]:
@@ -118,7 +123,7 @@ def test_navigate_then_emit_creates_sibling_branch():
         assert _view_ids(conv) == [e0.id]
 
         e3 = _emit(conv, _msg("b1"))  # branch B forks off the root
-        assert conv.state.events.get_by_id(e3.id).parent_id == e0.id
+        assert _by_id(conv.state.events, e3.id).parent_id == e0.id
 
         # Abandoned branch A is still on disk...
         assert e1.id in conv.state.events
@@ -129,7 +134,8 @@ def test_navigate_then_emit_creates_sibling_branch():
         assert view_ids == [e0.id, e3.id]
 
         # Both branches hang off the root as siblings.
-        assert set(conv.state.events.children_of(e0.id)) == {e1.id, e3.id}
+        assert _by_id(conv.state.events, e1.id).parent_id == e0.id
+        assert _by_id(conv.state.events, e3.id).parent_id == e0.id
 
 
 @pytest.mark.parametrize(
@@ -179,13 +185,15 @@ def test_navigate_to_none_then_emit_starts_a_fresh_root():
         fresh = _emit(conv, _msg("fresh"))  # a new root over a non-empty log
 
         events = conv.state.events
-        stored = events.get_by_id(fresh.id)
+        stored = _by_id(events, fresh.id)
         # Effective parent is None: a genuine root, not chained to a1.
         assert events._effective_parent_id(events.get_index(fresh.id), stored) is None
         # Active branch is exactly the fresh root; branch A stays off-view.
         assert _view_ids(conv) == [fresh.id]
-        # Both roots hang off None as siblings.
-        assert set(events.children_of(None)) == {e0.id, fresh.id}
+        # Both roots hang off None as siblings: e0 is a genuine root, and the
+        # fresh event carries the explicit ROOT_PARENT_ID sentinel.
+        assert _by_id(events, e0.id).parent_id is None
+        assert _by_id(events, fresh.id).parent_id == ROOT_PARENT_ID
 
 
 def test_fork_from_event_slices_the_branch():
@@ -207,7 +215,7 @@ def test_fork_from_event_slices_the_branch():
 
         # Running the fork continues from the cut point.
         e3 = _emit(fork, _msg("c"))
-        assert fork.state.events.get_by_id(e3.id).parent_id == e1.id
+        assert _by_id(fork.state.events, e3.id).parent_id == e1.id
 
 
 def test_fork_after_condensation_replays_correctly():
@@ -302,7 +310,7 @@ def test_legacy_conversation_resumes_and_continues():
 
         # A new event seamlessly continues the chain off the last legacy event.
         new = _emit(resumed, _msg("after-resume"))
-        assert resumed.state.events.get_by_id(new.id).parent_id == legacy[-1].id
+        assert _by_id(resumed.state.events, new.id).parent_id == legacy[-1].id
         assert resumed.state.leaf_event_id == new.id
         assert [e.id for e in resumed.state.events.path_to_root(new.id)] == [
             *(e.id for e in legacy),
@@ -370,7 +378,7 @@ def test_append_event_stamps_swapped_event_to_active_leaf_not_storage_tail():
         with conv._state:
             conv._state.append_event(swapped)
 
-        stored = conv.state.events.get_by_id(swapped.id)
+        stored = _by_id(conv.state.events, swapped.id)
         assert stored.parent_id == e0.id  # active leaf, not a2 (idx - 1)
         assert conv.state.leaf_event_id == swapped.id
         assert _view_ids(conv) == [e0.id, swapped.id]  # branch A stays off-view
@@ -438,8 +446,6 @@ def test_navigate_to_none_empties_single_root_tree():
     be a fresh root — not chained onto the abandoned one. (The legacy fallback in
     _resolve_active_leaf used to resurrect a lone root.)
     """
-    from openhands.sdk.conversation.event_store import ROOT_PARENT_ID
-
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)
         _emit(conv, _msg("only"))
@@ -449,7 +455,7 @@ def test_navigate_to_none_empties_single_root_tree():
         assert _view_ids(conv) == []
 
         fresh = _emit(conv, _msg("fresh"))
-        assert conv.state.events.get_by_id(fresh.id).parent_id == ROOT_PARENT_ID
+        assert _by_id(conv.state.events, fresh.id).parent_id == ROOT_PARENT_ID
         assert _view_ids(conv) == [fresh.id]
 
 

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -64,9 +64,6 @@ def _ground_truth_view_ids(conv: LocalConversation) -> list[str]:
     return [e.id for e in View.from_events(branch).events]
 
 
-# --------------------------------------------------------------------------- #
-# parent_id stamping + leaf advance  (#3747)
-# --------------------------------------------------------------------------- #
 def test_parent_id_stamped_and_leaf_advances():
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)
@@ -104,9 +101,6 @@ def test_view_reflects_only_the_active_branch():
         assert _view_ids(conv) == [e0.id, e1.id, e2.id]
 
 
-# --------------------------------------------------------------------------- #
-# navigate_to  (#3748)
-# --------------------------------------------------------------------------- #
 def test_navigate_then_emit_creates_sibling_branch():
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)
@@ -160,9 +154,6 @@ def test_navigate_to_none_empties_the_active_branch():
         assert _view_ids(conv) == []
 
 
-# --------------------------------------------------------------------------- #
-# fork(from_event_id=...)  (#3748)
-# --------------------------------------------------------------------------- #
 def test_fork_from_event_slices_the_branch():
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)
@@ -229,16 +220,11 @@ def test_default_fork_is_unchanged_full_copy():
         assert e1.id in fork.state.events  # abandoned branch copied too
 
 
-# --------------------------------------------------------------------------- #
-# Correctness invariants (not just the happy path)
-# --------------------------------------------------------------------------- #
 def test_incremental_view_matches_ground_truth_across_branch_switches():
-    """The cached/incremental ``state.view`` must equal a from-scratch rebuild.
+    """Cached ``state.view`` must equal a from-scratch rebuild after every step.
 
-    Reading the view between every mutation exercises the incremental fast path
-    (linear append, first-populate, ancestor detection) and the full-rebuild
-    path (branch switch); both are pinned against ``View.from_events`` so a
-    fast-path bug cannot pass silently.
+    Reading the view between mutations pins the incremental fast path and the
+    branch-switch rebuild against ``View.from_events``.
     """
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)
@@ -260,11 +246,7 @@ def test_incremental_view_matches_ground_truth_across_branch_switches():
 
 
 def test_legacy_conversation_resumes_and_continues():
-    """Events persisted without parent_id load as one linear branch and continue.
-
-    The headline back-compat guarantee, exercised through the real cold-load
-    (resume) path rather than an in-memory EventLog.
-    """
+    """Events persisted without parent_id load as one branch and continue (resume)."""
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp, delete_on_close=False)
         # Append directly to the log: bypasses the stamping chokepoint, so these

--- a/tests/sdk/conversation/test_base_span_management.py
+++ b/tests/sdk/conversation/test_base_span_management.py
@@ -73,6 +73,10 @@ class MockConversation(BaseConversation):
         """Mock implementation of fork method."""
         raise NotImplementedError("Mock fork not implemented")
 
+    def navigate_to(self, event_id: Any) -> None:
+        """Mock implementation of navigate_to method."""
+        raise NotImplementedError("Mock navigate_to not implemented")
+
 
 def test_base_conversation_span_management():
     """Test that BaseConversation properly manages span state to prevent double-ending."""  # noqa: E501

--- a/tests/sdk/conversation/test_event_tree.py
+++ b/tests/sdk/conversation/test_event_tree.py
@@ -51,13 +51,6 @@ def test_contains_accepts_event_id_or_event(as_event, target, expected):
     assert (item in log) is expected
 
 
-def test_get_by_id_returns_event_or_raises():
-    log = _log(_event("a"), _event("b", parent_id="a"))
-    assert log.get_by_id("b").id == "b"
-    with pytest.raises(KeyError):
-        log.get_by_id("missing")
-
-
 @pytest.mark.parametrize(
     "leaf, expected",
     [
@@ -83,27 +76,12 @@ def test_path_to_root_unknown_leaf_raises():
         _log(_event("a")).path_to_root("nope")
 
 
-@pytest.mark.parametrize(
-    "parent, expected",
-    [
-        (None, ["a"]),  # root(s)
-        ("a", ["b", "d"]),  # sibling branches
-        ("b", ["c"]),
-        ("c", []),  # leaf
-    ],
-)
-def test_children_of(parent, expected):
-    assert _branched_log().children_of(parent) == expected
-
-
 def test_legacy_events_form_a_single_linear_branch():
     """Events without parent_id resolve to the linear idx chain (no rewrite)."""
     # All parent_id default to None -> the effective-parent rule walks idx-1.
     log = _log(_event("a"), _event("b"), _event("c"))
 
     assert [e.id for e in log.path_to_root("c")] == ["a", "b", "c"]
-    assert log.children_of(None) == ["a"]  # only idx 0 is a genuine root
-    assert log.children_of("a") == ["b"]
 
 
 @pytest.mark.parametrize(

--- a/tests/sdk/conversation/test_event_tree.py
+++ b/tests/sdk/conversation/test_event_tree.py
@@ -1,11 +1,19 @@
 """Unit tests for the EventLog tree helpers and back-compat rule (#3747)."""
 
 import pytest
+from pydantic import ValidationError
 
-from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.conversation.event_store import ROOT_PARENT_ID, EventLog
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.io.memory import InMemoryFileStore
 from openhands.sdk.llm import Message, TextContent
+
+
+def test_event_id_cannot_equal_reserved_root_sentinel():
+    """No event may take the reserved ROOT_PARENT_ID as its id, else its children
+    would be read as parentless (parent_id == ROOT_PARENT_ID means "root")."""
+    with pytest.raises(ValidationError):
+        _event(ROOT_PARENT_ID)
 
 
 def _event(event_id: str, parent_id: str | None = None) -> MessageEvent:

--- a/tests/sdk/conversation/test_event_tree.py
+++ b/tests/sdk/conversation/test_event_tree.py
@@ -35,9 +35,6 @@ def _branched_log() -> EventLog:
     )
 
 
-# --------------------------------------------------------------------------- #
-# __contains__ / get_by_id
-# --------------------------------------------------------------------------- #
 @pytest.mark.parametrize("as_event", [False, True], ids=["by-id", "by-event"])
 @pytest.mark.parametrize("target, expected", [("a", True), ("missing", False)])
 def test_contains_accepts_event_id_or_event(as_event, target, expected):
@@ -53,9 +50,6 @@ def test_get_by_id_returns_event_or_raises():
         log.get_by_id("missing")
 
 
-# --------------------------------------------------------------------------- #
-# path_to_root
-# --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
     "leaf, expected",
     [
@@ -81,9 +75,6 @@ def test_path_to_root_unknown_leaf_raises():
         _log(_event("a")).path_to_root("nope")
 
 
-# --------------------------------------------------------------------------- #
-# children_of
-# --------------------------------------------------------------------------- #
 @pytest.mark.parametrize(
     "parent, expected",
     [
@@ -97,9 +88,6 @@ def test_children_of(parent, expected):
     assert _branched_log().children_of(parent) == expected
 
 
-# --------------------------------------------------------------------------- #
-# Back-compat: events persisted before parent_id existed
-# --------------------------------------------------------------------------- #
 def test_legacy_events_form_a_single_linear_branch():
     """Events without parent_id resolve to the linear idx chain (no rewrite)."""
     # All parent_id default to None -> the effective-parent rule walks idx-1.

--- a/tests/sdk/conversation/test_event_tree.py
+++ b/tests/sdk/conversation/test_event_tree.py
@@ -1,0 +1,124 @@
+"""Unit tests for the EventLog tree helpers and back-compat rule (#3747)."""
+
+import pytest
+
+from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.event.llm_convertible import MessageEvent
+from openhands.sdk.io.memory import InMemoryFileStore
+from openhands.sdk.llm import Message, TextContent
+
+
+def _event(event_id: str, parent_id: str | None = None) -> MessageEvent:
+    return MessageEvent(
+        id=event_id,
+        parent_id=parent_id,
+        llm_message=Message(role="user", content=[TextContent(text=event_id)]),
+        source="user",
+    )
+
+
+def _log(*events: MessageEvent) -> EventLog:
+    log = EventLog(InMemoryFileStore())
+    for event in events:
+        log.append(event)
+    return log
+
+
+def _branched_log() -> EventLog:
+    """Shared tree:  a -> b -> c   and   a -> d -> e  (b/d are siblings)."""
+    return _log(
+        _event("a"),
+        _event("b", parent_id="a"),
+        _event("c", parent_id="b"),
+        _event("d", parent_id="a"),
+        _event("e", parent_id="d"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# __contains__ / get_by_id
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("as_event", [False, True], ids=["by-id", "by-event"])
+@pytest.mark.parametrize("target, expected", [("a", True), ("missing", False)])
+def test_contains_accepts_event_id_or_event(as_event, target, expected):
+    log = _log(_event("a"))
+    item = _event(target) if as_event else target
+    assert (item in log) is expected
+
+
+def test_get_by_id_returns_event_or_raises():
+    log = _log(_event("a"), _event("b", parent_id="a"))
+    assert log.get_by_id("b").id == "b"
+    with pytest.raises(KeyError):
+        log.get_by_id("missing")
+
+
+# --------------------------------------------------------------------------- #
+# path_to_root
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "leaf, expected",
+    [
+        (None, []),
+        ("a", ["a"]),
+        ("c", ["a", "b", "c"]),
+        ("e", ["a", "d", "e"]),  # the b->c sibling branch is excluded
+    ],
+)
+def test_path_to_root(leaf, expected):
+    assert [e.id for e in _branched_log().path_to_root(leaf)] == expected
+
+
+def test_path_to_root_cycle_raises():
+    # a -> b -> a : a malformed cycle must be detected, not loop forever.
+    log = _log(_event("a", parent_id="b"), _event("b", parent_id="a"))
+    with pytest.raises(ValueError, match="Cycle in event tree"):
+        log.path_to_root("a")
+
+
+def test_path_to_root_unknown_leaf_raises():
+    with pytest.raises(KeyError):
+        _log(_event("a")).path_to_root("nope")
+
+
+# --------------------------------------------------------------------------- #
+# children_of
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "parent, expected",
+    [
+        (None, ["a"]),  # root(s)
+        ("a", ["b", "d"]),  # sibling branches
+        ("b", ["c"]),
+        ("c", []),  # leaf
+    ],
+)
+def test_children_of(parent, expected):
+    assert _branched_log().children_of(parent) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Back-compat: events persisted before parent_id existed
+# --------------------------------------------------------------------------- #
+def test_legacy_events_form_a_single_linear_branch():
+    """Events without parent_id resolve to the linear idx chain (no rewrite)."""
+    # All parent_id default to None -> the effective-parent rule walks idx-1.
+    log = _log(_event("a"), _event("b"), _event("c"))
+
+    assert [e.id for e in log.path_to_root("c")] == ["a", "b", "c"]
+    assert log.children_of(None) == ["a"]  # only idx 0 is a genuine root
+    assert log.children_of("a") == ["b"]
+
+
+@pytest.mark.parametrize(
+    "idx, expected",
+    [
+        (0, None),  # genuine root
+        (1, "a"),  # legacy linear chain (idx - 1)
+        (2, "a"),  # explicit parent wins over idx - 1
+    ],
+)
+def test_effective_parent_id_rule(idx, expected):
+    # idx 0, 1 are legacy (no explicit parent); idx 2 carries parent_id="a".
+    log = _log(_event("a"), _event("b"), _event("c", parent_id="a"))
+    assert log._effective_parent_id(idx, log[idx]) == expected

--- a/tests/sdk/conversation/test_state_change_callback.py
+++ b/tests/sdk/conversation/test_state_change_callback.py
@@ -175,3 +175,23 @@ def test_callback_receives_correct_new_value(state):
     assert len(callback_calls) == 1
     assert callback_calls[0].key == "max_iterations"
     assert callback_calls[0].value == 100
+
+
+def test_leaf_event_id_persists_but_does_not_broadcast(state):
+    """leaf_event_id autosaves but is not broadcast as a state-update event.
+
+    It changes on every appended event; broadcasting it would ~double the agent
+    server's persisted event log. The value still round-trips via base_state.json.
+    """
+    callback_calls = []
+    state.set_on_state_change(lambda event: callback_calls.append(event))
+
+    with state:
+        state.leaf_event_id = "evt-123"  # high-frequency field: no broadcast
+        state.execution_status = ConversationExecutionStatus.RUNNING  # broadcasts
+
+    keys = [c.key for c in callback_calls]
+    assert "leaf_event_id" not in keys
+    assert keys == ["execution_status"]
+    # The value is still applied (and would persist to base_state.json).
+    assert state.leaf_event_id == "evt-123"

--- a/tests/sdk/conversation/test_state_view_cache.py
+++ b/tests/sdk/conversation/test_state_view_cache.py
@@ -217,15 +217,15 @@ def test_resume_path_rebuilds_view(tmp_path):
 
 
 def test_rebuild_view_leaves_cache_unchanged_on_error(state):
-    """If View.from_events raises, the old cache and watermark are preserved."""
+    """If View.from_events raises, the old cache and branch marker are preserved."""
     state.events.append(_msg("pre-error"))
     _ = state.view  # populate the incremental cache
     old_view = state._view
-    old_watermark = state._view_watermark
+    old_branch_leaf = state._view_branch_leaf
 
     with patch.object(View, "from_events", side_effect=RuntimeError("boom")):
         with pytest.raises(RuntimeError, match="boom"):
             state.rebuild_view()
 
     assert state._view is old_view
-    assert state._view_watermark == old_watermark
+    assert state._view_branch_leaf == old_branch_leaf

--- a/tests/sdk/test_agent_step_bounded_scan.py
+++ b/tests/sdk/test_agent_step_bounded_scan.py
@@ -16,6 +16,10 @@ from openhands.sdk.workspace.local import LocalWorkspace
 class _LimitedIterEvents(EventLog):
     def __init__(self, events, max_iter: int):
         self._events = list(events)
+        # Mirror EventLog's id/index maps so id-based lookups (get_index,
+        # path_to_root, active_branch) work without touching __iter__.
+        self._id_to_idx = {e.id: i for i, e in enumerate(self._events)}
+        self._idx_to_id = {i: e.id for i, e in enumerate(self._events)}
         self._max_iter = max_iter
         self._iter_count = 0
 
@@ -38,6 +42,10 @@ class _LimitedIterEvents(EventLog):
 class _FailingIterEvents(EventLog):
     def __init__(self, events):
         self._events = list(events)
+        # Mirror EventLog's id/index maps so id-based lookups (get_index,
+        # path_to_root, active_branch) work without touching __iter__.
+        self._id_to_idx = {e.id: i for i, e in enumerate(self._events)}
+        self._idx_to_id = {i: e.id for i, e in enumerate(self._events)}
 
     def __len__(self) -> int:  # type: ignore[override]
         return len(self._events)


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

Add core for conversation history tree.

---

AGENT:

## Why

Today a conversation is a flat, linear event log: `Event` has no `parent_id`,
`ConversationState` has no HEAD, and `fork()` deep-copies *everything*. There is
no way to branch from a past point ("edit a turn and re-run", "A/B from turn N").

This PR is the **SDK foundation** for branchable conversations — the git model
applied to a conversation: every event gets a `parent_id`, the conversation has a
movable HEAD, and the agent's context is the active branch (`path_to_root(leaf)`).
Storage stays linear and append-only; the tree is purely logical.

## Summary

- **Event tree** — `Event.parent_id` + `EventLog` helpers (`path_to_root`,
  `children_of`, `get_by_id`, `__contains__`). An effective-parent rule loads
  legacy events (no `parent_id`) as one linear branch with **zero migration**.
- **Movable HEAD** — `ConversationState.leaf_event_id`; `state.view` now follows
  the active branch, keeping the O(k) incremental fast path (#3053) and
  rebuilding once on a branch switch.
- **Ops** — `LocalConversation.navigate_to()` and `fork(from_event_id=...)`;
  `parent_id` is stamped at the emit chokepoint and the leaf advances at the
  append site (robust to hook event-replacement). `RemoteConversation` raises
  `NotImplementedError` for these (HTTP surface is #3749).

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `8dac62fad46d` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -556,0 +557 @@
+schema ACPToolCallEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -605,0 +607 @@
+schema ActionEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -705,0 +708 @@
+schema AgentErrorEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1005,0 +1009 @@
+schema Condensation property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1012,0 +1017 @@
+schema CondensationRequest property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1017,0 +1023 @@
+schema CondensationSummaryEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1040,0 +1047 @@
+schema ConversationErrorEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1080,0 +1088 @@
+schema ConversationStateUpdateEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1326,0 +1335 @@
+schema HookExecutionEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1405,0 +1415 @@
+schema InterruptEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1543,0 +1554 @@
+schema LLMCompletionLogEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1678,0 +1690 @@
+schema MessageEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1708,0 +1721 @@
+schema ObservationEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1740,0 +1754 @@
+schema PauseEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -1881,0 +1896 @@
+schema ServerErrorEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -2026,0 +2042 @@
+schema StreamingDeltaEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -2107,0 +2124 @@
+schema SystemPromptEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -2214,0 +2232 @@
+schema TokenEvent property parent_id optional schema=anyOf=[type="string",type="null"]
@@ -2270,0 +2289 @@
+schema UserRejectObservation property parent_id optional schema=anyOf=[type="string",type="null"]
```
<!-- agent-server-rest-api-contract-summary:end -->

## Issue Number

Closes #3747
Closes #3748
Part of #3750

## How to Test

```bash
# Tree foundation + integration (stamping, leaf, view parity, navigate, fork,
# fork-after-condensation, legacy resume, on-disk parent_id round-trip):
uv run pytest tests/sdk/conversation/test_event_tree.py \
               tests/sdk/conversation/local/test_conversation_tree.py -v

# No regressions across conversation + agent-server event/stream suites:
uv run pytest tests/sdk/conversation tests/agent_server -q
```

**End-to-end evidence (beyond unit tests):**

- The integration tests drive a *real* `LocalConversation` through the full
  pipeline (emit → stamp → persist → resume → branch view), not mocks. They
  assert on-disk JSON: a root event's file omits `parent_id` (byte-for-byte
  additive) and a child's points at its parent, surviving a resume round-trip.
- **Mutation-tested** — breaking the legacy fallback, the `parent_id` stamping,
  and the view fast-path each makes the relevant test fail, so the suite pins
  behavior (not just coverage).
- **Amplification check** — with agent-server-style state-change wiring
  (`set_on_state_change(_on_event)`), emitting 3 events keeps the persisted log
  at 6 entries (3 real + 3 pre-existing `last_user_message_id` updates); without
  the non-broadcast guard it grew to 9. `leaf_event_id` still round-trips via
  `base_state.json` (`test_leaf_event_id_round_trips_through_base_state`).
- `examples/01_standalone_sdk/48_conversation_fork.py` was extended with
  `from_event_id` + `navigate_to`; running it requires `LLM_API_KEY` (a live
  model), so it was not executed in this environment.

## Video/Screenshots

N/A — SDK/library change with no GUI surface. Evidence is the test logs above.

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Scope**: SDK only (#3747 + #3748). The agent-server HTTP exposure
  (`ForkConversationRequest.from_event_id`, `POST /navigate`, OpenAPI/TS-client
  regen) is #3749 — hence the `RemoteConversation` `NotImplementedError` stubs.
- **Storage**: abandoned branches are retained by design (no GC in v1), as noted
  in the roadmap (#3750).
- **Back-compat**: additive only — optional `parent_id` defaults to `None` and is
  omitted from serialization, so existing persisted conversations load unchanged.












<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:309d2a6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-309d2a6-python \
  ghcr.io/openhands/agent-server:309d2a6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:309d2a6-golang-amd64
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-golang-amd64
ghcr.io/openhands/agent-server:vasco-tree-golang-amd64
ghcr.io/openhands/agent-server:309d2a6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:309d2a6-golang-arm64
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-golang-arm64
ghcr.io/openhands/agent-server:vasco-tree-golang-arm64
ghcr.io/openhands/agent-server:309d2a6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:309d2a6-java-amd64
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-java-amd64
ghcr.io/openhands/agent-server:vasco-tree-java-amd64
ghcr.io/openhands/agent-server:309d2a6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:309d2a6-java-arm64
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-java-arm64
ghcr.io/openhands/agent-server:vasco-tree-java-arm64
ghcr.io/openhands/agent-server:309d2a6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:309d2a6-python-amd64
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-python-amd64
ghcr.io/openhands/agent-server:vasco-tree-python-amd64
ghcr.io/openhands/agent-server:309d2a6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:309d2a6-python-arm64
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-python-arm64
ghcr.io/openhands/agent-server:vasco-tree-python-arm64
ghcr.io/openhands/agent-server:309d2a6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:309d2a6-golang
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-golang
ghcr.io/openhands/agent-server:vasco-tree-golang
ghcr.io/openhands/agent-server:309d2a6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:309d2a6-java
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-java
ghcr.io/openhands/agent-server:vasco-tree-java
ghcr.io/openhands/agent-server:309d2a6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:309d2a6-python
ghcr.io/openhands/agent-server:309d2a6859b434b5377eb7c0bcda2b7b09367276-python
ghcr.io/openhands/agent-server:vasco-tree-python
ghcr.io/openhands/agent-server:309d2a6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `309d2a6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `309d2a6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->

