### PR TITLE
Fix stale LLM profile parameters on activation

### DIFF
--- a/openhands-agent-server/openhands/agent_server/profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/profiles_router.py
@@ -337,14 +337,10 @@ async def activate_profile(
     settings_store = get_settings_store(config)
 
     def apply_profile(settings: PersistedSettings) -> PersistedSettings:
-        # Update the LLM configuration
-        llm_dict = llm.model_dump(mode="json", context={"expose_secrets": "plaintext"})
-        settings.update(
-            {
-                "agent_settings_diff": {"llm": llm_dict},
-                "active_profile": name,
-            }
+        settings.agent_settings = settings.agent_settings.model_copy(
+            update={"llm": llm}
         )
+        settings.active_profile = name
         return settings
 
     try:

--- a/tests/agent_server/test_profiles_router.py
+++ b/tests/agent_server/test_profiles_router.py
@@ -1014,6 +1014,38 @@ def test_activate_profile_applies_llm_config(client, store):
     assert agent_settings["llm"]["temperature"] == 0.8
 
 
+def test_activate_profile_replaces_stale_llm_extra_body(client, store):
+    """Activating a profile should not retain extra_body from the old LLM."""
+    response = client.patch(
+        "/api/settings",
+        json={
+            "agent_settings_diff": {
+                "llm": {
+                    "model": "openai/qwen3",
+                    "litellm_extra_body": {"enable_thinking": True, "store": False},
+                }
+            }
+        },
+    )
+    assert response.status_code == 200
+
+    llm = LLM(
+        model="openai/target-model",
+        base_url="https://api.example.test/v1",
+        litellm_extra_body={},
+    )
+    store.save("target-profile", llm)
+
+    response = client.post("/api/profiles/target-profile/activate")
+
+    assert response.status_code == 200
+    settings_response = client.get("/api/settings")
+    assert settings_response.status_code == 200
+    llm_settings = settings_response.json()["agent_settings"]["llm"]
+    assert llm_settings["model"] == "openai/target-model"
+    assert llm_settings["litellm_extra_body"] == {}
+
+
 def test_activate_profile_not_found(client):
     """POST /api/profiles/{name}/activate returns 404 for non-existent profile."""
     response = client.post("/api/profiles/nonexistent/activate")


### PR DESCRIPTION
## Summary
- Replace the active LLM config directly when applying a saved profile so nested request parameters from the previous profile cannot leak into the new one.
- Add regression coverage for clearing provider-specific `litellm_extra_body` values on profile activation.

## Tests
- `uv run ruff check openhands-agent-server/openhands/agent_server/profiles_router.py tests/agent_server/test_profiles_router.py`
- `uv run ruff format --check openhands-agent-server/openhands/agent_server/profiles_router.py tests/agent_server/test_profiles_router.py`
- `uv run pytest tests/agent_server/test_profiles_router.py`

_This PR was created by an AI agent (OpenHands) on behalf of the user._