### PR TITLE
fix(llm): restore Codex base_url when subscription LLM loses it in transport

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/auth/openai.py
+++ b/openhands-sdk/openhands/sdk/llm/auth/openai.py
@@ -914,7 +914,12 @@ def create_subscription_llm_from_config(llm: LLM) -> LLM:
     """Create a runtime subscription LLM from a serialized LLM config."""
     if getattr(llm, "auth_type", "api_key") != "subscription":
         return llm
-    if llm.is_subscription:
+    # Only short-circuit for a locally-created subscription LLM that still has
+    # its runtime credentials (PrivateAttr, lost during serialization). A
+    # deserialized LLM may have is_subscription=True but missing base_url or
+    # credentials, so it must be re-created to restore the Codex endpoint and
+    # refresh OAuth tokens.
+    if llm.is_subscription and llm._subscription_credentials is not None:
         return llm
 
     vendor = llm.subscription_vendor or "openai"

--- a/tests/sdk/llm/test_subscription_mode.py
+++ b/tests/sdk/llm/test_subscription_mode.py
@@ -417,3 +417,83 @@ def test_is_subscription_survives_serialization_round_trip():
         plain.model_dump(context={"expose_secrets": True})
     )
     assert restored_plain.is_subscription is False
+
+
+def test_create_subscription_llm_from_config_restores_missing_base_url():
+    """create_subscription_llm_from_config must re-create the LLM when
+    is_subscription=True but runtime credentials are missing (lost during
+    serialization).
+
+    Clients (e.g. agent-canvas) strip base_url and api_key before forwarding
+    a subscription LLM config. If the function short-circuits on
+    is_subscription=True alone, the LLM keeps base_url=None and requests fall
+    back to the default OpenAI Platform endpoint, producing
+    "Missing scopes: api.responses.write" errors.
+    """
+    from openhands.sdk.llm.auth.openai import (
+        CODEX_API_ENDPOINT,
+        create_subscription_llm_from_config,
+    )
+
+    # Simulate a config that went through agent-canvas: auth_type=subscription,
+    # is_subscription=True (survived serialization), but base_url stripped and
+    # _subscription_credentials lost (PrivateAttr doesn't survive serialization).
+    llm = LLM(
+        model="openai/gpt-5.5",
+        auth_type="subscription",
+        subscription_vendor="openai",
+        stream=True,
+        usage_id="test-restore-base-url",
+    )
+    llm._is_subscription = True
+    assert llm.base_url is None  # precondition: base_url was stripped
+    assert llm._subscription_credentials is None  # lost in serialization
+
+    # Stub credential refresh so the test doesn't require a real ChatGPT login.
+    fake_creds = SimpleNamespace(
+        access_token="fake-token",
+        refresh_token="fake-refresh",
+        expires_at=9999999999999,
+    )
+    with patch(
+        "openhands.sdk.llm.auth.openai.OpenAISubscriptionAuth.refresh_if_needed_sync",
+        return_value=fake_creds,
+    ):
+        result = create_subscription_llm_from_config(llm)
+
+    expected_base_url = CODEX_API_ENDPOINT.rsplit("/", 1)[0]
+    assert result.is_subscription is True
+    assert result.base_url == expected_base_url
+    assert result.api_key is None  # OAuth token lives in PrivateAttr, not api_key
+
+
+def test_create_subscription_llm_from_config_short_circuits_when_complete():
+    """When is_subscription=True AND runtime credentials are present (locally
+    created, not deserialized), the function should return the LLM as-is."""
+    from openhands.sdk.llm.auth.openai import (
+        create_subscription_llm_from_config,
+    )
+
+    # A locally-created subscription LLM has _subscription_credentials set.
+    llm = LLM(
+        model="openai/gpt-5.5",
+        auth_type="subscription",
+        subscription_vendor="openai",
+        base_url="https://chatgpt.com/backend-api/codex",
+        stream=True,
+        usage_id="test-short-circuit",
+    )
+    llm._is_subscription = True
+    llm._subscription_credentials = SimpleNamespace(
+        access_token="fake-token",
+        refresh_token="fake-refresh",
+        expires_at=9999999999999,
+    )
+
+    with patch(
+        "openhands.sdk.llm.auth.openai.OpenAISubscriptionAuth.refresh_if_needed_sync",
+        side_effect=AssertionError("should not be called"),
+    ):
+        result = create_subscription_llm_from_config(llm)
+
+    assert result is llm  # same object, no re-creation


### PR DESCRIPTION
## Problem

When using a GPT-5.5 ChatGPT subscription LLM via agent-canvas, conversations fail with:

```
litellm.BadRequestError: OpenAIException - {
  "error": {
    "message": "You have insufficient permissions for this operation. Missing scopes: api.responses.write. ..."
  }
}
```

## Root Cause

`create_subscription_llm_from_config()` had an early-return guard:

```python
if llm.is_subscription:
    return llm
```

This was fine **before** commit `48756c6f` (which made `is_subscription` survive serialization as a computed field). But now the flow is:

1. User activates the `gpt-5.5-sub` profile → `activate_profile` loads it via `from_persisted` → `create_subscription_llm_from_config` sets `is_subscription=True`, `base_url=https://chatgpt.com/backend-api/codex`, `_subscription_credentials=<OAuth token>`
2. The LLM is serialized to settings with `is_subscription=true` and `base_url=chatgpt.com` (but `_subscription_credentials` is a `PrivateAttr` — lost in serialization)
3. When starting a conversation, agent-canvas's `buildConfiguredOpenHandsAgentSettings` sees `auth_type=subscription` and **deletes `base_url`** before sending the config
4. The server validates the LLM → `_restore_is_subscription` sets `_is_subscription=True` from the serialized computed field
5. `create_subscription_llm_from_config` sees `is_subscription=True` → **returns the LLM as-is** with `base_url=None` and no `_subscription_credentials`
6. At request time, the OAuth token is fetched from the credential store, but `base_url=None` means the request goes to `api.openai.com/v1/responses` (the default OpenAI Platform endpoint) instead of `chatgpt.com/backend-api/codex`
7. The ChatGPT OAuth token lacks OpenAI Platform API scopes → `Missing scopes: api.responses.write`

## Fix

Change the early-return guard to check for `_subscription_credentials` (a `PrivateAttr` set by `auth.create_llm()`) instead of just `is_subscription`:

```python
if llm.is_subscription and llm._subscription_credentials is not None:
    return llm
```

`_subscription_credentials` is:
- **Set** when the LLM was locally created via `auth.create_llm()` — fully configured, safe to return as-is
- **`None`** when the LLM was deserialized (PrivateAttrs don't survive `model_dump`/`model_validate`) — needs re-creation to restore `base_url` and refresh OAuth tokens

This is more robust than checking a specific `base_url` string — it directly tests whether the LLM has its runtime state intact.

## Testing

- Added two regression tests:
  - `test_create_subscription_llm_from_config_restores_missing_base_url`: verifies the LLM is re-created with the correct Codex `base_url` when `is_subscription=True` but `_subscription_credentials` is `None`
  - `test_create_subscription_llm_from_config_short_circuits_when_complete`: verifies the function still short-circuits when `_subscription_credentials` is present
- All 861 existing LLM tests pass

---

_This PR was created by an AI agent (OpenHands) on behalf of Graham Neubig._

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a851dc6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a851dc6-python \
  ghcr.io/openhands/agent-server:a851dc6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a851dc6-golang-amd64
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-golang-amd64
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-golang-amd64
ghcr.io/openhands/agent-server:a851dc6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a851dc6-golang-arm64
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-golang-arm64
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-golang-arm64
ghcr.io/openhands/agent-server:a851dc6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a851dc6-java-amd64
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-java-amd64
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-java-amd64
ghcr.io/openhands/agent-server:a851dc6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a851dc6-java-arm64
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-java-arm64
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-java-arm64
ghcr.io/openhands/agent-server:a851dc6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a851dc6-python-amd64
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-python-amd64
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-python-amd64
ghcr.io/openhands/agent-server:a851dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a851dc6-python-arm64
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-python-arm64
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-python-arm64
ghcr.io/openhands/agent-server:a851dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a851dc6-golang
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-golang
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-golang
ghcr.io/openhands/agent-server:a851dc6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a851dc6-java
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-java
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-java
ghcr.io/openhands/agent-server:a851dc6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a851dc6-python
ghcr.io/openhands/agent-server:a851dc62fa6e5d3d9f605bd0a9f942e4bf1cbd8c-python
ghcr.io/openhands/agent-server:fix-subscription-missing-base-url-python
ghcr.io/openhands/agent-server:a851dc6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a851dc6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a851dc6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->