### PR TITLE
feat(agent): configurable content_response_policy for content-without-tool-call responses (#3992)

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/base.py
+++ b/openhands-sdk/openhands/sdk/agent/base.py
@@ -300,6 +300,23 @@ class AgentBase(DiscriminatedUnionMixin, ABC):
         ),
     )
 
+    content_response_policy: Literal["finish", "nudge"] = Field(
+        default="finish",
+        description=(
+            "Policy for assistant responses that contain text content but no tool "
+            "call. 'finish' (default) treats such a message as the final answer "
+            "and marks the conversation FINISHED. 'nudge' emits the message, then "
+            "sends corrective feedback and keeps the loop running, reserving "
+            "completion for an explicit signal such as the `finish` tool. The "
+            "'nudge' policy reduces false terminations from weaker/local models "
+            "that narrate a step in prose before emitting its tool call; runaway "
+            "prose loops are bounded by conversation-level stuck detection, the "
+            "same mechanism that bounds the existing empty-response nudge (the "
+            "nudge is emitted with source='environment' so it does not reset the "
+            "detector's human-turn boundary)."
+        ),
+    )
+
     # Runtime materialized tools; private and non-serializable
     _tools: dict[str, ToolDefinition] = PrivateAttr(default_factory=dict)
     _tools_lock: threading.RLock = PrivateAttr(default_factory=threading.RLock)

--- a/openhands-sdk/openhands/sdk/agent/response_dispatch.py
+++ b/openhands-sdk/openhands/sdk/agent/response_dispatch.py
@@ -9,7 +9,7 @@ Contains:
 from __future__ import annotations
 
 from enum import StrEnum
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from openhands.sdk.conversation.state import ConversationExecutionStatus
 from openhands.sdk.event import MessageEvent
@@ -34,6 +34,17 @@ if TYPE_CHECKING:
     from openhands.sdk.security.analyzer import SecurityAnalyzerBase
 
 logger = get_logger(__name__)
+
+
+# Corrective feedback for a content-without-tool-call turn under the "nudge"
+# policy. Unlike the empty-response nudge, the model DID produce a message
+# (preserved in history), so the feedback points at the missing tool call and at
+# the explicit way to signal completion.
+_CONTENT_NUDGE_TEXT = (
+    "Your last message did not include a function call. If the task is "
+    "complete, call the `finish` tool; otherwise continue with the next "
+    "tool call."
+)
 
 
 # ---------------------------------------------------------------------------
@@ -92,6 +103,7 @@ class ResponseDispatchMixin:
     # Declared for pyright — the actual implementations live on Agent.
     if TYPE_CHECKING:
         critic: CriticBase | None
+        content_response_policy: Literal["finish", "nudge"]
 
         def _get_action_event(
             self,
@@ -243,9 +255,25 @@ class ResponseDispatchMixin:
         state: ConversationState,
         on_event: ConversationCallbackType,
     ) -> None:
-        """Handle LLM response with text content — finishes conversation."""
+        """Handle LLM response with text content.
+
+        Under the default ``content_response_policy="finish"`` the message is
+        treated as the final answer and the conversation is marked FINISHED.
+        Under ``"nudge"`` the message is emitted (preserved in history), then
+        corrective feedback is sent and the loop continues — completion is
+        reserved for an explicit signal such as the ``finish`` tool. This keeps
+        weaker/local models that narrate a step in prose before its tool call
+        from being silently treated as done mid-task (#3992).
+        """
         self._emit_message_event(message, llm_response, conversation, on_event)
         self._maybe_emit_vllm_tokens(llm_response, on_event)
+        if self.content_response_policy == "nudge":
+            logger.debug(
+                "LLM produced a message response without a tool call - "
+                "content_response_policy='nudge', continuing agent loop"
+            )
+            self._send_corrective_nudge(on_event, text=_CONTENT_NUDGE_TEXT)
+            return
         logger.debug("LLM produced a message response - awaits user input")
         state.execution_status = ConversationExecutionStatus.FINISHED
 
@@ -293,15 +321,22 @@ class ResponseDispatchMixin:
         on_event(msg_event)
         return msg_event
 
-    def _send_corrective_nudge(self, on_event: ConversationCallbackType) -> None:
+    def _send_corrective_nudge(
+        self,
+        on_event: ConversationCallbackType,
+        *,
+        text: str | None = None,
+    ) -> None:
         """Inject corrective feedback when no tool call and no content.
 
         The model still receives this as a user-role message, but the event
-        source marks that it came from the framework rather than the human.
+        source marks that it came from the framework rather than the human, so
+        repeated synthetic nudges do not reset the human-turn boundary the
+        stuck detector uses. ``text`` overrides the default for the
+        content-without-tool-call case under ``content_response_policy="nudge"``.
         """
         logger.warning(
-            "LLM response contained no tool call and no content"
-            " - sending corrective feedback"
+            "LLM response contained no tool call - sending corrective feedback"
         )
         nudge = MessageEvent(
             source="environment",
@@ -309,7 +344,8 @@ class ResponseDispatchMixin:
                 role="user",
                 content=[
                     TextContent(
-                        text=(
+                        text=text
+                        or (
                             "Your last response did not include a "
                             "function call or a message. Please "
                             "use a tool to proceed with the task."

--- a/tests/sdk/agent/test_response_dispatch.py
+++ b/tests/sdk/agent/test_response_dispatch.py
@@ -22,6 +22,7 @@ from openhands.sdk.llm import (
     ThinkingBlock,
 )
 from openhands.sdk.llm.utils.metrics import MetricsSnapshot, TokenUsage
+from openhands.sdk.testing import TestLLM
 from openhands.sdk.tool import Action, Observation
 
 
@@ -200,6 +201,7 @@ def _run_single_step(
     *,
     seed_events: list[Event] | None = None,
     record_emitted_events_in_state: bool = False,
+    content_response_policy: str = "finish",
 ) -> tuple[list[Event], LocalConversation]:
     """Run one agent step with a canned LLM response."""
     from pydantic import PrivateAttr
@@ -217,7 +219,7 @@ def _run_single_step(
             return self._response
 
     llm = SingleShotLLM(llm_response)
-    agent = Agent(llm=llm, tools=[])
+    agent = Agent(llm=llm, tools=[], content_response_policy=content_response_policy)
     conversation = Conversation(agent=agent)
     conversation._ensure_agent_ready()
     if seed_events is not None:
@@ -285,6 +287,105 @@ def test_content_response_sets_finished():
     assert convo.state.execution_status == ConversationExecutionStatus.FINISHED
     assert len(msg_events) == 1
     assert msg_events[0].source == "agent"
+
+
+def test_content_response_default_policy_is_finish():
+    """The default policy is unchanged: content still finishes the conversation."""
+    assert (
+        Agent(llm=LLM(model="test-model"), tools=[]).content_response_policy == "finish"
+    )
+
+
+def test_content_response_nudge_policy_continues_loop():
+    """content_response_policy="nudge": prose without a tool call does not finish.
+
+    The agent message is preserved, a corrective nudge follows, and the
+    conversation stays runnable (regression for #3992: weaker/local models
+    narrating a step in prose were silently treated as finished mid-task).
+    """
+    msg = Message(
+        role="assistant",
+        content=[TextContent(text="Let me now check the config before I proceed.")],
+    )
+    events, convo = _run_single_step(
+        _make_llm_response(msg), content_response_policy="nudge"
+    )
+    msg_events = [e for e in events if isinstance(e, MessageEvent)]
+
+    assert convo.state.execution_status != ConversationExecutionStatus.FINISHED
+    assert len(msg_events) == 2
+    assert msg_events[0].source == "agent"  # the prose is not dropped
+    assert msg_events[1].source == "environment"  # framework feedback, not a human turn
+    assert msg_events[1].llm_message.role == "user"  # but the model still reads it
+    nudge_content = msg_events[1].llm_message.content[0]
+    assert isinstance(nudge_content, TextContent)
+    assert "finish" in nudge_content.text  # points at the explicit completion path
+
+
+def test_finish_tool_still_finishes_under_nudge_policy():
+    """Explicit completion via the finish tool works under the nudge policy."""
+    tool_call = MessageToolCall(
+        id="tc-finish",
+        name="finish",
+        arguments='{"message": "All done"}',
+        origin="completion",
+    )
+    msg = Message(role="assistant", tool_calls=[tool_call])
+    _, convo = _run_single_step(
+        _make_llm_response(msg), content_response_policy="nudge"
+    )
+    assert convo.state.execution_status == ConversationExecutionStatus.FINISHED
+
+
+def test_nudge_policy_repeated_prose_reaches_stuck_before_max_iteration():
+    """Regression for the #3997 review: the nudge policy must not run away.
+
+    A model that keeps returning prose without a tool call must be caught by the
+    conversation-level stuck detector, NOT run to ``max_iteration_per_run``. The
+    corrective nudge is emitted with ``source="environment"`` so it does not reset
+    the human-turn boundary the ``StuckDetector`` uses; the repeated agent messages
+    then register as monologue and trip stuck detection. A one-step test cannot
+    catch this control-flow failure, so this drives the real multi-step loop.
+    """
+    # Many more prose responses than the monologue threshold (3), far fewer than
+    # the default max_iteration_per_run (500). An unbounded loop would consume all
+    # of these; the fix must stop it after only a handful.
+    prose = [
+        Message(
+            role="assistant",
+            content=[TextContent(text=f"Let me keep thinking about step {i}.")],
+        )
+        for i in range(30)
+    ]
+    agent = Agent(
+        llm=TestLLM.from_messages(prose),
+        tools=[],
+        content_response_policy="nudge",
+    )
+    conversation = Conversation(agent=agent)
+    conversation.send_message(
+        Message(role="user", content=[TextContent(text="Do the task.")])
+    )
+    conversation.run()
+
+    # Stuck detection fired instead of running away to max_iteration_per_run.
+    assert conversation.state.execution_status == ConversationExecutionStatus.STUCK
+    # And it fired quickly — a few agent turns, nowhere near 500 or the 30 scripted
+    # responses (the monologue threshold is 3).
+    agent_msgs = [
+        e
+        for e in conversation.state.events
+        if isinstance(e, MessageEvent) and e.source == "agent"
+    ]
+    assert len(agent_msgs) < 10
+    # The synthetic nudges were NOT recorded as real user turns (the whole point):
+    # only the original task counts as a user message.
+    user_msgs = [
+        e
+        for e in conversation.state.events
+        if isinstance(e, MessageEvent) and e.source == "user"
+    ]
+    assert len(user_msgs) == 1
 
 
 def test_empty_response_sends_nudge():


### PR DESCRIPTION
HUMAN:


- [x] A human has tested these changes.

AGENT:

Investigated, implemented, and unit-tested by an AI agent (Claude Code) operating under
Solomon Okello's direction; every claim below is backed by the included tests.

---

## Why

#3992: `ResponseDispatchMixin` dispatches asymmetrically — an EMPTY response gets a
corrective nudge and the loop continues, but a CONTENT response (prose, no tool call)
sets `execution_status = FINISHED` unconditionally. Weaker/local models narrate a step
in prose before emitting its tool call, so they get silently terminated mid-task with
exit 0. Three earlier attempts to change the default (#1303, #1304, #1385) didn't merge —
plain content *is* a legitimate completion signal for strong models. So this PR follows
the issue's second suggested direction: make the policy **configurable, default
unchanged**.

## Summary

- New `AgentBase` field `content_response_policy: Literal["finish", "nudge"]`, default
  `"finish"` — zero behavior change unless opted in.
- Under `"nudge"`: the prose message is emitted (preserved in history), a corrective
  nudge is sent (pointing at the `finish` tool as the explicit completion path), and the
  loop continues. Runaway prose loops are bounded by conversation-level stuck detection —
  the same mechanism that already bounds the EMPTY-response nudge (per the existing
  docstring on `_send_corrective_nudge`).
- `_send_corrective_nudge` gains an optional `text` kwarg so the content-case feedback
  can differ from the empty-case feedback (the model *did* produce a message; telling it
  otherwise would be false).

## Issue Number

Fixes #3992

## How to Test

```bash
uv run pytest tests/sdk/agent/test_response_dispatch.py -q
```

Three new tests:
- `test_content_response_nudge_policy_continues_loop` — prose turn under `"nudge"`: not
  FINISHED, agent message preserved, nudge follows, nudge text points at `finish`
- `test_content_response_default_policy_is_finish` — guards the no-behavior-change
  contract
- `test_finish_tool_still_finishes_under_nudge_policy` — explicit completion still works

The pre-existing `test_content_response_sets_finished` continues to pass unchanged,
which is the other half of the compatibility guarantee.

