### PR TITLE
feat(profiles): store-agnostic FK + hoist router helpers (cloud AgentProfiles prereq, #3730)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -12,11 +12,9 @@ MCP references and returns :class:`~openhands.sdk.profiles.AgentProfileDiagnosti
 """
 
 import copy
-import shlex
 from collections.abc import Iterator
 from contextlib import contextmanager
 from typing import Annotated, Any
-from uuid import UUID, uuid4
 
 from fastapi import APIRouter, HTTPException, Path, Request, status
 from pydantic import BaseModel, Field, ValidationError
@@ -41,13 +39,13 @@ from openhands.sdk.profiles import (
     AgentProfileStore,
     OpenHandsAgentProfile,
     ProfileLimitExceeded,
-    ProfileVerificationSettings,
+    build_seed_profile,
     resolve_agent_profile_dry_run,
+    safe_validation_error_detail,
+    save_profile_preserving_identity,
     validate_agent_profile,
 )
 from openhands.sdk.profiles.agent_profile_store import PROFILE_NAME_PATTERN
-from openhands.sdk.settings import AgentSettingsConfig
-from openhands.sdk.settings.model import VerificationSettings
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.utils.pydantic_secrets import decrypt_str_with_cipher_or_keep
 
@@ -57,9 +55,6 @@ logger = get_logger(__name__)
 agent_profiles_router = APIRouter(prefix="/agent-profiles", tags=["Agent Profiles"])
 
 MAX_AGENT_PROFILES = 50
-
-# Name the lazily-seeded migration profile (and its LLM ref fallback).
-SEED_PROFILE_NAME = "default"
 
 ProfileName = Annotated[
     str,
@@ -179,67 +174,6 @@ def _decrypt_profile_mcp_tools(
     return profile.model_copy(update={"skills": new_skills})
 
 
-def _profile_verification(v: VerificationSettings) -> ProfileVerificationSettings:
-    """Project the secret-free subset of ``VerificationSettings``.
-
-    Drops ``critic_api_key`` — the profile is secret-free; the critic reuses
-    the resolved LLM profile's key.
-    """
-    return ProfileVerificationSettings(
-        critic_enabled=v.critic_enabled,
-        critic_mode=v.critic_mode,
-        enable_iterative_refinement=v.enable_iterative_refinement,
-        critic_threshold=v.critic_threshold,
-        max_refinement_iterations=v.max_refinement_iterations,
-        critic_server_url=v.critic_server_url,
-        critic_model_name=v.critic_model_name,
-    )
-
-
-def _build_seed_profile(
-    agent_settings: AgentSettingsConfig, active_llm_profile: str | None
-) -> OpenHandsAgentProfile | ACPAgentProfile:
-    """Build one ``AgentProfile`` faithfully from the current ``agent_settings``.
-
-    Carries every cleanly-overlapping launch field so the migrated profile is a
-    stable representation of the user's current configuration (the active
-    pointer is otherwise just a lightweight id). ``mcp_server_refs=None`` exposes
-    all of the user's MCP servers. An OpenHands profile references the active LLM
-    profile (falling back to ``"default"`` when none is set — a soft ref the
-    resolver checks at materialize time).
-    """
-    if agent_settings.agent_kind == "acp":
-        return ACPAgentProfile(
-            name=SEED_PROFILE_NAME,
-            acp_server=agent_settings.acp_server,
-            acp_model=agent_settings.acp_model,
-            acp_session_mode=agent_settings.acp_session_mode,
-            acp_prompt_timeout=agent_settings.acp_prompt_timeout,
-            # settings store the command as a token list; the profile holds a
-            # single (re-parseable) string. Empty list => use the server default.
-            acp_command=(
-                shlex.join(agent_settings.acp_command)
-                if agent_settings.acp_command
-                else None
-            ),
-            acp_args=list(agent_settings.acp_args) or None,
-            mcp_server_refs=None,
-        )
-    context = agent_settings.agent_context
-    return OpenHandsAgentProfile(
-        name=SEED_PROFILE_NAME,
-        llm_profile_ref=active_llm_profile or SEED_PROFILE_NAME,
-        agent=agent_settings.agent,
-        skills=list(context.skills),
-        system_message_suffix=context.system_message_suffix,
-        condenser=agent_settings.condenser,
-        verification=_profile_verification(agent_settings.verification),
-        enable_sub_agents=agent_settings.enable_sub_agents,
-        tool_concurrency_limit=agent_settings.tool_concurrency_limit,
-        mcp_server_refs=None,
-    )
-
-
 def _seed_default_profile(
     store: AgentProfileStore,
     request: Request,
@@ -251,13 +185,13 @@ def _seed_default_profile(
     The lock spans empty-check + save + pointer write so concurrent first
     requests seed exactly once and the pointer matches the persisted id.
     """
-    with _store_errors(), store._acquire_lock():
+    with _store_errors(), store.lock():
         # Double-checked under the lock: a concurrent first request may have
         # already seeded (the outer emptiness check in the list endpoint is
         # unlocked).
         if store.list():
             return
-        profile = _build_seed_profile(settings.agent_settings, settings.active_profile)
+        profile = build_seed_profile(settings.agent_settings, settings.active_profile)
         # Settings persist skills[].mcp_tools encrypted (and never decrypt on
         # load), so decrypt before re-encrypting at save to avoid double-encrypt.
         profile = _decrypt_profile_mcp_tools(profile, cipher)
@@ -282,29 +216,6 @@ def _summary_id_for_name(store: AgentProfileStore, name: str) -> str | None:
                 sid = summary.get("id")
                 return str(sid) if sid is not None else None
     return None
-
-
-def _existing_identity(
-    store: AgentProfileStore, name: str
-) -> tuple[UUID | None, int | None]:
-    """Return the stable ``(id, revision)`` of the profile under ``name``.
-
-    Used to keep ``id`` stable across an overwrite — the active pointer is keyed
-    on it — and to bump ``revision`` monotonically. Ignores a malformed stored
-    id (treated as no prior identity).
-    """
-    with _store_errors():
-        for summary in store.list_summaries():
-            if summary.get("name") != name:
-                continue
-            sid = summary.get("id")
-            rev = summary.get("revision")
-            try:
-                parsed = UUID(str(sid)) if sid is not None else None
-            except (ValueError, TypeError):
-                parsed = None
-            return parsed, rev if isinstance(rev, int) else None
-    return None, None
 
 
 @agent_profiles_router.get("", response_model=AgentProfileListResponse)
@@ -393,7 +304,7 @@ async def save_agent_profile(
         # MCPConfig error embeds the input (which may carry secrets) in ``msg``.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail=[{"loc": err["loc"], "type": err["type"]} for err in e.errors()],
+            detail=safe_validation_error_detail(e),
         )
     except Exception:
         # Any other validation failure (e.g. SkillValidationError from a
@@ -412,19 +323,14 @@ async def save_agent_profile(
     store = get_agent_profile_store()
     # The id is server-managed (the active pointer is keyed on it): overwrite
     # keeps the namesake's id and bumps revision; create mints a fresh id,
-    # ignoring any client-supplied one. The lock spans read + mint + save so two
-    # concurrent creates of the same new name can't both mint an id and clobber
-    # each other (the seed path guards the same window).
+    # ignoring any client-supplied one. ``save_profile_preserving_identity``
+    # holds the store lock across read + mint + save so two concurrent creates
+    # of the same new name can't both mint an id and clobber each other.
     try:
-        with _store_errors(), store._acquire_lock():
-            existing_id, existing_rev = _existing_identity(store, name)
-            if existing_id is not None:
-                profile = profile.model_copy(
-                    update={"id": existing_id, "revision": (existing_rev or 0) + 1}
-                )
-            else:
-                profile = profile.model_copy(update={"id": uuid4()})
-            store.save(profile, cipher=cipher, max_profiles=MAX_AGENT_PROFILES)
+        with _store_errors():
+            save_profile_preserving_identity(
+                store, profile, cipher=cipher, max_profiles=MAX_AGENT_PROFILES
+            )
     except ProfileLimitExceeded:
         raise HTTPException(
             status_code=status.HTTP_409_CONFLICT,

--- a/openhands-sdk/openhands/sdk/llm/__init__.py
+++ b/openhands-sdk/openhands/sdk/llm/__init__.py
@@ -6,7 +6,11 @@ from openhands.sdk.llm.auth import (
 )
 from openhands.sdk.llm.fallback_strategy import FallbackStrategy
 from openhands.sdk.llm.llm import LLM, LLM_PROFILE_SCHEMA_VERSION
-from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+from openhands.sdk.llm.llm_profile_store import (
+    LLMProfileLoader,
+    LLMProfileMutator,
+    LLMProfileStore,
+)
 from openhands.sdk.llm.llm_registry import LLMRegistry, RegistryEvent
 from openhands.sdk.llm.llm_response import LLMResponse
 from openhands.sdk.llm.message import (
@@ -45,6 +49,8 @@ __all__ = [
     "LLM",
     "LLM_PROFILE_SCHEMA_VERSION",
     "LLMRegistry",
+    "LLMProfileLoader",
+    "LLMProfileMutator",
     "LLMProfileStore",
     "RouterLLM",
     "RegistryEvent",

--- a/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
+++ b/openhands-sdk/openhands/sdk/llm/llm_profile_store.py
@@ -8,7 +8,7 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Protocol, runtime_checkable
 
 from filelock import FileLock, Timeout
 
@@ -37,6 +37,33 @@ logger = get_logger(__name__)
 
 class ProfileLimitExceeded(Exception):
     """Raised when saving would exceed the configured profile limit."""
+
+
+@runtime_checkable
+class LLMProfileLoader(Protocol):
+    """Minimal load-only contract consumed by ``resolve_agent_profile``.
+
+    The resolver reads an LLM profile by name via ``load`` only, so an alternate
+    backend — e.g. a cloud adapter over the ``org.llm_profiles`` column — need
+    implement just this, not the full file-backed :class:`LLMProfileStore`.
+    """
+
+    def load(self, name: str, *, cipher: Cipher | None = ...) -> LLM: ...
+
+
+@runtime_checkable
+class LLMProfileMutator(Protocol):
+    """Delete/rename contract used by the cross-store FK helpers.
+
+    ``profile_refs.delete_llm_profile`` / ``rename_llm_profile`` touch the LLM
+    store only through ``delete`` / ``rename``, so a cloud adapter over
+    ``org.llm_profiles`` can drive the same guarded FK lifecycle without being a
+    full :class:`LLMProfileStore`.
+    """
+
+    def delete(self, name: str) -> None: ...
+
+    def rename(self, old_name: str, new_name: str) -> None: ...
 
 
 class LLMProfileStore:

--- a/openhands-sdk/openhands/sdk/profiles/__init__.py
+++ b/openhands-sdk/openhands/sdk/profiles/__init__.py
@@ -8,11 +8,15 @@ from openhands.sdk.profiles.agent_profile import (
     LaunchedAgentProfile,
     OpenHandsAgentProfile,
     ProfileVerificationSettings,
+    build_profile_verification,
+    safe_validation_error_detail,
     validate_agent_profile,
 )
 from openhands.sdk.profiles.agent_profile_store import (
     AgentProfileStore,
+    AgentProfileStoreProtocol,
     ProfileLimitExceeded,
+    save_profile_preserving_identity,
 )
 from openhands.sdk.profiles.profile_refs import (
     ProfileReferenced,
@@ -28,6 +32,10 @@ from openhands.sdk.profiles.resolver import (
     resolve_agent_profile,
     resolve_agent_profile_dry_run,
 )
+from openhands.sdk.profiles.seed import (
+    SEED_PROFILE_NAME,
+    build_seed_profile,
+)
 
 
 __all__ = [
@@ -37,6 +45,7 @@ __all__ = [
     "AgentProfileBase",
     "AgentProfileDiagnostics",
     "AgentProfileStore",
+    "AgentProfileStoreProtocol",
     "DanglingMcpServerRef",
     "LaunchedAgentProfile",
     "OpenHandsAgentProfile",
@@ -44,11 +53,16 @@ __all__ = [
     "ProfileNotFound",
     "ProfileReferenced",
     "ProfileVerificationSettings",
+    "SEED_PROFILE_NAME",
+    "build_profile_verification",
+    "build_seed_profile",
     "cascade_rename",
     "delete_llm_profile",
     "find_referrers",
     "rename_llm_profile",
     "resolve_agent_profile",
     "resolve_agent_profile_dry_run",
+    "safe_validation_error_detail",
+    "save_profile_preserving_identity",
     "validate_agent_profile",
 ]

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -20,6 +20,7 @@ from pydantic import (
     Field,
     Tag,
     TypeAdapter,
+    ValidationError,
 )
 
 from openhands.sdk.settings.model import (
@@ -27,6 +28,7 @@ from openhands.sdk.settings.model import (
     CondenserSettingsConfig,
     CriticMode,
     LLMSummarizingCondenserSettings,
+    VerificationSettings,
 )
 from openhands.sdk.skills import Skill
 
@@ -50,6 +52,26 @@ class ProfileVerificationSettings(BaseModel):
     max_refinement_iterations: int = Field(default=3, ge=1)
     critic_server_url: str | None = None
     critic_model_name: str | None = None
+
+
+def build_profile_verification(
+    v: VerificationSettings,
+) -> ProfileVerificationSettings:
+    """Project the secret-free subset of ``VerificationSettings`` onto a profile.
+
+    Drops ``critic_api_key`` — the profile is secret-free; the critic reuses the
+    resolved LLM profile's key. Hoisted from the agent-server router so the
+    local and cloud seeds build verification identically.
+    """
+    return ProfileVerificationSettings(
+        critic_enabled=v.critic_enabled,
+        critic_mode=v.critic_mode,
+        enable_iterative_refinement=v.enable_iterative_refinement,
+        critic_threshold=v.critic_threshold,
+        max_refinement_iterations=v.max_refinement_iterations,
+        critic_server_url=v.critic_server_url,
+        critic_model_name=v.critic_model_name,
+    )
 
 
 class AgentProfileBase(BaseModel):
@@ -339,3 +361,16 @@ def validate_agent_profile(
         raise TypeError("AgentProfile payload must be a mapping or BaseModel.")
     payload = _apply_persisted_migrations(payload)
     return _AGENT_PROFILE_ADAPTER.validate_python(payload, context=context)
+
+
+def safe_validation_error_detail(exc: ValidationError) -> list[dict[str, Any]]:
+    """Secret-safe ``detail`` for a 422 from a failed profile validation.
+
+    Surfaces only ``loc``/``type`` per error and **drops ``msg``/``input``** — a
+    nested ``skills[].mcp_tools`` ``MCPConfig`` error embeds the offending input,
+    which may carry secrets. Shaped like FastAPI's request-validation ``detail``
+    (a list of error objects) so routers can hand it straight to ``HTTPException``.
+    Hoisted from the agent-server router so the local and cloud routers redact
+    identically.
+    """
+    return [{"loc": err["loc"], "type": err["type"]} for err in exc.errors()]

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
@@ -8,7 +8,8 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Final
+from typing import TYPE_CHECKING, Any, Final, Protocol, runtime_checkable
+from uuid import UUID, uuid4
 
 from filelock import FileLock, Timeout
 
@@ -17,7 +18,7 @@ from openhands.sdk.profiles.agent_profile import validate_agent_profile
 
 
 if TYPE_CHECKING:
-    from uuid import UUID
+    from contextlib import AbstractContextManager
 
     from openhands.sdk.profiles.agent_profile import (
         ACPAgentProfile,
@@ -80,6 +81,17 @@ class AgentProfileStore:
             raise TimeoutError(
                 f"Agent profile store lock acquisition timed out after {timeout}s"
             )
+
+    def lock(
+        self, timeout: float = _LOCK_TIMEOUT_SECONDS
+    ) -> AbstractContextManager[None]:
+        """Public, re-entrant store lock for the FK helpers (``profile_refs``).
+
+        Part of :class:`AgentProfileStoreProtocol` so a non-file store (e.g. a
+        DB-backed cloud store) can supply its own re-entrant transaction guard
+        under the same name. Delegates to :meth:`_acquire_lock`.
+        """
+        return self._acquire_lock(timeout)
 
     def list(self) -> list[str]:
         """Return the filenames of all stored profiles (e.g. ``["a.json"]``)."""
@@ -261,6 +273,29 @@ class AgentProfileStore:
                 f"[AgentProfile Store] Renamed profile `{old_name}` to `{new_name}`"
             )
 
+    def set_llm_profile_ref(self, name: str, new_ref: str) -> None:
+        """Surgically repoint one OpenHands profile's ``llm_profile_ref``.
+
+        The single-profile write primitive behind ``profile_refs.cascade_rename``
+        — callers hold :meth:`lock`. A raw-JSON edit (only the ref field
+        changes), so encrypted ``skills[].mcp_tools`` and the stable ``id`` are
+        untouched and no cipher is needed. No-op when the profile is missing,
+        non-dict, or an ACP profile (which carries no ``llm_profile_ref``).
+        """
+        path = self._get_profile_path(name)
+        if not path.exists():
+            return
+        try:
+            data = json.loads(path.read_text())
+        except (OSError, json.JSONDecodeError):
+            return
+        if not isinstance(data, dict):
+            return
+        if data.get("agent_kind", "openhands") != "openhands":
+            return
+        data["llm_profile_ref"] = new_ref
+        self._atomic_write(path, json.dumps(data, indent=2))
+
     def list_summaries(self) -> list[dict[str, Any]]:
         """Project profile metadata without instantiating secrets.
 
@@ -320,3 +355,101 @@ class AgentProfileStore:
             if str(summary.get("id")) == target:
                 return str(summary["name"])
         return None
+
+
+@runtime_checkable
+class AgentProfileStoreProtocol(Protocol):
+    """Structural contract shared by :class:`AgentProfileStore` (file-backed) and
+    any alternative backend — notably a multi-tenant DB store in the cloud
+    app-server.
+
+    The SDK's store-agnostic helpers — ``profile_refs`` (the LLM-profile FK) and
+    :func:`save_profile_preserving_identity` — are typed against this Protocol so
+    a non-file store reuses them verbatim instead of re-deriving the FK / id
+    lifecycle. :meth:`lock` must be **re-entrant**: the FK helpers nest it around
+    :meth:`list_summaries` / :meth:`set_llm_profile_ref`, and a cloud store whose
+    router already holds a row-level transaction must treat a nested ``lock()``
+    as a no-op rather than deadlocking.
+    """
+
+    def lock(self, timeout: float = ...) -> AbstractContextManager[None]: ...
+
+    def list(self) -> list[str]: ...
+
+    def list_summaries(self) -> list[dict[str, Any]]: ...
+
+    def save(
+        self,
+        profile: OpenHandsAgentProfile | ACPAgentProfile,
+        *,
+        cipher: Cipher | None = ...,
+        max_profiles: int | None = ...,
+    ) -> None: ...
+
+    def load(
+        self, name: str, *, cipher: Cipher | None = ...
+    ) -> OpenHandsAgentProfile | ACPAgentProfile: ...
+
+    def delete(self, name: str) -> None: ...
+
+    def rename(self, old_name: str, new_name: str) -> None: ...
+
+    def set_llm_profile_ref(self, name: str, new_ref: str) -> None: ...
+
+    def name_for_id(self, profile_id: str | UUID) -> str | None: ...
+
+
+def _existing_identity(
+    store: AgentProfileStoreProtocol, name: str
+) -> tuple[UUID | None, int | None]:
+    """Return the stored ``(id, revision)`` of the profile under ``name``.
+
+    Reads :meth:`~AgentProfileStoreProtocol.list_summaries` (no secret
+    instantiation). A malformed stored id is treated as "no prior identity".
+    """
+    for summary in store.list_summaries():
+        if summary.get("name") != name:
+            continue
+        sid = summary.get("id")
+        rev = summary.get("revision")
+        try:
+            parsed = UUID(str(sid)) if sid is not None else None
+        except (ValueError, TypeError):
+            parsed = None
+        return parsed, rev if isinstance(rev, int) else None
+    return None, None
+
+
+def save_profile_preserving_identity(
+    store: AgentProfileStoreProtocol,
+    profile: OpenHandsAgentProfile | ACPAgentProfile,
+    *,
+    cipher: Cipher | None = None,
+    max_profiles: int | None = None,
+) -> OpenHandsAgentProfile | ACPAgentProfile:
+    """Save ``profile`` with the server-managed id/revision policy.
+
+    Hoisted from the agent-server router so the file store and a cloud DB store
+    stamp identity identically (the active pointer is keyed on the id):
+
+    * **overwrite** a namesake → keep its stable ``id``, set
+      ``revision = prev + 1``;
+    * **create** → mint a fresh ``uuid4`` (ignoring any client-supplied id).
+
+    The read → stamp → save runs under :meth:`~AgentProfileStoreProtocol.lock`
+    so two concurrent creates of the same new name can't both mint an id and
+    clobber each other. Returns the saved profile (final ``id`` / ``revision``).
+
+    Raises:
+        ProfileLimitExceeded: If ``max_profiles`` would be exceeded.
+    """
+    with store.lock():
+        existing_id, existing_rev = _existing_identity(store, profile.name)
+        if existing_id is not None:
+            profile = profile.model_copy(
+                update={"id": existing_id, "revision": (existing_rev or 0) + 1}
+            )
+        else:
+            profile = profile.model_copy(update={"id": uuid4()})
+        store.save(profile, cipher=cipher, max_profiles=max_profiles)
+    return profile

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
@@ -87,9 +87,11 @@ class AgentProfileStore:
     ) -> AbstractContextManager[None]:
         """Public, re-entrant store lock for the FK helpers (``profile_refs``).
 
-        Part of :class:`AgentProfileStoreProtocol` so a non-file store (e.g. a
-        DB-backed cloud store) can supply its own re-entrant transaction guard
-        under the same name. Delegates to :meth:`_acquire_lock`.
+        Re-entrant because ``filelock.FileLock`` counts acquisitions per thread,
+        so a holder may nest it (e.g. ``save_profile_preserving_identity`` over
+        ``save``). Part of :class:`AgentProfileStoreProtocol` so a non-file store
+        (e.g. a DB-backed cloud store) can supply its own re-entrant transaction
+        guard under the same name. Delegates to :meth:`_acquire_lock`.
         """
         return self._acquire_lock(timeout)
 
@@ -276,25 +278,27 @@ class AgentProfileStore:
     def set_llm_profile_ref(self, name: str, new_ref: str) -> None:
         """Surgically repoint one OpenHands profile's ``llm_profile_ref``.
 
-        The single-profile write primitive behind ``profile_refs.cascade_rename``
-        — callers hold :meth:`lock`. A raw-JSON edit (only the ref field
-        changes), so encrypted ``skills[].mcp_tools`` and the stable ``id`` are
-        untouched and no cipher is needed. No-op when the profile is missing,
-        non-dict, or an ACP profile (which carries no ``llm_profile_ref``).
+        The single-profile write primitive behind ``profile_refs.cascade_rename``.
+        Self-locks (re-entrant), so the read-modify-write is atomic whether called
+        standalone or nested under the FK helpers' :meth:`lock`. A raw-JSON edit
+        (only the ref field changes), so encrypted ``skills[].mcp_tools`` and the
+        stable ``id`` are untouched and no cipher is needed. No-op when the profile
+        is missing, non-dict, or an ACP profile (which carries no ref).
         """
         path = self._get_profile_path(name)
-        if not path.exists():
-            return
-        try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            return
-        if not isinstance(data, dict):
-            return
-        if data.get("agent_kind", "openhands") != "openhands":
-            return
-        data["llm_profile_ref"] = new_ref
-        self._atomic_write(path, json.dumps(data, indent=2))
+        with self._acquire_lock():
+            if not path.exists():
+                return
+            try:
+                data = json.loads(path.read_text())
+            except (OSError, json.JSONDecodeError):
+                return
+            if not isinstance(data, dict):
+                return
+            if data.get("agent_kind", "openhands") != "openhands":
+                return
+            data["llm_profile_ref"] = new_ref
+            self._atomic_write(path, json.dumps(data, indent=2))
 
     def list_summaries(self) -> list[dict[str, Any]]:
         """Project profile metadata without instantiating secrets.
@@ -359,17 +363,13 @@ class AgentProfileStore:
 
 @runtime_checkable
 class AgentProfileStoreProtocol(Protocol):
-    """Structural contract shared by :class:`AgentProfileStore` (file-backed) and
-    any alternative backend — notably a multi-tenant DB store in the cloud
-    app-server.
+    """Structural contract shared by :class:`AgentProfileStore` and any alternative
+    backend (e.g. a multi-tenant cloud DB store).
 
-    The SDK's store-agnostic helpers — ``profile_refs`` (the LLM-profile FK) and
-    :func:`save_profile_preserving_identity` — are typed against this Protocol so
-    a non-file store reuses them verbatim instead of re-deriving the FK / id
-    lifecycle. :meth:`lock` must be **re-entrant**: the FK helpers nest it around
-    :meth:`list_summaries` / :meth:`set_llm_profile_ref`, and a cloud store whose
-    router already holds a row-level transaction must treat a nested ``lock()``
-    as a no-op rather than deadlocking.
+    The store-agnostic helpers (``profile_refs``,
+    :func:`save_profile_preserving_identity`) are typed against this Protocol.
+    :meth:`lock` must be **re-entrant**: the FK helpers nest it around
+    :meth:`list_summaries` / :meth:`set_llm_profile_ref`.
     """
 
     def lock(self, timeout: float = ...) -> AbstractContextManager[None]: ...
@@ -429,16 +429,12 @@ def save_profile_preserving_identity(
 ) -> OpenHandsAgentProfile | ACPAgentProfile:
     """Save ``profile`` with the server-managed id/revision policy.
 
-    Hoisted from the agent-server router so the file store and a cloud DB store
-    stamp identity identically (the active pointer is keyed on the id):
-
-    * **overwrite** a namesake → keep its stable ``id``, set
-      ``revision = prev + 1``;
+    * **overwrite** a namesake → keep its stable ``id``, ``revision = prev + 1``;
     * **create** → mint a fresh ``uuid4`` (ignoring any client-supplied id).
 
-    The read → stamp → save runs under :meth:`~AgentProfileStoreProtocol.lock`
-    so two concurrent creates of the same new name can't both mint an id and
-    clobber each other. Returns the saved profile (final ``id`` / ``revision``).
+    Runs under :meth:`~AgentProfileStoreProtocol.lock` so concurrent creates of
+    the same name can't both mint an id and clobber each other. Returns the saved
+    profile.
 
     Raises:
         ProfileLimitExceeded: If ``max_profiles`` would be exceeded.

--- a/openhands-sdk/openhands/sdk/profiles/profile_refs.py
+++ b/openhands-sdk/openhands/sdk/profiles/profile_refs.py
@@ -1,30 +1,17 @@
 """Foreign-key lifecycle between LLM profiles and ``AgentProfile``\\ s.
 
 An ``OpenHandsAgentProfile.llm_profile_ref`` is a soft FK onto an LLM-profile
-store key. This module keeps that FK from dangling:
+store key. ``find_referrers`` / ``cascade_rename`` / ``delete_llm_profile`` /
+``rename_llm_profile`` keep that FK from dangling.
 
-* :func:`find_referrers` — which agent profiles cite a given LLM profile.
-* :func:`cascade_rename` — rewrite every matching ``llm_profile_ref`` in lock-step
-  with an LLM-profile rename.
-* :func:`delete_llm_profile` / :func:`rename_llm_profile` — guarded cross-store
-  operations that raise :class:`ProfileReferenced` (routers map → 409) or cascade.
+Store-agnostic: these touch the agent-profile store only through
+:class:`~openhands.sdk.profiles.agent_profile_store.AgentProfileStoreProtocol`,
+never the filesystem, so the file store and a cloud DB store reuse them verbatim.
 
-These functions are **store-agnostic**: they touch the agent-profile store only
-through :class:`~openhands.sdk.profiles.agent_profile_store.AgentProfileStoreProtocol`
-(``lock`` / ``list_summaries`` / ``set_llm_profile_ref``), never the filesystem,
-so the file store and a cloud DB-backed store reuse the same FK logic verbatim.
-
-Lock acquisition order — **agent-profiles, then llm-profiles.**
-A guarded delete/rename holds the *agent-profiles* lock across the whole
-"scan referrers → mutate the LLM profile" window, so no concurrent
-``AgentProfileStore.save`` can introduce a new referrer between the check and
-the mutation (the TOCTOU this module exists to close). ``lock()`` is re-entrant.
-Always take the agent-profiles lock first; never the reverse, or two callers
-could deadlock.
-
-Scope: the FK covers ``llm_profile_ref`` only. ``mcp_server_refs`` are keys into
-the user's independently-mutable global ``mcp_config`` and are checked at
-resolve-time (#3717), not constrained here.
+Lock order: agent-profiles before llm-profiles (never the reverse — deadlock).
+A guarded delete/rename holds the re-entrant agent-profiles ``lock()`` across the
+whole scan→mutate window to close the TOCTOU. The FK covers ``llm_profile_ref``
+only; ``mcp_server_refs`` are checked at resolve-time (#3717).
 """
 
 from __future__ import annotations

--- a/openhands-sdk/openhands/sdk/profiles/profile_refs.py
+++ b/openhands-sdk/openhands/sdk/profiles/profile_refs.py
@@ -9,13 +9,18 @@ store key. This module keeps that FK from dangling:
 * :func:`delete_llm_profile` / :func:`rename_llm_profile` — guarded cross-store
   operations that raise :class:`ProfileReferenced` (routers map → 409) or cascade.
 
+These functions are **store-agnostic**: they touch the agent-profile store only
+through :class:`~openhands.sdk.profiles.agent_profile_store.AgentProfileStoreProtocol`
+(``lock`` / ``list_summaries`` / ``set_llm_profile_ref``), never the filesystem,
+so the file store and a cloud DB-backed store reuse the same FK logic verbatim.
+
 Lock acquisition order — **agent-profiles, then llm-profiles.**
-The two stores are HOME-rooted but independent (each has its own file lock).
 A guarded delete/rename holds the *agent-profiles* lock across the whole
 "scan referrers → mutate the LLM profile" window, so no concurrent
 ``AgentProfileStore.save`` can introduce a new referrer between the check and
-the mutation (the TOCTOU this module exists to close). Always take the
-agent-profiles lock first; never the reverse, or two callers could deadlock.
+the mutation (the TOCTOU this module exists to close). ``lock()`` is re-entrant.
+Always take the agent-profiles lock first; never the reverse, or two callers
+could deadlock.
 
 Scope: the FK covers ``llm_profile_ref`` only. ``mcp_server_refs`` are keys into
 the user's independently-mutable global ``mcp_config`` and are checked at
@@ -24,7 +29,6 @@ resolve-time (#3717), not constrained here.
 
 from __future__ import annotations
 
-import json
 from typing import TYPE_CHECKING
 
 from openhands.sdk.logger import get_logger
@@ -32,8 +36,8 @@ from openhands.sdk.profiles.agent_profile_store import PROFILE_NAME_REGEX
 
 
 if TYPE_CHECKING:
-    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-    from openhands.sdk.profiles.agent_profile_store import AgentProfileStore
+    from openhands.sdk.llm.llm_profile_store import LLMProfileMutator
+    from openhands.sdk.profiles.agent_profile_store import AgentProfileStoreProtocol
 
 logger = get_logger(__name__)
 
@@ -60,71 +64,56 @@ def _validate_name(name: str) -> None:
         raise ValueError(f"Invalid profile name: {name!r}.")
 
 
-def _scan_referrers(store: AgentProfileStore, llm_profile_name: str) -> list[str]:
-    """Return citing agent-profile names. Caller must hold the store lock.
+def _scan_referrers(
+    store: AgentProfileStoreProtocol, llm_profile_name: str
+) -> list[str]:
+    """Return citing agent-profile names. Caller must hold :meth:`store.lock`.
 
-    Reads JSON directly (no validation/secret instantiation). Non-dict and
-    corrupt files are skipped.
+    Reads metadata via ``list_summaries`` (no validation / secret
+    instantiation). Only the OpenHands variant carries ``llm_profile_ref``.
     """
-    referrers: list[str] = []
-    for path in sorted(store.base_dir.glob("*.json")):
-        if not PROFILE_NAME_REGEX.match(path.stem):
-            continue
-        try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(data, dict):
-            continue
-        # agent_kind defaults to "openhands"; only that variant has the ref.
-        if data.get("agent_kind", "openhands") != "openhands":
-            continue
-        if data.get("llm_profile_ref") == llm_profile_name:
-            referrers.append(path.stem)
-    return referrers
+    return [
+        str(summary["name"])
+        for summary in store.list_summaries()
+        if summary.get("agent_kind", "openhands") == "openhands"
+        and summary.get("llm_profile_ref") == llm_profile_name
+    ]
 
 
-def _rewrite_refs(store: AgentProfileStore, old_name: str, new_name: str) -> list[str]:
+def _rewrite_refs(
+    store: AgentProfileStoreProtocol, old_name: str, new_name: str
+) -> list[str]:
     """Repoint every ``llm_profile_ref == old_name`` to ``new_name``.
 
-    Caller must hold the store lock. Surgical raw-JSON edit: only the ref field
-    changes, so encrypted ``mcp_tools`` and the stable ``id`` are untouched and
+    Caller must hold :meth:`store.lock`. Finds referrers via ``list_summaries``
+    and applies the store's surgical ``set_llm_profile_ref`` write primitive per
+    profile, so encrypted ``mcp_tools`` and the stable ``id`` are untouched and
     no cipher is needed. Returns the names of the rewritten profiles.
     """
-    rewritten: list[str] = []
-    for path in sorted(store.base_dir.glob("*.json")):
-        if not PROFILE_NAME_REGEX.match(path.stem):
-            continue
-        try:
-            data = json.loads(path.read_text())
-        except (OSError, json.JSONDecodeError):
-            continue
-        if not isinstance(data, dict):
-            continue
-        if data.get("agent_kind", "openhands") != "openhands":
-            continue
-        if data.get("llm_profile_ref") != old_name:
-            continue
-        data["llm_profile_ref"] = new_name
-        store._atomic_write(path, json.dumps(data, indent=2))
-        rewritten.append(path.stem)
+    rewritten = _scan_referrers(store, old_name)
+    for name in rewritten:
+        store.set_llm_profile_ref(name, new_name)
     return rewritten
 
 
-def find_referrers(store: AgentProfileStore, llm_profile_name: str) -> list[str]:
+def find_referrers(
+    store: AgentProfileStoreProtocol, llm_profile_name: str
+) -> list[str]:
     """Names of the agent profiles whose ``llm_profile_ref == llm_profile_name``."""
-    with store._acquire_lock():
+    with store.lock():
         return _scan_referrers(store, llm_profile_name)
 
 
-def cascade_rename(store: AgentProfileStore, old_name: str, new_name: str) -> list[str]:
+def cascade_rename(
+    store: AgentProfileStoreProtocol, old_name: str, new_name: str
+) -> list[str]:
     """Atomically repoint all ``llm_profile_ref == old_name`` to ``new_name``.
 
     Holds the agent-profiles lock for the whole scan-and-rewrite, so concurrent
     saves cannot interleave. Returns the rewritten profile names.
     """
     _validate_name(new_name)
-    with store._acquire_lock():
+    with store.lock():
         rewritten = _rewrite_refs(store, old_name, new_name)
     if rewritten:
         logger.info(
@@ -135,8 +124,8 @@ def cascade_rename(store: AgentProfileStore, old_name: str, new_name: str) -> li
 
 
 def delete_llm_profile(
-    agent_store: AgentProfileStore,
-    llm_store: LLMProfileStore,
+    agent_store: AgentProfileStoreProtocol,
+    llm_store: LLMProfileMutator,
     llm_profile_name: str,
 ) -> None:
     """Delete an LLM profile only if no agent profile references it.
@@ -146,7 +135,7 @@ def delete_llm_profile(
     the agent-profiles-before-llm-profiles order. Raises
     :class:`ProfileReferenced` naming the referrers if any exist.
     """
-    with agent_store._acquire_lock():
+    with agent_store.lock():
         referrers = _scan_referrers(agent_store, llm_profile_name)
         if referrers:
             raise ProfileReferenced(referrers)
@@ -154,8 +143,8 @@ def delete_llm_profile(
 
 
 def rename_llm_profile(
-    agent_store: AgentProfileStore,
-    llm_store: LLMProfileStore,
+    agent_store: AgentProfileStoreProtocol,
+    llm_store: LLMProfileMutator,
     old_name: str,
     new_name: str,
 ) -> list[str]:
@@ -168,6 +157,6 @@ def rename_llm_profile(
     the rewritten agent-profile names.
     """
     _validate_name(new_name)
-    with agent_store._acquire_lock():
+    with agent_store.lock():
         llm_store.rename(old_name, new_name)
         return _rewrite_refs(agent_store, old_name, new_name)

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -45,7 +45,7 @@ from openhands.sdk.utils.pydantic_secrets import (
 
 if TYPE_CHECKING:
     from openhands.sdk.llm.llm import LLM
-    from openhands.sdk.llm.llm_profile_store import LLMProfileStore
+    from openhands.sdk.llm.llm_profile_store import LLMProfileLoader
     from openhands.sdk.utils.cipher import Cipher
 
 
@@ -266,7 +266,7 @@ def _build_acp_settings(
 def resolve_agent_profile(
     profile: OpenHandsAgentProfile | ACPAgentProfile,
     *,
-    llm_store: LLMProfileStore,
+    llm_store: LLMProfileLoader,
     mcp_config: MCPConfig | None,
     cipher: Cipher | None = None,
 ) -> AgentSettingsConfig:
@@ -300,7 +300,7 @@ def resolve_agent_profile(
 def resolve_agent_profile_dry_run(
     profile: OpenHandsAgentProfile | ACPAgentProfile,
     *,
-    llm_store: LLMProfileStore,
+    llm_store: LLMProfileLoader,
     mcp_config: MCPConfig | None,
     cipher: Cipher | None = None,
 ) -> AgentProfileDiagnostics:

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -1,0 +1,77 @@
+"""Seed an :class:`~openhands.sdk.profiles.AgentProfile` from live settings.
+
+The inverse of :func:`~openhands.sdk.profiles.resolve_agent_profile`: given the
+current ``AgentSettingsConfig``, build the single default profile used by the
+one-time migration (lazily on the local agent-server, as an eager backfill on
+the cloud app-server). Hoisted out of the agent-server router so both surfaces
+seed identically — see epic #3713.
+"""
+
+from __future__ import annotations
+
+import shlex
+from typing import TYPE_CHECKING
+
+from openhands.sdk.profiles.agent_profile import (
+    ACPAgentProfile,
+    OpenHandsAgentProfile,
+    build_profile_verification,
+)
+
+
+if TYPE_CHECKING:
+    from openhands.sdk.settings import AgentSettingsConfig
+
+
+# Name of the lazily-seeded default / migration profile and the soft LLM-ref
+# fallback (a "default" LLM profile the resolver checks at materialize time).
+SEED_PROFILE_NAME = "default"
+
+
+def build_seed_profile(
+    agent_settings: AgentSettingsConfig,
+    active_llm_profile: str | None,
+    *,
+    name: str = SEED_PROFILE_NAME,
+) -> OpenHandsAgentProfile | ACPAgentProfile:
+    """Build one ``AgentProfile`` faithfully from the current ``agent_settings``.
+
+    Carries every cleanly-overlapping launch field so the migrated profile is a
+    behavior-preserving representation of the user's current configuration (the
+    active pointer is otherwise just a lightweight id). Branches on
+    ``agent_kind`` so an ACP setup seeds an ACP profile (not a wrong OpenHands
+    one). ``mcp_server_refs=None`` exposes all of the user's MCP servers. An
+    OpenHands profile references the active LLM profile, falling back to
+    ``SEED_PROFILE_NAME`` when none is set (a soft ref the resolver checks at
+    materialize time).
+    """
+    if agent_settings.agent_kind == "acp":
+        return ACPAgentProfile(
+            name=name,
+            acp_server=agent_settings.acp_server,
+            acp_model=agent_settings.acp_model,
+            acp_session_mode=agent_settings.acp_session_mode,
+            acp_prompt_timeout=agent_settings.acp_prompt_timeout,
+            # Settings store the command as a token list; the profile holds a
+            # single (re-parseable) string. Empty list => use the server default.
+            acp_command=(
+                shlex.join(agent_settings.acp_command)
+                if agent_settings.acp_command
+                else None
+            ),
+            acp_args=list(agent_settings.acp_args) or None,
+            mcp_server_refs=None,
+        )
+    context = agent_settings.agent_context
+    return OpenHandsAgentProfile(
+        name=name,
+        llm_profile_ref=active_llm_profile or SEED_PROFILE_NAME,
+        agent=agent_settings.agent,
+        skills=list(context.skills),
+        system_message_suffix=context.system_message_suffix,
+        condenser=agent_settings.condenser,
+        verification=build_profile_verification(agent_settings.verification),
+        enable_sub_agents=agent_settings.enable_sub_agents,
+        tool_concurrency_limit=agent_settings.tool_concurrency_limit,
+        mcp_server_refs=None,
+    )

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -1,10 +1,8 @@
-"""Seed an :class:`~openhands.sdk.profiles.AgentProfile` from live settings.
+"""Build the default :class:`~openhands.sdk.profiles.AgentProfile` from live settings.
 
-The inverse of :func:`~openhands.sdk.profiles.resolve_agent_profile`: given the
-current ``AgentSettingsConfig``, build the single default profile used by the
-one-time migration (lazily on the local agent-server, as an eager backfill on
-the cloud app-server). Hoisted out of the agent-server router so both surfaces
-seed identically — see epic #3713.
+The inverse of :func:`~openhands.sdk.profiles.resolve_agent_profile`: turns the
+current ``AgentSettingsConfig`` into the single profile used by the one-time
+migration (lazy on the local agent-server, eager backfill on the cloud one).
 """
 
 from __future__ import annotations
@@ -34,16 +32,12 @@ def build_seed_profile(
     *,
     name: str = SEED_PROFILE_NAME,
 ) -> OpenHandsAgentProfile | ACPAgentProfile:
-    """Build one ``AgentProfile`` faithfully from the current ``agent_settings``.
+    """Build one behavior-preserving ``AgentProfile`` from ``agent_settings``.
 
-    Carries every cleanly-overlapping launch field so the migrated profile is a
-    behavior-preserving representation of the user's current configuration (the
-    active pointer is otherwise just a lightweight id). Branches on
-    ``agent_kind`` so an ACP setup seeds an ACP profile (not a wrong OpenHands
-    one). ``mcp_server_refs=None`` exposes all of the user's MCP servers. An
-    OpenHands profile references the active LLM profile, falling back to
-    ``SEED_PROFILE_NAME`` when none is set (a soft ref the resolver checks at
-    materialize time).
+    Branches on ``agent_kind`` so an ACP setup seeds an ACP profile.
+    ``mcp_server_refs=None`` exposes all of the user's MCP servers; an OpenHands
+    profile references ``active_llm_profile``, falling back to
+    ``SEED_PROFILE_NAME`` (a soft ref the resolver checks at materialize time).
     """
     if agent_settings.agent_kind == "acp":
         return ACPAgentProfile(

--- a/tests/sdk/profiles/test_store_protocol_hoists.py
+++ b/tests/sdk/profiles/test_store_protocol_hoists.py
@@ -1,0 +1,295 @@
+"""The store-agnostic prereqs for the cloud AgentProfiles surface (#3730).
+
+Proves the FK helpers (``profile_refs``), the id/revision lifecycle
+(``save_profile_preserving_identity``), and the seed/422 hoists work against a
+**non-file** store — i.e. a backend that satisfies ``AgentProfileStoreProtocol``
+without ``base_dir`` / ``_atomic_write``, the way a cloud DB-backed store will.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from typing import Any
+
+import pytest
+
+from openhands.sdk.profiles import (
+    SEED_PROFILE_NAME,
+    ACPAgentProfile,
+    AgentProfileStoreProtocol,
+    OpenHandsAgentProfile,
+    ProfileLimitExceeded,
+    ProfileReferenced,
+    ProfileVerificationSettings,
+    build_profile_verification,
+    build_seed_profile,
+    cascade_rename,
+    delete_llm_profile,
+    find_referrers,
+    rename_llm_profile,
+    safe_validation_error_detail,
+    save_profile_preserving_identity,
+    validate_agent_profile,
+)
+from openhands.sdk.settings.model import VerificationSettings, validate_agent_settings
+
+
+class InMemoryAgentProfileStore:
+    """Minimal non-file ``AgentProfileStoreProtocol`` impl (the cloud envelope).
+
+    Holds profiles in a dict keyed by name, exposes the metadata + write
+    primitives the SDK FK / identity helpers need, and provides a re-entrant
+    no-op ``lock`` (a cloud store's router holds the row transaction instead).
+    """
+
+    def __init__(self) -> None:
+        self._profiles: dict[str, OpenHandsAgentProfile | ACPAgentProfile] = {}
+
+    @contextmanager
+    def lock(self, timeout: float = 30.0):
+        yield  # re-entrant no-op
+
+    def list(self) -> list[str]:
+        return [f"{name}.json" for name in self._profiles]
+
+    def list_summaries(self) -> list[dict[str, Any]]:
+        out: list[dict[str, Any]] = []
+        for name, p in self._profiles.items():
+            d = p.model_dump(mode="json")
+            kind = d.get("agent_kind", "openhands")
+            out.append(
+                {
+                    "id": d.get("id"),
+                    "name": name,
+                    "agent_kind": kind,
+                    "revision": d.get("revision"),
+                    "llm_profile_ref": (
+                        d.get("llm_profile_ref") if kind == "openhands" else None
+                    ),
+                    "mcp_server_refs": d.get("mcp_server_refs"),
+                }
+            )
+        return out
+
+    def save(self, profile, *, cipher=None, max_profiles=None) -> None:
+        if (
+            max_profiles is not None
+            and profile.name not in self._profiles
+            and len(self._profiles) >= max_profiles
+        ):
+            raise ProfileLimitExceeded(f"Profile limit reached ({max_profiles}).")
+        self._profiles[profile.name] = profile
+
+    def load(self, name, *, cipher=None):
+        if name not in self._profiles:
+            raise FileNotFoundError(name)
+        return self._profiles[name]
+
+    def delete(self, name) -> None:
+        self._profiles.pop(name, None)
+
+    def rename(self, old_name, new_name) -> None:
+        if old_name not in self._profiles:
+            raise FileNotFoundError(old_name)
+        if new_name in self._profiles:
+            raise FileExistsError(new_name)
+        p = self._profiles.pop(old_name)
+        self._profiles[new_name] = p.model_copy(update={"name": new_name})
+
+    def set_llm_profile_ref(self, name, new_ref) -> None:
+        p = self._profiles.get(name)
+        if isinstance(p, OpenHandsAgentProfile):
+            self._profiles[name] = p.model_copy(update={"llm_profile_ref": new_ref})
+
+    def name_for_id(self, profile_id) -> str | None:
+        target = str(profile_id)
+        for name, p in self._profiles.items():
+            if str(p.id) == target:
+                return name
+        return None
+
+
+class FakeLLMStore:
+    """Stub LLM store exposing only ``delete`` / ``rename`` for the FK helpers."""
+
+    def __init__(self, names: list[str]) -> None:
+        self.names = list(names)
+
+    def delete(self, name: str) -> None:
+        if name in self.names:
+            self.names.remove(name)
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        if old_name not in self.names:
+            raise FileNotFoundError(old_name)
+        self.names[self.names.index(old_name)] = new_name
+
+
+def _seed(store: InMemoryAgentProfileStore) -> None:
+    save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="reviewer", llm_profile_ref="gpt")
+    )
+    save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="coder", llm_profile_ref="gpt")
+    )
+    save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="cheap", llm_profile_ref="haiku")
+    )
+    save_profile_preserving_identity(
+        store, ACPAgentProfile(name="claude", acp_server="claude-code")
+    )
+
+
+def test_inmemory_store_satisfies_protocol():
+    # runtime_checkable: a non-file backend is structurally interchangeable.
+    assert isinstance(InMemoryAgentProfileStore(), AgentProfileStoreProtocol)
+
+
+def test_find_referrers_over_protocol_store():
+    store = InMemoryAgentProfileStore()
+    _seed(store)
+    assert sorted(find_referrers(store, "gpt")) == ["coder", "reviewer"]
+    assert find_referrers(store, "haiku") == ["cheap"]
+    # ACP profiles carry no llm_profile_ref and never match.
+    assert find_referrers(store, "claude-code") == []
+    assert find_referrers(store, "missing") == []
+
+
+def test_cascade_rename_over_protocol_store():
+    store = InMemoryAgentProfileStore()
+    _seed(store)
+    rewritten = cascade_rename(store, "gpt", "gpt-5")
+    assert sorted(rewritten) == ["coder", "reviewer"]
+    assert find_referrers(store, "gpt") == []
+    assert sorted(find_referrers(store, "gpt-5")) == ["coder", "reviewer"]
+    # The unrelated ref is untouched.
+    assert find_referrers(store, "haiku") == ["cheap"]
+
+
+def test_delete_llm_profile_blocks_on_referrers():
+    store = InMemoryAgentProfileStore()
+    _seed(store)
+    llm_store = FakeLLMStore(["gpt", "haiku"])
+    # 'gpt' is referenced by reviewer + coder -> blocked, llm profile untouched.
+    with pytest.raises(ProfileReferenced) as exc:
+        delete_llm_profile(store, llm_store, "gpt")
+    assert sorted(exc.value.referrers) == ["coder", "reviewer"]
+    assert "gpt" in llm_store.names
+
+    # Detach the referrers; the delete then goes through.
+    store.delete("reviewer")
+    store.delete("coder")
+    delete_llm_profile(store, llm_store, "gpt")
+    assert "gpt" not in llm_store.names
+
+
+def test_rename_llm_profile_cascades_over_protocol_store():
+    store = InMemoryAgentProfileStore()
+    _seed(store)
+    llm_store = FakeLLMStore(["gpt", "haiku"])
+    rewritten = rename_llm_profile(store, llm_store, "gpt", "gpt-5")
+    assert sorted(rewritten) == ["coder", "reviewer"]
+    assert "gpt-5" in llm_store.names and "gpt" not in llm_store.names
+    assert sorted(find_referrers(store, "gpt-5")) == ["coder", "reviewer"]
+
+
+def test_save_preserving_identity_mints_then_keeps_id_and_bumps_revision():
+    store = InMemoryAgentProfileStore()
+    created = save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="p", llm_profile_ref="gpt")
+    )
+    assert created.revision == 0
+    first_id = created.id
+
+    # Overwrite keeps the id and bumps revision; a client-supplied id is ignored.
+    again = save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="p", llm_profile_ref="haiku")
+    )
+    assert again.id == first_id
+    assert again.revision == 1
+    reloaded = store.load("p")
+    assert isinstance(reloaded, OpenHandsAgentProfile)
+    assert reloaded.llm_profile_ref == "haiku"
+
+    # A different name mints a fresh id.
+    other = save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="q", llm_profile_ref="gpt")
+    )
+    assert other.id != first_id
+    assert other.revision == 0
+
+
+def test_save_preserving_identity_enforces_limit():
+    store = InMemoryAgentProfileStore()
+    save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="a", llm_profile_ref="gpt"), max_profiles=1
+    )
+    with pytest.raises(ProfileLimitExceeded):
+        save_profile_preserving_identity(
+            store,
+            OpenHandsAgentProfile(name="b", llm_profile_ref="gpt"),
+            max_profiles=1,
+        )
+    # Overwriting the existing one is allowed at the cap.
+    save_profile_preserving_identity(
+        store, OpenHandsAgentProfile(name="a", llm_profile_ref="haiku"), max_profiles=1
+    )
+
+
+def test_build_seed_profile_openhands_branch():
+    settings = validate_agent_settings({"agent_kind": "openhands"})
+    profile = build_seed_profile(settings, active_llm_profile="my-llm")
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.name == SEED_PROFILE_NAME
+    assert profile.llm_profile_ref == "my-llm"
+    assert profile.mcp_server_refs is None
+    # Secret-free verification projection (no critic_api_key on the profile type).
+    assert "critic_api_key" not in type(profile.verification).model_fields
+
+    # No active LLM profile -> soft fallback to SEED_PROFILE_NAME.
+    fallback = build_seed_profile(settings, active_llm_profile=None)
+    assert isinstance(fallback, OpenHandsAgentProfile)
+    assert fallback.llm_profile_ref == SEED_PROFILE_NAME
+
+
+def test_build_seed_profile_acp_branch():
+    settings = validate_agent_settings(
+        {"agent_kind": "acp", "acp_server": "claude-code"}
+    )
+    profile = build_seed_profile(settings, active_llm_profile="ignored")
+    assert isinstance(profile, ACPAgentProfile)
+    assert profile.name == SEED_PROFILE_NAME
+    assert profile.acp_server == "claude-code"
+    assert profile.mcp_server_refs is None
+    assert not hasattr(profile, "llm_profile_ref")
+
+
+def test_build_profile_verification_drops_critic_api_key():
+    v = VerificationSettings(
+        critic_enabled=True,
+        critic_threshold=0.9,
+        critic_model_name="some-model",
+    )
+    projected = build_profile_verification(v)
+    assert isinstance(projected, ProfileVerificationSettings)
+    assert projected.critic_enabled is True
+    assert projected.critic_threshold == 0.9
+    assert projected.critic_model_name == "some-model"
+    assert "critic_api_key" not in ProfileVerificationSettings.model_fields
+
+
+def test_safe_validation_error_detail_is_secret_safe():
+    secret = "sk-super-secret-value"
+    with pytest.raises(Exception) as exc_info:
+        # extra=forbid -> the unexpected key (carrying a secret) triggers a
+        # ValidationError that embeds the input in msg/input.
+        validate_agent_profile({"name": "p", "llm_profile_ref": "gpt", "leak": secret})
+    from pydantic import ValidationError
+
+    assert isinstance(exc_info.value, ValidationError)
+    detail = safe_validation_error_detail(exc_info.value)
+    assert detail, "expected at least one error entry"
+    for entry in detail:
+        assert set(entry.keys()) == {"loc", "type"}
+    # The secret never appears in the redacted detail.
+    assert secret not in repr(detail)


### PR DESCRIPTION
HUMAN:

SDK prerequisite for the cloud AgentProfiles surface (OpenHands/OpenHands#15044, umbrella #3730). This is a pure refactor + new store-agnostic abstractions — the local agent-server behavior is unchanged (the full existing `tests/sdk/profiles` + `tests/agent_server` profile suites pass untouched), and the new cloud-reuse path is exercised by a non-file store test. Reviewed the diff end-to-end.

AGENT:

Implements the **prerequisite SDK refactor** from OpenHands/OpenHands#15044 (the cloud AgentProfiles implementation) so the cloud diff can be a thin store + auth + wiring shim per the [thin-boundary contract](https://github.com/OpenHands/software-agent-sdk/issues/3730#issuecomment-4841528619), instead of re-deriving the resolve / FK / seed / identity logic. Today those helpers are either file-coupled or live only in the agent-server router, so a multi-tenant DB-backed store can't reuse them.

Closes the "Prerequisite SDK work" section of OpenHands/OpenHands#15044. No cloud or canvas code here.

## Why

The cloud (SaaS) AgentProfiles store is a single encrypted JSON envelope on the `org` row, mutated under a DB row-lock — not one file per profile under `~/.openhands`. But the SDK's FK lifecycle (`profile_refs`) reaches into file internals (`store.base_dir.glob("*.json")`, `store._atomic_write`), and the seed / id-stamping / 422-shaping live only in `openhands-agent-server/.../agent_profiles_router.py`. So without this PR, the cloud router would have to **re-implement** the delete-409 / cascade-rename / mint-id / seed logic — exactly what the thin-boundary contract forbids. This PR extracts the store contract as a Protocol and hoists the router-only helpers into the SDK so **both** the local file store and a cloud DB store reuse them verbatim.

## Summary

**Store-agnostic FK + Protocol** (`agent_profile_store.py`, `profile_refs.py`)
- New `AgentProfileStoreProtocol` (`@runtime_checkable`) — the structural contract (`lock` / `list` / `list_summaries` / `save` / `load` / `delete` / `rename` / `set_llm_profile_ref` / `name_for_id`) shared by the file store and any backend.
- Added a public re-entrant `lock()` + a surgical `set_llm_profile_ref()` write primitive to the concrete `AgentProfileStore`.
- Rewrote `profile_refs._scan_referrers` / `_rewrite_refs` to go through `list_summaries()` + `set_llm_profile_ref()` + `lock()` — **no filesystem access**. `find_referrers` / `cascade_rename` / `delete_llm_profile` / `rename_llm_profile` keep the same public signatures.

**Hoisted router helpers → SDK**
- `build_seed_profile` + `build_profile_verification` (new `seed.py` / `agent_profile.py`) — the settings→profile seed, kind-aware, secret-free verification projection.
- `save_profile_preserving_identity` (`agent_profile_store.py`) — the mint-on-create / keep-id-on-overwrite / bump-revision policy, under `lock()`.
- `safe_validation_error_detail` (`agent_profile.py`) — the secret-safe 422 detail (`loc`/`type` only, drops `msg`/`input`).

**Resolver / FK injectability** (`resolver.py`, `llm_profile_store.py`)
- Added `LLMProfileLoader` (load-only) + `LLMProfileMutator` (delete/rename) Protocols and retyped `resolve_agent_profile` / `resolve_agent_profile_dry_run` / `delete_llm_profile` / `rename_llm_profile` to them, so a cloud adapter over `org.llm_profiles` is type-clean without subclassing the file store.

**Local router refactor** (`agent_profiles_router.py`)
- Now delegates to the hoisted helpers; ~120 lines of duplicated logic deleted. Behavior unchanged (proven by the existing suite).

**Deferred (noted, not in scope):** unifying the router's `_decrypt_profile_mcp_tools` with the resolver's `_decrypt_skill_mcp_tools` — it's tied to the `X-Expose-Secrets` round-trip and is left router-side for a follow-up.

## How to Test

```bash
uv run pytest tests/sdk/profiles tests/agent_server/test_agent_profiles_router.py \
  tests/agent_server/test_agent_profile_conv_start.py tests/sdk/llm/test_llm_profile_store.py
uv run pyright openhands-sdk/openhands/sdk/profiles openhands-agent-server/openhands/agent_server/agent_profiles_router.py
uv run ruff check . && uv run ruff format --check .
```

- The full existing profile + router suites pass **unchanged** (behavior-preserving refactor).
- New `tests/sdk/profiles/test_store_protocol_hoists.py` proves the FK helpers (`find_referrers` / `cascade_rename` / `delete_llm_profile` / `rename_llm_profile`), `save_profile_preserving_identity`, `build_seed_profile`, `build_profile_verification`, and `safe_validation_error_detail` all work against a **non-file** `InMemoryAgentProfileStore` — i.e. the cloud DB-store path.

Refs: epic #3713 (Phase 5 / cloud) · umbrella #3730 · thin-boundary contract · OpenHands/OpenHands#15044.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ddaeb85-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ddaeb85-python \
  ghcr.io/openhands/agent-server:ddaeb85-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ddaeb85-golang-amd64
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-golang-amd64
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-golang-amd64
ghcr.io/openhands/agent-server:ddaeb85-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ddaeb85-golang-arm64
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-golang-arm64
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-golang-arm64
ghcr.io/openhands/agent-server:ddaeb85-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ddaeb85-java-amd64
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-java-amd64
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-java-amd64
ghcr.io/openhands/agent-server:ddaeb85-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ddaeb85-java-arm64
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-java-arm64
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-java-arm64
ghcr.io/openhands/agent-server:ddaeb85-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ddaeb85-python-amd64
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-python-amd64
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-python-amd64
ghcr.io/openhands/agent-server:ddaeb85-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ddaeb85-python-arm64
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-python-arm64
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-python-arm64
ghcr.io/openhands/agent-server:ddaeb85-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ddaeb85-golang
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-golang
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-golang
ghcr.io/openhands/agent-server:ddaeb85-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ddaeb85-java
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-java
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-java
ghcr.io/openhands/agent-server:ddaeb85-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ddaeb85-python
ghcr.io/openhands/agent-server:ddaeb85536a2928c60fb85ce323c854376b955a4-python
ghcr.io/openhands/agent-server:agent-profile-store-protocol-hoists-python
ghcr.io/openhands/agent-server:ddaeb85-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ddaeb85-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ddaeb85-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->