### PR TITLE
fix(sdk): reconnect remote conversation websocket

### DIFF
--- a/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py
@@ -5,13 +5,14 @@ import os
 import threading
 import time
 import uuid
-from collections.abc import Mapping
+from collections.abc import Callable, Mapping
 from queue import Empty, Queue
 from typing import TYPE_CHECKING, SupportsIndex, overload
 from urllib.parse import quote, urlparse
 
 import httpx
 import websockets
+from websockets.exceptions import ConnectionClosed
 
 from openhands.sdk.agent.base import AgentBase
 from openhands.sdk.conversation.base import BaseConversation, ConversationStateProtocol
@@ -63,6 +64,7 @@ from openhands.sdk.workspace import LocalWorkspace, RemoteWorkspace
 logger = get_logger(__name__)
 
 LEGACY_CONVERSATIONS_PATH = "/api/conversations"
+FATAL_WS_CLOSE_CODES = frozenset({4001, 4004})
 
 
 def _agent_kind_mismatch_message(conversation_id: ConversationID) -> str:
@@ -78,6 +80,19 @@ def _validate_remote_agent(agent_data: dict) -> AgentBase:
 
         return ACPAgent.model_validate(agent_data)
     return AgentBase.model_validate(agent_data)
+
+
+def _websocket_close_code(exc: ConnectionClosed) -> int | None:
+    for close_frame in (exc.rcvd, exc.sent):
+        if close_frame is not None:
+            return close_frame.code
+    return None
+
+
+def _is_fatal_websocket_close(
+    exc: ConnectionClosed,
+) -> bool:
+    return _websocket_close_code(exc) in FATAL_WS_CLOSE_CODES
 
 
 def _send_request(
@@ -114,6 +129,7 @@ class WebSocketCallbackClient:
     host: str
     conversation_id: str
     callback: ConversationCallbackType
+    on_reconnect: Callable[[], object] | None
     api_key: str | None
     _thread: threading.Thread | None
     _stop: threading.Event
@@ -125,11 +141,13 @@ class WebSocketCallbackClient:
         conversation_id: str,
         callback: ConversationCallbackType,
         api_key: str | None = None,
+        on_reconnect: Callable[[], object] | None = None,
     ):
         self.host = host
         self.conversation_id = conversation_id
         self.callback = callback
         self.api_key = api_key
+        self.on_reconnect = on_reconnect
         self._thread = None
         self._stop = threading.Event()
         self._ready = threading.Event()
@@ -201,10 +219,12 @@ class WebSocketCallbackClient:
             ws_url += f"?session_api_key={quote(self.api_key, safe='')}"
 
         delay = 1.0
+        has_connected = False
         while not self._stop.is_set():
             try:
                 async with websockets.connect(ws_url) as ws:
                     delay = 1.0
+                    connection_ready = False
                     async for message in ws:
                         if self._stop.is_set():
                             break
@@ -215,21 +235,48 @@ class WebSocketCallbackClient:
                             # The server sends this immediately after subscription
                             if (
                                 isinstance(event, ConversationStateUpdateEvent)
-                                and not self._ready.is_set()
+                                and not connection_ready
                             ):
-                                self._ready.set()
+                                connection_ready = True
+                                if has_connected:
+                                    await self._handle_reconnect()
+                                else:
+                                    has_connected = True
+                                    self._ready.set()
 
                             self.callback(event)
                         except Exception:
                             logger.exception(
                                 "ws_event_processing_error", stack_info=True
                             )
-            except websockets.exceptions.ConnectionClosed:
-                break
+            except ConnectionClosed as exc:
+                if _is_fatal_websocket_close(exc):
+                    logger.debug("ws_connection_closed_fatal", exc_info=True)
+                    self._stop.set()
+                    break
+                logger.debug("ws_connection_closed_retry", exc_info=True)
+                await self._sleep_before_retry(delay)
+                delay = min(delay * 2, 30.0)
             except Exception:
                 logger.debug("ws_connect_retry", exc_info=True)
-                await asyncio.sleep(delay)
+                await self._sleep_before_retry(delay)
                 delay = min(delay * 2, 30.0)
+
+    async def _handle_reconnect(self) -> None:
+        if not self.on_reconnect:
+            return
+        try:
+            await asyncio.to_thread(self.on_reconnect)
+        except Exception:
+            logger.exception("ws_reconnect_callback_error", stack_info=True)
+
+    async def _sleep_before_retry(self, delay: float) -> None:
+        deadline = time.monotonic() + delay
+        while not self._stop.is_set():
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return
+            await asyncio.sleep(min(0.1, remaining))
 
 
 class RemoteEventsList(EventsListBase):
@@ -946,6 +993,7 @@ class RemoteConversation(BaseConversation):
             conversation_id=str(self._id),
             callback=composed_callback,
             api_key=self.workspace.api_key,
+            on_reconnect=self._state.events.reconcile,
         )
         self._ws_client.start()
 

--- a/tests/sdk/conversation/remote/test_websocket_client.py
+++ b/tests/sdk/conversation/remote/test_websocket_client.py
@@ -1,6 +1,7 @@
 """Tests for WebSocketCallbackClient."""
 
 import asyncio
+import json
 import time
 from datetime import datetime
 from unittest.mock import MagicMock, patch
@@ -10,6 +11,7 @@ import websockets
 import websockets.frames
 
 from openhands.sdk.conversation.impl.remote_conversation import WebSocketCallbackClient
+from openhands.sdk.event.conversation_state import FULL_STATE_KEY
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm import Message, TextContent
 
@@ -140,8 +142,8 @@ def test_websocket_client_url_encodes_api_key():
         async def __aenter__(self):
             captured_urls.append(self.url)
             raise websockets.exceptions.ConnectionClosed(
-                rcvd=websockets.frames.Close(1000, "test"),
-                sent=websockets.frames.Close(1000, "test"),
+                rcvd=websockets.frames.Close(4001, "test"),
+                sent=websockets.frames.Close(4001, "test"),
                 rcvd_then_sent=False,
             )
 
@@ -167,3 +169,170 @@ def test_websocket_client_url_encodes_api_key():
 
     assert len(captured_urls) == 1
     assert "session_api_key=1%2BFYh%2FSRE%3Dds%208Q" in captured_urls[0]
+
+
+def _state_update_payload(event_id: str) -> str:
+    return json.dumps(
+        {
+            "kind": "ConversationStateUpdateEvent",
+            "id": event_id,
+            "timestamp": "2024-01-01T00:00:00Z",
+            "source": "environment",
+            "key": FULL_STATE_KEY,
+            "value": {"execution_status": "running"},
+        }
+    )
+
+
+def _connection_closed(code: int) -> websockets.exceptions.ConnectionClosed:
+    return websockets.exceptions.ConnectionClosed(
+        rcvd=websockets.frames.Close(code, "test"),
+        sent=websockets.frames.Close(code, "test"),
+        rcvd_then_sent=False,
+    )
+
+
+class _MockWebSocket:
+    def __init__(self, messages, close_code: int):
+        self._messages = list(messages)
+        self._close_code = close_code
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        if self._messages:
+            return self._messages.pop(0)
+        raise _connection_closed(self._close_code)
+
+
+class _MockWebSocketContext:
+    def __init__(self, ws: _MockWebSocket):
+        self._ws = ws
+
+    async def __aenter__(self):
+        return self._ws
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+def test_websocket_client_retries_after_retryable_connection_closed():
+    """Test that transient WebSocket closures reconnect instead of exiting."""
+    connect_calls = 0
+    callback_events = []
+
+    def callback(event):
+        callback_events.append(event)
+        if event.id == "state-2":
+            client._stop.set()
+
+    class _MockConnect:
+        def __call__(self, url, *args, **kwargs):
+            nonlocal connect_calls
+            connect_calls += 1
+            return _MockWebSocketContext(
+                _MockWebSocket(
+                    [_state_update_payload(f"state-{connect_calls}")],
+                    close_code=1000,
+                )
+            )
+
+    client = WebSocketCallbackClient(
+        host="http://localhost:8000",
+        conversation_id="test-conv-id",
+        callback=callback,
+    )
+
+    async def no_sleep(delay):
+        return None
+
+    client._sleep_before_retry = no_sleep
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.websockets.connect",
+        _MockConnect(),
+    ):
+        asyncio.run(client._client_loop())
+
+    assert connect_calls == 2
+    assert [event.id for event in callback_events] == ["state-1", "state-2"]
+
+
+@pytest.mark.parametrize("close_code", [4001, 4004])
+def test_websocket_client_stops_after_fatal_connection_closed(close_code):
+    """Test that fatal WebSocket close codes are not retried."""
+    connect_calls = 0
+
+    class _MockAsyncContextManager:
+        async def __aenter__(self):
+            raise _connection_closed(close_code)
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    class _MockConnect:
+        def __call__(self, url, *args, **kwargs):
+            nonlocal connect_calls
+            connect_calls += 1
+            return _MockAsyncContextManager()
+
+    client = WebSocketCallbackClient(
+        host="http://localhost:8000",
+        conversation_id="test-conv-id",
+        callback=lambda event: None,
+    )
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.websockets.connect",
+        _MockConnect(),
+    ):
+        asyncio.run(client._client_loop())
+
+    assert connect_calls == 1
+    assert client._stop.is_set()
+
+
+def test_websocket_client_calls_on_reconnect_after_subscription_restored():
+    """Test reconnect callback runs after the replacement subscription is ready."""
+    connect_calls = 0
+    reconnect = MagicMock()
+    callback_events = []
+
+    def callback(event):
+        callback_events.append(event)
+        if event.id == "state-2":
+            client._stop.set()
+
+    class _MockConnect:
+        def __call__(self, url, *args, **kwargs):
+            nonlocal connect_calls
+            connect_calls += 1
+            return _MockWebSocketContext(
+                _MockWebSocket(
+                    [_state_update_payload(f"state-{connect_calls}")],
+                    close_code=1000,
+                )
+            )
+
+    client = WebSocketCallbackClient(
+        host="http://localhost:8000",
+        conversation_id="test-conv-id",
+        callback=callback,
+        on_reconnect=reconnect,
+    )
+
+    async def no_sleep(delay):
+        return None
+
+    client._sleep_before_retry = no_sleep
+
+    with patch(
+        "openhands.sdk.conversation.impl.remote_conversation.websockets.connect",
+        _MockConnect(),
+    ):
+        asyncio.run(client._client_loop())
+
+    assert connect_calls == 2
+    assert [event.id for event in callback_events] == ["state-1", "state-2"]
+    reconnect.assert_called_once_with()


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:
This fixes a issue in RemoteConversation observed in production: after a transient events WebSocket disconnect, our SDK client stopped receiving live events because `WebSocketCallbackClient` exited permanently instead of reconnecting.

<!--
-->

---

AGENT:
<!-- AI/LLM agents:
In the AGENT section and the template fields below, provide evidence that the
code runs properly end-to-end. Just running unit tests is NOT sufficient. Explain
exactly what command you ran and include logs, screenshots, or reproduction notes.
-->

## Why

`WebSocketCallbackClient` used to exit permanently after any `ConnectionClosed`. For transient WebSocket closes, a `RemoteConversation` could silently stop receiving live events and only catch up later through REST polling or manual reconciliation.

## Summary

- Retry transient WebSocket `ConnectionClosed` failures with the existing backoff flow instead of exiting the client loop.
- Treat server-side fatal close codes `4001` (auth failure) and `4004` (conversation not found) as non-retryable.
- Reconcile remote events after a replacement WebSocket subscription becomes ready, so events missed while disconnected are merged into the local cache.
- Add regression coverage for retryable close, fatal close, and reconnect reconciliation callback behavior.

## Issue Number

Fixes https://github.com/OpenHands/software-agent-sdk/issues/3983

## How to Test

Environment setup:

```bash
make build
```

Targeted WebSocket/reconciliation tests:

```bash
uv run pytest tests/sdk/conversation/remote/test_websocket_client.py tests/sdk/conversation/remote/test_websocket_subscription_ready.py
```

Broader remote conversation SDK tests:

```bash
uv run pytest tests/sdk/conversation/remote
```

Lint/type checks on changed files:

```bash
uv run pre-commit run --files openhands-sdk/openhands/sdk/conversation/impl/remote_conversation.py tests/sdk/conversation/remote/test_websocket_client.py
```

Repo lint target:

```bash
make lint
```

Live reconnect smoke test:

I also ran a local smoke script that starts a real `websockets.serve(...)` server, sends an initial state update, closes the first connection with code `1000`, accepts the SDK client's reconnect, sends a second state update, and asserts:

- the server saw two WebSocket connections;
- the SDK callback received `state-1` and `state-2`;
- `on_reconnect` ran exactly once.

The script printed:

```text
live websocket reconnect smoke passed
```

## Video/Screenshots

N/A. This is SDK transport behavior covered by automated tests and the live reconnect smoke above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This PR does not change the agent-server WebSocket API. It uses the existing REST event reconciliation path after reconnect rather than `resend_mode=all/since`, avoiding duplicate delivery through user callbacks while still repairing the remote event cache.

No docs update: this is an internal SDK transport reliability fix with no user-facing API or configuration changes.
