### PR TITLE
fix(llm): tolerate wrapped Responses streams

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -62,10 +62,6 @@ from litellm.responses.main import (
     aresponses as litellm_aresponses,
     responses as litellm_responses,
 )
-from litellm.responses.streaming_iterator import (
-    ResponsesAPIStreamingIterator,
-    SyncResponsesAPIStreamingIterator,
-)
 from litellm.types.llms.openai import (
     OutputTextDeltaEvent,
     ReasoningSummaryTextDeltaEvent,
@@ -1633,12 +1629,9 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
                     # When stream=True, LiteLLM returns a streaming
                     # iterator rather than a single ResponsesAPIResponse.
-                    # Drain the iterator and use the completed response.
+                    # Third-party wrappers may replace LiteLLM's concrete
+                    # iterator with another iterable, so drain by protocol.
                     if final_kwargs.get("stream", False):
-                        if not isinstance(ret, SyncResponsesAPIStreamingIterator):
-                            raise AssertionError(
-                                f"Expected Responses stream iterator, got {type(ret)}"
-                            )
                         stream_callback = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
                         # Some endpoints (e.g., Codex subscription) send
@@ -1647,9 +1640,13 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         # accumulate them here and patch the completed
                         # response if needed.
                         collected_output_items: list[Any] = []
-                        for event in ret:
+                        completed_response = getattr(ret, "completed_response", None)
+                        stream = cast(Iterable[Any], ret)
+                        for event in stream:
                             if event is None:
                                 continue
+                            if isinstance(event, ResponseCompletedEvent):
+                                completed_response = event
                             output_item, delta_chunk = self._process_stream_event(
                                 event, emit_deltas=stream_callback is not None
                             )
@@ -1658,8 +1655,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                             if stream_callback is not None and delta_chunk is not None:
                                 stream_callback(delta_chunk)
 
+                        completed_response = getattr(
+                            ret, "completed_response", completed_response
+                        )
                         return self._finalize_stream_response(
-                            ret.completed_response, collected_output_items
+                            completed_response, collected_output_items
                         )
 
                     raise AssertionError(
@@ -1776,13 +1776,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
 
                     # When stream=True, LiteLLM returns a streaming
                     # iterator rather than a single ResponsesAPIResponse.
-                    # Drain the iterator and use the completed response.
+                    # Third-party wrappers may replace LiteLLM's concrete
+                    # iterator with another sync or async iterable, so drain
+                    # by protocol.
                     if final_kwargs.get("stream", False):
-                        if not isinstance(ret, ResponsesAPIStreamingIterator):
-                            raise AssertionError(
-                                "Expected Responses async stream "
-                                f"iterator, got {type(ret)}"
-                            )
                         stream_cb = on_token if user_enable_streaming else None
                         # Collect output items from streaming events.
                         # Some endpoints (e.g., Codex subscription) send
@@ -1791,19 +1788,44 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                         # accumulate them here and patch the completed
                         # response if needed.
                         collected_output_items: list[Any] = []
-                        async for event in ret:
-                            if event is None:
-                                continue
-                            output_item, delta_chunk = self._process_stream_event(
-                                event, emit_deltas=stream_cb is not None
+                        completed_response = getattr(ret, "completed_response", None)
+                        if hasattr(ret, "__aiter__"):
+                            stream = cast(AsyncIterable[Any], ret)
+                            async for event in stream:
+                                if event is None:
+                                    continue
+                                if isinstance(event, ResponseCompletedEvent):
+                                    completed_response = event
+                                output_item, delta_chunk = self._process_stream_event(
+                                    event, emit_deltas=stream_cb is not None
+                                )
+                                if output_item is not None:
+                                    collected_output_items.append(output_item)
+                                if stream_cb is not None and delta_chunk is not None:
+                                    await _invoke_token_callback(stream_cb, delta_chunk)
+                        else:
+                            loop = asyncio.get_running_loop()
+                            events: list[Any] = await loop.run_in_executor(
+                                None, list, cast(Iterable[Any], ret)
                             )
-                            if output_item is not None:
-                                collected_output_items.append(output_item)
-                            if stream_cb is not None and delta_chunk is not None:
-                                await _invoke_token_callback(stream_cb, delta_chunk)
+                            for event in events:
+                                if event is None:
+                                    continue
+                                if isinstance(event, ResponseCompletedEvent):
+                                    completed_response = event
+                                output_item, delta_chunk = self._process_stream_event(
+                                    event, emit_deltas=stream_cb is not None
+                                )
+                                if output_item is not None:
+                                    collected_output_items.append(output_item)
+                                if stream_cb is not None and delta_chunk is not None:
+                                    await _invoke_token_callback(stream_cb, delta_chunk)
 
+                        completed_response = getattr(
+                            ret, "completed_response", completed_response
+                        )
                         return self._finalize_stream_response(
-                            ret.completed_response, collected_output_items
+                            completed_response, collected_output_items
                         )
 
                     raise AssertionError(

--- a/tests/sdk/llm/test_responses_parsing_and_kwargs.py
+++ b/tests/sdk/llm/test_responses_parsing_and_kwargs.py
@@ -2,8 +2,11 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from litellm.types.llms.openai import (
+    OutputTextDeltaEvent,
     ResponseAPIUsage,
+    ResponseCompletedEvent,
     ResponsesAPIResponse,
+    ResponsesAPIStreamEvents,
 )
 from openai.types.responses.response_function_tool_call import ResponseFunctionToolCall
 from openai.types.responses.response_output_message import ResponseOutputMessage
@@ -448,3 +451,129 @@ async def test_aresponses_retries_without_caching_on_prompt_cache_too_small(
     second_kwargs = mock_aresponses.call_args_list[1].kwargs
     assert second_kwargs.get("store") is False
     assert second_kwargs.get("metadata") == {"trace_id": "abc-123"}
+
+
+def _make_wrapped_response_stream_events(text: str = "Hello wrapped stream"):
+    msg = build_responses_message_output([text])
+    usage = ResponseAPIUsage(input_tokens=1, output_tokens=1, total_tokens=2)
+    response = ResponsesAPIResponse(
+        id="resp-wrapped-stream",
+        created_at=0,
+        output=[msg],
+        parallel_tool_calls=False,
+        tool_choice="auto",
+        top_p=None,
+        tools=[],
+        usage=usage,
+        instructions="",
+        status="completed",
+    )
+    events = [
+        OutputTextDeltaEvent(
+            type=ResponsesAPIStreamEvents.OUTPUT_TEXT_DELTA,
+            item_id="m1",
+            output_index=0,
+            content_index=0,
+            delta=text,
+        ),
+        ResponseCompletedEvent(
+            type=ResponsesAPIStreamEvents.RESPONSE_COMPLETED,
+            response=response,
+        ),
+    ]
+    return events, response
+
+
+@patch("openhands.sdk.llm.llm.litellm_responses")
+def test_responses_streaming_accepts_wrapped_iterable(mock_responses):
+    """Responses streaming must not require LiteLLM's concrete iterator class."""
+    events, completed_response = _make_wrapped_response_stream_events()
+    mock_responses.return_value = iter(events)
+
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        usage_id="test-llm",
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+    )
+
+    received = []
+    response = llm.responses(
+        [Message(role="user", content=[TextContent(text="Hello")])],
+        stream=True,
+        on_token=received.append,
+    )
+
+    assert response.raw_response is completed_response
+    assert [chunk.choices[0].delta.content for chunk in received] == [
+        "Hello wrapped stream"
+    ]
+
+
+@pytest.mark.asyncio
+@patch("openhands.sdk.llm.llm.litellm_aresponses", new_callable=AsyncMock)
+async def test_aresponses_streaming_accepts_sync_generator(mock_aresponses):
+    """Async Responses streaming must also tolerate sync iterable wrappers."""
+    events, completed_response = _make_wrapped_response_stream_events()
+
+    def _return_sync_generator(*args, **kwargs):
+        return (event for event in events)
+
+    mock_aresponses.side_effect = _return_sync_generator
+
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        usage_id="test-llm",
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+    )
+
+    received = []
+    response = await llm.aresponses(
+        [Message(role="user", content=[TextContent(text="Hello")])],
+        stream=True,
+        on_token=received.append,
+    )
+
+    assert response.raw_response is completed_response
+    assert [chunk.choices[0].delta.content for chunk in received] == [
+        "Hello wrapped stream"
+    ]
+
+
+@pytest.mark.asyncio
+@patch("openhands.sdk.llm.llm.litellm_aresponses", new_callable=AsyncMock)
+async def test_aresponses_streaming_accepts_async_generator(mock_aresponses):
+    """Regression for lmnr 0.7.47 returning an async_generator wrapper."""
+    events, completed_response = _make_wrapped_response_stream_events()
+
+    async def _events():
+        for event in events:
+            yield event
+
+    mock_aresponses.return_value = _events()
+
+    llm = LLM(
+        model="gpt-4o",
+        api_key=SecretStr("test_key"),
+        usage_id="test-llm",
+        num_retries=2,
+        retry_min_wait=1,
+        retry_max_wait=2,
+    )
+
+    received = []
+    response = await llm.aresponses(
+        [Message(role="user", content=[TextContent(text="Hello")])],
+        stream=True,
+        on_token=received.append,
+    )
+
+    assert response.raw_response is completed_response
+    assert [chunk.choices[0].delta.content for chunk in received] == [
+        "Hello wrapped stream"
+    ]


### PR DESCRIPTION
HUMAN:

Engel asked to fix the PR description for CI.

---

AGENT:

## Why

PR #3975 made completion and acompletion tolerate third-party wrapped stream containers, but responses and aresponses still required LiteLLM concrete stream iterator classes. With the repo-locked lmnr 0.7.47, streamed async Responses can be wrapped as an async_generator, causing the SDK to raise: Expected Responses async stream iterator, got async_generator.

## Summary

- Drain Responses API streams by iterable protocol instead of requiring LiteLLM concrete iterator classes.
- Support sync iterables, async iterables, and the locked-Laminar async_generator wrapper case.
- Recover completed Responses from either ret.completed_response or the streamed ResponseCompletedEvent.
- Add regression coverage for wrapped sync iterables, sync generators from the async path, and async generators.

## Issue Number

N/A

## How to Test

Run:

```bash
uv run pytest tests/sdk/llm/test_responses_parsing_and_kwargs.py -k async_generator -q
uv run pytest tests/sdk/llm/test_responses_parsing_and_kwargs.py tests/sdk/llm/test_llm_no_response_retry.py -q
uv run pre-commit run --files openhands-sdk/openhands/sdk/llm/llm.py tests/sdk/llm/test_responses_parsing_and_kwargs.py
```

Live verification performed locally:

- Confirmed locked lmnr 0.7.47 returns async_generator for a coroutine-backed streamed Responses wrapper.
- Ran real OpenAI Responses streaming calls with gpt-4.1-mini through wrapped sync and async paths.
- Both returned pong and emitted token callbacks.

## Video/Screenshots

No UI changes. Live verification output:

```text
sync wrapped stream text: pong
sync token fragments: 1
async sync-generator stream text: pong
async token fragments: 1
LIVE_WRAPPED_RESPONSES_STREAM_OK
```

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

This pull request was created by an AI agent OpenHands on behalf of Engel Nyst.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:2c75c75-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-2c75c75-python \
  ghcr.io/openhands/agent-server:2c75c75-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:2c75c75-golang-amd64
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-golang-amd64
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-golang-amd64
ghcr.io/openhands/agent-server:2c75c75-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:2c75c75-golang-arm64
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-golang-arm64
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-golang-arm64
ghcr.io/openhands/agent-server:2c75c75-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:2c75c75-java-amd64
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-java-amd64
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-java-amd64
ghcr.io/openhands/agent-server:2c75c75-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:2c75c75-java-arm64
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-java-arm64
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-java-arm64
ghcr.io/openhands/agent-server:2c75c75-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:2c75c75-python-amd64
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-python-amd64
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-python-amd64
ghcr.io/openhands/agent-server:2c75c75-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:2c75c75-python-arm64
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-python-arm64
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-python-arm64
ghcr.io/openhands/agent-server:2c75c75-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:2c75c75-golang
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-golang
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-golang
ghcr.io/openhands/agent-server:2c75c75-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:2c75c75-java
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-java
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-java
ghcr.io/openhands/agent-server:2c75c75-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:2c75c75-python
ghcr.io/openhands/agent-server:2c75c7546abb10ae5e2bc0b0267db7c24d11e8a5-python
ghcr.io/openhands/agent-server:fix-responses-stream-wrapper-tolerance-python
ghcr.io/openhands/agent-server:2c75c75-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `2c75c75-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `2c75c75-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->