### PR TITLE
Extend browser_use logging workaround deadline to 1.35.0

### DIFF
--- a/openhands-tools/openhands/tools/browser_use/logging_fix.py
+++ b/openhands-tools/openhands/tools/browser_use/logging_fix.py
@@ -15,14 +15,16 @@ from openhands.sdk.utils.deprecation import warn_cleanup
 
 warn_cleanup(
     "Monkey patching to prevent browser_use logging interference",
-    cleanup_by="1.31.0",
+    cleanup_by="1.35.0",
     details=(
         "This workaround should be removed once browser_use fixes the "
         "problematic logging configuration code. The upstream PR #3717 "
         "(https://github.com/browser-use/browser-use/pull/3717) was closed "
-        "without merge. As of browser_use 0.11.9, the server still calls "
-        "_ensure_all_loggers_use_stderr() during import and initialization. "
-        "Re-evaluate when browser_use changes that behavior."
+        "without merge. As of browser_use 0.13.3, the server still calls "
+        "logging.basicConfig(), logging.disable() and "
+        "_ensure_all_loggers_use_stderr() during import and initialization, "
+        "and provides no opt-out env var. Re-evaluate when browser_use "
+        "changes that behavior."
     ),
 )
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I extended the deprecation because the fix is still not present upstream. Therefore, if we delete it then we will have a bug.

---

AGENT:

## Why

The `deprecation-check` CI job on the v1.31.0 release PR (#3965) fails because the
`browser_use` logging monkey-patch workaround has reached its `cleanup_by` deadline:

```
The following workarounds have passed their cleanup deadline:
- [openhands-tools] 'Monkey patching to prevent browser_use logging interference' (cleanup_call)
  cleanup by:    1.31.0
  defined at:    openhands-tools/openhands/tools/browser_use/logging_fix.py:16
```

The workaround cannot be removed yet: browser_use PR
[#3717](https://github.com/browser-use/browser-use/pull/3717) (which would have added a
`BROWSER_USE_SKIP_LOGGING_CONFIG` opt-out) was closed without merge on 2026-02-02, and as
of the latest browser_use release (0.13.3) `browser_use/mcp/server.py` still calls
`logging.basicConfig()`, `logging.disable()` and `_ensure_all_loggers_use_stderr()` at
import time with no opt-out. Removing it would reintroduce logging interference in
agent-server, so the deadline is extended instead.

## Summary

- Bump `cleanup_by` from `1.31.0` to `1.35.0` in `openhands-tools/openhands/tools/browser_use/logging_fix.py`.
- Refresh the `details` note to reflect that browser_use 0.13.3 still reconfigures logging at import and that PR #3717 was closed unmerged.

## Issue Number

No separate issue — unblocks release PR #3965.

## How to Test

Run the same script CI runs, from the repo root on this branch:

```
uv run --with packaging python .github/scripts/check_deprecations.py
```

On `rel-1.31.0` without this change it exits 1 with the "passed their cleanup deadline"
error shown above. With this change it exits 0:

```
openhands-sdk: checked 3 deprecation metadata entries against version 1.31.0.
openhands-tools: checked 1 deprecation metadata entries against version 1.31.0.
openhands-workspace: checked 0 deprecation metadata entries against version 1.31.0.
openhands-agent-server: checked 0 deprecation metadata entries against version 1.31.0.
Checked 4 deprecation metadata entries across 4 package(s).
```

## Video/Screenshots

N/A — CLI-only change; full command output is included under How to Test.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Targets the `rel-1.31.0` release branch so it lands in the release before the release PR
(#3965). Follow-up: remove the workaround entirely once browser_use stops reconfiguring
logging at import (re-evaluate by the new 1.35.0 deadline).

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0b014d8-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0b014d8-python \
  ghcr.io/openhands/agent-server:0b014d8-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0b014d8-golang-amd64
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-golang-amd64
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-golang-amd64
ghcr.io/openhands/agent-server:0b014d8-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0b014d8-golang-arm64
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-golang-arm64
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-golang-arm64
ghcr.io/openhands/agent-server:0b014d8-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0b014d8-java-amd64
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-java-amd64
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-java-amd64
ghcr.io/openhands/agent-server:0b014d8-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0b014d8-java-arm64
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-java-arm64
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-java-arm64
ghcr.io/openhands/agent-server:0b014d8-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0b014d8-python-amd64
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-python-amd64
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-python-amd64
ghcr.io/openhands/agent-server:0b014d8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0b014d8-python-arm64
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-python-arm64
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-python-arm64
ghcr.io/openhands/agent-server:0b014d8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0b014d8-golang
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-golang
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-golang
ghcr.io/openhands/agent-server:0b014d8-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0b014d8-java
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-java
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-java
ghcr.io/openhands/agent-server:0b014d8-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0b014d8-python
ghcr.io/openhands/agent-server:0b014d8b7909bb5e7ecc86e893a29b53ee9f129e-python
ghcr.io/openhands/agent-server:extend-browser-use-deadline-1.35.0-python
ghcr.io/openhands/agent-server:0b014d8-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0b014d8-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0b014d8-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->