### PR TITLE
ci: use conventional commit title for the generated OpenHands bump PR

### DIFF
--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -273,7 +273,7 @@ jobs:
                     # Create PR
                     gh pr create \
                       --repo "$REPO" \
-                      --title "Bump SDK packages to v$VERSION" \
+                      --title "chore: bump SDK packages to v$VERSION" \
                       --body "## Automated Version Bump
 
                   This PR updates the following packages to version **$VERSION**:


### PR DESCRIPTION
HUMAN:

Having the openhands PR title have chore: as a prefix so that PRs automatically pass the conventional commit PR title check.

---

AGENT:

## Why

The auto-created OpenHands bump PR title (`Bump SDK packages to v$VERSION`) fails OpenHands/OpenHands's `pr-title` conventional-commits lint on every release — v1.31.1's PR (OpenHands/OpenHands#15127) had to be retitled by hand. Prefixing the generated title with `chore:` matches the lint's allowed types and the repo's recent bump-PR precedent (`chore: bump SDK and agent-server to 1.29.0` / `1.30.0`). The OpenHands-CLI PR title is left unchanged since that repo has no title lint.

## Summary

- Changed the generated OpenHands PR title to `chore: bump SDK packages to v$VERSION` in `version-bump-prs.yml`.

## Issue Number

N/A

## How to Test

- YAML parses: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/version-bump-prs.yml'))"`.
- Verified `chore` is in the allowed types of the shared lint (`OpenHands/release-actions/.github/workflows/pr-title.yml`).
- End-to-end: next "Create Version Bump PRs" run should produce an OpenHands PR whose `pr-title` check passes without manual retitling.

## Video/Screenshots

N/A — one-line CI title change; see the failing check on OpenHands/OpenHands#15127 for the current behavior.

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

This PR was drafted by an AI agent on behalf of the user.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a7ea11f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a7ea11f-python \
  ghcr.io/openhands/agent-server:a7ea11f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a7ea11f-golang-amd64
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-golang-amd64
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-golang-amd64
ghcr.io/openhands/agent-server:a7ea11f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a7ea11f-golang-arm64
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-golang-arm64
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-golang-arm64
ghcr.io/openhands/agent-server:a7ea11f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a7ea11f-java-amd64
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-java-amd64
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-java-amd64
ghcr.io/openhands/agent-server:a7ea11f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a7ea11f-java-arm64
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-java-arm64
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-java-arm64
ghcr.io/openhands/agent-server:a7ea11f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a7ea11f-python-amd64
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-python-amd64
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-python-amd64
ghcr.io/openhands/agent-server:a7ea11f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a7ea11f-python-arm64
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-python-arm64
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-python-arm64
ghcr.io/openhands/agent-server:a7ea11f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a7ea11f-golang
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-golang
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-golang
ghcr.io/openhands/agent-server:a7ea11f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a7ea11f-java
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-java
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-java
ghcr.io/openhands/agent-server:a7ea11f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a7ea11f-python
ghcr.io/openhands/agent-server:a7ea11f2b670972a7cf8fe7c1ffbd9e3c2d99fb9-python
ghcr.io/openhands/agent-server:av-conventional-bump-pr-title-python
ghcr.io/openhands/agent-server:a7ea11f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a7ea11f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a7ea11f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->