### PR TITLE
fix(mcp): auto-reconnect when client session is lost after transient errors

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -66,12 +66,38 @@ class MCPToolExecutor(ToolExecutor):
 
     @observe(name="MCPToolExecutor.call_tool", span_type="TOOL")
     async def call_tool(self, action: MCPToolAction) -> MCPToolObservation:
-        """Execute the MCP tool call using the already-connected client."""
+        """Execute the MCP tool call using the already-connected client.
+
+        If the client's session has been lost (e.g., due to a transient
+        server error such as HTTP 503), attempt to reconnect once before
+        failing. This prevents a single transient error from permanently
+        disabling all MCP tools for the remainder of the conversation.
+        """
         if not self.client.is_connected():
-            raise RuntimeError(
-                f"MCP client not connected for tool '{self.tool_name}'. "
-                "The connection may have been closed or failed to establish."
+            if self.client._closed:
+                return MCPToolObservation.from_text(
+                    text=(
+                        f"MCP client not connected for tool '{self.tool_name}'. "
+                        "The client has been closed and cannot be reconnected."
+                    ),
+                    is_error=True,
+                    tool_name=self.tool_name,
+                )
+            logger.info(
+                f"MCP client not connected for tool '{self.tool_name}'; "
+                "attempting reconnection before failing."
             )
+            try:
+                await self.client.connect()
+            except Exception as exc:
+                return MCPToolObservation.from_text(
+                    text=(
+                        f"MCP client not connected for tool '{self.tool_name}'. "
+                        f"Reconnection attempt failed: {exc}"
+                    ),
+                    is_error=True,
+                    tool_name=self.tool_name,
+                )
         try:
             logger.debug(
                 f"Calling MCP tool {self.tool_name} with args: {action.model_dump()}"

--- a/tests/sdk/mcp/test_mcp_tool.py
+++ b/tests/sdk/mcp/test_mcp_tool.py
@@ -10,14 +10,17 @@ from openhands.sdk.mcp.client import MCPClient
 from openhands.sdk.mcp.definition import MCPToolObservation
 from openhands.sdk.mcp.tool import MCPToolDefinition, MCPToolExecutor
 from openhands.sdk.tool import ToolAnnotations
+from openhands.sdk.utils.async_executor import AsyncExecutor
 
 
 class MockMCPClient(MCPClient):
     """Mock MCPClient for testing that bypasses the complex constructor."""
 
     def __init__(self):
-        # Skip the parent constructor to avoid needing transport
-        pass
+        # Initialize only the fields needed for sync execution (no transport)
+        self._executor = AsyncExecutor()
+        self._closed = False
+        self._tools = []
 
 
 class TestMCPToolObservation:
@@ -244,6 +247,110 @@ class TestMCPToolExecutor:
         deletion and accumulate over a long-running server."""
         self.executor.close()
         self.mock_client.sync_close.assert_called_once()
+
+    def test_call_tool_reconnects_when_session_lost(self):
+        """When is_connected() returns False but the client is not closed,
+        call_tool should attempt reconnection before failing."""
+        mock_result = MagicMock(spec=mcp.types.CallToolResult)
+        mock_result.content = [
+            mcp.types.TextContent(type="text", text="Success after reconnect")
+        ]
+        mock_result.isError = False
+
+        mock_action = MagicMock()
+        mock_action.model_dump.return_value = {"param": "value"}
+        mock_action.to_mcp_arguments.return_value = {"param": "value"}
+
+        # Use MockMCPClient (real AsyncExecutor) so call_tool actually runs
+        client = MockMCPClient()
+        connect_calls: list[int] = []
+
+        async def mock_connect():
+            connect_calls.append(1)
+
+        async def mock_is_connected():
+            return False if not connect_calls else True
+
+        async def mock_call_tool_mcp(**kwargs):
+            return mock_result
+
+        # Patch the methods that fastmcp.Client.is_connected() and connect() use
+        client.is_connected = lambda: len(connect_calls) > 0  # type: ignore[method-assign]
+        client._closed = False
+        client.connect = mock_connect  # type: ignore[method-assign]
+        client.call_tool_mcp = mock_call_tool_mcp  # type: ignore[method-assign]
+
+        executor = MCPToolExecutor(tool_name="test_tool", client=client)
+        observation = executor(mock_action)
+
+        assert isinstance(observation, MCPToolObservation)
+        assert observation.tool_name == "test_tool"
+        assert observation.is_error is False
+        assert len(connect_calls) == 1
+        client.sync_close()
+
+    def test_call_tool_fails_when_client_closed(self):
+        """When the client has been closed (_closed=True), call_tool should
+        not attempt reconnection and should fail immediately."""
+        mock_action = MagicMock()
+        mock_action.model_dump.return_value = {"param": "value"}
+        mock_action.to_mcp_arguments.return_value = {"param": "value"}
+
+        client = MockMCPClient()
+        client.is_connected = lambda: False  # type: ignore[method-assign]
+        client._closed = True
+
+        async def mock_connect():
+            raise AssertionError("connect() should not be called on a closed client")
+
+        client.connect = mock_connect  # type: ignore[method-assign]
+
+        async def mock_call_tool_mcp(**kwargs):
+            raise AssertionError(
+                "call_tool_mcp should not be called when client is closed"
+            )
+
+        client.call_tool_mcp = mock_call_tool_mcp  # type: ignore[method-assign]
+
+        executor = MCPToolExecutor(tool_name="test_tool", client=client)
+        observation = executor(mock_action)
+
+        assert isinstance(observation, MCPToolObservation)
+        assert observation.is_error is True
+        assert "has been closed" in observation.text
+        client.sync_close()
+
+    def test_call_tool_fails_when_reconnect_fails(self):
+        """When reconnection attempt fails, call_tool should return an error
+        observation with the reconnection failure message."""
+        mock_action = MagicMock()
+        mock_action.model_dump.return_value = {"param": "value"}
+        mock_action.to_mcp_arguments.return_value = {"param": "value"}
+
+        client = MockMCPClient()
+        client.is_connected = lambda: False  # type: ignore[method-assign]
+        client._closed = False
+
+        async def mock_connect():
+            raise RuntimeError("Server unreachable")
+
+        client.connect = mock_connect  # type: ignore[method-assign]
+
+        async def mock_call_tool_mcp(**kwargs):
+            raise AssertionError(
+                "call_tool_mcp should not be called when reconnect fails"
+            )
+
+        client.call_tool_mcp = mock_call_tool_mcp  # type: ignore[method-assign]
+
+        executor = MCPToolExecutor(tool_name="test_tool", client=client)
+        observation = executor(mock_action)
+
+        assert isinstance(observation, MCPToolObservation)
+        assert observation.is_error is True
+        assert "Reconnection attempt failed" in observation.text
+        assert "Server unreachable" in observation.text
+        client.sync_close()
 
 
 class TestMCPTool:


### PR DESCRIPTION
HUMAN:

Graham here — the MCP client permanently breaks when the integrations server returns a transient 503. This PR adds automatic reconnection so a single error doesn't disable all MCP tools for the entire conversation.

---

AGENT:

## Why

When the MCP server (e.g., integrations-hub) returns a transient error such as HTTP 503, the `fastmcp.Client` session breaks and `is_connected()` returns `False` permanently. The previous code in `MCPToolExecutor.call_tool()` immediately raised `RuntimeError` with no recovery path, permanently disabling all MCP tools (Linear, Notion, Slack, etc.) for the remainder of the conversation. A single transient error takes down 110+ tools with no way to recover short of restarting the conversation.

## Summary

- **`openhands/sdk/mcp/tool.py`** — `MCPToolExecutor.call_tool()`: When `is_connected()` returns `False`, check if the client was intentionally closed (`_closed=True`). If closed, return an error observation immediately. If not closed, attempt `await self.client.connect()` to reconnect before proceeding. If reconnection fails, return an error observation with failure details. If it succeeds, proceed normally.
- **`tests/sdk/mcp/test_mcp_tool.py`** — Updated `MockMCPClient` to initialize `_executor`/`_closed`/`_tools` (needed for `call_async_from_sync`). Added 3 tests: `test_call_tool_reconnects_when_session_lost`, `test_call_tool_fails_when_client_closed`, `test_call_tool_fails_when_reconnect_fails`.

## Issue Number

Fixes #3928

## How to Test

Run the MCP test suite:

```bash
.venv/bin/python -m pytest tests/sdk/mcp/ -v
```

All 78 tests pass (including the 3 new reconnection tests):

```
tests/sdk/mcp/test_mcp_tool.py::TestMCPToolExecutor::test_call_tool_reconnects_when_session_lost PASSED
tests/sdk/mcp/test_mcp_tool.py::TestMCPToolExecutor::test_call_tool_fails_when_client_closed PASSED
tests/sdk/mcp/test_mcp_tool.py::TestMCPToolExecutor::test_call_tool_fails_when_reconnect_fails PASSED
============================= 78 passed in 20.77s ==============================
```

To manually verify the reconnection behavior: start a conversation with MCP integrations configured, trigger a transient server error (e.g., by overloading the server with parallel calls), then make a subsequent MCP tool call — it should now reconnect automatically instead of failing permanently.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

---
*This PR was created by an AI agent (OpenHands) on behalf of @neubig.*


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:530bc23-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-530bc23-python \
  ghcr.io/openhands/agent-server:530bc23-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:530bc23-golang-amd64
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-golang-amd64
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-golang-amd64
ghcr.io/openhands/agent-server:530bc23-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:530bc23-golang-arm64
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-golang-arm64
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-golang-arm64
ghcr.io/openhands/agent-server:530bc23-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:530bc23-java-amd64
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-java-amd64
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-java-amd64
ghcr.io/openhands/agent-server:530bc23-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:530bc23-java-arm64
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-java-arm64
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-java-arm64
ghcr.io/openhands/agent-server:530bc23-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:530bc23-python-amd64
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-python-amd64
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-python-amd64
ghcr.io/openhands/agent-server:530bc23-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:530bc23-python-arm64
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-python-arm64
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-python-arm64
ghcr.io/openhands/agent-server:530bc23-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:530bc23-golang
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-golang
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-golang
ghcr.io/openhands/agent-server:530bc23-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:530bc23-java
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-java
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-java
ghcr.io/openhands/agent-server:530bc23-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:530bc23-python
ghcr.io/openhands/agent-server:530bc2356d3e72c61f83a8a6e4f0b964da4da852-python
ghcr.io/openhands/agent-server:fix-mcp-client-reconnect-python
ghcr.io/openhands/agent-server:530bc23-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `530bc23-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `530bc23-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->