### PR TITLE
fix(sdk): disable streaming for title and ask_agent LLM calls

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -2361,9 +2361,12 @@ class LocalConversation(BaseConversation):
         try:
             question_llm = self.llm_registry.get("ask-agent-llm")
         except KeyError:
+            # stream=False: the reply is consumed whole with no on_token
+            # callback, which a streaming LLM requires.
             question_llm = self.agent.llm.model_copy(
                 update={
                     "usage_id": "ask-agent-llm",
+                    "stream": False,
                 },
                 deep=True,
             )

--- a/openhands-sdk/openhands/sdk/conversation/title_utils.py
+++ b/openhands-sdk/openhands/sdk/conversation/title_utils.py
@@ -118,7 +118,11 @@ def generate_title_with_llm(message: str, llm: LLM, max_length: int = 50) -> str
             ),
         ]
 
-        # Get completion from LLM
+        # Force non-streaming: the title is consumed whole with no on_token
+        # callback, which a streaming LLM requires.
+        if llm.stream:
+            llm = llm.model_copy(update={"stream": False})
+
         response = llm.completion(messages)
 
         # Extract the title from the response

--- a/tests/sdk/conversation/test_ask_agent.py
+++ b/tests/sdk/conversation/test_ask_agent.py
@@ -187,6 +187,57 @@ def test_local_conversation_ask_agent_copies_llm_config(mock_completion, tmp_pat
     assert ask_agent_llm.caching_prompt is False
 
 
+def create_mock_model_response(content: str) -> ModelResponse:
+    """A raw litellm ModelResponse, as returned by ``LLM._transport_call``."""
+    return ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(content=content, role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+@patch("openhands.sdk.llm.llm.LLM._transport_call", autospec=True)
+def test_ask_agent_disables_streaming_when_llm_streams(mock_transport, tmp_path):
+    """Regression test (sibling of PR #3901): a ``stream=True`` agent LLM must
+    still answer ask_agent even though the path passes no ``on_token`` callback.
+    Patching ``_transport_call`` keeps the real streaming guard in
+    ``completion()`` live, so the bug reproduces without the fix.
+    """
+    mock_transport.return_value = create_mock_model_response("4")
+
+    streaming_llm = LLM(
+        model="gpt-4o-mini",
+        api_key=SecretStr("test-key"),
+        usage_id="test-llm",
+        stream=True,
+    )
+    agent = Agent(llm=streaming_llm, tools=[])
+    conv = Conversation(
+        agent=agent,
+        persistence_dir=str(tmp_path),
+        workspace=str(tmp_path),
+    )
+
+    result = conv.ask_agent("What is 2+2?")
+
+    assert result == "4"
+    mock_transport.assert_called_once()
+    # Streaming was disabled on the dedicated ask-agent LLM; agent LLM untouched.
+    assert mock_transport.call_args.kwargs["enable_streaming"] is False
+    assert mock_transport.call_args.kwargs["on_token"] is None
+    assert streaming_llm.stream is True
+    assert conv.llm_registry.get("ask-agent-llm").stream is False
+
+
 @patch("openhands.sdk.conversation.impl.remote_conversation.WebSocketCallbackClient")
 def test_remote_conversation_ask_agent(mock_ws_client, agent):
     mock_ws_client.return_value.wait_until_ready.return_value = True

--- a/tests/sdk/conversation/test_generate_title.py
+++ b/tests/sdk/conversation/test_generate_title.py
@@ -220,3 +220,53 @@ def test_generate_title_empty_llm_response_fallback(mock_completion):
 
     # Verify fallback title was generated
     assert title == "Help with testing"
+
+
+def create_mock_model_response(content: str) -> ModelResponse:
+    """A raw litellm ModelResponse, as returned by ``LLM._transport_call``."""
+    return ModelResponse(
+        id="test-id",
+        choices=[
+            Choices(
+                finish_reason="stop",
+                index=0,
+                message=LiteLLMMessage(content=content, role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o-mini",
+        object="chat.completion",
+        usage=Usage(prompt_tokens=10, completion_tokens=5, total_tokens=15),
+    )
+
+
+@patch("openhands.sdk.llm.llm.LLM._transport_call", autospec=True)
+def test_generate_title_disables_streaming_when_llm_streams(mock_transport):
+    """Regression test (sibling of PR #3901): a ``stream=True`` agent LLM must
+    still generate a title even though title generation passes no ``on_token``
+    callback. Patching ``_transport_call`` keeps the real streaming guard in
+    ``completion()`` live, so the bug reproduces without the fix.
+    """
+    streaming_llm = LLM(
+        model="gpt-4o-mini",
+        api_key=SecretStr("test-key"),
+        usage_id="title-stream-test",
+        stream=True,
+    )
+    agent = Agent(llm=streaming_llm, tools=[])
+    conv = Conversation(agent=agent, visualizer=None)
+
+    user_message = create_user_message_event("Help me create a Python script")
+    conv.state.events.append(user_message)
+
+    mock_transport.return_value = create_mock_model_response("Create Python Script")
+
+    title = conv.generate_title()
+
+    # The title came from the LLM, not the truncation fallback.
+    assert title == "Create Python Script"
+    mock_transport.assert_called_once()
+    # Streaming was disabled on a copy; the agent's own LLM is untouched.
+    assert mock_transport.call_args.kwargs["enable_streaming"] is False
+    assert mock_transport.call_args.kwargs["on_token"] is None
+    assert streaming_llm.stream is True


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix similar to the one for the condenser when we don't have a token callback.

---

AGENT:

## Why

#3901 fixed `LLMSummarizingCondenser` crashing with
`Streaming requires an on_token callback` when the conversation's LLM has
`stream=True`. The root cause is general: `LLM.completion()` /
`acompletion()` enable streaming via
`enable_streaming = bool(kwargs.get("stream", False)) or self.stream` and then
raise `ValueError("Streaming requires an on_token callback")` for any
auxiliary (non-interactive) caller that passes no `on_token`.

An audit of every `.completion()`/`.acompletion()` call site for the same
pattern (auxiliary call, no `on_token`, LLM derived from `agent.llm` so
possibly `stream=True`, no stream-disable) found **two more callers** that the
condenser fix did not cover:

- **`generate_title_with_llm`** (`title_utils.py`) — `llm.completion(messages)`
  with no `on_token`. The LLM defaults to `self.agent.llm`
  (`local_conversation.py`: `effective_llm = llm if llm is not None else
  self.agent.llm`). The call sits inside a `try/except`, so a streaming agent
  did not crash but **silently never got an LLM-generated title** — it logged
  `Error generating conversation title with LLM: Streaming requires an
  on_token callback` and fell back to a truncated title.
- **`LocalConversation.ask_agent`** — builds `question_llm =
  self.agent.llm.model_copy(update={"usage_id": "ask-agent-llm"})`, which
  **inherits `stream`**, then calls `make_llm_completion(question_llm, ...)`
  with no `on_token`. This path is **not** wrapped in `try/except`, so the
  `ValueError` propagated to the caller — the exact failure mode of #3902.

Both are reachable from the agent-server too
(`conversation_service.generate_conversation_title` /
`conversation_service.ask_agent`), which delegate into these same two
functions.

The established fix idiom already exists in the sibling auxiliary callers:
`conversation/goal/judge.py` (`judge_llm.model_copy(update={"stream":
False})`), the delegate/task sub-agent paths, and now the condenser.

## Summary

- `title_utils.generate_title_with_llm`: force a non-streaming copy
  (`llm.model_copy(update={"stream": False})` when `llm.stream`) before
  `llm.completion()`. Non-mutating, shares `usage_id`/metrics, so title token
  usage stays attributed to the conversation.
- `LocalConversation.ask_agent`: add `"stream": False` to the existing
  `model_copy(update=...)` that builds the dedicated `ask-agent-llm`.
- Add regression tests for both paths using a real `LLM(stream=True)` with the
  transport (`LLM._transport_call`) mocked, so the genuine streaming guard in
  `completion()` runs. They fail with the exact production error without the
  fix and pass with it.

## Issue Number

No dedicated issue. Same bug class as #3902 (fixed for the summarizer by
#3901); these are the two remaining unguarded auxiliary call sites found by
auditing the rest of the SDK for the same pattern.

## How to Test

```bash
uv sync --dev

# Both new regression tests + full affected suites (58 tests):
uv run pytest \
  tests/sdk/conversation/test_generate_title.py \
  tests/sdk/conversation/test_ask_agent.py \
  tests/sdk/context/condenser/test_llm_summarizing_condenser.py -q
```

To confirm the new tests actually reproduce the bug, revert the two source
hunks and run only the streaming regressions — they fail with the exact
production error before the fix:

```bash
git stash push -- \
  openhands-sdk/openhands/sdk/conversation/title_utils.py \
  openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
uv run pytest \
  tests/sdk/conversation/test_generate_title.py::test_generate_title_disables_streaming_when_llm_streams \
  tests/sdk/conversation/test_ask_agent.py::test_ask_agent_disables_streaming_when_llm_streams -q
git stash pop
```

## Video/Screenshots

Deterministic CLI reproduction (no GUI). Captured locally:

**1. New regression tests FAIL on the unfixed source (fix stashed) — exact issue error:**

```
FAILED tests/sdk/conversation/test_generate_title.py::test_generate_title_disables_streaming_when_llm_streams
FAILED tests/sdk/conversation/test_ask_agent.py::test_ask_agent_disables_streaming_when_llm_streams
2 failed in 0.10s
```
(`title_utils` swallows the error and falls back to a truncated title, so its
assertion that the LLM title was used fails; `ask_agent` raises
`ValueError: Streaming requires an on_token callback` directly.)

**2. With the fix — affected suites pass:**

```
tests/sdk/conversation/test_generate_title.py ........                   [ 13%]
tests/sdk/conversation/test_ask_agent.py ...........                     [ 32%]
tests/sdk/context/condenser/test_llm_summarizing_condenser.py ........... [100%]
58 passed in 0.28s
```

**3. pre-commit on all changed files — green:**

```
Ruff format / Ruff lint / pycodestyle / pyright / import rules / Tool registration -> all Passed
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Metrics: title generation keeps the same `usage_id` (cost rolls up to the
  conversation, matching `judge.py`); `ask_agent` keeps its dedicated
  `ask-agent-llm` `usage_id` (separate bucket, as before) and only gains
  `stream=False`.
- Both fixes are guarded by `if llm.stream` / a one-field `model_copy` update,
  so non-streaming setups are byte-for-byte unaffected.
- A live end-to-end repro (real provider key + a streaming agent driving
  title/ask_agent) was not run; the bug is reproduced deterministically at the
  SDK layer with a real `LLM(stream=True)` and the transport mocked, so the
  real streaming guard executes.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:dbbe8f5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-dbbe8f5-python \
  ghcr.io/openhands/agent-server:dbbe8f5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:dbbe8f5-golang-amd64
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-golang-amd64
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-golang-amd64
ghcr.io/openhands/agent-server:dbbe8f5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:dbbe8f5-golang-arm64
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-golang-arm64
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-golang-arm64
ghcr.io/openhands/agent-server:dbbe8f5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:dbbe8f5-java-amd64
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-java-amd64
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-java-amd64
ghcr.io/openhands/agent-server:dbbe8f5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:dbbe8f5-java-arm64
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-java-arm64
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-java-arm64
ghcr.io/openhands/agent-server:dbbe8f5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:dbbe8f5-python-amd64
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-python-amd64
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-python-amd64
ghcr.io/openhands/agent-server:dbbe8f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:dbbe8f5-python-arm64
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-python-arm64
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-python-arm64
ghcr.io/openhands/agent-server:dbbe8f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:dbbe8f5-golang
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-golang
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-golang
ghcr.io/openhands/agent-server:dbbe8f5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:dbbe8f5-java
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-java
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-java
ghcr.io/openhands/agent-server:dbbe8f5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:dbbe8f5-python
ghcr.io/openhands/agent-server:dbbe8f56d3c285a72dd67161c474a503620260c3-python
ghcr.io/openhands/agent-server:vasco-fix-streaming-aux-llm-python
ghcr.io/openhands/agent-server:dbbe8f5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `dbbe8f5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `dbbe8f5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->