### PR TITLE
fix(sdk): accept 6+ digit event indices in EventLog filename regex

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/persistence_const.py
+++ b/openhands-sdk/openhands/sdk/conversation/persistence_const.py
@@ -3,7 +3,11 @@ import re
 
 BASE_STATE = "base_state.json"
 EVENTS_DIR = "events"
+# The index is zero-padded to a *minimum* of 5 digits by EVENT_FILE_PATTERN
+# ({idx:05d}); it is not capped, so logs past 99999 events emit 6+ digit names.
+# The reader must therefore accept 5 *or more* digits (\d{5,}) — matching exactly
+# 5 would silently drop every event with index >= 100000 on a cold reload.
 EVENT_NAME_RE = re.compile(
-    r"^event-(?P<idx>\d{5})-(?P<event_id>[0-9a-fA-F\-]{8,})\.json$"
+    r"^event-(?P<idx>\d{5,})-(?P<event_id>[0-9a-fA-F\-]{8,})\.json$"
 )
 EVENT_FILE_PATTERN = "event-{idx:05d}-{event_id}.json"

--- a/openhands-sdk/openhands/sdk/conversation/persistence_const.py
+++ b/openhands-sdk/openhands/sdk/conversation/persistence_const.py
@@ -3,10 +3,7 @@ import re
 
 BASE_STATE = "base_state.json"
 EVENTS_DIR = "events"
-# The index is zero-padded to a *minimum* of 5 digits by EVENT_FILE_PATTERN
-# ({idx:05d}); it is not capped, so logs past 99999 events emit 6+ digit names.
-# The reader must therefore accept 5 *or more* digits (\d{5,}) — matching exactly
-# 5 would silently drop every event with index >= 100000 on a cold reload.
+# Accept 5+ digits: the writer pads to a 5-digit minimum but does not cap width.
 EVENT_NAME_RE = re.compile(
     r"^event-(?P<idx>\d{5,})-(?P<event_id>[0-9a-fA-F\-]{8,})\.json$"
 )

--- a/tests/sdk/conversation/test_event_store.py
+++ b/tests/sdk/conversation/test_event_store.py
@@ -496,3 +496,65 @@ def test_event_cache_survives_across_multiple_iterations():
     first_pass = list(log)
     second_pass = list(log)
     assert all(a is b for a, b in zip(first_pass, second_pass, strict=True))
+
+
+# ---------------------------------------------------------------------------
+# Regression: event index width. The writer zero-pads to a *minimum* of 5
+# digits ({idx:05d}) and never caps, so a log past 99999 events emits 6+ digit
+# filenames. The reader regex must accept 5-or-more digits; a fixed-width
+# `\d{5}` silently dropped every event with index >= 100000 on a cold reload
+# (see issue #3926).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("idx", [0, 1, 99999, 100000, 100001, 999999, 1_000_000])
+def test_event_filename_writer_reader_agree(idx):
+    """The reader regex must match the exact filename the writer emits."""
+    from openhands.sdk.conversation.persistence_const import (
+        EVENT_FILE_PATTERN,
+        EVENT_NAME_RE,
+    )
+
+    event_id = f"{idx:08x}-0000-0000-0000-000000000000"
+    name = EVENT_FILE_PATTERN.format(idx=idx, event_id=event_id)
+
+    m = EVENT_NAME_RE.match(name)
+    assert m is not None, f"reader regex failed to match writer output: {name!r}"
+    assert int(m.group("idx")) == idx
+
+
+def test_event_log_cold_reload_past_100k_events():
+    """A log with >100000 events reloads without dropping the tail.
+
+    Before the fix the cold scan truncated the index at 100000 (silent data
+    loss) and the count/scan paths diverged, corrupting length accounting.
+    """
+    from openhands.sdk.conversation.persistence_const import (
+        EVENT_FILE_PATTERN,
+        EVENTS_DIR,
+    )
+
+    # Raise the test-double LRU caps so the in-memory store keeps every file;
+    # this configures only the storage stand-in, not the code under test.
+    fs = InMemoryFileStore(max_size=500_000, max_memory=2 * 1024 * 1024 * 1024)
+    payload = create_test_event("seed", "seed").model_dump_json(exclude_none=True)
+
+    n = 100_002  # straddles the 5-/6-digit boundary
+    for i in range(n):
+        event_id = f"{i:08x}-0000-0000-0000-000000000000"
+        path = f"{EVENTS_DIR}/" + EVENT_FILE_PATTERN.format(idx=i, event_id=event_id)
+        fs.write(path, payload)
+
+    log = EventLog(fs)
+
+    # No silent truncation: every event survives the cold scan.
+    assert len(log) == n
+
+    # The events straddling the boundary are readable, not unreachable holes.
+    assert log[99999] is not None
+    assert log[100000] is not None
+    assert log[100001] is not None
+
+    # Appending after reload keeps length accounting consistent.
+    log.append(create_test_event("after-reload", "after"))
+    assert len(log) == n + 1

--- a/tests/sdk/conversation/test_event_store.py
+++ b/tests/sdk/conversation/test_event_store.py
@@ -6,6 +6,11 @@ from unittest.mock import Mock
 import pytest
 
 from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.conversation.persistence_const import (
+    EVENT_FILE_PATTERN,
+    EVENT_NAME_RE,
+    EVENTS_DIR,
+)
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.io.memory import InMemoryFileStore
 from openhands.sdk.llm import Message, TextContent
@@ -498,23 +503,9 @@ def test_event_cache_survives_across_multiple_iterations():
     assert all(a is b for a, b in zip(first_pass, second_pass, strict=True))
 
 
-# ---------------------------------------------------------------------------
-# Regression: event index width. The writer zero-pads to a *minimum* of 5
-# digits ({idx:05d}) and never caps, so a log past 99999 events emits 6+ digit
-# filenames. The reader regex must accept 5-or-more digits; a fixed-width
-# `\d{5}` silently dropped every event with index >= 100000 on a cold reload
-# (see issue #3926).
-# ---------------------------------------------------------------------------
-
-
 @pytest.mark.parametrize("idx", [0, 1, 99999, 100000, 100001, 999999, 1_000_000])
 def test_event_filename_writer_reader_agree(idx):
     """The reader regex must match the exact filename the writer emits."""
-    from openhands.sdk.conversation.persistence_const import (
-        EVENT_FILE_PATTERN,
-        EVENT_NAME_RE,
-    )
-
     event_id = f"{idx:08x}-0000-0000-0000-000000000000"
     name = EVENT_FILE_PATTERN.format(idx=idx, event_id=event_id)
 
@@ -529,11 +520,6 @@ def test_event_log_cold_reload_past_100k_events():
     Before the fix the cold scan truncated the index at 100000 (silent data
     loss) and the count/scan paths diverged, corrupting length accounting.
     """
-    from openhands.sdk.conversation.persistence_const import (
-        EVENT_FILE_PATTERN,
-        EVENTS_DIR,
-    )
-
     # Raise the test-double LRU caps so the in-memory store keeps every file;
     # this configures only the storage stand-in, not the code under test.
     fs = InMemoryFileStore(max_size=500_000, max_memory=2 * 1024 * 1024 * 1024)


### PR DESCRIPTION
HUMAN:

The writer pads the event index with `{idx:05d}` (a 5-digit *minimum*, uncapped) while the reader regex matched exactly `\d{5}`. So any event log that grows past 99,999 events writes 6-digit filenames the reader can no longer recognise, and the tail of the history is silently dropped on the next cold reload. This widens the reader to `\d{5,}` and adds regression tests across the boundary.

---

AGENT:

## Why

`EVENT_FILE_PATTERN = "event-{idx:05d}-{event_id}.json"` zero-pads the event index to a **minimum** of 5 digits and never caps it, so an append-only event log that grows past 99,999 events writes 6-digit filenames (`event-100000-...`). The reader `EVENT_NAME_RE` matched **exactly** 5 digits (`\d{5}`), so on a cold reload (process restart → resume/fork) every event with index ≥ 100000 was treated as "Unrecognized event file name" and excluded from the rebuilt index.

Consequences (silent, persistent, irreversible):
- `_scan_and_build_index()` stops at the first missing contiguous index, so `len(EventLog)` is truncated to 100000 — the tail of the history is silently lost on reload.
- The prefix-based `_count_events_on_disk()` still counts the 6-digit files, so it diverges from the scan; the next `append()` triggers `_sync_from_disk` and the length accounting becomes permanently inconsistent (idx 100000+ are on disk but unreadable holes).

Reported and analysed in #3926.

## Summary

- Relax the reader regex from `\d{5}` to `\d{5,}` so it accepts whatever width the `{idx:05d}` writer emits. One character; fully backward compatible (existing 5-digit names still match).
- Add regression tests: a parametrized writer↔reader agreement check across the 5/6-digit boundary, and an end-to-end cold-reload test of a >100k-event log.

## Issue Number

Closes #3926

## How to Test

Run the new + existing EventLog tests:

```
uv run pytest tests/sdk/conversation/test_event_store.py -q
# 29 passed
```

Guard verification — the new tests fail on the pre-fix regex and pass after the fix. Temporarily reverting `\d{5,}` → `\d{5}`:

```
FAILED ...::test_event_filename_writer_reader_agree[100000]
FAILED ...::test_event_filename_writer_reader_agree[100001]
FAILED ...::test_event_filename_writer_reader_agree[999999]
FAILED ...::test_event_filename_writer_reader_agree[1000000]
FAILED ...::test_event_log_cold_reload_past_100k_events
WARNING event_store.py:237 Unrecognized event file name: event-100000-...json
```

End-to-end reproduction before the fix (a 100,002-event log cold-reloads as length 100000, and idx 100000/100001 raise `IndexError: Event index out of range`); after the fix the same log reloads as 100002 with all events readable.

lint/format: `uv run ruff check` and `ruff format --check` clean on both files.
