### PR TITLE
fix(llm): tolerate Laminar-wrapped Responses streams in responses/aresponses

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -62,10 +62,6 @@ from litellm.responses.main import (
     aresponses as litellm_aresponses,
     responses as litellm_responses,
 )
-from litellm.responses.streaming_iterator import (
-    ResponsesAPIStreamingIterator,
-    SyncResponsesAPIStreamingIterator,
-)
 from litellm.types.llms.openai import (
     OutputTextDeltaEvent,
     ReasoningSummaryTextDeltaEvent,
@@ -1631,14 +1627,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         self._telemetry.on_response(ret)
                         return ret
 
-                    # When stream=True, LiteLLM returns a streaming
-                    # iterator rather than a single ResponsesAPIResponse.
-                    # Drain the iterator and use the completed response.
+                    # When stream=True, LiteLLM returns a streaming iterator
+                    # rather than a single ResponsesAPIResponse. Drain it and
+                    # use the completed response; the iterator's class is an
+                    # implementation detail of LiteLLM, so don't restrict it
+                    # (some providers wrap their streams as plain generators).
                     if final_kwargs.get("stream", False):
-                        if not isinstance(ret, SyncResponsesAPIStreamingIterator):
-                            raise AssertionError(
-                                f"Expected Responses stream iterator, got {type(ret)}"
-                            )
                         stream_callback = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
                         # Some endpoints (e.g., Codex subscription) send
@@ -1647,7 +1641,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         # accumulate them here and patch the completed
                         # response if needed.
                         collected_output_items: list[Any] = []
-                        for event in ret:
+                        # litellm's declared stream response type doesn't
+                        # expose iteration protocols or `completed_response`
+                        # on the base class; bind through Any rather than
+                        # gating on a concrete subclass.
+                        stream: Any = ret
+                        for event in stream:
                             if event is None:
                                 continue
                             output_item, delta_chunk = self._process_stream_event(
@@ -1659,7 +1658,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                                 stream_callback(delta_chunk)
 
                         return self._finalize_stream_response(
-                            ret.completed_response, collected_output_items
+                            stream.completed_response, collected_output_items
                         )
 
                     raise AssertionError(
@@ -1774,15 +1773,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         self._telemetry.on_response(ret)
                         return ret
 
-                    # When stream=True, LiteLLM returns a streaming
-                    # iterator rather than a single ResponsesAPIResponse.
-                    # Drain the iterator and use the completed response.
+                    # When stream=True, LiteLLM returns a streaming iterator
+                    # rather than a single ResponsesAPIResponse. Drain it and
+                    # use the completed response; the iterator's class is an
+                    # implementation detail of LiteLLM, so don't restrict it
+                    # (some providers wrap their streams as plain async
+                    # generators).
                     if final_kwargs.get("stream", False):
-                        if not isinstance(ret, ResponsesAPIStreamingIterator):
-                            raise AssertionError(
-                                "Expected Responses async stream "
-                                f"iterator, got {type(ret)}"
-                            )
                         stream_cb = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
                         # Some endpoints (e.g., Codex subscription) send
@@ -1791,7 +1788,12 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         # accumulate them here and patch the completed
                         # response if needed.
                         collected_output_items: list[Any] = []
-                        async for event in ret:
+                        # litellm's declared stream response type doesn't
+                        # expose iteration protocols or `completed_response`
+                        # on the base class; bind through Any rather than
+                        # gating on a concrete subclass.
+                        stream: Any = ret
+                        async for event in stream:
                             if event is None:
                                 continue
                             output_item, delta_chunk = self._process_stream_event(
@@ -1803,7 +1805,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                                 await _invoke_token_callback(stream_cb, delta_chunk)
 
                         return self._finalize_stream_response(
-                            ret.completed_response, collected_output_items
+                            stream.completed_response, collected_output_items
                         )
 
                     raise AssertionError(

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1627,11 +1627,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         self._telemetry.on_response(ret)
                         return ret
 
-                    # When stream=True, LiteLLM returns a streaming iterator
-                    # rather than a single ResponsesAPIResponse. Drain it and
-                    # use the completed response; the iterator's class is an
-                    # implementation detail of LiteLLM, so don't restrict it
-                    # (some providers wrap their streams as plain generators).
+                    # When stream=True, LiteLLM returns a streaming
+                    # iterator rather than a single ResponsesAPIResponse.
+                    # Drain the iterator and use the completed response.
                     if final_kwargs.get("stream", False):
                         stream_callback = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
@@ -1773,12 +1771,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         self._telemetry.on_response(ret)
                         return ret
 
-                    # When stream=True, LiteLLM returns a streaming iterator
-                    # rather than a single ResponsesAPIResponse. Drain it and
-                    # use the completed response; the iterator's class is an
-                    # implementation detail of LiteLLM, so don't restrict it
-                    # (some providers wrap their streams as plain async
-                    # generators).
+                    # When stream=True, LiteLLM returns a streaming
+                    # iterator rather than a single ResponsesAPIResponse.
+                    # Drain the iterator and use the completed response.
                     if final_kwargs.get("stream", False):
                         stream_cb = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -62,6 +62,7 @@ from litellm.responses.main import (
     aresponses as litellm_aresponses,
     responses as litellm_responses,
 )
+from litellm.types.llms.base import BaseLiteLLMOpenAIResponseObject
 from litellm.types.llms.openai import (
     OutputTextDeltaEvent,
     ReasoningSummaryTextDeltaEvent,
@@ -952,19 +953,31 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
     def _process_stream_event(
         self, event: Any, *, emit_deltas: bool = True
-    ) -> tuple[Any | None, ModelResponseStream | None]:
-        """Extract output item and delta chunk from a Responses stream event.
+    ) -> tuple[Any | None, ModelResponseStream | None, Any | None]:
+        """Extract output item, delta chunk, and (optional) terminal item.
 
         Args:
-            event: A single Responses streaming event.
+            event: A single item yielded by a Responses stream iterator.
             emit_deltas: When ``False`` the delta chunk is never built — skip
                 the allocation when there is no stream callback to receive it.
 
         Returns:
-            (output_item, delta_chunk) — either or both may be ``None``.
+            ``(output_item, delta_chunk, terminal)`` — any element may be ``None``.
+
+            ``output_item`` is populated for ``response.output_item.done`` events.
+
+            ``delta_chunk`` is populated for text/refusal/reasoning delta events.
+
+            ``terminal`` is populated when the item already represents the
+            completed Responses payload — either as a typed ``ResponseCompletedEvent``
+            (the standard Responses stream shape) or as a
+            ``BaseLiteLLMOpenAIResponseObject`` (the shape that some third-party
+            litellm wrappers, e.g. ``lmnr``'s ``process_streaming_coroutine``,
+            yield when they re-shape the response into a pseudo-stream).
         """
         output_item: Any | None = None
         delta_chunk: ModelResponseStream | None = None
+        terminal: ResponseCompletedEvent | BaseLiteLLMOpenAIResponseObject | None = None
 
         # Collect finished output items
         evt_type = getattr(event, "type", None)
@@ -972,6 +985,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             item = getattr(event, "item", None)
             if item is not None:
                 output_item = item
+
+        # Recognise the standard Responses "completed" event.
+        if isinstance(event, ResponseCompletedEvent):
+            terminal = event
+
+        # Some litellm wrappers (Laminar's `process_streaming_coroutine`) yield
+        # the response payload directly via an async generator rather than as a
+        # typed stream event. Anything `BaseLiteLLMOpenAIResponseObject`-shaped
+        # we accept as the terminal response itself.
+        if terminal is None and isinstance(event, BaseLiteLLMOpenAIResponseObject):
+            terminal = event
 
         if emit_deltas and isinstance(
             event,
@@ -987,7 +1011,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                     choices=[StreamingChoices(delta=Delta(content=delta))]
                 )
 
-        return output_item, delta_chunk
+        return output_item, delta_chunk, terminal
 
     def _finalize_stream_response(
         self,
@@ -995,6 +1019,16 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         collected_output_items: list[Any],
     ) -> ResponsesAPIResponse:
         """Validate and patch the completed response from a Responses stream.
+
+        ``completed_response`` may be either:
+
+        - a ``ResponseCompletedEvent`` — the standard Responses stream shape;
+          the actual ``ResponsesAPIResponse`` is exposed via ``.response``.
+        - a ``BaseLiteLLMOpenAIResponseObject`` (or subclass such as
+          ``ResponsesAPIResponse`` itself) — already the terminal payload.
+          Some third-party litellm wrappers (e.g. Laminar's
+          ``process_streaming_coroutine``) yield this shape directly through
+          a pseudo-stream.
 
         Raises:
             LLMNoResponseError: If the stream finished without a completed
@@ -1004,12 +1038,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             raise LLMNoResponseError(
                 "Responses stream finished without a completed response"
             )
-        if not isinstance(completed_response, ResponseCompletedEvent):
+        if isinstance(completed_response, ResponseCompletedEvent):
+            completed_resp = completed_response.response
+        elif isinstance(completed_response, BaseLiteLLMOpenAIResponseObject):
+            # Concrete subclasses (``ResponsesAPIResponse`` and friends)
+            # declare ``.output`` and the other response fields; the empty
+            # base class doesn't. Cast through the standard Responses shape
+            # so the rest of this function can work against ``.output`` etc.
+            completed_resp = cast(ResponsesAPIResponse, completed_response)
+        else:
             raise LLMNoResponseError(
                 f"Unexpected completed event: {type(completed_response)}"
             )
 
-        completed_resp = completed_response.response
         # Patch empty output with items collected from stream
         if not completed_resp.output and collected_output_items:
             completed_resp.output = collected_output_items
@@ -1644,19 +1685,42 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         # on the base class; bind through Any rather than
                         # gating on a concrete subclass.
                         stream: Any = ret
+                        # Three independent sources for the terminal response:
+                        #   - the wrapper's `.completed_response` attribute
+                        #     (the standard ``ResponsesAPIStreamingIterator``)
+                        #   - a ``ResponseCompletedEvent`` yielded mid-stream
+                        #   - a ``BaseLiteLLMOpenAIResponseObject`` yielded
+                        #     mid-stream (e.g. Laminar's wrapped output)
+                        wrapper_terminal: Any = None
+                        stream_event_terminal: ResponseCompletedEvent | None = None
+                        stream_response_terminal: (
+                            BaseLiteLLMOpenAIResponseObject | None
+                        ) = None
                         for event in stream:
                             if event is None:
                                 continue
-                            output_item, delta_chunk = self._process_stream_event(
-                                event, emit_deltas=stream_callback is not None
+                            output_item, delta_chunk, terminal = (
+                                self._process_stream_event(
+                                    event, emit_deltas=stream_callback is not None
+                                )
                             )
                             if output_item is not None:
                                 collected_output_items.append(output_item)
                             if stream_callback is not None and delta_chunk is not None:
                                 stream_callback(delta_chunk)
+                            if isinstance(terminal, ResponseCompletedEvent):
+                                stream_event_terminal = terminal
+                            elif isinstance(terminal, BaseLiteLLMOpenAIResponseObject):
+                                stream_response_terminal = terminal
 
+                        wrapper_terminal = getattr(stream, "completed_response", None)
+                        completed_response = (
+                            wrapper_terminal
+                            or stream_event_terminal
+                            or stream_response_terminal
+                        )
                         return self._finalize_stream_response(
-                            stream.completed_response, collected_output_items
+                            completed_response, collected_output_items
                         )
 
                     raise AssertionError(
@@ -1788,19 +1852,42 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         # on the base class; bind through Any rather than
                         # gating on a concrete subclass.
                         stream: Any = ret
+                        # Three independent sources for the terminal response:
+                        #   - the wrapper's `.completed_response` attribute
+                        #     (the standard ``ResponsesAPIStreamingIterator``)
+                        #   - a ``ResponseCompletedEvent`` yielded mid-stream
+                        #   - a ``BaseLiteLLMOpenAIResponseObject`` yielded
+                        #     mid-stream (e.g. Laminar's wrapped output)
+                        wrapper_terminal: Any = None
+                        stream_event_terminal: ResponseCompletedEvent | None = None
+                        stream_response_terminal: (
+                            BaseLiteLLMOpenAIResponseObject | None
+                        ) = None
                         async for event in stream:
                             if event is None:
                                 continue
-                            output_item, delta_chunk = self._process_stream_event(
-                                event, emit_deltas=stream_cb is not None
+                            output_item, delta_chunk, terminal = (
+                                self._process_stream_event(
+                                    event, emit_deltas=stream_cb is not None
+                                )
                             )
                             if output_item is not None:
                                 collected_output_items.append(output_item)
                             if stream_cb is not None and delta_chunk is not None:
                                 await _invoke_token_callback(stream_cb, delta_chunk)
+                            if isinstance(terminal, ResponseCompletedEvent):
+                                stream_event_terminal = terminal
+                            elif isinstance(terminal, BaseLiteLLMOpenAIResponseObject):
+                                stream_response_terminal = terminal
 
+                        wrapper_terminal = getattr(stream, "completed_response", None)
+                        completed_response = (
+                            wrapper_terminal
+                            or stream_event_terminal
+                            or stream_response_terminal
+                        )
                         return self._finalize_stream_response(
-                            stream.completed_response, collected_output_items
+                            completed_response, collected_output_items
                         )
 
                     raise AssertionError(

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -452,3 +452,144 @@ async def test_async_aresponses_stream_path_retry_bumps_temperature(
     assert mock_aresponses.call_count == 2
     _, second_kwargs = mock_aresponses.call_args_list[1]
     assert second_kwargs.get("temperature") == 1.0
+
+
+# ------------------------------------------------------------------
+# Laminar-shaped Responses stream (bare generator yielding response objects)
+#
+# Laminar's `process_streaming_coroutine` (lmnr/opentelemetry_lib/opentelemetry/
+# instrumentation/litellm/wrappers/__init__.py:279) re-shapes
+# `litellm.aresponses` into an async generator that yields full
+# `BaseLiteLLMOpenAIResponseObject` instances rather than typed Responses
+# stream events. The SDK must accept that shape too.
+# ------------------------------------------------------------------
+
+
+class _FakeLaminarSyncStream:
+    """Sync plain generator yielding ``ResponsesAPIResponse`` items.
+
+    Has NO ``completed_response`` attribute (Laminar's wrapped output does
+    not expose the wrapper's interface), no ``__aiter__`` for the async
+    test, and no streaming-event shape either. Just raw response objects.
+    """
+
+    def __init__(self, *responses: ResponsesAPIResponse) -> None:
+        self._responses = list(responses)
+
+    def __iter__(self):
+        yield from self._responses
+
+
+class _FakeLaminarAsyncStream:
+    """Async plain generator yielding ``ResponsesAPIResponse`` items.
+
+    Mirror of :class:`_FakeLaminarSyncStream` for the async path.
+    """
+
+    def __init__(self, *responses: ResponsesAPIResponse) -> None:
+        self._responses = list(responses)
+
+    def __aiter__(self):
+        async def _gen():
+            for r in self._responses:
+                yield r
+
+        return _gen()
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_responses_recovers_response_from_laminar_shaped_generator(
+    mock_responses,
+) -> None:
+    """A sync ``litellm.responses`` that yields response-shaped items directly
+    (the Laminar wrapping pattern) must produce a normal LLMResponse with the
+    yielded payload's id — no AttributeError on `.completed_response`."""
+    streaming_llm = LLM(
+        usage_id="test-laminar-sync",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
+        stream=True,
+    )
+
+    expected = create_mock_responses_api_response("hello")
+    mock_responses.return_value = _FakeLaminarSyncStream(expected)
+
+    resp = streaming_llm.responses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_responses.call_count == 1
+
+
+@pytest.mark.asyncio
+@patch(
+    "openhands.sdk.llm.llm.litellm_aresponses",
+    new_callable=AsyncMock,
+)
+async def test_aresponses_recovers_response_from_laminar_shaped_generator(
+    mock_aresponses: AsyncMock,
+) -> None:
+    """The same Laminar-shape behaviour for the async path: a plain
+    ``async_generator`` yielding ``ResponsesAPIResponse`` items (no
+    ``.completed_response``, no ``ResponseCompletedEvent``) must be
+    unwrapped to a normal LLMResponse without raising."""
+    streaming_llm = LLM(
+        usage_id="test-laminar-async",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
+        stream=True,
+    )
+
+    expected = create_mock_responses_api_response("hello")
+    mock_aresponses.return_value = _FakeLaminarAsyncStream(expected)
+
+    resp = await streaming_llm.aresponses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_aresponses.call_count == 1
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_responses_laminar_shape_without_terminal_triggers_retry(
+    mock_responses,
+) -> None:
+    """A Laminar-shaped generator that yields no response-shaped item at all
+    should fall through to the existing LLMNoResponseError → retry path,
+    not crash with AttributeError. Verify retry kicks in and temperature
+    bumps from 0→1.0 like the other retry tests."""
+    streaming_llm = LLM(
+        usage_id="test-laminar-sync-empty",
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        num_retries=2,
+        retry_min_wait=0,
+        retry_max_wait=0,
+        temperature=0.0,
+        stream=True,
+    )
+
+    mock_responses.side_effect = [
+        _FakeLaminarSyncStream(),  # no terminal item → LLMNoResponseError
+        create_mock_responses_api_response("ok"),
+    ]
+
+    resp = streaming_llm.responses(
+        messages=[Message(role="user", content=[TextContent(text="hi")])],
+        on_token=lambda _chunk: None,
+    )
+
+    assert isinstance(resp, LLMResponse)
+    assert mock_responses.call_count == 2
+    _, second_kwargs = mock_responses.call_args_list[1]
+    assert second_kwargs.get("temperature") == 1.0

--- a/tests/sdk/llm/test_llm_no_response_retry.py
+++ b/tests/sdk/llm/test_llm_no_response_retry.py
@@ -1,10 +1,6 @@
 from unittest.mock import AsyncMock, patch
 
 import pytest
-from litellm.responses.streaming_iterator import (
-    ResponsesAPIStreamingIterator,
-    SyncResponsesAPIStreamingIterator,
-)
 from litellm.types.llms.openai import ResponsesAPIResponse
 from litellm.types.utils import Choices, Message as LiteLLMMessage, ModelResponse, Usage
 from openai.types.responses import ResponseOutputMessage, ResponseOutputText
@@ -331,13 +327,13 @@ def test_responses_retries_then_succeeds(mock_responses, base_llm: LLM) -> None:
 # ------------------------------------------------------------------
 
 
-class _FakeSyncStreamIterator(SyncResponsesAPIStreamingIterator):
+class _FakeSyncStreamIterator:
     """Minimal sync stream iterator for testing stream-path failures.
 
-    Mirrors :class:`_FakeAsyncStreamIterator` for the synchronous
-    ``responses`` path: inherits from ``SyncResponsesAPIStreamingIterator``
-    so it passes the ``isinstance`` check inside ``responses._one_attempt``,
-    but skips the heavyweight parent ``__init__``.
+    Deliberately *not* a subclass of ``SyncResponsesAPIStreamingIterator``:
+    it mirrors the bare async/sync iterators that some LiteLLM provider
+    wrappers (e.g. Codex subscriptions) return when ``stream=True`` and that
+    previously tripped an ``isinstance`` assertion in ``responses._one_attempt``.
     """
 
     def __init__(
@@ -345,8 +341,6 @@ class _FakeSyncStreamIterator(SyncResponsesAPIStreamingIterator):
         events: list,
         completed_response=None,
     ) -> None:
-        # Intentionally skip parent __init__; we only need iteration
-        # and the completed_response attribute.
         self._events = list(events)
         self.completed_response = completed_response
 
@@ -391,12 +385,14 @@ def test_responses_stream_path_retry_bumps_temperature(mock_responses) -> None:
     assert second_kwargs.get("temperature") == 1.0
 
 
-class _FakeAsyncStreamIterator(ResponsesAPIStreamingIterator):
+class _FakeAsyncStreamIterator:
     """Minimal async stream iterator for testing stream-path failures.
 
-    Inherits from ``ResponsesAPIStreamingIterator`` so it passes the
-    ``isinstance`` check inside ``aresponses._one_attempt``, but skips
-    the heavyweight parent ``__init__``.
+    Deliberately *not* a subclass of ``ResponsesAPIStreamingIterator``: it
+    mirrors the bare async iterators that some LiteLLM provider wrappers
+    (e.g. Codex subscriptions) return when ``stream=True`` and that
+    previously tripped an ``isinstance`` assertion in
+    ``aresponses._one_attempt``.
     """
 
     def __init__(
@@ -404,8 +400,6 @@ class _FakeAsyncStreamIterator(ResponsesAPIStreamingIterator):
         events: list,
         completed_response=None,
     ) -> None:
-        # Intentionally skip parent __init__; we only need iteration
-        # and the completed_response attribute.
         self._events = list(events)
         self.completed_response = completed_response
 


### PR DESCRIPTION
## Why

`responses` and `aresponses` raised
`AssertionError: Expected Responses async stream iterator, got <class 'async_generator'>`
when some litellm wrappers return a bare async generator instead of the
documented `Union[ResponsesAPIResponse, BaseResponsesAPIStreamingIterator]`.
The agent-server hit this in production because **Laminar's**
`process_streaming_coroutine` (at
`lmnr/opentelemetry_lib/opentelemetry/instrumentation/litellm/wrappers/__init__.py:279`)
re-shapes `litellm.aresponses` into an async generator yielding
`BaseLiteLLMOpenAIResponseObject` instances directly. The same file
already accommodates this wrapping for the chat completion path
(`_atransport_call`), but the Responses path had no fallback.

## Summary

- `responses` / `aresponses` drop the `isinstance` assertion against
  `SyncResponsesAPIStreamingIterator` / `ResponsesAPIStreamingIterator`.
  Iterators are bound to a locally typed `Any` variable so pyright sees an
  iterable without gating on a concrete subclass (no runtime gate).
- `_process_stream_event` returns a third tuple element — the terminal item
  when the event is a `ResponseCompletedEvent` (standard Responses stream) or
  a `BaseLiteLLMOpenAIResponseObject` (Laminar-wrapped shape).
- Both stream branches accumulate both terminal shapes from the drained
  events and resolve the terminal response in priority order:
    1. `stream.completed_response` (the standard wrapper),
    2. `ResponseCompletedEvent` yielded mid-stream,
    3. `BaseLiteLLMOpenAIResponseObject` yielded mid-stream,
    4. `None` → existing `LLMNoResponseError` retry path.
- `_finalize_stream_response` accepts either shape via `isinstance`
  branches; `on_response` telemetry is now recorded when Laminar yields a
  response-shaped item.
- Three new tests in `tests/sdk/llm/test_llm_no_response_retry.py` cover
  the sync Laminar path, the async Laminar path, and the missing-terminal
  retry. The two pre-existing stream-path retry tests now use plain fake
  iterators (no longer subclassing the LiteLLM wrapper classes), so they
  exercise exactly the shape that previously failed in production.

## How to Test

```
uv run pytest tests/sdk/llm/test_llm_no_response_retry.py -v
uv run pytest tests/sdk/llm/
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/llm.py \
                             tests/sdk/llm/test_llm_no_response_retry.py
```

- pre-commit (Ruff, PEP8, pyright, import-dependency, tool registration) all
  pass.
- 16/16 tests pass in `test_llm_no_response_retry.py` (13 originals + 3 new
  Laminar-shape cases).
- 866/866 tests pass under `tests/sdk/llm/`.
- 5129/5129 tests pass under `tests/sdk/`.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Companion agent-server change not required: the bug originated purely on the
SDK side at the litellm stream-response boundary.

**Upstream follow-up.** Laminar's wrapper silently changes
`litellm.aresponses`'s return type from `Response`-or-`StreamingIterator`
into a bare async generator of response-shaped objects. That contract
violation should be reported upstream against
`lmnr.opentelemetry_lib.opentelemetry.instrumentation.litellm.wrappers.process_streaming_coroutine`.
The SDK fix above is the poly-shape stopgap; the proper fix lives in lmnr.