### PR TITLE
fix: don't freeze agent-server's event loop while waiting on litellm's global modify_params lock

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -8,7 +8,7 @@ import os
 import threading
 import warnings
 from collections.abc import AsyncIterable, Callable, Iterable, Sequence
-from contextlib import contextmanager
+from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, get_args, get_origin
 
@@ -553,7 +553,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     _call_context: LLMCallContext = PrivateAttr(default_factory=LLMCallContext)
     _effective_max_input_tokens: int | None = PrivateAttr(default=None)
     _effective_max_output_tokens: int | None = PrivateAttr(default=None)
-    _litellm_modify_params_lock: ClassVar[threading.RLock] = threading.RLock()
+    # Plain (non-reentrant) Lock: the async transport path acquires this off
+    # the event loop thread (see `_alitellm_modify_params_ctx`) and releases
+    # it back on the event loop thread, which an RLock would reject since it
+    # tracks a single owning thread.
+    _litellm_modify_params_lock: ClassVar[threading.Lock] = threading.Lock()
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="ignore", arbitrary_types_allowed=True
@@ -855,8 +859,6 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         offloaded to a thread via :func:`asyncio.loop.run_in_executor` to
         avoid blocking the event loop.
         """
-        import asyncio
-
         assert self._telemetry is not None
         self._telemetry.on_error(error)
         if self.fallback_strategy and self.fallback_strategy.should_fallback(error):
@@ -1751,7 +1753,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
             assert self._telemetry is not None
             self._telemetry.on_request(telemetry_ctx=telemetry_ctx)
             final_kwargs = {**call_kwargs, **retry_kwargs}
-            with self._litellm_modify_params_ctx(self.modify_params):
+            async with self._alitellm_modify_params_ctx(self.modify_params):
                 with warnings.catch_warnings():
                     warnings.filterwarnings("ignore", category=DeprecationWarning)
                     auth_values = await self._aget_litellm_auth_values()
@@ -2000,6 +2002,36 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 )
                 yield
 
+    @asynccontextmanager
+    async def _atransport_ctx(self):
+        """Async variant of :meth:`_transport_ctx`.
+
+        See :meth:`_alitellm_modify_params_ctx` for why this must not use a
+        plain blocking ``with`` statement around the lock.
+        """
+        async with self._alitellm_modify_params_ctx(self.modify_params):
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore", category=DeprecationWarning, module="httpx.*"
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    message=r".*content=.*upload.*",
+                    category=DeprecationWarning,
+                )
+                warnings.filterwarnings(
+                    "ignore",
+                    message="There is no current event loop",
+                    category=DeprecationWarning,
+                )
+                warnings.filterwarnings("ignore", category=UserWarning)
+                warnings.filterwarnings(
+                    "ignore",
+                    category=DeprecationWarning,
+                    message="Accessing the 'model_fields' attribute.*",
+                )
+                yield
+
     def _prepare_transport_kwargs(
         self,
         *,
@@ -2074,7 +2106,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     ) -> ModelResponse:
         """Async variant of :meth:`_transport_call`."""
         auth_values = await self._aget_litellm_auth_values()
-        with self._transport_ctx():
+        async with self._atransport_ctx():
             ret = await litellm_acompletion(
                 **self._prepare_transport_kwargs(
                     messages=messages,
@@ -2118,6 +2150,42 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
                 yield
             finally:
                 litellm.modify_params = old
+
+    @asynccontextmanager
+    async def _alitellm_modify_params_ctx(self, flag: bool):
+        """Async variant of :meth:`_litellm_modify_params_ctx`.
+
+        ``litellm.modify_params`` is a process-wide global, so the lock must
+        stay held for the full duration of the transport call, not just the
+        moment the flag is set. A plain ``with self._litellm_modify_params_lock:``
+        would work for that, but only for the sync path: entering it here
+        with a blocking ``with`` statement would hold a real OS-level lock
+        across the ``await`` below. If a concurrent *sync* transport call
+        (e.g. a condenser or non-async agent step running in a worker
+        thread) is holding that lock at the time, this coroutine's attempt
+        to acquire it blocks the event loop thread itself -- which freezes
+        every other request the server is handling until the sync call
+        finishes (this is what makes agent-server stop responding to all
+        requests while waiting on a slow/local LLM response, most visible
+        during condensation).
+
+        Acquiring via ``run_in_executor`` moves the wait for the lock onto a
+        worker thread, so the event loop stays free to serve other requests
+        while this call is blocked on a concurrent transport call. The lock
+        is a plain (non-reentrant) ``threading.Lock``, so it is safe to
+        acquire on one thread and release on another.
+        """
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(None, self._litellm_modify_params_lock.acquire)
+        try:
+            old = getattr(litellm, "modify_params", None)
+            try:
+                litellm.modify_params = flag
+                yield
+            finally:
+                litellm.modify_params = old
+        finally:
+            self._litellm_modify_params_lock.release()
 
     # =========================================================================
     # Capabilities, formatting, and info

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -8,6 +8,7 @@ import os
 import threading
 import warnings
 from collections.abc import AsyncIterable, Callable, Iterable, Sequence
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager, contextmanager
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, ClassVar, Literal, get_args, get_origin
@@ -558,6 +559,16 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
     # it back on the event loop thread, which an RLock would reject since it
     # tracks a single owning thread.
     _litellm_modify_params_lock: ClassVar[threading.Lock] = threading.Lock()
+    # Waiting on the lock from the async path is offloaded to this dedicated
+    # executor rather than the event loop's default one. The coroutine that
+    # *holds* the lock may itself need a default-executor thread to make
+    # progress before it can release (e.g. draining a synchronous stream via
+    # ``run_in_executor``); if lock-waiters shared that pool they could occupy
+    # every worker and starve the holder, deadlocking instead of just
+    # serialising. Keeping the wait on its own pool prevents that.
+    _litellm_modify_params_lock_executor: ClassVar[ThreadPoolExecutor] = (
+        ThreadPoolExecutor(thread_name_prefix="llm-modify-params-lock")
+    )
 
     model_config: ClassVar[ConfigDict] = ConfigDict(
         extra="ignore", arbitrary_types_allowed=True
@@ -1972,6 +1983,33 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         api_key_value, _ = await self._aget_litellm_auth_values()
         return api_key_value
 
+    @staticmethod
+    @contextmanager
+    def _suppress_transport_warnings():
+        """Filter the noisy provider/litellm warnings emitted during a
+        transport call. Shared by the sync and async transport guards."""
+        with warnings.catch_warnings():
+            warnings.filterwarnings(
+                "ignore", category=DeprecationWarning, module="httpx.*"
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message=r".*content=.*upload.*",
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings(
+                "ignore",
+                message="There is no current event loop",
+                category=DeprecationWarning,
+            )
+            warnings.filterwarnings("ignore", category=UserWarning)
+            warnings.filterwarnings(
+                "ignore",
+                category=DeprecationWarning,
+                message="Accessing the 'model_fields' attribute.*",
+            )
+            yield
+
     @contextmanager
     def _transport_ctx(self):
         """Guard a litellm transport call.
@@ -1980,26 +2018,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         and the noisy provider/litellm warnings are filtered out for the call.
         """
         with self._litellm_modify_params_ctx(self.modify_params):
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", category=DeprecationWarning, module="httpx.*"
-                )
-                warnings.filterwarnings(
-                    "ignore",
-                    message=r".*content=.*upload.*",
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings(
-                    "ignore",
-                    message="There is no current event loop",
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings("ignore", category=UserWarning)
-                warnings.filterwarnings(
-                    "ignore",
-                    category=DeprecationWarning,
-                    message="Accessing the 'model_fields' attribute.*",
-                )
+            with self._suppress_transport_warnings():
                 yield
 
     @asynccontextmanager
@@ -2010,26 +2029,7 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         plain blocking ``with`` statement around the lock.
         """
         async with self._alitellm_modify_params_ctx(self.modify_params):
-            with warnings.catch_warnings():
-                warnings.filterwarnings(
-                    "ignore", category=DeprecationWarning, module="httpx.*"
-                )
-                warnings.filterwarnings(
-                    "ignore",
-                    message=r".*content=.*upload.*",
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings(
-                    "ignore",
-                    message="There is no current event loop",
-                    category=DeprecationWarning,
-                )
-                warnings.filterwarnings("ignore", category=UserWarning)
-                warnings.filterwarnings(
-                    "ignore",
-                    category=DeprecationWarning,
-                    message="Accessing the 'model_fields' attribute.*",
-                )
+            with self._suppress_transport_warnings():
                 yield
 
     def _prepare_transport_kwargs(
@@ -2174,9 +2174,35 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         while this call is blocked on a concurrent transport call. The lock
         is a plain (non-reentrant) ``threading.Lock``, so it is safe to
         acquire on one thread and release on another.
+
+        Cancellation subtlety: if this coroutine is cancelled while waiting
+        (conversation stop/pause, timeout), the worker thread has already
+        started ``acquire()`` and cannot be interrupted -- it will still take
+        the lock. We therefore ``shield`` the acquire so the cancellation does
+        not mark it cancelled: the shielded future still resolves to the real
+        acquire result, and a done-callback releases the lock if it was
+        actually taken. Without this the lock would be acquired with nobody to
+        release it, permanently wedging every LLM call process-wide.
         """
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, self._litellm_modify_params_lock.acquire)
+        acquire = loop.run_in_executor(
+            self._litellm_modify_params_lock_executor,
+            self._litellm_modify_params_lock.acquire,
+        )
+        try:
+            await asyncio.shield(acquire)
+        except asyncio.CancelledError:
+            lock = self._litellm_modify_params_lock
+
+            def _release_if_acquired(fut: asyncio.Future) -> None:
+                # ``shield`` kept ``acquire`` alive, so its result reflects
+                # whether the worker thread actually took the lock. Release it
+                # if so, since the cancelled coroutine below never will.
+                if not fut.cancelled() and fut.exception() is None:
+                    lock.release()
+
+            acquire.add_done_callback(_release_if_acquired)
+            raise
         try:
             old = getattr(litellm, "modify_params", None)
             try:

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -1,5 +1,6 @@
 """Tests for LLM completion functionality, configuration, and metrics tracking."""
 
+import asyncio
 import threading
 from collections.abc import Sequence
 from typing import Any, ClassVar
@@ -131,6 +132,126 @@ def test_litellm_modify_params_context_serializes_threads():
     assert errors == []
     assert observed == [("first", True), ("second", False)]
     assert llm_module.litellm.modify_params == original
+
+
+class _CountingLock:
+    """threading.Lock wrapper that counts successful acquires/releases.
+
+    Lets a test deterministically wait for a release that happens on a
+    different thread than the one that acquired -- here, the release scheduled
+    by the async guard's cancellation done-callback.
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._counter_lock = threading.Lock()
+        self.acquired = 0
+        self.released = 0
+
+    def acquire(self, *args, **kwargs) -> bool:
+        got = self._lock.acquire(*args, **kwargs)
+        if got:
+            with self._counter_lock:
+                self.acquired += 1
+        return got
+
+    def release(self) -> None:
+        self._lock.release()
+        with self._counter_lock:
+            self.released += 1
+
+    def locked(self) -> bool:
+        return self._lock.locked()
+
+
+async def _await_condition(pred, timeout: float = 2.0) -> bool:
+    """Poll ``pred`` off-loop-friendly: yields so scheduled callbacks run."""
+    for _ in range(int(timeout / 0.01)):
+        if pred():
+            return True
+        await asyncio.sleep(0.01)
+    return pred()
+
+
+async def test_alitellm_modify_params_ctx_releases_lock_on_cancel(monkeypatch):
+    """Regression: cancelling the async modify-params guard while it waits for
+    the lock must not leak the lock.
+
+    The acquire runs on an uninterruptible worker thread, so it still takes the
+    lock after the coroutine is cancelled. If that acquisition is not released,
+    every subsequent LLM call in the process wedges forever -- worse than the
+    freeze this guard was added to fix.
+    """
+    # Isolate from the process-wide class lock so a regression here cannot
+    # wedge the rest of the suite.
+    lock = _CountingLock()
+    monkeypatch.setattr(LLM, "_litellm_modify_params_lock", lock)
+    llm = LLM.model_construct(modify_params=True)
+
+    # Simulate a concurrent *sync* holder (condenser / non-async agent step)
+    # that owns the lock for the whole round trip.
+    assert lock.acquire()
+
+    async def enter_guard():
+        async with llm._alitellm_modify_params_ctx(True):
+            pass  # never reached while the sync holder owns the lock
+
+    task = asyncio.ensure_future(enter_guard())
+    # Let the coroutine reach the blocking acquire() on the worker thread.
+    await asyncio.sleep(0.1)
+    assert not task.done()
+
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    # Release the sync holder so the (uninterruptible) worker-thread acquire
+    # can now complete -- this is what would leak the lock without the fix.
+    lock.release()
+
+    # The worker acquire completes (acquired == 2); the done-callback must then
+    # release it (released == 2). Poll deterministically on the counters rather
+    # than racing the callback for the lock's state.
+    settled = await _await_condition(lambda: lock.acquired >= 2 and lock.released >= 2)
+    assert settled, "cancelled acquire never released the lock (leak)"
+    assert not lock.locked(), "modify_params lock left held after cancellation"
+
+
+async def test_alitellm_modify_params_ctx_waits_off_event_loop(monkeypatch):
+    """The async guard must wait for the lock off the event-loop thread.
+
+    While a concurrent sync holder owns the lock, entering the guard must not
+    freeze the loop: a heartbeat coroutine keeps ticking, and the guard only
+    proceeds once the holder releases.
+    """
+    lock = threading.Lock()
+    monkeypatch.setattr(LLM, "_litellm_modify_params_lock", lock)
+    llm = LLM.model_construct(modify_params=True)
+
+    assert lock.acquire()  # sync holder
+
+    entered = asyncio.Event()
+
+    async def enter_guard():
+        async with llm._alitellm_modify_params_ctx(True):
+            entered.set()
+
+    task = asyncio.ensure_future(enter_guard())
+
+    # The loop stays responsive while the guard blocks on the held lock.
+    ticks = 0
+    for _ in range(10):
+        await asyncio.sleep(0.01)
+        ticks += 1
+    assert ticks == 10
+    assert not entered.is_set()
+    assert not task.done()
+
+    # Release -> guard acquires, runs its body, and releases cleanly.
+    lock.release()
+    await asyncio.wait_for(task, timeout=2)
+    assert entered.is_set()
+    assert not lock.locked()
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Fix deadlock bug

<!--
Human author: please replace this comment with a short note (at least 20 visible
characters) before marking ready for review.
AI agents: you must not edit this section.
-->

---

AGENT:

## Why

Reported in Slack: agent-server stops responding to *all* requests while it's waiting on an LLM response — most noticeable with local inference and especially during condensation.

Root cause: `LLM._litellm_modify_params_lock` is a class-level `threading.RLock`, shared by every `LLM` instance in the process, used to guard the global `litellm.modify_params` flag for the *entire duration* of a transport call. The async transport path (`_atransport_call`, and `aresponses`) entered this lock with a plain blocking `with` statement wrapped around an `await`:

```python
with self._transport_ctx():
    ret = await litellm_acompletion(...)   # suspended while still holding a real OS lock
```

Whenever a **synchronous** LLM call is in flight on a worker thread (e.g. `LLMSummarizingCondenser.get_condensation()` calling `self.llm.completion()`, or the sync `conversation.run()` fallback path for agents without `astep`), it holds this same lock for the full round-trip. If *any other* coroutine then makes an LLM call via the async path directly on the event-loop thread, its lock acquisition blocks synchronously — because the lock is owned by a different OS thread, `threading.RLock`/`Lock.acquire()` has no asyncio awareness. That freezes the entire event loop, and therefore every request agent-server is serving (health checks, cancel, pause, unrelated conversations), until the first slow call finishes.

## Summary
- Add `_alitellm_modify_params_ctx` / `_atransport_ctx`: async-safe variants that acquire the shared lock via `loop.run_in_executor(...)`, moving the *wait* for the lock off the event-loop thread instead of blocking it.
- Switch `_litellm_modify_params_lock` from `threading.RLock` to a plain `threading.Lock`, since acquire and release can now legitimately happen on different threads (executor worker acquires, event-loop coroutine releases).
- Route `_atransport_call` (chat completions) and `aresponses` (Responses API) through the new async-safe context managers. The sync paths (`_transport_call`, `responses`) are unchanged.

## Issue Number
N/A (reported in Slack, no GitHub issue filed yet)

## How to Test

### Unit-level reproduction

Reproduced the freeze and verified the fix with a standalone script (not part of the test suite) that:
1. Monkeypatches `litellm_completion`/`litellm_acompletion` to simulate a slow local-inference response.
2. Starts a **sync** `llm.completion()` call on a background thread (simulating a condenser or non-async agent step) that sleeps for 3s while holding the lock.
3. Concurrently starts a **fast async** `llm.acompletion()` call for an unrelated `LLM` instance directly on the event loop.
4. Runs a heartbeat coroutine ticking every 10ms to detect event-loop stalls.

Before the fix: the heartbeat's max tick gap was 2.71s (event loop fully frozen for the sync call's remaining duration), and the unrelated async call also took 2.71s to return.

After the fix: the heartbeat's max tick gap is ~0.02s (event loop stays responsive); the unrelated async call still has to wait its turn for the shared `litellm.modify_params` global (correctness preserved — no cross-talk between concurrent calls with different `modify_params` settings), but every *other* request the server is handling is no longer blocked.

### Real end-to-end validation (real agent-server process, real HTTP, no mocking)

To validate against the actual regression path (not just an in-process simulation), built a harness with:
- A real fake OpenAI-compatible HTTP server (`ThreadingHTTPServer`) serving `POST /v1/chat/completions` — instant response for a `fast-model`, 6s sleep for a `slow-model`.
- A real `openhands.agent_server` **subprocess** (the actual uvicorn app, unmodified), with a conversation configured with an `LLMSummarizingCondenser` pointed at `slow-model`.
- Real HTTP calls via `httpx` / the SDK's `RemoteConversation` client against the running server — no mocking of agent-server or SDK internals.

Steps:
1. Triggered `POST /{conversation_id}/condense` — this is the reported "especially during condensation" trigger: it runs the condenser's **synchronous** `LLM.completion()` on a worker thread (`event_service.condense()` → `run_in_executor`), holding the shared lock for the full 6s fake-network wait.
2. While that request was in flight, polled `GET /health` every 100ms on the main thread and measured throughput + latency — the sharpest signal for "is the event loop alive," since `/health` is untouched by the LLM lock and should always be fast if the loop is free.
3. Also started a second, unrelated conversation (fast model only) concurrently, to observe its behavior (see note below).

**Before the fix** (checked out the pre-fix `RLock` code on this same branch):
```
FAIL: /health latency spiked to 5.03s while condense() was in flight
FAIL: only 13/66 expected /health polls completed during the window
```
Only 13 of ~66 expected health checks completed in the 6.6s window — the rest queued up because the event loop thread itself was blocked trying to acquire the contested lock.

**After the fix** (this PR's code):
```
PASS: /health stayed responsive (max latency 0.06s) while condense() was blocked
PASS: 52/64 expected /health polls completed during the window
```
Full throughput, sub-100ms latency, even while the slow condense call was still blocked on the fake network for the full 6s.

Note: the second, unrelated conversation's own LLM call still has to wait its turn for the shared `litellm.modify_params` lock on **both** sides of the fix — that's correct and expected, since it's a real process-wide mutable flag and two calls can't safely run concurrently against it without risking cross-talk. What the fix changes is that contesting that lock no longer freezes the event loop (and therefore every *other* unrelated request the server is handling) while waiting.

### Full test suite

Also ran the full existing suite to confirm no regressions:
- `tests/sdk/llm/`, `tests/sdk/context/condenser/`, `tests/sdk/agent/`, `tests/sdk/conversation/`, `tests/agent_server/test_llm_router.py`: 2403 passed.
- `tests/agent_server/`: 1438 passed, 1 pre-existing flaky test deselected (`TestAutoTitle::test_autotitle_sets_title_on_first_user_message`, confirmed failing identically on unmodified `main`, unrelated to this change).
- `pre-commit` (ruff format, ruff lint, pycodestyle, pyright, import rules, tool registration): all passed.

## Video/Screenshots

N/A (backend concurrency fix, no UI surface).

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

No behavior change for the synchronous `completion()`/`responses()` paths — only the async paths (`acompletion()`/`aresponses()`, used by the native `arun`/`astep` fast path in agent-server) are affected.


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:bcbae37-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-bcbae37-python \
  ghcr.io/openhands/agent-server:bcbae37-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:bcbae37-golang-amd64
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-golang-amd64
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-golang-amd64
ghcr.io/openhands/agent-server:bcbae37-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:bcbae37-golang-arm64
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-golang-arm64
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-golang-arm64
ghcr.io/openhands/agent-server:bcbae37-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:bcbae37-java-amd64
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-java-amd64
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-java-amd64
ghcr.io/openhands/agent-server:bcbae37-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:bcbae37-java-arm64
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-java-arm64
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-java-arm64
ghcr.io/openhands/agent-server:bcbae37-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:bcbae37-python-amd64
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-python-amd64
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-python-amd64
ghcr.io/openhands/agent-server:bcbae37-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:bcbae37-python-arm64
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-python-arm64
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-python-arm64
ghcr.io/openhands/agent-server:bcbae37-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:bcbae37-golang
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-golang
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-golang
ghcr.io/openhands/agent-server:bcbae37-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:bcbae37-java
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-java
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-java
ghcr.io/openhands/agent-server:bcbae37-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:bcbae37-python
ghcr.io/openhands/agent-server:bcbae377da2ee04ded4b62adc0320ce5acef3f18-python
ghcr.io/openhands/agent-server:fix-agent-server-llm-lock-freeze-python
ghcr.io/openhands/agent-server:bcbae37-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `bcbae37-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `bcbae37-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->
