### PR TITLE
fix(agent-profiles): backfill a resolvable 'default' LLM profile at seed time

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -251,7 +251,14 @@ def _seed_default_profile(
         if store.list():
             return
         active_llm_profile = settings.active_profile
-        if active_llm_profile is None and settings.agent_settings.agent_kind != "acp":
+        # Falsy check (not `is None`): mirrors build_seed_profile's own
+        # `active_llm_profile or SEED_PROFILE_NAME` fallback. A stray empty
+        # string (e.g. a hand-edited/legacy settings.json, or a direct
+        # PersistedSettings(active_profile="") construction — the HTTP PATCH
+        # payload's pattern validator blocks "" but the stored field has no
+        # such constraint) is falsy there too, so the backfill must trigger
+        # on the same condition or the exact #3933 dangling ref reappears.
+        if not active_llm_profile and settings.agent_settings.agent_kind != "acp":
             active_llm_profile = _seed_default_llm_profile(
                 settings.agent_settings.llm, cipher
             )

--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -32,8 +32,11 @@ from openhands.agent_server.persistence import (
     get_llm_profile_store,
     get_settings_store,
 )
+from openhands.agent_server.profiles_router import MAX_PROFILES
+from openhands.sdk.llm import LLM
 from openhands.sdk.logger import get_logger
 from openhands.sdk.profiles import (
+    SEED_PROFILE_NAME,
     ACPAgentProfile,
     AgentProfileDiagnostics,
     AgentProfileStore,
@@ -174,6 +177,39 @@ def _decrypt_profile_mcp_tools(
     return profile.model_copy(update={"skills": new_skills})
 
 
+def _seed_default_llm_profile(llm: LLM, cipher: Cipher | None) -> str:
+    """Mirror the live LLM config into a ``SEED_PROFILE_NAME`` LLM profile.
+
+    ``build_seed_profile`` falls back to the literal name ``SEED_PROFILE_NAME``
+    when no LLM profile is active, on the assumption that a profile by that
+    name exists — but nothing ever created one, so the seeded agent profile's
+    ``llm_profile_ref`` dangled from birth (#3933). Mirrors the cloud
+    ``SaasSettingsStore``'s legacy-LLM backfill: materialize the current
+    ``agent_settings.llm`` under that name so the reference resolves, unless a
+    profile is already stored there (never clobber it).
+    """
+    llm_store = get_llm_profile_store()
+    with _store_errors():
+        if f"{SEED_PROFILE_NAME}.json" not in llm_store.list():
+            try:
+                llm_store.save(
+                    SEED_PROFILE_NAME,
+                    llm,
+                    include_secrets=True,
+                    cipher=cipher,
+                    max_profiles=MAX_PROFILES,
+                )
+                logger.info(f"Seeded default LLM profile '{SEED_PROFILE_NAME}'")
+            except ProfileLimitExceeded:
+                # Can't mirror the live LLM as a profile; the agent profile's
+                # llm_profile_ref will still dangle, but no worse than before.
+                logger.warning(
+                    "Could not seed default LLM profile "
+                    f"'{SEED_PROFILE_NAME}': profile limit reached"
+                )
+    return SEED_PROFILE_NAME
+
+
 def _seed_default_profile(
     store: AgentProfileStore,
     request: Request,
@@ -191,7 +227,12 @@ def _seed_default_profile(
         # unlocked).
         if store.list():
             return
-        profile = build_seed_profile(settings.agent_settings, settings.active_profile)
+        active_llm_profile = settings.active_profile
+        if active_llm_profile is None and settings.agent_settings.agent_kind != "acp":
+            active_llm_profile = _seed_default_llm_profile(
+                settings.agent_settings.llm, cipher
+            )
+        profile = build_seed_profile(settings.agent_settings, active_llm_profile)
         # Settings persist skills[].mcp_tools encrypted (and never decrypt on
         # load), so decrypt before re-encrypting at save to avoid double-encrypt.
         profile = _decrypt_profile_mcp_tools(profile, cipher)

--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -34,6 +34,9 @@ from openhands.agent_server.persistence import (
 )
 from openhands.agent_server.profiles_router import MAX_PROFILES
 from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm_profile_store import (
+    ProfileLimitExceeded as LLMProfileLimitExceeded,
+)
 from openhands.sdk.logger import get_logger
 from openhands.sdk.profiles import (
     SEED_PROFILE_NAME,
@@ -187,26 +190,46 @@ def _seed_default_llm_profile(llm: LLM, cipher: Cipher | None) -> str:
     ``SaasSettingsStore``'s legacy-LLM backfill: materialize the current
     ``agent_settings.llm`` under that name so the reference resolves, unless a
     profile is already stored there (never clobber it).
+
+    Existence is checked via ``load()``, not ``list()``: the store resolves a
+    name straight to a filesystem path, so on a case-insensitive filesystem
+    (macOS/Windows) a differently-cased ``Default`` profile already occupies
+    the ``default`` path even though it wouldn't case-sensitively match a
+    ``list()`` membership check — that mismatch would otherwise let ``save()``
+    silently clobber it.
     """
     llm_store = get_llm_profile_store()
     with _store_errors():
-        if f"{SEED_PROFILE_NAME}.json" not in llm_store.list():
-            try:
-                llm_store.save(
-                    SEED_PROFILE_NAME,
-                    llm,
-                    include_secrets=True,
-                    cipher=cipher,
-                    max_profiles=MAX_PROFILES,
-                )
-                logger.info(f"Seeded default LLM profile '{SEED_PROFILE_NAME}'")
-            except ProfileLimitExceeded:
-                # Can't mirror the live LLM as a profile; the agent profile's
-                # llm_profile_ref will still dangle, but no worse than before.
-                logger.warning(
-                    "Could not seed default LLM profile "
-                    f"'{SEED_PROFILE_NAME}': profile limit reached"
-                )
+        try:
+            llm_store.load(SEED_PROFILE_NAME, cipher=cipher)
+            return SEED_PROFILE_NAME
+        except FileNotFoundError:
+            pass
+        except ValueError:
+            # Something already occupies the name (e.g. corrupted/unparsable
+            # file) — never overwrite it; a broken ref surfaces at
+            # materialize/launch time instead.
+            logger.warning(
+                f"Default LLM profile '{SEED_PROFILE_NAME}' exists but "
+                "failed to load; leaving it as-is"
+            )
+            return SEED_PROFILE_NAME
+        try:
+            llm_store.save(
+                SEED_PROFILE_NAME,
+                llm,
+                include_secrets=True,
+                cipher=cipher,
+                max_profiles=MAX_PROFILES,
+            )
+            logger.info(f"Seeded default LLM profile '{SEED_PROFILE_NAME}'")
+        except LLMProfileLimitExceeded:
+            # Can't mirror the live LLM as a profile; the agent profile's
+            # llm_profile_ref will still dangle, but no worse than before.
+            logger.warning(
+                "Could not seed default LLM profile "
+                f"'{SEED_PROFILE_NAME}': profile limit reached"
+            )
     return SEED_PROFILE_NAME
 
 

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -62,6 +62,14 @@ def store(temp_agent_profiles_dir):
     return AgentProfileStore(base_dir=temp_agent_profiles_dir)
 
 
+@pytest.fixture
+def default_llm_profile_store(temp_settings_dir):
+    """The real (unpatched) LLM profile store the ``client`` fixture's
+    ``get_llm_profile_store()`` resolves to, given ``OH_PERSISTENCE_DIR`` —
+    see ``_get_profile_persistence_dir`` (``<dir>/profiles``)."""
+    return LLMProfileStore(base_dir=temp_settings_dir / "profiles")
+
+
 # ── Lazy migration seed ─────────────────────────────────────────────────────
 
 
@@ -116,6 +124,49 @@ def test_seed_acp_when_settings_acp(client):
 
     detail = client.get("/api/agent-profiles/default").json()
     assert detail["profile"]["acp_server"] == "codex"
+
+
+def test_seed_backfills_default_llm_profile_when_none_active(
+    client, default_llm_profile_store
+):
+    """No active LLM profile: seed backfills a resolvable 'default' LLM profile.
+
+    Regression test for #3933 — previously ``llm_profile_ref`` fell back to
+    the literal 'default' without anything ever creating that LLM profile, so
+    the seeded (and active) agent profile 404'd at conversation launch.
+    """
+    body = client.get("/api/agent-profiles").json()
+    seeded = body["profiles"][0]
+    assert seeded["llm_profile_ref"] == "default"
+    assert "default.json" in default_llm_profile_store.list()
+
+    materialized = client.post("/api/agent-profiles/default/materialize").json()
+    assert materialized["valid"] is True
+    assert materialized["llm_profile_resolved"] is True
+
+
+def test_seed_does_not_clobber_existing_default_llm_profile(
+    client, default_llm_profile_store
+):
+    """A pre-existing 'default' LLM profile is left untouched by the seed."""
+    default_llm_profile_store.save("default", LLM(model="existing/model"))
+
+    client.get("/api/agent-profiles")
+
+    reloaded = default_llm_profile_store.load("default")
+    assert reloaded.model == "existing/model"
+
+
+def test_seed_acp_does_not_backfill_llm_profile(client, default_llm_profile_store):
+    """An ACP seed has no ``llm_profile_ref``, so no LLM profile is created."""
+    client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"agent_kind": "acp", "acp_server": "codex"}},
+    )
+
+    client.get("/api/agent-profiles")
+
+    assert default_llm_profile_store.list() == []
 
 
 def test_no_seed_when_store_nonempty(client, store):

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -6,6 +6,7 @@ activation by id (no ``agent_settings`` write), and the lazy migration seed.
 """
 
 import concurrent.futures
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -198,6 +199,42 @@ def test_seed_llm_profile_limit_reached_does_not_500(client, default_llm_profile
     seeded = response.json()["profiles"][0]
     assert seeded["llm_profile_ref"] == "default"
     assert "default.json" not in default_llm_profile_store.list()
+
+
+def test_seed_backfills_when_active_profile_is_empty_string(
+    client, default_llm_profile_store, temp_settings_dir
+):
+    """An empty-string (not ``None``) ``active_profile`` still triggers the
+    backfill.
+
+    Regression test: the trigger condition must be a falsy check, matching
+    ``build_seed_profile``'s own ``active_llm_profile or SEED_PROFILE_NAME``
+    fallback — an ``is None`` check would skip the backfill for ``""`` while
+    ``build_seed_profile`` still falls back to the unresolvable literal
+    ``"default"`` ref, reproducing the exact #3933 dangling ref. The HTTP
+    PATCH payload's pattern validator blocks a client from setting `""`, but
+    the stored ``PersistedSettings`` field has no such constraint, so a
+    hand-edited or legacy settings.json can still contain it.
+    """
+    (temp_settings_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "agent_settings": {"agent_kind": "openhands"},
+                "conversation_settings": {},
+                "active_profile": "",
+                "active_agent_profile_id": None,
+                "misc_settings": {},
+            }
+        )
+    )
+
+    body = client.get("/api/agent-profiles").json()
+    assert body["profiles"][0]["llm_profile_ref"] == "default"
+    assert "default.json" in default_llm_profile_store.list()
+
+    materialized = client.post("/api/agent-profiles/default/materialize").json()
+    assert materialized["valid"] is True
 
 
 def test_seed_acp_does_not_backfill_llm_profile(client, default_llm_profile_store):

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -17,6 +17,7 @@ from openhands.agent_server import agent_profiles_router as router_module
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.persistence import reset_stores
+from openhands.agent_server.profiles_router import MAX_PROFILES
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.profiles import (
@@ -155,6 +156,48 @@ def test_seed_does_not_clobber_existing_default_llm_profile(
 
     reloaded = default_llm_profile_store.load("default")
     assert reloaded.model == "existing/model"
+
+
+def test_seed_does_not_clobber_differently_cased_default_llm_profile(
+    client, default_llm_profile_store
+):
+    """A pre-existing differently-cased 'Default' LLM profile is never
+    overwritten.
+
+    Regression test: the existence check must resolve names the same way
+    ``save()`` does (via the store's own path resolution), not via a
+    case-sensitive ``list()`` membership check — on a case-insensitive
+    filesystem (macOS/Windows) 'default' and 'Default' are the same path, so
+    the naive check would miss the collision and ``save()`` would silently
+    clobber the existing profile.
+    """
+    default_llm_profile_store.save("Default", LLM(model="existing/model"))
+
+    client.get("/api/agent-profiles")
+
+    reloaded = default_llm_profile_store.load("Default")
+    assert reloaded.model == "existing/model"
+
+
+def test_seed_llm_profile_limit_reached_does_not_500(client, default_llm_profile_store):
+    """Hitting the LLM profile cap during backfill warns and continues
+    instead of 500ing.
+
+    Regression test: the backfill must catch the LLM store's own
+    ``ProfileLimitExceeded`` (``openhands.sdk.llm.llm_profile_store``), not
+    the identically-named exception from the agent-profile store
+    (``openhands.sdk.profiles``) — catching the wrong class let the real one
+    propagate as an unhandled 500.
+    """
+    for i in range(MAX_PROFILES):
+        default_llm_profile_store.save(f"other-{i}", LLM(model="x"))
+
+    response = client.get("/api/agent-profiles")
+
+    assert response.status_code == 200
+    seeded = response.json()["profiles"][0]
+    assert seeded["llm_profile_ref"] == "default"
+    assert "default.json" not in default_llm_profile_store.list()
 
 
 def test_seed_acp_does_not_backfill_llm_profile(client, default_llm_profile_store):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

backfill a resolvable 'default' LLM profile at seed time


<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

Diagnosed by reading the local `_seed_default_profile` (agent_profiles_router.py)
against the equivalent cloud implementation in OpenHands-Cloud's
`feat-agent-profiles-cloud` branch (`enterprise/storage/saas_settings_store.py`,
PR #15060): cloud always backfills a `Default`-named LLM profile from legacy
`agent_settings.llm` before it ever seeds the agent profile, so
`llm_profile_ref` always resolves. The local agent-server had the agent-profile
half of this migration (#3719) but never the LLM-profile half.

Verified end-to-end with `TestClient` against a fresh, isolated file store
(no cipher): `GET /api/agent-profiles` on an empty store now creates a
`default` LLM profile file alongside the seeded agent profile, and
`POST /api/agent-profiles/default/materialize` returns `valid: true` /
`llm_profile_resolved: true` — reproducing and then closing the exact 404
path from the issue. Also verified a pre-existing `default`-named LLM
profile is left untouched (not clobbered), and that the ACP seed path
(no `llm_profile_ref`) never creates one.

**Update (`c37453584`)** — addressed two review findings:
- @VascoSch92: the existence check used a case-sensitive `list()` membership
  test (`"default.json" not in llm_store.list()`), but `save()` resolves
  names to filesystem paths. On a case-insensitive filesystem (macOS/Windows)
  a differently-cased `Default` profile occupies the same path, so the check
  missed the collision and `save()` silently clobbered it. Reproduced locally
  (this sandbox is case-insensitive). Fixed by checking existence via
  `load()` instead, which follows the same path resolution `save()` already
  uses.
- @enyst: `llm_store.save()` raises
  `openhands.sdk.llm.llm_profile_store.ProfileLimitExceeded`, but the code
  caught the identically-named-but-distinct
  `openhands.sdk.profiles.ProfileLimitExceeded` (the agent-profile store's
  own exception), so hitting the LLM profile cap propagated as an unhandled
  500 instead of the intended warn-and-continue path. Fixed by importing the
  correct class under an alias.

Both fixes have regression tests that fail against the prior commit and pass
with the fix (verified via `git stash` on just the router file).

Ran:
- `uv run pytest tests/agent_server/test_agent_profiles_router.py -q` → 50
  passed (5 new regression tests total).
- `uv run pytest tests/agent_server -q` → 1382 passed, 1 failed
  (`TestAutoTitle::test_autotitle_sets_title_on_first_user_message`), which
  reproduces identically on `main` before this change — pre-existing,
  unrelated flake.
- `uv run pre-commit run --files openhands-agent-server/openhands/agent_server/agent_profiles_router.py tests/agent_server/test_agent_profiles_router.py` → all hooks passed (ruff format/lint, pycodestyle, pyright, import-rules).

## Why

The lazily-seeded default `AgentProfile` falls back to
`llm_profile_ref="default"` when no LLM profile is active, on the assumption
that a profile by that literal name exists — but nothing ever created one.
Since the seeded profile is also set as the *active* agent profile, any
conversation launched from it 404'd with `"LLM profile 'default' not
found"`. This breaks "launch from the active agent profile" for fresh local
users / any store without a `default`-named LLM profile.

## Summary

- `_seed_default_profile` now backfills a `default`-named LLM profile from
  the live `agent_settings.llm` whenever it would otherwise fall back to the
  unresolvable soft ref (no active LLM profile, non-ACP agent kind).
- Never clobbers a `default`-named LLM profile that already exists — checked
  via `load()` so a differently-cased `Default` profile is also protected on
  case-insensitive filesystems.
- Warns and continues (instead of 500ing) when the LLM profile store is at
  its cap.
- Adds 5 regression tests covering the backfill, the no-clobber case (exact
  and differently-cased name), the LLM-profile-limit case, and the ACP path
  (which has no `llm_profile_ref` and must not create one).

## Issue Number

Fixes #3933

## How to Test

1. Start a fresh agent-server against an empty persistence dir (no LLM
   profiles configured).
2. `GET /api/agent-profiles` — seeds a `default` agent profile and activates
   it.
3. `POST /api/agent-profiles/default/materialize` — before this fix,
   returns `valid: false` with `"LLM profile 'default' not found"`; after,
   returns `valid: true`.
4. `POST /api/conversations` using the active agent profile no longer 404s.

Or run the automated regression tests:
`uv run pytest tests/agent_server/test_agent_profiles_router.py -q`

## Video/Screenshots



## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Mirrors the cloud `SaasSettingsStore`'s legacy-LLM backfill
(OpenHands-Cloud PR #15060) so both backends share the same seeding
guarantee.





<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:6c42877-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-6c42877-python \
  ghcr.io/openhands/agent-server:6c42877-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:6c42877-golang-amd64
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-golang-amd64
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-golang-amd64
ghcr.io/openhands/agent-server:6c42877-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:6c42877-golang-arm64
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-golang-arm64
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-golang-arm64
ghcr.io/openhands/agent-server:6c42877-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:6c42877-java-amd64
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-java-amd64
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-java-amd64
ghcr.io/openhands/agent-server:6c42877-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:6c42877-java-arm64
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-java-arm64
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-java-arm64
ghcr.io/openhands/agent-server:6c42877-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:6c42877-python-amd64
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-python-amd64
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-python-amd64
ghcr.io/openhands/agent-server:6c42877-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:6c42877-python-arm64
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-python-arm64
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-python-arm64
ghcr.io/openhands/agent-server:6c42877-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:6c42877-golang
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-golang
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-golang
ghcr.io/openhands/agent-server:6c42877-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:6c42877-java
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-java
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-java
ghcr.io/openhands/agent-server:6c42877-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:6c42877-python
ghcr.io/openhands/agent-server:6c4287796344f036d9a666ff1e0ff4375ed7c9d8-python
ghcr.io/openhands/agent-server:fix-seeded-agent-profile-llm-ref-python
ghcr.io/openhands/agent-server:6c42877-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `6c42877-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `6c42877-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
