### PR TITLE
fix(llm): degrade gracefully when stream=True but no on_token wired

### DIFF
--- a/openhands-sdk/openhands/sdk/llm/llm.py
+++ b/openhands-sdk/openhands/sdk/llm/llm.py
@@ -1387,10 +1387,18 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming:
-            if on_token is None:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        if enable_streaming and on_token is None:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = enable_streaming
 
         (
             formatted_messages,
@@ -1476,10 +1484,18 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if enable_streaming:
-            if on_token is None:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        if enable_streaming and on_token is None:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = enable_streaming
 
         (
             formatted_messages,
@@ -1582,11 +1598,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if user_enable_streaming:
-            # We allow on_token to be None for subscription mode
-            if on_token is None and not self.is_subscription:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        # We allow on_token to be None for subscription mode.
+        if user_enable_streaming and on_token is None and not self.is_subscription:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            user_enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = user_enable_streaming
 
         (
             instructions,
@@ -1722,11 +1746,19 @@ class LLM(BaseModel, RetryMixin, NonNativeToolCallingMixin):
         """
         _caller_kwargs = kwargs.copy()
         user_enable_streaming = bool(kwargs.get("stream", False)) or self.stream
-        if user_enable_streaming:
-            # We allow on_token to be None for subscription mode
-            if on_token is None and not self.is_subscription:
-                raise ValueError("Streaming requires an on_token callback")
-            kwargs["stream"] = True
+        # We allow on_token to be None for subscription mode.
+        if user_enable_streaming and on_token is None and not self.is_subscription:
+            # Degrade gracefully instead of hard-raising: a stream/callback
+            # mismatch (e.g. a profile-launched conversation whose LLM has
+            # stream=True but no on_token wired) must not crash the run (#4014).
+            logger.warning(
+                "Streaming requested but no on_token callback was provided; "
+                "falling back to a non-streaming call."
+            )
+            user_enable_streaming = False
+        # Unconditional: a caller-supplied stream=True must be cleared on
+        # degrade, not just left un-set-to-True.
+        kwargs["stream"] = user_enable_streaming
 
         (
             instructions,

--- a/tests/sdk/llm/test_llm_completion.py
+++ b/tests/sdk/llm/test_llm_completion.py
@@ -167,15 +167,31 @@ def test_llm_completion_basic(mock_completion):
     assert not llm.should_mock_tool_calls(cc_tools)
 
 
-def test_llm_streaming_not_supported(default_config):
-    """Test that streaming requires an on_token callback."""
+@patch("openhands.sdk.llm.llm.logger")
+@patch("openhands.sdk.llm.llm.litellm_completion")
+def test_llm_streaming_without_callback_degrades_gracefully(
+    mock_completion, mock_logger, default_config
+):
+    """A stream/callback mismatch must not crash the run (#4014) — e.g. a
+    profile-launched conversation whose LLM has stream=True but no on_token
+    wired. ``completion`` degrades to a non-streaming call instead of raising,
+    and warns rather than silently swallowing the mismatch.
+
+    Patches the module logger locally (rather than relying on caplog) so the
+    mock is properly typed, unlike the module-level object the autouse
+    ``suppress_logging`` fixture substitutes it with.
+    """
     llm = default_config
+    mock_completion.return_value = create_mock_response("Test response")
 
     messages = [Message(role="user", content=[TextContent(text="Hello")])]
+    response = llm.completion(messages=messages, stream=True)
 
-    # Streaming without callback should raise an error
-    with pytest.raises(ValueError, match="Streaming requires an on_token callback"):
-        llm.completion(messages=messages, stream=True)
+    assert response.message.content[0].text == "Test response"
+    # Never asked litellm for a streaming response.
+    assert mock_completion.call_args.kwargs.get("stream") is not True
+    mock_logger.warning.assert_called_once()
+    assert "on_token" in mock_logger.warning.call_args.args[0]
 
 
 @patch("openhands.sdk.llm.llm.litellm_completion")


### PR DESCRIPTION
## Why

Extracted from #4018 to keep that PR scoped to agent-profile resolution — this streaming-robustness change is independent of it.

## Summary

`LLM.completion` / `acompletion` / `responses` / `aresponses` previously hard-raised `ValueError("Streaming requires an on_token callback")` when streaming was enabled (`stream=True` or `self.stream`) without an `on_token` callback wired. A stream/callback mismatch shouldn't crash a run — e.g. a conversation whose LLM has `stream=True` but no `on_token` (the `switch_llm` side of #4014, where `on_token` is frozen at `LocalConversation` construction and never re-evaluated).

These methods now log a warning and fall back to a **non-streaming** call. The `stream` kwarg is cleared unconditionally on degrade, so a caller-supplied `stream=True` isn't left set. Subscription mode (where `on_token` is legitimately `None`) is unchanged.

## How to test

- `tests/sdk/llm/test_llm_completion.py::test_llm_streaming_without_callback_degrades_gracefully` replaces the old `test_llm_streaming_not_supported` (which asserted the raise): it asserts the call succeeds non-streamed, never asks litellm to stream, and warns.
- `uv run pytest tests/sdk/llm/test_llm_completion.py` — 22 passed.

Refs #4014. Split out of #4018.

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:d8f2dd6-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-d8f2dd6-python \
  ghcr.io/openhands/agent-server:d8f2dd6-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:d8f2dd6-golang-amd64
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-golang-amd64
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-golang-amd64
ghcr.io/openhands/agent-server:d8f2dd6-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:d8f2dd6-golang-arm64
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-golang-arm64
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-golang-arm64
ghcr.io/openhands/agent-server:d8f2dd6-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:d8f2dd6-java-amd64
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-java-amd64
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-java-amd64
ghcr.io/openhands/agent-server:d8f2dd6-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:d8f2dd6-java-arm64
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-java-arm64
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-java-arm64
ghcr.io/openhands/agent-server:d8f2dd6-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:d8f2dd6-python-amd64
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-python-amd64
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-python-amd64
ghcr.io/openhands/agent-server:d8f2dd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:d8f2dd6-python-arm64
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-python-arm64
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-python-arm64
ghcr.io/openhands/agent-server:d8f2dd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:d8f2dd6-golang
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-golang
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-golang
ghcr.io/openhands/agent-server:d8f2dd6-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:d8f2dd6-java
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-java
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-java
ghcr.io/openhands/agent-server:d8f2dd6-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:d8f2dd6-python
ghcr.io/openhands/agent-server:d8f2dd6279400306fc891c67034ff58812170189-python
ghcr.io/openhands/agent-server:llm-stream-degrade-graceful-python
ghcr.io/openhands/agent-server:d8f2dd6-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `d8f2dd6-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `d8f2dd6-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->