### PR TITLE
Fix Laminar streaming async iterable handling

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -6,7 +6,7 @@ import json
 import os
 import threading
 import warnings
-from collections.abc import Callable, Sequence
+from collections.abc import AsyncIterable, Callable, Iterable, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, get_args, get_origin
@@ -46,7 +46,6 @@ from typing import Final, cast
 
 from litellm import (
     ChatCompletionToolParam,
-    CustomStreamWrapper,
     ResponseInputParam,
     acompletion as litellm_acompletion,
     completion as litellm_completion,
@@ -2030,7 +2029,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 )
             )
             if enable_streaming and on_token is not None:
-                assert isinstance(ret, CustomStreamWrapper)
+                if isinstance(ret, ModelResponse) or not isinstance(ret, Iterable):
+                    raise TypeError(
+                        f"Expected streaming response iterable, got {type(ret)}"
+                    )
                 chunks: list[ModelResponseStream] = []
                 for chunk in ret:
                     on_token(chunk)
@@ -2062,7 +2064,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 )
             )
             if enable_streaming and on_token is not None:
-                assert isinstance(ret, CustomStreamWrapper)
+                if not isinstance(ret, AsyncIterable):
+                    raise TypeError(
+                        f"Expected async streaming response iterable, got {type(ret)}"
+                    )
                 chunks: list[ModelResponseStream] = []
                 async for chunk in ret:
                     await _invoke_token_callback(on_token, chunk)

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -269,6 +269,71 @@ def test_llm_completion_streaming_with_callback(mock_stream_builder, mock_comple
     assert response.message.content[0].text == "Hello world!"
 
 
+@pytest.mark.asyncio
+@patch("openhands.sdk.llm.llm.litellm_acompletion", new_callable=AsyncMock)
+@patch("openhands.sdk.llm.llm.litellm.stream_chunk_builder")
+async def test_llm_acompletion_streaming_accepts_async_iterable(
+    mock_stream_builder, mock_acompletion
+):
+    """Laminar's litellm wrapper returns an async generator for streaming."""
+
+    chunk1 = ModelResponseStream(
+        id="chatcmpl-test",
+        choices=[
+            StreamingChoices(
+                finish_reason=None,
+                index=0,
+                delta=Delta(content="Hello", role="assistant"),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o",
+        object="chat.completion.chunk",
+    )
+    chunk2 = ModelResponseStream(
+        id="chatcmpl-test",
+        choices=[
+            StreamingChoices(
+                finish_reason="stop",
+                index=0,
+                delta=Delta(content=None, role=None),
+            )
+        ],
+        created=1234567890,
+        model="gpt-4o",
+        object="chat.completion.chunk",
+    )
+
+    async def async_stream():
+        yield chunk1
+        yield chunk2
+
+    mock_acompletion.return_value = async_stream()
+    mock_stream_builder.return_value = create_mock_response("Hello")
+
+    llm = LLM(
+        usage_id="test-llm",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+    )
+
+    received_chunks = []
+    messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    response = await llm.acompletion(
+        messages=messages, stream=True, on_token=received_chunks.append
+    )
+
+    assert received_chunks == [chunk1, chunk2]
+    mock_stream_builder.assert_called_once()
+    assert mock_stream_builder.call_args.args == ([chunk1, chunk2],)
+    assert response.message.role == "assistant"
+    assert isinstance(response.message.content[0], TextContent)
+    assert response.message.content[0].text == "Hello"
+
+
 @patch("openhands.sdk.llm.llm.litellm_completion")
 @patch("openhands.sdk.llm.llm.litellm.stream_chunk_builder")
 def test_llm_completion_streaming_with_tools(mock_stream_builder, mock_completion):


### PR DESCRIPTION
## Summary
- allow streaming chat completions to consume generic sync/async iterables instead of requiring litellm's concrete CustomStreamWrapper
- cover the Laminar/litellm async-generator streaming path with a regression test

Fixes #3972

## Tests
- uv run pytest tests/sdk/llm/test_llm_completion.py -q
- uv run ruff check openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_llm_completion.py
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:f507642-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-f507642-python \
  ghcr.io/openhands/agent-server:f507642-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:f507642-golang-amd64
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-golang-amd64
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-golang-amd64
ghcr.io/openhands/agent-server:f507642-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:f507642-golang-arm64
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-golang-arm64
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-golang-arm64
ghcr.io/openhands/agent-server:f507642-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:f507642-java-amd64
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-java-amd64
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-java-amd64
ghcr.io/openhands/agent-server:f507642-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:f507642-java-arm64
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-java-arm64
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-java-arm64
ghcr.io/openhands/agent-server:f507642-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:f507642-python-amd64
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-python-amd64
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-python-amd64
ghcr.io/openhands/agent-server:f507642-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:f507642-python-arm64
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-python-arm64
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-python-arm64
ghcr.io/openhands/agent-server:f507642-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:f507642-golang
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-golang
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-golang
ghcr.io/openhands/agent-server:f507642-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:f507642-java
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-java
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-java
ghcr.io/openhands/agent-server:f507642-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:f507642-python
ghcr.io/openhands/agent-server:f507642782623750f33d2015ec86ee2cd2778740-python
ghcr.io/openhands/agent-server:fix-laminar-streaming-async-iterable-python
ghcr.io/openhands/agent-server:f507642-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `f507642-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `f507642-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->