### PR TITLE
docs: fix DEVELOPMENT.md clone URL and repo layout name

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -3,8 +3,8 @@
 ## Setup
 
 ```bash
-git clone https://github.com/OpenHands/agent-sdk.git
-cd agent-sdk
+git clone https://github.com/OpenHands/software-agent-sdk.git
+cd software-agent-sdk
 make build
 ```
 
@@ -29,7 +29,7 @@ uv run pytest tests/tools/               # Tools tests only
 ## Project Structure
 
 ```
-agent-sdk/
+software-agent-sdk/
 ├── openhands-sdk/          # Core SDK package
 ├── openhands-tools/        # Built-in tools
 ├── openhands-workspace/    # Workspace management


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

I hit a stale clone URL in DEVELOPMENT.md while setting up locally. This just aligns the docs with the current repo name so new contributors do not copy a broken command.

---

AGENT:

## Why

DEVELOPMENT.md still referenced the old agent-sdk repository name and clone URL.

## Summary

- Update clone URL to OpenHands/software-agent-sdk
- Rename the illustrated top-level directory to software-agent-sdk

## Issue Number

N/A

## How to Test

Read DEVELOPMENT.md and confirm the clone/setup commands match the current repository.

## Video/Screenshots

N/A (docs-only change)

## Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

Small documentation alignment fix for new contributors.
