### PR TITLE
fix(profiles): deny-list skill selection (disabled_skills) + drop embedded skills

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -27,7 +27,7 @@ from openhands.agent_server.persistence import (
     get_settings_store,
 )
 from openhands.agent_server.profiles_router import MAX_PROFILES
-from openhands.agent_server.skills_service import discover_profile_skills_if_needed
+from openhands.agent_server.skills_service import discover_profile_skills
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import (
     ProfileLimitExceeded as LLMProfileLimitExceeded,
@@ -491,20 +491,20 @@ async def materialize_agent_profile(
     settings = get_settings_store(config).load() or PersistedSettings()
     mcp_config = settings.agent_settings.mcp_config
 
-    # Discover skills off the event loop so the dry-run can report which
-    # ``skill_refs`` resolve vs. dangle. A discovery failure must not 500 the
-    # preview: pass ``available_skills=None`` (catalog unknown — the dry-run then
-    # reports nothing dangling, rather than flagging every selected skill) and
-    # surface the failure as its own diagnostic below.
+    # Discover skills off the event loop so the dry-run can report which skills
+    # (catalog minus ``disabled_skills``) resolve. Only OpenHands profiles carry
+    # user/public skills; ACP profiles do not. A discovery failure must not 500
+    # the preview: pass ``available_skills=None`` and surface the failure as its
+    # own diagnostic below.
     discovery_error: str | None = None
-    try:
-        available_skills = await asyncio.to_thread(
-            discover_profile_skills_if_needed, profile
-        )
-    except Exception as exc:
-        available_skills = None
-        discovery_error = str(exc)
-        logger.warning("Skill discovery failed during materialize: %s", exc)
+    available_skills = None
+    if profile.agent_kind == "openhands":
+        try:
+            available_skills = await asyncio.to_thread(discover_profile_skills)
+        except Exception as exc:
+            available_skills = None
+            discovery_error = str(exc)
+            logger.warning("Skill discovery failed during materialize: %s", exc)
 
     llm_store = get_llm_profile_store()
     diagnostics = resolve_agent_profile_dry_run(

--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -300,8 +300,8 @@ async def save_agent_profile(
         profile = validate_agent_profile({**body, "name": name})
     except ValidationError as e:
         # Match FastAPI's request-validation shape (``detail`` is a list of
-        # error objects), but surface only ``loc``/``type`` (see
-        # safe_validation_error_detail's docstring).
+        # error objects): ``loc``/``type``/``msg`` (``input`` dropped — see
+        # safe_validation_error_detail's docstring for why msg is now safe).
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=safe_validation_error_detail(e),

--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -19,13 +19,7 @@ from typing import Annotated, Any
 from fastapi import APIRouter, HTTPException, Path, Request, status
 from pydantic import BaseModel, Field, ValidationError
 
-from openhands.agent_server._secrets_exposure import (
-    build_expose_context,
-    get_cipher,
-    get_config,
-    parse_expose_secrets_header,
-    translate_missing_cipher,
-)
+from openhands.agent_server._secrets_exposure import get_cipher, get_config
 from openhands.agent_server.persistence import (
     PersistedSettings,
     get_agent_profile_store,
@@ -213,7 +207,7 @@ def _seed_default_profile(
                 settings.agent_settings.llm, cipher
             )
         profile = build_seed_profile(settings.agent_settings, active_llm_profile)
-        store.save(profile, cipher=cipher, max_profiles=MAX_AGENT_PROFILES)
+        store.save(profile, max_profiles=MAX_AGENT_PROFILES)
 
         profile_id = str(profile.id)
         settings_store = get_settings_store(get_config(request))
@@ -266,31 +260,24 @@ async def list_agent_profiles(request: Request) -> AgentProfileListResponse:
 
 
 @agent_profiles_router.get("/{name}", response_model=AgentProfileDetailResponse)
-async def get_agent_profile(
-    request: Request, name: ProfileName
-) -> AgentProfileDetailResponse:
+async def get_agent_profile(name: ProfileName) -> AgentProfileDetailResponse:
     """Get a stored profile.
 
-    Use the ``X-Expose-Secrets`` header to control ``skills[].mcp_tools`` secret
-    exposure (``encrypted`` / ``plaintext``); absent, those values are masked.
+    A profile is secret-free at rest (#4017), so there is nothing to mask or
+    expose — unlike the LLM ``/api/profiles`` router, this endpoint has no
+    ``X-Expose-Secrets`` behavior.
     """
-    expose_mode = parse_expose_secrets_header(request)
-    cipher = get_cipher(request)
-
     store = get_agent_profile_store()
     try:
         with _store_errors():
-            profile = store.load(name, cipher=cipher)
+            profile = store.load(name)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Agent profile '{name}' not found",
         )
 
-    context = build_expose_context(expose_mode, cipher)
-    with translate_missing_cipher():
-        payload = profile.model_dump(mode="json", context=context)
-
+    payload = profile.model_dump(mode="json")
     return AgentProfileDetailResponse(name=name, profile=payload)
 
 
@@ -300,31 +287,29 @@ async def get_agent_profile(
     status_code=status.HTTP_201_CREATED,
 )
 async def save_agent_profile(
-    request: Request, name: ProfileName, body: dict[str, Any]
+    name: ProfileName, body: dict[str, Any]
 ) -> AgentProfileMutationResponse:
     """Save an ``AgentProfile`` under ``name`` (overwriting a namesake).
 
     The path ``name`` is authoritative — it overrides any ``name`` in the body.
-    With ``OH_SECRET_KEY`` configured, ``skills[].mcp_tools`` secrets are
-    encrypted at rest; otherwise they are redacted. Returns 409 if creating a
-    new profile would exceed ``MAX_AGENT_PROFILES``.
+    The profile is secret-free at rest (#4017), so no cipher/encryption is
+    involved. Returns 409 if creating a new profile would exceed
+    ``MAX_AGENT_PROFILES``.
     """
-    cipher = get_cipher(request)
     try:
         profile = validate_agent_profile({**body, "name": name})
     except ValidationError as e:
-        # Match FastAPI's request-validation shape (``detail`` is a list of error
-        # objects), but surface only ``loc``/``type`` — a nested mcp_tools
-        # FastMCP config error embeds the input (which may carry secrets) in
-        # ``msg``.
+        # Match FastAPI's request-validation shape (``detail`` is a list of
+        # error objects), but surface only ``loc``/``type`` (see
+        # safe_validation_error_detail's docstring).
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail=safe_validation_error_detail(e),
         )
     except Exception:
-        # Any other validation failure (e.g. SkillValidationError from a
-        # malformed mcp_tools, or a schema/migration error) is a client error,
-        # never a 500. Stay generic — these messages can embed the input.
+        # Any other validation failure (e.g. a schema/migration error) is a
+        # client error, never a 500. Stay generic — these messages can embed
+        # the input.
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail="Invalid agent profile",
@@ -339,7 +324,7 @@ async def save_agent_profile(
     try:
         with _store_errors():
             save_profile_preserving_identity(
-                store, profile, cipher=cipher, max_profiles=MAX_AGENT_PROFILES
+                store, profile, max_profiles=MAX_AGENT_PROFILES
             )
     except ProfileLimitExceeded:
         raise HTTPException(
@@ -489,18 +474,19 @@ async def materialize_agent_profile(
     than raising — the only error status is 404 (unknown profile name).
     resolved_settings is redacted (api_key_set booleans; no raw secrets).
     """
-    cipher = get_cipher(request)
-
     store = get_agent_profile_store()
     try:
         with _store_errors():
-            profile = store.load(name, cipher=cipher)
+            profile = store.load(name)
     except FileNotFoundError:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Agent profile '{name}' not found",
         )
 
+    # Still needed here (unlike the profile load above): resolve_agent_profile_
+    # dry_run uses it to decrypt the *referenced LLM profile's* own secret.
+    cipher = get_cipher(request)
     config = get_config(request)
     settings = get_settings_store(config).load() or PersistedSettings()
     mcp_config = settings.agent_settings.mcp_config

--- a/openhands-agent-server/openhands/agent_server/conversation_router.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_router.py
@@ -51,7 +51,6 @@ from openhands.sdk.marketplace.registry import (
 from openhands.sdk.plugin import PluginFetchError
 from openhands.sdk.profiles.resolver import (
     DanglingMcpServerRef,
-    DanglingSkillRef,
     ProfileNotFound,
 )
 from openhands.sdk.tool.client_tool import ClientToolRegistrationError
@@ -216,11 +215,6 @@ async def start_conversation(
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
             detail={"message": str(e), "dangling_mcp_server_refs": e.missing},
-        ) from e
-    except DanglingSkillRef as e:
-        raise HTTPException(
-            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
-            detail={"message": str(e), "dangling_skill_refs": e.missing},
         ) from e
     except ClientToolRegistrationError as e:
         raise HTTPException(

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -316,18 +316,11 @@ def _resolve_agent_from_profile(
         raise ValueError(f"Profile '{profile_name}' failed to resolve: {exc}") from exc
 
     if isinstance(settings_config, OpenHandsAgentSettings):
-        # Guarantee the on_token wiring this launch path needs (#4014): unlike
-        # an inline agent_settings launch, a client can't set llm.stream on a
-        # profile's referenced LLM ahead of time. This layer — not the SDK
-        # resolver, which runs for every caller including headless/scripted
-        # ones — is where the guarantee holds: this agent-server always wires
-        # _token_streaming_callback based on streaming_enabled (event_service.py,
-        # `any(llm.stream for llm in agent.get_all_llms())`), so setting it here
-        # is never a stream/callback mismatch. Forcing it any earlier (e.g. in
-        # the SDK resolver) would risk crashing a caller that resolves a
-        # profile without ever wiring on_token — acompletion now degrades
-        # gracefully in that case too (llm.py), but this is the layer that can
-        # make streaming actually happen instead of just failing safe.
+        # Force streaming so this launch path wires on_token: a client can't set
+        # llm.stream on a profile's referenced LLM ahead of time. Safe at this
+        # layer (not the SDK resolver) because this server wires the token
+        # callback whenever any llm.stream is set; a headless resolver caller
+        # that never wires on_token is covered by LLM's graceful degradation.
         settings_config = settings_config.model_copy(
             update={"llm": settings_config.llm.model_copy(update={"stream": True})}
         )

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -32,7 +32,7 @@ from openhands.agent_server.models import (
 )
 from openhands.agent_server.pub_sub import Subscriber
 from openhands.agent_server.server_details_router import update_last_execution_time
-from openhands.agent_server.skills_service import discover_profile_skills_if_needed
+from openhands.agent_server.skills_service import discover_profile_skills
 from openhands.agent_server.utils import safe_rmtree, utc_now
 from openhands.sdk import LLM, AgentContext, Event, Message
 from openhands.sdk.agent.base import AgentBase
@@ -267,7 +267,6 @@ def _resolve_agent_from_profile(
     Raises:
         ProfileNotFound: No stored profile has ``profile_id``.
         DanglingMcpServerRef: A referenced MCP server is absent from the global config.
-        DanglingSkillRef: A referenced skill is absent from the discovered catalog.
         ValueError: Profile load or settings validation failure.
     """
     from openhands.agent_server.persistence.store import (
@@ -293,15 +292,18 @@ def _resolve_agent_from_profile(
             f"Failed to load agent profile '{profile_name}': {exc}"
         ) from exc
 
-    # Both variants honor ``skill_refs``; the helper skips discovery when it
-    # selects none. A genuine discovery failure fails the launch loudly rather
-    # than silently producing a zero-skill agent.
-    try:
-        available_skills = discover_profile_skills_if_needed(profile)
-    except Exception as exc:
-        raise ValueError(
-            f"Skill discovery failed for profile '{profile_name}': {exc}"
-        ) from exc
+    # OpenHands profiles get the discovered catalog minus their ``disabled_skills``
+    # deny-list; ACP profiles carry no user/public skills so discovery is skipped.
+    # A genuine discovery failure fails the launch loudly rather than silently
+    # producing a zero-skill agent.
+    available_skills = None
+    if profile.agent_kind == "openhands":
+        try:
+            available_skills = discover_profile_skills()
+        except Exception as exc:
+            raise ValueError(
+                f"Skill discovery failed for profile '{profile_name}': {exc}"
+            ) from exc
 
     llm_store = get_llm_profile_store()
     try:

--- a/openhands-agent-server/openhands/agent_server/conversation_service.py
+++ b/openhands-agent-server/openhands/agent_server/conversation_service.py
@@ -275,6 +275,7 @@ def _resolve_agent_from_profile(
         get_llm_profile_store,
     )
     from openhands.sdk.profiles.resolver import ProfileNotFound, resolve_agent_profile
+    from openhands.sdk.settings.model import OpenHandsAgentSettings
 
     store = get_agent_profile_store()
     profile_name = store.name_for_id(profile_id)
@@ -282,7 +283,7 @@ def _resolve_agent_from_profile(
         raise ProfileNotFound(f"Agent profile with id '{profile_id}' not found")
 
     try:
-        profile = store.load(profile_name, cipher=cipher)
+        profile = store.load(profile_name)
     except FileNotFoundError:
         raise ProfileNotFound(
             f"Agent profile '{profile_name}' (id={profile_id}) not found"
@@ -313,6 +314,23 @@ def _resolve_agent_from_profile(
         )
     except (TypeError, ValueError) as exc:
         raise ValueError(f"Profile '{profile_name}' failed to resolve: {exc}") from exc
+
+    if isinstance(settings_config, OpenHandsAgentSettings):
+        # Guarantee the on_token wiring this launch path needs (#4014): unlike
+        # an inline agent_settings launch, a client can't set llm.stream on a
+        # profile's referenced LLM ahead of time. This layer — not the SDK
+        # resolver, which runs for every caller including headless/scripted
+        # ones — is where the guarantee holds: this agent-server always wires
+        # _token_streaming_callback based on streaming_enabled (event_service.py,
+        # `any(llm.stream for llm in agent.get_all_llms())`), so setting it here
+        # is never a stream/callback mismatch. Forcing it any earlier (e.g. in
+        # the SDK resolver) would risk crashing a caller that resolves a
+        # profile without ever wiring on_token — acompletion now degrades
+        # gracefully in that case too (llm.py), but this is the layer that can
+        # make streaming actually happen instead of just failing safe.
+        settings_config = settings_config.model_copy(
+            update={"llm": settings_config.llm.model_copy(update={"stream": True})}
+        )
 
     agent = settings_config.create_agent()
     # Browser is deliberately absent from the deterministic SDK default

--- a/openhands-agent-server/openhands/agent_server/skills_service.py
+++ b/openhands-agent-server/openhands/agent_server/skills_service.py
@@ -21,7 +21,6 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from time import monotonic
-from typing import TYPE_CHECKING
 
 from pydantic import BaseModel, ValidationError
 
@@ -55,10 +54,6 @@ from openhands.sdk.skills.utils import (
 )
 from openhands.sdk.utils import sanitized_env
 from openhands.sdk.utils.path import to_posix_path
-
-
-if TYPE_CHECKING:
-    from openhands.sdk.profiles import ACPAgentProfile, OpenHandsAgentProfile
 
 
 logger = get_logger(__name__)
@@ -458,20 +453,21 @@ def load_all_skills(
 
 
 def discover_profile_skills() -> list[Skill]:
-    """Skill catalog for ``AgentProfile.skill_refs`` resolution (#3868).
+    """Skill catalog an OpenHands profile launches with (#4017).
 
     Returns the merged user + public skills — the deterministic sources of
-    :func:`load_all_skills` that ``resolve_agent_profile`` filters by name.
-    ``load_all_skills`` already absorbs and logs benign per-source failures, so
-    this does not swallow errors: an unexpected failure propagates rather than
-    silently resolving the profile to a zero-skill agent.
+    :func:`load_all_skills`. ``resolve_agent_profile`` keeps all of them except
+    the profile's ``disabled_skills`` deny-list. ``load_all_skills`` already
+    absorbs and logs benign per-source failures, so this does not swallow errors:
+    an unexpected failure propagates rather than silently resolving the profile
+    to a zero-skill agent.
 
     Org / project skills need auth / workspace context not available at resolve
-    time, so they are not in this catalog (a follow-up). Because the resolver
-    now hard-fails dangling ``skill_refs`` (mirroring MCP), a profile that
-    selects an org/project skill via the picker would fail launch here until the
-    catalog is broadened — the SaaS app-server, which has that context, is
-    expected to supply the fuller catalog the same way it does for the picker.
+    time, so they are not in this catalog. That is safe under the deny-list
+    model: a skill missing from the catalog is simply never disabled (it stays
+    on when it does load, e.g. project skills loaded lazily by
+    ``LocalConversation``) — the old allow-list would instead have dangled and
+    failed the launch.
     """
     return list(
         load_all_skills(
@@ -481,21 +477,6 @@ def discover_profile_skills() -> list[Skill]:
             load_project=False,
         ).skills
     )
-
-
-def discover_profile_skills_if_needed(
-    profile: "OpenHandsAgentProfile | ACPAgentProfile",
-) -> list[Skill] | None:
-    """Discover the skill catalog a profile needs, or ``None`` to skip discovery.
-
-    ``skill_refs == []`` selects no discovered skills, so the (potentially
-    network-bound) discovery is skipped and the resolver receives ``None``. Any
-    other value — ``None`` (all discovered) or a name list — needs the catalog.
-    Centralizes the skip guard shared by conversation start and the dry-run.
-    """
-    if profile.skill_refs == []:
-        return None
-    return discover_profile_skills()
 
 
 def sync_public_skills() -> tuple[bool, str]:

--- a/openhands-sdk/openhands/sdk/context/agent_context.py
+++ b/openhands-sdk/openhands/sdk/context/agent_context.py
@@ -139,6 +139,18 @@ class AgentContext(BaseModel):
         ),
         json_schema_extra={"acp_compatible": True},
     )
+    disabled_skills: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of skills to EXCLUDE from this context — a deny-list applied "
+            "after every skill source is loaded (auto-loaded user/public, "
+            "explicit, and lazily-loaded project skills). A listed name absent "
+            "from the loaded set is a harmless no-op. [] (the default) keeps "
+            "every skill. This is the single, drift-tolerant skill-selection "
+            "mechanism (agent profiles set it from their own deny-list; #4017)."
+        ),
+        json_schema_extra={"acp_compatible": True},
+    )
     secrets: Mapping[str, SecretValue] | None = Field(
         default=None,
         description=(
@@ -218,29 +230,35 @@ class AgentContext(BaseModel):
 
     @model_validator(mode="after")
     def _load_auto_skills(self):
-        """Load user and/or legacy public skills if enabled."""
+        """Load user/legacy-public skills if enabled, then apply ``disabled_skills``."""
         # Any marketplace registration opts the context out of the legacy
         # public-skills path, even when the registration is resolution-only.
         include_public = self.load_public_skills and not self.registered_marketplaces
-        if not self.load_user_skills and not include_public:
-            return self
+        if self.load_user_skills or include_public:
+            auto_skills = load_available_skills(
+                work_dir=None,
+                include_user=self.load_user_skills,
+                include_project=False,
+                include_public=include_public,
+                marketplace_path=self.marketplace_path,
+            )
 
-        auto_skills = load_available_skills(
-            work_dir=None,
-            include_user=self.load_user_skills,
-            include_project=False,
-            include_public=include_public,
-            marketplace_path=self.marketplace_path,
-        )
+            # Explicit skills are authoritative; auto-loaded skills only fill gaps.
+            explicit_names = {skill.name for skill in self.skills}
+            for name in auto_skills:
+                if name in explicit_names:
+                    logger.debug(
+                        f"Skipping auto-loaded skill '{name}' "
+                        "(already in explicit skills)"
+                    )
+            self.skills = merge_skills_by_name(self.skills, auto_skills.values())
 
-        # Explicit skills are authoritative; auto-loaded skills only fill gaps.
-        explicit_names = {skill.name for skill in self.skills}
-        for name in auto_skills:
-            if name in explicit_names:
-                logger.debug(
-                    f"Skipping auto-loaded skill '{name}' (already in explicit skills)"
-                )
-        self.skills = merge_skills_by_name(self.skills, auto_skills.values())
+        # Deny-list: drop disabled skills from whatever ended up loaded (explicit
+        # + auto). A disabled name that isn't present is a harmless no-op — this
+        # is the drift-tolerant selection model that replaced allow-list refs.
+        if self.disabled_skills:
+            disabled = set(self.disabled_skills)
+            self.skills = [s for s in self.skills if s.name not in disabled]
         return self
 
     def get_secret_infos(self) -> list[dict[str, str | None]]:

--- a/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
+++ b/openhands-sdk/openhands/sdk/conversation/impl/local_conversation.py
@@ -937,6 +937,12 @@ class LocalConversation(BaseConversation):
                 merged_skills = merge_skills_by_name(
                     project_skills.values(), merged_context.skills
                 )
+                # Honor the context deny-list here too: model_copy below bypasses
+                # AgentContext's validator, and a project skill can match a
+                # disabled name (absent name => harmless no-op).
+                if merged_context.disabled_skills:
+                    disabled = set(merged_context.disabled_skills)
+                    merged_skills = [s for s in merged_skills if s.name not in disabled]
                 merged_context = merged_context.model_copy(
                     update={"skills": merged_skills}
                 )

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1387,18 +1387,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming and on_token is None:
-            # Degrade gracefully instead of hard-raising: a stream/callback
-            # mismatch (e.g. a profile-launched conversation whose LLM has
-            # stream=True but no on_token wired) must not crash the run (#4014).
-            logger.warning(
-                "Streaming requested but no on_token callback was provided; "
-                "falling back to a non-streaming call."
-            )
-            enable_streaming = False
-        # Unconditional: a caller-supplied stream=True must be cleared on
-        # degrade, not just left un-set-to-True.
-        kwargs["stream"] = enable_streaming
+        if enable_streaming:
+            if on_token is None:
+                raise ValueError("Streaming requires an on_token callback")
+            kwargs["stream"] = True
 
         (
             formatted_messages,
@@ -1484,18 +1476,10 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming and on_token is None:
-            # Degrade gracefully instead of hard-raising: a stream/callback
-            # mismatch (e.g. a profile-launched conversation whose LLM has
-            # stream=True but no on_token wired) must not crash the run (#4014).
-            logger.warning(
-                "Streaming requested but no on_token callback was provided; "
-                "falling back to a non-streaming call."
-            )
-            enable_streaming = False
-        # Unconditional: a caller-supplied stream=True must be cleared on
-        # degrade, not just left un-set-to-True.
-        kwargs["stream"] = enable_streaming
+        if enable_streaming:
+            if on_token is None:
+                raise ValueError("Streaming requires an on_token callback")
+            kwargs["stream"] = True
 
         (
             formatted_messages,
@@ -1598,19 +1582,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        # We allow on_token to be None for subscription mode.
-        if user_enable_streaming and on_token is None and not self.is_subscription:
-            # Degrade gracefully instead of hard-raising: a stream/callback
-            # mismatch (e.g. a profile-launched conversation whose LLM has
-            # stream=True but no on_token wired) must not crash the run (#4014).
-            logger.warning(
-                "Streaming requested but no on_token callback was provided; "
-                "falling back to a non-streaming call."
-            )
-            user_enable_streaming = False
-        # Unconditional: a caller-supplied stream=True must be cleared on
-        # degrade, not just left un-set-to-True.
-        kwargs["stream"] = user_enable_streaming
+        if user_enable_streaming:
+            # We allow on_token to be None for subscription mode
+            if on_token is None and not self.is_subscription:
+                raise ValueError("Streaming requires an on_token callback")
+            kwargs["stream"] = True
 
         (
             instructions,
@@ -1746,19 +1722,11 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        # We allow on_token to be None for subscription mode.
-        if user_enable_streaming and on_token is None and not self.is_subscription:
-            # Degrade gracefully instead of hard-raising: a stream/callback
-            # mismatch (e.g. a profile-launched conversation whose LLM has
-            # stream=True but no on_token wired) must not crash the run (#4014).
-            logger.warning(
-                "Streaming requested but no on_token callback was provided; "
-                "falling back to a non-streaming call."
-            )
-            user_enable_streaming = False
-        # Unconditional: a caller-supplied stream=True must be cleared on
-        # degrade, not just left un-set-to-True.
-        kwargs["stream"] = user_enable_streaming
+        if user_enable_streaming:
+            # We allow on_token to be None for subscription mode
+            if on_token is None and not self.is_subscription:
+                raise ValueError("Streaming requires an on_token callback")
+            kwargs["stream"] = True
 
         (
             instructions,

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1387,9 +1387,16 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming:
-            if on_token is None:
-                raise ValueError("Streaming requires an on_token callback")
+        if enable_streaming and on_token is None:
+            # Gracefully degrade to non-streaming rather than crashing a run when
+            # streaming is requested without a callback wired. See #4014.
+            logger.debug(
+                "Streaming requested without an on_token callback; "
+                "falling back to a non-streaming completion."
+            )
+            enable_streaming = False
+            kwargs.pop("stream", None)
+        elif enable_streaming:
             kwargs["stream"] = True
 
         (
@@ -1476,9 +1483,16 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming:
-            if on_token is None:
-                raise ValueError("Streaming requires an on_token callback")
+        if enable_streaming and on_token is None:
+            # Gracefully degrade to non-streaming rather than crashing a run when
+            # streaming is requested without a callback wired. See #4014.
+            logger.debug(
+                "Streaming requested without an on_token callback; "
+                "falling back to a non-streaming completion."
+            )
+            enable_streaming = False
+            kwargs.pop("stream", None)
+        elif enable_streaming:
             kwargs["stream"] = True
 
         (
@@ -1582,10 +1596,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if user_enable_streaming:
-            # We allow on_token to be None for subscription mode
-            if on_token is None and not self.is_subscription:
-                raise ValueError("Streaming requires an on_token callback")
+        if user_enable_streaming and on_token is None and not self.is_subscription:
+            # Gracefully degrade to non-streaming rather than crashing a run when
+            # streaming is requested without a callback wired (subscription mode
+            # is exempt — it streams internally without an on_token). See #4014.
+            logger.debug(
+                "Streaming requested without an on_token callback; "
+                "falling back to a non-streaming responses call."
+            )
+            user_enable_streaming = False
+            kwargs.pop("stream", None)
+        elif user_enable_streaming:
             kwargs["stream"] = True
 
         (
@@ -1722,10 +1743,17 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if user_enable_streaming:
-            # We allow on_token to be None for subscription mode
-            if on_token is None and not self.is_subscription:
-                raise ValueError("Streaming requires an on_token callback")
+        if user_enable_streaming and on_token is None and not self.is_subscription:
+            # Gracefully degrade to non-streaming rather than crashing a run when
+            # streaming is requested without a callback wired (subscription mode
+            # is exempt — it streams internally without an on_token). See #4014.
+            logger.debug(
+                "Streaming requested without an on_token callback; "
+                "falling back to a non-streaming responses call."
+            )
+            user_enable_streaming = False
+            kwargs.pop("stream", None)
+        elif user_enable_streaming:
             kwargs["stream"] = True
 
         (

--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1387,10 +1387,18 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming:
-            if on_token is None:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        if enable_streaming and on_token is None:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = enable_streaming
 
         (
             formatted_messages,
@@ -1476,10 +1484,18 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming:
-            if on_token is None:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        if enable_streaming and on_token is None:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = enable_streaming
 
         (
             formatted_messages,
@@ -1582,11 +1598,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if user_enable_streaming:
-            # We allow on_token to be None for subscription mode
-            if on_token is None and not self.is_subscription:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        # We allow on_token to be None for subscription mode.
+        if user_enable_streaming and on_token is None and not self.is_subscription:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            user_enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = user_enable_streaming
 
         (
             instructions,
@@ -1722,11 +1746,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if user_enable_streaming:
-            # We allow on_token to be None for subscription mode
-            if on_token is None and not self.is_subscription:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        # We allow on_token to be None for subscription mode.
+        if user_enable_streaming and on_token is None and not self.is_subscription:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            user_enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = user_enable_streaming
 
         (
             instructions,

--- a/openhands-sdk/openhands/sdk/profiles/__init__.py
+++ b/openhands-sdk/openhands/sdk/profiles/__init__.py
@@ -28,7 +28,6 @@ from openhands.sdk.profiles.profile_refs import (
 from openhands.sdk.profiles.resolver import (
     AgentProfileDiagnostics,
     DanglingMcpServerRef,
-    DanglingSkillRef,
     ProfileNotFound,
     resolve_agent_profile,
     resolve_agent_profile_dry_run,
@@ -48,7 +47,6 @@ __all__ = [
     "AgentProfileStore",
     "AgentProfileStoreProtocol",
     "DanglingMcpServerRef",
-    "DanglingSkillRef",
     "LaunchedAgentProfile",
     "OpenHandsAgentProfile",
     "ProfileLimitExceeded",

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -30,11 +30,10 @@ from openhands.sdk.settings.model import (
     LLMSummarizingCondenserSettings,
     VerificationSettings,
 )
-from openhands.sdk.skills import Skill
 from openhands.sdk.tool import Tool
 
 
-AGENT_PROFILE_SCHEMA_VERSION = 1
+AGENT_PROFILE_SCHEMA_VERSION = 2
 
 
 class ProfileVerificationSettings(BaseModel):
@@ -112,22 +111,20 @@ class AgentProfileBase(BaseModel):
             "null = all; [] = none; a non-null list = filter to the named keys."
         ),
     )
-    # On the base because both variants consume skills as prompt context. null
-    # (all discovered) and [] (none) are distinct; the default is [] — NOT null,
-    # unlike ``mcp_server_refs`` — because auto-injecting the whole catalog isn't
-    # behavior-preserving and a profile persisted before this field existed must
-    # not silently start pulling it on load. ``default_factory=list`` makes an
-    # absent field ([]) distinct from an explicit ``null`` (None), the opt-in for
-    # "all discovered".
+    # On the base because both variants consume skills as prompt context. A
+    # true twin of ``mcp_server_refs``: null = all discovered, [] = none, a
+    # non-null list filters to the named skills. OpenHands profiles default to
+    # null (all of the server-owned catalog) — there is no embedded ``skills``
+    # to fall back to anymore (#4017), so an unset field must mean "all",
+    # mirroring ``mcp_server_refs``. ``ACPAgentProfile`` overrides this default
+    # back to ``[]`` (see its docstring).
     skill_refs: list[str] | None = Field(
-        default_factory=list,
+        default=None,
         description=(
             "Which of the server-discovered skills to expose in the agent's "
             "prompt, selected by name (mirrors ``mcp_server_refs`` over "
-            "``mcp_config``). null = all discovered; [] = none (the default); a "
-            "non-null list = filter to the named skills. For OpenHands profiles, "
-            "any explicitly embedded ``skills`` are always included on top of "
-            "the filtered set."
+            "``mcp_config``). null = all discovered (the default); [] = none; "
+            "a non-null list = filter to the named skills."
         ),
     )
 
@@ -171,10 +168,6 @@ class OpenHandsAgentProfile(AgentProfileBase):
             "server's standard tool set; [] = an explicitly bare agent; a "
             "non-empty list is used exactly as given."
         ),
-    )
-    skills: list[Skill] = Field(
-        default_factory=list,
-        description="Skills that extend the agent's context.",
     )
     system_message_suffix: str | None = Field(
         default=None,
@@ -227,9 +220,18 @@ class ACPAgentProfile(AgentProfileBase):
             "ACP-delegating agent."
         ),
     )
-    # ``skill_refs`` is inherited from ``AgentProfileBase`` with the safe []
-    # default (no discovered skills injected unless a null/list is set) — ACP
-    # agents own their tooling, so that default is exactly right here.
+    # Overrides the base's null(=all) default back to [] (=none): ACP agents
+    # own their tooling and prompt construction, so no discovered skills are
+    # injected unless a profile explicitly opts in with a null/list value.
+    skill_refs: list[str] | None = Field(
+        default_factory=list,
+        description=(
+            "Which of the server-discovered skills to expose in the agent's "
+            "prompt, selected by name. null = all discovered; [] = none (the "
+            "default for ACP profiles); a non-null list = filter to the named "
+            "skills."
+        ),
+    )
     acp_server: ACPServerKind = Field(
         default="claude-code",
         description=(
@@ -317,10 +319,31 @@ validate/construct instances from raw payloads.
 
 PersistedProfileMigrator = Callable[[dict[str, Any]], dict[str, Any]]
 
+
+def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
+    """v1→v2: drop the embedded ``skills`` field (#4017).
+
+    Agent Profiles has no production data yet (both consumers — canvas#1571 and
+    OpenHands#15060 — are still open), so this is belt-and-suspenders for a
+    stray hand-authored payload rather than a real data migration: the field is
+    simply dropped, not folded into ``skill_refs`` by name, since a v1 payload's
+    ``skill_refs=[]`` default meant "no further discovery" was already implied
+    by the embed (see the old field's docstring). A v1 payload's ``skill_refs``
+    is otherwise left untouched by this migration; only the model's *class*
+    default changes going forward, which does not apply to already-serialized
+    values.
+    """
+    migrated = dict(payload)
+    migrated.pop("skills", None)
+    migrated["schema_version"] = 2
+    return migrated
+
+
 # Registered per *source* schema_version; each migrator returns a payload with
-# an advanced ``schema_version``. Empty while only v1 exists — the first schema
-# bump adds ``{1: _migrate_v1_to_v2}`` here.
-_AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {}
+# an advanced ``schema_version``.
+_AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {
+    1: _migrate_v1_to_v2,
+}
 
 
 def _apply_persisted_migrations(payload: dict[str, Any]) -> dict[str, Any]:
@@ -405,13 +428,16 @@ def validate_agent_profile(
 
 
 def safe_validation_error_detail(exc: ValidationError) -> list[dict[str, Any]]:
-    """Secret-safe ``detail`` for a 422 from a failed profile validation.
+    """Conservative ``detail`` for a 422 from a failed profile validation.
 
-    Surfaces only ``loc``/``type`` per error and **drops ``msg``/``input``** — a
-    nested ``skills[].mcp_tools`` FastMCP config error embeds the offending
-    input, which may carry secrets. Shaped like FastAPI's request-validation ``detail``
-    (a list of error objects) so routers can hand it straight to ``HTTPException``.
-    Hoisted from the agent-server router so the local and cloud routers redact
-    identically.
+    Surfaces only ``loc``/``type`` per error and **drops ``msg``/``input``**.
+    Since the profile dropped its last secret-bearing field (embedded
+    ``skills[].mcp_tools``, #4017), no field can currently embed a secret in a
+    validation error — this redaction is now defense-in-depth rather than
+    strictly required, kept so error shape doesn't change if a future field
+    reintroduces one. Shaped like FastAPI's request-validation ``detail`` (a
+    list of error objects) so routers can hand it straight to
+    ``HTTPException``. Hoisted from the agent-server router so the local and
+    cloud routers redact identically.
     """
     return [{"loc": list(err["loc"]), "type": str(err["type"])} for err in exc.errors()]

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -321,17 +321,11 @@ PersistedProfileMigrator = Callable[[dict[str, Any]], dict[str, Any]]
 
 
 def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
-    """v1→v2: drop the embedded ``skills`` field (#4017).
+    """v1→v2: drop the embedded ``skills`` field.
 
-    Agent Profiles has no production data yet (both consumers — canvas#1571 and
-    OpenHands#15060 — are still open), so this is belt-and-suspenders for a
-    stray hand-authored payload rather than a real data migration: the field is
-    simply dropped, not folded into ``skill_refs`` by name, since a v1 payload's
-    ``skill_refs=[]`` default meant "no further discovery" was already implied
-    by the embed (see the old field's docstring). A v1 payload's ``skill_refs``
-    is otherwise left untouched by this migration; only the model's *class*
-    default changes going forward, which does not apply to already-serialized
-    values.
+    No production data exists yet, so this only guards a stray hand-authored
+    payload. The field is dropped, not folded into ``skill_refs``; a v1
+    payload's ``skill_refs`` is left untouched.
     """
     migrated = dict(payload)
     migrated.pop("skills", None)

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -33,7 +33,7 @@ from openhands.sdk.settings.model import (
 from openhands.sdk.tool import Tool
 
 
-AGENT_PROFILE_SCHEMA_VERSION = 3
+AGENT_PROFILE_SCHEMA_VERSION = 1
 
 
 class ProfileVerificationSettings(BaseModel):
@@ -314,38 +314,15 @@ validate/construct instances from raw payloads.
 PersistedProfileMigrator = Callable[[dict[str, Any]], dict[str, Any]]
 
 
-def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
-    """v1→v2: drop the embedded ``skills`` field.
-
-    No production data exists yet, so this only guards a stray hand-authored
-    payload. The field is dropped, not folded into a ref list.
-    """
-    migrated = dict(payload)
-    migrated.pop("skills", None)
-    migrated["schema_version"] = 2
-    return migrated
-
-
-def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
-    """v2→v3: drop the allow-list ``skill_refs`` for the ``disabled_skills`` deny-list.
-
-    Skills are now selected by exclusion, so the former ``skill_refs`` name
-    filter is dropped. No production profile carries a real subset (no skill
-    picker ever shipped), so nothing is folded forward; an omitted
-    ``disabled_skills`` defaults to [] = all discovered skills.
-    """
-    migrated = dict(payload)
-    migrated.pop("skill_refs", None)
-    migrated["schema_version"] = 3
-    return migrated
-
-
-# Registered per *source* schema_version; each migrator returns a payload with
-# an advanced ``schema_version``.
-_AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {
-    1: _migrate_v1_to_v2,
-    2: _migrate_v2_to_v3,
-}
+# No migrations: the profile model has never shipped to prod or any client, so
+# v1 is a clean baseline — embedded ``skills`` and the allow-list ``skill_refs``
+# never existed in a released profile, so there is nothing to migrate. This
+# registry is the home for the first *real* post-ship schema change; until then
+# ``_apply_persisted_migrations`` is a validating no-op and a stray removed key
+# (``skills`` / ``skill_refs``) is rejected by ``extra="forbid"`` at validation
+# rather than silently dropped. Register migrators here (keyed by source version)
+# when the first shipped schema needs to evolve.
+_AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {}
 
 
 def _apply_persisted_migrations(payload: dict[str, Any]) -> dict[str, Any]:

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile.py
@@ -33,7 +33,7 @@ from openhands.sdk.settings.model import (
 from openhands.sdk.tool import Tool
 
 
-AGENT_PROFILE_SCHEMA_VERSION = 2
+AGENT_PROFILE_SCHEMA_VERSION = 3
 
 
 class ProfileVerificationSettings(BaseModel):
@@ -103,28 +103,18 @@ class AgentProfileBase(BaseModel):
         description="Monotonic revision counter, bumped on each saved edit.",
     )
     # null = all of the user's MCP servers; [] = none; a non-null list filters
-    # to the named keys. null and [] are deliberately distinct.
+    # to the named keys. null and [] are deliberately distinct. MCP servers are
+    # user-configured and persisted, so this reference is safe: every name that
+    # can be referenced is present in ``mcp_config``. Skills are NOT modeled this
+    # way — they are discovered from many lazy/incomplete sources, so a profile
+    # selects them by *exclusion* (``OpenHandsAgentProfile.disabled_skills``, a
+    # deny-list) rather than by an allow-list of names that can dangle. See the
+    # #4017 architecture discussion.
     mcp_server_refs: list[str] | None = Field(
         default=None,
         description=(
             "Which of the user's globally configured MCP servers to expose. "
             "null = all; [] = none; a non-null list = filter to the named keys."
-        ),
-    )
-    # On the base because both variants consume skills as prompt context. A
-    # true twin of ``mcp_server_refs``: null = all discovered, [] = none, a
-    # non-null list filters to the named skills. OpenHands profiles default to
-    # null (all of the server-owned catalog) — there is no embedded ``skills``
-    # to fall back to anymore (#4017), so an unset field must mean "all",
-    # mirroring ``mcp_server_refs``. ``ACPAgentProfile`` overrides this default
-    # back to ``[]`` (see its docstring).
-    skill_refs: list[str] | None = Field(
-        default=None,
-        description=(
-            "Which of the server-discovered skills to expose in the agent's "
-            "prompt, selected by name (mirrors ``mcp_server_refs`` over "
-            "``mcp_config``). null = all discovered (the default); [] = none; "
-            "a non-null list = filter to the named skills."
         ),
     )
 
@@ -173,6 +163,18 @@ class OpenHandsAgentProfile(AgentProfileBase):
         default=None,
         description="Optional suffix appended to the system prompt.",
     )
+    disabled_skills: list[str] = Field(
+        default_factory=list,
+        description=(
+            "Names of server-discovered skills to EXCLUDE from this agent's "
+            "prompt — a deny-list over the discovered catalog. [] (the default) "
+            "= all discovered skills; a listed name that is absent from the "
+            "catalog is simply a no-op, so the field never fails a launch when "
+            "the catalog drifts. Replaces the former allow-list ``skill_refs`` "
+            "(#4017): skills are discovered from many incomplete sources, so "
+            "exclusion is the only selection model that can't dangle."
+        ),
+    )
     condenser: CondenserSettingsConfig = Field(
         default_factory=LLMSummarizingCondenserSettings,
         description="Condenser settings for the agent.",
@@ -220,18 +222,10 @@ class ACPAgentProfile(AgentProfileBase):
             "ACP-delegating agent."
         ),
     )
-    # Overrides the base's null(=all) default back to [] (=none): ACP agents
-    # own their tooling and prompt construction, so no discovered skills are
-    # injected unless a profile explicitly opts in with a null/list value.
-    skill_refs: list[str] | None = Field(
-        default_factory=list,
-        description=(
-            "Which of the server-discovered skills to expose in the agent's "
-            "prompt, selected by name. null = all discovered; [] = none (the "
-            "default for ACP profiles); a non-null list = filter to the named "
-            "skills."
-        ),
-    )
+    # No skill-selection field: ACP agents own their tooling and prompt
+    # construction, so no user/public discovered skills are injected. (Only
+    # repo-scoped project skills reach an ACP agent, via the resolver's
+    # ``load_project_skills`` — see #4019 for whether even those should.)
     acp_server: ACPServerKind = Field(
         default="claude-code",
         description=(
@@ -324,8 +318,7 @@ def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
     """v1→v2: drop the embedded ``skills`` field.
 
     No production data exists yet, so this only guards a stray hand-authored
-    payload. The field is dropped, not folded into ``skill_refs``; a v1
-    payload's ``skill_refs`` is left untouched.
+    payload. The field is dropped, not folded into a ref list.
     """
     migrated = dict(payload)
     migrated.pop("skills", None)
@@ -333,10 +326,25 @@ def _migrate_v1_to_v2(payload: dict[str, Any]) -> dict[str, Any]:
     return migrated
 
 
+def _migrate_v2_to_v3(payload: dict[str, Any]) -> dict[str, Any]:
+    """v2→v3: drop the allow-list ``skill_refs`` for the ``disabled_skills`` deny-list.
+
+    Skills are now selected by exclusion, so the former ``skill_refs`` name
+    filter is dropped. No production profile carries a real subset (no skill
+    picker ever shipped), so nothing is folded forward; an omitted
+    ``disabled_skills`` defaults to [] = all discovered skills.
+    """
+    migrated = dict(payload)
+    migrated.pop("skill_refs", None)
+    migrated["schema_version"] = 3
+    return migrated
+
+
 # Registered per *source* schema_version; each migrator returns a payload with
 # an advanced ``schema_version``.
 _AGENT_PROFILE_MIGRATIONS: dict[int, PersistedProfileMigrator] = {
     1: _migrate_v1_to_v2,
+    2: _migrate_v2_to_v3,
 }
 
 
@@ -422,16 +430,20 @@ def validate_agent_profile(
 
 
 def safe_validation_error_detail(exc: ValidationError) -> list[dict[str, Any]]:
-    """Conservative ``detail`` for a 422 from a failed profile validation.
+    """FastAPI-shaped ``detail`` for a 422 from a failed profile validation.
 
-    Surfaces only ``loc``/``type`` per error and **drops ``msg``/``input``**.
-    Since the profile dropped its last secret-bearing field (embedded
-    ``skills[].mcp_tools``, #4017), no field can currently embed a secret in a
-    validation error — this redaction is now defense-in-depth rather than
-    strictly required, kept so error shape doesn't change if a future field
-    reintroduces one. Shaped like FastAPI's request-validation ``detail`` (a
-    list of error objects) so routers can hand it straight to
-    ``HTTPException``. Hoisted from the agent-server router so the local and
-    cloud routers redact identically.
+    Surfaces ``loc``/``type``/``msg`` per error. The profile carries no
+    secret-bearing field — embedded ``skills[].mcp_tools`` was removed in #4017,
+    and the ``disabled_skills`` deny-list holds only skill *names* — so the full
+    validation message is safe to return, and a client needs it to see *why* a
+    save failed (e.g. an invalid ``acp_server`` value). ``input`` is still
+    dropped: it echoes the whole rejected payload, which is noisy and not needed
+    to explain the error. Shaped like FastAPI's request-validation ``detail`` (a
+    list of error objects) so routers can hand it straight to ``HTTPException``.
+    Hoisted from the agent-server router so the local and cloud routers behave
+    identically.
     """
-    return [{"loc": list(err["loc"]), "type": str(err["type"])} for err in exc.errors()]
+    return [
+        {"loc": list(err["loc"]), "type": str(err["type"]), "msg": str(err["msg"])}
+        for err in exc.errors()
+    ]

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
@@ -50,8 +50,9 @@ class AgentProfileStore:
     JSON file per profile under ``~/.openhands/agent-profiles``, the filename is
     the (renameable) profile ``name``, and the stable ``id`` (uuid) lives inside
     the file. The profile is secret-free at rest — every field is a reference
-    (``llm_profile_ref``, ``mcp_server_refs``, ``skill_refs``) or a plain value,
-    so no cipher/encryption is needed to persist or load one (#4017).
+    (``llm_profile_ref``, ``mcp_server_refs``), a deny-list of names
+    (``disabled_skills``), or a plain value, so no cipher/encryption is needed to
+    persist or load one (#4017).
     """
 
     def __init__(self, base_dir: Path | str | None = None) -> None:

--- a/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
+++ b/openhands-sdk/openhands/sdk/profiles/agent_profile_store.py
@@ -24,7 +24,6 @@ if TYPE_CHECKING:
         ACPAgentProfile,
         OpenHandsAgentProfile,
     )
-    from openhands.sdk.utils.cipher import Cipher
 
 _DEFAULT_PROFILE_DIR: Final[Path] = Path.home() / ".openhands" / "agent-profiles"
 _LOCK_TIMEOUT_SECONDS: Final[float] = 30.0
@@ -50,9 +49,9 @@ class AgentProfileStore:
     Mirrors :class:`~openhands.sdk.llm.llm_profile_store.LLMProfileStore`: one
     JSON file per profile under ``~/.openhands/agent-profiles``, the filename is
     the (renameable) profile ``name``, and the stable ``id`` (uuid) lives inside
-    the file. The profile is secret-free at rest except for
-    ``skills[].mcp_tools`` env/headers, which are masked by default and
-    encrypted when a ``cipher`` is supplied.
+    the file. The profile is secret-free at rest — every field is a reference
+    (``llm_profile_ref``, ``mcp_server_refs``, ``skill_refs``) or a plain value,
+    so no cipher/encryption is needed to persist or load one (#4017).
     """
 
     def __init__(self, base_dir: Path | str | None = None) -> None:
@@ -136,17 +135,14 @@ class AgentProfileStore:
         self,
         profile: OpenHandsAgentProfile | ACPAgentProfile,
         *,
-        cipher: Cipher | None = None,
         max_profiles: int | None = None,
     ) -> None:
         """Save a profile under its own ``name``, overwriting any namesake.
 
-        With no ``cipher`` the profile is secret-free at rest:
-        ``skills[].mcp_tools`` env/headers are redacted. With a ``cipher`` those
-        values are encrypted (recoverable) rather than redacted; every other
-        field is a reference and dumps in the clear regardless. When
-        ``max_profiles`` is set, creating a *new* profile beyond the cap raises
-        ``ProfileLimitExceeded`` under the same lock as the write.
+        The profile is secret-free at rest, so it dumps in the clear with no
+        cipher/encryption needed. When ``max_profiles`` is set, creating a
+        *new* profile beyond the cap raises ``ProfileLimitExceeded`` under the
+        same lock as the write.
 
         Raises:
             ValueError: If ``profile.name`` is not a valid profile name.
@@ -154,12 +150,7 @@ class AgentProfileStore:
             TimeoutError: If the lock cannot be acquired.
         """
         profile_path = self._get_profile_path(profile.name)
-
-        # Cipher present => encrypt mcp_tools secrets; absent => redact them.
-        context: dict[str, Any] = (
-            {"cipher": cipher, "expose_secrets": "encrypted"} if cipher else {}
-        )
-        payload = profile.model_dump(mode="json", context=context)
+        payload = profile.model_dump(mode="json")
 
         with self._acquire_lock():
             if max_profiles is not None and not profile_path.exists():
@@ -186,15 +177,11 @@ class AgentProfileStore:
     def load(
         self,
         name: str,
-        *,
-        cipher: Cipher | None = None,
     ) -> OpenHandsAgentProfile | ACPAgentProfile:
         """Load and validate the profile stored under ``name``.
 
-        A ``cipher`` is threaded through the validation context for parity with
-        ``save``, so encrypted ``skills[].mcp_tools`` secrets are restored as
-        ``SecretStr`` values. Reference fields (``llm_profile_ref`` etc.) carry
-        no secret and load unchanged.
+        All fields are references or plain values, so no cipher is needed to
+        load one.
 
         Raises:
             FileNotFoundError: If ``name`` does not exist.
@@ -213,8 +200,7 @@ class AgentProfileStore:
 
             try:
                 data = json.loads(profile_path.read_text())
-                context = {"cipher": cipher} if cipher else None
-                profile = validate_agent_profile(data, context=context)
+                profile = validate_agent_profile(data)
             except Exception as e:
                 raise ValueError(f"Failed to load profile `{name}`: {e}") from e
 
@@ -244,8 +230,7 @@ class AgentProfileStore:
         """Atomically rename a profile, keeping the in-file ``name`` in sync.
 
         Unlike a bare file move this also rewrites the persisted ``name`` field
-        (a surgical raw-JSON edit, so encrypted ``mcp_tools`` are untouched and
-        no cipher is needed). The stable ``id`` is preserved.
+        (a surgical raw-JSON edit). The stable ``id`` is preserved.
 
         Raises:
             FileNotFoundError: If ``old_name`` is missing.
@@ -279,9 +264,9 @@ class AgentProfileStore:
         The single-profile write primitive behind ``profile_refs.cascade_rename``.
         Self-locks (re-entrant), so the read-modify-write is atomic whether called
         standalone or nested under the FK helpers' :meth:`lock`. A raw-JSON edit
-        (only the ref field changes), so encrypted ``skills[].mcp_tools`` and the
-        stable ``id`` are untouched and no cipher is needed. No-op when the profile
-        is missing, non-dict, or an ACP profile (which carries no ref).
+        (only the ref field changes), so the stable ``id`` is untouched. No-op
+        when the profile is missing, non-dict, or an ACP profile (which carries
+        no ref).
         """
         path = self._get_profile_path(name)
         with self._acquire_lock():
@@ -380,13 +365,10 @@ class AgentProfileStoreProtocol(Protocol):
         self,
         profile: OpenHandsAgentProfile | ACPAgentProfile,
         *,
-        cipher: Cipher | None = ...,
         max_profiles: int | None = ...,
     ) -> None: ...
 
-    def load(
-        self, name: str, *, cipher: Cipher | None = ...
-    ) -> OpenHandsAgentProfile | ACPAgentProfile: ...
+    def load(self, name: str) -> OpenHandsAgentProfile | ACPAgentProfile: ...
 
     def delete(self, name: str) -> None: ...
 
@@ -422,7 +404,6 @@ def save_profile_preserving_identity(
     store: AgentProfileStoreProtocol,
     profile: OpenHandsAgentProfile | ACPAgentProfile,
     *,
-    cipher: Cipher | None = None,
     max_profiles: int | None = None,
 ) -> OpenHandsAgentProfile | ACPAgentProfile:
     """Save ``profile`` with the server-managed id/revision policy.
@@ -445,5 +426,5 @@ def save_profile_preserving_identity(
             )
         else:
             profile = profile.model_copy(update={"id": uuid4()})
-        store.save(profile, cipher=cipher, max_profiles=max_profiles)
+        store.save(profile, max_profiles=max_profiles)
     return profile

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -176,18 +176,23 @@ def _apply_disabled_skills(
     is by *exclusion*, not by an allow-list of names (which would dangle when the
     catalog a profile was authored against differs from the one resolved at
     launch — the #4017 root cause). A disabled name absent from the catalog is a
-    harmless no-op; this can never raise.
+    harmless no-op.
+
+    The catalog is de-duplicated by name (last occurrence wins, matching
+    ``load_all_skills``'s later-source-overrides precedence) so a caller passing a
+    colliding catalog — the app-server's "fuller catalog" merges multiple sources
+    whose names can collide — cannot trip ``AgentContext``'s duplicate-name
+    validator. So this can never raise.
 
     ``available_skills is None`` (discovery skipped or failed) → no skills, the
     caller having surfaced its own signal. ``disabled == []`` → the whole
-    catalog.
+    (de-duplicated) catalog.
     """
     if not available_skills:
         return []
-    if not disabled:
-        return list(available_skills)
+    by_name = {s.name: s for s in available_skills}
     denied = set(disabled)
-    return [s for s in available_skills if s.name not in denied]
+    return [s for s in by_name.values() if s.name not in denied]
 
 
 def _api_key_set(llm: LLM) -> bool:

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -1,16 +1,20 @@
 """``resolve_agent_profile()`` — the join point between profiles and execution.
 
-A profile carries *references* (``llm_profile_ref`` / ``mcp_server_refs`` /
-``skill_refs``) and is secret-free at rest; an
+A profile carries *references* (``llm_profile_ref`` / ``mcp_server_refs``) plus a
+``disabled_skills`` deny-list, and is secret-free at rest; an
 :data:`~openhands.sdk.settings.model.AgentSettingsConfig` embeds the resolved
 ``llm`` / ``mcp_config`` / skills. This module resolves the former into the
 latter so ``create_agent`` / ``apply_agent_settings_diff`` /
 ``validate_agent_settings`` stay unchanged. See epic #3713.
 
-``skill_refs`` is a name filter over the server-discovered skill catalog,
-mirroring how ``mcp_server_refs`` filters ``mcp_config``: the caller passes the
-discovered skills (``load_all_skills``) and the resolver selects by name, so the
-client never has to round-trip full ``Skill`` objects (#3868).
+Skills are *not* modeled like MCP servers. ``mcp_server_refs`` is a safe
+allow-list because ``mcp_config`` is a complete, persisted, user-authored map.
+The skill catalog is discovered from many incomplete, drifting sources
+(user/public/org/project/marketplace), so an allow-list of names would dangle
+whenever the authoring catalog differs from the launch catalog. Instead the
+caller passes the discovered catalog (``load_all_skills``) and the resolver keeps
+all of it except the names in ``disabled_skills`` — a deny-list that can never
+dangle (#4017).
 
 Resource-specific secret channels:
 
@@ -74,21 +78,6 @@ class DanglingMcpServerRef(Exception):
         )
 
 
-class DanglingSkillRef(Exception):
-    """A ``skill_refs`` entry names a skill absent from the discovered catalog.
-
-    The skill analogue of :class:`DanglingMcpServerRef`: the router maps it to
-    HTTP 422. :attr:`missing` carries the offending name(s).
-    """
-
-    def __init__(self, missing: list[str]) -> None:
-        self.missing = missing
-        joined = ", ".join(repr(m) for m in missing)
-        super().__init__(
-            f"Skill ref(s) not present in the discovered catalog: {joined}"
-        )
-
-
 class AgentProfileDiagnostics(BaseModel):
     """Side-effect-free report of what :func:`resolve_agent_profile` would do.
 
@@ -116,11 +105,13 @@ class AgentProfileDiagnostics(BaseModel):
     )
     dangling_mcp_server_refs: list[str] = Field(default_factory=list)
 
-    # Skill selection (both variants). A dangling skill ref flips ``valid`` via
-    # an error, mirroring ``dangling_mcp_server_refs`` (see #3868 / Option A).
-    skill_refs: list[str] | None = None
+    # Skill selection (OpenHands only). ``disabled_skills`` is a deny-list over
+    # the discovered catalog, so — unlike ``mcp_server_refs`` — it can never
+    # dangle: a disabled name absent from the catalog is a harmless no-op.
+    # ``resolved_skills`` is what would actually reach the agent (catalog minus
+    # disabled).
+    disabled_skills: list[str] = Field(default_factory=list)
     resolved_skills: list[str] = Field(default_factory=list)
-    dangling_skill_refs: list[str] = Field(default_factory=list)
 
     # ACP provider credential channels the editor/materialize checks (ACP only).
     # These are NOT jointly required: authentication needs the API key *or* one
@@ -175,29 +166,28 @@ def _compute_mcp_filter(
     return {k: mcp_config[k] for k in resolved}, resolved, dangling
 
 
-def _compute_skill_filter(
+def _apply_disabled_skills(
     available_skills: list[Skill] | None,
-    refs: list[str] | None,
-) -> tuple[list[Skill], list[str], list[str]]:
-    """Resolve ``skill_refs`` against the server-discovered skill catalog.
+    disabled: list[str],
+) -> list[Skill]:
+    """Filter the discovered skill catalog by the profile's deny-list.
 
-    Mirrors :func:`_compute_mcp_filter`. ``refs is None`` selects all discovered
-    skills; a list filters to the named skills in ref order (duplicates
-    collapsed). Returns ``(filtered_skills, resolved_names, dangling_names)``.
+    Skills are discovered from many incomplete, drifting sources, so selection
+    is by *exclusion*, not by an allow-list of names (which would dangle when the
+    catalog a profile was authored against differs from the one resolved at
+    launch — the #4017 root cause). A disabled name absent from the catalog is a
+    harmless no-op; this can never raise.
 
-    ``available_skills is None`` means discovery was not run (e.g. an empty
-    ``skill_refs`` skips it) or failed: the catalog is unknown, so refs are
-    neither resolved nor reported dangling and the caller surfaces its own
-    signal. ``available_skills == []`` is a *known-empty* catalog, against which
-    any named ref is dangling.
+    ``available_skills is None`` (discovery skipped or failed) → no skills, the
+    caller having surfaced its own signal. ``disabled == []`` → the whole
+    catalog.
     """
-    if available_skills is None:
-        return [], [], []
-    by_name = {s.name: s for s in available_skills}
-    if refs is None:
-        return list(by_name.values()), list(by_name), []
-    resolved, dangling = _partition_refs(refs, by_name)
-    return [by_name[r] for r in resolved], resolved, dangling
+    if not available_skills:
+        return []
+    if not disabled:
+        return list(available_skills)
+    denied = set(disabled)
+    return [s for s in available_skills if s.name not in denied]
 
 
 def _api_key_set(llm: LLM) -> bool:
@@ -235,12 +225,14 @@ def _build_openhands_settings(
 ) -> AgentSettingsConfig:
     """Compose the resolved ``OpenHandsAgentSettings`` from a profile + LLM.
 
-    ``filtered_skills`` is the sole skill source (profiles no longer embed
-    skills). ``load_project_skills=True`` lets ``LocalConversation`` lazily load
-    repo-scoped project skills, which can't be resolved here (no workspace yet).
-    ``load_user_skills`` / ``load_public_skills`` stay False on purpose:
-    user/public skills already arrive via ``filtered_skills``, so enabling the
-    flags would double-load them.
+    ``filtered_skills`` (the discovered catalog minus ``disabled_skills``) is the
+    sole user/public skill source (profiles no longer embed skills).
+    ``load_project_skills=True`` lets ``LocalConversation`` lazily load
+    repo-scoped project skills, which can't be resolved here (no workspace yet);
+    ``disabled_skills`` is carried onto the context so that lazy load applies the
+    same deny-list. ``load_user_skills`` / ``load_public_skills`` stay False on
+    purpose: user/public skills already arrive via ``filtered_skills``, so
+    enabling the flags would double-load them.
     """
     payload = {
         "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
@@ -254,6 +246,7 @@ def _build_openhands_settings(
             skills=filtered_skills,
             system_message_suffix=profile.system_message_suffix,
             load_project_skills=True,
+            disabled_skills=profile.disabled_skills,
         ),
         "condenser": profile.condenser,
         "verification": profile.verification.model_dump(),
@@ -267,19 +260,18 @@ def _build_openhands_settings(
 def _build_acp_settings(
     profile: ACPAgentProfile,
     mcp_config: dict[str, MCPServer],
-    filtered_skills: list[Skill],
 ) -> AgentSettingsConfig:
     """Compose the resolved ``ACPAgentSettings`` from a profile.
 
     ``acp_command`` is stored as a shell string and split into the settings'
     token list. No credential is set — provider creds ride
-    ``state.secret_registry``. ``filtered_skills`` become prompt-only context
-    (``current_datetime=None`` matches ACP's no-timestamp convention).
-    ``agent_context`` is always built (never ``None``) so
-    ``load_project_skills=True`` reaches ``LocalConversation``'s lazy load;
-    project skills apply to ACP profiles too. Caveat: an ACP CLI that already
-    ingests repo files (e.g. AGENTS.md) may then see that content twice. A
-    ``custom`` server has no default command, so one must be supplied.
+    ``state.secret_registry``. ACP profiles carry no user/public skills (the ACP
+    subprocess owns its context), so ``agent_context`` has no discovered skills;
+    it is always built (never ``None``) only so ``load_project_skills=True``
+    reaches ``LocalConversation``'s lazy load (``current_datetime=None`` matches
+    ACP's no-timestamp convention). Caveat: an ACP CLI that already ingests repo
+    files (e.g. AGENTS.md) may then see that content twice (#4019). A ``custom``
+    server has no default command, so one must be supplied.
     """
     command = shlex.split(profile.acp_command) if profile.acp_command else []
     if profile.acp_server == "custom" and not command:
@@ -288,7 +280,7 @@ def _build_acp_settings(
             "default launch command to fall back to"
         )
     agent_context = AgentContext(
-        skills=filtered_skills, current_datetime=None, load_project_skills=True
+        skills=[], current_datetime=None, load_project_skills=True
     )
     payload = {
         "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
@@ -318,33 +310,26 @@ def resolve_agent_profile(
     ``mcp_config`` is the user's globally-configured MCP server map, already
     decrypted by the caller (the agent-server runs settings decryption
     before calling). ``available_skills`` is the server-discovered skill catalog
-    that ``skill_refs`` filters by name (the agent-server caller passes the
-    result of ``load_all_skills``); it feeds both variants — the OpenHands
-    agent_context and the ACP prompt catalog. Like ``mcp_config`` it is a
-    required argument so a caller cannot silently resolve a zero-skill agent by
-    forgetting it, and a ``skill_refs`` entry absent from the catalog raises
-    :class:`DanglingSkillRef` (mirroring the MCP contract) rather than being
-    dropped. ``None`` means discovery was not run (e.g. an empty ``skill_refs``
-    skips it): no catalog is consulted, so the resolved agent gets no skills
-    from this filter (project skills, loaded separately by ``LocalConversation``,
-    are unaffected). ``cipher`` decrypts the referenced LLM profile.
+    (the agent-server caller passes the result of ``load_all_skills``); an
+    OpenHands profile keeps all of it except the names in ``disabled_skills``.
+    ``None`` means discovery was not run or failed: no catalog, so the resolved
+    agent gets no user/public skills (project skills, loaded separately by
+    ``LocalConversation``, are unaffected). Unlike the ``mcp_server_refs``
+    allow-list, the ``disabled_skills`` deny-list can never dangle, so this
+    never raises for skills. ``cipher`` decrypts the referenced LLM profile.
 
     Raises:
         ProfileNotFound: ``llm_profile_ref`` does not exist (OpenHands path).
         DanglingMcpServerRef: an ``mcp_server_refs`` entry is not in ``mcp_config``.
-        DanglingSkillRef: a ``skill_refs`` entry is not in ``available_skills``.
     """
     filtered_mcp, _, dangling = _compute_mcp_filter(mcp_config, profile.mcp_server_refs)
     if dangling:
         raise DanglingMcpServerRef(dangling)
 
-    filtered_skills, _, dangling_skills = _compute_skill_filter(
-        available_skills, profile.skill_refs
-    )
-    if dangling_skills:
-        raise DanglingSkillRef(dangling_skills)
-
     if isinstance(profile, OpenHandsAgentProfile):
+        filtered_skills = _apply_disabled_skills(
+            available_skills, profile.disabled_skills
+        )
         try:
             llm = llm_store.load(profile.llm_profile_ref, cipher=cipher)
         except FileNotFoundError as e:
@@ -353,7 +338,7 @@ def resolve_agent_profile(
             ) from e
         return _build_openhands_settings(profile, llm, filtered_mcp, filtered_skills)
 
-    return _build_acp_settings(profile, filtered_mcp, filtered_skills)
+    return _build_acp_settings(profile, filtered_mcp)
 
 
 def resolve_agent_profile_dry_run(
@@ -367,10 +352,12 @@ def resolve_agent_profile_dry_run(
     """Compute :class:`AgentProfileDiagnostics` without raising or side effects.
 
     Mirrors :func:`resolve_agent_profile`'s composition but records dangling LLM /
-    MCP / skill refs as diagnostics instead of raising, so the editor /
-    ``/materialize`` (#3719) can show a faithful set/missing report with secrets
-    redacted. ``available_skills=None`` (discovery skipped or failed) leaves the
-    catalog unknown, so no skill ref is reported dangling.
+    MCP refs as diagnostics instead of raising, so the editor / ``/materialize``
+    (#3719) can show a faithful set/missing report with secrets redacted. Skills
+    use a deny-list (``disabled_skills``) that can't dangle, so there is no skill
+    error to report — ``resolved_skills`` is just the catalog minus the disabled
+    names. ``available_skills=None`` (discovery skipped or failed) means no
+    user/public skills resolve.
     """
     filtered_mcp, resolved, dangling = _compute_mcp_filter(
         mcp_config, profile.mcp_server_refs
@@ -387,17 +374,16 @@ def resolve_agent_profile_dry_run(
             "MCP server(s) not configured: " + ", ".join(dangling)
         )
 
-    # Skill selection report (both variants). Computed once and reused by the
-    # settings build below; a dangling ref adds an error (mirrors MCP), flipping
-    # ``valid`` at the verdict line below.
-    filtered_skills, resolved_skills, dangling_skills = _compute_skill_filter(
-        available_skills, profile.skill_refs
-    )
-    diagnostics.skill_refs = profile.skill_refs
-    diagnostics.resolved_skills = resolved_skills
-    diagnostics.dangling_skill_refs = dangling_skills
-    if dangling_skills:
-        diagnostics.errors.append("Skill(s) not found: " + ", ".join(dangling_skills))
+    # Skill selection report (OpenHands only; ACP injects no user/public skills).
+    # Deny-list semantics: the catalog minus disabled names, never dangling.
+    if isinstance(profile, OpenHandsAgentProfile):
+        filtered_skills = _apply_disabled_skills(
+            available_skills, profile.disabled_skills
+        )
+        diagnostics.disabled_skills = profile.disabled_skills
+    else:
+        filtered_skills = []
+    diagnostics.resolved_skills = [s.name for s in filtered_skills]
 
     llm: LLM | None = None
     if isinstance(profile, OpenHandsAgentProfile):
@@ -444,7 +430,7 @@ def resolve_agent_profile_dry_run(
                     profile, llm, filtered_mcp, filtered_skills
                 )
             else:
-                settings = _build_acp_settings(profile, filtered_mcp, filtered_skills)
+                settings = _build_acp_settings(profile, filtered_mcp)
             # No expose context => secrets redacted (mcp env/headers, llm api_key).
             diagnostics.resolved_settings = settings.model_dump(mode="json")
         except Exception as e:

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -235,18 +235,12 @@ def _build_openhands_settings(
 ) -> AgentSettingsConfig:
     """Compose the resolved ``OpenHandsAgentSettings`` from a profile + LLM.
 
-    ``filtered_skills`` (the ``skill_refs`` selection over the server-discovered
-    catalog) is the sole skill source — profiles no longer embed ``skills``
-    (#4017). ``load_project_skills=True`` restores the one enrichment the
-    catalog can't provide: project skills are repo-scoped, not resolvable at
-    profile-resolve time (no workspace yet), so ``LocalConversation`` loads them
-    lazily on first use, the same way an ``agent_settings``-launched
-    conversation already does (#4016). ``load_user_skills`` /
-    ``load_public_skills`` are deliberately left at their default ``False`` —
-    unlike project skills, user/public skills already reach the agent through
-    ``filtered_skills`` (the resolver's catalog, via ``discover_profile_skills``,
-    already includes them); flipping those flags too would trigger a second,
-    redundant discovery pass inside ``AgentContext`` itself.
+    ``filtered_skills`` is the sole skill source (profiles no longer embed
+    skills). ``load_project_skills=True`` lets ``LocalConversation`` lazily load
+    repo-scoped project skills, which can't be resolved here (no workspace yet).
+    ``load_user_skills`` / ``load_public_skills`` stay False on purpose:
+    user/public skills already arrive via ``filtered_skills``, so enabling the
+    flags would double-load them.
     """
     payload = {
         "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
@@ -279,19 +273,13 @@ def _build_acp_settings(
 
     ``acp_command`` is stored as a shell string and split into the settings'
     token list. No credential is set — provider creds ride
-    ``state.secret_registry`` (#3720). ``filtered_skills`` (the ``skill_refs``
-    selection, ``[]`` by default for ACP profiles) become prompt-only context
-    via ``agent_context``; ``current_datetime=None`` matches ACP's convention of
-    not injecting a timestamp. ``agent_context`` is always constructed (never
-    ``None``, even with no selected skills) so ``load_project_skills=True``
-    still reaches ``LocalConversation``'s lazy project-skill load (#4016) —
-    project skills are repo-scoped, not gated by ``skill_refs``, and apply to
-    ACP profiles the same as OpenHands ones. This is behavior-preserving for the
-    rendered ACP prompt: an ``AgentContext`` with no skills/suffix/secrets
-    renders the same "no context" content as ``None`` (see
-    ``ACPAgent._render_suffix``). A ``custom`` server has no default command, so
-    one must be supplied — the same invariant ``resolve_acp_command`` enforces
-    at ``create_agent``, surfaced here so the resolved settings stay executable.
+    ``state.secret_registry``. ``filtered_skills`` become prompt-only context
+    (``current_datetime=None`` matches ACP's no-timestamp convention).
+    ``agent_context`` is always built (never ``None``) so
+    ``load_project_skills=True`` reaches ``LocalConversation``'s lazy load;
+    project skills apply to ACP profiles too. Caveat: an ACP CLI that already
+    ingests repo files (e.g. AGENTS.md) may then see that content twice. A
+    ``custom`` server has no default command, so one must be supplied.
     """
     command = shlex.split(profile.acp_command) if profile.acp_command else []
     if profile.acp_server == "custom" and not command:

--- a/openhands-sdk/openhands/sdk/profiles/resolver.py
+++ b/openhands-sdk/openhands/sdk/profiles/resolver.py
@@ -42,7 +42,7 @@ from openhands.sdk.settings.model import (
     AgentSettingsConfig,
     validate_agent_settings,
 )
-from openhands.sdk.skills import Skill, merge_skills_by_name
+from openhands.sdk.skills import Skill
 from openhands.sdk.utils.pydantic_secrets import REDACTED_SECRET_VALUE
 
 
@@ -235,11 +235,19 @@ def _build_openhands_settings(
 ) -> AgentSettingsConfig:
     """Compose the resolved ``OpenHandsAgentSettings`` from a profile + LLM.
 
-    Skills are the profile's embedded ``skills`` composed with ``filtered_skills``
-    (the ``skill_refs`` selection); embedded skills win on a
-    name conflict, so the catalog selector composes with hand-authored skills.
+    ``filtered_skills`` (the ``skill_refs`` selection over the server-discovered
+    catalog) is the sole skill source — profiles no longer embed ``skills``
+    (#4017). ``load_project_skills=True`` restores the one enrichment the
+    catalog can't provide: project skills are repo-scoped, not resolvable at
+    profile-resolve time (no workspace yet), so ``LocalConversation`` loads them
+    lazily on first use, the same way an ``agent_settings``-launched
+    conversation already does (#4016). ``load_user_skills`` /
+    ``load_public_skills`` are deliberately left at their default ``False`` —
+    unlike project skills, user/public skills already reach the agent through
+    ``filtered_skills`` (the resolver's catalog, via ``discover_profile_skills``,
+    already includes them); flipping those flags too would trigger a second,
+    redundant discovery pass inside ``AgentContext`` itself.
     """
-    skills = merge_skills_by_name(profile.skills, filtered_skills)
     payload = {
         "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
         "agent_kind": "openhands",
@@ -249,8 +257,9 @@ def _build_openhands_settings(
         # Tri-state passthrough; create_agent materializes None.
         "tools": profile.tools,
         "agent_context": AgentContext(
-            skills=skills,
+            skills=filtered_skills,
             system_message_suffix=profile.system_message_suffix,
+            load_project_skills=True,
         ),
         "condenser": profile.condenser,
         "verification": profile.verification.model_dump(),
@@ -271,12 +280,18 @@ def _build_acp_settings(
     ``acp_command`` is stored as a shell string and split into the settings'
     token list. No credential is set — provider creds ride
     ``state.secret_registry`` (#3720). ``filtered_skills`` (the ``skill_refs``
-    selection) become prompt-only context via ``agent_context``; an empty
-    selection keeps ``agent_context=None`` (the unchanged "no context" prompt),
-    and ``current_datetime=None`` matches ACP's convention of not injecting a
-    timestamp. A ``custom`` server has no default command, so one must be
-    supplied — the same invariant ``resolve_acp_command`` enforces at
-    ``create_agent``, surfaced here so the resolved settings stay executable.
+    selection, ``[]`` by default for ACP profiles) become prompt-only context
+    via ``agent_context``; ``current_datetime=None`` matches ACP's convention of
+    not injecting a timestamp. ``agent_context`` is always constructed (never
+    ``None``, even with no selected skills) so ``load_project_skills=True``
+    still reaches ``LocalConversation``'s lazy project-skill load (#4016) —
+    project skills are repo-scoped, not gated by ``skill_refs``, and apply to
+    ACP profiles the same as OpenHands ones. This is behavior-preserving for the
+    rendered ACP prompt: an ``AgentContext`` with no skills/suffix/secrets
+    renders the same "no context" content as ``None`` (see
+    ``ACPAgent._render_suffix``). A ``custom`` server has no default command, so
+    one must be supplied — the same invariant ``resolve_acp_command`` enforces
+    at ``create_agent``, surfaced here so the resolved settings stay executable.
     """
     command = shlex.split(profile.acp_command) if profile.acp_command else []
     if profile.acp_server == "custom" and not command:
@@ -284,10 +299,8 @@ def _build_acp_settings(
             "acp_command is required when acp_server='custom' — there is no "
             "default launch command to fall back to"
         )
-    agent_context = (
-        AgentContext(skills=filtered_skills, current_datetime=None)
-        if filtered_skills
-        else None
+    agent_context = AgentContext(
+        skills=filtered_skills, current_datetime=None, load_project_skills=True
     )
     payload = {
         "schema_version": AGENT_SETTINGS_SCHEMA_VERSION,
@@ -324,9 +337,9 @@ def resolve_agent_profile(
     forgetting it, and a ``skill_refs`` entry absent from the catalog raises
     :class:`DanglingSkillRef` (mirroring the MCP contract) rather than being
     dropped. ``None`` means discovery was not run (e.g. an empty ``skill_refs``
-    skips it): no catalog is consulted, so only an OpenHands profile's embedded
-    ``skills`` reach the agent (an ACP profile gets none). ``cipher`` decrypts
-    the referenced LLM profile.
+    skips it): no catalog is consulted, so the resolved agent gets no skills
+    from this filter (project skills, loaded separately by ``LocalConversation``,
+    are unaffected). ``cipher`` decrypts the referenced LLM profile.
 
     Raises:
         ProfileNotFound: ``llm_profile_ref`` does not exist (OpenHands path).

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -55,7 +55,8 @@ def build_seed_profile(
             ),
             acp_args=list(agent_settings.acp_args) or None,
             mcp_server_refs=None,
-            # ACP default; explicit for symmetry with the OpenHands seed below.
+            # Explicit: matches ACPAgentProfile's own [] default (ACP agents own
+            # their tooling), which differs from the OpenHands seed below.
             skill_refs=[],
         )
     context = agent_settings.agent_context
@@ -65,11 +66,10 @@ def build_seed_profile(
         agent=agent_settings.agent,
         # Verbatim: preserves explicit toolsets; None stays "server default".
         tools=agent_settings.tools,
-        # Embed the global's already-resolved skills + skill_refs=[] (no further
-        # discovery) to reproduce its exact set; skill_refs=None would re-discover
-        # user+public and inject skills a partial-source global never had.
-        skills=list(context.skills),
-        skill_refs=[],
+        # None = all discovered — profiles no longer embed skills (#4017), so
+        # there is nothing to freeze an exact prior set against; the seed
+        # simply inherits whatever the server-owned catalog discovers.
+        skill_refs=None,
         system_message_suffix=context.system_message_suffix,
         condenser=agent_settings.condenser,
         verification=build_profile_verification(agent_settings.verification),

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -66,10 +66,12 @@ def build_seed_profile(
         agent=agent_settings.agent,
         # Verbatim: preserves explicit toolsets; None stays "server default".
         tools=agent_settings.tools,
-        # None = all discovered — profiles no longer embed skills (#4017), so
-        # there is nothing to freeze an exact prior set against; the seed
-        # simply inherits whatever the server-owned catalog discovers.
-        skill_refs=None,
+        # Freeze the global's already-resolved skills by name so the seed
+        # reproduces its exact set (empty -> [] -> no skills). The model's
+        # None=all-discovered default is for user-created profiles; the seed is
+        # a behavior-preserving migration and must not add skills the global
+        # never had.
+        skill_refs=[skill.name for skill in context.skills],
         system_message_suffix=context.system_message_suffix,
         condenser=agent_settings.condenser,
         verification=build_profile_verification(agent_settings.verification),

--- a/openhands-sdk/openhands/sdk/profiles/seed.py
+++ b/openhands-sdk/openhands/sdk/profiles/seed.py
@@ -55,9 +55,7 @@ def build_seed_profile(
             ),
             acp_args=list(agent_settings.acp_args) or None,
             mcp_server_refs=None,
-            # Explicit: matches ACPAgentProfile's own [] default (ACP agents own
-            # their tooling), which differs from the OpenHands seed below.
-            skill_refs=[],
+            # ACP profiles carry no skill field — the subprocess owns its context.
         )
     context = agent_settings.agent_context
     return OpenHandsAgentProfile(
@@ -66,12 +64,11 @@ def build_seed_profile(
         agent=agent_settings.agent,
         # Verbatim: preserves explicit toolsets; None stays "server default".
         tools=agent_settings.tools,
-        # Freeze the global's already-resolved skills by name so the seed
-        # reproduces its exact set (empty -> [] -> no skills). The model's
-        # None=all-discovered default is for user-created profiles; the seed is
-        # a behavior-preserving migration and must not add skills the global
-        # never had.
-        skill_refs=[skill.name for skill in context.skills],
+        # Deny-list defaults to [] — the seeded default profile launches with all
+        # discovered skills, matching the "all skills by default" model. No names
+        # are frozen, so nothing can dangle at launch (the freeze-by-name seed
+        # was the #4017 launch-break; the deny-list removes that failure mode).
+        disabled_skills=[],
         system_message_suffix=context.system_message_suffix,
         condenser=agent_settings.condenser,
         verification=build_profile_verification(agent_settings.verification),

--- a/tests/agent_server/test_agent_profile_conv_start.py
+++ b/tests/agent_server/test_agent_profile_conv_start.py
@@ -41,7 +41,6 @@ from openhands.sdk.profiles.agent_profile import (
 )
 from openhands.sdk.profiles.resolver import (
     DanglingMcpServerRef,
-    DanglingSkillRef,
     ProfileNotFound,
 )
 from openhands.sdk.workspace import LocalWorkspace
@@ -155,11 +154,10 @@ class TestStartConversationRequestValidation:
 _STORE_PATH = "openhands.agent_server.persistence.store.get_agent_profile_store"
 _LLM_STORE_PATH = "openhands.agent_server.persistence.store.get_llm_profile_store"
 _RESOLVE_PATH = "openhands.sdk.profiles.resolver.resolve_agent_profile"
-# Skill discovery is patched so OpenHands-profile resolves don't hit the
-# network (load_all_skills loads public skills from GitHub).
-# conversation_service calls discover_profile_skills_if_needed, which looks up
-# discover_profile_skills in skills_service — patch it at the source.
-_DISCOVER_PATH = "openhands.agent_server.skills_service.discover_profile_skills"
+# Skill discovery is patched so OpenHands-profile resolves don't hit the network
+# (load_all_skills loads public skills from GitHub). conversation_service imports
+# discover_profile_skills directly, so patch it in that namespace.
+_DISCOVER_PATH = "openhands.agent_server.conversation_service.discover_profile_skills"
 
 
 class TestResolveAgentFromProfile:
@@ -178,9 +176,9 @@ class TestResolveAgentFromProfile:
             _resolve_agent_from_profile,
         )
 
-        # skill_refs defaults to [] (skip); set None to exercise the
-        # all-discovered opt-in, where discovery runs and is threaded through.
-        profile = _make_openhands_profile().model_copy(update={"skill_refs": None})
+        # OpenHands profiles always discover the catalog (deny-list needs the
+        # full set), threaded through to the resolver as available_skills.
+        profile = _make_openhands_profile()
         agent = _make_agent()
 
         with (
@@ -211,7 +209,7 @@ class TestResolveAgentFromProfile:
         assert result_agent is agent
         assert launched.agent_profile_id == profile.id
         assert launched.revision == profile.revision
-        # skill_refs=None (all discovered) triggers discovery, threaded through.
+        # OpenHands discovery always runs; its result is threaded through.
         MockDiscover.assert_called_once()
         assert MockResolve.call_args.kwargs["available_skills"] == []
 
@@ -417,16 +415,15 @@ class TestResolveAgentFromProfile:
         assert result_agent is agent
 
     def test_openhands_default_profile_triggers_discovery(self):
-        """A profile's default ``skill_refs`` is ``None`` (all discovered,
-        #4017) — a true twin of ``mcp_server_refs``, since there is no
-        embedded-skills fallback anymore. This *does* trigger catalog
-        discovery by default, unlike the old ``[]``-default behavior."""
+        """An OpenHands profile always discovers the skill catalog (the deny-list
+        needs the full set, minus disabled names). The default deny-list is []
+        (all discovered); there is no discovery-skip path anymore (#4017)."""
         from openhands.agent_server.conversation_service import (
             _resolve_agent_from_profile,
         )
 
         profile = _make_openhands_profile()
-        assert profile.skill_refs is None  # the default, not []
+        assert profile.disabled_skills == []  # the default: disable nothing
         agent = _make_agent()
 
         with (
@@ -445,35 +442,6 @@ class TestResolveAgentFromProfile:
             _resolve_agent_from_profile(profile.id, cipher=None, mcp_config={})
 
         MockDiscover.assert_called_once()
-
-    def test_openhands_explicit_empty_skill_refs_skips_discovery(self):
-        """An explicit ``skill_refs=[]`` (none) still skips the (network-bound)
-        catalog discovery — the opt-out path #3868 introduced, unaffected by
-        the default changing from ``[]`` to ``None``."""
-        from openhands.agent_server.conversation_service import (
-            _resolve_agent_from_profile,
-        )
-
-        profile = _make_openhands_profile().model_copy(update={"skill_refs": []})
-        agent = _make_agent()
-
-        with (
-            patch(_STORE_PATH) as MockStore,
-            patch(_LLM_STORE_PATH),
-            patch(_RESOLVE_PATH) as MockResolve,
-            patch(_DISCOVER_PATH) as MockDiscover,
-        ):
-            store_inst = MockStore.return_value
-            store_inst.name_for_id.return_value = profile.name
-            store_inst.load.return_value = profile
-            mock_config = MagicMock()
-            mock_config.create_agent.return_value = agent
-            MockResolve.return_value = mock_config
-
-            _resolve_agent_from_profile(profile.id, cipher=None, mcp_config={})
-
-        MockDiscover.assert_not_called()
-        assert MockResolve.call_args.kwargs["available_skills"] is None
 
     def test_dangling_mcp_server_ref_propagates(self):
         from openhands.agent_server.conversation_service import (
@@ -502,42 +470,9 @@ class TestResolveAgentFromProfile:
         )
         from openhands.sdk.agent.acp_agent import ACPAgent
 
-        # ACP defaults skill_refs=[] (skip); set None to exercise the
-        # all-discovered opt-in, where discovery runs and is threaded through.
-        profile = _make_acp_profile().model_copy(update={"skill_refs": None})
-        acp_agent = MagicMock(spec=ACPAgent)
-
-        with (
-            patch(_STORE_PATH) as MockStore,
-            patch(_LLM_STORE_PATH),
-            patch(_RESOLVE_PATH) as MockResolve,
-            patch(_DISCOVER_PATH, return_value=[]) as MockDiscover,
-        ):
-            store_inst = MockStore.return_value
-            store_inst.name_for_id.return_value = profile.name
-            store_inst.load.return_value = profile
-            mock_config = MagicMock()
-            mock_config.create_agent.return_value = acp_agent
-            MockResolve.return_value = mock_config
-
-            result_agent, launched = _resolve_agent_from_profile(
-                profile.id, cipher=None, mcp_config={}
-            )
-
-        assert result_agent is acp_agent
-        assert launched.agent_profile_id == profile.id
-        assert launched.revision == profile.revision
-        MockDiscover.assert_called_once()
-        assert MockResolve.call_args.kwargs["available_skills"] == []
-
-    def test_acp_profile_with_empty_skill_refs_skips_discovery(self):
-        from openhands.agent_server.conversation_service import (
-            _resolve_agent_from_profile,
-        )
-        from openhands.sdk.agent.acp_agent import ACPAgent
-
+        # ACP profiles carry no user/public skills, so discovery never runs and
+        # the resolver receives available_skills=None.
         profile = _make_acp_profile()
-        profile = profile.model_copy(update={"skill_refs": []})
         acp_agent = MagicMock(spec=ACPAgent)
 
         with (
@@ -553,10 +488,13 @@ class TestResolveAgentFromProfile:
             mock_config.create_agent.return_value = acp_agent
             MockResolve.return_value = mock_config
 
-            _resolve_agent_from_profile(profile.id, cipher=None, mcp_config={})
+            result_agent, launched = _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config={}
+            )
 
-        # skill_refs == [] selects no discovered skills, so the (network-bound)
-        # discovery is skipped and the resolver gets available_skills=None.
+        assert result_agent is acp_agent
+        assert launched.agent_profile_id == profile.id
+        assert launched.revision == profile.revision
         MockDiscover.assert_not_called()
         assert MockResolve.call_args.kwargs["available_skills"] is None
 
@@ -707,23 +645,9 @@ class TestConversationRouterProfileErrors:
         assert "dangling_mcp_server_refs" in detail
         assert "missing-server" in detail["dangling_mcp_server_refs"]
 
-    def test_dangling_skill_ref_returns_422(self, client, mock_conversation_service):
-        mock_conversation_service.start_conversation.side_effect = DanglingSkillRef(
-            ["missing-skill"]
-        )
-        client.app.dependency_overrides[get_conversation_service] = lambda: (
-            mock_conversation_service
-        )
-
-        payload = {
-            "agent_profile_id": str(uuid4()),
-            "workspace": {"working_dir": "/tmp/test", "kind": "LocalWorkspace"},
-        }
-        resp = client.post("/api/conversations", json=payload)
-        assert resp.status_code == 422
-        detail = resp.json().get("detail", {})
-        assert "dangling_skill_refs" in detail
-        assert "missing-skill" in detail["dangling_skill_refs"]
+    # No dangling-skill 422: skills use a deny-list (disabled_skills) that can't
+    # dangle — a disabled name absent from the catalog is a no-op, so a profile
+    # launch never fails on skill selection (#4017).
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent_server/test_agent_profile_conv_start.py
+++ b/tests/agent_server/test_agent_profile_conv_start.py
@@ -215,6 +215,77 @@ class TestResolveAgentFromProfile:
         MockDiscover.assert_called_once()
         assert MockResolve.call_args.kwargs["available_skills"] == []
 
+    def test_openhands_profile_forces_llm_stream_true(self):
+        """A profile-launched OpenHands conversation must guarantee on_token
+        wiring (#4014): unlike an inline agent_settings launch, a client can't
+        set llm.stream ahead of time on a profile's referenced LLM. This
+        agent-server layer forces it after resolution — not the SDK resolver,
+        which runs for every caller including headless/scripted ones."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+        from openhands.sdk.settings.model import OpenHandsAgentSettings
+
+        profile = _make_openhands_profile()
+        # A real (unmocked) settings object so isinstance(...) narrows for real.
+        resolved_settings = OpenHandsAgentSettings(
+            llm=LLM(model="gpt-4o", usage_id="agent", stream=False)
+        )
+        assert resolved_settings.llm.stream is False
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH, return_value=resolved_settings),
+            patch(
+                "openhands.agent_server.conversation_service.is_tool_usable",
+                return_value=False,
+            ),
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+
+            result_agent, _ = _resolve_agent_from_profile(
+                profile.id, cipher=None, mcp_config={}
+            )
+
+        assert result_agent.llm.stream is True
+        # The original resolved settings object is untouched (model_copy, not
+        # a mutation), and the referenced LLM profile on disk is never
+        # rewritten — unlike a client-side self-heal that persists the flag.
+        assert resolved_settings.llm.stream is False
+
+    def test_acp_profile_does_not_force_llm_stream(self):
+        """The stream-forcing guarantee is OpenHands-only: ACP agents emit
+        their own message chunks through the ACP bridge without exposing an
+        LLM the same way (event_service.py's streaming_enabled already treats
+        every ACPAgent as streaming-capable regardless of llm.stream)."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_acp_profile()
+        agent = MagicMock()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            mock_config = MagicMock()
+            mock_config.create_agent.return_value = agent
+            MockResolve.return_value = mock_config
+
+            _resolve_agent_from_profile(profile.id, cipher=None, mcp_config={})
+
+        # No model_copy/mutation attempted on an ACP (non-OpenHandsAgentSettings)
+        # resolved settings object.
+        mock_config.model_copy.assert_not_called()
+
     def test_openhands_default_tools_get_browser_when_usable(self):
         """A default-toolset (tools=None) OpenHands profile launch injects the
         browser tool set when this server's runtime can run it — the
@@ -345,17 +416,45 @@ class TestResolveAgentFromProfile:
         MockUsable.assert_not_called()
         assert result_agent is agent
 
-    def test_openhands_default_profile_skips_discovery(self):
-        """A profile with the default ``skill_refs`` (== [], incl. any persisted
-        before the field existed) must NOT trigger catalog discovery — otherwise
-        every legacy OpenHands profile would silently inject the full discovered
-        skill set into its prompt on launch (regression guard for #3868)."""
+    def test_openhands_default_profile_triggers_discovery(self):
+        """A profile's default ``skill_refs`` is ``None`` (all discovered,
+        #4017) — a true twin of ``mcp_server_refs``, since there is no
+        embedded-skills fallback anymore. This *does* trigger catalog
+        discovery by default, unlike the old ``[]``-default behavior."""
         from openhands.agent_server.conversation_service import (
             _resolve_agent_from_profile,
         )
 
         profile = _make_openhands_profile()
-        assert profile.skill_refs == []  # the default, not None
+        assert profile.skill_refs is None  # the default, not []
+        agent = _make_agent()
+
+        with (
+            patch(_STORE_PATH) as MockStore,
+            patch(_LLM_STORE_PATH),
+            patch(_RESOLVE_PATH) as MockResolve,
+            patch(_DISCOVER_PATH, return_value=[]) as MockDiscover,
+        ):
+            store_inst = MockStore.return_value
+            store_inst.name_for_id.return_value = profile.name
+            store_inst.load.return_value = profile
+            mock_config = MagicMock()
+            mock_config.create_agent.return_value = agent
+            MockResolve.return_value = mock_config
+
+            _resolve_agent_from_profile(profile.id, cipher=None, mcp_config={})
+
+        MockDiscover.assert_called_once()
+
+    def test_openhands_explicit_empty_skill_refs_skips_discovery(self):
+        """An explicit ``skill_refs=[]`` (none) still skips the (network-bound)
+        catalog discovery — the opt-out path #3868 introduced, unaffected by
+        the default changing from ``[]`` to ``None``."""
+        from openhands.agent_server.conversation_service import (
+            _resolve_agent_from_profile,
+        )
+
+        profile = _make_openhands_profile().model_copy(update={"skill_refs": []})
         agent = _make_agent()
 
         with (
@@ -373,8 +472,6 @@ class TestResolveAgentFromProfile:
 
             _resolve_agent_from_profile(profile.id, cipher=None, mcp_config={})
 
-        # Default skill_refs=[] selects no discovered skills, so the
-        # (network-bound) discovery is skipped and the resolver gets None.
         MockDiscover.assert_not_called()
         assert MockResolve.call_args.kwargs["available_skills"] is None
 

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -670,29 +670,36 @@ def test_seed_preserves_openhands_fields(client):
     assert prof["enable_switch_llm_tool"] is False
     assert prof["tool_concurrency_limit"] == 3
     assert prof["system_message_suffix"] == "be terse"
-    # The seed no longer embeds skills (#4017); skill_refs=None (all
-    # discovered) is behavior-preserving going forward, since there is no
-    # partial-source global snapshot to freeze against anymore.
-    assert prof["skill_refs"] is None
+    # The seed freezes the global's resolved skills by name; this global has
+    # none, so skill_refs is the empty list (no skills), not None (all).
+    assert prof["skill_refs"] == []
     assert prof["verification"]["critic_enabled"] is True
     assert prof["verification"]["critic_model_name"] == "x-critic"
     # The profile verification is secret-free — no critic_api_key projected.
     assert "critic_api_key" not in prof["verification"]
 
 
-def test_seed_skill_refs_is_none_regardless_of_global_autoload_flags(client):
-    """The seed's ``skill_refs=None`` doesn't depend on the global's
-    ``load_user_skills`` / ``load_public_skills`` — those flags governed the
-    now-removed embedded-skills snapshot; the profile model has nothing left
-    to key off, so the seed is unconditionally ``None``."""
+def test_seed_freezes_resolved_skills_by_name(client):
+    """The seed reproduces the global's resolved skill set by name, so a
+    partial-source global (some skills, not the whole catalog) is preserved
+    rather than silently expanded to all-discovered."""
     client.patch(
         "/api/settings",
-        json={"agent_settings_diff": {"agent_context": {"load_user_skills": True}}},
+        json={
+            "agent_settings_diff": {
+                "agent_context": {
+                    "skills": [
+                        {"name": "alpha", "content": "x"},
+                        {"name": "beta", "content": "y"},
+                    ]
+                }
+            }
+        },
     )
     client.get("/api/agent-profiles")  # triggers the seed
 
     prof = client.get("/api/agent-profiles/default").json()["profile"]
-    assert prof["skill_refs"] is None
+    assert prof["skill_refs"] == ["alpha", "beta"]
 
 
 def test_seed_preserves_acp_fields(client):

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -425,10 +425,10 @@ def test_save_missing_required_ref_returns_422(client):
     assert any("llm_profile_ref" in err["loc"] for err in detail)
 
 
-def test_save_v1_body_with_stray_skills_key_is_migrated_and_saved(client, store):
-    """A body with no ``schema_version`` is treated as v1 and migrated (#4017):
-    the now-removed ``skills`` field is dropped before validation, so the save
-    succeeds rather than tripping extra='forbid'."""
+def test_save_schemaless_body_with_stray_skills_key_rejected(client):
+    """A body with no ``schema_version`` canonicalizes to the clean v1 baseline;
+    the removed ``skills`` field never shipped, so it is a genuine extra='forbid'
+    violation (422) — there is no migration to silently drop it (#4017)."""
     response = client.post(
         "/api/agent-profiles/legacy",
         json={
@@ -436,16 +436,12 @@ def test_save_v1_body_with_stray_skills_key_is_migrated_and_saved(client, store)
             "skills": [{"name": "old", "content": "x"}],
         },
     )
-    assert response.status_code == 201
-    loaded = store.load("legacy")
-    assert isinstance(loaded, OpenHandsAgentProfile)
-    assert not hasattr(loaded, "skills")
+    assert response.status_code == 422
 
 
 def test_save_current_schema_version_rejects_stray_skills_key(client):
-    """A body that already claims the current schema version skips migration,
-    so a stray ``skills`` key is a genuine extra='forbid' violation (422), not
-    silently dropped."""
+    """A body that claims the current schema version with a stray ``skills`` key
+    is a genuine extra='forbid' violation (422)."""
     from openhands.sdk.profiles.agent_profile import AGENT_PROFILE_SCHEMA_VERSION
 
     response = client.post(

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -425,25 +425,38 @@ def test_save_missing_required_ref_returns_422(client):
     assert any("llm_profile_ref" in err["loc"] for err in detail)
 
 
-def test_save_invalid_body_does_not_leak_mcp_secret(client):
-    """A malformed profile body's 422 must not echo skills[].mcp_tools secrets."""
-    secret = "ghp_should_never_appear_in_error"
+def test_save_v1_body_with_stray_skills_key_is_migrated_and_saved(client, store):
+    """A body with no ``schema_version`` is treated as v1 and migrated (#4017):
+    the now-removed ``skills`` field is dropped before validation, so the save
+    succeeds rather than tripping extra='forbid'."""
+    response = client.post(
+        "/api/agent-profiles/legacy",
+        json={
+            "llm_profile_ref": "base",
+            "skills": [{"name": "old", "content": "x"}],
+        },
+    )
+    assert response.status_code == 201
+    loaded = store.load("legacy")
+    assert isinstance(loaded, OpenHandsAgentProfile)
+    assert not hasattr(loaded, "skills")
+
+
+def test_save_current_schema_version_rejects_stray_skills_key(client):
+    """A body that already claims the current schema version skips migration,
+    so a stray ``skills`` key is a genuine extra='forbid' violation (422), not
+    silently dropped."""
+    from openhands.sdk.profiles.agent_profile import AGENT_PROFILE_SCHEMA_VERSION
+
     response = client.post(
         "/api/agent-profiles/bad",
         json={
+            "schema_version": AGENT_PROFILE_SCHEMA_VERSION,
             "llm_profile_ref": "base",
-            "skills": [
-                {
-                    "name": "leaky",
-                    "content": "x",
-                    # Malformed: mcpServers must be an object, forcing a failure.
-                    "mcp_tools": {"mcpServers": {"svc": {"headers": secret}}},
-                }
-            ],
+            "skills": [{"name": "old", "content": "x"}],
         },
     )
     assert response.status_code == 422
-    assert secret not in response.text
 
 
 def test_save_extra_field_returns_422(client):
@@ -479,6 +492,19 @@ def test_get_not_found(client):
     response = client.get("/api/agent-profiles/nonexistent")
     assert response.status_code == 404
     assert "not found" in response.json()["detail"].lower()
+
+
+def test_get_ignores_expose_secrets_header(client, store):
+    """A profile is secret-free at rest (#4017); GET has no ``X-Expose-Secrets``
+    behavior — unlike the LLM ``/api/profiles`` router, the header is simply
+    ignored rather than changing the response."""
+    store.save(OpenHandsAgentProfile(name="p", llm_profile_ref="base"))
+
+    plain = client.get("/api/agent-profiles/p").json()
+    encrypted = client.get(
+        "/api/agent-profiles/p", headers={"X-Expose-Secrets": "encrypted"}
+    ).json()
+    assert plain == encrypted
 
 
 def test_get_corrupted_returns_400(client, temp_agent_profiles_dir):
@@ -644,23 +670,21 @@ def test_seed_preserves_openhands_fields(client):
     assert prof["enable_switch_llm_tool"] is False
     assert prof["tool_concurrency_limit"] == 3
     assert prof["system_message_suffix"] == "be terse"
-    # The seed embeds the global's resolved skills and selects no further
-    # discovery (skill_refs=[]), so it resolves to exactly that skill set.
-    assert prof["skill_refs"] == []
+    # The seed no longer embeds skills (#4017); skill_refs=None (all
+    # discovered) is behavior-preserving going forward, since there is no
+    # partial-source global snapshot to freeze against anymore.
+    assert prof["skill_refs"] is None
     assert prof["verification"]["critic_enabled"] is True
     assert prof["verification"]["critic_model_name"] == "x-critic"
     # The profile verification is secret-free — no critic_api_key projected.
     assert "critic_api_key" not in prof["verification"]
 
 
-def test_seed_clears_skill_refs_even_when_global_autoloads(client):
-    """A global that auto-loads skills still seeds skill_refs=[] (embedded
-    snapshot), not None.
-
-    skill_refs=None would re-discover user+public at resolve time and inject
-    skills a partial-source global never had; the embedded snapshot of
-    context.skills is the faithful mapping regardless of source flags.
-    """
+def test_seed_skill_refs_is_none_regardless_of_global_autoload_flags(client):
+    """The seed's ``skill_refs=None`` doesn't depend on the global's
+    ``load_user_skills`` / ``load_public_skills`` — those flags governed the
+    now-removed embedded-skills snapshot; the profile model has nothing left
+    to key off, so the seed is unconditionally ``None``."""
     client.patch(
         "/api/settings",
         json={"agent_settings_diff": {"agent_context": {"load_user_skills": True}}},
@@ -668,7 +692,7 @@ def test_seed_clears_skill_refs_even_when_global_autoloads(client):
     client.get("/api/agent-profiles")  # triggers the seed
 
     prof = client.get("/api/agent-profiles/default").json()["profile"]
-    assert prof["skill_refs"] == []
+    assert prof["skill_refs"] is None
 
 
 def test_seed_preserves_acp_fields(client):
@@ -696,120 +720,6 @@ def test_seed_preserves_acp_fields(client):
     assert prof["skill_refs"] == []
 
 
-# ── Cipher: skills[].mcp_tools secret round-trip ────────────────────────────
-
-
-@pytest.fixture
-def secret_key():
-    from base64 import urlsafe_b64encode
-
-    return urlsafe_b64encode(b"a" * 32).decode("ascii")
-
-
-@pytest.fixture
-def cipher(secret_key):
-    from openhands.sdk.utils.cipher import Cipher
-
-    return Cipher(secret_key)
-
-
-@pytest.fixture
-def client_with_cipher(
-    temp_agent_profiles_dir, temp_settings_dir, secret_key, monkeypatch
-):
-    from pydantic import SecretStr
-
-    reset_stores()
-    monkeypatch.setenv("OH_PERSISTENCE_DIR", str(temp_settings_dir))
-    config = Config(
-        static_files_path=None, session_api_keys=[], secret_key=SecretStr(secret_key)
-    )
-    app = create_app(config)
-    with patch(
-        "openhands.agent_server.agent_profiles_router.get_agent_profile_store",
-        lambda: AgentProfileStore(base_dir=temp_agent_profiles_dir),
-    ):
-        yield TestClient(app)
-    reset_stores()
-
-
-def _profile_with_mcp_secret(token_value: str) -> dict:
-    return {
-        "llm_profile_ref": "base",
-        "skills": [
-            {
-                "name": "leaky",
-                "content": "do stuff",
-                "mcp_tools": {
-                    "mcpServers": {
-                        "svc": {
-                            "url": "https://x.test",
-                            "auth": {
-                                "strategy": "bearer",
-                                "value": token_value,
-                            },
-                        }
-                    }
-                },
-            }
-        ],
-    }
-
-
-def _mcp_auth_value(profile_payload: dict) -> str:
-    servers = profile_payload["skills"][0]["mcp_tools"]
-    return servers["svc"]["auth"]["value"]
-
-
-def test_mcp_tools_secret_encrypted_roundtrip(client_with_cipher, cipher):
-    """GET(encrypted) -> POST -> the secret still decrypts exactly once.
-
-    Without decrypt-incoming-before-save the re-posted token would be encrypted
-    again and the stored value would decrypt to a stale token.
-    """
-    secret = "ghp_roundtrip_secret"
-
-    created = client_with_cipher.post(
-        "/api/agent-profiles/p", json=_profile_with_mcp_secret(secret)
-    )
-    assert created.status_code == 201
-
-    # GET encrypted: a Fernet token of the ORIGINAL secret (not double-encrypted).
-    enc = client_with_cipher.get(
-        "/api/agent-profiles/p", headers={"X-Expose-Secrets": "encrypted"}
-    ).json()
-    token = _mcp_auth_value(enc["profile"])
-    assert token != secret
-    assert cipher.decrypt(token).get_secret_value() == secret
-
-    # Re-post the encrypted API payload (an ordinary client edit round-trip).
-    reposted = client_with_cipher.post("/api/agent-profiles/p", json=enc["profile"])
-    assert reposted.status_code == 201
-
-    # Plaintext GET returns the original secret -> decrypted exactly once.
-    plain = client_with_cipher.get(
-        "/api/agent-profiles/p", headers={"X-Expose-Secrets": "plaintext"}
-    ).json()
-    assert _mcp_auth_value(plain["profile"]) == secret
-
-
-def test_mcp_tools_secret_encrypted_at_rest(
-    client_with_cipher, temp_agent_profiles_dir, cipher
-):
-    """A posted plaintext MCP secret is encrypted on disk, never stored raw."""
-    import json
-
-    secret = "ghp_at_rest_secret"
-    client_with_cipher.post(
-        "/api/agent-profiles/p", json=_profile_with_mcp_secret(secret)
-    )
-
-    raw = json.loads((temp_agent_profiles_dir / "p.json").read_text())
-    stored = raw["skills"][0]["mcp_tools"]["svc"]["auth"]["value"]
-    assert stored != secret
-    assert cipher.decrypt(stored).get_secret_value() == secret
-
-
 # ── Store errors → HTTP ─────────────────────────────────────────────────────
 
 
@@ -823,7 +733,7 @@ def test_list_timeout_returns_503(client, monkeypatch):
 
 
 def test_save_timeout_returns_503(client, monkeypatch):
-    def boom(self, profile, *, cipher=None, max_profiles=None):
+    def boom(self, profile, *, max_profiles=None):
         raise TimeoutError("locked")
 
     monkeypatch.setattr(AgentProfileStore, "save", boom)

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -670,19 +670,20 @@ def test_seed_preserves_openhands_fields(client):
     assert prof["enable_switch_llm_tool"] is False
     assert prof["tool_concurrency_limit"] == 3
     assert prof["system_message_suffix"] == "be terse"
-    # The seed freezes the global's resolved skills by name; this global has
-    # none, so skill_refs is the empty list (no skills), not None (all).
-    assert prof["skill_refs"] == []
+    # The seed disables nothing — the default profile launches with all
+    # discovered skills (deny-list model).
+    assert prof["disabled_skills"] == []
     assert prof["verification"]["critic_enabled"] is True
     assert prof["verification"]["critic_model_name"] == "x-critic"
     # The profile verification is secret-free — no critic_api_key projected.
     assert "critic_api_key" not in prof["verification"]
 
 
-def test_seed_freezes_resolved_skills_by_name(client):
-    """The seed reproduces the global's resolved skill set by name, so a
-    partial-source global (some skills, not the whole catalog) is preserved
-    rather than silently expanded to all-discovered."""
+def test_seed_disables_nothing_even_with_inline_global_skills(client):
+    """The seed never freezes the global's skills by name — it sets an empty
+    deny-list, so the migrated default profile launches with all discovered
+    skills. Freezing by name was the #4017 launch-break (an inline global skill
+    absent from the launch catalog would dangle)."""
     client.patch(
         "/api/settings",
         json={
@@ -699,7 +700,7 @@ def test_seed_freezes_resolved_skills_by_name(client):
     client.get("/api/agent-profiles")  # triggers the seed
 
     prof = client.get("/api/agent-profiles/default").json()["profile"]
-    assert prof["skill_refs"] == ["alpha", "beta"]
+    assert prof["disabled_skills"] == []
 
 
 def test_seed_preserves_acp_fields(client):
@@ -722,9 +723,9 @@ def test_seed_preserves_acp_fields(client):
     assert prof["acp_server"] == "codex"
     assert prof["acp_model"] == "gpt-5.5"
     assert prof["acp_args"] == ["--foo", "--bar"]
-    # Conservative ACP seed: skill_refs=[] so an existing ACP run doesn't start
-    # receiving the discovered skill catalog until the user opts in.
-    assert prof["skill_refs"] == []
+    # ACP profiles carry no skill-selection field at all.
+    assert "skill_refs" not in prof
+    assert "disabled_skills" not in prof
 
 
 # ── Store errors → HTTP ─────────────────────────────────────────────────────
@@ -863,11 +864,12 @@ def test_materialize_dangling_mcp_ref(client_with_llm_store, store, llm_store):
     assert body["resolved_settings"] is None
 
 
-def test_materialize_reports_resolved_and_dangling_skill_refs(
+def test_materialize_reports_disabled_and_resolved_skills(
     client_with_llm_store, store, llm_store
 ):
-    """skill_refs are resolved against the discovered catalog; a stale ref is
-    reported and invalidates the profile (mirrors dangling MCP refs)."""
+    """The materialize dry-run reports the deny-list and the resolved set
+    (catalog minus disabled). A disabled name absent from the catalog is a no-op
+    and does NOT invalidate the profile — the deny-list can't dangle (#4017)."""
     from openhands.sdk.skills import Skill
 
     llm_store.save("base-llm", LLM(model="gpt-4o"), include_secrets=True)
@@ -875,23 +877,25 @@ def test_materialize_reports_resolved_and_dangling_skill_refs(
         OpenHandsAgentProfile(
             name="p",
             llm_profile_ref="base-llm",
-            skill_refs=["known", "stale"],
+            disabled_skills=["beta", "not-in-catalog"],
         )
     )
 
     with patch(
-        "openhands.agent_server.skills_service.discover_profile_skills",
-        return_value=[Skill(name="known", content="x")],
+        "openhands.agent_server.agent_profiles_router.discover_profile_skills",
+        return_value=[
+            Skill(name="alpha", content="x"),
+            Skill(name="beta", content="y"),
+        ],
     ):
         response = client_with_llm_store.post("/api/agent-profiles/p/materialize")
 
     assert response.status_code == 200
     body = response.json()
-    assert body["valid"] is False
-    assert body["skill_refs"] == ["known", "stale"]
-    assert body["resolved_skills"] == ["known"]
-    assert body["dangling_skill_refs"] == ["stale"]
-    assert body["resolved_settings"] is None
+    assert body["valid"] is True
+    assert body["disabled_skills"] == ["beta", "not-in-catalog"]
+    assert body["resolved_skills"] == ["alpha"]
+    assert body["resolved_settings"] is not None
 
 
 def test_materialize_unknown_name_returns_404(client_with_llm_store):

--- a/tests/agent_server/test_skills_service.py
+++ b/tests/agent_server/test_skills_service.py
@@ -13,7 +13,6 @@ from openhands.agent_server.skills_service import (
     SkillLoadResult,
     create_sandbox_skill,
     discover_profile_skills,
-    discover_profile_skills_if_needed,
     load_all_skills,
     load_org_skills_from_url,
     load_registered_marketplace_skills,
@@ -21,7 +20,6 @@ from openhands.agent_server.skills_service import (
     sync_public_skills,
 )
 from openhands.sdk.marketplace.registration import MarketplaceRegistration
-from openhands.sdk.profiles import OpenHandsAgentProfile
 from openhands.sdk.skills import Skill
 
 
@@ -575,7 +573,7 @@ class TestLoadAllSkills:
 
 
 class TestDiscoverProfileSkills:
-    """Tests for discover_profile_skills (AgentProfile.skill_refs catalog)."""
+    """Tests for discover_profile_skills (the OpenHands profile launch catalog)."""
 
     _LOAD_ALL = "openhands.agent_server.skills_service.load_all_skills"
 
@@ -601,32 +599,6 @@ class TestDiscoverProfileSkills:
         with patch(self._LOAD_ALL, side_effect=RuntimeError("boom")):
             with pytest.raises(RuntimeError, match="boom"):
                 discover_profile_skills()
-
-
-class TestDiscoverProfileSkillsIfNeeded:
-    """Tests for the skip-discovery guard shared by start + dry-run."""
-
-    _DISCOVER = "openhands.agent_server.skills_service.discover_profile_skills"
-
-    def test_empty_skill_refs_skips_discovery(self):
-        profile = OpenHandsAgentProfile(name="p", llm_profile_ref="x", skill_refs=[])
-        with patch(self._DISCOVER) as mock_discover:
-            assert discover_profile_skills_if_needed(profile) is None
-            mock_discover.assert_not_called()
-
-    def test_null_skill_refs_discovers(self):
-        profile = OpenHandsAgentProfile(name="p", llm_profile_ref="x", skill_refs=None)
-        skills = [Skill(name="a", content="x")]
-        with patch(self._DISCOVER, return_value=skills) as mock_discover:
-            assert discover_profile_skills_if_needed(profile) == skills
-            mock_discover.assert_called_once()
-
-    def test_named_skill_refs_discovers(self):
-        profile = OpenHandsAgentProfile(name="p", llm_profile_ref="x", skill_refs=["a"])
-        skills = [Skill(name="a", content="x")]
-        with patch(self._DISCOVER, return_value=skills) as mock_discover:
-            assert discover_profile_skills_if_needed(profile) == skills
-            mock_discover.assert_called_once()
 
 
 class TestSyncPublicSkills:

--- a/tests/sdk/context/test_agent_context.py
+++ b/tests/sdk/context/test_agent_context.py
@@ -51,6 +51,26 @@ class TestAgentContext:
         with pytest.raises(ValueError, match="Duplicate skill name found: duplicate"):
             AgentContext(skills=[repo_skill1, repo_skill2])
 
+    def test_disabled_skills_drops_named_skill(self):
+        """The disabled_skills deny-list drops the named skill from the context
+        after loading, regardless of source; a name not present is a no-op."""
+        keep = Skill(name="keep", content="k", source="keep.md", trigger=None)
+        drop = Skill(name="drop", content="d", source="drop.md", trigger=None)
+        context = AgentContext(
+            skills=[keep, drop],
+            # "absent" is not among the skills — must be a harmless no-op.
+            disabled_skills=["drop", "absent"],
+        )
+        assert [s.name for s in context.skills] == ["keep"]
+
+    def test_disabled_skills_empty_keeps_all(self):
+        """The default empty deny-list keeps every skill."""
+        a = Skill(name="a", content="a", source="a.md", trigger=None)
+        b = Skill(name="b", content="b", source="b.md", trigger=None)
+        context = AgentContext(skills=[a, b])
+        assert context.disabled_skills == []
+        assert {s.name for s in context.skills} == {"a", "b"}
+
     def test_get_system_message_suffix_no_repo_skills(self):
         """Test system message suffix with no repo skills but with triggered skills."""
         knowledge_skill = Skill(

--- a/tests/sdk/conversation/test_repo_root_project_skills.py
+++ b/tests/sdk/conversation/test_repo_root_project_skills.py
@@ -174,6 +174,40 @@ def test_load_project_skills_flag_merges_with_project_precedence(tmp_path: Path)
     conversation.close()
 
 
+def test_disabled_skills_drops_project_skill_at_lazy_merge(tmp_path: Path):
+    """A project skill whose name is in ``disabled_skills`` is dropped during the
+    lazy ``LocalConversation`` merge — the ``model_copy`` path that bypasses the
+    ``AgentContext`` validator. An unrelated disabled name is a harmless no-op.
+    """
+    # AGENTS.md becomes a project skill named "agents".
+    (tmp_path / "AGENTS.md").write_text("# Guidelines\n\nSENTINEL\n")
+
+    agent = _agent(
+        AgentContext(
+            skills=[Skill(name="keep", content="keep me")],
+            load_project_skills=True,
+            disabled_skills=["agents", "not-in-catalog"],
+            current_datetime="2026-01-01T00:00:00Z",
+        )
+    )
+    conversation = LocalConversation(
+        agent=agent,
+        workspace=tmp_path,
+        persistence_dir=tmp_path / "conversation",
+        delete_on_close=True,
+    )
+    conversation.send_message("hi")
+
+    assert conversation.agent.agent_context is not None
+    names = {s.name for s in conversation.agent.agent_context.skills}
+    # The lazily-loaded project skill "agents" is disabled -> dropped at merge.
+    assert "agents" not in names
+    # A non-disabled skill is unaffected; the absent "not-in-catalog" is a no-op.
+    assert "keep" in names
+
+    conversation.close()
+
+
 def test_load_project_skills_failure_does_not_block_conversation(tmp_path: Path):
     """Project-skill loading is best-effort: a load error must not break startup."""
     (tmp_path / "AGENTS.md").write_text("# Guidelines\n\nSENTINEL\n")

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -167,15 +167,21 @@ def test_llm_completion_basic(mock_completion):
     assert not llm.should_mock_tool_calls(cc_tools)
 
 
-def test_llm_streaming_not_supported(default_config):
-    """Test that streaming requires an on_token callback."""
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_llm_streaming_without_callback_degrades(mock_completion, default_config):
+    """Streaming requested without an on_token callback degrades to a plain
+    non-streaming completion instead of crashing the run (#4014)."""
     llm = default_config
+    mock_completion.return_value = create_mock_response("Test response")
 
     messages = [Message(role="user", content=[TextContent(text="Hello")])]
 
-    # Streaming without callback should raise an error
-    with pytest.raises(ValueError, match="Streaming requires an on_token callback"):
-        llm.completion(messages=messages, stream=True)
+    response = llm.completion(messages=messages, stream=True)
+
+    # No stream kwarg is forwarded to litellm — the call ran non-streaming.
+    assert mock_completion.call_args.kwargs.get("stream") in (None, False)
+    assert isinstance(response.message.content[0], TextContent)
+    assert response.message.content[0].text == "Test response"
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -167,31 +167,15 @@ def test_llm_completion_basic(mock_completion):
     assert not llm.should_mock_tool_calls(cc_tools)
 
 
-@patch("openhands.sdk.llm.llm.logger")
-@patch("openhands.sdk.llm.llm.litellm_completion")
-def test_llm_streaming_without_callback_degrades_gracefully(
-    mock_completion, mock_logger, default_config
-):
-    """A stream/callback mismatch must not crash the run (#4014) — e.g. a
-    profile-launched conversation whose LLM has stream=True but no on_token
-    wired. ``completion`` degrades to a non-streaming call instead of raising,
-    and warns rather than silently swallowing the mismatch.
-
-    Patches the module logger locally (rather than relying on caplog) so the
-    mock is properly typed, unlike the module-level object the autouse
-    ``suppress_logging`` fixture substitutes it with.
-    """
+def test_llm_streaming_not_supported(default_config):
+    """Test that streaming requires an on_token callback."""
     llm = default_config
-    mock_completion.return_value = create_mock_response("Test response")
 
     messages = [Message(role="user", content=[TextContent(text="Hello")])]
-    response = llm.completion(messages=messages, stream=True)
 
-    assert response.message.content[0].text == "Test response"
-    # Never asked litellm for a streaming response.
-    assert mock_completion.call_args.kwargs.get("stream") is not True
-    mock_logger.warning.assert_called_once()
-    assert "on_token" in mock_logger.warning.call_args.args[0]
+    # Streaming without callback should raise an error
+    with pytest.raises(ValueError, match="Streaming requires an on_token callback"):
+        llm.completion(messages=messages, stream=True)
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -167,15 +167,31 @@ def test_llm_completion_basic(mock_completion):
     assert not llm.should_mock_tool_calls(cc_tools)
 
 
-def test_llm_streaming_not_supported(default_config):
-    """Test that streaming requires an on_token callback."""
+@patch("openhands.sdk.llm.llm.logger")
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_llm_streaming_without_callback_degrades_gracefully(
+    mock_completion, mock_logger, default_config
+):
+    """A stream/callback mismatch must not crash the run (#4014) — e.g. a
+    profile-launched conversation whose LLM has stream=True but no on_token
+    wired. ``completion`` degrades to a non-streaming call instead of raising,
+    and warns rather than silently swallowing the mismatch.
+
+    Patches the module logger locally (rather than relying on caplog) so the
+    mock is properly typed, unlike the module-level object the autouse
+    ``suppress_logging`` fixture substitutes it with.
+    """
     llm = default_config
+    mock_completion.return_value = create_mock_response("Test response")
 
     messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    response = llm.completion(messages=messages, stream=True)
 
-    # Streaming without callback should raise an error
-    with pytest.raises(ValueError, match="Streaming requires an on_token callback"):
-        llm.completion(messages=messages, stream=True)
+    assert response.message.content[0].text == "Test response"
+    # Never asked litellm for a streaming response.
+    assert mock_completion.call_args.kwargs.get("stream") is not True
+    mock_logger.warning.assert_called_once()
+    assert "on_token" in mock_logger.warning.call_args.args[0]
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -10,9 +10,8 @@ import json
 from uuid import UUID, uuid4
 
 import pytest
-from pydantic import SecretStr, TypeAdapter, ValidationError
+from pydantic import TypeAdapter, ValidationError
 
-from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.profiles import (
     AGENT_PROFILE_SCHEMA_VERSION,
     ACPAgentProfile,
@@ -20,7 +19,6 @@ from openhands.sdk.profiles import (
     OpenHandsAgentProfile,
     validate_agent_profile,
 )
-from openhands.sdk.skills import Skill
 
 
 _ADAPTER: TypeAdapter[OpenHandsAgentProfile | ACPAgentProfile] = TypeAdapter(
@@ -61,23 +59,18 @@ def test_openhands_profile_round_trips() -> None:
 
 def test_openhands_profile_new_field_defaults() -> None:
     """``enable_switch_llm_tool`` defaults True (global parity); ``skill_refs``
-    defaults [] (none) — NOT None. A missing field must not silently inject the
-    whole discovered catalog. ``None`` (all discovered) stays an explicit opt-in,
-    reachable only when the field is present as ``null`` (see
-    ``test_skill_refs_empty_vs_null_are_distinct``)."""
+    defaults ``None`` (all discovered) — a true twin of ``mcp_server_refs``
+    (#4017). There is no embedded ``skills`` fallback anymore, so an unset
+    field must mean "all", not "none"."""
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     assert profile.enable_switch_llm_tool is True
-    assert profile.skill_refs == []
-    # An older persisted payload without the fields still validates and adopts
-    # the safe defaults — critically, an absent ``skill_refs`` resolves to [],
-    # so a profile persisted before the field existed does not start pulling the
-    # discovered catalog on load.
+    assert profile.skill_refs is None
     reloaded = validate_agent_profile(
         {"agent_kind": "openhands", "name": "oh", "llm_profile_ref": "default"}
     )
     assert isinstance(reloaded, OpenHandsAgentProfile)
     assert reloaded.enable_switch_llm_tool is True
-    assert reloaded.skill_refs == []
+    assert reloaded.skill_refs is None
 
 
 def test_skill_refs_empty_vs_null_are_distinct() -> None:
@@ -100,10 +93,9 @@ def test_skill_refs_empty_vs_null_are_distinct() -> None:
 
 
 def test_acp_profile_skill_refs_defaults_empty() -> None:
-    """ACP profiles default ``skill_refs=[]`` (they own their tooling), inheriting
-    the safe base default shared with OpenHands. A payload without the field —
-    incl. one persisted before the field existed — adopts the [] default rather
-    than injecting the catalog."""
+    """ACP profiles default ``skill_refs=[]`` (they own their tooling) —
+    overriding the shared base's ``None`` (all discovered) default, which is
+    right for OpenHands profiles but not ACP ones."""
     from openhands.sdk.profiles import ACPAgentProfile
 
     profile = ACPAgentProfile(name="acp", acp_server="claude-code")
@@ -394,46 +386,74 @@ def test_verification_field_cannot_carry_a_secret() -> None:
     assert "sk-real-secret-value" not in json.dumps(exposed)
 
 
-def _skill_with_mcp_secret() -> Skill:
-    return Skill(
-        name="leaky",
-        content="do stuff",
-        mcp_tools={
-            "svc": MCPServer(
-                url="https://x.test",
-                headers={"Authorization": SecretStr("Bearer sk-HEADER-SECRET")},
-                env={"API_KEY": SecretStr("env-SECRET")},
-            )
-        },
-    )
+def test_openhands_profile_has_no_embedded_skills_field() -> None:
+    """Profiles no longer carry embedded ``skills`` (#4017): the field is gone,
+    and ``extra="forbid"`` rejects a stray one rather than silently accepting
+    or dropping it. This is what makes the profile genuinely secret-free at
+    rest — the only field that could ever carry a secret (``skills[].mcp_tools``)
+    is gone."""
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {
+                "agent_kind": "openhands",
+                "name": "oh",
+                "llm_profile_ref": "default",
+                "schema_version": AGENT_PROFILE_SCHEMA_VERSION,
+                "skills": [],
+            }
+        )
 
 
-def test_skills_mcp_tools_credentials_are_masked_at_rest() -> None:
-    """``Skill.mcp_tools`` can carry an MCP server credential in ``env`` /
-    ``headers``; the profile must mask it at rest like
-    ``OpenHandsAgentSettings.mcp_config`` does — not dump it in plaintext."""
-    profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skills=[_skill_with_mcp_secret()]
-    )
-
-    default_dump = json.dumps(profile.model_dump(mode="json"))
-    assert "sk-HEADER-SECRET" not in default_dump
-    assert "env-SECRET" not in default_dump
-
-    # Opt-in exposure surfaces the real values (parity with mcp_config).
-    exposed = json.dumps(
-        profile.model_dump(mode="json", context={"expose_secrets": True})
-    )
-    assert "sk-HEADER-SECRET" in exposed
-    assert "env-SECRET" in exposed
+# ---------------------------------------------------------------------------
+# v1 -> v2 migration: drop embedded ``skills`` (#4017)
+# ---------------------------------------------------------------------------
 
 
-def test_skills_without_secrets_round_trip() -> None:
-    """A plain skill (no mcp_tools secrets) still round-trips unchanged."""
-    profile = OpenHandsAgentProfile(
-        name="oh",
-        llm_profile_ref="default",
-        skills=[Skill(name="clean", content="hello")],
-    )
-    reloaded = validate_agent_profile(profile.model_dump(mode="json"))
-    assert reloaded == profile
+def test_v1_payload_with_embedded_skills_migrates_cleanly() -> None:
+    """A v1 payload carrying the now-removed ``skills`` field migrates to v2
+    with the field dropped, rather than tripping ``extra="forbid"``."""
+    payload = {
+        "schema_version": 1,
+        "agent_kind": "openhands",
+        "name": "oh",
+        "llm_profile_ref": "default",
+        "skills": [{"name": "old-skill", "content": "do stuff"}],
+    }
+    profile = validate_agent_profile(payload)
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
+    assert not hasattr(profile, "skills")
+
+
+def test_v1_payload_missing_skill_refs_adopts_current_default() -> None:
+    """A v1 payload that never set ``skill_refs`` picks up the model's
+    *current* class default on reload — ``None`` (all discovered), not the
+    ``[]`` the class defaulted to when the payload was written. Intentional
+    (#4017): Agent Profiles has no production data yet, so there is no
+    compatibility contract to preserve, and ``None``-by-default now mirrors
+    ``mcp_server_refs``."""
+    payload = {
+        "schema_version": 1,
+        "agent_kind": "openhands",
+        "name": "oh",
+        "llm_profile_ref": "default",
+    }
+    profile = validate_agent_profile(payload)
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.skill_refs is None
+
+
+def test_v1_payload_explicit_skill_refs_is_untouched_by_migration() -> None:
+    """The migration only drops ``skills``; an explicit ``skill_refs`` on a v1
+    payload (e.g. the canvas ``withDefaultSkillRefs`` shim's ``null``) survives
+    unchanged."""
+    payload = {
+        "schema_version": 1,
+        "agent_kind": "openhands",
+        "name": "oh",
+        "llm_profile_ref": "default",
+        "skill_refs": [],
+    }
+    profile = validate_agent_profile(payload)
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.skill_refs == []

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -394,57 +394,52 @@ def test_openhands_profile_has_no_embedded_skills_field() -> None:
 
 
 # ---------------------------------------------------------------------------
-# migration: v1 drops embedded ``skills``; v2->v3 drops allow-list ``skill_refs``
-# for the ``disabled_skills`` deny-list (#4017)
+# clean v1 baseline: nothing ever shipped, so the removed ``skills`` /
+# ``skill_refs`` fields are rejected (``extra="forbid"``), not migrated (#4017)
 # ---------------------------------------------------------------------------
 
 
-def test_v1_payload_with_embedded_skills_migrates_cleanly() -> None:
-    """A v1 payload carrying the now-removed ``skills`` field migrates to the
-    current schema with the field dropped, rather than tripping
-    ``extra="forbid"``."""
-    payload = {
-        "schema_version": 1,
-        "agent_kind": "openhands",
-        "name": "oh",
-        "llm_profile_ref": "default",
-        "skills": [{"name": "old-skill", "content": "do stuff"}],
-    }
-    profile = validate_agent_profile(payload)
-    assert isinstance(profile, OpenHandsAgentProfile)
-    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
-    assert not hasattr(profile, "skills")
+def test_removed_skills_field_is_rejected() -> None:
+    """The embedded ``skills`` field never shipped, so a payload carrying it is a
+    genuine ``extra="forbid"`` violation — there is no migration to drop it."""
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {
+                "schema_version": 1,
+                "agent_kind": "openhands",
+                "name": "oh",
+                "llm_profile_ref": "default",
+                "skills": [{"name": "old-skill", "content": "do stuff"}],
+            }
+        )
 
 
-def test_migrated_payload_adopts_empty_disabled_skills_default() -> None:
-    """A pre-``disabled_skills`` payload picks up the model's current default on
-    reload — ``[]`` (all discovered skills). No production data exists, so there
-    is no compatibility contract to preserve (#4017)."""
-    payload = {
-        "schema_version": 1,
-        "agent_kind": "openhands",
-        "name": "oh",
-        "llm_profile_ref": "default",
-    }
-    profile = validate_agent_profile(payload)
+def test_removed_skill_refs_field_is_rejected() -> None:
+    """The allow-list ``skill_refs`` was replaced by the ``disabled_skills``
+    deny-list and never shipped, so a payload carrying it is rejected."""
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {
+                "schema_version": 1,
+                "agent_kind": "openhands",
+                "name": "oh",
+                "llm_profile_ref": "default",
+                "skill_refs": ["pdf-tools"],
+            }
+        )
+
+
+def test_payload_without_disabled_skills_adopts_empty_default() -> None:
+    """A payload that omits ``disabled_skills`` picks up the model default —
+    ``[]`` (all discovered skills)."""
+    profile = validate_agent_profile(
+        {
+            "schema_version": 1,
+            "agent_kind": "openhands",
+            "name": "oh",
+            "llm_profile_ref": "default",
+        }
+    )
     assert isinstance(profile, OpenHandsAgentProfile)
     assert profile.disabled_skills == []
-
-
-def test_v2_payload_skill_refs_is_dropped_by_migration() -> None:
-    """v2->v3 drops the allow-list ``skill_refs`` entirely (skills are now a
-    deny-list). A v2 payload carrying ``skill_refs`` migrates to a profile with
-    no ``skill_refs`` and the default empty ``disabled_skills`` — the field is
-    not folded forward (no real subset ever shipped)."""
-    payload = {
-        "schema_version": 2,
-        "agent_kind": "openhands",
-        "name": "oh",
-        "llm_profile_ref": "default",
-        "skill_refs": ["pdf-tools"],
-    }
-    profile = validate_agent_profile(payload)
-    assert isinstance(profile, OpenHandsAgentProfile)
-    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
-    assert not hasattr(profile, "skill_refs")
     assert profile.disabled_skills == []

--- a/tests/sdk/profiles/test_agent_profile.py
+++ b/tests/sdk/profiles/test_agent_profile.py
@@ -37,7 +37,7 @@ def test_openhands_profile_round_trips() -> None:
         llm_profile_ref="default",
         revision=3,
         mcp_server_refs=["fetch"],
-        skill_refs=["pdf-tools"],
+        disabled_skills=["pdf-tools"],
         system_message_suffix="be terse",
         enable_sub_agents=True,
         enable_switch_llm_tool=False,
@@ -52,64 +52,56 @@ def test_openhands_profile_round_trips() -> None:
     assert reloaded.llm_profile_ref == "default"
     assert reloaded.revision == 3
     assert reloaded.mcp_server_refs == ["fetch"]
-    assert reloaded.skill_refs == ["pdf-tools"]
+    assert reloaded.disabled_skills == ["pdf-tools"]
     assert reloaded.enable_switch_llm_tool is False
     assert reloaded.tool_concurrency_limit == 4
 
 
 def test_openhands_profile_new_field_defaults() -> None:
-    """``enable_switch_llm_tool`` defaults True (global parity); ``skill_refs``
-    defaults ``None`` (all discovered) — a true twin of ``mcp_server_refs``
-    (#4017). There is no embedded ``skills`` fallback anymore, so an unset
-    field must mean "all", not "none"."""
+    """``enable_switch_llm_tool`` defaults True (global parity); ``disabled_skills``
+    defaults ``[]`` — the deny-list starts empty, so an unset field means "all
+    discovered skills" (#4017). Skills are selected by exclusion, never an
+    allow-list of names that could dangle."""
     profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     assert profile.enable_switch_llm_tool is True
-    assert profile.skill_refs is None
+    assert profile.disabled_skills == []
     reloaded = validate_agent_profile(
         {"agent_kind": "openhands", "name": "oh", "llm_profile_ref": "default"}
     )
     assert isinstance(reloaded, OpenHandsAgentProfile)
     assert reloaded.enable_switch_llm_tool is True
-    assert reloaded.skill_refs is None
+    assert reloaded.disabled_skills == []
 
 
-def test_skill_refs_empty_vs_null_are_distinct() -> None:
-    """``[]`` (none) and ``None`` (all discovered) must survive round-trip
-    distinctly, mirroring ``mcp_server_refs``."""
-    none_ref = validate_agent_profile(
+def test_disabled_skills_round_trips() -> None:
+    """A non-empty deny-list survives the JSON round-trip verbatim."""
+    profile = validate_agent_profile(
         OpenHandsAgentProfile(
-            name="oh", llm_profile_ref="default", skill_refs=None
+            name="oh", llm_profile_ref="default", disabled_skills=["a", "b"]
         ).model_dump(mode="json")
     )
-    empty_ref = validate_agent_profile(
-        OpenHandsAgentProfile(
-            name="oh", llm_profile_ref="default", skill_refs=[]
-        ).model_dump(mode="json")
-    )
-    assert isinstance(none_ref, OpenHandsAgentProfile)
-    assert isinstance(empty_ref, OpenHandsAgentProfile)
-    assert none_ref.skill_refs is None
-    assert empty_ref.skill_refs == []
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.disabled_skills == ["a", "b"]
 
 
-def test_acp_profile_skill_refs_defaults_empty() -> None:
-    """ACP profiles default ``skill_refs=[]`` (they own their tooling) —
-    overriding the shared base's ``None`` (all discovered) default, which is
-    right for OpenHands profiles but not ACP ones."""
+def test_acp_profile_has_no_skill_field() -> None:
+    """ACP profiles carry no skill-selection field at all — the subprocess owns
+    its tooling and prompt context (#4017). ``extra="forbid"`` rejects a stray
+    ``skill_refs``/``disabled_skills`` on an ACP payload."""
     from openhands.sdk.profiles import ACPAgentProfile
 
     profile = ACPAgentProfile(name="acp", acp_server="claude-code")
-    assert profile.skill_refs == []
-    reloaded = validate_agent_profile(
-        {"agent_kind": "acp", "name": "acp", "acp_server": "claude-code"}
-    )
-    assert isinstance(reloaded, ACPAgentProfile)
-    assert reloaded.skill_refs == []
-    # null stays an explicit opt-in (all discovered), distinct from the default.
-    explicit_null = ACPAgentProfile(
-        name="acp", acp_server="claude-code", skill_refs=None
-    )
-    assert explicit_null.skill_refs is None
+    assert not hasattr(profile, "skill_refs")
+    assert not hasattr(profile, "disabled_skills")
+    with pytest.raises(ValidationError):
+        validate_agent_profile(
+            {
+                "agent_kind": "acp",
+                "name": "acp",
+                "acp_server": "claude-code",
+                "disabled_skills": ["x"],
+            }
+        )
 
 
 def test_acp_profile_round_trips() -> None:
@@ -122,7 +114,6 @@ def test_acp_profile_round_trips() -> None:
         acp_command="codex-acp",
         acp_args=["--flag"],
         mcp_server_refs=None,
-        skill_refs=["pdf-tools"],
     )
     reloaded = validate_agent_profile(profile.model_dump(mode="json"))
 
@@ -134,8 +125,6 @@ def test_acp_profile_round_trips() -> None:
     assert reloaded.acp_command == "codex-acp"
     assert reloaded.acp_args == ["--flag"]
     assert reloaded.mcp_server_refs is None
-    # skill_refs lives on the shared base, so ACP profiles round-trip it too.
-    assert reloaded.skill_refs == ["pdf-tools"]
 
 
 def test_acp_profile_minimal_defaults() -> None:
@@ -405,13 +394,15 @@ def test_openhands_profile_has_no_embedded_skills_field() -> None:
 
 
 # ---------------------------------------------------------------------------
-# v1 -> v2 migration: drop embedded ``skills`` (#4017)
+# migration: v1 drops embedded ``skills``; v2->v3 drops allow-list ``skill_refs``
+# for the ``disabled_skills`` deny-list (#4017)
 # ---------------------------------------------------------------------------
 
 
 def test_v1_payload_with_embedded_skills_migrates_cleanly() -> None:
-    """A v1 payload carrying the now-removed ``skills`` field migrates to v2
-    with the field dropped, rather than tripping ``extra="forbid"``."""
+    """A v1 payload carrying the now-removed ``skills`` field migrates to the
+    current schema with the field dropped, rather than tripping
+    ``extra="forbid"``."""
     payload = {
         "schema_version": 1,
         "agent_kind": "openhands",
@@ -425,13 +416,10 @@ def test_v1_payload_with_embedded_skills_migrates_cleanly() -> None:
     assert not hasattr(profile, "skills")
 
 
-def test_v1_payload_missing_skill_refs_adopts_current_default() -> None:
-    """A v1 payload that never set ``skill_refs`` picks up the model's
-    *current* class default on reload — ``None`` (all discovered), not the
-    ``[]`` the class defaulted to when the payload was written. Intentional
-    (#4017): Agent Profiles has no production data yet, so there is no
-    compatibility contract to preserve, and ``None``-by-default now mirrors
-    ``mcp_server_refs``."""
+def test_migrated_payload_adopts_empty_disabled_skills_default() -> None:
+    """A pre-``disabled_skills`` payload picks up the model's current default on
+    reload — ``[]`` (all discovered skills). No production data exists, so there
+    is no compatibility contract to preserve (#4017)."""
     payload = {
         "schema_version": 1,
         "agent_kind": "openhands",
@@ -440,20 +428,23 @@ def test_v1_payload_missing_skill_refs_adopts_current_default() -> None:
     }
     profile = validate_agent_profile(payload)
     assert isinstance(profile, OpenHandsAgentProfile)
-    assert profile.skill_refs is None
+    assert profile.disabled_skills == []
 
 
-def test_v1_payload_explicit_skill_refs_is_untouched_by_migration() -> None:
-    """The migration only drops ``skills``; an explicit ``skill_refs`` on a v1
-    payload (e.g. the canvas ``withDefaultSkillRefs`` shim's ``null``) survives
-    unchanged."""
+def test_v2_payload_skill_refs_is_dropped_by_migration() -> None:
+    """v2->v3 drops the allow-list ``skill_refs`` entirely (skills are now a
+    deny-list). A v2 payload carrying ``skill_refs`` migrates to a profile with
+    no ``skill_refs`` and the default empty ``disabled_skills`` — the field is
+    not folded forward (no real subset ever shipped)."""
     payload = {
-        "schema_version": 1,
+        "schema_version": 2,
         "agent_kind": "openhands",
         "name": "oh",
         "llm_profile_ref": "default",
-        "skill_refs": [],
+        "skill_refs": ["pdf-tools"],
     }
     profile = validate_agent_profile(payload)
     assert isinstance(profile, OpenHandsAgentProfile)
-    assert profile.skill_refs == []
+    assert profile.schema_version == AGENT_PROFILE_SCHEMA_VERSION
+    assert not hasattr(profile, "skill_refs")
+    assert profile.disabled_skills == []

--- a/tests/sdk/profiles/test_agent_profile_store.py
+++ b/tests/sdk/profiles/test_agent_profile_store.py
@@ -1,9 +1,9 @@
 """Tests for ``AgentProfileStore`` — mirrors the ``LLMProfileStore`` suite.
 
 Adds the profile-specific contracts: both union variants round-trip, the
-``id`` is stable across rename, ``list_summaries`` projects the FK fields
-without instantiating secrets, and ``skills[].mcp_tools`` secrets are redacted
-by default / encrypted (never cleartext) under a cipher.
+``id`` is stable across rename, and ``list_summaries`` projects the FK fields.
+The profile is secret-free at rest (#4017) — every field is a reference or a
+plain value, so no cipher is involved anywhere in this store.
 """
 
 import concurrent.futures
@@ -13,9 +13,7 @@ import threading
 from pathlib import Path
 
 import pytest
-from pydantic import SecretStr
 
-from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.profiles import (
     ACPAgentProfile,
     AgentProfileStore,
@@ -23,12 +21,6 @@ from openhands.sdk.profiles import (
     ProfileLimitExceeded,
 )
 from openhands.sdk.profiles.agent_profile import AGENT_PROFILE_SCHEMA_VERSION
-from openhands.sdk.skills import Skill
-from openhands.sdk.utils.cipher import FERNET_TOKEN_PREFIX, Cipher
-
-
-# A clearly identifiable secret carried by a skill's mcp_tools env/headers.
-_MCP_SECRET = "ghp_SUPER_SECRET_TOKEN_SHOULD_NOT_LEAK"
 
 
 @pytest.fixture
@@ -49,28 +41,6 @@ def openhands_profile() -> OpenHandsAgentProfile:
 @pytest.fixture
 def acp_profile() -> ACPAgentProfile:
     return ACPAgentProfile(name="acp", acp_server="codex", acp_model="gpt-5.5/medium")
-
-
-def _skill_with_secret() -> Skill:
-    return Skill(
-        name="leaky",
-        content="do stuff",
-        mcp_tools={
-            "svc": MCPServer(
-                url="https://x.test",
-                headers={"Authorization": SecretStr(f"Bearer {_MCP_SECRET}")},
-                env={"API_KEY": SecretStr(_MCP_SECRET)},
-            )
-        },
-    )
-
-
-def _profile_with_secret_skill(name: str = "secretful") -> OpenHandsAgentProfile:
-    return OpenHandsAgentProfile(
-        name=name,
-        llm_profile_ref="default",
-        skills=[_skill_with_secret()],
-    )
 
 
 # ── Init ────────────────────────────────────────────────────────────────────
@@ -214,39 +184,10 @@ def test_save_overwrites_existing(
     assert loaded.llm_profile_ref == "other"
 
 
-# ── Cipher round-trip / secret-at-rest ──────────────────────────────────────
+# ── Round-trip (secret-free, no cipher) ─────────────────────────────────────
 
 
-def test_save_without_cipher_redacts_skill_secret(
-    agent_store: AgentProfileStore,
-) -> None:
-    agent_store.save(_profile_with_secret_skill())
-
-    content = (agent_store.base_dir / "secretful.json").read_text()
-    assert _MCP_SECRET not in content
-
-
-def test_save_with_cipher_encrypts_skill_secret(
-    agent_store: AgentProfileStore,
-) -> None:
-    cipher = Cipher(secret_key="test-key")
-    agent_store.save(_profile_with_secret_skill(), cipher=cipher)
-
-    content = (agent_store.base_dir / "secretful.json").read_text()
-    # No cleartext, but recoverable: the stored token decrypts back via cipher.
-    assert _MCP_SECRET not in content
-    assert FERNET_TOKEN_PREFIX in content
-
-    data = json.loads(content)
-    env = data["skills"][0]["mcp_tools"]["svc"]["env"]
-    token = env["API_KEY"]
-    assert token != _MCP_SECRET
-    decrypted = cipher.decrypt(token)
-    assert decrypted is not None
-    assert decrypted.get_secret_value() == _MCP_SECRET
-
-
-def test_roundtrip_openhands_without_cipher(
+def test_roundtrip_openhands(
     agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
 ) -> None:
     agent_store.save(openhands_profile)
@@ -259,7 +200,7 @@ def test_roundtrip_openhands_without_cipher(
     assert loaded.revision == 2
 
 
-def test_roundtrip_acp_without_cipher(
+def test_roundtrip_acp(
     agent_store: AgentProfileStore, acp_profile: ACPAgentProfile
 ) -> None:
     agent_store.save(acp_profile)
@@ -269,36 +210,6 @@ def test_roundtrip_acp_without_cipher(
     assert loaded.id == acp_profile.id
     assert loaded.acp_server == "codex"
     assert loaded.acp_model == "gpt-5.5/medium"
-
-
-def test_roundtrip_with_cipher_preserves_non_secret_fields(
-    agent_store: AgentProfileStore,
-) -> None:
-    cipher = Cipher(secret_key="test-key")
-    profile = _profile_with_secret_skill()
-    agent_store.save(profile, cipher=cipher)
-    loaded = agent_store.load("secretful", cipher=cipher)
-
-    assert isinstance(loaded, OpenHandsAgentProfile)
-    assert loaded.id == profile.id
-    assert loaded.llm_profile_ref == "default"
-    assert loaded.skills[0].name == "leaky"
-
-
-def test_load_with_cipher_decrypts_skill_secret(
-    agent_store: AgentProfileStore,
-) -> None:
-    cipher = Cipher(secret_key="test-key")
-    agent_store.save(_profile_with_secret_skill(), cipher=cipher)
-    loaded = agent_store.load("secretful", cipher=cipher)
-
-    assert isinstance(loaded, OpenHandsAgentProfile)
-    mcp_tools = loaded.skills[0].mcp_tools
-    assert mcp_tools is not None
-    env = mcp_tools["svc"].env
-    assert env is not None
-    token = env["API_KEY"]
-    assert token.get_secret_value() == _MCP_SECRET
 
 
 # ── Load ────────────────────────────────────────────────────────────────────
@@ -438,17 +349,21 @@ def test_list_summaries_returns_fk_fields(
     assert acp["llm_profile_ref"] is None
 
 
-def test_list_summaries_does_not_decrypt_secrets(
-    agent_store: AgentProfileStore,
+def test_list_summaries_projects_only_fk_fields(
+    agent_store: AgentProfileStore, openhands_profile: OpenHandsAgentProfile
 ) -> None:
-    cipher = Cipher(secret_key="test-key")
-    agent_store.save(_profile_with_secret_skill(), cipher=cipher)
+    agent_store.save(openhands_profile)
 
     summaries = agent_store.list_summaries()
-    # No skill content / secret is loaded — only the FK projection.
-    assert _MCP_SECRET not in json.dumps(summaries)
-    assert summaries[0]["name"] == "secretful"
-    assert "skills" not in summaries[0]
+    assert summaries[0]["name"] == "oh"
+    assert set(summaries[0]) == {
+        "id",
+        "name",
+        "agent_kind",
+        "revision",
+        "llm_profile_ref",
+        "mcp_server_refs",
+    }
 
 
 def test_list_summaries_skips_corrupted(

--- a/tests/sdk/profiles/test_profile_refs.py
+++ b/tests/sdk/profiles/test_profile_refs.py
@@ -5,11 +5,9 @@ import json
 from pathlib import Path
 
 import pytest
-from pydantic import SecretStr
 
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import LLMProfileStore
-from openhands.sdk.mcp.config import MCPServer
 from openhands.sdk.profiles import (
     ACPAgentProfile,
     AgentProfileStore,
@@ -20,8 +18,6 @@ from openhands.sdk.profiles import (
     find_referrers,
     rename_llm_profile,
 )
-from openhands.sdk.skills import Skill
-from openhands.sdk.utils.cipher import Cipher
 
 
 @pytest.fixture
@@ -90,37 +86,25 @@ def test_cascade_rename_no_match_is_noop(agent_store: AgentProfileStore) -> None
     assert _ref(agent_store, "a") == "other"
 
 
-def test_cascade_rename_preserves_id_and_encrypted_secret(
+def test_cascade_rename_preserves_id_and_other_fields(
     agent_store: AgentProfileStore,
 ) -> None:
-    cipher = Cipher(secret_key="test-key")
-    secret = "ghp_DO_NOT_LEAK"
+    """The surgical raw-JSON edit (``set_llm_profile_ref``) only touches the
+    ref field — id, mcp_server_refs, and everything else survive untouched.
+    No cipher is involved: the profile is secret-free at rest (#4017)."""
     profile = OpenHandsAgentProfile(
-        name="a",
-        llm_profile_ref="default",
-        skills=[
-            Skill(
-                name="s",
-                content="x",
-                mcp_tools={
-                    "svc": MCPServer(command="run", env={"K": SecretStr(secret)})
-                },
-            )
-        ],
+        name="a", llm_profile_ref="default", mcp_server_refs=["fetch"], revision=3
     )
-    agent_store.save(profile, cipher=cipher)
+    agent_store.save(profile)
 
     cascade_rename(agent_store, "default", "renamed")
 
     raw = (agent_store.base_dir / "a.json").read_text()
-    assert secret not in raw  # encrypted token survives the surgical edit
     data = json.loads(raw)
     assert data["id"] == str(profile.id)
     assert data["llm_profile_ref"] == "renamed"
-    token = data["skills"][0]["mcp_tools"]["svc"]["env"]["K"]
-    decrypted = cipher.decrypt(token)
-    assert decrypted is not None
-    assert decrypted.get_secret_value() == secret
+    assert data["mcp_server_refs"] == ["fetch"]
+    assert data["revision"] == 3
 
 
 def test_cascade_rename_invalid_new_name_raises(

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -346,6 +346,32 @@ def test_disabled_skills_missing_name_is_noop(
     }
 
 
+def test_duplicate_named_catalog_is_deduped(
+    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
+) -> None:
+    # A colliding catalog (e.g. the app-server's fuller catalog merging sources
+    # whose names overlap) is de-duplicated by name, last-wins — resolution must
+    # not trip AgentContext's duplicate-name validator.
+    catalog = [
+        Skill(name="alpha", content="first"),
+        Skill(name="beta", content="b"),
+        Skill(name="alpha", content="second"),
+    ]
+    profile = OpenHandsAgentProfile(
+        name="oh", llm_profile_ref="default", disabled_skills=["beta"]
+    )
+    settings = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=mcp_config,
+        available_skills=catalog,
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    skills = {s.name: s.content for s in settings.agent_context.skills}
+    assert skills == {"alpha": "second"}  # de-duped (last wins); beta disabled
+
+
 def test_acp_profile_gets_no_user_public_skills(
     llm_store: LLMProfileStore,
 ) -> None:

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -1,8 +1,9 @@
 """Tests for ``resolve_agent_profile`` / ``resolve_agent_profile_dry_run``.
 
 Covers both union variants, the null/empty/filter/dangling MCP cases, the
-dangling-LLM hard error, ``skills[].mcp_tools`` decryption, and the dry-run's
-redacted, side-effect-free diagnostics.
+dangling-LLM hard error, and the dry-run's redacted, side-effect-free
+diagnostics. Profiles no longer embed ``skills`` (#4017) — the skill catalog
+is server-discovered and filtered by ``skill_refs`` only.
 """
 
 from pathlib import Path
@@ -16,7 +17,6 @@ from openhands.sdk.llm.llm_profile_store import LLMProfileStore
 from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config
 from openhands.sdk.profiles import (
     ACPAgentProfile,
-    AgentProfileStore,
     DanglingMcpServerRef,
     DanglingSkillRef,
     OpenHandsAgentProfile,
@@ -27,7 +27,6 @@ from openhands.sdk.profiles import (
 from openhands.sdk.settings.model import ACPAgentSettings, OpenHandsAgentSettings
 from openhands.sdk.skills import Skill
 from openhands.sdk.tool import Tool
-from openhands.sdk.utils.cipher import Cipher
 
 
 _LLM_SECRET = "sk-LLM-SECRET-SHOULD-NOT-LEAK"
@@ -174,14 +173,10 @@ def test_openhands_profile_tools_selection_is_passed_through(
     assert settings.create_agent().tools == []
 
 
-def test_openhands_copies_skills_and_verification(
+def test_openhands_copies_verification(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
-    profile = OpenHandsAgentProfile(
-        name="oh",
-        llm_profile_ref="default",
-        skills=[Skill(name="s1", content="do x")],
-    )
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     profile.verification.critic_enabled = True
     profile.verification.critic_model_name = "critic-x"
 
@@ -193,11 +188,30 @@ def test_openhands_copies_skills_and_verification(
         cipher=None,
     )
     assert isinstance(settings, OpenHandsAgentSettings)
-    assert [s.name for s in settings.agent_context.skills] == ["s1"]
     assert settings.verification.critic_enabled is True
     assert settings.verification.critic_model_name == "critic-x"
     # The profile carries no critic_api_key; it defaults to None on resolve.
     assert settings.verification.critic_api_key is None
+
+
+def test_openhands_resolve_sets_load_project_skills(
+    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
+) -> None:
+    """Project skills are repo-scoped and can't be resolved at profile-resolve
+    time (no workspace yet); ``LocalConversation`` loads them lazily on first
+    use, gated on ``load_project_skills`` (#4016). The resolver must set it,
+    since the resolved ``AgentContext`` otherwise defaults it False."""
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
+    settings = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=mcp_config,
+        available_skills=None,
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert settings.agent_context is not None
+    assert settings.agent_context.load_project_skills is True
 
 
 def test_missing_llm_ref_raises_profile_not_found(
@@ -371,59 +385,14 @@ def test_skill_refs_duplicate_is_deduped(
     assert [s.name for s in acp_settings.agent_context.skills] == ["alpha"]
 
 
-def test_embedded_skills_compose_with_filtered_discovered(
+def test_no_available_skills_yields_no_skills(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
+    # available_skills=None (no discovery run) → no skills reach the agent from
+    # this filter, regardless of skill_refs. Profiles no longer embed skills
+    # (#4017), so there is no other source.
     profile = OpenHandsAgentProfile(
-        name="oh",
-        llm_profile_ref="default",
-        skills=[Skill(name="embedded", content="x")],
-        skill_refs=["beta"],
-    )
-    settings = resolve_agent_profile(
-        profile,
-        llm_store=llm_store,
-        mcp_config=mcp_config,
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(settings, OpenHandsAgentSettings)
-    assert [s.name for s in settings.agent_context.skills] == ["embedded", "beta"]
-
-
-def test_embedded_skill_wins_name_conflict_over_discovered(
-    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
-) -> None:
-    profile = OpenHandsAgentProfile(
-        name="oh",
-        llm_profile_ref="default",
-        skills=[Skill(name="alpha", content="EMBEDDED")],
-        skill_refs=["alpha"],
-    )
-    settings = resolve_agent_profile(
-        profile,
-        llm_store=llm_store,
-        mcp_config=mcp_config,
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(settings, OpenHandsAgentSettings)
-    skills = settings.agent_context.skills
-    assert [s.name for s in skills] == ["alpha"]
-    # Embedded definition is authoritative on a name collision.
-    assert skills[0].content == "EMBEDDED"
-
-
-def test_no_available_skills_yields_embedded_only(
-    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
-) -> None:
-    # available_skills=None (no discovery run) → only embedded skills reach the
-    # agent, regardless of skill_refs.
-    profile = OpenHandsAgentProfile(
-        name="oh",
-        llm_profile_ref="default",
-        skills=[Skill(name="embedded", content="x")],
-        skill_refs=None,
+        name="oh", llm_profile_ref="default", skill_refs=None
     )
     settings = resolve_agent_profile(
         profile,
@@ -433,7 +402,7 @@ def test_no_available_skills_yields_embedded_only(
         cipher=None,
     )
     assert isinstance(settings, OpenHandsAgentSettings)
-    assert [s.name for s in settings.agent_context.skills] == ["embedded"]
+    assert settings.agent_context.skills == []
 
 
 # --------------------------------------------------------------------------- #
@@ -523,58 +492,6 @@ def test_mcp_dangling_when_config_is_none(
             cipher=None,
         )
     assert exc.value.missing == ["fetch"]
-
-
-# --------------------------------------------------------------------------- #
-# skills[].mcp_tools decryption
-# --------------------------------------------------------------------------- #
-
-
-def test_profile_load_decrypts_skill_mcp_tools_before_resolve(tmp_path: Path) -> None:
-    cipher = Cipher("k" * 64)
-    secret = "ghp_SKILL_MCP_SECRET"
-    skill = Skill(
-        name="leaky",
-        content="x",
-        mcp_tools={
-            "svc": MCPServer(
-                url="https://svc.test",
-                headers={"Authorization": SecretStr(f"Bearer {secret}")},
-                env={"API_KEY": SecretStr(secret)},
-            )
-        },
-    )
-    lstore = LLMProfileStore(base_dir=tmp_path / "llm")
-    lstore.save(
-        "default",
-        LLM(model="gpt-4o", api_key=SecretStr("sk-x"), usage_id="x"),
-        include_secrets=True,
-    )
-    astore = AgentProfileStore(base_dir=tmp_path / "agent")
-    astore.save(
-        OpenHandsAgentProfile(name="p", llm_profile_ref="default", skills=[skill]),
-        cipher=cipher,
-    )
-
-    loaded = astore.load("p", cipher=cipher)
-    assert isinstance(loaded, OpenHandsAgentProfile)
-    stored_tools = loaded.skills[0].mcp_tools
-    assert stored_tools is not None
-    stored = stored_tools["svc"]
-    assert stored.env is not None
-    assert stored.env["API_KEY"].get_secret_value() == secret
-
-    settings = resolve_agent_profile(
-        loaded, llm_store=lstore, mcp_config={}, available_skills=None, cipher=cipher
-    )
-    assert isinstance(settings, OpenHandsAgentSettings)
-    resolved_tools = settings.agent_context.skills[0].mcp_tools
-    assert resolved_tools is not None
-    resolved = resolved_tools["svc"]
-    assert resolved.headers is not None
-    assert resolved.env is not None
-    assert resolved.headers["Authorization"].get_secret_value() == f"Bearer {secret}"
-    assert resolved.env["API_KEY"].get_secret_value() == secret
 
 
 # --------------------------------------------------------------------------- #
@@ -674,11 +591,14 @@ def test_acp_skill_refs_none_includes_all_discovered(
     }
 
 
-def test_acp_skill_refs_empty_leaves_agent_context_none(
+def test_acp_skill_refs_empty_still_carries_load_project_skills(
     llm_store: LLMProfileStore,
 ) -> None:
-    # No selected skills => no agent_context, preserving the unchanged
-    # "no prompt context" ACP behavior.
+    """No selected skills leaves the *prompt* content unchanged (empty skills,
+    same as before), but ``agent_context`` is no longer ``None`` — it must
+    always be constructed so ``load_project_skills=True`` reaches
+    ``LocalConversation``'s lazy project-skill load (#4016), which applies to
+    ACP profiles the same as OpenHands ones."""
     profile = ACPAgentProfile(name="acp", acp_server="claude-code", skill_refs=[])
     settings = resolve_agent_profile(
         profile,
@@ -688,7 +608,10 @@ def test_acp_skill_refs_empty_leaves_agent_context_none(
         cipher=None,
     )
     assert isinstance(settings, ACPAgentSettings)
-    assert settings.agent_context is None
+    assert settings.agent_context is not None
+    assert settings.agent_context.skills == []
+    assert settings.agent_context.load_project_skills is True
+    assert settings.agent_context.current_datetime is None
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/sdk/profiles/test_resolver.py
+++ b/tests/sdk/profiles/test_resolver.py
@@ -2,8 +2,9 @@
 
 Covers both union variants, the null/empty/filter/dangling MCP cases, the
 dangling-LLM hard error, and the dry-run's redacted, side-effect-free
-diagnostics. Profiles no longer embed ``skills`` (#4017) — the skill catalog
-is server-discovered and filtered by ``skill_refs`` only.
+diagnostics. Profiles no longer embed ``skills`` (#4017) — the skill catalog is
+server-discovered and filtered by the ``disabled_skills`` deny-list (never an
+allow-list, which could dangle).
 """
 
 from pathlib import Path
@@ -18,7 +19,6 @@ from openhands.sdk.mcp.config import MCPServer, coerce_mcp_config
 from openhands.sdk.profiles import (
     ACPAgentProfile,
     DanglingMcpServerRef,
-    DanglingSkillRef,
     OpenHandsAgentProfile,
     ProfileNotFound,
     resolve_agent_profile,
@@ -267,7 +267,7 @@ def test_enable_switch_llm_tool_false_threads_through(
 
 
 # --------------------------------------------------------------------------- #
-# skill_refs filter over discovered skills (#3868)
+# disabled_skills deny-list over discovered skills (#4017)
 # --------------------------------------------------------------------------- #
 
 
@@ -279,11 +279,57 @@ def _discovered_skills() -> list[Skill]:
     ]
 
 
-def test_skill_refs_none_includes_all_discovered(
+def test_disabled_skills_empty_includes_all_discovered(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
+    # The default deny-list ([]) keeps every discovered skill.
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
+    assert profile.disabled_skills == []
+    settings = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=mcp_config,
+        available_skills=_discovered_skills(),
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert {s.name for s in settings.agent_context.skills} == {
+        "alpha",
+        "beta",
+        "gamma",
+    }
+    # The deny-list is carried onto the context so the lazy project-skill load
+    # honors it too.
+    assert settings.agent_context.disabled_skills == []
+
+
+def test_disabled_skills_excludes_named(
+    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
+) -> None:
+    # Disabling one skill drops exactly it; the rest of the catalog remains.
     profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=None
+        name="oh", llm_profile_ref="default", disabled_skills=["beta"]
+    )
+    settings = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=mcp_config,
+        available_skills=_discovered_skills(),
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert {s.name for s in settings.agent_context.skills} == {"alpha", "gamma"}
+    assert settings.agent_context.disabled_skills == ["beta"]
+
+
+def test_disabled_skills_missing_name_is_noop(
+    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
+) -> None:
+    # The #4017 fix: a disabled name absent from the catalog is a harmless no-op
+    # — resolution succeeds (never DanglingSkillRef) and yields all catalog
+    # skills. This is the whole point of the deny-list over an allow-list.
+    profile = OpenHandsAgentProfile(
+        name="oh", llm_profile_ref="default", disabled_skills=["not-in-catalog"]
     )
     settings = resolve_agent_profile(
         profile,
@@ -300,79 +346,14 @@ def test_skill_refs_none_includes_all_discovered(
     }
 
 
-def test_skill_refs_empty_includes_none(
-    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
+def test_acp_profile_gets_no_user_public_skills(
+    llm_store: LLMProfileStore,
 ) -> None:
-    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default", skill_refs=[])
-    settings = resolve_agent_profile(
-        profile,
-        llm_store=llm_store,
-        mcp_config=mcp_config,
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(settings, OpenHandsAgentSettings)
-    assert settings.agent_context.skills == []
-
-
-def test_skill_refs_filters_to_named_subset_in_ref_order(
-    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
-) -> None:
-    profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=["gamma", "alpha"]
-    )
-    settings = resolve_agent_profile(
-        profile,
-        llm_store=llm_store,
-        mcp_config=mcp_config,
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(settings, OpenHandsAgentSettings)
-    assert [s.name for s in settings.agent_context.skills] == ["gamma", "alpha"]
-
-
-def test_skill_refs_dangling_raises(
-    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
-) -> None:
-    # Mirroring mcp_server_refs, a skill ref absent from the discovered catalog
-    # hard-fails (DanglingSkillRef) rather than being silently dropped.
-    profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=["alpha", "missing"]
-    )
-    with pytest.raises(DanglingSkillRef) as exc_info:
-        resolve_agent_profile(
-            profile,
-            llm_store=llm_store,
-            mcp_config=mcp_config,
-            available_skills=_discovered_skills(),
-            cipher=None,
-        )
-    assert exc_info.value.missing == ["missing"]
-
-
-def test_skill_refs_duplicate_is_deduped(
-    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
-) -> None:
-    # A repeated skill ref collapses to one entry (shared _partition_refs), so
-    # the ACP path — which feeds AgentContext, where duplicate names are
-    # rejected — no longer crashes on a duplicated selection.
-    oh = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=["alpha", "alpha"]
-    )
-    oh_settings = resolve_agent_profile(
-        oh,
-        llm_store=llm_store,
-        mcp_config=mcp_config,
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(oh_settings, OpenHandsAgentSettings)
-    assert [s.name for s in oh_settings.agent_context.skills] == ["alpha"]
-
-    acp = ACPAgentProfile(
-        name="acp", acp_server="claude-code", skill_refs=["alpha", "alpha"]
-    )
+    # ACP profiles carry no skill field — the subprocess owns its context, so no
+    # user/public discovered skills are injected regardless of the catalog.
+    acp = ACPAgentProfile(name="acp", acp_server="claude-code")
+    assert not hasattr(acp, "skill_refs")
+    assert not hasattr(acp, "disabled_skills")
     acp_settings = resolve_agent_profile(
         acp,
         llm_store=llm_store,
@@ -382,18 +363,16 @@ def test_skill_refs_duplicate_is_deduped(
     )
     assert isinstance(acp_settings, ACPAgentSettings)
     assert acp_settings.agent_context is not None
-    assert [s.name for s in acp_settings.agent_context.skills] == ["alpha"]
+    assert acp_settings.agent_context.skills == []
 
 
 def test_no_available_skills_yields_no_skills(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
-    # available_skills=None (no discovery run) → no skills reach the agent from
-    # this filter, regardless of skill_refs. Profiles no longer embed skills
-    # (#4017), so there is no other source.
-    profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=None
-    )
+    # available_skills=None (no discovery run) → no user/public skills reach the
+    # agent. Profiles no longer embed skills (#4017), so there is no other
+    # source (project skills load separately in LocalConversation).
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     settings = resolve_agent_profile(
         profile,
         llm_store=llm_store,
@@ -403,6 +382,43 @@ def test_no_available_skills_yields_no_skills(
     )
     assert isinstance(settings, OpenHandsAgentSettings)
     assert settings.agent_context.skills == []
+
+
+def test_seed_then_resolve_with_narrower_catalog_does_not_dangle(
+    llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
+) -> None:
+    # #4017 regression: a global whose AgentContext carries an inline skill whose
+    # name is NOT in the launch discovery catalog. The old freeze-by-name seed
+    # would name that skill and then hard-fail at launch (DanglingSkillRef). The
+    # deny-list seed disables nothing, so seed->resolve against the narrower
+    # catalog succeeds and yields exactly the catalog skills.
+    from openhands.sdk.profiles import build_seed_profile
+    from openhands.sdk.settings.model import validate_agent_settings
+
+    settings = validate_agent_settings(
+        {
+            "agent_kind": "openhands",
+            "agent_context": {"skills": [{"name": "inline-only", "content": "x"}]},
+        }
+    )
+    profile = build_seed_profile(settings, active_llm_profile="default")
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.disabled_skills == []
+
+    # Launch catalog does NOT contain "inline-only" — must still resolve.
+    resolved = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=mcp_config,
+        available_skills=_discovered_skills(),
+        cipher=None,
+    )
+    assert isinstance(resolved, OpenHandsAgentSettings)
+    assert {s.name for s in resolved.agent_context.skills} == {
+        "alpha",
+        "beta",
+        "gamma",
+    }
 
 
 # --------------------------------------------------------------------------- #
@@ -548,58 +564,14 @@ def test_acp_blank_command_resolves_empty_list(
     assert settings.acp_args == []
 
 
-def test_acp_skill_refs_filter_into_agent_context_prompt(
+def test_acp_carries_no_user_public_skills_but_keeps_load_project_skills(
     llm_store: LLMProfileStore,
 ) -> None:
-    # ACP agents receive the selected skills as prompt context via
-    # agent_context.to_acp_prompt_context — skill_refs honors that too.
-    profile = ACPAgentProfile(
-        name="acp", acp_server="claude-code", skill_refs=["gamma", "alpha"]
-    )
-    settings = resolve_agent_profile(
-        profile,
-        llm_store=llm_store,
-        mcp_config={},
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(settings, ACPAgentSettings)
-    assert settings.agent_context is not None
-    # Ref order preserved; ACP has no embedded skills to compose.
-    assert [s.name for s in settings.agent_context.skills] == ["gamma", "alpha"]
-    # ACP convention: no injected datetime (unlike the OpenHands agent).
-    assert settings.agent_context.current_datetime is None
-
-
-def test_acp_skill_refs_none_includes_all_discovered(
-    llm_store: LLMProfileStore,
-) -> None:
-    profile = ACPAgentProfile(name="acp", acp_server="claude-code", skill_refs=None)
-    settings = resolve_agent_profile(
-        profile,
-        llm_store=llm_store,
-        mcp_config={},
-        available_skills=_discovered_skills(),
-        cipher=None,
-    )
-    assert isinstance(settings, ACPAgentSettings)
-    assert settings.agent_context is not None
-    assert {s.name for s in settings.agent_context.skills} == {
-        "alpha",
-        "beta",
-        "gamma",
-    }
-
-
-def test_acp_skill_refs_empty_still_carries_load_project_skills(
-    llm_store: LLMProfileStore,
-) -> None:
-    """No selected skills leaves the *prompt* content unchanged (empty skills,
-    same as before), but ``agent_context`` is no longer ``None`` — it must
-    always be constructed so ``load_project_skills=True`` reaches
-    ``LocalConversation``'s lazy project-skill load (#4016), which applies to
-    ACP profiles the same as OpenHands ones."""
-    profile = ACPAgentProfile(name="acp", acp_server="claude-code", skill_refs=[])
+    """ACP profiles inject no user/public discovered skills (the subprocess owns
+    its context), but ``agent_context`` is still constructed (never ``None``) so
+    ``load_project_skills=True`` reaches ``LocalConversation``'s lazy
+    project-skill load (#4016). ACP convention: no injected datetime."""
+    profile = ACPAgentProfile(name="acp", acp_server="claude-code")
     settings = resolve_agent_profile(
         profile,
         llm_store=llm_store,
@@ -669,11 +641,14 @@ def test_dry_run_reports_dangling_llm_and_mcp(
     assert diag.resolved_settings is None
 
 
-def test_dry_run_reports_resolved_and_dangling_skill_refs(
+def test_dry_run_reports_disabled_and_resolved_skills(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
+    # Deny-list: the dry-run reports the disabled names and the resolved set
+    # (catalog minus disabled). A disabled name absent from the catalog does not
+    # invalidate the profile — the deny-list can't dangle.
     profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=["alpha", "missing"]
+        name="oh", llm_profile_ref="default", disabled_skills=["beta", "missing"]
     )
     diag = resolve_agent_profile_dry_run(
         profile,
@@ -682,22 +657,18 @@ def test_dry_run_reports_resolved_and_dangling_skill_refs(
         available_skills=_discovered_skills(),
         cipher=None,
     )
-    assert diag.skill_refs == ["alpha", "missing"]
-    assert diag.resolved_skills == ["alpha"]
-    assert diag.dangling_skill_refs == ["missing"]
-    # A dangling skill ref flips validity via an error (mirrors MCP).
-    assert diag.valid is False
-    assert any("Skill(s) not found" in e for e in diag.errors)
-    assert diag.resolved_settings is None
+    assert diag.disabled_skills == ["beta", "missing"]
+    assert set(diag.resolved_skills) == {"alpha", "gamma"}
+    assert diag.valid is True
+    assert not any("Skill" in e for e in diag.errors)
+    assert diag.resolved_settings is not None
 
 
-def test_dry_run_skill_refs_null_resolves_all_discovered(
+def test_dry_run_default_disabled_resolves_all_discovered(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
-    # Explicit null (all discovered) — NOT the default, which is [] (none).
-    profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=None
-    )
+    # Default deny-list ([]) resolves the whole catalog.
+    profile = OpenHandsAgentProfile(name="oh", llm_profile_ref="default")
     diag = resolve_agent_profile_dry_run(
         profile,
         llm_store=llm_store,
@@ -705,9 +676,8 @@ def test_dry_run_skill_refs_null_resolves_all_discovered(
         available_skills=_discovered_skills(),
         cipher=None,
     )
-    assert diag.skill_refs is None
+    assert diag.disabled_skills == []
     assert set(diag.resolved_skills) == {"alpha", "beta", "gamma"}
-    assert diag.dangling_skill_refs == []
 
 
 def test_dry_run_total_on_llm_store_transient_error(
@@ -783,14 +753,12 @@ def test_dry_run_acp_reports_credential_channels_by_role(
     assert diag.resolved_settings is not None
 
 
-def test_dry_run_acp_reports_skill_refs(
+def test_dry_run_acp_reports_no_skills(
     llm_store: LLMProfileStore,
 ) -> None:
-    # skill_refs diagnostics are reported for ACP profiles too (the field is on
-    # the shared base); a dangling ref invalidates the profile, as for OpenHands.
-    profile = ACPAgentProfile(
-        name="acp", acp_server="codex", skill_refs=["alpha", "missing"]
-    )
+    # ACP profiles carry no skill field, so the dry-run reports no resolved
+    # skills regardless of the catalog, and stays valid.
+    profile = ACPAgentProfile(name="acp", acp_server="codex")
     diag = resolve_agent_profile_dry_run(
         profile,
         llm_store=llm_store,
@@ -798,20 +766,19 @@ def test_dry_run_acp_reports_skill_refs(
         available_skills=_discovered_skills(),
         cipher=None,
     )
-    assert diag.skill_refs == ["alpha", "missing"]
-    assert diag.resolved_skills == ["alpha"]
-    assert diag.dangling_skill_refs == ["missing"]
-    assert diag.valid is False
-    assert any("Skill(s) not found" in e for e in diag.errors)
+    assert diag.disabled_skills == []
+    assert diag.resolved_skills == []
+    assert diag.valid is True
 
 
 def test_dry_run_skill_verdict_matches_real_resolve(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
-    # A dangling skill ref: dry-run says invalid, real resolve raises — the same
-    # dry-run/resolve agreement the MCP path has.
+    # A disabled name absent from the catalog never invalidates: dry-run stays
+    # valid and the real resolve succeeds with the full catalog. The deny-list
+    # cannot dangle (unlike the MCP allow-list).
     profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=["missing"]
+        name="oh", llm_profile_ref="default", disabled_skills=["missing"]
     )
     diag = resolve_agent_profile_dry_run(
         profile,
@@ -820,25 +787,29 @@ def test_dry_run_skill_verdict_matches_real_resolve(
         available_skills=_discovered_skills(),
         cipher=None,
     )
-    assert diag.valid is False
-    with pytest.raises(DanglingSkillRef):
-        resolve_agent_profile(
-            profile,
-            llm_store=llm_store,
-            mcp_config=mcp_config,
-            available_skills=_discovered_skills(),
-            cipher=None,
-        )
+    assert diag.valid is True
+    settings = resolve_agent_profile(
+        profile,
+        llm_store=llm_store,
+        mcp_config=mcp_config,
+        available_skills=_discovered_skills(),
+        cipher=None,
+    )
+    assert isinstance(settings, OpenHandsAgentSettings)
+    assert {s.name for s in settings.agent_context.skills} == {
+        "alpha",
+        "beta",
+        "gamma",
+    }
 
 
-def test_dry_run_skill_refs_unknown_catalog_reports_nothing_dangling(
+def test_dry_run_unknown_catalog_resolves_no_skills(
     llm_store: LLMProfileStore, mcp_config: dict[str, MCPServer]
 ) -> None:
-    # available_skills=None (discovery skipped/failed) → catalog unknown, so a
-    # named ref is NOT reported dangling (the materialize path relies on this so
-    # a discovery failure doesn't mislabel every selected skill as missing).
+    # available_skills=None (discovery skipped/failed) → no user/public skills
+    # resolve, and the profile stays valid (the deny-list has nothing to flag).
     profile = OpenHandsAgentProfile(
-        name="oh", llm_profile_ref="default", skill_refs=["alpha"]
+        name="oh", llm_profile_ref="default", disabled_skills=["alpha"]
     )
     diag = resolve_agent_profile_dry_run(
         profile,
@@ -847,7 +818,6 @@ def test_dry_run_skill_refs_unknown_catalog_reports_nothing_dangling(
         available_skills=None,
         cipher=None,
     )
-    assert diag.dangling_skill_refs == []
     assert diag.resolved_skills == []
     assert diag.valid is True
 

--- a/tests/sdk/profiles/test_store_protocol_hoists.py
+++ b/tests/sdk/profiles/test_store_protocol_hoists.py
@@ -245,9 +245,9 @@ def test_build_seed_profile_openhands_branch():
     assert profile.mcp_server_refs is None
     # Default settings carry tools=None -> the seed inherits the server default.
     assert profile.tools is None
-    # Default settings resolve to no skills, so the seed freezes an empty
-    # selection (== [], no skills) rather than None (all discovered).
-    assert profile.skill_refs == []
+    # The seed disables nothing -> the default profile launches with all
+    # discovered skills (deny-list model; nothing frozen, nothing can dangle).
+    assert profile.disabled_skills == []
     # Secret-free verification projection (no critic_api_key on the profile type).
     assert "critic_api_key" not in type(profile.verification).model_fields
 
@@ -257,9 +257,12 @@ def test_build_seed_profile_openhands_branch():
     assert fallback.llm_profile_ref == SEED_PROFILE_NAME
 
 
-def test_build_seed_profile_freezes_resolved_skills_by_name():
-    """A global with a resolved skill set seeds a profile that names exactly
-    those skills, so a partial-source global isn't expanded to all-discovered."""
+def test_build_seed_profile_disables_nothing_even_with_inline_global_skills():
+    """The seed never freezes the global's skills by name — it sets an empty
+    deny-list, so the migrated default profile launches with all discovered
+    skills. Freezing by name was the #4017 launch-break: an inline global skill
+    absent from the launch catalog would have dangled. See the seed->resolve
+    regression in test_resolver.py."""
     settings = validate_agent_settings(
         {
             "agent_kind": "openhands",
@@ -273,7 +276,7 @@ def test_build_seed_profile_freezes_resolved_skills_by_name():
     )
     profile = build_seed_profile(settings, active_llm_profile="my-llm")
     assert isinstance(profile, OpenHandsAgentProfile)
-    assert profile.skill_refs == ["alpha", "beta"]
+    assert profile.disabled_skills == []
 
 
 def test_build_seed_profile_copies_explicit_tools():
@@ -301,8 +304,9 @@ def test_build_seed_profile_acp_branch():
     assert profile.name == SEED_PROFILE_NAME
     assert profile.acp_server == "claude-code"
     assert profile.mcp_server_refs is None
-    # ACP profiles keep the [] (none) default — they own their tooling.
-    assert profile.skill_refs == []
+    # ACP profiles have no skill-selection field — they own their tooling.
+    assert not hasattr(profile, "skill_refs")
+    assert not hasattr(profile, "disabled_skills")
     assert not hasattr(profile, "llm_profile_ref")
 
 
@@ -320,18 +324,21 @@ def test_build_profile_verification_drops_critic_api_key():
     assert "critic_api_key" not in ProfileVerificationSettings.model_fields
 
 
-def test_safe_validation_error_detail_is_secret_safe():
+def test_safe_validation_error_detail_surfaces_msg_without_input():
     secret = "sk-super-secret-value"
     with pytest.raises(Exception) as exc_info:
-        # extra=forbid -> the unexpected key (carrying a secret) triggers a
-        # ValidationError that embeds the input in msg/input.
+        # extra=forbid -> the unexpected key (carrying a value) triggers a
+        # ValidationError whose ``input`` echoes the rejected value.
         validate_agent_profile({"name": "p", "llm_profile_ref": "gpt", "leak": secret})
     from pydantic import ValidationError
 
     assert isinstance(exc_info.value, ValidationError)
     detail = safe_validation_error_detail(exc_info.value)
     assert detail, "expected at least one error entry"
+    # loc/type/msg are surfaced so a client can see *why* the save failed;
+    # ``input`` (which echoes the whole rejected payload) is dropped.
     for entry in detail:
-        assert set(entry.keys()) == {"loc", "type"}
-    # The secret never appears in the redacted detail.
+        assert set(entry.keys()) == {"loc", "type", "msg"}
+    # The rejected value lived in ``input``, which is dropped — so a value passed
+    # in an unexpected field never appears in the detail.
     assert secret not in repr(detail)

--- a/tests/sdk/profiles/test_store_protocol_hoists.py
+++ b/tests/sdk/profiles/test_store_protocol_hoists.py
@@ -71,7 +71,7 @@ class InMemoryAgentProfileStore:
             )
         return out
 
-    def save(self, profile, *, cipher=None, max_profiles=None) -> None:
+    def save(self, profile, *, max_profiles=None) -> None:
         if (
             max_profiles is not None
             and profile.name not in self._profiles
@@ -80,7 +80,7 @@ class InMemoryAgentProfileStore:
             raise ProfileLimitExceeded(f"Profile limit reached ({max_profiles}).")
         self._profiles[profile.name] = profile
 
-    def load(self, name, *, cipher=None):
+    def load(self, name):
         if name not in self._profiles:
             raise FileNotFoundError(name)
         return self._profiles[name]
@@ -245,6 +245,9 @@ def test_build_seed_profile_openhands_branch():
     assert profile.mcp_server_refs is None
     # Default settings carry tools=None -> the seed inherits the server default.
     assert profile.tools is None
+    # None (all discovered) — there is no embedded skills to freeze against
+    # anymore (#4017), so the seed simply inherits future catalog discovery.
+    assert profile.skill_refs is None
     # Secret-free verification projection (no critic_api_key on the profile type).
     assert "critic_api_key" not in type(profile.verification).model_fields
 
@@ -279,6 +282,8 @@ def test_build_seed_profile_acp_branch():
     assert profile.name == SEED_PROFILE_NAME
     assert profile.acp_server == "claude-code"
     assert profile.mcp_server_refs is None
+    # ACP profiles keep the [] (none) default — they own their tooling.
+    assert profile.skill_refs == []
     assert not hasattr(profile, "llm_profile_ref")
 
 

--- a/tests/sdk/profiles/test_store_protocol_hoists.py
+++ b/tests/sdk/profiles/test_store_protocol_hoists.py
@@ -245,9 +245,9 @@ def test_build_seed_profile_openhands_branch():
     assert profile.mcp_server_refs is None
     # Default settings carry tools=None -> the seed inherits the server default.
     assert profile.tools is None
-    # None (all discovered) — there is no embedded skills to freeze against
-    # anymore (#4017), so the seed simply inherits future catalog discovery.
-    assert profile.skill_refs is None
+    # Default settings resolve to no skills, so the seed freezes an empty
+    # selection (== [], no skills) rather than None (all discovered).
+    assert profile.skill_refs == []
     # Secret-free verification projection (no critic_api_key on the profile type).
     assert "critic_api_key" not in type(profile.verification).model_fields
 
@@ -255,6 +255,25 @@ def test_build_seed_profile_openhands_branch():
     fallback = build_seed_profile(settings, active_llm_profile=None)
     assert isinstance(fallback, OpenHandsAgentProfile)
     assert fallback.llm_profile_ref == SEED_PROFILE_NAME
+
+
+def test_build_seed_profile_freezes_resolved_skills_by_name():
+    """A global with a resolved skill set seeds a profile that names exactly
+    those skills, so a partial-source global isn't expanded to all-discovered."""
+    settings = validate_agent_settings(
+        {
+            "agent_kind": "openhands",
+            "agent_context": {
+                "skills": [
+                    {"name": "alpha", "content": "x"},
+                    {"name": "beta", "content": "y"},
+                ]
+            },
+        }
+    )
+    profile = build_seed_profile(settings, active_llm_profile="my-llm")
+    assert isinstance(profile, OpenHandsAgentProfile)
+    assert profile.skill_refs == ["alpha", "beta"]
 
 
 def test_build_seed_profile_copies_explicit_tools():


### PR DESCRIPTION
HUMAN:

Reviewed SDK issue #4017 against the code and implemented it, then — after an architectural review found skills were being modeled like MCP servers when they structurally can't be — pivoted this PR to the deny-list design (Option A from the discussion in the comments). The full reasoning is in the architecture comment and the Option-A pivot note below. Both consumer PRs (agent-canvas#1571, OpenHands#15060) are updated to match.

---

AGENT:

## Why

Conversations launched from an **AgentProfile** kept coming up subtly wrong — no project skills (#4016), no streaming / an `on_token` crash (#4014), and a recurring class of **launch-breaking `DanglingSkillRef` → 422**. These share one root: skills were modeled like MCP servers — `skill_refs`, a name **allow-list** over a "catalog." But a skill catalog is discovered from many incomplete, drifting sources (user / public / org / project / marketplace) and is recomputed per launch, so an allow-list dangles the moment the catalog a profile was authored against differs from the one resolved at launch. Three successive regressions (most recently the seed's freeze-by-name) were all facets of that one mismatch.

Separately, the profile carried an embedded `skills: list[Skill]` whose `mcp_tools` can hold a secret — the only thing that forced cipher / mask / restore machinery through the resolver, the store, and both routers.

## Summary

**Skills → a `disabled_skills` deny-list** (the model the product already runs at the member level — canvas `settings.disabled_skills`, cloud `user.disabled_skills`, migrations 102/104):
- `OpenHandsAgentProfile.skill_refs` → `disabled_skills: list[str] = []`. A deny-list over the discovered catalog: `[]` = all skills; a listed name absent from the catalog is a no-op, so a profile **can never fail launch on catalog drift**. `ACPAgentProfile` drops the skill field entirely (the subprocess owns its context).
- `AgentContext.disabled_skills`, applied in `_load_auto_skills` and the `LocalConversation` project-skill merge — one drift-tolerant chokepoint honored by every skill source (explicit, auto-loaded, lazy project).
- Deleted `_compute_skill_filter`, `DanglingSkillRef`, and `discover_profile_skills_if_needed` (the `None`/`[]`/freeze tri-state); added `_apply_disabled_skills` (catalog minus disabled, never raises). Dry-run diagnostics report `disabled_skills` / `resolved_skills`.
- The migration **seed sets `disabled_skills=[]`** — the freeze-by-name launch break is structurally gone (regression test `test_seed_then_resolve_with_narrower_catalog_does_not_dangle`).

**Drop embedded skills + the secret machinery:**
- Removed `skills: list[Skill]` from the profile. It now carries only references + the `disabled_skills` deny-list, so it is genuinely secret-free at rest. Removed the `cipher` parameter from `AgentProfileStore.save`/`load` and the `X-Expose-Secrets` handling from the local `agent_profiles_router`.

**Resolver defaults (closes #4016; profile-launch side of #4014):**
- `load_project_skills=True` on the resolved `AgentContext` (OpenHands *and* ACP) so profile-launched conversations get repo-scoped project skills.
- `conversation_service` forces `llm.stream=True` for OpenHands profile launches — the agent-server layer, which guarantees the `on_token` wiring, not the SDK resolver (which runs for headless callers too).
- **`LLM` now gracefully degrades streaming without an `on_token` callback** instead of hard-raising `ValueError` across all four entrypoints (`completion` / `acompletion` / `responses` / `aresponses`). This hardens the class so a stream/callback mismatch can never crash a run — covering the `switch_llm` side of #4014, where `on_token` is frozen at `LocalConversation` construction and never re-evaluated. Subscription mode stays exempt (it streams internally without an `on_token`).

**Schema / API:** the profile model has never shipped (no prod, no client, no persisted data), so this collapses the pre-ship schema history into a clean **v1 baseline** — `AGENT_PROFILE_SCHEMA_VERSION = 1`, no migrators (the versioning scaffold stays as the home for the first *real* post-ship change). A stray removed `skills` / `skill_refs` key is now rejected by `extra="forbid"` rather than migrated away. `safe_validation_error_detail` returns `msg` (no secret-bearing field remains to redact).

Net: a deletion overall — the deny-list and the clean-baseline collapse remove far more than they add.

<!-- agent-server-rest-api-contract-summary:start -->
### REST API contract changes

Compared with base OpenAPI `bd8a846c894f` for public `/api/**` paths.

```diff
--- base public OpenAPI
+++ head public OpenAPI
@@ -684,0 +685 @@
+schema AgentContext-Input property disabled_skills optional schema=type="array" items=type="string"
@@ -695,0 +697 @@
+schema AgentContext-Output property disabled_skills optional schema=type="array" items=type="string"
@@ -751 +753 @@
-schema AgentProfileDiagnostics property dangling_skill_refs optional schema=type="array" items=type="string"
+schema AgentProfileDiagnostics property disabled_skills optional schema=type="array" items=type="string"
@@ -761 +762,0 @@
-schema AgentProfileDiagnostics property skill_refs optional schema=anyOf=[type="array" items=type="string",type="null"]
```
<!-- agent-server-rest-api-contract-summary:end -->

## Where this differs from #4017

#4017 proposed keeping `skill_refs` as an allow-list with the default flipped to `None`. That doesn't fix the root problem — an allow-list over a *discovered* catalog still dangles. The deny-list does (a name that isn't there is a no-op) and it makes the profile speak the same skill-selection language the product already uses at the global level.

## Downstream (both updated; land after this)

- **agent-canvas#1571** — already deny-list-native (user-level `disabled_skills` UI + a generic profile merge that carries the field), so only stale comments needed fixing. Per-profile skill picker stays out of scope for the minimal editor.
- **OpenHands#15060** — unions the launched profile's `disabled_skills` with the member's (`effective_disabled_skills`) into the existing deny filter. Needs this SDK released and the `openhands-sdk` pin bumped before its CI is green.

## Known follow-ups (not blocking)

- The lazy `LocalConversation` project-skill deny path is exercised via the eager and resolver paths but lacks a dedicated runtime test.
- ts-client / OpenAPI regen for the changed `AgentProfileDiagnostics` shape (`disabled_skills` in, `skill_refs` / `dangling_skill_refs` out) at the consumer pin bump.

## How to Test

```
uv run pytest tests/sdk/profiles/ \
  tests/agent_server/test_agent_profile_conv_start.py \
  tests/agent_server/test_agent_profiles_router.py \
  tests/agent_server/test_skills_service.py \
  tests/sdk/context/test_agent_context.py
```

308 pass, including `test_seed_then_resolve_with_narrower_catalog_does_not_dangle` (proves the launch break is fixed) and the deny-list no-op-on-missing-name tests. `ruff check` / `ruff format --check` / `pyright` clean.




<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:780de42-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-780de42-python \
  ghcr.io/openhands/agent-server:780de42-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:780de42-golang-amd64
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-golang-amd64
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-golang-amd64
ghcr.io/openhands/agent-server:780de42-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:780de42-golang-arm64
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-golang-arm64
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-golang-arm64
ghcr.io/openhands/agent-server:780de42-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:780de42-java-amd64
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-java-amd64
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-java-amd64
ghcr.io/openhands/agent-server:780de42-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:780de42-java-arm64
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-java-arm64
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-java-arm64
ghcr.io/openhands/agent-server:780de42-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:780de42-python-amd64
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-python-amd64
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-python-amd64
ghcr.io/openhands/agent-server:780de42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:780de42-python-arm64
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-python-arm64
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-python-arm64
ghcr.io/openhands/agent-server:780de42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:780de42-golang
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-golang
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-golang
ghcr.io/openhands/agent-server:780de42-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:780de42-java
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-java
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-java
ghcr.io/openhands/agent-server:780de42-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:780de42-python
ghcr.io/openhands/agent-server:780de42de18ff960dc9d409a041473d9f2bc1134-python
ghcr.io/openhands/agent-server:simplify-agent-profile-resolution-python
ghcr.io/openhands/agent-server:780de42-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `780de42-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `780de42-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->