### PR TITLE
cherry-pick: backfill a resolvable 'default' LLM profile at seed time (#3934)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -32,8 +32,14 @@ from openhands.agent_server.persistence import (
     get_llm_profile_store,
     get_settings_store,
 )
+from openhands.agent_server.profiles_router import MAX_PROFILES
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.llm_profile_store import (
+    ProfileLimitExceeded as LLMProfileLimitExceeded,
+)
 from openhands.sdk.logger import get_logger
 from openhands.sdk.profiles import (
+    SEED_PROFILE_NAME,
     ACPAgentProfile,
     AgentProfileDiagnostics,
     AgentProfileStore,
@@ -174,6 +180,59 @@ def _decrypt_profile_mcp_tools(
     return profile.model_copy(update={"skills": new_skills})
 
 
+def _seed_default_llm_profile(llm: LLM, cipher: Cipher | None) -> str:
+    """Mirror the live LLM config into a ``SEED_PROFILE_NAME`` LLM profile.
+
+    ``build_seed_profile`` falls back to the literal name ``SEED_PROFILE_NAME``
+    when no LLM profile is active, on the assumption that a profile by that
+    name exists — but nothing ever created one, so the seeded agent profile's
+    ``llm_profile_ref`` dangled from birth (#3933). Mirrors the cloud
+    ``SaasSettingsStore``'s legacy-LLM backfill: materialize the current
+    ``agent_settings.llm`` under that name so the reference resolves, unless a
+    profile is already stored there (never clobber it).
+
+    Existence is checked via ``load()``, not ``list()``: the store resolves a
+    name straight to a filesystem path, so on a case-insensitive filesystem
+    (macOS/Windows) a differently-cased ``Default`` profile already occupies
+    the ``default`` path even though it wouldn't case-sensitively match a
+    ``list()`` membership check — that mismatch would otherwise let ``save()``
+    silently clobber it.
+    """
+    llm_store = get_llm_profile_store()
+    with _store_errors():
+        try:
+            llm_store.load(SEED_PROFILE_NAME, cipher=cipher)
+            return SEED_PROFILE_NAME
+        except FileNotFoundError:
+            pass
+        except ValueError:
+            # Something already occupies the name (e.g. corrupted/unparsable
+            # file) — never overwrite it; a broken ref surfaces at
+            # materialize/launch time instead.
+            logger.warning(
+                f"Default LLM profile '{SEED_PROFILE_NAME}' exists but "
+                "failed to load; leaving it as-is"
+            )
+            return SEED_PROFILE_NAME
+        try:
+            llm_store.save(
+                SEED_PROFILE_NAME,
+                llm,
+                include_secrets=True,
+                cipher=cipher,
+                max_profiles=MAX_PROFILES,
+            )
+            logger.info(f"Seeded default LLM profile '{SEED_PROFILE_NAME}'")
+        except LLMProfileLimitExceeded:
+            # Can't mirror the live LLM as a profile; the agent profile's
+            # llm_profile_ref will still dangle, but no worse than before.
+            logger.warning(
+                "Could not seed default LLM profile "
+                f"'{SEED_PROFILE_NAME}': profile limit reached"
+            )
+    return SEED_PROFILE_NAME
+
+
 def _seed_default_profile(
     store: AgentProfileStore,
     request: Request,
@@ -191,7 +250,19 @@ def _seed_default_profile(
         # unlocked).
         if store.list():
             return
-        profile = build_seed_profile(settings.agent_settings, settings.active_profile)
+        active_llm_profile = settings.active_profile
+        # Falsy check (not `is None`): mirrors build_seed_profile's own
+        # `active_llm_profile or SEED_PROFILE_NAME` fallback. A stray empty
+        # string (e.g. a hand-edited/legacy settings.json, or a direct
+        # PersistedSettings(active_profile="") construction — the HTTP PATCH
+        # payload's pattern validator blocks "" but the stored field has no
+        # such constraint) is falsy there too, so the backfill must trigger
+        # on the same condition or the exact #3933 dangling ref reappears.
+        if not active_llm_profile and settings.agent_settings.agent_kind != "acp":
+            active_llm_profile = _seed_default_llm_profile(
+                settings.agent_settings.llm, cipher
+            )
+        profile = build_seed_profile(settings.agent_settings, active_llm_profile)
         # Settings persist skills[].mcp_tools encrypted (and never decrypt on
         # load), so decrypt before re-encrypting at save to avoid double-encrypt.
         profile = _decrypt_profile_mcp_tools(profile, cipher)

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -6,6 +6,7 @@ activation by id (no ``agent_settings`` write), and the lazy migration seed.
 """
 
 import concurrent.futures
+import json
 import tempfile
 from pathlib import Path
 from unittest.mock import patch
@@ -17,6 +18,7 @@ from openhands.agent_server import agent_profiles_router as router_module
 from openhands.agent_server.api import create_app
 from openhands.agent_server.config import Config
 from openhands.agent_server.persistence import reset_stores
+from openhands.agent_server.profiles_router import MAX_PROFILES
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.profiles import (
@@ -60,6 +62,14 @@ def client(temp_agent_profiles_dir, temp_settings_dir, monkeypatch):
 @pytest.fixture
 def store(temp_agent_profiles_dir):
     return AgentProfileStore(base_dir=temp_agent_profiles_dir)
+
+
+@pytest.fixture
+def default_llm_profile_store(temp_settings_dir):
+    """The real (unpatched) LLM profile store the ``client`` fixture's
+    ``get_llm_profile_store()`` resolves to, given ``OH_PERSISTENCE_DIR`` —
+    see ``_get_profile_persistence_dir`` (``<dir>/profiles``)."""
+    return LLMProfileStore(base_dir=temp_settings_dir / "profiles")
 
 
 # ── Lazy migration seed ─────────────────────────────────────────────────────
@@ -116,6 +126,127 @@ def test_seed_acp_when_settings_acp(client):
 
     detail = client.get("/api/agent-profiles/default").json()
     assert detail["profile"]["acp_server"] == "codex"
+
+
+def test_seed_backfills_default_llm_profile_when_none_active(
+    client, default_llm_profile_store
+):
+    """No active LLM profile: seed backfills a resolvable 'default' LLM profile.
+
+    Regression test for #3933 — previously ``llm_profile_ref`` fell back to
+    the literal 'default' without anything ever creating that LLM profile, so
+    the seeded (and active) agent profile 404'd at conversation launch.
+    """
+    body = client.get("/api/agent-profiles").json()
+    seeded = body["profiles"][0]
+    assert seeded["llm_profile_ref"] == "default"
+    assert "default.json" in default_llm_profile_store.list()
+
+    materialized = client.post("/api/agent-profiles/default/materialize").json()
+    assert materialized["valid"] is True
+    assert materialized["llm_profile_resolved"] is True
+
+
+def test_seed_does_not_clobber_existing_default_llm_profile(
+    client, default_llm_profile_store
+):
+    """A pre-existing 'default' LLM profile is left untouched by the seed."""
+    default_llm_profile_store.save("default", LLM(model="existing/model"))
+
+    client.get("/api/agent-profiles")
+
+    reloaded = default_llm_profile_store.load("default")
+    assert reloaded.model == "existing/model"
+
+
+def test_seed_does_not_clobber_differently_cased_default_llm_profile(
+    client, default_llm_profile_store
+):
+    """A pre-existing differently-cased 'Default' LLM profile is never
+    overwritten.
+
+    Regression test: the existence check must resolve names the same way
+    ``save()`` does (via the store's own path resolution), not via a
+    case-sensitive ``list()`` membership check — on a case-insensitive
+    filesystem (macOS/Windows) 'default' and 'Default' are the same path, so
+    the naive check would miss the collision and ``save()`` would silently
+    clobber the existing profile.
+    """
+    default_llm_profile_store.save("Default", LLM(model="existing/model"))
+
+    client.get("/api/agent-profiles")
+
+    reloaded = default_llm_profile_store.load("Default")
+    assert reloaded.model == "existing/model"
+
+
+def test_seed_llm_profile_limit_reached_does_not_500(client, default_llm_profile_store):
+    """Hitting the LLM profile cap during backfill warns and continues
+    instead of 500ing.
+
+    Regression test: the backfill must catch the LLM store's own
+    ``ProfileLimitExceeded`` (``openhands.sdk.llm.llm_profile_store``), not
+    the identically-named exception from the agent-profile store
+    (``openhands.sdk.profiles``) — catching the wrong class let the real one
+    propagate as an unhandled 500.
+    """
+    for i in range(MAX_PROFILES):
+        default_llm_profile_store.save(f"other-{i}", LLM(model="x"))
+
+    response = client.get("/api/agent-profiles")
+
+    assert response.status_code == 200
+    seeded = response.json()["profiles"][0]
+    assert seeded["llm_profile_ref"] == "default"
+    assert "default.json" not in default_llm_profile_store.list()
+
+
+def test_seed_backfills_when_active_profile_is_empty_string(
+    client, default_llm_profile_store, temp_settings_dir
+):
+    """An empty-string (not ``None``) ``active_profile`` still triggers the
+    backfill.
+
+    Regression test: the trigger condition must be a falsy check, matching
+    ``build_seed_profile``'s own ``active_llm_profile or SEED_PROFILE_NAME``
+    fallback — an ``is None`` check would skip the backfill for ``""`` while
+    ``build_seed_profile`` still falls back to the unresolvable literal
+    ``"default"`` ref, reproducing the exact #3933 dangling ref. The HTTP
+    PATCH payload's pattern validator blocks a client from setting `""`, but
+    the stored ``PersistedSettings`` field has no such constraint, so a
+    hand-edited or legacy settings.json can still contain it.
+    """
+    (temp_settings_dir / "settings.json").write_text(
+        json.dumps(
+            {
+                "schema_version": 2,
+                "agent_settings": {"agent_kind": "openhands"},
+                "conversation_settings": {},
+                "active_profile": "",
+                "active_agent_profile_id": None,
+                "misc_settings": {},
+            }
+        )
+    )
+
+    body = client.get("/api/agent-profiles").json()
+    assert body["profiles"][0]["llm_profile_ref"] == "default"
+    assert "default.json" in default_llm_profile_store.list()
+
+    materialized = client.post("/api/agent-profiles/default/materialize").json()
+    assert materialized["valid"] is True
+
+
+def test_seed_acp_does_not_backfill_llm_profile(client, default_llm_profile_store):
+    """An ACP seed has no ``llm_profile_ref``, so no LLM profile is created."""
+    client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"agent_kind": "acp", "acp_server": "codex"}},
+    )
+
+    client.get("/api/agent-profiles")
+
+    assert default_llm_profile_store.list() == []
 
 
 def test_no_seed_when_store_nonempty(client, store):


### PR DESCRIPTION
## Summary
- Cherry-picks the squash-merged commit from #3934 (`ab9f99e79`) onto the `rel-1.30.0` release branch so the fix ships in v1.30.0.
- No conflicts; diff is byte-identical to the original merge commit.

## Why
#3934 merged into `main` after `rel-1.30.0` was cut, so it isn't included in the release branch yet.

## How to Test
- `uv run pytest tests/agent_server/test_agent_profiles_router.py -q` — 51 passed.

HUMAN: Cherry-picking a just-merged main fix onto the open release branch per repo convention (see #3935, which used the same pattern).