### PR TITLE
fix(sdk): release conversation state lock during the async LLM call

### DIFF
--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -876,12 +876,9 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         )
 
         try:
-            # Do not hold the conversation state lock across the LLM network
-            # round-trip. arun() holds it across the whole step to serialize
-            # state mutations, but keeping it during the provider wait blocks
-            # send_message() and state snapshots for the full response time.
-            # Release it for just the network call (a no-op when the caller is
-            # not the lock-holding run loop, e.g. a direct astep() in tests).
+            # Release the state lock for just the network wait so send_message()
+            # and state snapshots aren't blocked for the whole response. No-op
+            # unless the run loop holds the lock (e.g. direct astep() in tests).
             async with conversation._released_state_lock_during_io():
                 llm_response = await amake_llm_completion(
                     self.llm,

--- a/openhands-sdk/openhands/sdk/agent/agent.py
+++ b/openhands-sdk/openhands/sdk/agent/agent.py
@@ -876,13 +876,20 @@ class Agent(CriticMixin, ResponseDispatchMixin, AgentBase):
         )
 
         try:
-            llm_response = await amake_llm_completion(
-                self.llm,
-                _messages,
-                tools=list(self.tools_map.values()),
-                on_token=on_token,
-                call_context=call_context,
-            )
+            # Do not hold the conversation state lock across the LLM network
+            # round-trip. arun() holds it across the whole step to serialize
+            # state mutations, but keeping it during the provider wait blocks
+            # send_message() and state snapshots for the full response time.
+            # Release it for just the network call (a no-op when the caller is
+            # not the lock-holding run loop, e.g. a direct astep() in tests).
+            async with conversation._released_state_lock_during_io():
+                llm_response = await amake_llm_completion(
+                    self.llm,
+                    _messages,
+                    tools=list(self.tools_map.values()),
+                    on_token=on_token,
+                    call_context=call_context,
+                )
         except FunctionCallValidationError as e:
             logger.warning(f"LLM generated malformed function call: {e}")
             error_message = MessageEvent(

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -1,5 +1,6 @@
+import contextlib
 from abc import ABC, abstractmethod
-from collections.abc import Iterable, Mapping
+from collections.abc import AsyncIterator, Iterable, Mapping
 from pathlib import Path
 from typing import TYPE_CHECKING, Protocol, TypeVar, cast
 
@@ -225,6 +226,17 @@ class BaseConversation(ABC):
         to use async agent steps for non-blocking LLM I/O.
         """
         self.run()
+
+    @contextlib.asynccontextmanager
+    async def _released_state_lock_during_io(self) -> AsyncIterator[None]:
+        """Release any run-loop state lock across an awaited LLM call.
+
+        Default implementation is a no-op. :class:`LocalConversation` overrides
+        it to drop its state lock during the LLM network round-trip so other
+        callers (e.g. ``send_message``) are not blocked for the whole response
+        time. ``Agent.astep`` wraps its LLM call in this context manager.
+        """
+        yield
 
     @abstractmethod
     def set_confirmation_policy(self, policy: ConfirmationPolicyBase) -> None:

--- a/openhands-sdk/openhands/sdk/conversation/base.py
+++ b/openhands-sdk/openhands/sdk/conversation/base.py
@@ -231,10 +231,7 @@ class BaseConversation(ABC):
     async def _released_state_lock_during_io(self) -> AsyncIterator[None]:
         """Release any run-loop state lock across an awaited LLM call.
 
-        Default implementation is a no-op. :class:`LocalConversation` overrides
-        it to drop its state lock during the LLM network round-trip so other
-        callers (e.g. ``send_message``) are not blocked for the whole response
-        time. ``Agent.astep`` wraps its LLM call in this context manager.
+        No-op by default; :class:`LocalConversation` overrides it.
         """
         yield
 

--- a/openhands-sdk/openhands/sdk/conversation/fifo_lock.py
+++ b/openhands-sdk/openhands/sdk/conversation/fifo_lock.py
@@ -114,6 +114,41 @@ class FIFOLock:
                 if self._waiters:
                     self._waiters[0].notify()
 
+    def release_all(self) -> int:
+        """Fully release this thread's hold, returning the prior reentrancy depth.
+
+        Mirrors :meth:`release` reaching count 0 (it hands the lock to the next
+        FIFO waiter), but drops *all* reentrant levels at once so a held lock
+        can be handed off across an awaited call and later restored with
+        :meth:`reacquire`.
+
+        Raises:
+            RuntimeError: If the current thread doesn't own the lock.
+        """
+        ident = threading.get_ident()
+        with self._mutex:
+            if self._owner != ident:
+                raise RuntimeError("Cannot release lock not owned by current thread")
+            depth = self._count
+            self._count = 0
+            self._owner = None
+            if self._waiters:
+                self._waiters[0].notify()
+        return depth
+
+    def reacquire(self, depth: int) -> None:
+        """Re-acquire the lock and restore a reentrancy ``depth`` from release_all().
+
+        Blocks until the lock is acquired (FIFO-fair), then restores the
+        reentrancy counter so a subsequent matching number of releases behaves
+        exactly as it would have before the paired :meth:`release_all`.
+        """
+        if depth <= 0:
+            return
+        self.acquire()
+        with self._mutex:
+            self._count = depth
+
     def __enter__(self: Self) -> Self:
         """Context manager entry."""
         self.acquire()

--- a/openhands-sdk/openhands/sdk/conversation/fifo_lock.py
+++ b/openhands-sdk/openhands/sdk/conversation/fifo_lock.py
@@ -115,15 +115,10 @@ class FIFOLock:
                     self._waiters[0].notify()
 
     def release_all(self) -> int:
-        """Fully release this thread's hold, returning the prior reentrancy depth.
+        """Drop all reentrant levels at once, returning the prior depth.
 
-        Mirrors :meth:`release` reaching count 0 (it hands the lock to the next
-        FIFO waiter), but drops *all* reentrant levels at once so a held lock
-        can be handed off across an awaited call and later restored with
-        :meth:`reacquire`.
-
-        Raises:
-            RuntimeError: If the current thread doesn't own the lock.
+        Hands the lock to the next FIFO waiter, so it can be restored later with
+        :meth:`reacquire`. Raises RuntimeError if not owned by the current thread.
         """
         ident = threading.get_ident()
         with self._mutex:
@@ -137,12 +132,7 @@ class FIFOLock:
         return depth
 
     def reacquire(self, depth: int) -> None:
-        """Re-acquire the lock and restore a reentrancy ``depth`` from release_all().
-
-        Blocks until the lock is acquired (FIFO-fair), then restores the
-        reentrancy counter so a subsequent matching number of releases behaves
-        exactly as it would have before the paired :meth:`release_all`.
-        """
+        """Re-acquire (FIFO-fair) and restore the ``depth`` from release_all()."""
         if depth <= 0:
             return
         self.acquire()

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1613,24 +1613,11 @@ class LocalConversation(BaseConversation):
     async def _released_state_lock_during_io(self):
         """Release the run loop's state lock across an awaited LLM network call.
 
-        ``arun()`` holds the conversation state lock across the entire agent
-        step so state mutations are serialized. That is correct for the fast
-        in-memory prep/processing sections but wrong for the LLM round-trip:
-        holding the lock there blocks ``send_message()``, new WebSocket state
-        snapshots, and every other caller that needs this conversation's lock
-        for the whole provider response time (many seconds for reasoning
-        models). Release it for just the network wait and restore it -- at the
-        same reentrancy depth, on this event-loop thread -- afterward.
-
-        This is a no-op unless the caller is the run loop holding the lock on
-        the current thread, so direct ``astep`` calls (tests, custom drivers,
-        the confirmation-mode early return) are unaffected.
-
-        Safe against deadlock because ``arun`` is the only coroutine that ever
-        holds this lock across an ``await``; every other holder -- worker
-        threads via ``run_in_executor`` and short synchronous sections on the
-        event-loop thread -- takes it only briefly, so the re-acquire below
-        cannot block for long and cannot deadlock.
+        ``arun()`` holds the state lock across the whole step; releasing it for
+        just the network wait keeps ``send_message()`` and state snapshots
+        responsive. No-op unless this thread holds the lock, so direct ``astep``
+        calls are unaffected. Deadlock-safe: ``arun`` is the only holder across
+        an ``await``; every other holder takes it only briefly.
         """
         lock = self._state._lock
         if not lock.owned():
@@ -1638,10 +1625,8 @@ class LocalConversation(BaseConversation):
             return
         held_flag = self._step_holds_state_lock
         depth = lock.release_all()
-        # The lock is genuinely not held now; keep _step_holds_state_lock
-        # honest so a concurrent switch_llm (which runs on the event-loop
-        # thread from its HTTP handler) takes the now-free lock instead of
-        # skipping it and racing worker-thread state mutators.
+        # Keep the flag honest while released so a concurrent switch_llm (on the
+        # event-loop thread) takes the now-free lock instead of racing mutators.
         self._step_holds_state_lock = False
         try:
             yield

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -1609,6 +1609,46 @@ class LocalConversation(BaseConversation):
         with self._state:
             self._on_event(event)
 
+    @contextlib.asynccontextmanager
+    async def _released_state_lock_during_io(self):
+        """Release the run loop's state lock across an awaited LLM network call.
+
+        ``arun()`` holds the conversation state lock across the entire agent
+        step so state mutations are serialized. That is correct for the fast
+        in-memory prep/processing sections but wrong for the LLM round-trip:
+        holding the lock there blocks ``send_message()``, new WebSocket state
+        snapshots, and every other caller that needs this conversation's lock
+        for the whole provider response time (many seconds for reasoning
+        models). Release it for just the network wait and restore it -- at the
+        same reentrancy depth, on this event-loop thread -- afterward.
+
+        This is a no-op unless the caller is the run loop holding the lock on
+        the current thread, so direct ``astep`` calls (tests, custom drivers,
+        the confirmation-mode early return) are unaffected.
+
+        Safe against deadlock because ``arun`` is the only coroutine that ever
+        holds this lock across an ``await``; every other holder -- worker
+        threads via ``run_in_executor`` and short synchronous sections on the
+        event-loop thread -- takes it only briefly, so the re-acquire below
+        cannot block for long and cannot deadlock.
+        """
+        lock = self._state._lock
+        if not lock.owned():
+            yield
+            return
+        held_flag = self._step_holds_state_lock
+        depth = lock.release_all()
+        # The lock is genuinely not held now; keep _step_holds_state_lock
+        # honest so a concurrent switch_llm (which runs on the event-loop
+        # thread from its HTTP handler) takes the now-free lock instead of
+        # skipping it and racing worker-thread state mutators.
+        self._step_holds_state_lock = False
+        try:
+            yield
+        finally:
+            lock.reacquire(depth)
+            self._step_holds_state_lock = held_flag
+
     @observe(name="conversation.run")
     def run(self) -> None:
         """Runs the conversation until the agent finishes.

--- a/tests/sdk/agent/test_astep_releases_state_lock.py
+++ b/tests/sdk/agent/test_astep_releases_state_lock.py
@@ -1,0 +1,110 @@
+"""The conversation state lock must not be held across the LLM network call.
+
+Regression: ``arun()`` holds the conversation state lock across the whole agent
+step. Holding it during the LLM round-trip blocked ``send_message()`` and state
+snapshots for the full provider response time, so the agent-server appeared to
+"stop responding" while waiting for the model. ``Agent.astep`` now releases the
+lock for just the network call via
+``LocalConversation._released_state_lock_during_io``.
+"""
+
+import asyncio
+import threading
+
+import pytest
+from pydantic import PrivateAttr
+
+from openhands.sdk.agent import Agent
+from openhands.sdk.conversation import Conversation
+from openhands.sdk.conversation.impl.local_conversation import LocalConversation
+from openhands.sdk.llm import LLM
+from openhands.sdk.llm.exceptions import LLMContentPolicyViolationError
+
+
+class _LockProbingLLM(LLM):
+    """Records the conversation-lock state observed mid-``acompletion``.
+
+    Raises a *recoverable* content-policy error so ``astep`` returns cleanly
+    without us having to synthesize a full ``LLMResponse``.
+    """
+
+    _convo_box: list = PrivateAttr(default_factory=list)
+    _probe: dict = PrivateAttr(default_factory=dict)
+
+    def __init__(self):
+        super().__init__(model="test-model", usage_id="test-llm")
+
+    def uses_responses_api(self) -> bool:  # override gating
+        return False
+
+    async def acompletion(self, *, messages, tools=None, **kwargs):  # type: ignore[override]
+        convo = self._convo_box[0]
+        lock = convo._state._lock
+        # 1) No thread should own the state lock during the network call.
+        self._probe["locked_during_call"] = lock.locked()
+        # 2) The run-loop flag must reflect reality (lock is free right now).
+        self._probe["step_flag_during_call"] = convo._step_holds_state_lock
+
+        # 3) A different thread (as send_message runs, via run_in_executor)
+        #    must be able to actually grab the lock while the call is in flight.
+        acquired: dict = {}
+
+        def _try_acquire():
+            got = lock.acquire(blocking=True, timeout=2.0)
+            acquired["ok"] = got
+            if got:
+                lock.release()
+
+        t = threading.Thread(target=_try_acquire)
+        t.start()
+        await asyncio.to_thread(t.join)
+        self._probe["worker_acquired_during_call"] = acquired.get("ok", False)
+
+        raise LLMContentPolicyViolationError()
+
+
+@pytest.mark.asyncio
+async def test_astep_releases_state_lock_during_llm_call():
+    llm = _LockProbingLLM()
+    agent = Agent(llm=llm, tools=[])
+    convo = Conversation(agent=agent)
+    assert isinstance(convo, LocalConversation)
+    convo._ensure_agent_ready()
+    llm._convo_box.append(convo)
+    convo.send_message("hello")
+
+    # Mimic arun()'s per-step critical section: hold the state lock across the
+    # step and set the flag arun sets before calling astep.
+    convo._step_holds_state_lock = True
+    with convo._state:
+        assert convo._state._lock.locked()
+        await agent.astep(convo, on_event=[].append)
+        # The context manager restored the lock (same thread) and the flag.
+        assert convo._state._lock.owned()
+        assert convo._step_holds_state_lock is True
+
+    # The lock was NOT held during the provider round-trip...
+    assert llm._probe["locked_during_call"] is False
+    # ...another thread could take it mid-call...
+    assert llm._probe["worker_acquired_during_call"] is True
+    # ...and the run-loop flag told the truth while it was released.
+    assert llm._probe["step_flag_during_call"] is False
+
+
+@pytest.mark.asyncio
+async def test_direct_astep_without_lock_is_unaffected():
+    """A direct astep() (no run loop, lock not held) must still work: the
+    context manager is a no-op when the current thread doesn't own the lock."""
+    llm = _LockProbingLLM()
+    agent = Agent(llm=llm, tools=[])
+    convo = Conversation(agent=agent)
+    assert isinstance(convo, LocalConversation)
+    convo._ensure_agent_ready()
+    llm._convo_box.append(convo)
+    convo.send_message("hello")
+
+    # No `with convo._state:` here — the lock is not held on entry.
+    await agent.astep(convo, on_event=[].append)
+
+    assert llm._probe["locked_during_call"] is False
+    assert llm._probe["worker_acquired_during_call"] is True

--- a/tests/sdk/conversation/test_fifo_lock.py
+++ b/tests/sdk/conversation/test_fifo_lock.py
@@ -275,6 +275,97 @@ def run_fairness_test_multiple(num_runs: int = 100) -> list[bool]:
     return results
 
 
+def test_release_all_drops_all_reentrant_levels_and_returns_depth():
+    """release_all() fully frees a reentrantly-held lock and reports the depth."""
+    lock = FIFOLock()
+    lock.acquire()
+    lock.acquire()
+    lock.acquire()
+    assert lock.owned()
+
+    depth = lock.release_all()
+
+    assert depth == 3
+    assert not lock.locked()
+    assert not lock.owned()
+
+
+def test_release_all_requires_ownership():
+    """release_all() from a non-owning thread raises, like release()."""
+    lock = FIFOLock()
+
+    def _grab_and_hold(started: threading.Event, release: threading.Event):
+        lock.acquire()
+        started.set()
+        release.wait()
+        lock.release()
+
+    started, release = threading.Event(), threading.Event()
+    holder = threading.Thread(target=_grab_and_hold, args=(started, release))
+    holder.start()
+    started.wait()
+    try:
+        with pytest.raises(RuntimeError):
+            lock.release_all()
+    finally:
+        release.set()
+        holder.join()
+
+
+def test_reacquire_restores_reentrancy_depth():
+    """reacquire(depth) restores the counter so releases balance out."""
+    lock = FIFOLock()
+    lock.acquire()
+    lock.acquire()
+    depth = lock.release_all()
+    assert depth == 2
+
+    lock.reacquire(depth)
+    assert lock.owned()
+
+    # Exactly `depth` releases return the lock to fully free.
+    lock.release()
+    assert lock.owned()  # still held (was reentrant)
+    lock.release()
+    assert not lock.owned()
+
+
+def test_reacquire_zero_depth_is_noop():
+    lock = FIFOLock()
+    lock.reacquire(0)
+    assert not lock.owned()
+
+
+def test_release_all_then_reacquire_hands_off_to_waiter_first():
+    """A thread waiting during the released window gets the lock before the
+    releaser reacquires (FIFO fairness is preserved across the hand-off)."""
+    lock = FIFOLock()
+    lock.acquire()
+
+    order: list[str] = []
+    waiter_ready = threading.Event()
+
+    def _waiter():
+        waiter_ready.set()
+        with lock:
+            order.append("waiter")
+
+    t = threading.Thread(target=_waiter)
+    t.start()
+    waiter_ready.wait()
+    # Give the waiter a moment to actually enqueue on the lock.
+    time.sleep(0.05)
+
+    depth = lock.release_all()
+    # Waiter should now be able to take it; reacquire queues behind it.
+    lock.reacquire(depth)
+    order.append("releaser")
+    lock.release()
+    t.join()
+
+    assert order == ["waiter", "releaser"]
+
+
 if __name__ == "__main__":
     print("Running FIFO lock fairness test 100 times sequentially...")
 


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fixing problem with lock in `agent.step()`

---

AGENT:

## Why

The agent-server appears to **stop responding to requests while it is waiting for an LLM response**.

Root cause is lock scope: in the regular (non-ACP) run path, `arun()` holds the per-conversation `ConversationState` FIFOLock across the **entire `await agent.astep()`**, i.e. across the whole LLM round-trip. Because that lock is held on the event-loop thread across the await, every operation that needs the *same conversation's* lock blocks (in a worker thread) until the model responds:

- `send_message()` — you cannot queue/interject a follow-up during a model turn.
- New WebSocket subscribers — the initial state snapshot blocks.
- Execution-status reads and other lock-taking ops.

Those blocked ops run on the shared default `ThreadPoolExecutor`; under concurrency they saturate it, at which point even lock-free reads queue behind them and the server looks fully unresponsive. The ACP run path already releases the lock during its round-trip for exactly this reason — this PR brings the regular LLM path in line.

## Summary

- **`FIFOLock`**: add `release_all()` / `reacquire(depth)` to hand a reentrantly-held lock across an awaited call and restore it at the same depth.
- **`LocalConversation._released_state_lock_during_io()`**: async context manager that drops the run loop's lock for just the network wait and restores it. No-op unless the current thread owns the lock, so direct `astep()` calls (tests/custom drivers) are unaffected. Flips `_step_holds_state_lock` to `False` for the window so a concurrent `switch_llm` takes the now-free lock instead of racing worker-thread mutators.
- **`BaseConversation`**: no-op default of the CM (non-local / sync-only subclasses unaffected).
- **`Agent.astep`**: wrap only `amake_llm_completion` in the CM.

## Issue Number

N/A (reported in Slack, no GitHub issue filed).

## How to Test

Automated — the two test files added in this PR:

```bash
uv run pytest tests/sdk/conversation/test_fifo_lock.py tests/sdk/agent/test_astep_releases_state_lock.py -q
# 14 passed in 2.52s
```

- `test_fifo_lock.py` — `release_all`/`reacquire`: depth reporting, ownership enforcement, reentrancy restoration, and FIFO hand-off to a waiter across the released window.
- `test_astep_releases_state_lock.py` — drives `astep` inside a simulated `arun` critical section with an LLM whose `acompletion` probes the lock mid-call; asserts the lock is **not** held during the call, a separate thread can acquire it, and `_step_holds_state_lock` reads `False`. This regression test **fails on `main`** (lock held → worker thread times out) and **passes with the fix** (verified by reverting only `agent.py`).

Manual / integration:
- Start the agent-server, begin a run with a slow model, and during the model's "thinking" send a second message (`POST .../events` or the events WebSocket) — it should be accepted immediately instead of hanging until the response returns.

## Video/Screenshots

N/A (backend concurrency fix, no UI surface).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- **Sync path parity** (follow-up, not in this PR): the sync `step`/`run` fallback still holds the lock across `make_llm_completion`. It runs in a worker thread so it can't freeze the event loop, but it does block worker-thread `send_message`. A sync twin of the CM would give parity; the async path is the default.
- **Condenser**: `aprepare_llm_messages` is still awaited under the lock, but it defers condensation via `CondensationRequest` rather than making an inline LLM call, so it's fine.
- Related: PR #4012 fixes a **different** lock (the process-wide `litellm.modify_params` lock) — complementary to this change, not overlapping.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:ce7ced5-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-ce7ced5-python \
  ghcr.io/openhands/agent-server:ce7ced5-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:ce7ced5-golang-amd64
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-golang-amd64
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-golang-amd64
ghcr.io/openhands/agent-server:ce7ced5-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:ce7ced5-golang-arm64
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-golang-arm64
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-golang-arm64
ghcr.io/openhands/agent-server:ce7ced5-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:ce7ced5-java-amd64
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-java-amd64
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-java-amd64
ghcr.io/openhands/agent-server:ce7ced5-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:ce7ced5-java-arm64
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-java-arm64
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-java-arm64
ghcr.io/openhands/agent-server:ce7ced5-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:ce7ced5-python-amd64
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-python-amd64
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-python-amd64
ghcr.io/openhands/agent-server:ce7ced5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:ce7ced5-python-arm64
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-python-arm64
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-python-arm64
ghcr.io/openhands/agent-server:ce7ced5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:ce7ced5-golang
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-golang
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-golang
ghcr.io/openhands/agent-server:ce7ced5-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:ce7ced5-java
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-java
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-java
ghcr.io/openhands/agent-server:ce7ced5-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:ce7ced5-python
ghcr.io/openhands/agent-server:ce7ced587f6c068667889f8bfdad2d7b58215340-python
ghcr.io/openhands/agent-server:vasco-release-state-lock-during-llm-call-python
ghcr.io/openhands/agent-server:ce7ced5-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `ce7ced5-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `ce7ced5-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
