### PR TITLE
fix(conversation): hold state lock in update_secrets

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -2272,8 +2272,12 @@ class LocalConversation(BaseConversation):
                      SecretValue = str | Callable[[], str]. Callables are invoked lazily
                      when a command references the secret key.
         """
-        secret_registry = self._state.secret_registry
-        secret_registry.update_secrets(secrets)
+        # Hold the state lock: mutating secret_sources while another thread's
+        # state autosave is serializing it panics pydantic-core ("dictionary
+        # changed size during iteration").
+        with self._state:
+            secret_registry = self._state.secret_registry
+            secret_registry.update_secrets(secrets)
         logger.info(f"Added {len(secrets)} secrets to conversation")
 
     def set_security_analyzer(self, analyzer: SecurityAnalyzerBase | None) -> None:

--- a/tests/sdk/conversation/local/test_update_secrets_thread_safety.py
+++ b/tests/sdk/conversation/local/test_update_secrets_thread_safety.py
@@ -1,0 +1,93 @@
+"""update_secrets must hold the state lock like every other state mutator.
+
+Without the lock, an update_secrets call from a user/HTTP thread mutates
+``state.secret_registry.secret_sources`` in place while another thread's
+state-field assignment is autosaving (``_save_base_state`` ->
+``model_dump_json``), which iterates that same dict during pydantic
+serialization. pydantic-core surfaces the mutation as
+``pyo3_runtime.PanicException`` ("dictionary changed size during iteration") —
+a BaseException that escapes the run loop's ``except Exception`` handlers, so
+the conversation thread dies without transitioning to ERROR.
+
+The test freezes the autosave mid-iteration with a blocking secret serializer,
+then calls the real ``conversation.update_secrets()`` from another thread, and
+asserts the autosave completes without crashing.
+"""
+
+import threading
+
+from pydantic import SecretStr
+
+import openhands.sdk.secret.secrets as secrets_mod
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.state import ConversationExecutionStatus
+from openhands.sdk.llm import LLM
+
+
+AUTOSAVE_THREAD_NAME = "autosave-thread"
+
+
+def test_update_secrets_does_not_race_autosave_serialization(tmp_path, monkeypatch):
+    llm = LLM(model="gpt-4o-mini", api_key=SecretStr("test-key"), usage_id="test-llm")
+    agent = Agent(llm=llm, tools=[])
+    conversation = Conversation(
+        agent=agent,
+        workspace=str(tmp_path / "workspace"),
+        persistence_dir=str(tmp_path / "persist"),
+    )
+    # Seed secrets so the autosave serialization iterates secret_sources.
+    conversation.update_secrets({"seed_a": "value-a", "seed_b": "value-b"})
+
+    in_serializer = threading.Event()
+    proceed = threading.Event()
+    original_serialize = secrets_mod.serialize_secret
+
+    def blocking_serialize(v, info):
+        # Freeze the autosave thread on the first secret it serializes,
+        # holding pydantic-core mid-iteration of secret_sources.
+        if (
+            threading.current_thread().name == AUTOSAVE_THREAD_NAME
+            and not in_serializer.is_set()
+        ):
+            in_serializer.set()
+            assert proceed.wait(timeout=10), "test orchestration timeout"
+        return original_serialize(v, info)
+
+    monkeypatch.setattr(secrets_mod, "serialize_secret", blocking_serialize)
+
+    state = conversation.state
+    autosave_exc: list[BaseException] = []
+
+    def autosave_thread():
+        try:
+            # What the run loop does on every step under `with self._state:` —
+            # any field assignment triggers _save_base_state -> model_dump_json.
+            with state:
+                state.execution_status = ConversationExecutionStatus.RUNNING
+        except BaseException as e:  # noqa: BLE001 - PanicException is not Exception
+            autosave_exc.append(e)
+
+    t_autosave = threading.Thread(target=autosave_thread, name=AUTOSAVE_THREAD_NAME)
+    t_autosave.start()
+    assert in_serializer.wait(timeout=10), "autosave never reached the serializer"
+
+    # A user/HTTP thread updates secrets while the autosave is mid-iteration.
+    t_update = threading.Thread(
+        target=lambda: conversation.update_secrets({"injected": "value-c"})
+    )
+    t_update.start()
+    # Fixed: update_secrets blocks on the state lock held by the autosave
+    # thread. Unfixed: it mutates secret_sources immediately.
+    t_update.join(timeout=1.0)
+
+    proceed.set()
+    t_autosave.join(timeout=10)
+    t_update.join(timeout=10)
+    assert not t_autosave.is_alive()
+    assert not t_update.is_alive()
+
+    assert not autosave_exc, (
+        f"autosave crashed while update_secrets ran concurrently: {autosave_exc!r}"
+    )
+    assert "injected" in state.secret_registry.secret_sources


### PR DESCRIPTION
HUMAN:

`update_secrets` is the only conversation state mutator that doesn't take the state lock — it mutates `secret_registry.secret_sources` in place. When called from a user/HTTP thread while the run thread's autosave is serializing the same dict (any state field assignment triggers a full `model_dump_json`), pydantic-core panics with "dictionary changed size during iteration". The resulting `PanicException` is a `BaseException`, so it escapes the run loop's `except Exception` — the conversation never transitions to ERROR and the thread dies silently. The fix takes the state lock, matching the neighboring mutators.

- [x] A human has tested these changes.

---

AGENT:

## Why

Every other mutator (`send_message`, `pause`, `set_security_analyzer`, the run loop itself) acquires `with self._state:`. `update_secrets` doesn't:

```python
secret_registry = self._state.secret_registry
secret_registry.update_secrets(secrets)   # in-place dict.update, no lock
```

Both ends of the race exist in a stock agent-server deployment: the run loop executes in a dedicated executor thread and assigns state fields on every step (each assignment autosaves via `model_dump_json`, iterating `secret_sources`), while `POST .../secrets` dispatches `update_secrets` to another executor thread. A user updating secrets while a conversation runs hits it.

The failure is worse than a normal crash: pydantic-core surfaces the mutation as `pyo3_runtime.PanicException` — a `BaseException` — which bypasses `except Exception` in both `ConversationState.__setattr__` and the run loop. No ERROR status, no `ConversationErrorEvent`; the conversation just hangs forever from the client's perspective.

## Summary

- Acquire the state lock in `update_secrets` before mutating the registry, matching the neighboring mutators.

## Issue Number

None filed.

## How to Test

```bash
uv run pytest tests/sdk/conversation/local/test_update_secrets_thread_safety.py -v
```

The new test freezes an autosave mid-iteration of `secret_sources` (blocking secret serializer), then calls the real `conversation.update_secrets()` from another thread. On `main` without this fix it fails with:

```
AssertionError: autosave crashed while update_secrets ran concurrently:
[PanicException('dictionary changed size during iteration')]
```

With the fix, `update_secrets` waits for the lock and both threads complete safely; the injected secret is present afterwards.

## Video/Screenshots

Red run (fix stashed, test on main behavior):

```
E   AssertionError: autosave crashed while update_secrets ran concurrently:
E   [PanicException('dictionary changed size during iteration')]
1 failed in 0.07s
```

Green run (with fix): `1 passed`. Related suites (`test_secrets_manager.py`, `test_conversation_secrets_constructor.py`, `test_conversation_core.py`): 36 passed. pre-commit (ruff / pycodestyle / pyright): all pass.

## Type

- [x] Bug fix

## Notes

`switch_llm` has a related (milder) pattern — it calls `llm_registry.add` before taking the lock and writes `stats.usage_to_metrics` unlocked; left out of scope here to keep this PR minimal, can file separately if useful.
