### PR TITLE
ci: create OpenHands bump PR before the OpenHands-CLI PR

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -97,83 +97,6 @@ jobs:
 
                   echo "✅ All packages are resolvable on PyPI!"
 
-            # OpenHands-CLI step runs first since it's simpler and less error-prone
-            - name: Create PR for OpenHands-CLI repo
-              env:
-                  VERSION: ${{ steps.get_version.outputs.version }}
-              run: |
-                  set -euo pipefail
-
-                  REPO="OpenHands/openhands-cli"
-                  BRANCH="bump-sdk-$VERSION"
-
-                  echo "🔄 Creating PR for $REPO..."
-
-                  # Clone the repo
-                  git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" openhands-cli-repo
-                  cd openhands-cli-repo
-
-                  # Configure git
-                  git config user.name "github-actions[bot]"
-                  git config user.email "github-actions[bot]@users.noreply.github.com"
-
-                  # Check if branch already exists on remote
-                  if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
-                    echo "⚠️ Branch $BRANCH already exists, checking out existing branch"
-                    git fetch origin "$BRANCH"
-                    git checkout "$BRANCH"
-                  else
-                    # Create branch
-                    git checkout -b "$BRANCH"
-                  fi
-
-                  # OpenHands-CLI currently requires Python 3.12, so resolve with that interpreter.
-                  # The target repo uses exclude-newer-package to exempt openhands-sdk/tools
-                  # from its 7-day freshness guardrail, so no UV_EXCLUDE_NEWER override
-                  # is needed — doing so would actually break the per-package exemptions.
-                  # We use --no-cache to avoid stale index data from just-published packages.
-                  uv add --python 3.12 --no-cache \
-                    "openhands-sdk==$VERSION" \
-                    "openhands-tools==$VERSION"
-
-                  # Check if there are changes
-                  if git diff --quiet; then
-                    echo "⚠️ No changes detected in $REPO - versions may already be up to date"
-                    exit 0
-                  fi
-
-                  # Commit and push
-                  git add pyproject.toml uv.lock
-                  git commit -m "Bump openhands-sdk, openhands-tools to $VERSION" \
-                    -m "Automated version bump after PyPI release." \
-                    -m "Co-authored-by: openhands <openhands@all-hands.dev>"
-                  git push -u origin "$BRANCH"
-
-                  # Check if PR already exists
-                  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number')
-                  if [ -n "$EXISTING_PR" ]; then
-                    echo "✅ PR #$EXISTING_PR already exists for $REPO"
-                  else
-                    # Create PR
-                    gh pr create \
-                      --repo "$REPO" \
-                      --title "Bump SDK packages to v$VERSION" \
-                      --body "## Automated Version Bump
-
-                  This PR updates the following packages to version **$VERSION**:
-                  - \`openhands-sdk\`
-                  - \`openhands-tools\`
-
-                  **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
-
-                  ---
-                  _This PR was automatically created by the version-bump-prs workflow._" \
-                      --base main \
-                      --head "$BRANCH"
-
-                    echo "✅ PR created for $REPO"
-                  fi
-
             - name: Create PR for OpenHands repo
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
@@ -365,6 +288,82 @@ jobs:
                   - Regenerated \`uv.lock\` to match the updated SDK versions
                   - Updated \`AGENT_SERVER_IMAGE\` to \`${VERSION}\` in \`sandbox_spec_service.py\`
                   - Updated mypy \`additional_dependencies\` pins in \`.pre-commit-config.yaml\`
+
+                  **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
+
+                  ---
+                  _This PR was automatically created by the version-bump-prs workflow._" \
+                      --base main \
+                      --head "$BRANCH"
+
+                    echo "✅ PR created for $REPO"
+                  fi
+
+            - name: Create PR for OpenHands-CLI repo
+              env:
+                  VERSION: ${{ steps.get_version.outputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  REPO="OpenHands/openhands-cli"
+                  BRANCH="bump-sdk-$VERSION"
+
+                  echo "🔄 Creating PR for $REPO..."
+
+                  # Clone the repo
+                  git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" openhands-cli-repo
+                  cd openhands-cli-repo
+
+                  # Configure git
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Check if branch already exists on remote
+                  if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+                    echo "⚠️ Branch $BRANCH already exists, checking out existing branch"
+                    git fetch origin "$BRANCH"
+                    git checkout "$BRANCH"
+                  else
+                    # Create branch
+                    git checkout -b "$BRANCH"
+                  fi
+
+                  # OpenHands-CLI currently requires Python 3.12, so resolve with that interpreter.
+                  # The target repo uses exclude-newer-package to exempt openhands-sdk/tools
+                  # from its 7-day freshness guardrail, so no UV_EXCLUDE_NEWER override
+                  # is needed — doing so would actually break the per-package exemptions.
+                  # We use --no-cache to avoid stale index data from just-published packages.
+                  uv add --python 3.12 --no-cache \
+                    "openhands-sdk==$VERSION" \
+                    "openhands-tools==$VERSION"
+
+                  # Check if there are changes
+                  if git diff --quiet; then
+                    echo "⚠️ No changes detected in $REPO - versions may already be up to date"
+                    exit 0
+                  fi
+
+                  # Commit and push
+                  git add pyproject.toml uv.lock
+                  git commit -m "Bump openhands-sdk, openhands-tools to $VERSION" \
+                    -m "Automated version bump after PyPI release." \
+                    -m "Co-authored-by: openhands <openhands@all-hands.dev>"
+                  git push -u origin "$BRANCH"
+
+                  # Check if PR already exists
+                  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number')
+                  if [ -n "$EXISTING_PR" ]; then
+                    echo "✅ PR #$EXISTING_PR already exists for $REPO"
+                  else
+                    # Create PR
+                    gh pr create \
+                      --repo "$REPO" \
+                      --title "Bump SDK packages to v$VERSION" \
+                      --body "## Automated Version Bump
+
+                  This PR updates the following packages to version **$VERSION**:
+                  - \`openhands-sdk\`
+                  - \`openhands-tools\`
 
                   **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
 


### PR DESCRIPTION
HUMAN:

Reordering the openhands PR and openhands CLI SDK bump PR creation so that the failure in the CLI step does not block creating the openhands PR.

---

AGENT:

## Why

A failure in the OpenHands-CLI bump step aborts the job before the OpenHands PR is created — as happened for v1.31.1, where the CLI's `agent-client-protocol<0.9.0` pin conflicts with the SDK's `>=0.10.1` floor (OpenHands/OpenHands-CLI#786). Moving the OpenHands PR step ahead of the CLI step lets the OpenHands bump land regardless, while a CLI failure still fails the run so it stays visible and actionable (unlike a `continue-on-error` approach, which would hide it behind a green check — see #3998 for that alternative).

## Summary

- Reordered the `create-version-bump-prs` job so "Create PR for OpenHands repo" runs before "Create PR for OpenHands-CLI repo" (pure block swap; a stale ordering comment was removed).

## Issue Number

OpenHands/OpenHands-CLI#786 (the CLI-side conflict this unblocks the OpenHands PR from)

## How to Test

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/version-bump-prs.yml'))"`.
- `git diff main` shows the two steps swapped with no content changes besides the removed comment; neither step reads the other's outputs, so ordering is otherwise inert.
- End-to-end: after merge, re-run the "Create Version Bump PRs" workflow with `version: 1.31.1` — the OpenHands bump PR should be created, then the run should still fail on the CLI step until OpenHands/OpenHands-CLI#786 is fixed.

## Video/Screenshots

N/A — CI workflow change; see failing run https://github.com/OpenHands/software-agent-sdk/actions/runs/28753258260/job/85255901119 for the current blocking behavior.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR was drafted by an AI agent on behalf of the user.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a0c6eb1-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a0c6eb1-python \
  ghcr.io/openhands/agent-server:a0c6eb1-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a0c6eb1-golang-amd64
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-golang-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-golang-amd64
ghcr.io/openhands/agent-server:a0c6eb1-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a0c6eb1-golang-arm64
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-golang-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-golang-arm64
ghcr.io/openhands/agent-server:a0c6eb1-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a0c6eb1-java-amd64
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-java-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-java-amd64
ghcr.io/openhands/agent-server:a0c6eb1-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a0c6eb1-java-arm64
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-java-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-java-arm64
ghcr.io/openhands/agent-server:a0c6eb1-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a0c6eb1-python-amd64
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-python-amd64
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-python-amd64
ghcr.io/openhands/agent-server:a0c6eb1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a0c6eb1-python-arm64
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-python-arm64
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-python-arm64
ghcr.io/openhands/agent-server:a0c6eb1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a0c6eb1-golang
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-golang
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-golang
ghcr.io/openhands/agent-server:a0c6eb1-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a0c6eb1-java
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-java
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-java
ghcr.io/openhands/agent-server:a0c6eb1-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a0c6eb1-python
ghcr.io/openhands/agent-server:a0c6eb19e613216ff52b74ba397382a474f95065-python
ghcr.io/openhands/agent-server:av-version-bump-prs-openhands-first-python
ghcr.io/openhands/agent-server:a0c6eb1-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a0c6eb1-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a0c6eb1-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->