### PR TITLE
deprecate(sdk): warn on the custom Jinja system-prompt fallback

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -43,6 +43,7 @@ from openhands.sdk.tool import (
 )
 from openhands.sdk.tool.builtins import InvokeSkillTool
 from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
+from openhands.sdk.utils.deprecation import warn_deprecated
 from openhands.sdk.utils.models import DiscriminatedUnionMixin, get_handler_class_name
 
 
@@ -252,7 +253,14 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
             "System prompt template filename. Can be either:\n"
             "- A relative filename (e.g., 'system_prompt.j2') loaded from the "
             "agent's prompts directory\n"
-            "- An absolute path (e.g., '/path/to/custom_prompt.j2')"
+            "- An absolute path (e.g., '/path/to/custom_prompt.j2')\n\n"
+            "**Deprecated (since 1.30.0, removed in 1.35.0)**: Pointing this at a "
+            "*custom* '.j2' template renders it through the legacy Jinja fallback, "
+            "which is deprecated. Migrate to the typed prompt registry (custom "
+            "sections/presets via `create_registry`) or the inline `system_prompt` "
+            "field. The built-in sentinel filenames 'system_prompt.j2' and "
+            "'system_prompt_planning.j2' route through the registry and are "
+            "unaffected."
         ),
     )
     security_policy_filename: str = Field(
@@ -506,6 +514,20 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         # own Jinja template; everything else (incl. custom policies) uses the registry.
         preset = self._prompt_preset
         if preset is None:
+            warn_deprecated(
+                "AgentBase custom Jinja system prompt",
+                deprecated_in="1.30.0",
+                removed_in="1.35.0",
+                details=(
+                    "Rendering a system prompt from a custom '.j2' template "
+                    "(a custom 'system_prompt_filename' or a subclass with its own "
+                    "'prompt_dir') is deprecated. Migrate to the typed prompt "
+                    "registry (custom sections/presets via 'create_registry') or "
+                    "pass the prompt text directly with the inline 'system_prompt' "
+                    "field. Built-in sentinel filenames such as 'system_prompt.j2' "
+                    "and 'system_prompt_planning.j2' are unaffected."
+                ),
+            )
             return render_template(
                 prompt_dir=self.prompt_dir,
                 template_name=self.system_prompt_filename,

--- a/tests/sdk/agent/test_system_prompt.py
+++ b/tests/sdk/agent/test_system_prompt.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import ClassVar
 
 import pytest
+from deprecation import DeprecatedWarning
 
 from openhands.sdk.agent import Agent
 from openhands.sdk.agent.base import AgentBase
@@ -104,6 +105,25 @@ def test_builtin_default_prompt_uses_registry() -> None:
     agent = Agent(llm=_make_llm(), tools=[])
     expected = create_registry().build(agent._build_prompt_context()).static
     assert agent.static_system_message == expected
+
+
+def test_custom_jinja_fallback_warns_deprecated(tmp_path: Path) -> None:
+    """The custom ``.j2`` fallback (custom filename) emits a deprecation warning."""
+    template = tmp_path / "custom.j2"
+    template.write_text("CUSTOM PROMPT", encoding="utf-8")
+    agent = Agent(
+        llm=_make_llm(),
+        tools=[],
+        system_prompt_filename=str(template),
+    )
+    with pytest.warns(DeprecatedWarning, match="custom Jinja system prompt"):
+        assert agent.static_system_message == "CUSTOM PROMPT"
+
+
+def test_registry_prompt_does_not_warn(recwarn: pytest.WarningsRecorder) -> None:
+    """Built-in registry prompts must not emit the Jinja deprecation warning."""
+    Agent(llm=_make_llm(), tools=[]).static_system_message
+    assert not [w for w in recwarn if issubclass(w.category, DeprecatedWarning)]
 
 
 # --- planning preset (sentinel-filename routing) ---


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

HUMAN:

---

AGENT:

## Why

Fixes #3914 (first step: the deprecation runway).

After #3910 ported the last built-in planning prompt to the typed prompt
registry, `AgentBase` still keeps a second prompt-rendering engine alive: the
Jinja escape hatch for custom `system_prompt_filename` values and subclasses
that ship their own `prompt_dir`. This PR marks that fallback deprecated so it
can be removed once the compatibility runway is complete, without reintroducing
a parallel built-in prompt path.

## What

- Emit a `DeprecationWarning` (via the canonical `warn_deprecated` helper) when
  `AgentBase.static_system_message` takes the custom `.j2` fallback path — i.e.
  `_prompt_preset is None`, which is exactly a custom `system_prompt_filename`
  or a subclass with its own `prompt_dir`.
- `deprecated_in="1.30.0"`, `removed_in="1.35.0"` (≥ 5 minor releases, per the
  SDK Public API Removal Policy in `AGENTS.md`).
- Document the migration path in the `system_prompt_filename` field description
  and the warning `details`: move to the typed prompt registry (custom
  sections/presets via `create_registry`) or the inline `system_prompt` field.

## What is intentionally *not* changed

- Built-in sentinel filenames `system_prompt.j2` / `system_prompt_planning.j2`
  keep routing through the registry and do **not** warn — their own
  compatibility runway is untouched.
- Inline `system_prompt` overrides are returned verbatim and do not warn.
- No removal yet — this is only the deprecation notice. Removing the Jinja-only
  plumbing is the follow-up once the runway completes.

## Migration

| Before | After |
| --- | --- |
| Custom `system_prompt_filename="my_prompt.j2"` / subclass `prompt_dir` | Typed registry: build custom sections/presets with `create_registry(...)`, or pass `system_prompt="<text>"` inline |

## Testing

- `test_custom_jinja_fallback_warns_deprecated` — the custom `.j2` path warns.
- `test_registry_prompt_does_not_warn` — the built-in registry path does not.
- Existing escape-hatch tests still pass (`tests/sdk/agent/test_system_prompt.py`,
  `tests/sdk/context/test_prompt_absolute_path.py`).
- `.github/scripts/check_deprecations.py` passes.

## Acceptance criteria (issue #3914)

- [x] Custom Jinja prompt usage has a documented deprecation notice and removal
      target consistent with the SDK compatibility policy.
- [x] Users have a clear migration path preserving legitimate customization.
- [x] Built-in sentinel filenames continue to resolve compatibly.
- [ ] Final removal of the custom `.j2` fallback (follow-up after the runway).

> Docs update (github.com/OpenHands/docs) to be added per the documentation
> workflow.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:aaf2eb3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-aaf2eb3-python \
  ghcr.io/openhands/agent-server:aaf2eb3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:aaf2eb3-golang-amd64
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-golang-amd64
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-golang-amd64
ghcr.io/openhands/agent-server:aaf2eb3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:aaf2eb3-golang-arm64
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-golang-arm64
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-golang-arm64
ghcr.io/openhands/agent-server:aaf2eb3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:aaf2eb3-java-amd64
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-java-amd64
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-java-amd64
ghcr.io/openhands/agent-server:aaf2eb3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:aaf2eb3-java-arm64
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-java-arm64
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-java-arm64
ghcr.io/openhands/agent-server:aaf2eb3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:aaf2eb3-python-amd64
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-python-amd64
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-python-amd64
ghcr.io/openhands/agent-server:aaf2eb3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:aaf2eb3-python-arm64
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-python-arm64
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-python-arm64
ghcr.io/openhands/agent-server:aaf2eb3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:aaf2eb3-golang
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-golang
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-golang
ghcr.io/openhands/agent-server:aaf2eb3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:aaf2eb3-java
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-java
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-java
ghcr.io/openhands/agent-server:aaf2eb3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:aaf2eb3-python
ghcr.io/openhands/agent-server:aaf2eb3fadce216cddb7d94a0b0b1233ab9210d7-python
ghcr.io/openhands/agent-server:deprecate-custom-jinja-system-prompt-python
ghcr.io/openhands/agent-server:aaf2eb3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `aaf2eb3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `aaf2eb3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->