### PR TITLE
ci(version-bump-prs): also open an automation bump PR on SDK release

### DIFF
--- a/.github/workflows/README-RELEASE.md
+++ b/.github/workflows/README-RELEASE.md
@@ -104,18 +104,20 @@ If the matching manifest is already in GHCR, the wait step exits immediately.
 
 After successful PyPI publication, the workflow will automatically create PRs to update SDK versions in downstream repositories:
 
-- **[OpenHands](https://github.com/All-Hands-AI/OpenHands)** - Updates `openhands-sdk`, `openhands-tools`, and `openhands-agent-server` versions
-- **[OpenHands-CLI](https://github.com/All-Hands-AI/openhands-cli)** - Updates `openhands-sdk` and `openhands-tools` versions
+- **[OpenHands](https://github.com/OpenHands/OpenHands)** - Updates `openhands-sdk`, `openhands-tools`, and `openhands-agent-server` versions
+- **[OpenHands-CLI](https://github.com/OpenHands/openhands-cli)** - Updates `openhands-sdk` and `openhands-tools` versions
+- **[automation](https://github.com/OpenHands/automation)** - Updates `openhands-sdk` and `openhands-workspace` versions. Opened with a `fix:` title so the repo's release-please cuts a patch release, publishing an `openhands-automation` build pinned to this SDK (which the agent-canvas `sdk-version-sync` check requires).
+- **[typescript-client](https://github.com/OpenHands/typescript-client)** - Updates the pinned `agent-server` image tag (`config.agentServerImage`); runs as a separate job that waits on the GHCR image rather than PyPI.
 
 These PRs will:
-- Be created automatically with branch name `bump-sdk-X.Y.Z`
+- Be created automatically with branch name `bump-sdk-X.Y.Z` (`bump-agent-server-X.Y.Z` for typescript-client)
 - Include links back to the SDK release
 - Need to be reviewed and merged by the respective repository maintainers
 
 ### Step 6: Post-Release Tasks
 
 - [ ] Merge the release PR to main
-- [ ] Review and merge the auto-created version bump PRs in OpenHands and OpenHands-CLI
+- [ ] Review and merge the auto-created version bump PRs in OpenHands, OpenHands-CLI, automation, and typescript-client (merging the automation PR triggers its release-please release PR; merge that too to publish the pinned `openhands-automation`)
 - [ ] Run evaluation on OpenHands Index (manual step)
 - [ ] Announce the release
 

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -375,6 +375,92 @@ jobs:
                     echo "✅ PR created for $REPO"
                   fi
 
+            - name: Create PR for automation repo
+              env:
+                  VERSION: ${{ steps.get_version.outputs.version }}
+              run: |
+                  set -euo pipefail
+
+                  REPO="OpenHands/automation"
+                  BRANCH="bump-sdk-$VERSION"
+
+                  echo "🔄 Creating PR for $REPO..."
+
+                  # Clone the repo
+                  git clone "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" automation-repo
+                  cd automation-repo
+
+                  # Configure git
+                  git config user.name "github-actions[bot]"
+                  git config user.email "github-actions[bot]@users.noreply.github.com"
+
+                  # Check if branch already exists on remote
+                  if git ls-remote --heads origin "$BRANCH" | grep -q "$BRANCH"; then
+                    echo "⚠️ Branch $BRANCH already exists, checking out existing branch"
+                    git fetch origin "$BRANCH"
+                    git checkout "$BRANCH"
+                  else
+                    # Create branch
+                    git checkout -b "$BRANCH"
+                  fi
+
+                  # automation pins openhands-sdk + openhands-workspace as exact
+                  # PEP 621 dependencies and keeps a uv.lock. Update the pins with
+                  # sed (exact, no normalization), then regenerate the lock.
+                  echo "📝 Updating pyproject.toml SDK pins..."
+                  sed -i -E 's/"openhands-sdk==[^"]*"/"openhands-sdk=='"$VERSION"'"/' pyproject.toml
+                  sed -i -E 's/"openhands-workspace==[^"]*"/"openhands-workspace=='"$VERSION"'"/' pyproject.toml
+
+                  # --no-config bypasses ~/.config/uv/uv.toml where setup-uv writes
+                  # its 7-day freshness guardrail (automation has no
+                  # exclude-newer-package exemption of its own); --no-cache avoids
+                  # stale index data from the just-published packages.
+                  echo "📝 Regenerating uv.lock..."
+                  uv lock --no-cache --no-config
+
+                  # Check if there are changes
+                  if git diff --quiet; then
+                    echo "⚠️ No changes detected in $REPO - versions may already be up to date"
+                    exit 0
+                  fi
+
+                  # Commit and push. Use a Conventional Commit `fix:` subject so the
+                  # target repo's release-please opens a release PR on merge — that
+                  # published openhands-automation is what unblocks agent-canvas's
+                  # sdk-version-sync check.
+                  git add pyproject.toml uv.lock
+                  git commit -m "fix: bump SDK to $VERSION" \
+                    -m "Bump openhands-sdk, openhands-workspace to $VERSION (regenerated uv.lock)." \
+                    -m "Automated version bump after PyPI release." \
+                    -m "Co-authored-by: openhands <openhands@all-hands.dev>"
+                  git push -u origin "$BRANCH"
+
+                  # Check if PR already exists
+                  EXISTING_PR=$(gh pr list --repo "$REPO" --head "$BRANCH" --json number --jq '.[0].number')
+                  if [ -n "$EXISTING_PR" ]; then
+                    echo "✅ PR #$EXISTING_PR already exists for $REPO"
+                  else
+                    # Create PR. The `fix:` title matches the repo's manual bump
+                    # convention and triggers release-please to cut a patch release.
+                    gh pr create \
+                      --repo "$REPO" \
+                      --title "fix: bump SDK to $VERSION" \
+                      --body "## Automated Version Bump
+
+                  This PR updates the following packages to version **$VERSION**:
+                  - \`openhands-sdk\`
+                  - \`openhands-workspace\`
+
+                  **Triggered by:** Release of [software-agent-sdk v$VERSION](https://github.com/OpenHands/software-agent-sdk/releases/tag/v$VERSION)
+
+                  ---
+                  _This PR was automatically created by the version-bump-prs workflow._" \
+                      --base main \
+                      --head "$BRANCH"
+
+                    echo "✅ PR created for $REPO"
+                  fi
+
             - name: Summary
               env:
                   VERSION: ${{ steps.get_version.outputs.version }}
@@ -385,6 +471,7 @@ jobs:
                   echo "" >> $GITHUB_STEP_SUMMARY
                   echo "- [OpenHands](https://github.com/OpenHands/OpenHands/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
                   echo "- [OpenHands-CLI](https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
+                  echo "- [automation](https://github.com/OpenHands/automation/pulls?q=is%3Apr+bump-sdk-$VERSION)" >> $GITHUB_STEP_SUMMARY
 
             - name: Notify Slack
               if: env.SLACK_BOT_TOKEN != ''
@@ -394,7 +481,7 @@ jobs:
                   token: ${{ env.SLACK_BOT_TOKEN }}
                   payload: |
                       channel: C08E1SYKEM9
-                      text: "🚀 *SDK v${{ steps.get_version.outputs.version }} published to PyPI!*\n\nVersion bump PRs created:\n• <https://github.com/OpenHands/OpenHands/pulls?q=is%3Apr+bump-sdk-${{ steps.get_version.outputs.version }}|OpenHands>\n• <https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-${{ steps.get_version.outputs.version }}|OpenHands-CLI>\n\n<https://github.com/OpenHands/software-agent-sdk/releases/tag/v${{ steps.get_version.outputs.version }}|View Release>"
+                      text: "🚀 *SDK v${{ steps.get_version.outputs.version }} published to PyPI!*\n\nVersion bump PRs created:\n• <https://github.com/OpenHands/OpenHands/pulls?q=is%3Apr+bump-sdk-${{ steps.get_version.outputs.version }}|OpenHands>\n• <https://github.com/OpenHands/openhands-cli/pulls?q=is%3Apr+bump-sdk-${{ steps.get_version.outputs.version }}|OpenHands-CLI>\n• <https://github.com/OpenHands/automation/pulls?q=is%3Apr+bump-sdk-${{ steps.get_version.outputs.version }}|automation>\n\n<https://github.com/OpenHands/software-agent-sdk/releases/tag/v${{ steps.get_version.outputs.version }}|View Release>"
 
     bump-typescript-client:
         # Open a PR in OpenHands/typescript-client bumping the pinned

--- a/.github/workflows/version-bump-prs.yml
+++ b/.github/workflows/version-bump-prs.yml
@@ -440,11 +440,15 @@ jobs:
                   if [ -n "$EXISTING_PR" ]; then
                     echo "✅ PR #$EXISTING_PR already exists for $REPO"
                   else
-                    # Create PR. The `fix:` title matches the repo's manual bump
-                    # convention and triggers release-please to cut a patch release.
+                    # Create PR with a `chore:` title to match the automation
+                    # repo's bump-PR convention (and the other steps here).
+                    # release-please still cuts a patch release: the repo squashes
+                    # single-commit PRs using the commit message (the `fix:` subject
+                    # above), not the PR title (squash_title_source is
+                    # COMMIT_OR_PR_TITLE).
                     gh pr create \
                       --repo "$REPO" \
-                      --title "fix: bump SDK to $VERSION" \
+                      --title "chore: bump SDK to $VERSION" \
                       --body "## Automated Version Bump
 
                   This PR updates the following packages to version **$VERSION**:


### PR DESCRIPTION
HUMAN:

Automation kept drifting behind the SDK because nothing opened its bump PR — let's wire it into the same release automation as OpenHands/CLI so it tracks releases automatically.

---

AGENT:

## Why

`OpenHands/automation` depends on `openhands-sdk` + `openhands-workspace`, but it was **not** a target of `version-bump-prs.yml`. Its SDK pin was bumped manually and routinely drifted — it was sitting on `1.22.1` while the SDK shipped `1.33.0`. Because `agent-canvas`'s `sdk-version-sync` check requires a *released* `openhands-automation` pinned to the target SDK, a stale automation blocks canvas from moving forward.

## Summary

- Add a **"Create PR for automation repo"** step to the `create-version-bump-prs` job (reuses the existing PyPI wait — `openhands-sdk`/`openhands-workspace` are already awaited).
- The step `sed`s the two exact pins in `pyproject.toml` and regenerates `uv.lock` with `uv lock --no-cache --no-config` (automation has no `exclude-newer-package` exemption, so `--no-config` is needed to bypass setup-uv's freshness guardrail — same pattern as the OpenHands step's lock regen).
- PR/commit use a Conventional Commit **`fix:`** subject (matching the repo's manual `fix: bump SDK to X.Y.Z` history) so its **release-please** opens a release PR on merge — publishing the `openhands-automation` build that unblocks canvas.
- Update the Summary step, Slack notification, and `README-RELEASE.md` to list `automation` (and document the previously-undocumented `typescript-client` job).

## Issue Number

N/A

## How to Test

Static validation performed locally (workflow isn't runnable outside a release):
- `python3 -c "import yaml; yaml.safe_load(...)"` parses the workflow; the new step lands between "Create PR for OpenHands-CLI repo" and "Summary".
- `actionlint` reports **no new** findings — the only warnings (6× SC2086) are pre-existing on `main` in the Summary step.
- Rendered the `--body` block scalar: it dedents to column 0 (no accidental markdown code block).
- Validated the exact mechanics out-of-band by hand-running them against a fresh automation checkout in **OpenHands/automation#235** (bump to 1.33.0): `sed` pins + `uv lock` produced a clean 2-file diff (`pyproject.toml` + `uv.lock`, SDK packages only), and `from openhands.automation.app import app` imported cleanly against `openhands-sdk 1.33.0`.

First live exercise will be the next SDK release; a manual `workflow_dispatch` with a `version` input can also drive it.

## Type

- [x] Feature
- [ ] Bug fix
- [ ] Refactor
- [ ] Breaking change
- [x] Docs / chore

## Notes

- `OpenHands/automation` is public, so the existing `OPENHANDS_BOT_GITHUB_PAT_PUBLIC` already has write access — no new secret needed.
- The step is idempotent (existing-branch/existing-PR guards, no-op when pins already match), matching the other targets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:a0b0a1c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-a0b0a1c-python \
  ghcr.io/openhands/agent-server:a0b0a1c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:a0b0a1c-golang-amd64
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-golang-amd64
ghcr.io/openhands/agent-server:ci-version-bump-automation-golang-amd64
ghcr.io/openhands/agent-server:a0b0a1c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:a0b0a1c-golang-arm64
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-golang-arm64
ghcr.io/openhands/agent-server:ci-version-bump-automation-golang-arm64
ghcr.io/openhands/agent-server:a0b0a1c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:a0b0a1c-java-amd64
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-java-amd64
ghcr.io/openhands/agent-server:ci-version-bump-automation-java-amd64
ghcr.io/openhands/agent-server:a0b0a1c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:a0b0a1c-java-arm64
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-java-arm64
ghcr.io/openhands/agent-server:ci-version-bump-automation-java-arm64
ghcr.io/openhands/agent-server:a0b0a1c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:a0b0a1c-python-amd64
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-python-amd64
ghcr.io/openhands/agent-server:ci-version-bump-automation-python-amd64
ghcr.io/openhands/agent-server:a0b0a1c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:a0b0a1c-python-arm64
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-python-arm64
ghcr.io/openhands/agent-server:ci-version-bump-automation-python-arm64
ghcr.io/openhands/agent-server:a0b0a1c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:a0b0a1c-golang
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-golang
ghcr.io/openhands/agent-server:ci-version-bump-automation-golang
ghcr.io/openhands/agent-server:a0b0a1c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:a0b0a1c-java
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-java
ghcr.io/openhands/agent-server:ci-version-bump-automation-java
ghcr.io/openhands/agent-server:a0b0a1c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:a0b0a1c-python
ghcr.io/openhands/agent-server:a0b0a1c71d8c816de86422607031c29593ce9c0d-python
ghcr.io/openhands/agent-server:ci-version-bump-automation-python
ghcr.io/openhands/agent-server:a0b0a1c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `a0b0a1c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `a0b0a1c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->