### PR TITLE
fix(skills): match keyword triggers on whole words only

### DIFF
--- a/openhands-sdk/openhands/sdk/skills/skill.py
+++ b/openhands-sdk/openhands/sdk/skills/skill.py
@@ -117,6 +117,20 @@ TriggerType = Annotated[
 ]
 
 
+def _keyword_matches(keyword: str, message_lower: str) -> bool:
+    """Return True if ``keyword`` appears as a whole token in ``message_lower``.
+
+    Uses alphanumeric boundaries (not ``\\b``) so ``git`` does not fire on
+    ``github`` while slash-prefixed keywords like ``/linear`` still match.
+    ``message_lower`` is expected to be lowercased by the caller.
+    """
+    keyword_lower = keyword.lower()
+    if not keyword_lower:
+        return False
+    pattern = rf"(?<![a-z0-9]){re.escape(keyword_lower)}(?![a-z0-9])"
+    return re.search(pattern, message_lower) is not None
+
+
 class Skill(BaseModel):
     """A skill provides specialized knowledge or functionality.
 
@@ -594,17 +608,23 @@ class Skill(BaseModel):
 
         Returns the first trigger that matches the message, or None if no match.
         Only applies to KeywordTrigger and TaskTrigger types.
+
+        Matching is whole-token and case-insensitive: a keyword only fires when
+        it appears bounded by non-alphanumeric characters, so ``git`` does not
+        match ``github`` and ``issue`` does not match ``tissue``. See
+        :func:`_keyword_matches` for details.
         """
         if isinstance(self.trigger, KeywordTrigger):
-            message_lower = message.lower()
-            for keyword in self.trigger.keywords:
-                if keyword.lower() in message_lower:
-                    return keyword
+            keywords = self.trigger.keywords
         elif isinstance(self.trigger, TaskTrigger):
-            message_lower = message.lower()
-            for trigger_str in self.trigger.triggers:
-                if trigger_str.lower() in message_lower:
-                    return trigger_str
+            keywords = self.trigger.triggers
+        else:
+            return None
+
+        message_lower = message.lower()
+        for keyword in keywords:
+            if _keyword_matches(keyword, message_lower):
+                return keyword
         return None
 
     def extract_variables(self, content: str) -> list[str]:

--- a/tests/sdk/skills/test_skill_utils.py
+++ b/tests/sdk/skills/test_skill_utils.py
@@ -9,6 +9,7 @@ from openhands.sdk.context import (
     KeywordTrigger,
     Skill,
     SkillValidationError,
+    TaskTrigger,
     load_project_skills,
     load_skills_from_dir,
 )
@@ -91,6 +92,100 @@ def test_knowledge_agent():
     assert agent.match_trigger("no match here") is None
     assert isinstance(agent.trigger, KeywordTrigger)
     assert agent.trigger.keywords == ["testing", "pytest"]
+
+
+def _skill_with_keywords(*keywords: str, task: bool = False) -> Skill:
+    """Build a Skill whose (Keyword|Task)Trigger fires on the given keywords."""
+    trigger = (
+        TaskTrigger(triggers=list(keywords))
+        if task
+        else KeywordTrigger(keywords=list(keywords))
+    )
+    return Skill(name="s", content="c", source="s.md", trigger=trigger)
+
+
+# (keyword, message, expected) where expected is the matched keyword or None.
+# Regression coverage for #3643: substring matching fired ``git`` on ``github``
+# and ``issue`` on ``tissue``. Matching must be whole-token on alnum boundaries.
+_MATCH_CASES = [
+    # --- whole-word matches fire ---
+    pytest.param("git", "run git status", "git", id="word-in-middle"),
+    pytest.param("git", "git", "git", id="whole-message"),
+    pytest.param("git", "git status", "git", id="word-at-start"),
+    pytest.param("git", "use git", "git", id="word-at-end"),
+    pytest.param("git", "run git status twice, git", "git", id="repeated"),
+    # --- case-insensitive matching, original keyword returned ---
+    pytest.param("git", "GIT rocks", "git", id="uppercase-message"),
+    pytest.param("git", "use Git today", "git", id="titlecase-message"),
+    pytest.param("GIT", "run git status", "GIT", id="uppercase-keyword-preserved"),
+    pytest.param("GitHub", "open github now", "GitHub", id="mixedcase-keyword"),
+    # --- non-alnum boundaries fire ---
+    pytest.param("git", "git!", "git", id="trailing-bang"),
+    pytest.param("git", "git.", "git", id="trailing-dot"),
+    pytest.param("git", "(git)", "git", id="parenthesized"),
+    pytest.param("git", "git:status", "git", id="colon-after"),
+    pytest.param("git", "use-git-now", "git", id="hyphen-bounded"),
+    pytest.param("git", "my_git_repo", "git", id="underscore-is-a-boundary"),
+    pytest.param("git", "line1\ngit\nline2", "git", id="newline-bounded"),
+    pytest.param("git", "tab\tgit\tend", "git", id="tab-bounded"),
+    # --- alphanumeric adjacency blocks (the #3643 false positives) ---
+    pytest.param("git", "check out github.com", None, id="prefix-of-word"),
+    pytest.param("git", "the digit five", None, id="suffix-of-word"),
+    pytest.param("git", "a legitimate reason", None, id="inside-word"),
+    pytest.param("git", "git2 branch", None, id="trailing-digit"),
+    pytest.param("git", "2git branch", None, id="leading-digit"),
+    pytest.param("issue", "hand me a tissue", None, id="issue-in-tissue"),
+    # --- no match ---
+    pytest.param("git", "no match here", None, id="absent"),
+    pytest.param("git", "", None, id="empty-message"),
+    # --- slash-prefixed keywords (why alnum boundaries, not \\b) ---
+    pytest.param("/linear", "use /linear now", "/linear", id="slash-in-middle"),
+    pytest.param("/linear", "/linear", "/linear", id="slash-whole-message"),
+    pytest.param("/linear", "please /linear", "/linear", id="slash-at-end"),
+    pytest.param("/linear", "run a linearization", None, id="slash-vs-bareword"),
+    pytest.param("/linear", "src/linear.py", None, id="slash-after-alnum"),
+    # --- multi-word phrases match as a unit ---
+    pytest.param("pull request", "open a pull request", "pull request", id="phrase"),
+    pytest.param("pull request", "pull request!", "pull request", id="phrase-punct"),
+    pytest.param("pull request", "pullrequest", None, id="phrase-no-space"),
+    pytest.param("pull request", "pull requests", None, id="phrase-plural"),
+    # --- re.escape keeps regex metacharacters literal ---
+    pytest.param("c++", "write c++ code", "c++", id="metachar-plus"),
+    pytest.param("c++", "c++today", None, id="metachar-plus-adjacent"),
+    pytest.param("a.b", "call a.b now", "a.b", id="metachar-dot-literal"),
+    pytest.param("a.b", "call axb now", None, id="metachar-dot-not-wildcard"),
+]
+
+
+@pytest.mark.parametrize("task", [False, True], ids=["keyword", "task"])
+@pytest.mark.parametrize(("keyword", "message", "expected"), _MATCH_CASES)
+def test_match_trigger_whole_word(
+    keyword: str, message: str, expected: str | None, task: bool
+) -> None:
+    """match_trigger fires on whole tokens only, for both trigger types."""
+    skill = _skill_with_keywords(keyword, task=task)
+    assert skill.match_trigger(message) == expected
+
+
+def test_match_trigger_returns_first_matching_keyword_in_list_order() -> None:
+    """The first keyword (in list order) that matches wins, not the earliest
+    occurrence in the message."""
+    skill = _skill_with_keywords("alpha", "beta")
+    assert skill.match_trigger("beta then alpha") == "alpha"
+    assert skill.match_trigger("only beta here") == "beta"
+
+
+def test_match_trigger_empty_keyword_never_matches() -> None:
+    """An empty trigger keyword must not match everything."""
+    skill = _skill_with_keywords("")
+    assert skill.match_trigger("anything at all") is None
+    assert skill.match_trigger("") is None
+
+
+def test_match_trigger_no_trigger_returns_none() -> None:
+    """Skills without a KeywordTrigger/TaskTrigger never match."""
+    skill = Skill(name="s", content="c", source="s.md", trigger=None)
+    assert skill.match_trigger("git issue linear") is None
 
 
 def test_load_skills(temp_skills_dir):


### PR DESCRIPTION
HUMAN:

Make the skill disclosure more precise in case of KeyWordTriggered skills.

---

AGENT:

## Why

`Skill.match_trigger` used substring matching (`keyword.lower() in message_lower`), so short trigger keywords fired on unrelated words: `git` matched `github`/`digit`/`legitimate` and `issue` matched `tissue`. This injected irrelevant public-skill context into unrelated tasks — observed in SWE-bench Verified runs where `github`/`gitlab`/`bitbucket`/`linear` activated on ordinary issue-description vocabulary (#3643).

This implements **Proposal 1** from the issue: whole-word (word-boundary) matching. It is intentionally scoped to that one change; Proposals 2 (model-invoked activation by default) and 3 (dropping bare `git`/`linear` triggers, which live in the separate `OpenHands/extensions` repo) are out of scope here.

## Summary

- `_keyword_matches()` helper matches a trigger keyword only when it appears on **alphanumeric boundaries** (`(?<![a-z0-9])<re.escape(kw)>(?![a-z0-9])`), and `match_trigger` now routes both `KeywordTrigger` and `TaskTrigger` through it.
- Alnum lookarounds (not `\b`) are used deliberately so slash-prefixed keywords like `/linear` still match; `re.escape` keeps multi-word phrases and regex metacharacters literal.
- Added a parametrized test table (39 cases × both trigger types) plus standalone tests covering the #3643 false positives, punctuation/underscore/whitespace boundaries, case-insensitivity, phrases, `re.escape` safety, first-match ordering, and empty/None triggers.

## Issue Number

Closes #3643

## How to Test

Run the skills test suite:

```
uv run python -m pytest tests/sdk/skills/ -q
```

Result: `297 passed, 2 skipped`. The new parametrized cases in `tests/sdk/skills/test_skill_utils.py` exercise the behavior end-to-end through the public `Skill.match_trigger` API — e.g. `git` matches `run git status` but not `check out github.com`, `the digit five`, or `a legitimate reason`; `/linear` matches `use /linear now` but not `run a linearization`.

Quick manual check:

```python
from openhands.sdk.context import Skill, KeywordTrigger
s = Skill(name="s", content="c", source="s.md", trigger=KeywordTrigger(keywords=["git"]))
print(s.match_trigger("run git status"))   # -> "git"
print(s.match_trigger("check out github.com"))  # -> None
```

`uv run pre-commit run` passes (ruff format/lint, pycodestyle, pyright, import rules).

## Video/Screenshots

N/A — non-visual change (skill trigger-matching logic).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Behavior change worth flagging: boundaries are alphanumeric, so `_` counts as a boundary (`my_git_repo` matches `git`). This is intentional to keep the rule simple and to support slash/punctuation-delimited keywords. No config or API changes.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:0bda03d-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-0bda03d-python \
  ghcr.io/openhands/agent-server:0bda03d-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:0bda03d-golang-amd64
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-golang-amd64
ghcr.io/openhands/agent-server:vasco-skills-triggered-golang-amd64
ghcr.io/openhands/agent-server:0bda03d-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:0bda03d-golang-arm64
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-golang-arm64
ghcr.io/openhands/agent-server:vasco-skills-triggered-golang-arm64
ghcr.io/openhands/agent-server:0bda03d-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:0bda03d-java-amd64
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-java-amd64
ghcr.io/openhands/agent-server:vasco-skills-triggered-java-amd64
ghcr.io/openhands/agent-server:0bda03d-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:0bda03d-java-arm64
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-java-arm64
ghcr.io/openhands/agent-server:vasco-skills-triggered-java-arm64
ghcr.io/openhands/agent-server:0bda03d-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:0bda03d-python-amd64
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-python-amd64
ghcr.io/openhands/agent-server:vasco-skills-triggered-python-amd64
ghcr.io/openhands/agent-server:0bda03d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:0bda03d-python-arm64
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-python-arm64
ghcr.io/openhands/agent-server:vasco-skills-triggered-python-arm64
ghcr.io/openhands/agent-server:0bda03d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:0bda03d-golang
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-golang
ghcr.io/openhands/agent-server:vasco-skills-triggered-golang
ghcr.io/openhands/agent-server:0bda03d-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:0bda03d-java
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-java
ghcr.io/openhands/agent-server:vasco-skills-triggered-java
ghcr.io/openhands/agent-server:0bda03d-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:0bda03d-python
ghcr.io/openhands/agent-server:0bda03d0ab7aed9fae868cf45e352431d4733343-python
ghcr.io/openhands/agent-server:vasco-skills-triggered-python
ghcr.io/openhands/agent-server:0bda03d-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `0bda03d-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `0bda03d-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->