### PR TITLE
fix(io): make InMemoryFileStore.list respect directory boundaries

### DIFF
--- a/openhands-sdk/openhands/sdk/io/memory.py
+++ b/openhands-sdk/openhands/sdk/io/memory.py
@@ -46,14 +46,21 @@ class InMemoryFileStore(FileStore):
         return self.files[path]
 
     def list(self, path: str) -> list[str]:
+        # If path is an exact file, return the file itself
+        # (S3-consistent behavior, matching LocalFileStore.list)
+        if path in self.files:
+            return [path]
+        # Only match across a directory boundary, so that listing "a/b"
+        # doesn't pick up sibling keys like "a/bc.txt"
+        prefix = path if path == "" or path.endswith("/") else path + "/"
         files = []
         for file in self.files:
-            if not file.startswith(path):
+            if not file.startswith(prefix):
                 continue
-            suffix = file.removeprefix(path)
+            suffix = file[len(prefix) :]
+            if not suffix:
+                continue
             parts = suffix.split("/")
-            if parts[0] == "":
-                parts.pop(0)
             if len(parts) == 1:
                 files.append(file)
             else:

--- a/tests/sdk/io/test_filestore_list_consistency.py
+++ b/tests/sdk/io/test_filestore_list_consistency.py
@@ -1,0 +1,75 @@
+"""InMemoryFileStore.list must agree with LocalFileStore.list on path boundaries.
+
+Regression tests: the in-memory store used bare string prefix matching
+(``file.startswith(path)`` + ``removeprefix``), which is not aware of the
+``/`` directory boundary. Compared with ``LocalFileStore`` (documented as
+S3-consistent) it diverged in two ways:
+
+1. Listing a directory whose name is a prefix of a sibling (``a/b`` vs
+   ``a/bc.txt``) invented phantom subdirectories from the sibling's keys.
+2. Listing an exact file path raised ``IndexError`` instead of returning
+   ``[path]``.
+"""
+
+import pytest
+
+from openhands.sdk.io.local import LocalFileStore
+from openhands.sdk.io.memory import InMemoryFileStore
+
+
+FIXTURE = {
+    "sessions/abc/event.json": "{}",
+    "sessions/abcdef/other.json": "{}",
+    "sessions/abc/nested/deep.json": "{}",
+    "top.txt": "x",
+}
+
+
+def make_stores(tmp_path):
+    memory = InMemoryFileStore()
+    local = LocalFileStore(root=str(tmp_path))
+    for store in (memory, local):
+        for key, contents in FIXTURE.items():
+            store.write(key, contents)
+    return memory, local
+
+
+def test_list_exact_file_returns_path_and_does_not_raise(tmp_path):
+    memory, local = make_stores(tmp_path)
+
+    assert local.list("sessions/abc/event.json") == ["sessions/abc/event.json"]
+    # Used to raise IndexError on the in-memory store
+    assert memory.list("sessions/abc/event.json") == ["sessions/abc/event.json"]
+
+
+def test_list_sibling_prefix_produces_no_phantom_entries(tmp_path):
+    memory, local = make_stores(tmp_path)
+
+    expected = {"sessions/abc/event.json", "sessions/abc/nested/"}
+    assert set(local.list("sessions/abc")) == expected
+    # Used to also contain a phantom "sessions/abc/def/" derived from the
+    # sibling key "sessions/abcdef/other.json"
+    assert set(memory.list("sessions/abc")) == expected
+
+
+@pytest.mark.parametrize(
+    "path",
+    ["sessions", "sessions/", "sessions/abc", "sessions/abc/nested"],
+)
+def test_list_directories_matches_local(tmp_path, path):
+    memory, local = make_stores(tmp_path)
+
+    assert set(memory.list(path)) == set(local.list(path))
+
+
+def test_list_missing_path_is_empty(tmp_path):
+    memory, local = make_stores(tmp_path)
+
+    assert local.list("sessions/zzz") == []
+    assert memory.list("sessions/zzz") == []
+
+
+def test_list_root_still_works(tmp_path):
+    memory, _ = make_stores(tmp_path)
+
+    assert set(memory.list("")) == {"sessions/", "top.txt"}


### PR DESCRIPTION
HUMAN:

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->The in-memory file store's list() disagreed with the local (disk) one:
it invented phantom directories from sibling names, and crashed with an
IndexError when given an exact file path. I went through the
side-by-side repro before and after the fix myself.


---

AGENT:

## Why

`InMemoryFileStore.list` uses bare string prefix matching (`file.startswith(path)` + `removeprefix`), which is not aware of the `/` directory boundary. It diverges from `LocalFileStore.list` (whose implementation is explicitly commented as *S3-consistent behavior*) in two observable ways:

1. **Phantom directories from sibling keys.** With keys `sessions/abc/event.json` and `sessions/abcdef/other.json`, `list("sessions/abc")` returns a phantom `sessions/abc/def/` entry derived from the sibling's suffix. `LocalFileStore` returns only the real children.
2. **Crash on exact file paths.** `list("sessions/abc/event.json")` raises `IndexError: list index out of range` (`suffix=""` → `parts=[]` → `parts[0]`). `LocalFileStore` returns `[path]`.

Both classes implement the same `FileStore` interface, so consumers switching between the in-memory and local backends currently see different results for identical inputs.

The in-repo consumer (`conversation/event_store.py`) happens to be shielded by its `EVENT_NAME_RE` filename filter and fixed-width event IDs, so this is not currently user-visible there — but the divergence is a trap for any other `FileStore` consumer.

## Summary

- Short-circuit exact file hits to return `[path]`, matching `LocalFileStore`.
- Normalize the search prefix to end with `/` so listing `a/b` cannot match sibling keys like `a/bc.txt`.
- Skip empty suffixes; keep root listing (`""`) behavior unchanged.
- Add a consistency test suite that runs the same fixture through both backends and asserts they agree (red on main for the two facets above, green with this change).

## Issue Number

N/A (searched existing issues/PRs: #3163/#3146 are about LRU eviction in this class, not `list` semantics).

## How to Test

```bash
uv run pytest tests/sdk/io/ -q
```

New tests fail on main:

```
FAILED test_list_exact_file_returns_path_and_does_not_raise  (IndexError)
FAILED test_list_sibling_prefix_produces_no_phantom_entries
FAILED test_list_directories_matches_local[sessions/abc]
```

With this change: `tests/sdk/io/` 26 passed. Downstream consumer regression: `tests/sdk/conversation` **708 passed**.

## Video/Screenshots

Side-by-side on main (same fixture, same call):

```
InMemory list('sessions/abc'): ['sessions/abc/def/', 'sessions/abc/event.json']  <- phantom def/
Local    list('sessions/abc'): ['sessions/abc/event.json', 'sessions/abc/nested/']
InMemory list('sessions/abc/event.json'): IndexError: list index out of range
Local    list('sessions/abc/event.json'): ['sessions/abc/event.json']
```

After this change the two backends return identical results for all cases in the new test suite.