### PR TITLE
fix(sdk): preserve nested MCP input schema

### DIFF
--- a/openhands-sdk/openhands/sdk/mcp/tool.py
+++ b/openhands-sdk/openhands/sdk/mcp/tool.py
@@ -1,5 +1,6 @@
 """Utility functions for MCP integration."""
 
+import copy
 import re
 from collections.abc import Sequence
 from typing import TYPE_CHECKING, Any
@@ -27,6 +28,7 @@ from openhands.sdk.tool import (
     ToolExecutor,
 )
 from openhands.sdk.tool.schema import Schema
+from openhands.sdk.tool.tool import _prioritize_schema_fields
 from openhands.sdk.utils.models import DiscriminatedUnionMixin
 
 
@@ -372,10 +374,8 @@ class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):
             )
 
         assert self.name == self.mcp_tool.name
-        mcp_action_type = _create_mcp_action_type(self.mcp_tool)
         return super().to_openai_tool(
             add_security_risk_prediction=add_security_risk_prediction,
-            action_type=mcp_action_type,
         )
 
     def to_responses_tool(
@@ -402,8 +402,42 @@ class MCPToolDefinition(ToolDefinition[MCPToolAction, MCPToolObservation]):
             )
 
         assert self.name == self.mcp_tool.name
-        mcp_action_type = _create_mcp_action_type(self.mcp_tool)
         return super().to_responses_tool(
+            add_security_risk_prediction=add_security_risk_prediction,
+        )
+
+    def _get_tool_schema(
+        self,
+        add_security_risk_prediction: bool = False,
+        action_type: type[Schema] | None = None,
+    ) -> dict[str, Any]:
+        """Build provider-facing schema from the original MCP inputSchema."""
+        if action_type is not None:
+            raise ValueError(
+                "MCPTool._get_tool_schema does not support overriding action_type"
+            )
+
+        mcp_action_type = _create_mcp_action_type(self.mcp_tool)
+        sdk_schema = super()._get_tool_schema(
             add_security_risk_prediction=add_security_risk_prediction,
             action_type=mcp_action_type,
         )
+        sdk_props: dict[str, Any] = sdk_schema.get("properties", {})
+        sdk_required: list[str] = sdk_schema.get("required", []) or []
+
+        merged = copy.deepcopy(self.mcp_tool.inputSchema)
+        merged.setdefault("type", "object")
+        props = merged.setdefault("properties", {})
+        for meta in ("security_risk", "summary"):
+            if meta in sdk_props and meta not in props:
+                props[meta] = sdk_props[meta]
+                if meta in sdk_required:
+                    required = merged.setdefault("required", [])
+                    if meta not in required:
+                        required.append(meta)
+
+        _prioritize_schema_fields(
+            schema=merged,
+            priority=("security_risk", "summary"),
+        )
+        return merged

--- a/tests/sdk/mcp/test_mcp_tool.py
+++ b/tests/sdk/mcp/test_mcp_tool.py
@@ -23,6 +23,73 @@ class MockMCPClient(MCPClient):
         self._tools = []
 
 
+def _nested_object_mcp_tool() -> mcp.types.Tool:
+    return mcp.types.Tool(
+        name="add_diagram_component",
+        description="Add a component to a diagram",
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "definition": {
+                    "description": "Component model ID",
+                    "type": "string",
+                },
+                "position": {
+                    "description": "Component position",
+                    "type": "object",
+                    "properties": {
+                        "0": {"type": "number"},
+                        "1": {"type": "number"},
+                    },
+                    "required": ["0", "1"],
+                },
+            },
+            "required": ["definition", "position"],
+        },
+    )
+
+
+def test_mcp_tool_openai_schema_preserves_nested_object_properties():
+    mcp_tool = _nested_object_mcp_tool()
+    tool = MCPToolDefinition.create(mcp_tool, MockMCPClient())[0]
+
+    openai_tool = tool.to_openai_tool()
+    params = openai_tool["function"].get("parameters")
+    assert isinstance(params, dict)
+
+    properties = params["properties"]
+    assert isinstance(properties, dict)
+    position = properties["position"]
+    assert isinstance(position, dict)
+
+    assert position["properties"] == {
+        "0": {"type": "number"},
+        "1": {"type": "number"},
+    }
+    assert position["required"] == ["0", "1"]
+
+
+def test_mcp_tool_responses_schema_preserves_nested_object_properties_with_risk():
+    mcp_tool = _nested_object_mcp_tool()
+    tool = MCPToolDefinition.create(mcp_tool, MockMCPClient())[0]
+
+    responses_tool = tool.to_responses_tool(add_security_risk_prediction=True)
+    params = responses_tool["parameters"]
+    assert isinstance(params, dict)
+
+    properties = params["properties"]
+    assert isinstance(properties, dict)
+    position = properties["position"]
+    assert isinstance(position, dict)
+
+    assert position["properties"] == {
+        "0": {"type": "number"},
+        "1": {"type": "number"},
+    }
+    assert position["required"] == ["0", "1"]
+    assert "security_risk" in properties
+
+
 class TestMCPToolObservation:
     """Test MCPToolObservation functionality."""
 


### PR DESCRIPTION
## Summary
- preserve nested MCP `inputSchema` objects when building OpenAI and Responses tool schemas
- keep runtime MCP argument validation on the existing dynamic Pydantic model path
- add regression coverage for nested object parameters plus SDK `security_risk` schema injection

## Why
MCP tools can declare nested object parameters such as `position.properties`. The current LLM-facing schema is rebuilt from the dynamic Pydantic action type, so nested JSON Schema details collapse to `{ "type": "object" }` even though the MCP server supplied the full schema.

This addresses OpenHands/OpenHands#15094.

## Testing
- RED: `uv run pytest tests/sdk/mcp/test_mcp_tool.py::test_mcp_tool_openai_schema_preserves_nested_object_properties tests/sdk/mcp/test_mcp_tool.py::test_mcp_tool_responses_schema_preserves_nested_object_properties_with_risk -q` failed with `KeyError: 'properties'`
- `uv run pytest tests/sdk/mcp/test_mcp_tool.py::test_mcp_tool_openai_schema_preserves_nested_object_properties tests/sdk/mcp/test_mcp_tool.py::test_mcp_tool_responses_schema_preserves_nested_object_properties_with_risk -q`
- `uv run pytest tests/sdk/mcp/test_mcp_tool.py tests/sdk/mcp/test_mcp_security_risk.py tests/sdk/tool/test_to_responses_tool_summary.py -q`
- `uv run ruff check openhands-sdk/openhands/sdk/mcp/tool.py tests/sdk/mcp/test_mcp_tool.py`
- `uv run ruff format --check openhands-sdk/openhands/sdk/mcp/tool.py tests/sdk/mcp/test_mcp_tool.py`
- `uv run pyright openhands-sdk/openhands/sdk/mcp/tool.py tests/sdk/mcp/test_mcp_tool.py`
- `uv run pre-commit run --files openhands-sdk/openhands/sdk/mcp/tool.py tests/sdk/mcp/test_mcp_tool.py`
- `git diff --check HEAD~1 HEAD`

Note: `uv run pytest tests/sdk/mcp -q` reached 83 passed / 2 failed. The failures are unrelated HTTP server readiness / nonexistent server cleanup cases returning `503 Service Unavailable` in `tests/sdk/mcp/test_create_mcp_tool.py`; the changed schema/tool tests pass.
