### PR TITLE
ci: inline integration-test model config to drop private eval-repo checkout

### DIFF
--- a/.github/workflows/integration-runner.yml
+++ b/.github/workflows/integration-runner.yml
@@ -70,17 +70,6 @@ jobs:
                   ref: ${{ github.event.pull_request.head.sha || github.ref }}
                   persist-credentials: false
 
-            - name: Checkout evaluation model config
-              uses: actions/checkout@v6
-              with:
-                  repository: OpenHands/evaluation
-                  ref: main
-                  token: ${{ secrets.OPENHANDS_BOT_GITHUB_PAT_PRIVATE }}
-                  path: .evaluation-model-config
-                  sparse-checkout: |
-                      eval-job/model-config
-                  persist-credentials: false
-
             - name: Set up Python
               uses: actions/setup-python@v5
               with:
@@ -109,15 +98,30 @@ jobs:
                   import json
                   import os
                   import sys
-                  sys.path.insert(0, '.evaluation-model-config/eval-job/model-config')
-                  from resolve_model_config import find_models_by_id
+                  # Inlined from OpenHands/evaluation (eval-job/model-config) so this
+                  # public workflow no longer clones the private eval repo. Only `model`
+                  # plus tuning params are needed here; api_key/base_url are injected from
+                  # env (LLM_API_KEY/LLM_BASE_URL) by tests/integration/base.py.
+                  MODELS = {
+                      "gpt-5.5": {"display_name": "GPT-5.5",
+                          "llm_config": {"model": "litellm_proxy/openai/gpt-5.5", "reasoning_effort": "high"}},
+                      "deepseek-v4-flash": {"display_name": "DeepSeek V4 Flash",
+                          "llm_config": {"model": "litellm_proxy/deepseek/deepseek-v4-flash"}},
+                      "minimax-m2.7": {"display_name": "MiniMax M2.7",
+                          "llm_config": {"model": "litellm_proxy/minimax/MiniMax-M2.7", "temperature": 1.0, "top_p": 0.95}},
+                      "gemini-3.1-pro": {"display_name": "Gemini 3.1 Pro",
+                          "llm_config": {"model": "litellm_proxy/gemini-3.1-pro-preview", "temperature": 0.0}},
+                  }
 
                   model_ids = os.environ["MODEL_IDS"].split(",")
                   model_ids = [m.strip() for m in model_ids if m.strip()]
 
-                  # find_models_by_id exits with code 1 and prints a helpful
-                  # message if any model ID cannot be resolved.
-                  resolved = find_models_by_id(model_ids)
+                  # Fail fast with a helpful message if any model ID is unknown.
+                  try:
+                      resolved = [MODELS[m] for m in model_ids]
+                  except KeyError as exc:
+                      print(f"Unknown model id {exc}; known ids: {', '.join(MODELS)}", file=sys.stderr)
+                      sys.exit(1)
 
                   matrix = []
                   for model_id, model in zip(model_ids, resolved):


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small changes to don't use anymore the eval repo in the integration tests.

---

AGENT:

## Why

`integration-runner.yml`'s `setup-matrix` job cloned the private `OpenHands/evaluation`
repo (`eval-job/model-config`) to resolve model IDs, authenticating with
`OPENHANDS_BOT_GITHUB_PAT_PRIVATE`. That secret is not available to this public repo's
Actions, so `actions/checkout` received an empty token and failed immediately:

```
Error: Input required and not supplied: token
```

`setup-matrix` failed → `run-integration-tests` was skipped → `consolidate-results`
failed, blocking every integration/behavior run (including the v1.30.0 release checklist).

## Summary

- Remove the `Checkout evaluation model config` step that cloned the private eval repo with `OPENHANDS_BOT_GITHUB_PAT_PRIVATE`.
- Inline the default model configs (`gpt-5.5`, `deepseek-v4-flash`, `minimax-m2.7`, `gemini-3.1-pro`) directly in `setup-matrix`; `api_key`/`base_url` are still injected from env by `tests/integration/base.py`.
- Net one file, +20/-16 — no private-repo checkout, no private token, no org-secret dependency.

## Issue Number

No dedicated issue. This is the `main`-targeted twin of #3935 (which merged the same change into `rel-1.30.0`). Landing it on `main` turns the release PR #3931 and the nightly scheduled run green.

## How to Test

CI-only change (no runtime code), so I verified the generated matrix is equivalent to the
previous resolver and that the workflow is well-formed.

**1. The generated matrix is byte-for-byte identical to the eval-repo resolver.**
Ran the original `resolve_model_config.find_models_by_id` from `OpenHands/evaluation@main`
and the new inline dict over the 4 default IDs (Python 3.13) and diffed them:

```
$ diff orig_matrix.json inline_matrix.json
✅ IDENTICAL — inline output matches the eval-repo resolver byte-for-byte
```

Resulting matrix (unchanged from before):

```json
[
  {"id":"gpt-5.5","name":"GPT-5.5","run-suffix":"gpt_5_5_run",
   "llm-config":{"model":"litellm_proxy/openai/gpt-5.5","reasoning_effort":"high"}},
  {"id":"deepseek-v4-flash","name":"DeepSeek V4 Flash","run-suffix":"deepseek_v4_flash_run",
   "llm-config":{"model":"litellm_proxy/deepseek/deepseek-v4-flash"}},
  {"id":"minimax-m2.7","name":"MiniMax M2.7","run-suffix":"minimax_m2_7_run",
   "llm-config":{"model":"litellm_proxy/minimax/MiniMax-M2.7","temperature":1.0,"top_p":0.95}},
  {"id":"gemini-3.1-pro","name":"Gemini 3.1 Pro","run-suffix":"gemini_3_1_pro_run",
   "llm-config":{"model":"litellm_proxy/gemini-3.1-pro-preview","temperature":0.0}}
]
```

**2. Credentials still resolve.** The matrix `llm-config` only carries `model` + tuning
params; `api_key`/`base_url` come from env in `tests/integration/base.py:118-136`
(`os.getenv("LLM_API_KEY")` / `os.getenv("LLM_BASE_URL")`), so no credentials belong in the
inlined config.

**3. The workflow is well-formed.**

```
$ uvx pre-commit run yamlfmt --files .github/workflows/integration-runner.yml
Format YAML files........................................................Passed

$ python -c "import yaml; yaml.safe_load(open('.github/workflows/integration-runner.yml'))"
✅ YAML parses OK
```

Full end-to-end confirmation requires the `integration-test` / `behavior-test` label to
dispatch a real run on this base branch (which needs `LLM_API_KEY_EVAL`); that can't be
triggered locally.

## Video/Screenshots

N/A — CI/workflow-only change with no GUI. Command logs are included above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **`pull_request_target`**: this workflow reads its definition from the PR's **base**
  branch. Merging this into `main` fixes runs based on `main` — including the release PR
  #3931 and the nightly scheduled `main` run. (#3935 already landed the identical change on
  `rel-1.30.0`.)
- **Drift**: `OpenHands/evaluation` stays the source of truth; the inline table must be
  updated when a default model or proxy string changes there.
- **`workflow_dispatch` `model_ids`** now resolves only IDs present in the inline table;
  scheduled/label runs (the 4 defaults) are unaffected.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2b6ada0-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2b6ada0-python \
  ghcr.io/openhands/agent-server:2b6ada0-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2b6ada0-golang-amd64
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-golang-amd64
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-golang-amd64
ghcr.io/openhands/agent-server:2b6ada0-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2b6ada0-golang-arm64
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-golang-arm64
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-golang-arm64
ghcr.io/openhands/agent-server:2b6ada0-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2b6ada0-java-amd64
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-java-amd64
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-java-amd64
ghcr.io/openhands/agent-server:2b6ada0-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2b6ada0-java-arm64
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-java-arm64
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-java-arm64
ghcr.io/openhands/agent-server:2b6ada0-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2b6ada0-python-amd64
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-python-amd64
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-python-amd64
ghcr.io/openhands/agent-server:2b6ada0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2b6ada0-python-arm64
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-python-arm64
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-python-arm64
ghcr.io/openhands/agent-server:2b6ada0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2b6ada0-golang
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-golang
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-golang
ghcr.io/openhands/agent-server:2b6ada0-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2b6ada0-java
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-java
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-java
ghcr.io/openhands/agent-server:2b6ada0-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2b6ada0-python
ghcr.io/openhands/agent-server:2b6ada0347a5ad0ab849f17aaa2fc6735ee303b9-python
ghcr.io/openhands/agent-server:vasco-ci-inline-eval-model-config-main-python
ghcr.io/openhands/agent-server:2b6ada0-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2b6ada0-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2b6ada0-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->