### PR TITLE
fix(tools): default toolset at create_agent — SDK-owned names, profile passthrough (#3967)

### DIFF
--- a/examples/01_standalone_sdk/46_agent_settings.py
+++ b/examples/01_standalone_sdk/46_agent_settings.py
@@ -45,7 +45,7 @@ print()
 restored = OpenHandsAgentSettings.model_validate(payload)
 assert restored.condenser.enabled is True
 assert restored.condenser.max_size == 50
-assert len(restored.tools) == 2
+assert restored.tools is not None and len(restored.tools) == 2
 print("✓ Roundtrip deserialization successful — all fields preserved")
 print()
 

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -313,15 +313,12 @@ def _resolve_agent_from_profile(
         raise ValueError(f"Profile '{profile_name}' failed to resolve: {exc}") from exc
 
     agent = settings_config.create_agent()
-    # Browser is an environment-dependent capability, deliberately absent from
-    # the SDK's deterministic default (#3978): this server knows its own
-    # runtime, so it injects browser onto a default-toolset OpenHands profile
-    # when the chromium stack is actually present. An explicit profile.tools
-    # list is authoritative and never amended; the cloud conversation-builder
-    # does its own equivalent injection.
+    # Browser is deliberately absent from the deterministic SDK default
+    # (environment-dependent); this server knows its runtime, so it injects
+    # browser when usable. An explicit profile.tools list is authoritative.
     if (
-        getattr(profile, "tools", None) is None
-        and profile.agent_kind == "openhands"
+        profile.agent_kind == "openhands"
+        and profile.tools is None
         and is_tool_usable(BROWSER_TOOL_NAME)
     ):
         agent = agent.model_copy(

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -48,6 +48,7 @@ from openhands.sdk.event import MessageEvent
 from openhands.sdk.event.conversation_state import ConversationStateUpdateEvent
 from openhands.sdk.git.exceptions import GitCommandError, GitRepositoryError
 from openhands.sdk.git.utils import run_git_command, validate_git_repository
+from openhands.sdk.tool import BROWSER_TOOL_NAME, Tool, is_tool_usable
 from openhands.sdk.tool.client_tool import register_client_tools
 from openhands.sdk.utils.cipher import Cipher
 from openhands.sdk.workspace import LocalWorkspace
@@ -312,6 +313,20 @@ def _resolve_agent_from_profile(
         raise ValueError(f"Profile '{profile_name}' failed to resolve: {exc}") from exc
 
     agent = settings_config.create_agent()
+    # Browser is an environment-dependent capability, deliberately absent from
+    # the SDK's deterministic default (#3978): this server knows its own
+    # runtime, so it injects browser onto a default-toolset OpenHands profile
+    # when the chromium stack is actually present. An explicit profile.tools
+    # list is authoritative and never amended; the cloud conversation-builder
+    # does its own equivalent injection.
+    if (
+        getattr(profile, "tools", None) is None
+        and profile.agent_kind == "openhands"
+        and is_tool_usable(BROWSER_TOOL_NAME)
+    ):
+        agent = agent.model_copy(
+            update={"tools": [*agent.tools, Tool(name=BROWSER_TOOL_NAME)]}
+        )
     launched = LaunchedAgentProfile(
         agent_profile_id=profile.id,
         revision=profile.revision,

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -31,6 +31,7 @@ from openhands.sdk.settings.model import (
     VerificationSettings,
 )
 from openhands.sdk.skills import Skill
+from openhands.sdk.tool import Tool
 
 
 AGENT_PROFILE_SCHEMA_VERSION = 1
@@ -159,6 +160,17 @@ class OpenHandsAgentProfile(AgentProfileBase):
     agent: str = Field(
         default="CodeActAgent",
         description="Agent class to build.",
+    )
+    # Same tri-state as the resolved settings' ``tools``: passed through
+    # verbatim by the resolver, so ``create_agent`` is the single defaulting
+    # point (#3978). Secret-free by construction (``Tool`` is name + params).
+    tools: list[Tool] | None = Field(
+        default=None,
+        description=(
+            "Tool selection for the resolved agent. None (the default) = the "
+            "server's standard tool set; [] = an explicitly bare agent; a "
+            "non-empty list is used exactly as given."
+        ),
     )
     skills: list[Skill] = Field(
         default_factory=list,

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -44,10 +44,32 @@ from openhands.sdk.settings.model import (
     validate_agent_settings,
 )
 from openhands.sdk.skills import Skill, merge_skills_by_name
+from openhands.sdk.tool import Tool
 from openhands.sdk.utils.pydantic_secrets import (
     REDACTED_SECRET_VALUE,
     decrypt_str_with_cipher_or_keep,
 )
+
+
+# Default exec tools for a profile-resolved agent: a profile carries no ``tools``,
+# so without this ``create_agent`` gets ``tools=[]`` and only the Finish/Think
+# built-ins (#3967). String literals, not ``openhands-tools`` imports (this
+# package can't depend on it); browser is omitted since it isn't registered on
+# every runtime and ``resolve_tool`` raises on an unknown tool.
+_DEFAULT_OPENHANDS_TOOL_NAMES: tuple[str, ...] = (
+    "terminal",
+    "file_editor",
+    "task_tracker",
+)
+_SUB_AGENT_TOOL_NAME = "task_tool_set"  # delegation; gated on enable_sub_agents
+
+
+def _default_openhands_tools(enable_sub_agents: bool) -> list[Tool]:
+    """Standard exec tool specs for a profile-resolved OpenHands agent (#3967)."""
+    names = list(_DEFAULT_OPENHANDS_TOOL_NAMES)
+    if enable_sub_agents:
+        names.append(_SUB_AGENT_TOOL_NAME)
+    return [Tool(name=name) for name in names]
 
 
 if TYPE_CHECKING:
@@ -294,6 +316,7 @@ def _build_openhands_settings(
         "agent": profile.agent,
         "llm": llm,
         "mcp_config": mcp_config,
+        "tools": _default_openhands_tools(profile.enable_sub_agents),
         "agent_context": AgentContext(
             skills=skills,
             system_message_suffix=profile.system_message_suffix,

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -294,9 +294,7 @@ def _build_openhands_settings(
         "agent": profile.agent,
         "llm": llm,
         "mcp_config": mcp_config,
-        # Tri-state passthrough: None lets ``create_agent`` attach the server
-        # default set (which honors ``enable_sub_agents``) — the resolver does
-        # not re-derive the default toolset (#3967, #3978).
+        # Tri-state passthrough; create_agent materializes None.
         "tools": profile.tools,
         "agent_context": AgentContext(
             skills=skills,

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -44,32 +44,10 @@ from openhands.sdk.settings.model import (
     validate_agent_settings,
 )
 from openhands.sdk.skills import Skill, merge_skills_by_name
-from openhands.sdk.tool import Tool
 from openhands.sdk.utils.pydantic_secrets import (
     REDACTED_SECRET_VALUE,
     decrypt_str_with_cipher_or_keep,
 )
-
-
-# Default exec tools for a profile-resolved agent: a profile carries no ``tools``,
-# so without this ``create_agent`` gets ``tools=[]`` and only the Finish/Think
-# built-ins (#3967). String literals, not ``openhands-tools`` imports (this
-# package can't depend on it); browser is omitted since it isn't registered on
-# every runtime and ``resolve_tool`` raises on an unknown tool.
-_DEFAULT_OPENHANDS_TOOL_NAMES: tuple[str, ...] = (
-    "terminal",
-    "file_editor",
-    "task_tracker",
-)
-_SUB_AGENT_TOOL_NAME = "task_tool_set"  # delegation; gated on enable_sub_agents
-
-
-def _default_openhands_tools(enable_sub_agents: bool) -> list[Tool]:
-    """Standard exec tool specs for a profile-resolved OpenHands agent (#3967)."""
-    names = list(_DEFAULT_OPENHANDS_TOOL_NAMES)
-    if enable_sub_agents:
-        names.append(_SUB_AGENT_TOOL_NAME)
-    return [Tool(name=name) for name in names]
 
 
 if TYPE_CHECKING:
@@ -316,7 +294,10 @@ def _build_openhands_settings(
         "agent": profile.agent,
         "llm": llm,
         "mcp_config": mcp_config,
-        "tools": _default_openhands_tools(profile.enable_sub_agents),
+        # Tri-state passthrough: None lets ``create_agent`` attach the server
+        # default set (which honors ``enable_sub_agents``) — the resolver does
+        # not re-derive the default toolset (#3967, #3978).
+        "tools": profile.tools,
         "agent_context": AgentContext(
             skills=skills,
             system_message_suffix=profile.system_message_suffix,

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -63,6 +63,9 @@ def build_seed_profile(
         name=name,
         llm_profile_ref=active_llm_profile or SEED_PROFILE_NAME,
         agent=agent_settings.agent,
+        # Copy verbatim (None = server default) so a global config with e.g.
+        # browser or client tools seeds a genuinely behavior-preserving profile.
+        tools=agent_settings.tools,
         # Embed the global's already-resolved skills + skill_refs=[] (no further
         # discovery) to reproduce its exact set; skill_refs=None would re-discover
         # user+public and inject skills a partial-source global never had.

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -63,8 +63,7 @@ def build_seed_profile(
         name=name,
         llm_profile_ref=active_llm_profile or SEED_PROFILE_NAME,
         agent=agent_settings.agent,
-        # Copy verbatim (None = server default) so a global config with e.g.
-        # browser or client tools seeds a genuinely behavior-preserving profile.
+        # Verbatim: preserves explicit toolsets; None stays "server default".
         tools=agent_settings.tools,
         # Embed the global's already-resolved skills + skill_refs=[] (no further
         # discovery) to reproduce its exact set; skill_refs=None would re-discover

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1000,10 +1000,11 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         default=None,
         description=(
             "Tools available to the agent. None (the default) resolves to the "
-            "standard exec set (see openhands.sdk.tool.defaults), plus browser "
-            "tools when the runtime has them registered and usable, plus the "
+            "standard exec set (see openhands.sdk.tool.defaults), plus the "
             "sub-agent tool set when enable_sub_agents is set; [] is an "
-            "explicitly bare agent; a non-empty list is used exactly as given."
+            "explicitly bare agent; a non-empty list is used exactly as given. "
+            "Environment-dependent tools (browser) are injected by the serving "
+            "layer, not the default."
         ),
         json_schema_extra={
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1000,7 +1000,8 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         default=None,
         description=(
             "Tools available to the agent. None (the default) resolves to the "
-            "standard exec set (see openhands.sdk.tool.defaults), plus the "
+            "standard exec set (see openhands.sdk.tool.defaults), plus browser "
+            "tools when the runtime has them registered and usable, plus the "
             "sub-agent tool set when enable_sub_agents is set; [] is an "
             "explicitly bare agent; a non-empty list is used exactly as given."
         ),

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -1136,10 +1136,8 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, SwitchLLMTool
         from openhands.sdk.tool.defaults import default_tool_specs
 
-        # tools=None means "server default": the canonical exec set, with the
-        # sub-agent tool set gated on enable_sub_agents. [] stays an explicitly
-        # bare agent. This is the single defaulting point — callers and the
-        # profile resolver do not re-derive the default toolset (#3978).
+        # Single defaulting point: None = the canonical default set (honoring
+        # enable_sub_agents); [] stays an explicitly bare agent.
         tools = (
             self.tools
             if self.tools is not None

--- a/openhands-sdk/openhands/sdk/settings/model.py
+++ b/openhands-sdk/openhands/sdk/settings/model.py
@@ -996,9 +996,14 @@ class OpenHandsAgentSettings(AgentSettingsBase):
             ).model_dump()
         },
     )
-    tools: list[Tool] = Field(
-        default_factory=list,
-        description="Tools available to the agent.",
+    tools: list[Tool] | None = Field(
+        default=None,
+        description=(
+            "Tools available to the agent. None (the default) resolves to the "
+            "standard exec set (see openhands.sdk.tool.defaults), plus the "
+            "sub-agent tool set when enable_sub_agents is set; [] is an "
+            "explicitly bare agent; a non-empty list is used exactly as given."
+        ),
         json_schema_extra={
             SETTINGS_METADATA_KEY: SettingsFieldMetadata(
                 label="Tools",
@@ -1127,6 +1132,17 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         from openhands.sdk.agent import Agent
         from openhands.sdk.llm.auth.openai import create_subscription_llm_from_config
         from openhands.sdk.tool.builtins import BUILT_IN_TOOLS, SwitchLLMTool
+        from openhands.sdk.tool.defaults import default_tool_specs
+
+        # tools=None means "server default": the canonical exec set, with the
+        # sub-agent tool set gated on enable_sub_agents. [] stays an explicitly
+        # bare agent. This is the single defaulting point — callers and the
+        # profile resolver do not re-derive the default toolset (#3978).
+        tools = (
+            self.tools
+            if self.tools is not None
+            else default_tool_specs(enable_sub_agents=self.enable_sub_agents)
+        )
 
         # Bypass ``_serialize_mcp_config``: MCP servers need real env/headers.
         mcp_config = (
@@ -1142,7 +1158,7 @@ class OpenHandsAgentSettings(AgentSettingsBase):
         condenser = None if llm.is_subscription else self.build_condenser(llm)
         return Agent(
             llm=llm,
-            tools=self.tools,
+            tools=tools,
             mcp_config=mcp_config,
             include_default_tools=include_default_tools,
             agent_context=self.agent_context,

--- a/openhands-sdk/openhands/sdk/tool/__init__.py
+++ b/openhands-sdk/openhands/sdk/tool/__init__.py
@@ -11,6 +11,11 @@ from openhands.sdk.tool.client_tool import (
     ClientToolSpec,
     register_client_tools,
 )
+from openhands.sdk.tool.defaults import (
+    DEFAULT_EXEC_TOOL_NAMES,
+    SUB_AGENT_TOOL_NAME,
+    default_tool_specs,
+)
 from openhands.sdk.tool.registry import (
     list_registered_tools,
     register_tool,
@@ -38,6 +43,9 @@ __all__ = [
     "register_client_tools",
     "DeclaredResources",
     "Tool",
+    "DEFAULT_EXEC_TOOL_NAMES",
+    "SUB_AGENT_TOOL_NAME",
+    "default_tool_specs",
     "ToolDefinition",
     "ToolAnnotations",
     "ToolExecutor",

--- a/openhands-sdk/openhands/sdk/tool/__init__.py
+++ b/openhands-sdk/openhands/sdk/tool/__init__.py
@@ -12,11 +12,13 @@ from openhands.sdk.tool.client_tool import (
     register_client_tools,
 )
 from openhands.sdk.tool.defaults import (
+    BROWSER_TOOL_NAME,
     DEFAULT_EXEC_TOOL_NAMES,
     SUB_AGENT_TOOL_NAME,
     default_tool_specs,
 )
 from openhands.sdk.tool.registry import (
+    is_tool_usable,
     list_registered_tools,
     register_tool,
     resolve_tool,
@@ -43,9 +45,11 @@ __all__ = [
     "register_client_tools",
     "DeclaredResources",
     "Tool",
+    "BROWSER_TOOL_NAME",
     "DEFAULT_EXEC_TOOL_NAMES",
     "SUB_AGENT_TOOL_NAME",
     "default_tool_specs",
+    "is_tool_usable",
     "ToolDefinition",
     "ToolAnnotations",
     "ToolExecutor",

--- a/openhands-sdk/openhands/sdk/tool/defaults.py
+++ b/openhands-sdk/openhands/sdk/tool/defaults.py
@@ -22,8 +22,14 @@ DEFAULT_EXEC_TOOL_NAMES: tuple[str, ...] = (
 """Names of the standard exec tools every default OpenHands agent gets."""
 
 BROWSER_TOOL_NAME = "browser_tool_set"
-"""Name of the browser tool set, included in the default when the runtime
-has it registered and usable (chromium available)."""
+"""Name of the browser tool set.
+
+Not part of the deterministic default: browser is an environment-dependent
+capability, so the serving layer that knows its runtime injects it — the
+agent-server appends it on profile launches when ``is_tool_usable`` says the
+chromium stack is present, and the cloud conversation-builder does its own
+injection. Clients (canvas) add it themselves on the settings launch path.
+"""
 
 SUB_AGENT_TOOL_NAME = "task_tool_set"
 """Name of the sub-agent delegation tool set, gated on ``enable_sub_agents``."""
@@ -32,25 +38,16 @@ SUB_AGENT_TOOL_NAME = "task_tool_set"
 def default_tool_specs(
     *,
     enable_sub_agents: bool = False,
-    enable_browser: bool | None = None,
+    enable_browser: bool = False,
 ) -> list[Tool]:
     """Default tool specs for an OpenHands agent whose settings carry no tools.
 
-    ``enable_browser=None`` (the default) is adaptive: browser tools are
-    included exactly when the current runtime has them registered and usable
-    (chromium present) — the same bar canvas applies via ``GET /tools`` on the
-    settings launch path — so a default-toolset agent gets browser wherever it
-    can actually run, and resolving the spec never raises on a runtime without
-    it. Pass True/False to force.
+    Deterministic: the same inputs yield the same specs on every runtime.
+    Browser is off by default (see :data:`BROWSER_TOOL_NAME` — the serving
+    layer injects it where it can actually run); pass ``enable_browser=True``
+    to include it explicitly.
     """
     names = list(DEFAULT_EXEC_TOOL_NAMES)
-    if enable_browser is None:
-        # Local import: the registry is populated by openhands-tools at import
-        # time in the serving process; consulted lazily so this module stays
-        # import-light and cycle-free.
-        from openhands.sdk.tool.registry import is_tool_usable
-
-        enable_browser = is_tool_usable(BROWSER_TOOL_NAME)
     if enable_browser:
         names.append(BROWSER_TOOL_NAME)
     if enable_sub_agents:

--- a/openhands-sdk/openhands/sdk/tool/defaults.py
+++ b/openhands-sdk/openhands/sdk/tool/defaults.py
@@ -1,0 +1,38 @@
+"""Canonical default tool names for the standard OpenHands agent.
+
+Tool *names* are a wire contract: they are persisted in settings/profile JSON
+and sent by clients, independently of where the implementations live. Keeping
+the canonical defaults here lets ``openhands-sdk`` (which must not import
+``openhands-tools``) default a toolset from data alone — ``Tool`` is a spec
+(name + params) resolved to an implementation only at runtime via the registry.
+
+``openhands.tools.preset.default.get_default_tools`` remains the constructor
+that also registers the implementations; ``tests/cross`` asserts it stays in
+lockstep with these names.
+"""
+
+from openhands.sdk.tool.spec import Tool
+
+
+DEFAULT_EXEC_TOOL_NAMES: tuple[str, ...] = (
+    "terminal",
+    "file_editor",
+    "task_tracker",
+)
+"""Names of the standard exec tools every default OpenHands agent gets."""
+
+SUB_AGENT_TOOL_NAME = "task_tool_set"
+"""Name of the sub-agent delegation tool set, gated on ``enable_sub_agents``."""
+
+
+def default_tool_specs(*, enable_sub_agents: bool = False) -> list[Tool]:
+    """Default tool specs for an OpenHands agent whose settings carry no tools.
+
+    Browser tools are not included: they are not registered on every runtime
+    and resolving an unknown tool raises at conversation start. A caller (or a
+    profile) that wants browser opts in with an explicit tools list.
+    """
+    names = list(DEFAULT_EXEC_TOOL_NAMES)
+    if enable_sub_agents:
+        names.append(SUB_AGENT_TOOL_NAME)
+    return [Tool(name=name) for name in names]

--- a/openhands-sdk/openhands/sdk/tool/defaults.py
+++ b/openhands-sdk/openhands/sdk/tool/defaults.py
@@ -21,18 +21,38 @@ DEFAULT_EXEC_TOOL_NAMES: tuple[str, ...] = (
 )
 """Names of the standard exec tools every default OpenHands agent gets."""
 
+BROWSER_TOOL_NAME = "browser_tool_set"
+"""Name of the browser tool set, included in the default when the runtime
+has it registered and usable (chromium available)."""
+
 SUB_AGENT_TOOL_NAME = "task_tool_set"
 """Name of the sub-agent delegation tool set, gated on ``enable_sub_agents``."""
 
 
-def default_tool_specs(*, enable_sub_agents: bool = False) -> list[Tool]:
+def default_tool_specs(
+    *,
+    enable_sub_agents: bool = False,
+    enable_browser: bool | None = None,
+) -> list[Tool]:
     """Default tool specs for an OpenHands agent whose settings carry no tools.
 
-    Browser tools are not included: they are not registered on every runtime
-    and resolving an unknown tool raises at conversation start. A caller (or a
-    profile) that wants browser opts in with an explicit tools list.
+    ``enable_browser=None`` (the default) is adaptive: browser tools are
+    included exactly when the current runtime has them registered and usable
+    (chromium present) — the same bar canvas applies via ``GET /tools`` on the
+    settings launch path — so a default-toolset agent gets browser wherever it
+    can actually run, and resolving the spec never raises on a runtime without
+    it. Pass True/False to force.
     """
     names = list(DEFAULT_EXEC_TOOL_NAMES)
+    if enable_browser is None:
+        # Local import: the registry is populated by openhands-tools at import
+        # time in the serving process; consulted lazily so this module stays
+        # import-light and cycle-free.
+        from openhands.sdk.tool.registry import is_tool_usable
+
+        enable_browser = is_tool_usable(BROWSER_TOOL_NAME)
+    if enable_browser:
+        names.append(BROWSER_TOOL_NAME)
     if enable_sub_agents:
         names.append(SUB_AGENT_TOOL_NAME)
     return [Tool(name=name) for name in names]

--- a/openhands-sdk/openhands/sdk/tool/registry.py
+++ b/openhands-sdk/openhands/sdk/tool/registry.py
@@ -163,6 +163,19 @@ def list_registered_tools() -> list[str]:
         return list(_REG.keys())
 
 
+def is_tool_usable(name: str) -> bool:
+    """Whether ``name`` is registered AND its usability check passes.
+
+    False for unregistered names; a checker that raises counts as unusable
+    (mirrors :func:`list_usable_tools`).
+    """
+    with _LOCK:
+        if name not in _REG:
+            return False
+        checker = _USABILITY_REG.get(name, lambda: True)
+    return _check_tool_usable(name, checker)
+
+
 def list_usable_tools() -> list[str]:
     with _LOCK:
         tool_names = list(_REG.keys())

--- a/tests/agent_server/test_agent_profile_conv_start.py
+++ b/tests/agent_server/test_agent_profile_conv_start.py
@@ -188,6 +188,13 @@ class TestResolveAgentFromProfile:
             patch(_LLM_STORE_PATH),
             patch(_RESOLVE_PATH) as MockResolve,
             patch(_DISCOVER_PATH, return_value=[]) as MockDiscover,
+            # Pin the environment probe: tools=None profiles get browser
+            # injected iff the host has chromium (covered by the dedicated
+            # injection tests below); this test is about resolution plumbing.
+            patch(
+                "openhands.agent_server.conversation_service.is_tool_usable",
+                return_value=False,
+            ),
         ):
             store_inst = MockStore.return_value
             store_inst.name_for_id.return_value = profile.name
@@ -207,6 +214,136 @@ class TestResolveAgentFromProfile:
         # skill_refs=None (all discovered) triggers discovery, threaded through.
         MockDiscover.assert_called_once()
         assert MockResolve.call_args.kwargs["available_skills"] == []
+
+    def test_openhands_default_tools_get_browser_when_usable(self):
+        """A default-toolset (tools=None) OpenHands profile launch injects the
+        browser tool set when this server's runtime can run it — the
+        serving-layer counterpart of the SDK's deterministic default (#3978)."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_openhands_profile()
+        assert profile.tools is None
+        agent = _make_agent()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(
+                "openhands.agent_server.conversation_service.is_tool_usable",
+                return_value=True,
+            ) as MockUsable,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            mock_config = MagicMock()
+            mock_config.create_agent.return_value = agent
+            MockResolve.return_value = mock_config
+
+            result_agent, _ = _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config=None
+            )
+
+        MockUsable.assert_called_once_with("browser_tool_set")
+        assert [tool.name for tool in result_agent.tools] == ["browser_tool_set"]
+
+    def test_openhands_default_tools_skip_browser_when_unusable(self):
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_openhands_profile()
+        agent = _make_agent()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(
+                "openhands.agent_server.conversation_service.is_tool_usable",
+                return_value=False,
+            ),
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            mock_config = MagicMock()
+            mock_config.create_agent.return_value = agent
+            MockResolve.return_value = mock_config
+
+            result_agent, _ = _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config=None
+            )
+
+        assert result_agent is agent
+
+    def test_openhands_explicit_tools_never_amended(self):
+        """An explicit profile tools list ([] included) is authoritative: the
+        serving layer must not inject browser on top of it."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_openhands_profile().model_copy(update={"tools": []})
+        agent = _make_agent()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(
+                "openhands.agent_server.conversation_service.is_tool_usable",
+                return_value=True,
+            ) as MockUsable,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            mock_config = MagicMock()
+            mock_config.create_agent.return_value = agent
+            MockResolve.return_value = mock_config
+
+            result_agent, _ = _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config=None
+            )
+
+        MockUsable.assert_not_called()
+        assert result_agent is agent
+
+    def test_acp_profile_never_gets_browser_injection(self):
+        """ACP agents own their tooling — the injection is OpenHands-only."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_acp_profile()
+        agent = _make_agent()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(
+                "openhands.agent_server.conversation_service.is_tool_usable",
+                return_value=True,
+            ) as MockUsable,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            mock_config = MagicMock()
+            mock_config.create_agent.return_value = agent
+            MockResolve.return_value = mock_config
+
+            result_agent, _ = _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config=None
+            )
+
+        MockUsable.assert_not_called()
+        assert result_agent is agent
 
     def test_openhands_default_profile_skips_discovery(self):
         """A profile with the default ``skill_refs`` (== [], incl. any persisted

--- a/tests/agent_server/test_agent_server_wsproto.py
+++ b/tests/agent_server/test_agent_server_wsproto.py
@@ -35,35 +35,57 @@ def run_agent_server(port, api_key):
     main()
 
 
-@pytest.fixture(scope="session")
-def agent_server():
-    port = find_free_port()
-    api_key = "test-wsproto-key"
-
-    ctx = multiprocessing.get_context("spawn")
-    process = ctx.Process(target=run_agent_server, args=(port, api_key))
-    process.start()
-
-    for _ in range(30):
-        try:
-            response = requests.get(f"http://127.0.0.1:{port}/docs", timeout=1)
-            if response.status_code == 200:
-                break
-        except requests.exceptions.ConnectionError:
-            pass
-        time.sleep(2)
-    else:
-        process.terminate()
-        process.join()
-        pytest.fail(f"Agent server failed to start on port {port}")
-
-    yield {"port": port, "api_key": api_key}
-
+def _terminate(process):
     process.terminate()
     process.join(timeout=5)
     if process.is_alive():
         process.kill()
         process.join()
+
+
+def _wait_until_ready(process, port, timeout=30.0):
+    """Poll the lightweight /alive endpoint until the server responds.
+
+    Returns False (rather than blocking for the whole timeout) as soon as the
+    server process exits, so a failed port bind can be retried on a fresh port.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        if not process.is_alive():
+            return False
+        try:
+            response = requests.get(f"http://127.0.0.1:{port}/alive", timeout=1)
+            if response.status_code == 200:
+                return True
+        except requests.exceptions.RequestException:
+            pass
+        time.sleep(0.5)
+    return False
+
+
+@pytest.fixture(scope="session")
+def agent_server():
+    api_key = "test-wsproto-key"
+    ctx = multiprocessing.get_context("spawn")
+
+    # find_free_port() closes the socket before the server rebinds it, leaving a
+    # TOCTOU window in which another process on a busy CI host can steal the port
+    # and crash startup. Retry on a fresh port to absorb that race.
+    process = None
+    port = None
+    for _ in range(3):
+        port = find_free_port()
+        process = ctx.Process(target=run_agent_server, args=(port, api_key))
+        process.start()
+        if _wait_until_ready(process, port):
+            break
+        _terminate(process)
+    else:
+        pytest.fail("Agent server failed to start after multiple attempts")
+
+    yield {"port": port, "api_key": api_key}
+
+    _terminate(process)
 
 
 def test_agent_server_starts_with_wsproto(agent_server):

--- a/tests/agent_server/test_agent_server_wsproto.py
+++ b/tests/agent_server/test_agent_server_wsproto.py
@@ -22,7 +22,29 @@ def find_free_port():
         return s.getsockname()[1]
 
 
+def _drop_site_packages_subdir_paths():
+    """Remove sys.path entries that point *inside* a site-packages directory.
+
+    This test spawns the server with the ``spawn`` start method from within a
+    pytest-xdist worker, so the child inherits the worker's ``sys.path``. Under
+    the full suite another test leaves a stray package directory
+    (``.../site-packages/browser_use``) at ``sys.path[0]``, which makes its
+    sub-packages importable as top-level modules — ``browser_use/mcp`` then
+    shadows the real ``mcp`` and fastmcp's eager ``import mcp`` crashes startup
+    with a ``mcp`` <-> ``browser_use.mcp`` circular import. Dropping such
+    entries restores normal top-level resolution.
+    """
+    cleaned = [
+        entry
+        for entry in sys.path
+        if os.path.basename(os.path.dirname(entry.rstrip(os.sep))) != "site-packages"
+    ]
+    sys.path[:] = cleaned
+
+
 def run_agent_server(port, api_key):
+    _drop_site_packages_subdir_paths()
+
     # Configure authentication for the server process.
     #
     # Use both the V1 indexed env var and the legacy V0 var to keep this test

--- a/tests/cross/test_default_tool_names.py
+++ b/tests/cross/test_default_tool_names.py
@@ -8,6 +8,7 @@ the two together so a tool rename cannot silently drift the SDK-side defaults
 """
 
 from openhands.sdk.tool.defaults import (
+    BROWSER_TOOL_NAME,
     DEFAULT_EXEC_TOOL_NAMES,
     SUB_AGENT_TOOL_NAME,
     default_tool_specs,
@@ -32,17 +33,29 @@ def test_sub_agent_name_matches_task_tool_set() -> None:
     assert SUB_AGENT_TOOL_NAME == TaskToolSet.name
 
 
+def test_browser_name_matches_browser_tool_set() -> None:
+    from openhands.tools.browser_use import BrowserToolSet
+
+    assert BROWSER_TOOL_NAME == BrowserToolSet.name
+
+
 def test_default_tool_specs_parity_with_get_default_tools() -> None:
     from openhands.tools.preset.default import get_default_tools
 
-    for enable_sub_agents in (False, True):
-        sdk_names = [
-            t.name for t in default_tool_specs(enable_sub_agents=enable_sub_agents)
-        ]
-        preset_names = [
-            t.name
-            for t in get_default_tools(
-                enable_browser=False, enable_sub_agents=enable_sub_agents
-            )
-        ]
-        assert sdk_names == preset_names
+    for enable_browser in (False, True):
+        for enable_sub_agents in (False, True):
+            sdk_names = [
+                t.name
+                for t in default_tool_specs(
+                    enable_browser=enable_browser,
+                    enable_sub_agents=enable_sub_agents,
+                )
+            ]
+            preset_names = [
+                t.name
+                for t in get_default_tools(
+                    enable_browser=enable_browser,
+                    enable_sub_agents=enable_sub_agents,
+                )
+            ]
+            assert sdk_names == preset_names

--- a/tests/cross/test_default_tool_names.py
+++ b/tests/cross/test_default_tool_names.py
@@ -1,0 +1,48 @@
+"""Parity between the SDK's canonical default tool names and openhands-tools.
+
+``openhands.sdk.tool.defaults`` owns the default tool *names* as data (the SDK
+cannot import ``openhands-tools``); the implementations and the historical
+``get_default_tools`` constructor live in ``openhands-tools``. These tests pin
+the two together so a tool rename cannot silently drift the SDK-side defaults
+(the review concern on #3968, resolved per #3978).
+"""
+
+from openhands.sdk.tool.defaults import (
+    DEFAULT_EXEC_TOOL_NAMES,
+    SUB_AGENT_TOOL_NAME,
+    default_tool_specs,
+)
+
+
+def test_default_exec_names_match_tool_classes() -> None:
+    from openhands.tools.file_editor import FileEditorTool
+    from openhands.tools.task_tracker import TaskTrackerTool
+    from openhands.tools.terminal import TerminalTool
+
+    assert DEFAULT_EXEC_TOOL_NAMES == (
+        TerminalTool.name,
+        FileEditorTool.name,
+        TaskTrackerTool.name,
+    )
+
+
+def test_sub_agent_name_matches_task_tool_set() -> None:
+    from openhands.tools.task import TaskToolSet
+
+    assert SUB_AGENT_TOOL_NAME == TaskToolSet.name
+
+
+def test_default_tool_specs_parity_with_get_default_tools() -> None:
+    from openhands.tools.preset.default import get_default_tools
+
+    for enable_sub_agents in (False, True):
+        sdk_names = [
+            t.name for t in default_tool_specs(enable_sub_agents=enable_sub_agents)
+        ]
+        preset_names = [
+            t.name
+            for t in get_default_tools(
+                enable_browser=False, enable_sub_agents=enable_sub_agents
+            )
+        ]
+        assert sdk_names == preset_names

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -96,8 +96,43 @@ def test_openhands_resolves_to_settings_with_injected_llm(
     # MCP filtered to the referenced key.
     assert settings.mcp_config is not None
     assert list(settings.mcp_config.mcpServers.keys()) == ["fetch"]
-    # Output feeds the unchanged create_agent path.
-    assert isinstance(settings.create_agent(), Agent)
+    # Default exec toolset is attached (#3967); the sub-agent tool set is
+    # included because enable_sub_agents=True.
+    tool_names = [t.name for t in settings.tools]
+    assert {"terminal", "file_editor", "task_tracker"} <= set(tool_names)
+    assert "task_tool_set" in tool_names
+    # Output feeds the unchanged create_agent path, tools included.
+    agent = settings.create_agent()
+    assert isinstance(agent, Agent)
+    assert {"terminal", "file_editor", "task_tracker"} <= {t.name for t in agent.tools}
+
+
+def test_openhands_resolves_default_exec_tools(
+    llm_store: LLMProfileStore,
+) -> None:
+    """A profile has no ``tools`` field, so resolution must attach the standard
+    exec set (#3967) — otherwise ``create_agent`` yields an agent with only the
+    Finish/Think built-ins and no way to run shell commands or edit files. The
+    sub-agent tool set stays out when ``enable_sub_agents`` is False (default)."""
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
+    assert profile.enable_sub_agents is False
+
+    settings = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=None,
+        available_skills=None,
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert [t.name for t in settings.tools] == [
+        "terminal",
+        "file_editor",
+        "task_tracker",
+    ]
+    # The resolved agent carries the exec tools, not just the built-ins.
+    agent = settings.create_agent()
+    assert {"terminal", "file_editor", "task_tracker"} <= {t.name for t in agent.tools}
 
 
 def test_openhands_copies_skills_and_verification(

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -26,6 +26,7 @@ from openhands.sdk.profiles import (
 )
 from openhands.sdk.settings.model import ACPAgentSettings, OpenHandsAgentSettings
 from openhands.sdk.skills import Skill
+from openhands.sdk.tool import Tool
 from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
 
 
@@ -96,26 +97,28 @@ def test_openhands_resolves_to_settings_with_injected_llm(
     # MCP filtered to the referenced key.
     assert settings.mcp_config is not None
     assert list(settings.mcp_config.mcpServers.keys()) == ["fetch"]
-    # Default exec toolset is attached (#3967); the sub-agent tool set is
-    # included because enable_sub_agents=True.
-    tool_names = [t.name for t in settings.tools]
-    assert {"terminal", "file_editor", "task_tracker"} <= set(tool_names)
-    assert "task_tool_set" in tool_names
-    # Output feeds the unchanged create_agent path, tools included.
+    # The profile's tools default (None) rides through so create_agent is the
+    # single defaulting point (#3967 / #3978); the built agent carries the
+    # standard exec set plus the sub-agent tool set (enable_sub_agents=True).
+    assert settings.tools is None
     agent = settings.create_agent()
     assert isinstance(agent, Agent)
-    assert {"terminal", "file_editor", "task_tracker"} <= {t.name for t in agent.tools}
+    agent_tool_names = [t.name for t in agent.tools]
+    assert {"terminal", "file_editor", "task_tracker"} <= set(agent_tool_names)
+    assert "task_tool_set" in agent_tool_names
 
 
 def test_openhands_resolves_default_exec_tools(
     llm_store: LLMProfileStore,
 ) -> None:
-    """A profile has no ``tools`` field, so resolution must attach the standard
-    exec set (#3967) — otherwise ``create_agent`` yields an agent with only the
-    Finish/Think built-ins and no way to run shell commands or edit files. The
-    sub-agent tool set stays out when ``enable_sub_agents`` is False (default)."""
+    """A profile with no explicit ``tools`` resolves to ``tools=None``, and
+    ``create_agent`` attaches the standard exec set (#3967) — otherwise the
+    agent has only the Finish/Think built-ins and no way to run shell commands
+    or edit files. The sub-agent tool set stays out when ``enable_sub_agents``
+    is False (default)."""
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     assert profile.enable_sub_agents is False
+    assert profile.tools is None
 
     settings = resolve_agent_profile(
         profile,
@@ -125,14 +128,49 @@ def test_openhands_resolves_default_exec_tools(
         cipher=None,
     )
     assert isinstance(settings, OpenHandsAgentSettings)
-    assert [t.name for t in settings.tools] == [
+    assert settings.tools is None
+    # The built agent carries the exec tools, not just the built-ins.
+    agent = settings.create_agent()
+    assert [t.name for t in agent.tools] == [
         "terminal",
         "file_editor",
         "task_tracker",
     ]
-    # The resolved agent carries the exec tools, not just the built-ins.
-    agent = settings.create_agent()
-    assert {"terminal", "file_editor", "task_tracker"} <= {t.name for t in agent.tools}
+
+
+def test_openhands_profile_tools_selection_is_passed_through(
+    llm_store: LLMProfileStore,
+) -> None:
+    """An explicit profile ``tools`` list is authoritative: used exactly as
+    given ([] = deliberately bare), independent of ``enable_sub_agents``."""
+    picked = OpenHandsAgentProfile(
+        name="picked",
+        llm_profile_ref="default",
+        tools=[Tool(name="terminal")],
+        enable_sub_agents=True,
+    )
+    settings = resolve_agent_profile(
+        picked,
+        llm_store=llm_store,
+        mcp_config=None,
+        available_skills=None,
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert settings.tools == [Tool(name="terminal")]
+    assert [t.name for t in settings.create_agent().tools] == ["terminal"]
+
+    bare = OpenHandsAgentProfile(name="bare", llm_profile_ref="default", tools=[])
+    settings = resolve_agent_profile(
+        bare,
+        llm_store=llm_store,
+        mcp_config=None,
+        available_skills=None,
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert settings.tools == []
+    assert settings.create_agent().tools == []
 
 
 def test_openhands_copies_skills_and_verification(

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -110,18 +110,13 @@ def test_openhands_resolves_to_settings_with_injected_llm(
 
 def test_openhands_resolves_default_exec_tools(
     llm_store: LLMProfileStore,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A profile with no explicit ``tools`` resolves to ``tools=None``, and
     ``create_agent`` attaches the standard exec set (#3967) — otherwise the
     agent has only the Finish/Think built-ins and no way to run shell commands
     or edit files. The sub-agent tool set stays out when ``enable_sub_agents``
-    is False (default); browser is pinned unregistered here for determinism
-    (adaptive default, see tests/sdk/tool/test_defaults.py)."""
-    from openhands.sdk.tool import registry
-    from openhands.sdk.tool.defaults import BROWSER_TOOL_NAME
-
-    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
+    is False (default); browser is a serving-layer injection, never part of
+    the deterministic default (see tests/sdk/tool/test_defaults.py)."""
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     assert profile.enable_sub_agents is False
     assert profile.tools is None

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -110,12 +110,18 @@ def test_openhands_resolves_to_settings_with_injected_llm(
 
 def test_openhands_resolves_default_exec_tools(
     llm_store: LLMProfileStore,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """A profile with no explicit ``tools`` resolves to ``tools=None``, and
     ``create_agent`` attaches the standard exec set (#3967) — otherwise the
     agent has only the Finish/Think built-ins and no way to run shell commands
     or edit files. The sub-agent tool set stays out when ``enable_sub_agents``
-    is False (default)."""
+    is False (default); browser is pinned unregistered here for determinism
+    (adaptive default, see tests/sdk/tool/test_defaults.py)."""
+    from openhands.sdk.tool import registry
+    from openhands.sdk.tool.defaults import BROWSER_TOOL_NAME
+
+    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     assert profile.enable_sub_agents is False
     assert profile.tools is None

--- a/tests/sdk/profiles/test_store_protocol_hoists.py
+++ b/tests/sdk/profiles/test_store_protocol_hoists.py
@@ -243,6 +243,8 @@ def test_build_seed_profile_openhands_branch():
     assert profile.name == SEED_PROFILE_NAME
     assert profile.llm_profile_ref == "my-llm"
     assert profile.mcp_server_refs is None
+    # Default settings carry tools=None -> the seed inherits the server default.
+    assert profile.tools is None
     # Secret-free verification projection (no critic_api_key on the profile type).
     assert "critic_api_key" not in type(profile.verification).model_fields
 
@@ -250,6 +252,22 @@ def test_build_seed_profile_openhands_branch():
     fallback = build_seed_profile(settings, active_llm_profile=None)
     assert isinstance(fallback, OpenHandsAgentProfile)
     assert fallback.llm_profile_ref == SEED_PROFILE_NAME
+
+
+def test_build_seed_profile_copies_explicit_tools():
+    """A global config with an explicit toolset (e.g. browser) seeds a
+    behavior-preserving profile — the tools are copied verbatim, not reset to
+    the server default (#3978)."""
+    settings = validate_agent_settings(
+        {
+            "agent_kind": "openhands",
+            "tools": [{"name": "terminal"}, {"name": "browser_use"}],
+        }
+    )
+    profile = build_seed_profile(settings, active_llm_profile="my-llm")
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.tools is not None
+    assert [t.name for t in profile.tools] == ["terminal", "browser_use"]
 
 
 def test_build_seed_profile_acp_branch():

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -548,30 +548,17 @@ def test_llm_create_agent_defaults_tool_concurrency_limit_to_one() -> None:
     assert agent.tool_concurrency_limit == 1
 
 
-def test_create_agent_defaults_tools_when_none(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_create_agent_defaults_tools_when_none() -> None:
     """tools=None (the default) materializes the canonical exec set at
-    create_agent — the single defaulting point (#3967 / #3978). Browser is
-    pinned unregistered here so the expectation is deterministic; the
-    registered/usable cases live in tests/sdk/tool/test_defaults.py."""
-    from openhands.sdk.tool import registry
-    from openhands.sdk.tool.defaults import BROWSER_TOOL_NAME
-
-    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
+    create_agent — the single defaulting point (#3967 / #3978). Deterministic:
+    browser is a serving-layer injection, never part of the default."""
     settings = OpenHandsAgentSettings(llm=LLM(model="test-model"))
     assert settings.tools is None
     agent = settings.create_agent()
     assert [t.name for t in agent.tools] == ["terminal", "file_editor", "task_tracker"]
 
 
-def test_create_agent_default_tools_honor_enable_sub_agents(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    from openhands.sdk.tool import registry
-    from openhands.sdk.tool.defaults import BROWSER_TOOL_NAME
-
-    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
+def test_create_agent_default_tools_honor_enable_sub_agents() -> None:
     settings = OpenHandsAgentSettings(
         llm=LLM(model="test-model"), enable_sub_agents=True
     )

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -548,16 +548,30 @@ def test_llm_create_agent_defaults_tool_concurrency_limit_to_one() -> None:
     assert agent.tool_concurrency_limit == 1
 
 
-def test_create_agent_defaults_tools_when_none() -> None:
+def test_create_agent_defaults_tools_when_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """tools=None (the default) materializes the canonical exec set at
-    create_agent — the single defaulting point (#3967 / #3978)."""
+    create_agent — the single defaulting point (#3967 / #3978). Browser is
+    pinned unregistered here so the expectation is deterministic; the
+    registered/usable cases live in tests/sdk/tool/test_defaults.py."""
+    from openhands.sdk.tool import registry
+    from openhands.sdk.tool.defaults import BROWSER_TOOL_NAME
+
+    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
     settings = OpenHandsAgentSettings(llm=LLM(model="test-model"))
     assert settings.tools is None
     agent = settings.create_agent()
     assert [t.name for t in agent.tools] == ["terminal", "file_editor", "task_tracker"]
 
 
-def test_create_agent_default_tools_honor_enable_sub_agents() -> None:
+def test_create_agent_default_tools_honor_enable_sub_agents(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from openhands.sdk.tool import registry
+    from openhands.sdk.tool.defaults import BROWSER_TOOL_NAME
+
+    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
     settings = OpenHandsAgentSettings(
         llm=LLM(model="test-model"), enable_sub_agents=True
     )

--- a/tests/sdk/test_settings.py
+++ b/tests/sdk/test_settings.py
@@ -75,7 +75,8 @@ def test_llm_agent_settings_export_schema_groups_sections() -> None:
     assert general_fields["agent"].default == "CodeActAgent"
     assert general_fields["agent"].prominence is SettingProminence.MAJOR
     assert general_fields["tools"].value_type == "array"
-    assert general_fields["tools"].default == []
+    # None = "server default toolset" (materialized by create_agent, #3978).
+    assert general_fields["tools"].default is None
     assert general_fields["tools"].prominence is SettingProminence.MAJOR
     assert general_fields["enable_sub_agents"].value_type == "boolean"
     assert general_fields["enable_sub_agents"].default is False
@@ -545,6 +546,36 @@ def test_llm_create_agent_uses_settings_llm_and_tools() -> None:
 def test_llm_create_agent_defaults_tool_concurrency_limit_to_one() -> None:
     agent = OpenHandsAgentSettings(llm=LLM(model="test-model")).create_agent()
     assert agent.tool_concurrency_limit == 1
+
+
+def test_create_agent_defaults_tools_when_none() -> None:
+    """tools=None (the default) materializes the canonical exec set at
+    create_agent — the single defaulting point (#3967 / #3978)."""
+    settings = OpenHandsAgentSettings(llm=LLM(model="test-model"))
+    assert settings.tools is None
+    agent = settings.create_agent()
+    assert [t.name for t in agent.tools] == ["terminal", "file_editor", "task_tracker"]
+
+
+def test_create_agent_default_tools_honor_enable_sub_agents() -> None:
+    settings = OpenHandsAgentSettings(
+        llm=LLM(model="test-model"), enable_sub_agents=True
+    )
+    agent = settings.create_agent()
+    assert [t.name for t in agent.tools] == [
+        "terminal",
+        "file_editor",
+        "task_tracker",
+        "task_tool_set",
+    ]
+
+
+def test_create_agent_empty_tools_stays_bare() -> None:
+    """tools=[] is an explicit choice: no default injection (persisted-payload
+    compatibility — [] predates the None default and keeps its old meaning)."""
+    settings = OpenHandsAgentSettings(llm=LLM(model="test-model"), tools=[])
+    agent = settings.create_agent()
+    assert agent.tools == []
 
 
 def test_tool_concurrency_limit_defaults_to_one_when_omitted_from_payload() -> None:

--- a/tests/sdk/tool/test_defaults.py
+++ b/tests/sdk/tool/test_defaults.py
@@ -1,0 +1,66 @@
+"""Tests for the canonical default tool specs (openhands.sdk.tool.defaults)."""
+
+import pytest
+
+from openhands.sdk.tool import registry
+from openhands.sdk.tool.defaults import (
+    BROWSER_TOOL_NAME,
+    DEFAULT_EXEC_TOOL_NAMES,
+    SUB_AGENT_TOOL_NAME,
+    default_tool_specs,
+)
+
+
+def _names(**kwargs) -> list[str]:
+    return [t.name for t in default_tool_specs(**kwargs)]
+
+
+def test_forced_browser_off_is_exec_set_only() -> None:
+    assert _names(enable_browser=False) == list(DEFAULT_EXEC_TOOL_NAMES)
+
+
+def test_forced_browser_on_appends_browser_before_sub_agents() -> None:
+    assert _names(enable_browser=True, enable_sub_agents=True) == [
+        *DEFAULT_EXEC_TOOL_NAMES,
+        BROWSER_TOOL_NAME,
+        SUB_AGENT_TOOL_NAME,
+    ]
+
+
+def test_auto_excludes_browser_when_unregistered(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
+    monkeypatch.delitem(registry._USABILITY_REG, BROWSER_TOOL_NAME, raising=False)
+    assert _names() == list(DEFAULT_EXEC_TOOL_NAMES)
+
+
+def test_auto_includes_browser_when_registered_and_usable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setitem(registry._REG, BROWSER_TOOL_NAME, lambda params, conv: [])
+    monkeypatch.setitem(registry._USABILITY_REG, BROWSER_TOOL_NAME, lambda: True)
+    assert _names() == [*DEFAULT_EXEC_TOOL_NAMES, BROWSER_TOOL_NAME]
+
+
+def test_auto_excludes_browser_when_registered_but_unusable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Registered but no chromium: the default must not produce a spec that
+    fails at conversation start."""
+    monkeypatch.setitem(registry._REG, BROWSER_TOOL_NAME, lambda params, conv: [])
+    monkeypatch.setitem(registry._USABILITY_REG, BROWSER_TOOL_NAME, lambda: False)
+    assert _names() == list(DEFAULT_EXEC_TOOL_NAMES)
+
+
+def test_is_tool_usable_contract(monkeypatch: pytest.MonkeyPatch) -> None:
+    assert registry.is_tool_usable("definitely-not-registered") is False
+    monkeypatch.setitem(registry._REG, "probe", lambda params, conv: [])
+    monkeypatch.setitem(registry._USABILITY_REG, "probe", lambda: True)
+    assert registry.is_tool_usable("probe") is True
+
+    def _boom() -> bool:
+        raise RuntimeError("checker crashed")
+
+    monkeypatch.setitem(registry._USABILITY_REG, "probe", _boom)
+    assert registry.is_tool_usable("probe") is False

--- a/tests/sdk/tool/test_defaults.py
+++ b/tests/sdk/tool/test_defaults.py
@@ -15,42 +15,26 @@ def _names(**kwargs) -> list[str]:
     return [t.name for t in default_tool_specs(**kwargs)]
 
 
-def test_forced_browser_off_is_exec_set_only() -> None:
-    assert _names(enable_browser=False) == list(DEFAULT_EXEC_TOOL_NAMES)
+def test_default_is_deterministic_exec_set() -> None:
+    """The default never depends on runtime/registry state — browser is a
+    serving-layer injection (see BROWSER_TOOL_NAME), not part of the default."""
+    assert _names() == list(DEFAULT_EXEC_TOOL_NAMES)
+    assert BROWSER_TOOL_NAME not in _names()
 
 
-def test_forced_browser_on_appends_browser_before_sub_agents() -> None:
+def test_enable_sub_agents_appends_task_tool_set() -> None:
+    assert _names(enable_sub_agents=True) == [
+        *DEFAULT_EXEC_TOOL_NAMES,
+        SUB_AGENT_TOOL_NAME,
+    ]
+
+
+def test_explicit_browser_appends_before_sub_agents() -> None:
     assert _names(enable_browser=True, enable_sub_agents=True) == [
         *DEFAULT_EXEC_TOOL_NAMES,
         BROWSER_TOOL_NAME,
         SUB_AGENT_TOOL_NAME,
     ]
-
-
-def test_auto_excludes_browser_when_unregistered(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.delitem(registry._REG, BROWSER_TOOL_NAME, raising=False)
-    monkeypatch.delitem(registry._USABILITY_REG, BROWSER_TOOL_NAME, raising=False)
-    assert _names() == list(DEFAULT_EXEC_TOOL_NAMES)
-
-
-def test_auto_includes_browser_when_registered_and_usable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    monkeypatch.setitem(registry._REG, BROWSER_TOOL_NAME, lambda params, conv: [])
-    monkeypatch.setitem(registry._USABILITY_REG, BROWSER_TOOL_NAME, lambda: True)
-    assert _names() == [*DEFAULT_EXEC_TOOL_NAMES, BROWSER_TOOL_NAME]
-
-
-def test_auto_excludes_browser_when_registered_but_unusable(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Registered but no chromium: the default must not produce a spec that
-    fails at conversation start."""
-    monkeypatch.setitem(registry._REG, BROWSER_TOOL_NAME, lambda params, conv: [])
-    monkeypatch.setitem(registry._USABILITY_REG, BROWSER_TOOL_NAME, lambda: False)
-    assert _names() == list(DEFAULT_EXEC_TOOL_NAMES)
 
 
 def test_is_tool_usable_contract(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/sdk/tool/test_switch_llm.py
+++ b/tests/sdk/tool/test_switch_llm.py
@@ -55,8 +55,10 @@ def test_switch_llm_tool_description_lists_available_profiles(profile_store):
 
 
 def test_agent_settings_includes_switch_llm_tool_when_profiles_exist(profile_store):
+    # tools=[] (not the None default): these tests resolve tools for real via
+    # _ensure_agent_ready and tests/sdk registers no exec tools.
     agent = OpenHandsAgentSettings(
-        llm=_make_llm("default-model", "default")
+        llm=_make_llm("default-model", "default"), tools=[]
     ).create_agent()
 
     assert "SwitchLLMTool" in agent.include_default_tools
@@ -69,6 +71,7 @@ def test_agent_settings_includes_switch_llm_tool_when_profiles_exist(profile_sto
 def test_agent_settings_omits_switch_llm_tool_when_disabled(profile_store):
     agent = OpenHandsAgentSettings(
         llm=_make_llm("default-model", "default"),
+        tools=[],
         enable_switch_llm_tool=False,
     ).create_agent()
 
@@ -81,7 +84,7 @@ def test_agent_settings_omits_switch_llm_tool_when_disabled(profile_store):
 
 def test_agent_settings_includes_switch_llm_tool_without_profiles(empty_profile_store):
     agent = OpenHandsAgentSettings(
-        llm=_make_llm("default-model", "default")
+        llm=_make_llm("default-model", "default"), tools=[]
     ).create_agent()
 
     assert "SwitchLLMTool" in agent.include_default_tools


### PR DESCRIPTION
HUMAN:

Found while addressing the code review on the canvas Agent Profiles PR (OpenHands/agent-canvas#1571): a conversation launched from an agent profile came up with an agent that couldn't run shell commands or edit files. Reworked after the review discussion on the hardcoded tool names: the default toolset is now SDK-owned data materialized at `create_agent()` (design: #3978), instead of string literals in the profile resolver. A human should sanity-check the chosen default toolset, the `tools=None` vs `tools=[]` semantics, and the final browser placement (deterministic SDK default; the agent-server injects browser on profile launches where chromium is usable — settled with Vasco across two review iterations).

- [x] A human has tested these changes.

AGENT:

## Why

A conversation started from an **AgentProfile** (`agent_profile_id`, instead of an inline `agent_settings` payload) resolved to an agent with **no `terminal` / `file_editor` / `task_tracker`** — `OpenHandsAgentProfile` has no `tools` field and `OpenHandsAgentSettings.tools` defaulted to `[]`, so `create_agent()` only attached the Finish/Think built-ins (#3967). This hit local agent-server, cloud, and eval identically.

The first iteration of this PR fixed it with hardcoded tool-name literals in the resolver. Review pushback (correct): those literals drift-race the real `.name` attributes and re-derive a set that already exists in `openhands.tools.preset.default.get_default_tools`. The deeper problem is that the default toolset existed in **four copies** — canvas `getAgentTools()` (client-side), `get_default_tools()`, the resolver literals, and the cloud caller-side override — so the same profile produced different agents on different surfaces. Full design: **#3978**.

Both the drift objection and the "don't touch callers in other repos" constraint are satisfiable at once: `Tool` is `{name, params}` and `create_agent()` only builds *specs* (implementations resolve later via the runtime registry), so the default tool **names are a wire contract** — data the SDK can own without importing `openhands-tools`.

## Summary

- **`openhands/sdk/tool/defaults.py` (new)**: `DEFAULT_EXEC_TOOL_NAMES` (`terminal`, `file_editor`, `task_tracker`), `SUB_AGENT_TOOL_NAME` (`task_tool_set`), `BROWSER_TOOL_NAME` (`browser_tool_set`), and the pure `default_tool_specs(enable_sub_agents=..., enable_browser=...)`. A new `tests/cross/test_default_tool_names.py` pins these to the real `TerminalTool.name` etc. and to `get_default_tools()` — a tool rename now breaks CI in this repo instead of silently drifting.
- **`OpenHandsAgentSettings.tools` is now `list[Tool] | None = None`**, and `create_agent()` is the **single defaulting point**: `None` → the standard exec set, plus `task_tool_set` when `enable_sub_agents` is set (that field was previously **dead server-side** — nothing consumed it); `[]` → explicitly bare (old persisted payloads keep their exact behavior); explicit list → used as given.
- **The resolver literals are gone.** `OpenHandsAgentProfile` gains the same tri-state `tools: list[Tool] | None = None`, passed through verbatim — `None` inherits the server default at `create_agent`, an explicit list enables per-profile tool selection (the `mcp_server_refs` pattern; catalog for a picker already exists via `GET /tools`).
- **`build_seed_profile` copies `agent_settings.tools`** instead of dropping it, so a global config with e.g. browser tools seeds a genuinely behavior-preserving profile.
- **Browser is injected by the serving layer, not the default** (review follow-up, superseding an adaptive-default iteration): the SDK default stays deterministic (exec set + optional `task_tool_set`; `enable_browser` is an explicit bool, off by default), and the **agent-server** appends `browser_tool_set` on a default-toolset (`tools=None`) OpenHands profile launch when the new `registry.is_tool_usable()` confirms the chromium stack — the layer that *is* the runtime makes the environment call, mirroring cloud's existing caller-side injection and canvas's client-side behavior on the settings path. An explicit `profile.tools` list (`[]` included) is authoritative and never amended; ACP profiles are never touched. Net: profile launches get browser wherever it can actually run, with zero client changes and no environment-dependent SDK defaults.

Follow-ups tracked in #3978: `StartConversationRequest.extra_tools` for client tools (`canvas_ui`), canvas dropping its client-side `DEFAULT_TOOL_NAMES`, and narrowing cloud's caller-side `get_default_tools` override to the tools-unset case (its environment injection is now the sanctioned pattern, not a wart to delete).

Closes #3967. Design: #3978. Epic: #3713.

## How to Test

- `uv run pytest tests/sdk/profiles/ tests/sdk/test_settings.py tests/sdk/tool/test_defaults.py tests/cross/test_default_tool_names.py` — profile resolution passes `tools` through as tri-state (`None` default / explicit list / `[]` bare), `create_agent()` materializes the default exec set and honors `enable_sub_agents`, the seed copies explicit toolsets, and the cross-package parity tests pin the SDK names to `openhands-tools`. (269 passed, incl. `tests/sdk/tool/test_defaults.py`)
- `tests/sdk/tool/test_defaults.py` pins the deterministic default (no registry dependence) + the `is_tool_usable` contract; `tests/agent_server/test_agent_profile_conv_start.py` covers the serving-layer injection (usable → injected; unusable → not; explicit `tools` incl. `[]` → never amended; ACP → never touched); the cross parity test runs the full `enable_browser` × `enable_sub_agents` matrix against `get_default_tools`.
- Full suites: `uv run pytest tests/sdk` (5111 passed) and `tests/agent_server/test_agent_profile_conv_start.py tests/agent_server/test_agent_profiles_router.py tests/sdk/test_apply_agent_settings_diff.py tests/cross/test_check_persisted_settings_compat.py` (104 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:91e24e3-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-91e24e3-python \
  ghcr.io/openhands/agent-server:91e24e3-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:91e24e3-golang-amd64
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-golang-amd64
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-golang-amd64
ghcr.io/openhands/agent-server:91e24e3-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:91e24e3-golang-arm64
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-golang-arm64
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-golang-arm64
ghcr.io/openhands/agent-server:91e24e3-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:91e24e3-java-amd64
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-java-amd64
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-java-amd64
ghcr.io/openhands/agent-server:91e24e3-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:91e24e3-java-arm64
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-java-arm64
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-java-arm64
ghcr.io/openhands/agent-server:91e24e3-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:91e24e3-python-amd64
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-python-amd64
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-python-amd64
ghcr.io/openhands/agent-server:91e24e3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:91e24e3-python-arm64
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-python-arm64
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-python-arm64
ghcr.io/openhands/agent-server:91e24e3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:91e24e3-golang
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-golang
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-golang
ghcr.io/openhands/agent-server:91e24e3-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:91e24e3-java
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-java
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-java
ghcr.io/openhands/agent-server:91e24e3-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:91e24e3-python
ghcr.io/openhands/agent-server:91e24e3bea37979752f88f675dc9a8b504d28305-python
ghcr.io/openhands/agent-server:fix-profile-resolve-default-tools-python
ghcr.io/openhands/agent-server:91e24e3-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `91e24e3-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `91e24e3-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->