### PR TITLE
example: add file-based subagent discovery walkthrough

### DIFF
--- a/examples/01_standalone_sdk/55_file_based_subagents/.agents/agents/code-reviewer.md
+++ b/examples/01_standalone_sdk/55_file_based_subagents/.agents/agents/code-reviewer.md
@@ -1,0 +1,10 @@
+---
+name: code-reviewer
+description: Reviews code changes for correctness, edge cases, and clarity.
+tools:
+  - file_editor
+  - terminal
+---
+
+You are a code reviewer. Read the relevant files and return a concise bullet
+list of findings. Prioritize correctness and security issues over style nits.

--- a/examples/01_standalone_sdk/55_file_based_subagents/.agents/agents/security-auditor.md
+++ b/examples/01_standalone_sdk/55_file_based_subagents/.agents/agents/security-auditor.md
@@ -1,0 +1,10 @@
+---
+name: security-auditor
+description: Audits commands and file changes for risky or unsafe behavior.
+tools:
+  - file_editor
+  - terminal
+---
+
+You are a security auditor. Flag commands or edits that could leak secrets,
+modify system files, or reach untrusted networks. Recommend safer alternatives.

--- a/examples/01_standalone_sdk/55_file_based_subagents/README.md
+++ b/examples/01_standalone_sdk/55_file_based_subagents/README.md
@@ -1,0 +1,45 @@
+# File-Based Subagent Definitions
+
+This folder demonstrates how to define subagents as Markdown files with YAML
+frontmatter. The SDK discovers them from `.agents/agents/` (or the legacy
+`.openhands/agents/`) at project start and registers them for delegation.
+
+## Layout
+
+```
+55_file_based_subagents/
+├── main.py
+└── .agents/
+    └── agents/
+        ├── code-reviewer.md
+        └── security-auditor.md
+```
+
+Only top-level `*.md` files are loaded. `README.md` and subdirectories (such
+as `skills/`) are ignored.
+
+## Running
+
+```bash
+uv run python examples/01_standalone_sdk/55_file_based_subagents/main.py
+```
+
+The script prints discovered and registered agent names. No LLM credentials are
+required.
+
+## Delegating work
+
+Pair file-based agents with the task tool in a main agent:
+
+```python
+from openhands.tools.task import TaskToolSet
+
+agent = Agent(llm=llm, tools=[Tool(name=TaskToolSet.name)])
+conversation.send_message("Delegate to code-reviewer to review README.md")
+```
+
+See also:
+
+- `examples/01_standalone_sdk/41_task_tool_set.py` — task handoff with resume
+- `examples/01_standalone_sdk/42_file_based_subagents.py` — inline `AgentDefinition`
+- `openhands-sdk/openhands/sdk/subagent/AGENTS.md` — precedence and invariants

--- a/examples/01_standalone_sdk/55_file_based_subagents/main.py
+++ b/examples/01_standalone_sdk/55_file_based_subagents/main.py
@@ -1,0 +1,41 @@
+"""Example: File-based subagent definitions.
+
+Demonstrates the `.agents/agents/*.md` convention for defining subagents
+that can be delegated to via the TaskToolSet. This script discovers and
+registers the bundled agent definitions without calling an LLM.
+
+For programmatic registration, see `42_file_based_subagents.py`.
+For end-to-end delegation with an LLM, see `41_task_tool_set.py`.
+"""
+
+from pathlib import Path
+
+from openhands.sdk.subagent import discover_agents, register_file_agents
+from openhands.sdk.subagent.registry import get_registered_agent_definitions
+
+
+script_dir = Path(__file__).resolve().parent
+
+print("=" * 60)
+print("File-based subagent discovery")
+print("=" * 60)
+
+discovered = discover_agents(script_dir, include_user=False)
+print(f"Discovered {len(discovered)} project agent(s):")
+for agent_def in discovered:
+    print(f"  - {agent_def.name}: {agent_def.description}")
+    if agent_def.tools:
+        print(f"    tools={agent_def.tools}")
+
+registered = register_file_agents(script_dir)
+print(f"\nRegistered agent names: {registered}")
+
+registered_defs = get_registered_agent_definitions()
+registered_names = {agent_def.name for agent_def in registered_defs}
+for name in registered:
+    assert name in registered_names, f"Expected {name} in registry"
+
+print("\nTo delegate work, give a main agent the TaskToolSet and ask it to")
+print("call a subagent by name. For example:")
+print('  conversation.send_message("Delegate to code-reviewer to ...")')
+print("\nEXAMPLE_COST: 0")

--- a/tests/examples/test_examples.py
+++ b/tests/examples/test_examples.py
@@ -29,6 +29,7 @@ _TARGET_DIRECTORIES = (
     EXAMPLES_ROOT / "01_standalone_sdk" / "33_hooks",
     EXAMPLES_ROOT / "01_standalone_sdk" / "37_llm_profile_store",
     EXAMPLES_ROOT / "01_standalone_sdk" / "51_agent_hooks",
+    EXAMPLES_ROOT / "01_standalone_sdk" / "55_file_based_subagents",
     EXAMPLES_ROOT / "02_remote_agent_server" / "06_custom_tool",
     EXAMPLES_ROOT / "05_skills_and_plugins" / "01_loading_agentskills",
     EXAMPLES_ROOT / "05_skills_and_plugins" / "02_loading_plugins",
@@ -100,6 +101,9 @@ def test_directory_example_is_discovered() -> None:
     ) in EXAMPLES
     assert (
         EXAMPLES_ROOT / "01_standalone_sdk" / "51_agent_hooks" / "main.py"
+    ) in EXAMPLES
+    assert (
+        EXAMPLES_ROOT / "01_standalone_sdk" / "55_file_based_subagents" / "main.py"
     ) in EXAMPLES
     assert (
         EXAMPLES_ROOT


### PR DESCRIPTION
HUMAN:

I wanted a runnable example for file-based subagents that does not need API keys. This matches how I would lay out .agents/agents/ in a real project and made the discovery flow much clearer for me.

---

AGENT:

## Why

File-based subagent definitions (.agents/agents/*.md) lacked a non-LLM runnable example with templates.

## Summary

- Add examples/01_standalone_sdk/55_file_based_subagents with template agents
- Register the example in tests/examples/test_examples.py discovery list

## Issue Number

N/A

## How to Test

```bash
uv run python examples/01_standalone_sdk/55_file_based_subagents/main.py
uv run pytest tests/examples/test_examples.py::test_directory_example_is_discovered -q
```

Validated locally: example prints EXAMPLE_COST: 0 and discovery test passes.

## Video/Screenshots

N/A

## Type

- [ ] Bug fix
- [x] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Demonstrates subagent discovery/registration for task handoff workflows without requiring LLM credentials.
