### PR TITLE
ci: don't block OpenHands bump PR when OpenHands-CLI PR creation fails

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -97,8 +97,12 @@ jobs:
 
                   echo "✅ All packages are resolvable on PyPI!"
 
-            # OpenHands-CLI step runs first since it's simpler and less error-prone
+            # continue-on-error: a CLI bump failure (e.g. the agent-client-protocol
+            # pin conflict, OpenHands-CLI#786) must not block the OpenHands PR below.
+            # The failure is surfaced in the Summary step via steps.cli_pr.outcome.
             - name: Create PR for OpenHands-CLI repo
+              id: cli_pr
+              continue-on-error: true
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
               run: |
@@ -385,7 +389,11 @@ jobs:
                   echo "PRs have been created to bump SDK packages to version **$VERSION**:" >> $GITHUB_STEP_SUMMARY
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- [OpenHands](https://github.com/OpenHands/OpenHands/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
-                  echo "- [OpenHands-CLI](https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  if [ "${{ steps.cli_pr.outcome }}" = "failure" ]; then
+                    echo "- ⚠️ **OpenHands-CLI PR creation FAILED** — see the \"Create PR for OpenHands-CLI repo\" step logs" >> $GITHUB_STEP_SUMMARY
+                  else
+                    echo "- [OpenHands-CLI](https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  fi
 
             - name: Notify Slack
               if: env.SLACK_BOT_TOKEN != ''


### PR DESCRIPTION
## Why
The OpenHands-CLI bump step currently aborts the whole job when it fails, which blocks the OpenHands PR from ever being created — as happened for v1.31.1, where the CLI's `agent-client-protocol<0.9.0` pin conflicts with the SDK's `>=0.10.1` floor (OpenHands/OpenHands-CLI#786) and will keep failing until that migration lands. Marking the CLI step `continue-on-error` lets the OpenHands PR proceed independently, and the job summary now flags a CLI failure explicitly so it doesn't fail silently behind a green check.

## Validation
- YAML parses (`python3 -c "yaml.safe_load(...)"`).
- Re-traced the v1.31.1 failure path: with `continue-on-error: true` on `cli_pr`, the OpenHands step and Summary still run, and `steps.cli_pr.outcome == 'failure'` selects the warning line in the summary.

This PR was drafted by an AI agent on behalf of the user.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:8541979-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-8541979-python \
  ghcr.io/openhands/agent-server:8541979-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:8541979-golang-amd64
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-golang-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-golang-amd64
ghcr.io/openhands/agent-server:8541979-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:8541979-golang-arm64
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-golang-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-golang-arm64
ghcr.io/openhands/agent-server:8541979-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:8541979-java-amd64
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-java-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-java-amd64
ghcr.io/openhands/agent-server:8541979-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:8541979-java-arm64
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-java-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-java-arm64
ghcr.io/openhands/agent-server:8541979-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:8541979-python-amd64
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-python-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-python-amd64
ghcr.io/openhands/agent-server:8541979-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:8541979-python-arm64
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-python-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-python-arm64
ghcr.io/openhands/agent-server:8541979-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:8541979-golang
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-golang
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-golang
ghcr.io/openhands/agent-server:8541979-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:8541979-java
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-java
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-java
ghcr.io/openhands/agent-server:8541979-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:8541979-python
ghcr.io/openhands/agent-server:8541979b172f7db8ca6fa24a00a1dab609643156-python
ghcr.io/openhands/agent-server:av-version-bump-prs-cli-nonblocking-python
ghcr.io/openhands/agent-server:8541979-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `8541979-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `8541979-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->