### PR TITLE
fix(agent-profiles): only seed a 'default' LLM profile for real config (#4031)

### DIFF
--- a/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
+++ b/openhands-agent-server/openhands/agent_server/agent_profiles_router.py
@@ -26,7 +26,7 @@ from openhands.agent_server.persistence import (
     get_llm_profile_store,
     get_settings_store,
 )
-from openhands.agent_server.profiles_router import MAX_PROFILES
+from openhands.agent_server.profiles_router import MAX_PROFILES, _has_api_key
 from openhands.agent_server.skills_service import discover_profile_skills
 from openhands.sdk.llm import LLM
 from openhands.sdk.llm.llm_profile_store import (
@@ -124,6 +124,25 @@ def _store_errors() -> Iterator[None]:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
+def _llm_has_real_config(llm: LLM) -> bool:
+    """True when ``llm`` carries real, user-provided configuration.
+
+    Distinguishes an already-working setup — a real API key, subscription auth,
+    or a custom endpoint — from bare SDK field defaults on a never-configured
+    account (``model="gpt-5.5"``, no ``api_key``). Only the former is worth
+    mirroring into a named ``default`` LLM profile; persisting the latter leaves
+    a keyless, non-functional "ghost" profile that the user never asked for and
+    that nothing ever cleans up (#4031).
+    """
+    if _has_api_key(llm):
+        return True
+    if llm.is_subscription or llm.auth_type == "subscription":
+        return True
+    if llm.base_url and llm.base_url.strip():
+        return True
+    return False
+
+
 def _seed_default_llm_profile(llm: LLM, cipher: Cipher | None) -> str:
     """Mirror the live LLM config into a ``SEED_PROFILE_NAME`` LLM profile.
 
@@ -134,6 +153,17 @@ def _seed_default_llm_profile(llm: LLM, cipher: Cipher | None) -> str:
     ``SaasSettingsStore``'s legacy-LLM backfill: materialize the current
     ``agent_settings.llm`` under that name so the reference resolves, unless a
     profile is already stored there (never clobber it).
+
+    Only a *real, pre-existing* LLM config is persisted (``_llm_has_real_config``
+    — an API key, subscription auth, or a custom base_url), which is exactly the
+    legacy/cloud migration case the backfill exists for. On a fresh,
+    never-configured account the live LLM is untouched SDK defaults (keyless
+    ``gpt-5.5``); persisting *that* only litters the profile list with a keyless,
+    unusable ``default`` "ghost" profile (#4031), so we skip the save and leave
+    ``llm_profile_ref="default"`` as a soft/dangling ref — the canvas
+    "LLM not configured" banner and the legible launch-time error already cover
+    that state, and materialize/dry-run reports it as ``dangling_llm_profile_ref``
+    rather than raising.
 
     Existence is checked via ``load()``, not ``list()``: the store resolves a
     name straight to a filesystem path, so on a case-insensitive filesystem
@@ -156,6 +186,15 @@ def _seed_default_llm_profile(llm: LLM, cipher: Cipher | None) -> str:
             logger.warning(
                 f"Default LLM profile '{SEED_PROFILE_NAME}' exists but "
                 "failed to load; leaving it as-is"
+            )
+            return SEED_PROFILE_NAME
+        if not _llm_has_real_config(llm):
+            # Never-configured account: don't persist a keyless ghost profile.
+            # Leave the ref soft/dangling; the banner + launch-time error handle
+            # it, and it resolves for real once the user saves a profile.
+            logger.info(
+                f"Skipping default LLM profile '{SEED_PROFILE_NAME}' seed: "
+                "no real LLM config yet (leaving llm_profile_ref as a soft ref)"
             )
             return SEED_PROFILE_NAME
         try:

--- a/tests/agent_server/test_agent_profiles_router.py
+++ b/tests/agent_server/test_agent_profiles_router.py
@@ -13,6 +13,7 @@ from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+from pydantic import SecretStr
 
 from openhands.agent_server import agent_profiles_router as router_module
 from openhands.agent_server.api import create_app
@@ -128,15 +129,25 @@ def test_seed_acp_when_settings_acp(client):
     assert detail["profile"]["acp_server"] == "codex"
 
 
-def test_seed_backfills_default_llm_profile_when_none_active(
+def test_seed_backfills_default_llm_profile_when_real_config(
     client, default_llm_profile_store
 ):
-    """No active LLM profile: seed backfills a resolvable 'default' LLM profile.
+    """No active LLM profile but a *real* live LLM config: seed backfills a
+    resolvable 'default' LLM profile.
 
-    Regression test for #3933 — previously ``llm_profile_ref`` fell back to
-    the literal 'default' without anything ever creating that LLM profile, so
-    the seeded (and active) agent profile 404'd at conversation launch.
+    Regression test for #3933 — previously ``llm_profile_ref`` fell back to the
+    literal 'default' without anything ever creating that LLM profile, so the
+    seeded (and active) agent profile 404'd at conversation launch. The backfill
+    fires only when the live ``agent_settings.llm`` is real, pre-existing config
+    (here: a custom ``base_url``) — the legacy/cloud migration case — not for a
+    fresh account's bare SDK defaults (see the ghost-profile test below, #4031).
     """
+    # Give the live LLM real config so the backfill is warranted.
+    client.patch(
+        "/api/settings",
+        json={"agent_settings_diff": {"llm": {"base_url": "https://proxy.example/v1"}}},
+    )
+
     body = client.get("/api/agent-profiles").json()
     seeded = body["profiles"][0]
     assert seeded["llm_profile_ref"] == "default"
@@ -145,6 +156,33 @@ def test_seed_backfills_default_llm_profile_when_none_active(
     materialized = client.post("/api/agent-profiles/default/materialize").json()
     assert materialized["valid"] is True
     assert materialized["llm_profile_resolved"] is True
+
+
+def test_seed_skips_ghost_llm_profile_for_bare_defaults(
+    client, default_llm_profile_store
+):
+    """A fresh, never-configured account must NOT get a keyless 'default' LLM
+    profile persisted (#4031).
+
+    On bare SDK defaults (``model="gpt-5.5"``, no api_key) the backfill is
+    skipped: no ``default.json`` is written, so the LLM profiles list stays
+    empty rather than showing an unexplained, non-functional 'ghost' profile.
+    The agent profile's ``llm_profile_ref`` is left as a *soft* 'default' ref —
+    which materialize reports as dangling (never raises) and which resolves for
+    real the moment the user saves an actual LLM profile.
+    """
+    body = client.get("/api/agent-profiles").json()
+    seeded = body["profiles"][0]
+    # The agent profile is still seeded, with a soft (unresolved) ref.
+    assert seeded["llm_profile_ref"] == "default"
+    # ...but no ghost LLM profile is left behind.
+    assert "default.json" not in default_llm_profile_store.list()
+    assert default_llm_profile_store.list() == []
+
+    # The soft ref surfaces as dangling at materialize time, not a 500.
+    materialized = client.post("/api/agent-profiles/default/materialize").json()
+    assert materialized["valid"] is False
+    assert materialized["llm_profile_resolved"] is False
 
 
 def test_seed_does_not_clobber_existing_default_llm_profile(
@@ -215,12 +253,18 @@ def test_seed_backfills_when_active_profile_is_empty_string(
     PATCH payload's pattern validator blocks a client from setting `""`, but
     the stored ``PersistedSettings`` field has no such constraint, so a
     hand-edited or legacy settings.json can still contain it.
+
+    The live LLM carries a custom ``base_url`` so it counts as real config and
+    the backfill actually persists a profile (#4031 gates it on real config).
     """
     (temp_settings_dir / "settings.json").write_text(
         json.dumps(
             {
                 "schema_version": 2,
-                "agent_settings": {"agent_kind": "openhands"},
+                "agent_settings": {
+                    "agent_kind": "openhands",
+                    "llm": {"model": "gpt-5.5", "base_url": "https://proxy.example/v1"},
+                },
                 "conversation_settings": {},
                 "active_profile": "",
                 "active_agent_profile_id": None,
@@ -247,6 +291,29 @@ def test_seed_acp_does_not_backfill_llm_profile(client, default_llm_profile_stor
     client.get("/api/agent-profiles")
 
     assert default_llm_profile_store.list() == []
+
+
+@pytest.mark.parametrize(
+    "llm, expected",
+    [
+        # Bare SDK defaults on a never-configured account -> not real config.
+        (LLM(model="gpt-5.5"), False),
+        (LLM(model="gpt-5.5", base_url=""), False),
+        (LLM(model="gpt-5.5", base_url="   "), False),
+        # A real API key.
+        (LLM(model="gpt-5.5", api_key=SecretStr("sk-real")), True),
+        # A blank API key does not count.
+        (LLM(model="gpt-5.5", api_key=SecretStr("  ")), False),
+        # A custom endpoint (proxy / self-hosted) counts.
+        (LLM(model="gpt-5.5", base_url="https://proxy.example/v1"), True),
+        # Subscription auth counts even without an api_key.
+        (LLM(model="gpt-5.5", auth_type="subscription"), True),
+    ],
+)
+def test_llm_has_real_config(llm, expected):
+    """``_llm_has_real_config`` gates the seed so only real, pre-existing
+    configuration is mirrored into a persisted 'default' LLM profile (#4031)."""
+    assert router_module._llm_has_real_config(llm) is expected
 
 
 def test_no_seed_when_store_nonempty(client, store):
@@ -907,7 +974,6 @@ def test_materialize_no_raw_secrets_in_resolved_settings(
 ):
     """resolved_settings must not contain raw API key values."""
     raw_key = "sk-secret-key-should-not-appear"
-    from pydantic import SecretStr
 
     llm_store.save(
         "base-llm",


### PR DESCRIPTION
HUMAN:

Ghost profiles are being created in agent-canvas with latest SDK. This is the fix. 

---

AGENT:

## Why

The #3933 fix (#3934) makes a freshly-seeded default `AgentProfile`'s `llm_profile_ref` resolve by backfilling a persisted LLM profile named `default` at seed time. But it did this **unconditionally** — including on a fresh, never-configured account whose live `agent_settings.llm` is just bare SDK defaults (`model="gpt-5.5"`, no `api_key`).

That leaves a keyless, non-functional `default` "ghost" profile in the LLM profiles list **forever**: the user never created it, it can't be used (no credentials), nothing references it once a real profile is created, and nothing ever cleans it up. See #4031 for the full repro and analysis.

## Summary

- Add `_llm_has_real_config(llm)` — true when the live LLM carries real, user-provided config (an API key, subscription auth, or a custom `base_url`).
- Gate `_seed_default_llm_profile` on it: persist the `default` LLM profile **only** for real, pre-existing config — exactly the legacy/cloud `SaasSettingsStore` backfill case the mechanism exists for.
- On bare defaults, skip the save and leave `llm_profile_ref="default"` as a **soft/dangling** ref. The canvas "LLM not configured" banner (`useLlmConfigured` checks the *referenced* profile's `api_key_set`, not whether a `default` profile exists), the graceful materialize/dry-run `dangling_llm_profile_ref`, and the legible launch-time error already cover that state — and the ref resolves for real the moment the user saves an actual LLM profile.

This is the "gate on real config" option from the issue's refined recommendation: it fixes the ghost-profile problem for every new account while preserving the real cloud/legacy-account migration case. Unconditional AgentProfile seeding is unchanged.

## Issue Number

Fixes #4031

## How to Test

Unit tests (new + updated):

```bash
uv run pytest tests/agent_server/test_agent_profiles_router.py -q   # 61 passed
```

New/updated coverage:
- `test_seed_skips_ghost_llm_profile_for_bare_defaults` — fresh account: no `default.json` written, ref left as a soft `default`, materialize reports dangling (not a 500).
- `test_seed_backfills_default_llm_profile_when_real_config` — real config (custom `base_url`): backfill still fires and resolves (#3933 regression preserved).
- `test_seed_backfills_when_active_profile_is_empty_string` — updated to carry real config so the falsy-trigger regression still exercises a real backfill.
- `test_llm_has_real_config` — parametrized unit test for the gate (api_key / blank key / base_url / subscription / bare defaults).

End-to-end through the real FastAPI app + real on-disk stores (fresh temp `OH_PERSISTENCE_DIR`, no mocks), driving `GET /api/agent-profiles` (triggers the lazy seed) then inspecting the LLM profile store and `POST .../materialize`:

```
=== FRESH account (bare gpt-5.5 defaults) ===
  agent profile llm_profile_ref : 'default'
  LLM profile files on disk      : []          # <- no ghost profile (was ['default.json'])
  /api/profiles names            : []
  materialize valid / resolved   : False / False   # <- graceful dangling ref

=== REAL config (base_url set) ===
  agent profile llm_profile_ref : 'default'
  LLM profile files on disk      : ['default.json']   # <- backfill preserved
  /api/profiles names            : ['default']
  materialize valid / resolved   : True / True
```

`uv run pre-commit run` (ruff format/lint, pycodestyle, pyright, import rules) passes on both changed files.

## Video/Screenshots

N/A — server-side seed logic; covered by unit tests + the e2e transcript above.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

- Additive and safe: only *narrows* when a profile is persisted; a fresh account simply gets no ghost profile instead of a broken one. No migration needed; existing real `default` profiles are still never clobbered (the pre-existing `load()` existence check runs first).
- Left out of scope (issue's "optional polish"): recoding the launch-time `ProfileNotFound` from 404 → 422 structured detail. Can follow up separately if wanted.
- Downstream (canvas): no change required — the banner already keys off the referenced profile, not the presence of a `default` LLM profile.

_This PR was created by an AI agent (OpenHands) on behalf of the user._


<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:cf98b0c-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-cf98b0c-python \
  ghcr.io/openhands/agent-server:cf98b0c-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:cf98b0c-golang-amd64
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-golang-amd64
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-golang-amd64
ghcr.io/openhands/agent-server:cf98b0c-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:cf98b0c-golang-arm64
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-golang-arm64
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-golang-arm64
ghcr.io/openhands/agent-server:cf98b0c-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:cf98b0c-java-amd64
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-java-amd64
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-java-amd64
ghcr.io/openhands/agent-server:cf98b0c-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:cf98b0c-java-arm64
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-java-arm64
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-java-arm64
ghcr.io/openhands/agent-server:cf98b0c-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:cf98b0c-python-amd64
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-python-amd64
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-python-amd64
ghcr.io/openhands/agent-server:cf98b0c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:cf98b0c-python-arm64
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-python-arm64
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-python-arm64
ghcr.io/openhands/agent-server:cf98b0c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:cf98b0c-golang
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-golang
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-golang
ghcr.io/openhands/agent-server:cf98b0c-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:cf98b0c-java
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-java
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-java
ghcr.io/openhands/agent-server:cf98b0c-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:cf98b0c-python
ghcr.io/openhands/agent-server:cf98b0c8b6c106f2535afd642476f3b329e3f9ce-python
ghcr.io/openhands/agent-server:fix-seed-ghost-llm-profile-python
ghcr.io/openhands/agent-server:cf98b0c-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `cf98b0c-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `cf98b0c-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->