### PR TITLE
fix(observability): skip Laminar.initialize when already initialized

### DIFF
--- a/openhands-sdk/openhands/sdk/observability/laminar.py
+++ b/openhands-sdk/openhands/sdk/observability/laminar.py
@@ -90,6 +90,9 @@ def maybe_init_laminar():
 
     from lmnr import Instruments, Laminar
 
+    if Laminar.is_initialized():
+        return
+
     base_url = get_env("LMNR_BASE_URL") or None
     force_http = _get_bool_env("LMNR_FORCE_HTTP")
 

--- a/tests/sdk/observability/test_laminar.py
+++ b/tests/sdk/observability/test_laminar.py
@@ -139,6 +139,37 @@ def test_lmnr_base_url_not_passed_when_empty():
             del os.environ["LMNR_PROJECT_API_KEY"]
 
 
+def test_maybe_init_laminar_skips_when_already_initialized():
+    """Laminar.initialize must not be called again when already initialized.
+
+    Re-calling Laminar.initialize after a previous init emits
+    'Laminar is already initialized. Skipping initialization.' at INFO level
+    from lmnr. Since ``maybe_init_laminar`` runs at import time in agent.py
+    and acp_agent.py, that line shows up on every module load after the
+    first one. Guard against the re-init to keep logs clean.
+    """
+    original_key = os.environ.get("LMNR_PROJECT_API_KEY")
+
+    try:
+        os.environ["LMNR_PROJECT_API_KEY"] = "test-key"
+
+        with patch("lmnr.Laminar") as mock_laminar:
+            with patch("lmnr.LaminarLiteLLMCallback"):
+                with patch("litellm.callbacks", new=MagicMock()):
+                    mock_laminar.is_initialized.return_value = True
+                    from openhands.sdk.observability.laminar import maybe_init_laminar
+
+                    maybe_init_laminar()
+                    maybe_init_laminar()
+
+                    mock_laminar.initialize.assert_not_called()
+    finally:
+        if original_key is not None:
+            os.environ["LMNR_PROJECT_API_KEY"] = original_key
+        elif "LMNR_PROJECT_API_KEY" in os.environ:
+            del os.environ["LMNR_PROJECT_API_KEY"]
+
+
 @pytest.mark.parametrize(
     ("env_value", "expected"),
     [


### PR DESCRIPTION
<!-- Keep this PR as draft until it is ready for review. -->

<!-- AI/LLM agents:
Do not edit the HUMAN section.
-->

HUMAN:

Laminar logs this as an error `Laminar is already initialized. Skipping initialization` over and over. I want it quiet.

---

AGENT:
<!-- Created by OpenHands (https://docs.openhands.dev/) on behalf of tofarr. -->

## Why

The lmnr SDK's `Laminar.initialize()` emits `"Laminar is already initialized. Skipping initialization."` at INFO level whenever it is called after the first successful initialization. Our `maybe_init_laminar()` in `openhands.sdk.observability.laminar` calls `Laminar.initialize(...)` unconditionally, and the function runs at module-import time in both `agent.py` and `acp_agent.py`. Any process that imports both modules (or imports `agent.py` after `Laminar` was initialized externally) sees the duplicate INFO line on every subsequent module load — which is what shows up as spam in our logs.

## Summary

- Guard `maybe_init_laminar()` with `Laminar.is_initialized()` (the same check lmnr uses internally) so the second-and-later invocations become silent no-ops.
- Add `test_maybe_init_laminar_skips_when_already_initialized` covering the new behavior.

## Issue Number

None.

## How to Test

```bash
uv run pytest tests/sdk/observability/test_laminar.py -v
```

All 36 tests pass (35 existing + 1 new). The full SDK suite (`uv run pytest tests/sdk/`) — 5143 tests — also passes with no regressions.

To reproduce the original log spam locally:

1. `export LMNR_PROJECT_API_KEY=test` (or any other key listed in `_OBSERVABILITY_ENV_KEYS`).
2. In a single Python session: `import openhands.sdk.agent.agent`, then `import openhands.sdk.agent.acp_agent`. Before the fix the second import logs `Laminar is already initialized. Skipping initialization.` at INFO; after the fix it stays quiet.

## Video/Screenshots

N/A — observable via stdout/log capture only; no UI changes.

## Type

- [x] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Breaking change
- [ ] Docs / chore

## Notes

Pure observability tweak. No public API change. The early-exit happens after we already import `lmnr`, so we pay the import cost once (same as today) and skip the re-init log thereafter. Since `Laminar.initialize()` is itself a no-op past the first call, the functional behavior of fresh installs is unchanged.
<!-- AGENT_SERVER_IMAGES_START -->
---
**Agent Server images for this PR**

• **GHCR package:** https://github.com/OpenHands/agent-sdk/pkgs/container/agent-server

**Variants & Base Images**
| Variant | Architectures | Base Image | Docs / Tags |
|---|---|---|---|
| java | amd64, arm64 | `eclipse-temurin:17-jdk` | [Link](https://hub.docker.com/_/eclipse-temurin:17-jdk) |
| python | amd64, arm64 | `nikolaik/python-nodejs:python3.13-nodejs22-slim` | [Link](https://hub.docker.com/_/nikolaik/python-nodejs:python3.13-nodejs22-slim) |
| golang | amd64, arm64 | `golang:1.21-bookworm` | [Link](https://hub.docker.com/_/golang:1.21-bookworm) |


**Pull (multi-arch manifest)**
```bash
# Each variant is a multi-arch manifest supporting both amd64 and arm64
docker pull ghcr.io/openhands/agent-server:4bcd21f-python
```

**Run**
```bash
docker run -it --rm \
  -p 8000:8000 \
  --name agent-server-4bcd21f-python \
  ghcr.io/openhands/agent-server:4bcd21f-python
```

**All tags pushed for this build**
```
ghcr.io/openhands/agent-server:4bcd21f-golang-amd64
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-golang-amd64
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-golang-amd64
ghcr.io/openhands/agent-server:4bcd21f-golang_tag_1.21-bookworm-amd64
ghcr.io/openhands/agent-server:4bcd21f-golang-arm64
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-golang-arm64
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-golang-arm64
ghcr.io/openhands/agent-server:4bcd21f-golang_tag_1.21-bookworm-arm64
ghcr.io/openhands/agent-server:4bcd21f-java-amd64
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-java-amd64
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-java-amd64
ghcr.io/openhands/agent-server:4bcd21f-eclipse-temurin_tag_17-jdk-amd64
ghcr.io/openhands/agent-server:4bcd21f-java-arm64
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-java-arm64
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-java-arm64
ghcr.io/openhands/agent-server:4bcd21f-eclipse-temurin_tag_17-jdk-arm64
ghcr.io/openhands/agent-server:4bcd21f-python-amd64
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-python-amd64
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-python-amd64
ghcr.io/openhands/agent-server:4bcd21f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-amd64
ghcr.io/openhands/agent-server:4bcd21f-python-arm64
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-python-arm64
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-python-arm64
ghcr.io/openhands/agent-server:4bcd21f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim-arm64
ghcr.io/openhands/agent-server:4bcd21f-golang
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-golang
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-golang
ghcr.io/openhands/agent-server:4bcd21f-golang_tag_1.21-bookworm
ghcr.io/openhands/agent-server:4bcd21f-java
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-java
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-java
ghcr.io/openhands/agent-server:4bcd21f-eclipse-temurin_tag_17-jdk
ghcr.io/openhands/agent-server:4bcd21f-python
ghcr.io/openhands/agent-server:4bcd21f90dbfbc4ce8f742b81404485f313c7437-python
ghcr.io/openhands/agent-server:fix-laminar-skip-reinit-python
ghcr.io/openhands/agent-server:4bcd21f-nikolaik_s_python-nodejs_tag_python3.13-nodejs22-slim
```

**About Multi-Architecture Support**
- Each variant tag (e.g., `4bcd21f-python`) is a **multi-arch manifest** supporting both **amd64** and **arm64**
- Docker automatically pulls the correct architecture for your platform
- Individual architecture tags (e.g., `4bcd21f-python-amd64`) are also available if needed
<!-- AGENT_SERVER_IMAGES_END -->