### PR TITLE
fix(agent-server): survive webhook rate limiting and reap stale run tasks

### DIFF
--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -2,6 +2,7 @@ import asyncio
 import importlib
 import json
 import logging
+import time
 from collections.abc import Awaitable, Callable
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import suppress
@@ -1598,6 +1599,11 @@ class AutoTitleSubscriber(Subscriber):
             return None
 
 
+# Cap for the exponential retry/cooldown backoff so a long outage retries at a
+# steady cadence instead of growing unboundedly.
+_WEBHOOK_MAX_BACKOFF_SECONDS = 60.0
+
+
 @dataclass
 class WebhookSubscriber(Subscriber):
     conversation_id: UUID
@@ -1606,6 +1612,15 @@ class WebhookSubscriber(Subscriber):
     session_api_key: str | None = None
     queue: list[Event] = field(default_factory=list)
     _flush_timer: asyncio.Task | None = field(default=None, init=False)
+    # Serializes flushes: without it a burst of events (e.g. streaming deltas)
+    # fires overlapping _post_events volleys that hammer a rate-limited
+    # downstream and deliver out of order.
+    _post_lock: asyncio.Lock = field(default_factory=asyncio.Lock, init=False)
+    # Cooldown circuit: monotonic deadline before which no post is attempted.
+    # Set after a flush exhausts its retries; grows exponentially with
+    # consecutive failures so a downstream returning 429 gets room to recover.
+    _backoff_until: float = field(default=0.0, init=False)
+    _consecutive_failures: int = field(default=0, init=False)
     # Per-instance sleep seam so tests override delays without patching the
     # global asyncio.sleep. default_factory (not default) keeps it an instance
     # attribute, else the function would be descriptor-bound as a method.
@@ -1617,7 +1632,20 @@ class WebhookSubscriber(Subscriber):
         """Add event to queue and post to webhook when buffer size is reached."""
         self.queue.append(event)
 
-        if len(self.queue) >= self.spec.event_buffer_size:
+        # Enforce the queue bound on enqueue as well as on failed-flush
+        # re-queue: during a failure cooldown events accumulate here without
+        # passing through _post_events, and the bound must hold throughout.
+        overflow = len(self.queue) - self.spec.max_queue_size
+        if overflow > 0:
+            del self.queue[:overflow]
+            logger.warning(
+                f"Webhook queue exceeded max_queue_size="
+                f"{self.spec.max_queue_size}; dropped {overflow} oldest "
+                f"event(s) for conversation {self.conversation_id}."
+            )
+
+        in_cooldown = time.monotonic() < self._backoff_until
+        if len(self.queue) >= self.spec.event_buffer_size and not in_cooldown:
             # Cancel timer since we're flushing due to buffer size
             self._cancel_flush_timer()
             await self._post_events()
@@ -1630,11 +1658,47 @@ class WebhookSubscriber(Subscriber):
         self._cancel_flush_timer()
 
         if self.queue:
+            # Best effort on shutdown: skip any active cooldown so the tail of
+            # the conversation gets one final delivery attempt.
+            self._backoff_until = 0.0
             await self._post_events()
+
+    def _retry_wait(self, error: Exception, attempt: int) -> float:
+        """Exponential backoff wait, honouring a Retry-After header when present."""
+        wait = min(self.spec.retry_delay * (2**attempt), _WEBHOOK_MAX_BACKOFF_SECONDS)
+        if isinstance(error, httpx.HTTPStatusError):
+            retry_after = error.response.headers.get("Retry-After")
+            if retry_after:
+                # TypeError guards non-string values (e.g. mocked responses).
+                with suppress(TypeError, ValueError):
+                    wait = max(wait, float(retry_after))
+        return wait
+
+    def _schedule_retry_flush(self):
+        """Arm a flush timer so delivery resumes after the cooldown expires.
+
+        Without this, events re-queued after a failed flush would only be
+        retried when a NEW event arrived - the tail of a conversation could
+        stay undelivered forever after a downstream outage.
+        """
+        if self._flush_timer:
+            return
+        delay = max(self._backoff_until - time.monotonic(), 0.0)
+        self._flush_timer = asyncio.create_task(self._flush_after_delay(delay))
 
     async def _post_events(self):
         """Post queued events to the webhook with retry logic."""
+        async with self._post_lock:
+            await self._post_events_locked()
+
+    async def _post_events_locked(self):
         if not self.queue:
+            return
+        if time.monotonic() < self._backoff_until:
+            # Still cooling down after exhausted retries (e.g. the downstream
+            # is rate limiting with 429s). Leave events queued; the retry
+            # flush timer will deliver them once the cooldown expires.
+            self._schedule_retry_flush()
             return
 
         events_to_post = self.queue.copy()
@@ -1662,7 +1726,9 @@ class WebhookSubscriber(Subscriber):
             f"{self.spec.base_url.rstrip('/')}/events/{self.conversation_id.hex}"
         )
 
-        # Retry logic
+        # Retry logic: exponential backoff (honouring Retry-After) between
+        # attempts; after the final failure, enter a cooldown and re-arm the
+        # flush timer instead of hammering a struggling downstream.
         for attempt in range(self.spec.num_retries + 1):
             try:
                 async with httpx.AsyncClient() as client:
@@ -1678,17 +1744,32 @@ class WebhookSubscriber(Subscriber):
                         f"Successfully posted {len(event_data)} events "
                         f"to webhook {events_url}"
                     )
+                    self._consecutive_failures = 0
+                    self._backoff_until = 0.0
                     return
             except Exception as e:
                 logger.warning(f"Webhook post attempt {attempt + 1} failed: {e}")
                 if attempt < self.spec.num_retries:
-                    await self._sleep(self.spec.retry_delay)
+                    await self._sleep(self._retry_wait(e, attempt))
                 else:
+                    self._consecutive_failures += 1
+                    # Floor of 1s so retry_delay=0 cannot produce a hot loop.
+                    cooldown = max(
+                        min(
+                            self.spec.retry_delay * (2**self._consecutive_failures),
+                            _WEBHOOK_MAX_BACKOFF_SECONDS,
+                        ),
+                        1.0,
+                    )
+                    self._backoff_until = time.monotonic() + cooldown
                     logger.error(
                         f"Failed to post events to webhook {events_url} "
-                        f"after {self.spec.num_retries + 1} attempts"
+                        f"after {self.spec.num_retries + 1} attempts; "
+                        f"retrying in {cooldown:.0f}s"
                     )
-                    self.queue.extend(events_to_post)
+                    # Prepend so delivery order is preserved when events
+                    # queued during this flush are eventually posted.
+                    self.queue = events_to_post + self.queue
                     overflow = len(self.queue) - self.spec.max_queue_size
                     if overflow > 0:
                         del self.queue[:overflow]
@@ -1697,6 +1778,7 @@ class WebhookSubscriber(Subscriber):
                             f"{self.spec.max_queue_size}; dropped {overflow} "
                             f"oldest event(s) for {events_url}."
                         )
+                    self._schedule_retry_flush()
 
     def _cancel_flush_timer(self):
         """Cancel the current flush timer if it exists."""
@@ -1704,18 +1786,21 @@ class WebhookSubscriber(Subscriber):
             self._flush_timer.cancel()
         self._flush_timer = None
 
-    async def _flush_after_delay(self):
-        """Wait for flush_delay seconds then flush events if any exist."""
+    async def _flush_after_delay(self, delay: float | None = None):
+        """Wait (flush_delay by default) then flush events if any exist."""
         try:
-            await self._sleep(self.spec.flush_delay)
+            await self._sleep(self.spec.flush_delay if delay is None else delay)
+        except asyncio.CancelledError:
+            # Timer was cancelled, which is expected behavior
+            self._flush_timer = None
+            return
+        # The timer has fired: clear it BEFORE flushing so a flush that ends
+        # in cooldown (or another failure) can re-arm the next retry timer.
+        self._flush_timer = None
+        with suppress(asyncio.CancelledError):
             # Only flush if there are events in the queue
             if self.queue:
                 await self._post_events()
-        except asyncio.CancelledError:
-            # Timer was cancelled, which is expected behavior
-            pass
-        finally:
-            self._flush_timer = None
 
 
 @dataclass

--- a/openhands-agent-server/openhands/agent_server/event_service.py
+++ b/openhands-agent-server/openhands/agent_server/event_service.py
@@ -1,4 +1,5 @@
 import asyncio
+import time
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import nullcontext, suppress
 from dataclasses import dataclass, field
@@ -67,6 +68,11 @@ LEASE_RENEW_INTERVAL_SECONDS = 15.0
 # Bounds initial-state push so subscribe_to_events does not stall on a
 # subscriber whose __call__ blocks (e.g. WS with a full TCP send buffer).
 INITIAL_STATE_PUSH_TIMEOUT_SECONDS = 0.5
+# How long a lingering _run_task may stay not-done while execution_status
+# reports non-RUNNING before run() reaps it and starts fresh (#3842). Must
+# comfortably exceed the legitimate wrap-up tail (wait_for_pending is bounded
+# at 30s) so a normal finishing run is never cancelled.
+STALE_RUN_TASK_REAP_SECONDS = 120.0
 
 
 logger = get_logger(__name__)
@@ -90,6 +96,15 @@ class EventService:
         default_factory=lambda: PubSub[Event](max_subscribers=50), init=False
     )
     _run_task: asyncio.Task | None = field(default=None, init=False)
+    # Stale run-task detection (#3842): a _run_task that never completes while
+    # execution_status reports non-RUNNING wedges the conversation forever -
+    # every run() raises conversation_already_running and there is no
+    # self-heal. Track the first time run() observed a given lingering task so
+    # a later attempt can reap it once it has been stale beyond the grace
+    # period (which comfortably exceeds the legitimate wrap-up tail:
+    # wait_for_pending is bounded at 30s).
+    _stale_run_task_ref: asyncio.Task | None = field(default=None, init=False)
+    _stale_run_first_seen: float | None = field(default=None, init=False)
     # Set when a send_message(run=True) is rejected because a run is still
     # wrapping up; consumed by _run_and_publish to re-run the stranded message.
     _rerun_requested: bool = field(default=False, init=False)
@@ -902,6 +917,45 @@ class EventService:
         # Publish initial state update
         await self._publish_state_update()
 
+    def _maybe_reap_stale_run_task(self) -> bool:
+        """Reap a wedged ``_run_task`` so the conversation can run again (#3842).
+
+        Called (with ``_run_lock`` held) when ``run()`` finds a live task while
+        ``execution_status`` reports non-RUNNING. A legitimately finishing run
+        clears its task reference within seconds (``wait_for_pending`` is
+        bounded at 30s), so the same task object still lingering on a second
+        observation ``STALE_RUN_TASK_REAP_SECONDS`` later is wedged: cancel it,
+        clear the reference, and let the caller start a fresh run.
+
+        Returns True when a stale task was reaped and the caller may proceed.
+        """
+        task = self._run_task
+        if task is None:
+            return True
+        now = time.monotonic()
+        if self._stale_run_task_ref is not task:
+            # First observation of this lingering task: start the clock.
+            self._stale_run_task_ref = task
+            self._stale_run_first_seen = now
+            return False
+        if (
+            self._stale_run_first_seen is None
+            or now - self._stale_run_first_seen < STALE_RUN_TASK_REAP_SECONDS
+        ):
+            return False
+        logger.warning(
+            "Reaping stale _run_task for conversation %s: task still not done "
+            "%.0fs after execution_status first reported non-RUNNING; "
+            "cancelling it so the conversation can run again.",
+            self.stored.id,
+            now - self._stale_run_first_seen,
+        )
+        task.cancel()
+        self._run_task = None
+        self._stale_run_task_ref = None
+        self._stale_run_first_seen = None
+        return True
+
     async def run(self, acp_internal_rerun_generation: int | None = None):
         """Run the conversation asynchronously in the background.
 
@@ -934,9 +988,14 @@ class EventService:
             ):
                 return
 
-            # Check if there's already a running task
+            # Check if there's already a running task. execution_status is
+            # non-RUNNING at this point (checked above), so a live task here
+            # is either a run wrapping up (transient, seconds) or the #3842
+            # wedge: a task that never completes, leaving the conversation
+            # permanently answering 409 with no self-heal. Reap the latter.
             if self._run_task is not None and not self._run_task.done():
-                raise ValueError("conversation_already_running")
+                if not self._maybe_reap_stale_run_task():
+                    raise ValueError("conversation_already_running")
 
             # Capture conversation reference for the closure
             conversation = self._conversation
@@ -992,8 +1051,12 @@ class EventService:
                             None, self._callback_wrapper.wait_for_pending, 30.0
                         )
 
-                    # Clear task reference and publish state update
-                    self._run_task = None
+                    # Clear task reference and publish state update. Only
+                    # clear our own reference: a task reaped as stale (#3842)
+                    # may reach this finally after a replacement run has
+                    # already been started, and must not clobber it.
+                    if self._run_task is asyncio.current_task():
+                        self._run_task = None
                     await self._publish_state_update()
 
                     # Re-arm a run for input stranded while this task was
@@ -1050,6 +1113,9 @@ class EventService:
 
             # Create task but don't await it - runs in background
             self._run_task = asyncio.create_task(_run_and_publish())
+            # A fresh, healthy run: forget any stale-task observation.
+            self._stale_run_task_ref = None
+            self._stale_run_first_seen = None
 
     async def start_goal_loop(
         self,

--- a/tests/agent_server/test_event_service.py
+++ b/tests/agent_server/test_event_service.py
@@ -3402,3 +3402,56 @@ async def test_event_service_creates_lease_with_custom_ttl(tmp_path: Path) -> No
     assert service._lease is not None
     assert service._lease._ttl_seconds == 10.0
     assert (tmp_path / stored.id.hex / LEASE_FILE_NAME).exists()
+
+
+class TestStaleRunTaskReaper:
+    """Regression tests for #3842: a _run_task that never completes while
+    execution_status reports non-RUNNING must eventually be reaped so the
+    conversation can run again."""
+
+    @pytest.mark.asyncio
+    async def test_first_observation_does_not_reap(self, event_service):
+        never_done = asyncio.create_task(asyncio.Event().wait())
+        event_service._run_task = never_done
+
+        assert event_service._maybe_reap_stale_run_task() is False
+        assert event_service._run_task is never_done
+        assert event_service._stale_run_task_ref is never_done
+
+        never_done.cancel()
+
+    @pytest.mark.asyncio
+    async def test_reaps_after_grace_period(self, event_service, monkeypatch):
+        import openhands.agent_server.event_service as event_service_module
+
+        monkeypatch.setattr(event_service_module, "STALE_RUN_TASK_REAP_SECONDS", 0.05)
+        never_done = asyncio.create_task(asyncio.Event().wait())
+        event_service._run_task = never_done
+
+        assert event_service._maybe_reap_stale_run_task() is False
+        await asyncio.sleep(0.1)
+        assert event_service._maybe_reap_stale_run_task() is True
+
+        assert event_service._run_task is None
+        assert event_service._stale_run_task_ref is None
+        await asyncio.sleep(0)
+        assert never_done.cancelled()
+
+    @pytest.mark.asyncio
+    async def test_new_task_restarts_the_clock(self, event_service, monkeypatch):
+        import openhands.agent_server.event_service as event_service_module
+
+        monkeypatch.setattr(event_service_module, "STALE_RUN_TASK_REAP_SECONDS", 0.05)
+        first = asyncio.create_task(asyncio.Event().wait())
+        event_service._run_task = first
+        assert event_service._maybe_reap_stale_run_task() is False
+        await asyncio.sleep(0.1)
+
+        # A different lingering task is a fresh observation, not a stale one.
+        second = asyncio.create_task(asyncio.Event().wait())
+        event_service._run_task = second
+        assert event_service._maybe_reap_stale_run_task() is False
+        assert event_service._run_task is second
+
+        first.cancel()
+        second.cancel()

--- a/tests/agent_server/test_webhook_subscriber.py
+++ b/tests/agent_server/test_webhook_subscriber.py
@@ -7,6 +7,7 @@ without dependencies on the openhands.sdk module.
 
 import asyncio
 import tempfile
+import time
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
@@ -23,7 +24,7 @@ from openhands.agent_server.conversation_service import (
 from openhands.agent_server.event_service import EventService
 from openhands.agent_server.models import StoredConversation
 from openhands.agent_server.utils import utc_now
-from openhands.sdk import LLM, Agent
+from openhands.sdk import LLM, Agent, Event
 from openhands.sdk.event.llm_convertible import MessageEvent
 from openhands.sdk.llm.message import Message, TextContent
 from openhands.sdk.workspace import LocalWorkspace
@@ -503,7 +504,8 @@ class TestWebhookSubscriberPostEvents:
         # Verify retries were attempted
         assert len(retry_attempts) == 3
         # Only this instance's delays are recorded — no global-sleep pollution.
-        assert sleep_calls == [webhook_spec.retry_delay] * 2
+        # Waits grow exponentially: retry_delay * 2**attempt.
+        assert sleep_calls == [webhook_spec.retry_delay, webhook_spec.retry_delay * 2]
 
         # Verify queue is cleared after success
         assert subscriber.queue == []
@@ -545,14 +547,23 @@ class TestWebhookSubscriberPostEvents:
 
             await subscriber._post_events()
 
+        # A retry flush was re-armed so delivery resumes without new events;
+        # stop it here so the always-failing mock does not loop in the test.
+        assert subscriber._flush_timer is not None
+        subscriber._cancel_flush_timer()
+
         # Verify all retries were attempted (num_retries + 1 = 3 total attempts)
         assert len(retry_attempts) == 3
         # Only this instance's delays are recorded — no global-sleep pollution.
-        assert sleep_calls == [webhook_spec.retry_delay] * 2
+        # Waits grow exponentially: retry_delay * 2**attempt.
+        assert sleep_calls == [webhook_spec.retry_delay, webhook_spec.retry_delay * 2]
 
         # Verify events are re-queued after failure
         assert len(subscriber.queue) == 2
         assert subscriber.queue == original_events
+
+        # A failure cooldown is armed so the next flush waits out the storm.
+        assert subscriber._backoff_until > 0
 
     @pytest.mark.asyncio
     async def test_post_events_drops_oldest_when_requeue_exceeds_max_queue_size(
@@ -596,6 +607,9 @@ class TestWebhookSubscriberPostEvents:
             mock_client.request = mock_request
             mock_client_class.return_value.__aenter__.return_value = mock_client
             await subscriber._post_events()
+
+        # Stop the re-armed retry timer so the failing mock does not loop.
+        subscriber._cancel_flush_timer()
 
         # Bound is honored, and the *oldest* events are the ones dropped.
         assert len(subscriber.queue) == spec.max_queue_size
@@ -821,10 +835,12 @@ class TestWebhookSubscriberErrorHandling:
 
         subscriber._sleep = record_sleep
         await subscriber._post_events()
+        subscriber._cancel_flush_timer()  # stop the re-armed retry timer
 
         # Verify retries were attempted
         assert mock_client.request.call_count == 3  # num_retries + 1
-        assert sleep_calls == [webhook_spec.retry_delay] * 2
+        # Waits grow exponentially: retry_delay * 2**attempt.
+        assert sleep_calls == [webhook_spec.retry_delay, webhook_spec.retry_delay * 2]
 
         # Events should be re-queued after failure
         assert len(subscriber.queue) == 2
@@ -861,10 +877,12 @@ class TestWebhookSubscriberErrorHandling:
 
         subscriber._sleep = record_sleep
         await subscriber._post_events()
+        subscriber._cancel_flush_timer()  # stop the re-armed retry timer
 
         # Verify retries were attempted
         assert mock_client.request.call_count == 3
-        assert sleep_calls == [webhook_spec.retry_delay] * 2
+        # Waits grow exponentially: retry_delay * 2**attempt.
+        assert sleep_calls == [webhook_spec.retry_delay, webhook_spec.retry_delay * 2]
 
         # Events should be re-queued after failure
         assert len(subscriber.queue) == 1
@@ -1418,3 +1436,128 @@ async def test_webhook_subscribe_errors_surface(tmp_path, monkeypatch):
                 usage_id="webhook-error",
                 initial_text=None,
             )
+
+
+class TestWebhookBackoffAndRecovery:
+    """Regression tests for #3842: a rate-limited webhook must not lose events
+    or hammer the downstream; delivery must resume once it recovers."""
+
+    @pytest.fixture
+    def spec(self):
+        return WebhookSpec(
+            base_url="https://example.com",
+            event_buffer_size=2,
+            flush_delay=0.1,
+            num_retries=2,
+            retry_delay=1,
+            max_queue_size=100,
+        )
+
+    def _events(self, n) -> list[Event]:
+        return [
+            MessageEvent(
+                source="user",
+                llm_message=Message(role="user", content=[TextContent(text=f"e{i}")]),
+            )
+            for i in range(n)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_429_storm_honours_retry_after_and_delivers_everything(
+        self, mock_event_service, spec, sample_conversation_id
+    ):
+        """Persistent 429s: waits honour Retry-After, nothing is dropped, and
+        the full queue is delivered in order once the downstream recovers."""
+        subscriber = WebhookSubscriber(
+            conversation_id=sample_conversation_id,
+            service=mock_event_service,
+            spec=spec,
+        )
+        events = self._events(4)
+        subscriber.queue = events.copy()
+
+        posted_bodies = []
+        request_count = 0
+
+        async def mock_request(*args, **kwargs):
+            nonlocal request_count
+            request_count += 1
+            if request_count <= 4:  # first volley (3 attempts) + 1 more fail
+                response = httpx.Response(
+                    status_code=429,
+                    headers={"Retry-After": "7"},
+                    request=httpx.Request("POST", "https://example.com"),
+                )
+                raise httpx.HTTPStatusError(
+                    "Too Many Requests",
+                    request=response.request,
+                    response=response,
+                )
+            posted_bodies.append(kwargs.get("json"))
+            response = AsyncMock()
+            response.raise_for_status.return_value = None
+            return response
+
+        sleep_calls = []
+
+        async def mock_sleep(delay):
+            sleep_calls.append(delay)
+
+        subscriber._sleep = mock_sleep
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client.request = mock_request
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            # First flush: exhausts retries, re-queues, arms cooldown + timer.
+            await subscriber._post_events()
+            assert subscriber.queue == events  # nothing lost, order intact
+            assert subscriber._backoff_until > 0
+
+            # Let the re-armed retry flush run (mocked sleep returns at once).
+            # Skip the cooldown gate the way the timer's real wait would.
+            subscriber._backoff_until = 0.0
+            for _ in range(10):
+                await asyncio.sleep(0)
+                if posted_bodies:
+                    break
+
+        subscriber._cancel_flush_timer()
+        # Retry-After (7s) exceeded the computed backoff (1s, 2s) and was
+        # honoured for the in-volley waits.
+        assert sleep_calls[:2] == [7.0, 7.0]
+        # Everything delivered, in order, exactly once.
+        assert len(posted_bodies) == 1
+        texts = [item["llm_message"]["content"][0]["text"] for item in posted_bodies[0]]
+        assert texts == ["e0", "e1", "e2", "e3"]
+        assert subscriber.queue == []
+        # Success resets the failure circuit.
+        assert subscriber._consecutive_failures == 0
+        assert subscriber._backoff_until == 0.0
+
+    @pytest.mark.asyncio
+    async def test_size_triggered_flush_waits_out_cooldown(
+        self, mock_event_service, spec, sample_conversation_id
+    ):
+        """During a failure cooldown a full buffer queues instead of posting,
+        so a struggling downstream is not hammered."""
+        subscriber = WebhookSubscriber(
+            conversation_id=sample_conversation_id,
+            service=mock_event_service,
+            spec=spec,
+        )
+        subscriber._backoff_until = time.monotonic() + 60.0
+
+        with patch("httpx.AsyncClient") as mock_client_class:
+            mock_client = AsyncMock()
+            mock_client_class.return_value.__aenter__.return_value = mock_client
+
+            for event in self._events(3):  # exceeds event_buffer_size=2
+                await subscriber(event)
+
+            mock_client.request.assert_not_called()
+
+        assert len(subscriber.queue) == 3
+        # A timer is armed so delivery resumes after the cooldown.
+        assert subscriber._flush_timer is not None
+        subscriber._cancel_flush_timer()


### PR DESCRIPTION
HUMAN:

Follow-up to my report in #3842, which VascoSch92 reproduced. We caught the trigger in the wild on our fleet: the app server rate-limits its own sandbox's webhook posts (429), the stock poster gives up, the app-side transcript freezes, and the lingering run task answers 409 forever with no self-heal. Fix validated end to end on a self-hosted box (evidence below) on top of the unit suites.

---

AGENT:

## Why

Fixes #3842.

Two defects compound into the wedge:

1. `WebhookSubscriber._post_events` retries on a fixed delay with no backoff, does not honour `Retry-After`, fires overlapping volleys (each buffer-full flush posts concurrently), and after exhausting retries only tries again when a NEW event arrives. Against a rate-limited downstream (the OpenHands app server applies `InMemoryRateLimiter(requests=10, seconds=1)` per client IP to ALL routes, including `/api/v1/webhooks/events/...`) the concurrent volleys trip the limiter, keep it tripped, and delivery stalls; the queue trim then drops events permanently. Production signature: hundreds of `Webhook post attempt 4 failed: 429` / `Failed to post events ... after 4 attempts` per second for 90+ minutes while the app-side transcript sat frozen (the agent's local store reached 8,622 events; the app side had 270).

2. `EventService.run()` raises `conversation_already_running` whenever `_run_task` is alive, even while `execution_status` reports non-RUNNING. A run task that never completes therefore wedges the conversation forever - the self-heal added in #3364 never fires because the task never reaches its cleanup tail.

## Summary

- Webhook poster: serialise flushes behind a lock; exponential backoff between attempts, honouring `Retry-After`; after a failed volley enter an exponentially growing cooldown (1s floor, 60s cap) instead of hammering; re-arm the flush timer on failure so delivery resumes WITHOUT requiring a new event; preserve delivery order by prepending re-queued events.
- `EventService.run()`: when a live `_run_task` coexists with non-RUNNING `execution_status`, start a staleness clock; if the SAME task is still lingering on a later attempt past `STALE_RUN_TASK_REAP_SECONDS` (120s, comfortably beyond the 30s-bounded `wait_for_pending` tail), cancel and reap it, then start the requested run. The task's `finally` now only clears its own task reference so a reaped task cannot clobber a replacement run.

## How to Test

Commands run in a clean checkout with the patch applied:

- `uv run pytest tests/agent_server/test_webhook_subscriber.py tests/agent_server/test_event_service.py` -> **150 passed**. 5 new tests cover Retry-After/backoff with zero event loss and order preservation, cooldown queueing without posts, and the stale-run-task reaper (first observation never reaps; same lingering task past the grace period is cancelled and cleared; a different task restarts the clock). 5 existing assertions updated where the fixed-delay retry cadence intentionally changed to exponential.
- `uv run ruff check` / `uv run ruff format` on the four touched files: clean.

End to end on a self-hosted deployment (agent-server image built from this branch's changes applied to v1.30.0, `--target source`; OpenHands app at current main). The app's global rate limit was tightened to `requests=1/second` to force the storm, then a long multi-step streaming conversation was driven through the full app -> sandbox -> webhook path:

- **Stock agent-server (1.30.0)**: webhook volleys tripped repeated 429s and logged the permanent give-up (`Failed to post events to webhook ... after 4 attempts`); the app-side transcript stalls until unrelated later events happen to re-trigger a flush - or forever when the storm persists (the production case above).
- **Patched agent-server**: the serialised, paced poster stayed under the SAME limiter - zero 429s - and the full transcript including the final assistant message reached the app store; the conversation completed normally. Under a separately induced sustained-failure scenario, the cooldown machinery held: re-arms progressed 10s -> 20s -> 40s -> 60s (capped), no hot loop, no drops within the queue bound.
