### PR TITLE
fix(sdk): stamp explicit root for navigate_to(None) branches

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/event_store.py
+++ b/openhands-sdk/openhands/sdk/conversation/event_store.py
@@ -2,7 +2,7 @@
 import operator
 from collections.abc import Callable, Iterator
 from contextlib import AbstractContextManager, nullcontext
-from typing import SupportsIndex, overload
+from typing import Final, SupportsIndex, overload
 
 from openhands.sdk.conversation.events_list_base import EventsListBase
 from openhands.sdk.conversation.persistence_const import (
@@ -20,6 +20,11 @@ logger = get_logger(__name__)
 
 LOCK_FILE_NAME = ".eventlog.lock"
 LOCK_TIMEOUT_SECONDS = 30
+
+# Marks a feature-created root at a non-zero index (e.g. navigate_to(None) then
+# emit), where parent_id=None is ambiguous with a legacy event. Reserved value:
+# never collides with a real id (event ids are uuid4).
+ROOT_PARENT_ID: Final = "__root__"
 
 
 class EventLog(EventsListBase):
@@ -94,6 +99,8 @@ class EventLog(EventsListBase):
         the linear chain (event ``idx - 1``) so old conversations load unbranched
         with no disk rewrite.
         """
+        if event.parent_id == ROOT_PARENT_ID:
+            return None  # explicit root (feature-created root at idx > 0)
         if event.parent_id is not None:
             return event.parent_id  # explicit (new events)
         if idx == 0:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -14,7 +14,7 @@ from openhands.sdk.context.condenser import CondenserBase, LLMSummarizingCondens
 from openhands.sdk.context.prompts.prompt import render_template
 from openhands.sdk.conversation.base import BaseConversation
 from openhands.sdk.conversation.cancellation import CancellationToken
-from openhands.sdk.conversation.event_store import EventLog
+from openhands.sdk.conversation.event_store import ROOT_PARENT_ID, EventLog
 from openhands.sdk.conversation.exceptions import ConversationRunError
 from openhands.sdk.conversation.secret_registry import SecretValue
 from openhands.sdk.conversation.state import (
@@ -465,9 +465,13 @@ class LocalConversation(BaseConversation):
 
         def wrapped(event: Event) -> None:
             if event.parent_id is None:
-                event = event.model_copy(
-                    update={"parent_id": self._state._resolve_active_leaf()}
-                )
+                parent = self._state._resolve_active_leaf()
+                # An empty HEAD over a non-empty log is a deliberate new root
+                # (e.g. after navigate_to(None)); mark it explicitly so it is
+                # not misread as a legacy event chained to its storage neighbour.
+                if parent is None and len(self._state.events) > 0:
+                    parent = ROOT_PARENT_ID
+                event = event.model_copy(update={"parent_id": parent})
             inner(event)
 
         return cast(ConversationCallbackType, wrapped)

--- a/tests/sdk/conversation/local/test_conversation_tree.py
+++ b/tests/sdk/conversation/local/test_conversation_tree.py
@@ -154,6 +154,35 @@ def test_navigate_to_none_empties_the_active_branch():
         assert _view_ids(conv) == []
 
 
+def test_navigate_to_none_then_emit_starts_a_fresh_root():
+    """After navigate_to(None), the next event is a genuine root — not silently
+    re-parented onto the abandoned branch's leaf.
+
+    A stamped root landing at a non-zero storage index has parent_id=None, the
+    same shape as a legacy event; without an explicit marker the effective-parent
+    rule would treat it as a legacy child (idx-1) and resurrect the whole
+    abandoned branch into the active view.
+    """
+    with tempfile.TemporaryDirectory() as tmp:
+        conv = _conversation(tmp)
+        e0 = _emit(conv, _msg("root"))
+        _emit(conv, _msg("a1"))  # branch A: root -> a1, then abandoned
+
+        conv.navigate_to(None)  # deliberate empty HEAD
+        assert _view_ids(conv) == []
+
+        fresh = _emit(conv, _msg("fresh"))  # a new root over a non-empty log
+
+        events = conv.state.events
+        stored = events.get_by_id(fresh.id)
+        # Effective parent is None: a genuine root, not chained to a1.
+        assert events._effective_parent_id(events.get_index(fresh.id), stored) is None
+        # Active branch is exactly the fresh root; branch A stays off-view.
+        assert _view_ids(conv) == [fresh.id]
+        # Both roots hang off None as siblings.
+        assert set(events.children_of(None)) == {e0.id, fresh.id}
+
+
 def test_fork_from_event_slices_the_branch():
     with tempfile.TemporaryDirectory() as tmp:
         conv = _conversation(tmp)


### PR DESCRIPTION
## Why

Stacked on #3922 (targets `vasco/tree`). Fixes a correctness bug found while reviewing that PR.

`navigate_to(None)` is documented as moving HEAD to *the empty tree*, and appending after a navigation is supposed to *create a sibling branch*. But the next emitted event was silently re-parented onto the abandoned branch's leaf, resurrecting the whole branch into `state.view`.

**Root cause:** `parent_id = None` is overloaded — it means *both* "genuine root" *and* "legacy event, resolve linearly via `idx-1`". `EventLog._effective_parent_id` can only separate them with `idx == 0`. A root created by `navigate_to(None)` then emit lands at a **non-zero** storage index with `parent_id=None`, so it is misread as a legacy child and chained to its storage neighbour. No `parent_id`/index-only heuristic can disambiguate the two meanings (it also breaks for a single-root log immediately followed by `navigate_to(None)`), so the write side must record the distinction.

## What

- Reserve a `ROOT_PARENT_ID` sentinel (`"\x00root"`, never a real id).
- In `_tree_stamping`, when the resolved active leaf is `None` **over a non-empty log** (a deliberate new root), stamp the sentinel instead of `None`.
- `_effective_parent_id` maps the sentinel back to `None`.

Only feature-created roots at `idx > 0` carry the sentinel, so everything else is untouched:
- the byte-additive `idx-0` root still serializes without `parent_id`;
- legacy logs never contain the sentinel → the `idx-1` back-compat path is unchanged;
- forks copy events verbatim, so the sentinel resolves correctly in a fork too.

## Evidence

Before → after `navigate_to(None)` then emit:
- `state.view`: `[root, a1, fresh]` → **`[fresh]`** (abandoned branch no longer resurrected)
- `children_of(None)`: `[root]` → **`[root, fresh]`** (new root recognized as a sibling)

The bug slipped through because `test_navigate_to_none_empties_the_active_branch` stops right after `navigate_to(None)`. This PR adds `test_navigate_to_none_then_emit_starts_a_fresh_root`, which emits afterward and asserts the new event's effective parent is `None`, the view is only the fresh branch, and both roots are siblings off `None`. It fails on `vasco/tree` and passes here.

## How to test

```bash
uv run pytest tests/sdk/conversation/local/test_conversation_tree.py \
              tests/sdk/conversation/test_event_tree.py -v
```

Full `tests/sdk/conversation` + `tests/sdk/event` suites pass (811); `pre-commit` (ruff, pycodestyle, pyright) clean.