### PR TITLE
feat(agent-server): expose repository metadata for workspace archives

### DIFF
--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -336,9 +336,7 @@ def _git_probe(args: list[str], root: Path) -> str:
 
 
 def _header_safe(value: str) -> str:
-    """Percent-encode a value if needed so it is always a legal ASCII header value."""
-    if value.isascii() and value.isprintable():
-        return value
+    """Percent-encode a header value."""
     return quote(value, safe="")
 
 

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -31,16 +31,12 @@ from openhands.agent_server.server_details_router import update_last_execution_t
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import (
     GIT_EMPTY_TREE_HASH,
+    get_git_repository_metadata,
     get_valid_ref,
     run_git_command,
-    run_git_subprocess,
     validate_git_repository,
 )
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils.redact import (
-    redact_url_credentials_in_text,
-    redact_url_params,
-)
 
 
 class SubdirectoryEntry(BaseModel):
@@ -329,37 +325,9 @@ def _head_is_detached(root: Path) -> bool:
     return branch.strip() == "HEAD"
 
 
-def _git_probe(args: list[str], root: Path) -> str:
-    """Run a read-only git probe; never logs or raises, returns "" on any failure."""
-    try:
-        result = run_git_subprocess(["git", "--no-pager", *args], root, timeout=30)
-    except (OSError, subprocess.SubprocessError):
-        return ""
-    return result.stdout.strip() if result.returncode == 0 else ""
-
-
 def _header_safe(value: str) -> str:
     """Percent-encode a header value."""
     return quote(value, safe="")
-
-
-def _git_repo_metadata(root: Path) -> dict[str, str]:
-    """Best-effort repo identity headers (remote/branch/HEAD) for the archived tree."""
-    metadata: dict[str, str] = {}
-    remote = _git_probe(["remote", "get-url", "origin"], root)
-    if remote:
-        metadata["X-Archive-Repo-Remote"] = redact_url_params(
-            redact_url_credentials_in_text(remote)
-        )
-    # Combine into one call: --abbrev-ref only applies to args after it, so the
-    # first HEAD stays a full sha while the second is abbreviated to the branch.
-    head_and_branch = _git_probe(["rev-parse", "HEAD", "--abbrev-ref", "HEAD"], root)
-    lines = head_and_branch.splitlines()
-    if len(lines) == 2:
-        head, branch = lines
-        metadata["X-Archive-Head-Commit"] = head
-        metadata["X-Archive-Branch"] = "DETACHED" if branch == "HEAD" else branch
-    return {k: _header_safe(v) for k, v in metadata.items()}
 
 
 def _create_git_delta(
@@ -1016,7 +984,14 @@ async def archive_directory(
     # git-delta-only (they describe the patch's replay base).
     headers: dict[str, str] = {}
     if (repo_root / ".git").exists():
-        headers.update(await asyncio.to_thread(_git_repo_metadata, repo_root))
+        repo_metadata = await asyncio.to_thread(get_git_repository_metadata, repo_root)
+        for key, header in (
+            ("repo_remote", "X-Archive-Repo-Remote"),
+            ("branch", "X-Archive-Branch"),
+            ("head_commit", "X-Archive-Head-Commit"),
+        ):
+            if value := repo_metadata.get(key):
+                headers[header] = _header_safe(value)
         headers["X-Archive-Repo-Root"] = _header_safe(str(repo_root))
     if base_commit:
         # Make a git-delta self-describing so consumers can replay the patch.

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -35,6 +35,7 @@ from openhands.sdk.git.utils import (
     validate_git_repository,
 )
 from openhands.sdk.logger import get_logger
+from openhands.sdk.utils.redact import redact_url_credentials
 
 
 class SubdirectoryEntry(BaseModel):
@@ -321,6 +322,49 @@ def _head_is_detached(root: Path) -> bool:
     except GitCommandError:
         return False
     return branch.strip() == "HEAD"
+
+
+def _git_probe(args: list[str], root: Path) -> str:
+    """Run a read-only git probe, returning stripped stdout or ``""``.
+
+    Unlike ``run_git_command`` this never logs or raises on a non-zero exit:
+    a repo with no ``origin`` remote, a detached HEAD, or no commits is the
+    expected case here, not an error worth surfacing.
+    """
+    try:
+        result = subprocess.run(
+            ["git", "--no-pager", *args],
+            cwd=root,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def _git_repo_metadata(root: Path) -> dict[str, str]:
+    """Best-effort repo identity headers for the archived work-tree.
+
+    Returns the redacted ``origin`` remote URL, the current branch
+    (``DETACHED`` for a detached HEAD), and the HEAD commit, keyed by response
+    header name. Each value is independently best-effort and omitted when
+    unavailable; values that an HTTP header cannot carry (e.g. a non-ASCII
+    branch name) are dropped so an exotic ref cannot 500 the response.
+    """
+    metadata: dict[str, str] = {}
+    remote = _git_probe(["remote", "get-url", "origin"], root)
+    if remote:
+        metadata["X-Archive-Repo-Remote"] = redact_url_credentials(remote)
+    branch = _git_probe(["rev-parse", "--abbrev-ref", "HEAD"], root)
+    if branch:
+        metadata["X-Archive-Branch"] = "DETACHED" if branch == "HEAD" else branch
+    head = _git_probe(["rev-parse", "HEAD"], root)
+    if head:
+        metadata["X-Archive-Head-Commit"] = head
+    return {k: v for k, v in metadata.items() if v.isascii()}
 
 
 def _create_git_delta(
@@ -972,13 +1016,16 @@ async def archive_directory(
             detail=f"Failed to archive directory: {str(e)}",
         )
 
-    headers: dict[str, str] | None = None
+    # Repo identity (remote / branch / HEAD) applies to both formats so a
+    # tar.gz snapshot is self-describing too; base_commit/base_ref are
+    # git-delta-only (they describe the patch's replay base).
+    headers: dict[str, str] = {}
+    if (repo_root / ".git").exists():
+        headers.update(await asyncio.to_thread(_git_repo_metadata, repo_root))
     if base_commit:
         # Make a git-delta self-describing so consumers can replay the patch.
-        headers = {
-            "X-Archive-Base-Commit": base_commit,
-            "X-Archive-Base-Ref": base_ref or "auto",
-        }
+        headers["X-Archive-Base-Commit"] = base_commit
+        headers["X-Archive-Base-Ref"] = base_ref or "auto"
 
     return FileResponse(
         path=output_path,

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -10,6 +10,7 @@ import tempfile
 import zipfile
 from pathlib import Path, PurePosixPath
 from typing import IO, Annotated, Literal
+from urllib.parse import quote
 from uuid import UUID
 
 from fastapi import (
@@ -32,6 +33,7 @@ from openhands.sdk.git.utils import (
     GIT_EMPTY_TREE_HASH,
     get_valid_ref,
     run_git_command,
+    run_git_subprocess,
     validate_git_repository,
 )
 from openhands.sdk.logger import get_logger
@@ -325,46 +327,36 @@ def _head_is_detached(root: Path) -> bool:
 
 
 def _git_probe(args: list[str], root: Path) -> str:
-    """Run a read-only git probe, returning stripped stdout or ``""``.
-
-    Unlike ``run_git_command`` this never logs or raises on a non-zero exit:
-    a repo with no ``origin`` remote, a detached HEAD, or no commits is the
-    expected case here, not an error worth surfacing.
-    """
+    """Run a read-only git probe; never logs or raises, returns "" on any failure."""
     try:
-        result = subprocess.run(
-            ["git", "--no-pager", *args],
-            cwd=root,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=30,
-        )
+        result = run_git_subprocess(["git", "--no-pager", *args], root, timeout=30)
     except (OSError, subprocess.SubprocessError):
         return ""
     return result.stdout.strip() if result.returncode == 0 else ""
 
 
-def _git_repo_metadata(root: Path) -> dict[str, str]:
-    """Best-effort repo identity headers for the archived work-tree.
+def _header_safe(value: str) -> str:
+    """Percent-encode a value if needed so it is always a legal ASCII header value."""
+    if value.isascii() and value.isprintable():
+        return value
+    return quote(value, safe="")
 
-    Returns the redacted ``origin`` remote URL, the current branch
-    (``DETACHED`` for a detached HEAD), and the HEAD commit, keyed by response
-    header name. Each value is independently best-effort and omitted when
-    unavailable; values that an HTTP header cannot carry (e.g. a non-ASCII
-    branch name) are dropped so an exotic ref cannot 500 the response.
-    """
+
+def _git_repo_metadata(root: Path) -> dict[str, str]:
+    """Best-effort repo identity headers (remote/branch/HEAD) for the archived tree."""
     metadata: dict[str, str] = {}
     remote = _git_probe(["remote", "get-url", "origin"], root)
     if remote:
         metadata["X-Archive-Repo-Remote"] = redact_url_credentials(remote)
-    branch = _git_probe(["rev-parse", "--abbrev-ref", "HEAD"], root)
-    if branch:
-        metadata["X-Archive-Branch"] = "DETACHED" if branch == "HEAD" else branch
-    head = _git_probe(["rev-parse", "HEAD"], root)
-    if head:
+    # Combine into one call: --abbrev-ref only applies to args after it, so the
+    # first HEAD stays a full sha while the second is abbreviated to the branch.
+    head_and_branch = _git_probe(["rev-parse", "HEAD", "--abbrev-ref", "HEAD"], root)
+    lines = head_and_branch.splitlines()
+    if len(lines) == 2:
+        head, branch = lines
         metadata["X-Archive-Head-Commit"] = head
-    return {k: v for k, v in metadata.items() if v.isascii()}
+        metadata["X-Archive-Branch"] = "DETACHED" if branch == "HEAD" else branch
+    return {k: _header_safe(v) for k, v in metadata.items()}
 
 
 def _create_git_delta(

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -37,7 +37,10 @@ from openhands.sdk.git.utils import (
     validate_git_repository,
 )
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils.redact import redact_url_credentials_in_text
+from openhands.sdk.utils.redact import (
+    redact_url_credentials_in_text,
+    redact_url_params,
+)
 
 
 class SubdirectoryEntry(BaseModel):
@@ -345,7 +348,9 @@ def _git_repo_metadata(root: Path) -> dict[str, str]:
     metadata: dict[str, str] = {}
     remote = _git_probe(["remote", "get-url", "origin"], root)
     if remote:
-        metadata["X-Archive-Repo-Remote"] = redact_url_credentials_in_text(remote)
+        metadata["X-Archive-Repo-Remote"] = redact_url_params(
+            redact_url_credentials_in_text(remote)
+        )
     # Combine into one call: --abbrev-ref only applies to args after it, so the
     # first HEAD stays a full sha while the second is abbreviated to the branch.
     head_and_branch = _git_probe(["rev-parse", "HEAD", "--abbrev-ref", "HEAD"], root)
@@ -1012,6 +1017,7 @@ async def archive_directory(
     headers: dict[str, str] = {}
     if (repo_root / ".git").exists():
         headers.update(await asyncio.to_thread(_git_repo_metadata, repo_root))
+        headers["X-Archive-Repo-Root"] = _header_safe(str(repo_root))
     if base_commit:
         # Make a git-delta self-describing so consumers can replay the patch.
         headers["X-Archive-Base-Commit"] = base_commit

--- a/openhands-agent-server/openhands/agent_server/file_router.py
+++ b/openhands-agent-server/openhands/agent_server/file_router.py
@@ -37,7 +37,7 @@ from openhands.sdk.git.utils import (
     validate_git_repository,
 )
 from openhands.sdk.logger import get_logger
-from openhands.sdk.utils.redact import redact_url_credentials
+from openhands.sdk.utils.redact import redact_url_credentials_in_text
 
 
 class SubdirectoryEntry(BaseModel):
@@ -347,7 +347,7 @@ def _git_repo_metadata(root: Path) -> dict[str, str]:
     metadata: dict[str, str] = {}
     remote = _git_probe(["remote", "get-url", "origin"], root)
     if remote:
-        metadata["X-Archive-Repo-Remote"] = redact_url_credentials(remote)
+        metadata["X-Archive-Repo-Remote"] = redact_url_credentials_in_text(remote)
     # Combine into one call: --abbrev-ref only applies to args after it, so the
     # first HEAD stays a full sha while the second is abbreviated to the branch.
     head_and_branch = _git_probe(["rev-parse", "HEAD", "--abbrev-ref", "HEAD"], root)

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -8,6 +8,7 @@ from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.utils.redact import (
     redact_url_credentials,
     redact_url_credentials_in_text,
+    redact_url_params,
 )
 
 
@@ -33,6 +34,34 @@ def run_git_subprocess(
         check=False,
         timeout=timeout,
     )
+
+
+def _run_git_probe(args: list[str], cwd: str | Path) -> str:
+    try:
+        result = run_git_subprocess(["git", "--no-pager", *args], cwd, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return result.stdout.strip() if result.returncode == 0 else ""
+
+
+def get_git_repository_metadata(repo_dir: str | Path) -> dict[str, str]:
+    """Return best-effort repository identity metadata."""
+    metadata: dict[str, str] = {}
+    remote = _run_git_probe(["remote", "get-url", "origin"], repo_dir)
+    if remote:
+        metadata["repo_remote"] = redact_url_params(
+            redact_url_credentials_in_text(remote)
+        )
+
+    head_and_branch = _run_git_probe(
+        ["rev-parse", "HEAD", "--abbrev-ref", "HEAD"], repo_dir
+    )
+    lines = head_and_branch.splitlines()
+    if len(lines) == 2:
+        head, branch = lines
+        metadata["head_commit"] = head
+        metadata["branch"] = "DETACHED" if branch == "HEAD" else branch
+    return metadata
 
 
 def run_git_command(

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -18,6 +18,23 @@ logger = logging.getLogger(__name__)
 GIT_EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
+def run_git_subprocess(
+    args: list[str],
+    cwd: str | Path | None,
+    timeout: int,
+) -> subprocess.CompletedProcess[str]:
+    """Run a subprocess with the capture/decode settings all git callers need."""
+    return subprocess.run(
+        args,
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+        errors="replace",
+        check=False,
+        timeout=timeout,
+    )
+
+
 def run_git_command(
     args: list[str],
     cwd: str | Path | None = None,
@@ -40,14 +57,7 @@ def run_git_command(
     cmd_str = shlex.join(redacted_args)
 
     try:
-        result = subprocess.run(
-            args,
-            cwd=cwd,
-            capture_output=True,
-            text=True,
-            check=False,
-            timeout=timeout,
-        )
+        result = run_git_subprocess(args, cwd, timeout)
 
         if result.returncode != 0:
             error_msg = f"Git command failed: {cmd_str}"

--- a/openhands-sdk/openhands/sdk/git/utils.py
+++ b/openhands-sdk/openhands/sdk/git/utils.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 GIT_EMPTY_TREE_HASH = "4b825dc642cb6eb9a060e54bf8d69288fbee4904"
 
 
-def run_git_subprocess(
+def _run_git_subprocess(
     args: list[str],
     cwd: str | Path | None,
     timeout: int,
@@ -38,7 +38,7 @@ def run_git_subprocess(
 
 def _run_git_probe(args: list[str], cwd: str | Path) -> str:
     try:
-        result = run_git_subprocess(["git", "--no-pager", *args], cwd, timeout=30)
+        result = _run_git_subprocess(["git", "--no-pager", *args], cwd, timeout=30)
     except (OSError, subprocess.SubprocessError):
         return ""
     return result.stdout.strip() if result.returncode == 0 else ""
@@ -86,7 +86,7 @@ def run_git_command(
     cmd_str = shlex.join(redacted_args)
 
     try:
-        result = run_git_subprocess(args, cwd, timeout)
+        result = _run_git_subprocess(args, cwd, timeout)
 
         if result.returncode != 0:
             error_msg = f"Git command failed: {cmd_str}"

--- a/openhands-sdk/openhands/sdk/utils/redact.py
+++ b/openhands-sdk/openhands/sdk/utils/redact.py
@@ -174,7 +174,7 @@ def redact_url_credentials(url: str, *, preserve_placeholders: bool = False) -> 
 # larger string. The userinfo portion excludes ``/``, ``@``, and whitespace so
 # the match stops at the first credential boundary and never spans a path
 # segment or another token.
-_EMBEDDED_URL_CREDENTIALS_RE = re.compile(r"(https?://)[^/@\s]+@")
+_EMBEDDED_URL_CREDENTIALS_RE = re.compile(r"(https?://)[^/@\s]+@", re.IGNORECASE)
 
 
 def redact_url_credentials_in_text(text: str) -> str:

--- a/tests/agent_server/test_conversation_service.py
+++ b/tests/agent_server/test_conversation_service.py
@@ -2976,7 +2976,13 @@ class TestConversationTreeForkAndNavigate:
             info, source_service, events = await self._start_with_events(
                 svc, workspace_dir, ["first", "second", "third"]
             )
-            branch_point = events[1]
+            branch_point = next(e for e in events if isinstance(e, MessageEvent))
+            expected_branch_ids = [
+                e.id
+                for e in source_service.get_conversation()._state.events.path_to_root(
+                    branch_point.id
+                )
+            ]
 
             fork_info = await svc.fork_conversation(
                 info.id, from_event_id=branch_point.id
@@ -2994,9 +3000,7 @@ class TestConversationTreeForkAndNavigate:
             fork_service = await svc.get_event_service(fork_info.id)
             assert fork_service is not None
             fork_events = list(fork_service.get_conversation()._state.events)
-            # Only path_to_root(branch_point) was copied — the active branch up
-            # to and including the branch point, not the whole log.
-            assert [e.id for e in fork_events] == [events[0].id, events[1].id]
+            assert [e.id for e in fork_events] == expected_branch_ids
             assert len(fork_events) < len(events)
 
             # Source is untouched by the fork.

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -813,8 +813,8 @@ def test_git_delta_response_includes_repo_metadata_headers(client, tmp_path):
     )
 
     assert resp.status_code == 200, resp.text
-    assert (
-        resp.headers["x-archive-repo-remote"] == "https://github.com/example/repo.git"
+    assert resp.headers["x-archive-repo-remote"] == quote(
+        "https://github.com/example/repo.git", safe=""
     )
     assert resp.headers["x-archive-branch"] == "feature-x"
     assert resp.headers["x-archive-head-commit"] == head_sha
@@ -833,8 +833,8 @@ def test_tar_gz_response_includes_repo_metadata_headers(client, tmp_path):
     )
 
     assert resp.status_code == 200, resp.text
-    assert (
-        resp.headers["x-archive-repo-remote"] == "https://github.com/example/repo.git"
+    assert resp.headers["x-archive-repo-remote"] == quote(
+        "https://github.com/example/repo.git", safe=""
     )
     assert resp.headers["x-archive-branch"] == "feature-x"
     assert resp.headers["x-archive-head-commit"] == head_sha
@@ -855,7 +855,22 @@ def test_archive_redacts_remote_credentials_in_header(client, tmp_path):
     assert resp.status_code == 200, resp.text
     remote = resp.headers["x-archive-repo-remote"]
     assert "ghp_secrettoken" not in remote
-    assert remote == "https://****@github.com/example/repo.git"
+    assert remote == quote("https://****@github.com/example/repo.git", safe="")
+
+
+def test_archive_literal_percent_is_encoded(client, tmp_path):
+    _repo_with_remote(
+        tmp_path / "repo",
+        "https://github.com/example/feature%2Frepo.git",
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "%252F" in resp.headers["x-archive-repo-remote"]
 
 
 def test_archive_redacts_multiline_remote_credentials_in_header(client, tmp_path):

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -779,6 +779,112 @@ def test_git_delta_new_repo_has_no_base_commit_header(client, tmp_path):
     assert "x-archive-base-commit" not in resp.headers
 
 
+def _repo_with_remote(root: Path, remote_url: str, branch: str = "feature-x") -> str:
+    """Init a repo with one commit, an ``origin`` remote, and a named branch.
+
+    Returns the HEAD commit sha.
+    """
+    root.mkdir()
+    _git(["init"], root)
+    _git(["remote", "add", "origin", remote_url], root)
+    (root / "a.txt").write_text("original\n", encoding="utf-8")
+    _git(["add", "-A"], root)
+    _git(["commit", "-m", "init"], root)
+    _git(["checkout", "-b", branch], root)
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"],
+        cwd=root,
+        check=True,
+        capture_output=True,
+        text=True,
+    ).stdout.strip()
+
+
+def test_git_delta_response_includes_repo_metadata_headers(client, tmp_path):
+    head_sha = _repo_with_remote(
+        tmp_path / "repo", "https://github.com/example/repo.git"
+    )
+    (tmp_path / "repo" / "a.txt").write_text("changed\n", encoding="utf-8")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "git-delta"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert (
+        resp.headers["x-archive-repo-remote"] == "https://github.com/example/repo.git"
+    )
+    assert resp.headers["x-archive-branch"] == "feature-x"
+    assert resp.headers["x-archive-head-commit"] == head_sha
+
+
+def test_tar_gz_response_includes_repo_metadata_headers(client, tmp_path):
+    # The new repo-identity headers make a tar.gz snapshot self-describing too,
+    # even though it carries no base_commit/base_ref.
+    head_sha = _repo_with_remote(
+        tmp_path / "repo", "https://github.com/example/repo.git"
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert (
+        resp.headers["x-archive-repo-remote"] == "https://github.com/example/repo.git"
+    )
+    assert resp.headers["x-archive-branch"] == "feature-x"
+    assert resp.headers["x-archive-head-commit"] == head_sha
+    assert "x-archive-base-commit" not in resp.headers
+
+
+def test_archive_redacts_remote_credentials_in_header(client, tmp_path):
+    _repo_with_remote(
+        tmp_path / "repo",
+        "https://user:ghp_secrettoken@github.com/example/repo.git",
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    remote = resp.headers["x-archive-repo-remote"]
+    assert "ghp_secrettoken" not in remote
+    assert remote == "https://****@github.com/example/repo.git"
+
+
+def test_archive_detached_head_reports_detached_branch(client, tmp_path):
+    head_sha = _repo_with_remote(
+        tmp_path / "repo", "https://github.com/example/repo.git"
+    )
+    # Detach HEAD at the commit (SWE-bench-style pinned checkout).
+    _git(["checkout", head_sha], tmp_path / "repo")
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["x-archive-branch"] == "DETACHED"
+    assert resp.headers["x-archive-head-commit"] == head_sha
+
+
+def test_archive_non_git_directory_has_no_repo_metadata_headers(client, workspace):
+    resp = client.get(
+        "/api/file/archive", params={"path": str(workspace), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert "x-archive-repo-remote" not in resp.headers
+    assert "x-archive-branch" not in resp.headers
+    assert "x-archive-head-commit" not in resp.headers
+
+
 # =============================================================================
 # Archive Tests - format=tar.gz (full-workspace archive)
 # =============================================================================

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -10,6 +10,7 @@ import time
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
+from urllib.parse import quote
 from uuid import uuid4
 
 import pytest
@@ -883,6 +884,40 @@ def test_archive_non_git_directory_has_no_repo_metadata_headers(client, workspac
     assert "x-archive-repo-remote" not in resp.headers
     assert "x-archive-branch" not in resp.headers
     assert "x-archive-head-commit" not in resp.headers
+
+
+def test_archive_remote_with_embedded_control_char_is_percent_encoded(client, tmp_path):
+    # A remote URL is free-form text (unlike a ref name), so it can carry a
+    # literal control character straight into what becomes a header value.
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init"], repo)
+    _git(["config", "remote.origin.url", "https://example.com/repo\nline-two"], repo)
+    _git(["commit", "--allow-empty", "-m", "init"], repo)
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(repo), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    remote = resp.headers["x-archive-repo-remote"]
+    assert "\n" not in remote
+    assert remote == quote("https://example.com/repo\nline-two", safe="")
+
+
+def test_archive_non_ascii_branch_is_percent_encoded_not_dropped(client, tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(["init"], repo)
+    _git(["commit", "--allow-empty", "-m", "init"], repo)
+    _git(["checkout", "-b", "café-branch"], repo)
+
+    resp = client.get(
+        "/api/file/archive", params={"path": str(repo), "format": "tar.gz"}
+    )
+
+    assert resp.status_code == 200, resp.text
+    assert resp.headers["x-archive-branch"] == quote("café-branch", safe="")
 
 
 # =============================================================================

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -858,6 +858,23 @@ def test_archive_redacts_remote_credentials_in_header(client, tmp_path):
     assert remote == "https://****@github.com/example/repo.git"
 
 
+def test_archive_redacts_multiline_remote_credentials_in_header(client, tmp_path):
+    _repo_with_remote(
+        tmp_path / "repo",
+        "https://user:ghp_secrettoken@github.com/example/repo.git\nextra",
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    remote = resp.headers["x-archive-repo-remote"]
+    assert "ghp_secrettoken" not in remote
+    assert remote == quote("https://****@github.com/example/repo.git\nextra", safe="")
+
+
 def test_archive_detached_head_reports_detached_branch(client, tmp_path):
     head_sha = _repo_with_remote(
         tmp_path / "repo", "https://github.com/example/repo.git"

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -10,7 +10,7 @@ import time
 import zipfile
 from pathlib import Path
 from types import SimpleNamespace
-from urllib.parse import quote
+from urllib.parse import quote, unquote
 from uuid import uuid4
 
 import pytest
@@ -858,6 +858,24 @@ def test_archive_redacts_remote_credentials_in_header(client, tmp_path):
     assert remote == quote("https://****@github.com/example/repo.git", safe="")
 
 
+def test_archive_redacts_remote_query_credentials_in_header(client, tmp_path):
+    _repo_with_remote(
+        tmp_path / "repo",
+        "https://github.com/example/repo.git?access_token=SECRET&depth=1",
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    remote = unquote(resp.headers["x-archive-repo-remote"])
+    assert "SECRET" not in remote
+    assert "access_token=%3Credacted%3E" in remote
+    assert "depth=1" in remote
+
+
 def test_archive_literal_percent_is_encoded(client, tmp_path):
     _repo_with_remote(
         tmp_path / "repo",
@@ -1199,6 +1217,7 @@ def test_git_delta_auto_descends_to_single_repo_under_base(client, tmp_path):
 
     assert resp.status_code == 200, resp.text
     assert resp.headers["content-type"].startswith("text/x-patch")
+    assert unquote(resp.headers["x-archive-repo-root"]) == str(repo)
     assert "app.py" in resp.content.decode("utf-8")
 
 

--- a/tests/agent_server/test_file_router.py
+++ b/tests/agent_server/test_file_router.py
@@ -858,6 +858,23 @@ def test_archive_redacts_remote_credentials_in_header(client, tmp_path):
     assert remote == quote("https://****@github.com/example/repo.git", safe="")
 
 
+def test_archive_redacts_mixed_case_remote_credentials_in_header(client, tmp_path):
+    _repo_with_remote(
+        tmp_path / "repo",
+        "HTTPS://user:ghp_secrettoken@github.com/example/repo.git",
+    )
+
+    resp = client.get(
+        "/api/file/archive",
+        params={"path": str(tmp_path / "repo"), "format": "tar.gz"},
+    )
+
+    assert resp.status_code == 200, resp.text
+    remote = resp.headers["x-archive-repo-remote"]
+    assert "ghp_secrettoken" not in remote
+    assert remote == quote("HTTPS://****@github.com/example/repo.git", safe="")
+
+
 def test_archive_redacts_remote_query_credentials_in_header(client, tmp_path):
     _repo_with_remote(
         tmp_path / "repo",

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -2,6 +2,7 @@
 
 import logging
 import subprocess
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -10,6 +11,7 @@ from openhands.sdk.git.exceptions import GitCommandError
 from openhands.sdk.git.utils import (
     redact_url_credentials,
     run_git_command,
+    run_git_subprocess,
 )  # re-exported for compat
 from openhands.sdk.plugin.types import PluginSource, ResolvedPluginSource
 from openhands.sdk.utils.redact import (
@@ -326,3 +328,14 @@ class TestRunGitCommandCredentialRedaction:
                     run_git_command(self._args())
         assert "SUPERSECRET" not in caplog.text
         assert REDACTED_URL in caplog.text
+
+
+def test_run_git_subprocess_replaces_undecodable_stdout_bytes():
+    """Invalid-encoding stdout must not raise UnicodeDecodeError (AGE-1871)."""
+    result = run_git_subprocess(
+        [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff\\xfe')"],
+        cwd=None,
+        timeout=5,
+    )
+    assert result.returncode == 0
+    assert result.stdout == "��"

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -12,7 +12,6 @@ from openhands.sdk.git.utils import (
     get_git_repository_metadata,
     redact_url_credentials,
     run_git_command,
-    run_git_subprocess,
 )  # re-exported for compat
 from openhands.sdk.plugin.types import PluginSource, ResolvedPluginSource
 from openhands.sdk.utils.redact import (
@@ -331,15 +330,14 @@ class TestRunGitCommandCredentialRedaction:
         assert REDACTED_URL in caplog.text
 
 
-def test_run_git_subprocess_replaces_undecodable_stdout_bytes():
+def test_run_git_command_replaces_undecodable_stdout_bytes():
     """Invalid-encoding stdout must not raise UnicodeDecodeError (AGE-1871)."""
-    result = run_git_subprocess(
+    result = run_git_command(
         [sys.executable, "-c", "import sys; sys.stdout.buffer.write(b'\\xff\\xfe')"],
         cwd=None,
         timeout=5,
     )
-    assert result.returncode == 0
-    assert result.stdout == "��"
+    assert result == "��"
 
 
 def test_get_git_repository_metadata():
@@ -357,7 +355,7 @@ def test_get_git_repository_metadata():
             stderr="",
         ),
     ]
-    with patch("openhands.sdk.git.utils.run_git_subprocess", side_effect=responses):
+    with patch("openhands.sdk.git.utils._run_git_subprocess", side_effect=responses):
         metadata = get_git_repository_metadata("/repo")
 
     assert metadata == {

--- a/tests/sdk/git/test_url_redaction.py
+++ b/tests/sdk/git/test_url_redaction.py
@@ -9,6 +9,7 @@ import pytest
 
 from openhands.sdk.git.exceptions import GitCommandError
 from openhands.sdk.git.utils import (
+    get_git_repository_metadata,
     redact_url_credentials,
     run_git_command,
     run_git_subprocess,
@@ -339,3 +340,28 @@ def test_run_git_subprocess_replaces_undecodable_stdout_bytes():
     )
     assert result.returncode == 0
     assert result.stdout == "��"
+
+
+def test_get_git_repository_metadata():
+    responses = [
+        subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="HTTPS://user:secret@github.com/org/repo.git\n",
+            stderr="",
+        ),
+        subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout="abc123\nfeature-x\n",
+            stderr="",
+        ),
+    ]
+    with patch("openhands.sdk.git.utils.run_git_subprocess", side_effect=responses):
+        metadata = get_git_repository_metadata("/repo")
+
+    assert metadata == {
+        "repo_remote": "HTTPS://****@github.com/org/repo.git",
+        "head_commit": "abc123",
+        "branch": "feature-x",
+    }

--- a/tests/sdk/utils/test_redact.py
+++ b/tests/sdk/utils/test_redact.py
@@ -208,6 +208,10 @@ class TestRedactUrlCredentialsInText:
         assert "user:pw" not in result
         assert "http://****@internal.example.com/x" in result
 
+    def test_redacts_mixed_case_scheme(self):
+        s = "HTTPS://user:token@github.com/o/r.git"
+        assert redact_url_credentials_in_text(s) == ("HTTPS://****@github.com/o/r.git")
+
     def test_redacts_multiple_embedded_urls(self):
         s = "a https://t1@github.com/o/r.git b https://user:t2@gitlab.com/o/r.git c"
         result = redact_url_credentials_in_text(s)


### PR DESCRIPTION
HUMAN:

Make final workspace archives self-describing so evaluation tooling can identify the captured repository, branch, and commit without a database join.

AGENT:

## Why

Archive blobs expose their patch replay base but not the repository identity or committed HEAD captured with the workspace. Both archive formats need safe, best-effort identity metadata.

## Summary

`GET /api/file/archive` now emits these headers for both `git-delta` and `tar.gz`:

- `X-Archive-Repo-Remote`: credential-redacted origin URL
- `X-Archive-Branch`: current branch, or `DETACHED`
- `X-Archive-Head-Commit`: committed HEAD at capture time
- `X-Archive-Repo-Root`: resolved repository root used by consumers for enrichment probes

Header values are percent-encoded so non-ASCII values are preserved and control characters cannot break HTTP header construction. Git output uses replacement decoding so malformed bytes cannot fail archive creation. Missing remotes, empty repositories, and other expected probe failures simply omit unavailable identity fields.

Repository probing lives in the SDK Git utilities; HTTP header mapping and encoding remain in the agent-server router. Embedded HTTP credentials are redacted case-insensitively, including mixed-case schemes.

## Compatibility

Consumers treat missing headers as empty metadata, so producer and consumer changes can be deployed independently.

## How to Test

`.venv/bin/pytest tests/agent_server/test_file_router.py tests/sdk/git/test_url_redaction.py tests/sdk/utils/test_redact.py -q` — 151 passed. Ruff, Pyright, and import dependency checks pass.

Part of [infra#1454](https://github.com/All-Hands-AI/infra/issues/1454). Consumers: [runtime-api#630](https://github.com/OpenHands/runtime-api/pull/630) and [OpenHands#15058](https://github.com/OpenHands/OpenHands/pull/15058).



<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f9d6aed-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f9d6aed-python \
  ghcr.io/openhands/agent-server:f9d6aed-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f9d6aed-golang-amd64
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-golang-amd64
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-golang-amd64
ghcr.io/openhands/agent-server:f9d6aed-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f9d6aed-golang-arm64
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-golang-arm64
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-golang-arm64
ghcr.io/openhands/agent-server:f9d6aed-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f9d6aed-java-amd64
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-java-amd64
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-java-amd64
ghcr.io/openhands/agent-server:f9d6aed-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f9d6aed-java-arm64
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-java-arm64
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-java-arm64
ghcr.io/openhands/agent-server:f9d6aed-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f9d6aed-python-amd64
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-python-amd64
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-python-amd64
ghcr.io/openhands/agent-server:f9d6aed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f9d6aed-python-arm64
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-python-arm64
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-python-arm64
ghcr.io/openhands/agent-server:f9d6aed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f9d6aed-golang
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-golang
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-golang
ghcr.io/openhands/agent-server:f9d6aed-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f9d6aed-java
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-java
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-java
ghcr.io/openhands/agent-server:f9d6aed-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f9d6aed-python
ghcr.io/openhands/agent-server:f9d6aedee12495afe2e2eae7d093a9428a38a3c3-python
ghcr.io/openhands/agent-server:feat-archive-repo-metadata-python
ghcr.io/openhands/agent-server:f9d6aed-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f9d6aed-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f9d6aed-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
