### PR TITLE
chore(ci): use conventional 'chore:' title for typescript-client bump PR

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -517,7 +517,7 @@ jobs:
                     --repo "$REPO" \
                     --base main \
                     --head "$BRANCH" \
-                    --title "Bump agent-server (software-agent-sdk) to v$VERSION" \
+                    --title "chore: agent-server (software-agent-sdk) to v$VERSION" \
                     --body-file pr_body.md
                   echo "✅ PR created for $REPO"
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Small edit such that we do have the correct PR title when we open a PR in the typescript-client.

---

AGENT:

## Why

The `bump-typescript-client` job creates the recurring agent-server bump PR in
`OpenHands/typescript-client` with the title `Bump agent-server (software-agent-sdk) to v$VERSION`.
That doesn't match the repo's conventional-commit title convention (`chore:`, `feat:`, `fix:` …),
and the actual open bump PR (typescript-client#252) already shows up as `chore: agent-server …`.
This aligns the generated title with the convention.

## Summary

- `version-bump-prs.yml` (`bump-typescript-client` job): change the `gh pr create --title` from `Bump agent-server (software-agent-sdk) to v$VERSION` to `chore: agent-server (software-agent-sdk) to v$VERSION`.

## Issue Number

N/A

## How to Test

This is a one-line change to the string passed to `gh pr create --title`; no runtime behavior
other than the generated PR title changes.

- Diff review confirms only the title string changed:
  ```
  -                    --title "Bump agent-server (software-agent-sdk) to v$VERSION" \
  +                    --title "chore: agent-server (software-agent-sdk) to v$VERSION" \
  ```
- YAML validity verified by the repo's pre-commit `Format YAML files` hook (Passed) on commit.
- End-to-end note: the `bump-typescript-client` job only runs from the release trigger of this
  workflow, so it can't be exercised outside an actual `software-agent-sdk` release. On the next
  release the job will open/refresh the typescript-client bump PR titled
  `chore: agent-server (software-agent-sdk) to v<version>`.

## Video/Screenshots

N/A — CI-config string change with no UI surface.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Only the title is changed; the PR body template and branch name (`bump-agent-server-<version>`)
are unchanged, so existing-PR de-duplication in the job still works.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a1237c2-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a1237c2-python \
  ghcr.io/openhands/agent-server:a1237c2-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a1237c2-golang-amd64
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-golang-amd64
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-golang-amd64
ghcr.io/openhands/agent-server:a1237c2-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a1237c2-golang-arm64
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-golang-arm64
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-golang-arm64
ghcr.io/openhands/agent-server:a1237c2-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a1237c2-java-amd64
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-java-amd64
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-java-amd64
ghcr.io/openhands/agent-server:a1237c2-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a1237c2-java-arm64
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-java-arm64
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-java-arm64
ghcr.io/openhands/agent-server:a1237c2-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a1237c2-python-amd64
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-python-amd64
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-python-amd64
ghcr.io/openhands/agent-server:a1237c2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a1237c2-python-arm64
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-python-arm64
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-python-arm64
ghcr.io/openhands/agent-server:a1237c2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a1237c2-golang
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-golang
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-golang
ghcr.io/openhands/agent-server:a1237c2-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a1237c2-java
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-java
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-java
ghcr.io/openhands/agent-server:a1237c2-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a1237c2-python
ghcr.io/openhands/agent-server:a1237c2e3ff225f7174c14ca238e2e7292008290-python
ghcr.io/openhands/agent-server:vasco-ts-client-bump-pr-title-chore-python
ghcr.io/openhands/agent-server:a1237c2-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a1237c2-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a1237c2-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->