### PR TITLE
fix(llm): raise retryable LLMNoResponseError when stream yields no chunks

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -2036,6 +2036,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     on_token(chunk)
                     chunks.append(chunk)
                 ret = litellm.stream_chunk_builder(chunks, messages=messages)
+                # stream_chunk_builder returns None for an empty stream; raise
+                # LLMNoResponseError inside the retry boundary so it is retried,
+                # matching the empty-choices handling in the non-streaming path.
+                if ret is None:
+                    raise LLMNoResponseError(
+                        "Streaming completion finished without any chunks"
+                    )
 
             assert isinstance(ret, ModelResponse), (
                 f"Expected ModelResponse, got {type(ret)}"
@@ -2068,6 +2075,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     await _invoke_token_callback(on_token, chunk)
                     chunks.append(chunk)
                 ret = litellm.stream_chunk_builder(chunks, messages=messages)
+                # stream_chunk_builder returns None for an empty stream; raise
+                # LLMNoResponseError inside the retry boundary so it is retried,
+                # matching the empty-choices handling in the non-streaming path.
+                if ret is None:
+                    raise LLMNoResponseError(
+                        "Streaming completion finished without any chunks"
+                    )
 
             assert isinstance(ret, ModelResponse), (
                 f"Expected ModelResponse, got {type(ret)}"

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -1,12 +1,20 @@
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from litellm import CustomStreamWrapper
 from litellm.responses.streaming_iterator import (
     ResponsesAPIStreamingIterator,
     SyncResponsesAPIStreamingIterator,
 )
 from litellm.types.llms.openai import ResponsesAPIResponse
-from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
+from litellm.types.utils import (
+    Choices,
+    Delta,
+    Message as LiteLLMMessage,
+    ModelResponse,
+    StreamingChoices,
+    Usage,
+)
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
 from pydantic import SecretStr
 
@@ -458,3 +466,122 @@ async def test_async_aresponses_stream_path_retry_bumps_temperature(
     assert mock_aresponses.call_count == 2
     _, second_kwargs = mock_aresponses.call_args_list[1]
     assert second_kwargs.get("temperature") == 1.0
+
+
+# ------------------------------------------------------------------
+# Chat Completions streaming: empty stream (zero chunks)
+# ------------------------------------------------------------------
+
+
+def create_chunk_stream(content: str = "ok") -> MagicMock:
+    chunk = ModelResponse(
+        id="chatcmpl-stream",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content=content, role="assistant"),
+            )
+        ],
+        created=1,
+        model="gpt-4o",
+        object="chat.completion.chunk",
+    )
+    stream = MagicMock(spec=CustomStreamWrapper)
+    stream.__iter__.return_value = iter([chunk])
+    stream.__aiter__.return_value = [chunk]
+    return stream
+
+
+def create_empty_stream() -> MagicMock:
+    stream = MagicMock(spec=CustomStreamWrapper)
+    stream.__iter__.return_value = iter([])
+    stream.__aiter__.return_value = []
+    return stream
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_streaming_empty_stream_raises_llm_no_response(
+    mock_completion, base_llm: LLM
+) -> None:
+    """A stream that yields zero chunks must raise the retryable
+    LLMNoResponseError, not a bare AssertionError."""
+    mock_completion.side_effect = [
+        create_empty_stream(),
+        create_empty_stream(),
+    ]
+
+    with pytest.raises(LLMNoResponseError):
+        base_llm.completion(
+            messages=[Message(role="user", content=[TextContent(text="hi")])],
+            stream=True,
+            on_token=lambda _chunk: None,
+        )
+
+    # Retryable: tenacity ran the attempt num_retries times
+    assert mock_completion.call_count == base_llm.num_retries
+
+
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_streaming_empty_stream_retries_then_succeeds(
+    mock_completion, base_llm: LLM
+) -> None:
+    mock_completion.side_effect = [
+        create_empty_stream(),
+        create_chunk_stream("ok"),
+    ]
+
+    resp = base_llm.completion(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        stream=True,
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_completion.call_count == 2
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_acompletion",
+    new_callable=AsyncMock,
+)
+async def test_async_streaming_empty_stream_raises_llm_no_response(
+    mock_acompletion: AsyncMock, base_llm: LLM
+) -> None:
+    mock_acompletion.side_effect = [
+        create_empty_stream(),
+        create_empty_stream(),
+    ]
+
+    with pytest.raises(LLMNoResponseError):
+        await base_llm.acompletion(
+            messages=[Message(role="user", content=[TextContent(text="hi")])],
+            stream=True,
+            on_token=lambda _chunk: None,
+        )
+
+    assert mock_acompletion.call_count == base_llm.num_retries
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_acompletion",
+    new_callable=AsyncMock,
+)
+async def test_async_streaming_empty_stream_retries_then_succeeds(
+    mock_acompletion: AsyncMock, base_llm: LLM
+) -> None:
+    mock_acompletion.side_effect = [
+        create_empty_stream(),
+        create_chunk_stream("ok"),
+    ]
+
+    resp = await base_llm.acompletion(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        stream=True,
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_acompletion.call_count == 2


### PR DESCRIPTION
HUMAN:

When a provider opens a streaming response but closes it after zero chunks (overloaded backend, truncated SSE body), `litellm.stream_chunk_builder([])` returns `None` and the transport layer dies on a bare `AssertionError`. Since `AssertionError` is not in `LLM_RETRY_EXCEPTIONS`, the call is never retried — while the non-streaming path raises the retryable `LLMNoResponseError` for the equivalent "empty choices" case. This PR makes the streaming path raise the same retryable error, so the existing retry + temperature-bump recovery applies. Sync and async transports are both fixed, symmetrically.

- [x] A human has tested these changes.

---

AGENT:

## Why

`_transport_call` / `_atransport_call` rebuild the final response from collected stream chunks:

```python
ret = litellm.stream_chunk_builder(chunks, messages=messages)
assert isinstance(ret, ModelResponse), f"Expected ModelResponse, got {type(ret)}"
```

If the provider yields **zero chunks** (stream opens, then closes immediately — the degenerate case behind "streaming hangs/crashes" reports), `stream_chunk_builder([])` returns `None`, and the assert raises:

```
AssertionError: Expected ModelResponse, got <class 'NoneType'>
```

Two problems with that:

1. **Not retried.** `AssertionError` is not in `LLM_RETRY_EXCEPTIONS` and is not mapped by `map_provider_exception`, so a transient provider hiccup kills the whole agent step. This is inconsistent with the non-streaming path, which raises the *retryable* `LLMNoResponseError` for empty `choices` (`_validate_chat_response`), and with the Responses streaming path (`_finalize_stream_response`), which already raises `LLMNoResponseError` when the stream finishes without a completed response.
2. **Unactionable error.** A bare `AssertionError` about types tells the user nothing about what actually happened (provider returned no content).

## Summary

- When `stream_chunk_builder` returns `None` (empty stream), raise `LLMNoResponseError` inside the retry boundary — same treatment as empty choices in the non-streaming path.
- Applied symmetrically to `_transport_call` (sync) and `_atransport_call` (async).

## Issue Number

No SDK issue filed; the failure mode is the degenerate case behind streaming-crash reports such as OpenHands/software-agent-sdk#4260.

## How to Test

```bash
uv run pytest tests/sdk/llm/test_llm_no_response_retry.py -v
```

4 new tests (sync/async × two scenarios). On `main` without this fix, `test_streaming_empty_stream_raises_llm_no_response` fails with the exact `AssertionError` above and `litellm_completion` is called only once (no retry); with the fix, the empty stream is retried and `..._retries_then_succeeds` shows a transient empty stream recovering transparently.

## Video/Screenshots

End-to-end behavior demo (mocked transport: first call returns an empty stream, second returns a normal one — simulating a transient provider hiccup):

**Before (main):**
```
💥 AssertionError: Expected ModelResponse, got <class 'NoneType'>
   litellm called 1 time — never retried
```

**After (this branch):**
```
✅ response recovered on second attempt
   litellm called 2 times — empty stream retried transparently
```

## Type

- [x] Bug fix

## Notes

The fix intentionally reuses `LLMNoResponseError` (rather than a new exception type) so the existing temperature-bump recovery in `RetryMixin` engages — some providers return empty output at `temperature=0` and succeed after the bump. Full test file (17 tests), `tests/sdk/llm/test_llm_completion.py`, and pre-commit (ruff/pycodestyle/pyright) all pass.
